### PR TITLE
[TechDocs] Allow Addon Tester to be extended

### DIFF
--- a/.changeset/techdocs-money-banana-stand.md
+++ b/.changeset/techdocs-money-banana-stand.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+The `TechDocsAddonTester` class may now be extended if custom test configuration is needed.

--- a/plugins/techdocs-addons-test-utils/api-report.md
+++ b/plugins/techdocs-addons-test-utils/api-report.md
@@ -12,6 +12,7 @@ import { TechDocsMetadata } from '@backstage/plugin-techdocs-react';
 
 // @public (undocumented)
 export class TechDocsAddonTester {
+  protected constructor(addons: ReactElement[]);
   // (undocumented)
   atPath(path: string): this;
   // (undocumented)

--- a/plugins/techdocs-addons-test-utils/src/test-utils.tsx
+++ b/plugins/techdocs-addons-test-utils/src/test-utils.tsx
@@ -119,7 +119,8 @@ export class TechDocsAddonTester {
     return new TechDocsAddonTester(addons);
   }
 
-  private constructor(addons: ReactElement[]) {
+  // Protected in order to allow extension but not direct instantiation.
+  protected constructor(addons: ReactElement[]) {
     this.addons = addons;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Protected constructer allows the class to be extended, in the event custom test configuration/setup logic is needed.

Our need for this internally is to support testing Addons which we know to be rendered within a custom context; creating a wrapper around the tester class (which extends it) allows us to add custom methods to control the custom context's value in the same, fluent, idiomatic way as the rest of the tester.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
