### PR TITLE
Extend DocsTable component on techdocs

### DIFF
--- a/.changeset/selfish-carrots-kneel.md
+++ b/.changeset/selfish-carrots-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': major
+---
+
+Extend the DocsTable component to accept custom user-defined options while still providing default values in case of empty.

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -95,6 +95,7 @@ export type DocsTableProps = {
   entities: Entity[] | undefined;
   title?: string | undefined;
   loading?: boolean | undefined;
+  options?: object | undefined;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
 };
@@ -145,6 +146,7 @@ export const EntityListDocsTable: {
 
 // @public
 export type EntityListDocsTableProps = {
+  options?: object;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
 };

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -45,6 +45,7 @@ export type DocsTableProps = {
   entities: Entity[] | undefined;
   title?: string | undefined;
   loading?: boolean | undefined;
+  options?: object | undefined;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
 };
@@ -55,7 +56,7 @@ export type DocsTableProps = {
  * @public
  */
 export const DocsTable = (props: DocsTableProps) => {
-  const { entities, title, loading, columns, actions } = props;
+  const { entities, title, loading, options, columns, actions } = props;
   const [, copyToClipboard] = useCopyToClipboard();
   const getRouteToReaderPageFor = useRouteRef(rootDocsRouteRef);
   const config = useApi(configApiRef);
@@ -82,6 +83,13 @@ export const DocsTable = (props: DocsTableProps) => {
     };
   });
 
+  const defaultOptions: object = {
+    paging: true,
+    pageSize: 20,
+    search: true,
+    actionsColumnIndex: -1,
+  };
+
   const defaultColumns: TableColumn<DocsTableRow>[] = [
     columnFactories.createNameColumn(),
     columnFactories.createOwnerColumn(),
@@ -97,12 +105,7 @@ export const DocsTable = (props: DocsTableProps) => {
       {loading || (documents && documents.length > 0) ? (
         <Table<DocsTableRow>
           isLoading={loading}
-          options={{
-            paging: true,
-            pageSize: 20,
-            search: true,
-            actionsColumnIndex: -1,
-          }}
+          options={options || defaultOptions}
           data={documents}
           columns={columns || defaultColumns}
           actions={actions || defaultActions}

--- a/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
@@ -38,6 +38,7 @@ import { DocsTableRow } from './types';
  * @public
  */
 export type EntityListDocsTableProps = {
+  options?: object;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
 };
@@ -48,7 +49,7 @@ export type EntityListDocsTableProps = {
  * @public
  */
 export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
-  const { columns, actions } = props;
+  const { options, columns, actions } = props;
   const { loading, error, entities, filters } = useEntityList();
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const [, copyToClipboard] = useCopyToClipboard();
@@ -79,6 +80,7 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
       title={title}
       entities={entities}
       loading={loading}
+      options={options}
       actions={actions || defaultActions}
       columns={columns}
     />


### PR DESCRIPTION
Signed-off-by: Peter Leonard <peter.leonard@grabtaxi.com>

## Hey, I just made a Pull Request!

This pull request intended to extend the capabilities of DocsTable component in techdocs plugin. Previously the options value was hard-coded, and thus cannot unleash the full potential of material-table component.

This changes allow to keep previous hard-coded values as default values, and also accept user-defined options value if needed.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
~~- [ ] Tests for new functionality and regression tests for bug fixes~~
~~- [ ] Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
