### PR TITLE
feat: allow repositories with nested namespace 

### DIFF
--- a/.changeset/dry-scissors-dream.md
+++ b/.changeset/dry-scissors-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+added the possibility to handle raw Gitlab URLs with nested namespaces

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@backstage/config": "^1.0.1-next.0",
+    "@backstage/errors": "^1.0.0",
     "cross-fetch": "^3.1.5",
     "git-url-parse": "^11.6.0",
     "@octokit/rest": "^18.5.3",

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -87,6 +87,26 @@ describe('gitlab core', () => {
         url: 'https://gitlab.example.com/a/b/blob/master/c.yaml',
         result: 'https://gitlab.example.com/a/b/raw/master/c.yaml',
       },
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.example.com/a/b/repo/blob/master/c.yaml',
+        result: 'https://gitlab.example.com/a/b/repo/raw/master/c.yaml',
+      },
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.example.com/a/blob/blob/master/c.yaml',
+        result: 'https://gitlab.example.com/a/blob/raw/master/c.yaml',
+      },
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.example.com/a/b/blob/blob/c.yaml',
+        result: 'https://gitlab.example.com/a/b/raw/blob/c.yaml',
+      },
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.example.com/a//blob/blob/c.yaml',
+        result: 'https://gitlab.example.com/a/blob/raw/c.yaml',
+      },
     ])('should handle happy path %#', async ({ config, url, result }) => {
       await expect(getGitLabFileFetchUrl(url, config)).resolves.toBe(result);
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added the possibility to handle raw Gitlab URLs with nested namespaces, ex: `https://gitlab.example.com/groupA/TeamB/repo/blob/master/c.yaml` 

The only problem with this feature is that it can create problems when you call some repository `blob,` or `blob` is contained in the namespace. To solve this problem we can add a warning when a URL without `/-/blob` is used. 
I put the blob check starting from length `2` then we maintain at least the compatibility with the old code. 

ref #11259 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
