### PR TITLE
Use the default kind when resolving a EntityRefLink.

### DIFF
--- a/.changeset/wet-zebras-dance.md
+++ b/.changeset/wet-zebras-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Use the default kind to resolve entity refs in EntityRefLink.

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.test.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.test.tsx
@@ -185,4 +185,19 @@ describe('<EntityRefLink />', () => {
       '/catalog/test/component/software',
     );
   });
+
+  it('renders link for an unqualified entity name', async () => {
+    const { getByText } = await renderInTestApp(
+      <EntityRefLink entityRef="test/software" defaultKind="component" />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+        },
+      },
+    );
+    expect(getByText('test/software')).toHaveAttribute(
+      'href',
+      '/catalog/test/component/software',
+    );
+  });
 });

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -54,7 +54,7 @@ export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
     let name;
 
     if (typeof entityRef === 'string') {
-      const parsed = parseEntityRef(entityRef);
+      const parsed = parseEntityRef(entityRef, { defaultKind: defaultKind });
       kind = parsed.kind;
       namespace = parsed.namespace;
       name = parsed.name;


### PR DESCRIPTION
When the EntityRefLink resolves a stringified entity reference, use
the default kind if it is provided.

This fixes #11408.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
