### PR TITLE
delete headings transformations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,15 @@
 # Documentation
 
 The Backstage documentation is available at https://backstage.io/docs
+
+# H1
+
+## H2
+
+### H3
+
+#### H4
+
+##### H5
+
+###### H6

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -46,14 +46,6 @@ import {
   copyToClipboard,
 } from '../../transformers';
 
-type TypographyHeadings = Pick<
-  Theme['typography'],
-  'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
->;
-type TypographyHeadingsKeys = keyof TypographyHeadings;
-
-const headings: TypographyHeadingsKeys[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
-
 /**
  * Hook that encapsulates the behavior of getting raw HTML and applying
  * transforms to it in order to make it function at a basic level in the
@@ -511,31 +503,6 @@ export const useTechDocsReaderDom = (
               .md-typeset {
                 font-size: var(--md-typeset-font-size);
               }
-  
-              ${headings.reduce<string>((style, heading) => {
-                const styles = theme.typography[heading];
-                const { lineHeight, fontFamily, fontWeight, fontSize } = styles;
-                const calculate = (value: typeof fontSize) => {
-                  let factor: number | string = 1;
-                  if (typeof value === 'number') {
-                    // 60% of the size defined because it is too big
-                    factor = (value / 16) * 0.6;
-                  }
-                  if (typeof value === 'string') {
-                    factor = value.replace('rem', '');
-                  }
-                  return `calc(${factor} * var(--md-typeset-font-size))`;
-                };
-                return style.concat(`
-                  .md-typeset ${heading} {
-                    color: var(--md-default-fg-color);
-                    line-height: ${lineHeight};
-                    font-family: ${fontFamily};
-                    font-weight: ${fontWeight};
-                    font-size: ${calculate(fontSize)};
-                  }
-                `);
-              }, '')}
   
               .md-typeset .md-content__button {
                 color: var(--md-default-fg-color);


### PR DESCRIPTION
Signed-off-by: Emma Indal <emma.indahl@gmail.com>

## Hey, I just made a Pull Request!

This PR suggest we delete the transformations we do on headings to follow the mkdocs material theme default. 

Note: I do not have context on why this was added from the start.  

mkdocs material theme headings default
<img width="1728" alt="Screenshot 2022-05-13 at 15 33 33" src="https://user-images.githubusercontent.com/25153114/168298201-83fa07fc-909c-40e3-9c47-adbbb94c2d97.png">

techdocs headings before change (note that h5 is bigger than h4 for example)
<img width="1728" alt="Screenshot 2022-05-13 at 15 35 53" src="https://user-images.githubusercontent.com/25153114/168298213-81a7ba2f-bac5-48d0-99ad-d3f1714f3a43.png">

techdocs headings after change
<img width="1728" alt="Screenshot 2022-05-13 at 15 46 26" src="https://user-images.githubusercontent.com/25153114/168298368-87e9530c-a5f0-4200-b52a-bfd67f9764cd.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
