### PR TITLE
[Kubernetes Plugin] Fix for HPA matching when deploying same HPA in multiple namespaces

### DIFF
--- a/.changeset/sixty-plums-kick.md
+++ b/.changeset/sixty-plums-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Fix for HPA matching when deploying same HPA in multiple namespaces

--- a/plugins/kubernetes/src/components/CustomResources/ArgoRollouts/Rollout.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/ArgoRollouts/Rollout.tsx
@@ -268,8 +268,11 @@ export const RolloutAccordions = ({
             <RolloutAccordion
               defaultExpanded={defaultExpanded}
               matchingHpa={getMatchingHpa(
-                rollout.metadata?.name,
-                'rollout',
+                {
+                  name: rollout.metadata?.name,
+                  namespace: rollout.metadata?.namespace,
+                  kind: 'rollout',
+                },
                 groupedResponses.horizontalPodAutoscalers,
               )}
               ownedPods={getOwnedPodsThroughReplicaSets(

--- a/plugins/kubernetes/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
+++ b/plugins/kubernetes/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
@@ -186,8 +186,11 @@ export const DeploymentsAccordions = ({}: DeploymentsAccordionsProps) => {
           <Grid item xs>
             <DeploymentAccordion
               matchingHpa={getMatchingHpa(
-                deployment.metadata?.name,
-                'deployment',
+                {
+                  name: deployment.metadata?.name,
+                  namespace: deployment.metadata?.namespace,
+                  kind: 'deployment',
+                },
                 groupedResponses.horizontalPodAutoscalers,
               )}
               ownedPods={getOwnedPodsThroughReplicaSets(

--- a/plugins/kubernetes/src/utils/owner.ts
+++ b/plugins/kubernetes/src/utils/owner.ts
@@ -54,17 +54,24 @@ export const getOwnedPodsThroughReplicaSets = (
   }, [] as V1Pod[]);
 };
 
+interface ResourceRef {
+  kind: string;
+  namespace?: string;
+  name?: string;
+}
+
 export const getMatchingHpa = (
-  ownerName: string | undefined,
-  ownerKind: string,
+  owner: ResourceRef,
   hpas: V1HorizontalPodAutoscaler[],
 ): V1HorizontalPodAutoscaler | undefined => {
   return hpas.find(hpa => {
     return (
       (hpa.spec?.scaleTargetRef?.kind ?? '').toLocaleLowerCase('en-US') ===
-        ownerKind.toLocaleLowerCase('en-US') &&
+        owner.kind.toLocaleLowerCase('en-US') &&
+      (hpa.metadata?.namespace ?? '') ===
+        (owner.namespace ?? 'unknown-namespace') &&
       (hpa.spec?.scaleTargetRef?.name ?? '') ===
-        (ownerName ?? 'unknown-deployment')
+        (owner.name ?? 'unknown-deployment')
     );
   });
 };


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Hey, I just made a Pull Request!

HPA is a namespaced resource, so TargetRef does not have a namespace value, but the HPA's namespace is used during the ref process within K8s. 

In our org, we deploy multiple HPA across multiple Namespaces and they all have the same name, the only difference is the namespace they are in. What happens today is that the first HPA CPU% is displayed across all deployments, like this:

<img width="1813" alt="Screenshot 2022-05-16 at 16 40 12" src="https://user-images.githubusercontent.com/94755/168633423-58604529-471d-430a-ad9e-fe13b29fd544.png">

This PR fixes the matching algorithm to take the Deployment namespace in consideration when searching for the HPA. The result is that each deployment has it's respective CPU% shown:

<img width="2652" alt="Screenshot 2022-05-16 at 16 46 47" src="https://user-images.githubusercontent.com/94755/168633635-11164462-0628-41db-bd50-300e14ca4074.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
