### PR TITLE
Fixed InfoCard with external link

### DIFF
--- a/.changeset/serious-baboons-report.md
+++ b/.changeset/serious-baboons-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed multiple scrolls appearing on Page when added InfoCard with external bottom link

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useAnalytics } from '@backstage/core-plugin-api';
+import classnames from 'classnames';
 import MaterialLink, {
   LinkProps as MaterialLinkProps,
 } from '@material-ui/core/Link';
@@ -35,6 +36,9 @@ const useStyles = makeStyles(
       whiteSpace: 'nowrap',
       height: 1,
       width: 1,
+    },
+    externalLink: {
+      position: 'relative',
     },
   },
   { name: 'Link' },
@@ -100,6 +104,7 @@ export const Link = React.forwardRef<any, LinkProps>(
         onClick={handleClick}
         {...(newWindow ? { target: '_blank', rel: 'noopener' } : {})}
         {...props}
+        className={classnames(classes.externalLink, props.className)}
       >
         {props.children}
         <span className={classes.visuallyHidden}>, Opens in a new window</span>

--- a/plugins/git-release-manager/src/features/Features.test.tsx
+++ b/plugins/git-release-manager/src/features/Features.test.tsx
@@ -72,7 +72,7 @@ describe('Features', () => {
           : The source control system where releases reside in a practical sense. Read more about
            
           <a
-            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover Link-externalLink-12 MuiTypography-colorPrimary"
             href="https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository"
             rel="noopener"
             target="_blank"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This one fixes multiple scrolls appearing on Page when added InfoCard with external bottom link. This happened because of recently added `visuallyHidden` text component with absolute position - the height of the Page doubled, so just added relative property to the Link.

<img width="801" alt="image" src="https://user-images.githubusercontent.com/3530856/168634636-60bd90ff-5860-4a4c-9602-06f7e70d8346.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
