### PR TITLE
[TechDocs] Addons re-render tweaks

### DIFF
--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -113,18 +113,36 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
     const contentElement = shadowRoot?.querySelector(
       '[data-md-component="content"]',
     );
+
     const primarySidebarElement = shadowRoot?.querySelector(
       'div[data-md-component="sidebar"][data-md-type="navigation"], div[data-md-component="navigation"]',
     );
+    let primarySidebarAddonLocation = primarySidebarElement?.querySelector(
+      '[data-techdocs-addons-location="primary sidebar"]',
+    );
+    if (!primarySidebarAddonLocation) {
+      primarySidebarAddonLocation = document.createElement('div');
+      primarySidebarAddonLocation.setAttribute(
+        'data-techdocs-addons-location',
+        'primary sidebar',
+      );
+      primarySidebarElement?.prepend(primarySidebarAddonLocation);
+    }
+
     const secondarySidebarElement = shadowRoot?.querySelector(
       'div[data-md-component="sidebar"][data-md-type="toc"], div[data-md-component="toc"]',
     );
-
-    const primarySidebarAddonLocation = document.createElement('div');
-    primarySidebarElement?.prepend(primarySidebarAddonLocation);
-
-    const secondarySidebarAddonLocation = document.createElement('div');
-    secondarySidebarElement?.prepend(secondarySidebarAddonLocation);
+    let secondarySidebarAddonLocation = secondarySidebarElement?.querySelector(
+      '[data-techdocs-addons-location="secondary sidebar"]',
+    );
+    if (!secondarySidebarAddonLocation) {
+      secondarySidebarAddonLocation = document.createElement('div');
+      secondarySidebarAddonLocation.setAttribute(
+        'data-techdocs-addons-location',
+        'secondary sidebar',
+      );
+      secondarySidebarElement?.prepend(secondarySidebarAddonLocation);
+    }
 
     // No entity metadata = 404. Don't render content at all.
     if (entityMetadataLoading === false && !entityMetadata)

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -95,6 +95,8 @@ export const useTechDocsReaderDom = (
       } else {
         sidebar.style.top = `${newTop}px`;
       }
+      // Show the sidebar only after updating its position
+      sidebar.style.removeProperty('opacity');
     });
   }, [dom, sidebars]);
 
@@ -725,6 +727,13 @@ export const useTechDocsReaderDom = (
           docStorageUrl: await techdocsStorageApi.getApiOrigin(),
           onLoading: (renderedElement: Element) => {
             (renderedElement as HTMLElement).style.setProperty('opacity', '0');
+            const renderedSidebars = Array.from(
+              renderedElement.querySelectorAll<HTMLElement>('.md-sidebar'),
+            );
+            // Hide sidebars until your position is updated
+            for (const sidebar of renderedSidebars) {
+              sidebar.style.setProperty('opacity', '0');
+            }
           },
           onLoaded: (renderedElement: Element) => {
             (renderedElement as HTMLElement).style.removeProperty('opacity');
@@ -732,9 +741,11 @@ export const useTechDocsReaderDom = (
             renderedElement
               .querySelector('.md-nav__title')
               ?.removeAttribute('for');
-            setSidebars(
-              Array.from(renderedElement.querySelectorAll('.md-sidebar')),
+            const renderedSidebars = Array.from(
+              renderedElement.querySelectorAll<HTMLElement>('.md-sidebar'),
             );
+            // Wait for styles to be calculated to update sidebar position
+            setSidebars(renderedSidebars);
           },
         }),
       ]),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request packages a set of tweaks to the TechDocs addons rendering process:
- [x] Prevent new sidebar locations from being created every time the reader page is rendered if these locations already exist;
- [x] Prevents displaying sidebars until page styles are loaded and also the sidebar position is updated;
- [x] Avoid re-rendering content if it doesn't change during the sync process;

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
