### PR TITLE
[TechDocs] Fix typing on addon test-utils' withApis()

### DIFF
--- a/.changeset/techdocs-wee-britain.md
+++ b/.changeset/techdocs-wee-britain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Fixed a type bug preventing `buildAddonsInTechDocs().withApis()` from being called with multiple partial API implementations.

--- a/plugins/techdocs-addons-test-utils/api-report.md
+++ b/plugins/techdocs-addons-test-utils/api-report.md
@@ -29,7 +29,7 @@ export class TechDocsAddonTester {
     }
   >;
   // (undocumented)
-  withApis<T>(apis: TechdocsAddonTesterApis<T>): this;
+  withApis<T extends any[]>(apis: TechdocsAddonTesterApis<T>): this;
   // (undocumented)
   withDom(dom: ReactElement): this;
   // (undocumented)

--- a/plugins/techdocs-addons-test-utils/src/test-utils.tsx
+++ b/plugins/techdocs-addons-test-utils/src/test-utils.tsx
@@ -65,14 +65,18 @@ type TechDocsAddonTesterTestApiPair<TApi> = TApi extends infer TImpl
   : never;
 
 /** @ignore */
-type TechdocsAddonTesterApis<T> = TechDocsAddonTesterTestApiPair<T>[];
+type TechdocsAddonTesterApis<TApiPairs> = {
+  [TIndex in keyof TApiPairs]: TechDocsAddonTesterTestApiPair<
+    TApiPairs[TIndex]
+  >;
+};
 
 type TechDocsAddonTesterOptions = {
   dom: ReactElement;
   entity: Partial<TechDocsEntityMetadata>;
   metadata: Partial<TechDocsMetadata>;
   componentId: string;
-  apis: TechdocsAddonTesterApis<any>;
+  apis: TechdocsAddonTesterApis<any[]>;
   path: string;
 };
 
@@ -125,7 +129,7 @@ export class TechDocsAddonTester {
     this.addons = addons;
   }
 
-  withApis<T>(apis: TechdocsAddonTesterApis<T>) {
+  withApis<T extends any[]>(apis: TechdocsAddonTesterApis<T>) {
     const refs = apis.map(([ref]) => ref);
     this.options.apis = this.options.apis
       .filter(([ref]) => !refs.includes(ref))
@@ -154,7 +158,7 @@ export class TechDocsAddonTester {
   }
 
   build() {
-    const apis: TechdocsAddonTesterApis<any> = [
+    const apis: TechdocsAddonTesterApis<any[]> = [
       [techdocsApiRef, techdocsApi],
       [techdocsStorageApiRef, techdocsStorageApi],
       [searchApiRef, searchApi],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a typing fix that allows something like the following:

```tsx
import { analyticsApiRef, featureFlagsApiRef } from '@backstage/core-plugin-api';
import React from 'react';
import buildAddonsInTechDocs from './test-utils';

buildAddonsInTechDocs([<></>]).withApis([
  [analyticsApiRef, { captureEvent: jest.fn() }],
  [featureFlagsApiRef, { save: jest.fn() }],
])
```

^ Previously the `featureFlagsApiRef` line would be unhappy because it did not adhere to `analyticsApiRef`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
