### PR TITLE
[TechDocs] Work around node-fetch 2.x bug in TechDocs collator

### DIFF
--- a/.changeset/techdocs-seal-deal.md
+++ b/.changeset/techdocs-seal-deal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Fixed a bug that could cause TechDocs index generation to hang and fail when an underlying TechDocs site's `search_index.json` was empty.

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollatorFactory.ts
@@ -179,7 +179,18 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
                   },
                 },
               );
-              const searchIndex = await searchIndexResponse.json();
+
+              // todo(@backstage/techdocs-core): remove Promise.race() when node-fetch is 3.x+
+              // workaround for fetch().json() hanging in node-fetch@2.x.x, fixed in 3.x.x
+              // https://github.com/node-fetch/node-fetch/issues/665
+              const searchIndex = await Promise.race([
+                searchIndexResponse.json(),
+                new Promise((_resolve, reject) => {
+                  setTimeout(() => {
+                    reject('Could not parse JSON in 5 seconds.');
+                  }, 5000);
+                }),
+              ]);
 
               return searchIndex.docs.map((doc: MkSearchIndexDoc) => ({
                 title: unescape(doc.title),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There is a bug in `node-fetch` 2.x (resolved in 3.x) which causes `response.json()` and `response.text()` to hang in rare situations (empty response body).  The hanging promise causes the default TechDocs collator to hang indefinitely and eventually time out, preventing the index from being (re)generated.

...Until we can bump to 3.x of `node-fetch`  (see: https://github.com/backstage/backstage/issues/8242), we have to put in a workaround like this.

See also: https://github.com/node-fetch/node-fetch/issues/665

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
