### PR TITLE
feat: Add ability to customize Read More button destination in MissingAnnotationEmptyState component

### DIFF
--- a/.changeset/fresh-beans-call.md
+++ b/.changeset/fresh-beans-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add ability to customize `Read More` destination with `readMoreUrl` prop for `MissingAnnotationEmptyState` component.

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -37,6 +37,7 @@ spec:
 
 type Props = {
   annotation: string;
+  readMoreUrl?: string;
 };
 
 export type MissingAnnotationEmptyStateClassKey = 'code';
@@ -53,7 +54,10 @@ const useStyles = makeStyles<BackstageTheme>(
 );
 
 export function MissingAnnotationEmptyState(props: Props) {
-  const { annotation } = props;
+  const { annotation, readMoreUrl } = props;
+  const url =
+    readMoreUrl ||
+    'https://backstage.io/docs/features/software-catalog/well-known-annotations';
   const classes = useStyles();
   const description = (
     <>
@@ -81,11 +85,7 @@ export function MissingAnnotationEmptyState(props: Props) {
               customStyle={{ background: 'inherit', fontSize: '115%' }}
             />
           </div>
-          <Button
-            color="primary"
-            component={Link}
-            to="https://backstage.io/docs/features/software-catalog/well-known-annotations"
-          >
+          <Button color="primary" component={Link} to={url}>
             Read more
           </Button>
         </>


### PR DESCRIPTION
Signed-off-by: Sergey Shevchenko <shevchenko@simple.life>

## Hey, I just made a Pull Request!

I've added the ability to customize the destination link for the `Read More` button in the `MissingAnnotationEmptyState` component. 
A new prop `link` was added and it can be empty so it will not break backward compatibility. If the link is not specified then the default link Is used. 

## Use case:

For some plugins, it will be better to specify the `Read More` link destination to the documentation page of such plugin. For example, I want to specify such a link for the `Prometheus` plugin to https://roadie.io/backstage/plugins/prometheus/ or to my internal documentation page in confluence

This fix also addresses some changes related to #3217 IMO

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
