### PR TITLE
Allow customization of the MicDrop Image

### DIFF
--- a/.changeset/hip-balloons-worry.md
+++ b/.changeset/hip-balloons-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Introduce new `micDropSvgUrl` configuration property to allow customization of the MicDrop Image shown on ErrorPage.

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -265,3 +265,13 @@ const LogoFull = () => {
 
 In addition to a custom theme, a custom logo, you can also customize the
 homepage of your app. Read the full guide on the [next page](homepage.md).
+
+## Custom MicDrop Image
+
+If you made changes to the theme-colors, you may also want to change colors of the default MicDrop Image shown on the ErrorPage. To do that, add the customized image to your `public`-folder and provide the filename in `micDropSvgUrl` property of `app-config.yaml` under `app`:
+
+```yaml
+# app-config.yaml
+app:
+  micDropSvgUrl: custom-micdrop.svg
+```

--- a/packages/core-components/config.d.ts
+++ b/packages/core-components/config.d.ts
@@ -20,6 +20,6 @@ export interface Config {
      * The filename of the custom MicDrop SVG. Must be placed in /packages/app/public/ folder.
      * @visibility frontend
      */
-    micDropSvg?: string;
+    micDropSvgUrl?: string;
   };
 }

--- a/packages/core-components/config.d.ts
+++ b/packages/core-components/config.d.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  app: {
+    /**
+     * The filename of the custom MicDrop SVG. Must be placed in /packages/app/public/ folder.
+     * @visibility frontend
+     */
+    micDropSvg?: string;
+  };
+}

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -104,5 +104,6 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.test.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MicDrop } from './MicDrop';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { ConfigReader } from '@backstage/core-app-api';
+import { configApiRef } from '@backstage/core-plugin-api';
+
+describe('<MicDrop/>', () => {
+  it('should render with default svg', async () => {
+    const { getByAltText } = await renderInTestApp(<MicDrop />);
+    expect(
+      getByAltText(/Girl dropping mic from her hands/i),
+    ).toBeInTheDocument();
+  });
+
+  it('should render with svg-url from app-config', async () => {
+    const dummySvg = 'branded-mic-drop.svg';
+    const { getByAltText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            configApiRef,
+            new ConfigReader({
+              app: {
+                micDropSvg: dummySvg,
+              },
+            }),
+          ],
+        ]}
+      >
+        <MicDrop />
+      </TestApiProvider>,
+    );
+    expect(getByAltText(/Girl dropping mic from her hands/i)).toHaveAttribute(
+      'src',
+      expect.stringContaining(dummySvg),
+    );
+  });
+});

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.test.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.test.tsx
@@ -37,7 +37,7 @@ describe('<MicDrop/>', () => {
             configApiRef,
             new ConfigReader({
               app: {
-                micDropSvg: dummySvg,
+                micDropSvgUrl: dummySvg,
               },
             }),
           ],

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
@@ -51,10 +51,11 @@ const publicPath = () => {
 
 export const MicDrop = () => {
   const classes = useStyles();
-  const customSvg = useApi(configApiRef).getOptionalString('app.micDropSvg');
+  const customSvgUrl =
+    useApi(configApiRef).getOptionalString('app.micDropSvgUrl');
   return (
     <img
-      src={customSvg ? `${publicPath()}${customSvg}` : MicDropSvgUrl}
+      src={customSvgUrl ? `${publicPath()}${customSvgUrl}` : MicDropSvgUrl}
       className={classes.micDrop}
       alt="Girl dropping mic from her hands"
     />

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import MicDropSvgUrl from './mic-drop.svg';
 
 const useStyles = makeStyles(
@@ -39,11 +40,21 @@ const useStyles = makeStyles(
 
 export type MicDropClassKey = 'micDrop';
 
+const publicPath = () => {
+  if (typeof __webpack_public_path__ !== 'undefined') {
+    return __webpack_public_path__;
+  } else if (process.env.ASSET_PATH) {
+    return process.env.ASSET_PATH;
+  }
+  return '/';
+};
+
 export const MicDrop = () => {
   const classes = useStyles();
+  const customSvg = useApi(configApiRef).getOptionalString('app.micDropSvg');
   return (
     <img
-      src={MicDropSvgUrl}
+      src={customSvg ? `${publicPath()}${customSvg}` : MicDropSvgUrl}
       className={classes.micDrop}
       alt="Girl dropping mic from her hands"
     />


### PR DESCRIPTION
We customized backstage-theme according to our company colors and were really happy with the results. Only the MicDrop image didn't fit in as can be seen on the screenshot:

![image](https://user-images.githubusercontent.com/7346919/168096452-ee8f3f72-05f1-403b-88c1-77732b55f8b3.png)

This could be a common issue, hence this PR.

It allows customization of the MicDrop Image shown on the ErrorPage. To do that, add the customized MicDrop Image to your `public`-folder and provide the filename in the optional `micDropSvgUrl` property of `app-config.yaml` under `app`:

```yaml
# app-config.yaml
app:
  micDropSvgUrl: custom-micdrop.svg
```

This will result in customized MicDrop image:

![image](https://user-images.githubusercontent.com/7346919/168096116-97e19550-675f-4ea5-be75-126e5fb83191.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<sup>Hans Krebs <hans.krebs@mercedes-benz.com>, on behalf of Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>
