### PR TITLE
[TechDocs] Allow Addons that affect img tags to be tested

### DIFF
--- a/.changeset/techdocs-loose-seal-blooth.md
+++ b/.changeset/techdocs-loose-seal-blooth.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Fixed a bug preventing testing of TechDocs Addons whose dom contained `<img />` tags.

--- a/plugins/techdocs-addons-test-utils/src/test-utils.tsx
+++ b/plugins/techdocs-addons-test-utils/src/test-utils.tsx
@@ -46,6 +46,7 @@ const techdocsApi = {
 
 const techdocsStorageApi = {
   getApiOrigin: jest.fn(),
+  getBaseUrl: jest.fn(),
   getEntityDocs: jest.fn(),
   syncEntityDocs: jest.fn(),
 };
@@ -180,7 +181,9 @@ export class TechDocsAddonTester {
     techdocsStorageApi.getApiOrigin.mockResolvedValue(
       'https://backstage.example.com/api/techdocs',
     );
-
+    techdocsStorageApi.getBaseUrl.mockResolvedValue(
+      `https://backstage.example.com/api/techdocs/${entityName.namespace}/${entityName.kind}/${entityName.name}/${this.options.path}`,
+    );
     techdocsStorageApi.getEntityDocs.mockResolvedValue(
       renderToStaticMarkup(this.options.dom || defaultDom),
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Prior to this fix, if you have an Addon with a test setup like this:

```tsx
const { getByTestId } = await buildAddonsInTechDocs([<SomeAddon />])
  .withDom(<img src="..." />)
  .renderWithEffects();
```

The test would always fail due to `techdocsStorageApi.getBaseUrl` being undefined (because it's called in [a base URL update transformer](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/reader/transformers/addBaseUrl.ts#L60) that [affects static assets](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/reader/transformers/addBaseUrl.ts#L85-L89)).  So, we should provide a default implementation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
