### PR TITLE
Fix healthcheck for the example-backend

### DIFF
--- a/.changeset/eleven-students-film.md
+++ b/.changeset/eleven-students-film.md
@@ -1,0 +1,16 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix the health check in example-backend by putting the plugin under the API route because the 404 React page was giving a false positive
+
+```diff
++  apiRouter.use('/healthcheck', await healthcheck(healthcheckEnv))
+  apiRouter.use(notFoundHandler());
+
+  const service = createServiceBuilder(module)
+    .loadConfig(config)
+-    .addRouter('', await healthcheck(healthcheckEnv))
+```
+
+Changed the default path of `createStatusCheckRouter` to '/' as the `/healthcheck` route will be specified in the apiRouter configuration

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -362,11 +362,11 @@ spec:
 #          readinessProbe:
 #            httpGet:
 #              port: 7007
-#              path: /healthcheck
+#              path: /api/healthcheck
 #          livenessProbe:
 #            httpGet:
 #              port: 7007
-#              path: /healthcheck
+#              path: /api/healthcheck
 ```
 
 For production deployments, the `image` reference will usually be a full URL to

--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -38,7 +38,7 @@ An example log line could look as follows:
 ## Health Checks
 
 The example backend in the Backstage repository
-[supplies](https://github.com/backstage/backstage/blob/bc18571b7a742863a770b2a54e785d6bbef7e184/packages/backend/src/index.ts#L99)
-a very basic health check endpoint on the `/healthcheck` route. You may add such
+[supplies](https://github.com/backstage/backstage/blob/e8bb11cba298fdaf9185e4fdcd5d314cee23e1e4/packages/backend/src/index.ts#155)
+a very basic health check endpoint on the `/api/healthcheck` route. You may add such
 a handler to your backend as well, and supply your own logic to it that fits
 your particular health checking needs.

--- a/packages/backend-common/src/service/createStatusCheckRouter.test.ts
+++ b/packages/backend-common/src/service/createStatusCheckRouter.test.ts
@@ -26,7 +26,7 @@ describe('createStatusCheckRouter', () => {
     const app = express();
     app.use('', await createStatusCheckRouter({ logger }));
 
-    const response = await request(app).get('/healthcheck');
+    const response = await request(app).get('/');
 
     expect(response.status).toBe(200);
     expect(response.text).toBe(JSON.stringify({ status: 'ok' }));
@@ -49,7 +49,7 @@ describe('createStatusCheckRouter', () => {
     };
     app.use('', await createStatusCheckRouter({ logger, statusCheck }));
 
-    const response = await request(app).get('/healthcheck');
+    const response = await request(app).get('/');
 
     expect(response.status).toBe(500);
   });

--- a/packages/backend-common/src/service/createStatusCheckRouter.ts
+++ b/packages/backend-common/src/service/createStatusCheckRouter.ts
@@ -25,7 +25,7 @@ import { errorHandler, statusCheckHandler, StatusCheck } from '../middleware';
  *
  * @remarks
  *
- * This adds a `/healthcheck` route (or any other path, if given as an
+ * This adds a `/` route (or any other path, if given as an
  * argument), which your infra can call to see if the service is ready to serve
  * requests.
  *
@@ -37,7 +37,7 @@ export async function createStatusCheckRouter(options: {
    * The path (including a leading slash) that the health check should be
    * mounted on.
    *
-   * @defaultValue '/healthcheck'
+   * @defaultValue '/'
    */
   path?: string;
   /**
@@ -47,7 +47,7 @@ export async function createStatusCheckRouter(options: {
   statusCheck?: StatusCheck;
 }): Promise<express.Router> {
   const router = Router();
-  const { path = '/healthcheck', statusCheck } = options;
+  const { path = '/', statusCheck } = options;
 
   router.use(path, await statusCheckHandler({ statusCheck }));
   router.use(errorHandler());

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -152,11 +152,11 @@ async function main() {
   apiRouter.use('/badges', await badges(badgesEnv));
   apiRouter.use('/jenkins', await jenkins(jenkinsEnv));
   apiRouter.use('/permission', await permission(permissionEnv));
+  apiRouter.use('/healthcheck', await healthcheck(healthcheckEnv));
   apiRouter.use(notFoundHandler());
 
   const service = createServiceBuilder(module)
     .loadConfig(config)
-    .addRouter('', await healthcheck(healthcheckEnv))
     .addRouter('', metricsHandler())
     .addRouter('/api', apiRouter)
     .addRouter('', await app(appEnv));

--- a/packages/backend/src/plugins/healthcheck.ts
+++ b/packages/backend/src/plugins/healthcheck.ts
@@ -23,6 +23,6 @@ export default async function createPlugin(
 ): Promise<Router> {
   return await createStatusCheckRouter({
     logger: env.logger,
-    path: '/healthcheck',
+    path: '/',
   });
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I was adding a healthcheck to @thefrontside's instance of Backstage and noticed the example provided [here](https://github.com/backstage/backstage/blob/master/packages/backend/src/index.ts#L159) returns a false positive because of its 404 page:

![Screen Shot 2022-05-09 at 11 16 48 AM](https://user-images.githubusercontent.com/29791650/167442480-de18b699-d695-462d-92a1-3538f8a4262d.png)

If you create a new backstage app, build the image without actually adding a health check, and deploy it to a local cluster with the startup probe configured:

```yaml
...
spec:
  containers:
    - name: backstage
      image: backstage:x
      imagePullPolicy: Never
      startupProbe:
        httpGet:
          path: /healthcheck
          port: http
```

You should be able to see that the probe succeeds despite there not being a `/healthcheck` route. Then if you update the deployment so that the probe's path is `/api/whatever`, the probe will then correctly fail.

### Approach

- I replaced the current healthcheck route to use the `apiRouter` instead
- Changed the default path of `createStatusCheckRouter()` from `/healthcheck` to `/` (otherwise the default path would end up being `/api/healthcheck/healthcheck`)
- Updated the documentation in `Deploying with Kubernetes` and `Observability`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
