### PR TITLE
workflows/verify_dco: stronger wording

### DIFF
--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -54,7 +54,7 @@ jobs:
               console.log(`creating comment on PR #${pull.number}`);
               const body = `
               Thanks for the contribution!
-              All commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.
+              All commits need to be DCO signed before they are reviewed. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.
               <!-- dco -->`;
               await github.rest.issues.createComment({
                 repo,


### PR DESCRIPTION
Suggesting a slightly stronger wording and process around DCO. PRs that don't end up having DCO signed can be a big time sink, so we generally prefer to not review until DCO has been signed.