### PR TITLE
fix accidental wrong dep ranges on new plugin

### DIFF
--- a/plugins/codescene/package.json
+++ b/plugins/codescene/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@backstage/config": "^1.0.0",
-    "@backstage/core-components": "^0.9.3-next.1",
-    "@backstage/core-plugin-api": "^1.0.0",
+    "@backstage/core-components": "^0.9.4-next.0",
+    "@backstage/core-plugin-api": "^1.0.2-next.0",
     "@backstage/errors": "^1.0.0",
     "@backstage/theme": "^0.2.15",
     "@material-ui/core": "^4.9.10",
@@ -39,9 +39,9 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.17.1-next.0",
-    "@backstage/core-app-api": "^1.0.1-next.0",
+    "@backstage/core-app-api": "^1.0.2-next.0",
     "@backstage/dev-utils": "^1.0.2-next.0",
-    "@backstage/test-utils": "^1.0.2-next.0",
+    "@backstage/test-utils": "^1.1.0-next.1",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.1.8",


### PR DESCRIPTION
 no changeset needed, covered by #10777