### PR TITLE
Add aria-label to sidebar & fix heading sizes in entity about card 

### DIFF
--- a/.changeset/rotten-impalas-clap.md
+++ b/.changeset/rotten-impalas-clap.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog': patch
+---
+
+Sidebar NAV now includes aria-label. Component AboutField now uses h2 variant instead of subtitle2 (font properties unchanged)

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -189,7 +189,7 @@ const DesktopSidebar = (props: DesktopSidebarProps) => {
   };
 
   return (
-    <nav style={{}}>
+    <nav style={{}} aria-label="sidebar nav">
       <A11ySkipSidebar />
       <SidebarContext.Provider value={{ isOpen, setOpen }}>
         <div

--- a/plugins/catalog/src/components/AboutCard/AboutField.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutField.tsx
@@ -66,7 +66,7 @@ export function AboutField(props: AboutFieldProps) {
     );
   return (
     <Grid item {...gridSizes}>
-      <Typography variant="subtitle2" className={classes.label}>
+      <Typography variant="h2" className={classes.label}>
         {label}
       </Typography>
       {content}


### PR DESCRIPTION
Signed-off-by: Michael Haley <mike.f.haley@gmail.com>

## Hey, I just made a Pull Request!

Addressed some additional a11y violations that came form a scan of the Entity page, below screenshot shows the results of the scan:


Following changes were added:
* An `aria-label` attribute has been added to the sidebar.   Without this, there was an a11y violation because there were two `nav` items on the page, so a label is needed to differentiate them.
* `AboutField` labels were violating heading level increases so the `variant` has been changed to make it compliant.  This does not change the actual font size.

**Before**
<img width="995" alt="image" src="https://user-images.githubusercontent.com/2686352/167214527-5049f7c9-f39b-481d-9eb5-0459692c92f4.png">

**After**
<img width="994" alt="image" src="https://user-images.githubusercontent.com/2686352/167215118-df7d04fc-9780-4d81-99a6-804df0bb929f.png">

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
