### PR TITLE
feat(scaffolder): remove sections or fields based on if current user is member of specified group

### DIFF
--- a/.changeset/shy-melons-fold.md
+++ b/.changeset/shy-melons-fold.md
@@ -1,0 +1,39 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+You can now hide sections of fields in your template based on if the current user is a member of a specific group entity. For example, take this template:
+
+```json
+{
+  title: 'my-schema',
+  steps: [
+    {
+      title: 'Fill in some steps',
+      schema: {
+        title: 'Fill in some steps',
+        'backstage:memberOf': 'group:default/internal',
+        properties: {
+          name: {
+            title: 'Name',
+            type: 'string',
+            'backstage:memberOf': 'group:default/admins',
+          },
+          description: {
+            title: 'Description',
+            type: 'string',
+            description: 'A description for the component',
+          },
+          owner: {
+            title: 'Owner',
+            type: 'string',
+            description: 'Owner of the component',
+          },
+        },
+        type: 'object',
+      },
+  },
+}
+```
+
+If you have a a group entity ref that is `group:default/internal` then your first step would be shown if the current user is a member of that group, otherwise it would not bne shown. The same goes for the properties in the schema. Make sure to use the key `backstage:memberOf` in your templates if you want to use this functionality.

--- a/.changeset/shy-melons-fold.md
+++ b/.changeset/shy-melons-fold.md
@@ -4,36 +4,36 @@
 
 You can now hide sections of fields in your template based on if the current user is a member of a specific group entity. For example, take this template:
 
-```json
-{
-  title: 'my-schema',
-  steps: [
-    {
-      title: 'Fill in some steps',
-      schema: {
-        title: 'Fill in some steps',
-        'backstage:memberOf': 'group:default/internal',
-        properties: {
-          name: {
-            title: 'Name',
-            type: 'string',
-            'backstage:memberOf': 'group:default/admins',
-          },
-          description: {
-            title: 'Description',
-            type: 'string',
-            description: 'A description for the component',
-          },
-          owner: {
-            title: 'Owner',
-            type: 'string',
-            description: 'Owner of the component',
-          },
-        },
-        type: 'object',
-      },
-  },
-}
+```yaml
+spec:
+  type: website
+  owner: team-a
+  parameters:
+    - name: Enter some stuff
+      description: Enter some stuff
+      backstage:memberOf: group:default/internal
+      properties:
+        inputString:
+          type: string
+          title: string input test
+    - name: Enter more stuff
+      description: Enter more stuff
+      properties:
+        inputString:
+          type: string
+          title: string input test
+        inputObject:
+          type: object
+          title: object input test
+          description: a little nested thing never hurt anyone right?
+          properties:
+            first:
+              type: string
+              title: first
+              backstage:memberOf: group:default/internal
+            second:
+              type: number
+              title: second
 ```
 
-If you have a a group entity ref that is `group:default/internal` then your first step would be shown if the current user is a member of that group, otherwise it would not bne shown. The same goes for the properties in the schema. Make sure to use the key `backstage:memberOf` in your templates if you want to use this functionality.
+If you have a a group entity ref that is `group:default/internal` then your first step would be shown if the current user is a member of that group, otherwise it would not be shown. The same goes for the nested properties in the spec. Make sure to use the key `backstage:memberOf` in your templates if you want to use this functionality.

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -291,6 +291,51 @@ your first step would be shown. The same goes for the nested properties in the
 spec. Make sure to use the key `backstage:featureFlag` in your templates if
 you want to use this functionality.
 
+### Remove sections or fields based on groups
+
+Based on is the current use is a member of a group you can hide sections or even
+only fields of your template. This is a good use case if you want to test
+experimental parameters in a production environment. To use it let's look at the
+following template:
+
+```yaml
+spec:
+  type: website
+  owner: team-a
+  parameters:
+    - name: Enter some stuff
+      description: Enter some stuff
+      backstage:memberOf: group:default/internal
+      properties:
+        inputString:
+          type: string
+          title: string input test
+    - name: Enter more stuff
+      description: Enter more stuff
+      properties:
+        inputString:
+          type: string
+          title: string input test
+        inputObject:
+          type: object
+          title: object input test
+          description: a little nested thing never hurt anyone right?
+          properties:
+            first:
+              type: string
+              title: first
+              backstage:memberOf: group:default/internal
+            second:
+              type: number
+              title: second
+```
+
+If you have a a group entity ref that is `group:default/internal` then your
+first step would be shown if the current user is a member of that group,
+otherwise it would not be shown. The same goes for the nested properties in the
+spec. Make sure to use the key `backstage:memberOf` in your templates if you
+want to use this functionality.
+
 ### The Repository Picker
 
 In order to make working with repository providers easier, we've built a custom


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Allows for the ability to hide certain sections of the scaffolder based on if the current user is a member of the specified group. I was originally attempting to solve [the issue I created using permissions](https://github.com/backstage/backstage/issues/11403). Using groups could solve our immediate use case but would definitely like to see permissions implemented here as well.

This expands on the work from #9665 for feature flags and allows for an easier way to add more feature like these in the future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
