### PR TITLE
Accessibility updates for the Catalog page and example App

### DIFF
--- a/.changeset/blue-roses-give.md
+++ b/.changeset/blue-roses-give.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog-react': patch
 ---
 
 Accessibility updates:

--- a/.changeset/blue-roses-give.md
+++ b/.changeset/blue-roses-give.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Accessibility updates:
+
+- Wrapped the `EntityLifecyclePicker`, `EntityOwnerPicker`, `EntityTagPicker`, in `label` elements
+- Changed group name `Typography` component to `span` (from default `h6`), added `aria-label` to the `List` component, and `role` of `menuitem` to the container of the `MenuItem` component

--- a/.changeset/olive-rats-rest.md
+++ b/.changeset/olive-rats-rest.md
@@ -1,0 +1,7 @@
+---
+'@backstage/create-app': minor
+---
+
+Accessibility updates:
+
+- Added `aria-label` to the sidebar Logo link

--- a/.changeset/olive-rats-rest.md
+++ b/.changeset/olive-rats-rest.md
@@ -1,7 +1,30 @@
 ---
-'@backstage/create-app': minor
+'@backstage/create-app': patch
 ---
 
 Accessibility updates:
 
-- Added `aria-label` to the sidebar Logo link
+- Added `aria-label` to the sidebar Logo link. To enable this for an existing app, please make the following changes:
+
+`packages/app/src/components/Root/Root.tsx`
+
+```diff
+const SidebarLogo = () => {
+  const classes = useSidebarLogoStyles();
+  const { isOpen } = useContext(SidebarContext);
+
+  return (
+    <div className={classes.root}>
+      <Link
+        component={NavLink}
+        to="/"
+        underline="none"
+        className={classes.link}
++       aria-label="Home"
+      >
+        {isOpen ? <LogoFull /> : <LogoIcon />}
+      </Link>
+    </div>
+  );
+};
+```

--- a/.changeset/quick-ladybugs-try.md
+++ b/.changeset/quick-ladybugs-try.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Accessibility updates:
+
+- Added screen reader elements to describe default table `Action` buttons

--- a/.changeset/quick-ladybugs-try.md
+++ b/.changeset/quick-ladybugs-try.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog': minor
+'@backstage/plugin-catalog': patch
 ---
 
 Accessibility updates:

--- a/.changeset/short-jokes-applaud.md
+++ b/.changeset/short-jokes-applaud.md
@@ -1,13 +1,8 @@
 ---
-'@backstage/core-components': minor
-'@backstage/plugin-catalog': minor
-'@backstage/plugin-catalog-react': minor
+'@backstage/core-components': patch
 ---
 
 Accessibility updates:
 
-- Added `aria-label` to the `Select` component in `core-components`
-- Changed heading level used in the header of `Table` component in `core-components`
-- Added screen reader elements to describe default table `Action` buttons in `plugin-catalog`
-- Wrapped the `EntityLifecyclePicker`, `EntityOwnerPicker`, `EntityTagPicker`, in `label` elements in `plugin-catalog-react`
-- Changed group name `Typography` component to `span` (from default `h6`), added `aria-label` to the `List` component, and `role` of `menuitem` to the container of the `MenuItem` component in `plugin-catalog-react`
+- Added `aria-label` to the `Select` component
+- Changed heading level used in the header of `Table` component

--- a/.changeset/short-jokes-applaud.md
+++ b/.changeset/short-jokes-applaud.md
@@ -8,6 +8,6 @@ Accessibility updates:
 
 - Added `aria-label` to the `Select` component in `core-components`
 - Changed heading level used in the header of `Table` component in `core-components`
-- Added screenreader elements to describe default table `Action` buttons in `plugin-catalog`
+- Added screen reader elements to describe default table `Action` buttons in `plugin-catalog`
 - Wrapped the `EntityLifecyclePicker`, `EntityOwnerPicker`, `EntityTagPicker`, in `label` elements in `plugin-catalog-react`
 - Changed group name `Typography` component to `span` (from default `h6`), added `aria-label` to the `List` component, and `role` of `menuitem` to the container of the `MenuItem` component in `plugin-catalog-react`

--- a/.changeset/short-jokes-applaud.md
+++ b/.changeset/short-jokes-applaud.md
@@ -1,5 +1,4 @@
 ---
-'example-app': minor
 '@backstage/core-components': minor
 '@backstage/plugin-catalog': minor
 '@backstage/plugin-catalog-react': minor
@@ -7,7 +6,6 @@
 
 Accessibility updates:
 
-- Added `aria-label` to the sidebar Logo link in `example-app`
 - Added `aria-label` to the `Select` component in `core-components`
 - Changed heading level used in the header of `Table` component in `core-components`
 - Added screenreader elements to describe default table `Action` buttons in `plugin-catalog`

