### PR TITLE
Fix alpha imports in permission docs

### DIFF
--- a/docs/permission/custom-rules.md
+++ b/docs/permission/custom-rules.md
@@ -12,7 +12,7 @@ Plugins should export a rule factory that provides type-safety that ensures comp
 
 ```typescript
 import type { Entity } from '@backstage/plugin-catalog-model';
-import { createCatalogPermissionRule } from '@backstage/plugin-catalog-backend';
+import { createCatalogPermissionRule } from '@backstage/plugin-catalog-backend/alpha';
 import { createConditionFactory } from '@backstage/plugin-permission-node';
 
 export const isInSystemRule = createCatalogPermissionRule({

--- a/docs/permission/writing-a-policy.md
+++ b/docs/permission/writing-a-policy.md
@@ -50,7 +50,7 @@ Let's change the policy to the following:
 + import {
 +   catalogConditions,
 +   createCatalogConditionalDecision,
-+ } from '@backstage/plugin-catalog-backend';
++ } from '@backstage/plugin-catalog-backend/alpha';
 + import {
 +   catalogEntityDeletePermission,
 + } from '@backstage/plugin-catalog-common';
@@ -103,7 +103,7 @@ import {
  import {
    catalogConditions,
    createCatalogConditionalDecision,
- } from '@backstage/plugin-catalog-backend';
+ } from '@backstage/plugin-catalog-backend/alpha';
 - import {
 -   catalogEntityDeletePermission,
 - } from '@backstage/plugin-catalog-common';


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

Adds the missing `/alpha` path to `@backstage/plugin-catalog-backend` imports in the permission docs example snippets.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
