### PR TITLE
fix(elasticSearch): do not define pageCursor on last page

### DIFF
--- a/.changeset/pretty-hornets-listen.md
+++ b/.changeset/pretty-hornets-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Fix issue where `nextPageCursor` is defined on the last page of results

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -268,7 +268,7 @@ export class ElasticSearchSearchEngine implements SearchEngine {
         body: elasticSearchQuery,
       });
       const { page } = decodePageCursor(query.pageCursor);
-      const hasNextPage = result.body.hits.total.value > page * pageSize;
+      const hasNextPage = result.body.hits.total.value > (page + 1) * pageSize;
       const hasPreviousPage = page > 0;
       const nextPageCursor = hasNextPage
         ? encodePageCursor({ page: page + 1 })


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Fixes off-by-one error since pages are 0-based 😋 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
