### PR TITLE
catalog-react: improve link rendering in entity inspector

### DIFF
--- a/.changeset/real-lions-crash.md
+++ b/.changeset/real-lions-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Update the rendering of links in the entity inspector so that values starting with `https?://` are rendered as links as well.

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/common.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/common.tsx
@@ -89,26 +89,30 @@ export function Container(props: {
   );
 }
 
+// Extracts a link from a value, if possible
+function findLink(value: string): string | undefined {
+  if (value.match(/^url:https?:\/\//)) {
+    return value.slice('url:'.length);
+  }
+  if (value.match(/^https?:\/\//)) {
+    return value;
+  }
+  return undefined;
+}
+
 export function KeyValueListItem(props: {
   indent?: boolean;
   entry: [string, string];
 }) {
   const [key, value] = props.entry;
+  const link = findLink(value);
+
   return (
     <ListItem>
       {props.indent && <ListItemIcon />}
       <ListItemText
         primary={key}
-        secondary={
-          !value.match(/^url:https?:\/\//) ? (
-            value
-          ) : (
-            <>
-              {value.substring(0, 4)}
-              <Link to={value.substring(4)}>{value.substring(4)}</Link>
-            </>
-          )
-        }
+        secondary={link ? <Link to={link}>{value}</Link> : value}
       />
     </ListItem>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes the rendering of links in the entity inspector so that not only `url:https?://` values are rendered as links, but `https?://` as well. Considering this a fix for #11252 since this is what caused the confusion. This also makes the entire rendered value into a link, as in it doesn't both splitting out the part that is not a link.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
