### PR TITLE
remove unused parameter from the debug:log action

### DIFF
--- a/.changeset/flat-actors-laugh.md
+++ b/.changeset/flat-actors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Remove unused extras parameter from the debug:log scaffolder action.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/log.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/log.ts
@@ -45,9 +45,6 @@ export function createDebugLogAction() {
             title: 'List all files in the workspace, if true.',
             type: 'boolean',
           },
-          extra: {
-            title: 'Extra info',
-          },
         },
       },
     },


### PR DESCRIPTION
I am removing the extras param. I was looking into the action and noticed this option is not used. I could be mistaken.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
