### PR TITLE
Remove ctx.metadata from documentation

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -95,8 +95,6 @@ argument. It looks like the following:
 - `createTemporaryDirectory` a function to call to give you a temporary
   directory somewhere on the runner so you can store some files there rather
   than polluting the `workspacePath`
-- `ctx.metadata` - an object containing a `name` field, indicating the template
-  name. More metadata fields may be added later.
 
 ## Registering Custom Actions
 


### PR DESCRIPTION
`ActionContext` type doesn't have a `metadata` field.