### PR TITLE
[Search] Optional icon for catalog and techdocs results

### DIFF
--- a/.changeset/big-bears-fold.md
+++ b/.changeset/big-bears-fold.md
@@ -1,0 +1,7 @@
+---
+'example-app': minor
+'@backstage/plugin-catalog': minor
+'@backstage/plugin-techdocs': minor
+---
+
+Add an optional icon to the Catalog and TechDocs search results

--- a/.changeset/big-bears-fold.md
+++ b/.changeset/big-bears-fold.md
@@ -1,5 +1,4 @@
 ---
-'example-app': minor
 '@backstage/plugin-catalog': minor
 '@backstage/plugin-techdocs': minor
 ---

--- a/packages/app/src/components/search/SearchModal.tsx
+++ b/packages/app/src/components/search/SearchModal.tsx
@@ -26,7 +26,12 @@ import {
   useTheme,
 } from '@material-ui/core';
 import LaunchIcon from '@material-ui/icons/Launch';
-import { Link, useContent } from '@backstage/core-components';
+import {
+  CatalogIcon,
+  DocsIcon,
+  Link,
+  useContent,
+} from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import {
@@ -186,6 +191,7 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
                       case 'software-catalog':
                         resultItem = (
                           <CatalogSearchResultListItem
+                            icon={<CatalogIcon />}
                             key={document.location}
                             result={document}
                             highlight={highlight}
@@ -195,6 +201,7 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
                       case 'techdocs':
                         resultItem = (
                           <TechDocsSearchResultListItem
+                            icon={<DocsIcon />}
                             key={document.location}
                             result={document}
                             highlight={highlight}

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -137,6 +137,7 @@ const SearchPage = () => {
                       case 'software-catalog':
                         return (
                           <CatalogSearchResultListItem
+                            icon={<CatalogIcon />}
                             key={document.location}
                             result={document}
                             highlight={highlight}
@@ -145,6 +146,7 @@ const SearchPage = () => {
                       case 'techdocs':
                         return (
                           <TechDocsSearchResultListItem
+                            icon={<DocsIcon />}
                             key={document.location}
                             result={document}
                             highlight={highlight}

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -112,6 +112,8 @@ export interface CatalogSearchResultListItemProps {
   // (undocumented)
   highlight?: ResultHighlight;
   // (undocumented)
+  icon?: ReactNode;
+  // (undocumented)
   result: IndexableDocument;
 }
 

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   Box,
   Chip,
   Divider,
   ListItem,
+  ListItemIcon,
   ListItemText,
   makeStyles,
 } from '@material-ui/core';
@@ -47,6 +48,7 @@ const useStyles = makeStyles({
  * @public
  */
 export interface CatalogSearchResultListItemProps {
+  icon?: ReactNode;
   result: IndexableDocument;
   highlight?: ResultHighlight;
 }
@@ -60,39 +62,44 @@ export function CatalogSearchResultListItem(
   const classes = useStyles();
   return (
     <Link to={result.location}>
-      <ListItem alignItems="flex-start" className={classes.flexContainer}>
-        <ListItemText
-          className={classes.itemText}
-          primaryTypographyProps={{ variant: 'h6' }}
-          primary={
-            props.highlight?.fields.title ? (
-              <HighlightedSearchResultText
-                text={props.highlight.fields.title}
-                preTag={props.highlight.preTag}
-                postTag={props.highlight.postTag}
-              />
-            ) : (
-              result.title
-            )
-          }
-          secondary={
-            props.highlight?.fields.text ? (
-              <HighlightedSearchResultText
-                text={props.highlight.fields.text}
-                preTag={props.highlight.preTag}
-                postTag={props.highlight.postTag}
-              />
-            ) : (
-              result.text
-            )
-          }
-        />
-        <Box>
-          {result.kind && <Chip label={`Kind: ${result.kind}`} size="small" />}
-          {result.lifecycle && (
-            <Chip label={`Lifecycle: ${result.lifecycle}`} size="small" />
-          )}
-        </Box>
+      <ListItem alignItems="flex-start">
+        {props.icon && <ListItemIcon>{props.icon}</ListItemIcon>}
+        <div className={classes.flexContainer}>
+          <ListItemText
+            className={classes.itemText}
+            primaryTypographyProps={{ variant: 'h6' }}
+            primary={
+              props.highlight?.fields.title ? (
+                <HighlightedSearchResultText
+                  text={props.highlight.fields.title}
+                  preTag={props.highlight.preTag}
+                  postTag={props.highlight.postTag}
+                />
+              ) : (
+                result.title
+              )
+            }
+            secondary={
+              props.highlight?.fields.text ? (
+                <HighlightedSearchResultText
+                  text={props.highlight.fields.text}
+                  preTag={props.highlight.preTag}
+                  postTag={props.highlight.postTag}
+                />
+              ) : (
+                result.text
+              )
+            }
+          />
+          <Box>
+            {result.kind && (
+              <Chip label={`Kind: ${result.kind}`} size="small" />
+            )}
+            {result.lifecycle && (
+              <Chip label={`Lifecycle: ${result.lifecycle}`} size="small" />
+            )}
+          </Box>
+        </div>
       </ListItem>
       <Divider component="li" />
     </Link>

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -388,6 +388,7 @@ export const TechDocsSearchResultListItem: (
 
 // @public
 export type TechDocsSearchResultListItemProps = {
+  icon?: ReactNode;
   result: any;
   highlight?: ResultHighlight;
   lineClamp?: number;

--- a/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren } from 'react';
-import { Divider, ListItem, ListItemText, makeStyles } from '@material-ui/core';
+import React, { PropsWithChildren, ReactNode } from 'react';
+import {
+  Divider,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  makeStyles,
+} from '@material-ui/core';
 import { Link } from '@backstage/core-components';
 import { ResultHighlight } from '@backstage/plugin-search-common';
 import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
@@ -36,6 +42,7 @@ const useStyles = makeStyles({
  * @public
  */
 export type TechDocsSearchResultListItemProps = {
+  icon?: ReactNode;
   result: any;
   highlight?: ResultHighlight;
   lineClamp?: number;
@@ -59,6 +66,7 @@ export const TechDocsSearchResultListItem = (
     asListItem = true,
     asLink = true,
     title,
+    icon,
   } = props;
   const classes = useStyles();
   const TextItem = () => {
@@ -135,8 +143,9 @@ export const TechDocsSearchResultListItem = (
   const ListItemWrapper = ({ children }: PropsWithChildren<{}>) =>
     asListItem ? (
       <>
-        <ListItem alignItems="flex-start" className={classes.flexContainer}>
-          {children}
+        <ListItem alignItems="flex-start">
+          {icon && <ListItemIcon>{icon}</ListItemIcon>}
+          <div className={classes.flexContainer}>{children}</div>
         </ListItem>
         <Divider component="li" />
       </>


### PR DESCRIPTION
Signed-off-by: Leon <leonvanginneken@gmail.com>

## Hey, I just made a Pull Request!

In our Backstage instance, we have search results both with an icon and without an icon. This leads to an inconsistent alignment of the search results:

![image](https://user-images.githubusercontent.com/14820561/168069752-1f9f3a05-a093-4330-8d37-41c9b22576de.png)

It also seems inconsistent that the [DefaultResultListItem](https://github.com/backstage/backstage/blob/master/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx) has the option for an icon while both the [TechDocsSearchResultListItem](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx) and the [CatalogSearchResultListItem.tsx](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx) don't have that option.

This PR adds the option for an icon for these components.

Without icon (current situation):

![image](https://user-images.githubusercontent.com/14820561/168076791-b877615b-561c-449a-bdb4-087e1996f7b5.png)
![image](https://user-images.githubusercontent.com/14820561/168077001-ba130f4a-20b0-4455-83a3-95b2c2317381.png)

With icon:

![image](https://user-images.githubusercontent.com/14820561/168076853-5f415aa2-6519-489a-9579-4109905e5c13.png)
![image](https://user-images.githubusercontent.com/14820561/168076937-05550b15-c778-43c2-92f6-c386c6d1fc17.png)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