--- a/.changeset/short-jokes-applaud.md
+++ b/.changeset/short-jokes-applaud.md
@@ -1,0 +1,15 @@
+---
+'example-app': minor
+'@backstage/core-components': minor
+'@backstage/plugin-catalog': minor
+'@backstage/plugin-catalog-react': minor
+---
+
+Accessibility updates:
+
+- Added `aria-label` to the sidebar Logo link in `example-app`
+- Added `aria-label` to the `Select` component in `core-components`
+- Changed heading level used in the header of `Table` component in `core-components`
+- Added screenreader elements to describe default table `Action` buttons in `plugin-catalog`
+- Wrapped the `EntityLifecyclePicker`, `EntityOwnerPicker`, `EntityTagPicker`, in `label` elements in `plugin-catalog-react`
+- Changed group name `Typography` component to `span` (from default `h6`), added `aria-label` to the `List` component, and `role` of `menuitem` to the container of the `MenuItem` component in `plugin-catalog-react`

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -77,6 +77,7 @@ const SidebarLogo = () => {
         to="/"
         underline="none"
         className={classes.link}
+        aria-label="Home"
       >
         {isOpen ? <LogoFull /> : <LogoIcon />}
       </Link>

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -199,6 +199,7 @@ export function SelectComponent(props: SelectProps) {
         <FormControl className={classes.formControl}>
           <InputLabel className={classes.formLabel}>{label}</InputLabel>
           <Select
+            aria-label={label}
             value={value}
             native={native}
             disabled={disabled}

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -499,7 +499,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
         icons={tableIcons}
         title={
           <>
-            <Typography variant="h5" component="h3">
+            <Typography variant="h5" component="h2">
               {title}
             </Typography>
             {subtitle && (

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -69,6 +69,7 @@ const SidebarLogo = () => {
         to="/"
         underline="none"
         className={classes.link}
+        aria-label="Home"
       >
         {isOpen ? <LogoFull /> : <LogoIcon />}
       </Link>

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -99,31 +99,38 @@ export const EntityLifecyclePicker = () => {
 
   return (
     <Box pb={1} pt={1}>
-      <Typography variant="button">Lifecycle</Typography>
-      <Autocomplete
-        aria-label="Lifecycle"
-        multiple
-        options={availableLifecycles}
-        value={selectedLifecycles}
-        onChange={(_: object, value: string[]) => setSelectedLifecycles(value)}
-        renderOption={(option, { selected }) => (
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={icon}
-                checkedIcon={checkedIcon}
-                checked={selected}
-              />
-            }
-            label={option}
-          />
-        )}
-        size="small"
-        popupIcon={<ExpandMoreIcon data-testid="lifecycle-picker-expand" />}
-        renderInput={params => (
-          <TextField {...params} className={classes.input} variant="outlined" />
-        )}
-      />
+      <Typography variant="button" component="label">
+        Lifecycle
+        <Autocomplete
+          multiple
+          options={availableLifecycles}
+          value={selectedLifecycles}
+          onChange={(_: object, value: string[]) =>
+            setSelectedLifecycles(value)
+          }
+          renderOption={(option, { selected }) => (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  icon={icon}
+                  checkedIcon={checkedIcon}
+                  checked={selected}
+                />
+              }
+              label={option}
+            />
+          )}
+          size="small"
+          popupIcon={<ExpandMoreIcon data-testid="lifecycle-picker-expand" />}
+          renderInput={params => (
+            <TextField
+              {...params}
+              className={classes.input}
+              variant="outlined"
+            />
+          )}
+        />
+      </Typography>
     </Box>
   );
 };

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -103,31 +103,36 @@ export const EntityOwnerPicker = () => {
 
   return (
     <Box pb={1} pt={1}>
-      <Typography variant="button">Owner</Typography>
-      <Autocomplete
-        multiple
-        aria-label="Owner"
-        options={availableOwners}
-        value={selectedOwners}
-        onChange={(_: object, value: string[]) => setSelectedOwners(value)}
-        renderOption={(option, { selected }) => (
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={icon}
-                checkedIcon={checkedIcon}
-                checked={selected}
-              />
-            }
-            label={option}
-          />
-        )}
-        size="small"
-        popupIcon={<ExpandMoreIcon data-testid="owner-picker-expand" />}
-        renderInput={params => (
-          <TextField {...params} className={classes.input} variant="outlined" />
-        )}
-      />
+      <Typography variant="button" component="label">
+        Owner
+        <Autocomplete
+          multiple
+          options={availableOwners}
+          value={selectedOwners}
+          onChange={(_: object, value: string[]) => setSelectedOwners(value)}
+          renderOption={(option, { selected }) => (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  icon={icon}
+                  checkedIcon={checkedIcon}
+                  checked={selected}
+                />
+              }
+              label={option}
+            />
+          )}
+          size="small"
+          popupIcon={<ExpandMoreIcon data-testid="owner-picker-expand" />}
+          renderInput={params => (
+            <TextField
+              {...params}
+              className={classes.input}
+              variant="outlined"
+            />
+          )}
+        />
+      </Typography>
     </Box>
   );
 };

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -95,31 +95,36 @@ export const EntityTagPicker = () => {
 
   return (
     <Box pb={1} pt={1}>
-      <Typography variant="button">Tags</Typography>
-      <Autocomplete
-        multiple
-        aria-label="Tags"
-        options={availableTags}
-        value={selectedTags}
-        onChange={(_: object, value: string[]) => setSelectedTags(value)}
-        renderOption={(option, { selected }) => (
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={icon}
-                checkedIcon={checkedIcon}
-                checked={selected}
-              />
-            }
-            label={option}
-          />
-        )}
-        size="small"
-        popupIcon={<ExpandMoreIcon data-testid="tag-picker-expand" />}
-        renderInput={params => (
-          <TextField {...params} className={classes.input} variant="outlined" />
-        )}
-      />
+      <Typography variant="button" component="label">
+        Tags
+        <Autocomplete
+          multiple
+          options={availableTags}
+          value={selectedTags}
+          onChange={(_: object, value: string[]) => setSelectedTags(value)}
+          renderOption={(option, { selected }) => (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  icon={icon}
+                  checkedIcon={checkedIcon}
+                  checked={selected}
+                />
+              }
+              label={option}
+            />
+          )}
+          size="small"
+          popupIcon={<ExpandMoreIcon data-testid="tag-picker-expand" />}
+          renderInput={params => (
+            <TextField
+              {...params}
+              className={classes.input}
+              variant="outlined"
+            />
+          )}
+        />
+      </Typography>
     </Box>
   );
 };

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -167,7 +167,7 @@ describe('<UserListPicker />', () => {
 
     expect(
       getAllByRole('menuitem').map(({ textContent }) => textContent),
-    ).toEqual(['Owned', 'Starred', 'All']);
+    ).toEqual(['Owned 1', 'Starred 1', 'All 4']);
   });
 
   it('includes counts alongside each filter', async () => {
@@ -183,10 +183,8 @@ describe('<UserListPicker />', () => {
     // menuitem itself, so we pick off the next sibling.
     await waitFor(() => {
       expect(
-        getAllByRole('menuitem').map(
-          ({ nextSibling }) => nextSibling?.textContent,
-        ),
-      ).toEqual(['1', '1', '4']);
+        getAllByRole('menuitem').map(({ textContent }) => textContent),
+      ).toEqual(['Owned 1', 'Starred 1', 'All 4']);
     });
   });
 
@@ -206,10 +204,8 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() => {
       expect(
-        getAllByRole('menuitem').map(
-          ({ nextSibling }) => nextSibling?.textContent,
-        ),
-      ).toEqual(['1', '0', '2']);
+        getAllByRole('menuitem').map(({ textContent }) => textContent),
+      ).toEqual(['Owned 1', 'Starred 0', 'All 2']);
     });
   });
 

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -238,13 +238,18 @@ export const UserListPicker = (props: UserListPickerProps) => {
     <Card className={classes.root}>
       {filterGroups.map(group => (
         <Fragment key={group.name}>
-          <Typography variant="subtitle2" className={classes.title}>
+          <Typography
+            variant="subtitle2"
+            component="span"
+            className={classes.title}
+          >
             {group.name}
           </Typography>
           <Card className={classes.groupWrapper}>
-            <List disablePadding dense role="menu">
+            <List disablePadding dense role="menu" aria-label={group.name}>
               {group.items.map(item => (
                 <MenuItem
+                  role="none presentation"
                   key={item.id}
                   button
                   divider
@@ -254,6 +259,7 @@ export const UserListPicker = (props: UserListPickerProps) => {
                   disabled={filterCounts[item.id] === 0}
                   data-testid={`user-picker-${item.id}`}
                   tabIndex={0}
+                  ContainerProps={{ role: 'menuitem' }}
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -267,7 +267,7 @@ export const UserListPicker = (props: UserListPickerProps) => {
                     </ListItemIcon>
                   )}
                   <ListItemText>
-                    <Typography variant="body1">{item.label}</Typography>
+                    <Typography variant="body1">{item.label} </Typography>
                   </ListItemText>
                   <ListItemSecondaryAction>
                     {filterCounts[item.id] ?? '-'}

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -41,6 +41,7 @@ import {
 import StarBorder from '@material-ui/icons/StarBorder';
 import { withStyles } from '@material-ui/core/styles';
 import Star from '@material-ui/icons/Star';
+import { Typography } from '@material-ui/core';
 
 /**
  * Props for {@link CatalogTable}.
@@ -115,9 +116,16 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const defaultActions: TableProps<CatalogTableRow>['actions'] = [
     ({ entity }) => {
       const url = entity.metadata.annotations?.[ANNOTATION_VIEW_URL];
+      const title = 'View';
+
       return {
-        icon: () => <OpenInNew aria-label="View" fontSize="small" />,
-        tooltip: 'View',
+        icon: () => (
+          <>
+            <Typography variant="srOnly" title={title} />
+            <OpenInNew fontSize="small" />
+          </>
+        ),
+        tooltip: title,
         disabled: !url,
         onClick: () => {
           if (!url) return;
@@ -127,9 +135,16 @@ export const CatalogTable = (props: CatalogTableProps) => {
     },
     ({ entity }) => {
       const url = entity.metadata.annotations?.[ANNOTATION_EDIT_URL];
+      const title = 'Edit';
+
       return {
-        icon: () => <Edit aria-label="Edit" fontSize="small" />,
-        tooltip: 'Edit',
+        icon: () => (
+          <>
+            <Typography variant="srOnly" title={title} />
+            <Edit fontSize="small" />
+          </>
+        ),
+        tooltip: title,
         disabled: !url,
         onClick: () => {
           if (!url) return;
@@ -139,10 +154,17 @@ export const CatalogTable = (props: CatalogTableProps) => {
     },
     ({ entity }) => {
       const isStarred = isStarredEntity(entity);
+      const title = isStarred ? 'Remove from favorites' : 'Add to favorites';
+
       return {
         cellStyle: { paddingLeft: '1em' },
-        icon: () => (isStarred ? <YellowStar /> : <StarBorder />),
-        tooltip: isStarred ? 'Remove from favorites' : 'Add to favorites',
+        icon: () => (
+          <>
+            <Typography variant="srOnly" title={title} />
+            {isStarred ? <YellowStar /> : <StarBorder />}
+          </>
+        ),
+        tooltip: title,
         onClick: () => toggleStarredEntity(entity),
       };
     },

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -121,7 +121,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
       return {
         icon: () => (
           <>
-            <Typography variant="srOnly" title={title} />
+            <Typography variant="srOnly">{title}</Typography>
             <OpenInNew fontSize="small" />
           </>
         ),
@@ -140,7 +140,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
       return {
         icon: () => (
           <>
-            <Typography variant="srOnly" title={title} />
+            <Typography variant="srOnly">{title}</Typography>
             <Edit fontSize="small" />
           </>
         ),
@@ -160,7 +160,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         cellStyle: { paddingLeft: '1em' },
         icon: () => (
           <>
-            <Typography variant="srOnly" title={title} />
+            <Typography variant="srOnly">{title}</Typography>
             {isStarred ? <YellowStar /> : <StarBorder />}
           </>
         ),

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
@@ -88,8 +88,8 @@ describe('TemplateListPage', () => {
       { mountedRoutes: { '/': rootRouteRef } },
     );
 
-    expect(getByRole('menuitem', { name: 'All' })).toBeInTheDocument();
-    expect(getByRole('menuitem', { name: 'Starred' })).toBeInTheDocument();
+    expect(getByRole('menuitem', { name: 'All 0' })).toBeInTheDocument();
+    expect(getByRole('menuitem', { name: 'Starred 0' })).toBeInTheDocument();
   });
 
   it('should render the category picker', async () => {

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
@@ -88,8 +88,8 @@ describe('TemplateListPage', () => {
       { mountedRoutes: { '/': rootRouteRef } },
     );
 
-    expect(getByRole('menuitem', { name: 'All 0' })).toBeInTheDocument();
-    expect(getByRole('menuitem', { name: 'Starred 0' })).toBeInTheDocument();
+    expect(getByRole('menuitem', { name: /All/ })).toBeInTheDocument();
+    expect(getByRole('menuitem', { name: /Starred/ })).toBeInTheDocument();
   });
 
   it('should render the category picker', async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Accessibility updates to correct violations reported by aXe.

- Added `aria-label` to the sidebar Logo link in `example-app`
- Added `aria-label` to the `Select` component in `core-components`
- Changed heading level used in the header of `Table` component in `core-components`
- Added screenreader elements to describe default table `Action` buttons in `plugin-catalog`
- Wrapped the `EntityLifecyclePicker`, `EntityOwnerPicker`, `EntityTagPicker`, in `label` elements in `plugin-catalog-react`
- Changed group name `Typography` component to `span` (from default `h6`), added `aria-label` to the `List` component, and `role` of `menuitem` to the container of the `MenuItem` component in `plugin-catalog-react`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
