### PR TITLE
fix(entityTypeFilter): generate unique available types

### DIFF
--- a/.changeset/sweet-icons-sneeze.md
+++ b/.changeset/sweet-icons-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix `EntityTypeFilter` so generating available types is case insensitive

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -96,7 +96,13 @@ export function useEntityTypeFilter(): {
     }
 
     // Sort by facet count descending, so the most common types appear on top
-    const newTypes = sortBy(facets, f => -f.count).map(f => f.value);
+    const newTypes = [
+      ...new Set(
+        sortBy(facets, f => -f.count).map(f =>
+          f.value.toLocaleLowerCase('en-US'),
+        ),
+      ),
+    ];
     setAvailableTypes(newTypes);
 
     // Update type filter to only valid values when the list of available types has changed


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Restores case-insensitive logic lost from [facets change](https://github.com/backstage/backstage/pull/9491/files#diff-2cd158572d2e155d18b8a4c5f2a0106f318cbceb73daad9b8b8118406e7321eeL104) so that a unique list of available types is correctly generated.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
