### PR TITLE
Add Restart to Backstage Task Worker

### DIFF
--- a/.changeset/funny-suns-pay.md
+++ b/.changeset/funny-suns-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Allow tasks that fail to retry on a loop emitting a warning log every time it fails with the amount of attempts it has

--- a/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
@@ -69,7 +69,7 @@ export class LocalTaskWorker {
           this.logger.warn(
             `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
-          await sleep(Duration.fromISO('P1S'));
+          await sleep(Duration.fromObject({ seconds: 1 }));
         }
       }
     })();

--- a/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
@@ -64,6 +64,7 @@ export class LocalTaskWorker {
         this.logger.info(`Task worker finished: ${this.taskId}`);
       } catch (e) {
         this.logger.warn(`Task worker failed unexpectedly, ${e}`);
+        this.start(settings, options)
       }
     })();
   }

--- a/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
@@ -40,31 +40,36 @@ export class LocalTaskWorker {
     this.logger.info(
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
-
+    const success = false;
+    let attemptNum = 1;
     (async () => {
-      try {
-        if (settings.initialDelayDuration) {
-          await this.sleep(
-            Duration.fromISO(settings.initialDelayDuration),
-            options?.signal,
+      while (!success) {
+        try {
+          if (settings.initialDelayDuration) {
+            await this.sleep(
+              Duration.fromISO(settings.initialDelayDuration),
+              options?.signal,
+            );
+          }
+
+          while (!options?.signal?.aborted) {
+            const startTime = process.hrtime();
+            await this.runOnce(settings, options?.signal);
+            const timeTaken = process.hrtime(startTime);
+            await this.waitUntilNext(
+              settings,
+              (timeTaken[0] + timeTaken[1] / 1e9) * 1000,
+              options?.signal,
+            );
+          }
+          this.logger.info(`Task worker finished: ${this.taskId}`);
+          break;
+        } catch (e) {
+          attemptNum += 1;
+          this.logger.warn(
+            `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
         }
-
-        while (!options?.signal?.aborted) {
-          const startTime = process.hrtime();
-          await this.runOnce(settings, options?.signal);
-          const timeTaken = process.hrtime(startTime);
-          await this.waitUntilNext(
-            settings,
-            (timeTaken[0] + timeTaken[1] / 1e9) * 1000,
-            options?.signal,
-          );
-        }
-
-        this.logger.info(`Task worker finished: ${this.taskId}`);
-      } catch (e) {
-        this.logger.warn(`Task worker failed unexpectedly, ${e}`);
-        this.start(settings, options)
       }
     })();
   }

--- a/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
@@ -40,10 +40,9 @@ export class LocalTaskWorker {
     this.logger.info(
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
-    const success = false;
     let attemptNum = 1;
     (async () => {
-      while (!success) {
+      for (;;) {
         try {
           if (settings.initialDelayDuration) {
             await this.sleep(
@@ -63,12 +62,14 @@ export class LocalTaskWorker {
             );
           }
           this.logger.info(`Task worker finished: ${this.taskId}`);
+          attemptNum = 0;
           break;
         } catch (e) {
           attemptNum += 1;
           this.logger.warn(
             `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
+          await sleep(Duration.fromISO('P1S'));
         }
       }
     })();

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -79,7 +79,7 @@ export class TaskWorker {
           this.logger.warn(
             `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
-          await sleep(Duration.fromISO('P1S'));
+          await sleep(Duration.fromObject({ seconds: 1 }));
         }
       }
     })();

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -51,10 +51,9 @@ export class TaskWorker {
     this.logger.info(
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
-    const success = false;
     let attemptNum = 1;
     (async () => {
-      while (!success) {
+      for (;;) {
         try {
           if (settings.initialDelayDuration) {
             await sleep(
@@ -73,12 +72,14 @@ export class TaskWorker {
           }
 
           this.logger.info(`Task worker finished: ${this.taskId}`);
+          attemptNum = 0;
           break;
         } catch (e) {
           attemptNum += 1;
           this.logger.warn(
             `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
+          await sleep(Duration.fromISO('P1S'));
         }
       }
     })();

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -72,6 +72,7 @@ export class TaskWorker {
 
         this.logger.info(`Task worker finished: ${this.taskId}`);
       } catch (e) {
+        this.start(settings, options)
         this.logger.warn(`Task worker failed unexpectedly, ${e}`);
       }
     })();

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -72,8 +72,8 @@ export class TaskWorker {
 
         this.logger.info(`Task worker finished: ${this.taskId}`);
       } catch (e) {
-        this.start(settings, options)
         this.logger.warn(`Task worker failed unexpectedly, ${e}`);
+        this.start(settings, options)
       }
     })();
   }

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -51,29 +51,35 @@ export class TaskWorker {
     this.logger.info(
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
-
+    const success = false;
+    let attemptNum = 1;
     (async () => {
-      try {
-        if (settings.initialDelayDuration) {
-          await sleep(
-            Duration.fromISO(settings.initialDelayDuration),
-            options?.signal,
-          );
-        }
-
-        while (!options?.signal?.aborted) {
-          const runResult = await this.runOnce(options?.signal);
-          if (runResult.result === 'abort') {
-            break;
+      while (!success) {
+        try {
+          if (settings.initialDelayDuration) {
+            await sleep(
+              Duration.fromISO(settings.initialDelayDuration),
+              options?.signal,
+            );
           }
 
-          await sleep(this.workCheckFrequency, options?.signal);
-        }
+          while (!options?.signal?.aborted) {
+            const runResult = await this.runOnce(options?.signal);
+            if (runResult.result === 'abort') {
+              break;
+            }
 
-        this.logger.info(`Task worker finished: ${this.taskId}`);
-      } catch (e) {
-        this.logger.warn(`Task worker failed unexpectedly, ${e}`);
-        this.start(settings, options)
+            await sleep(this.workCheckFrequency, options?.signal);
+          }
+
+          this.logger.info(`Task worker finished: ${this.taskId}`);
+          break;
+        } catch (e) {
+          attemptNum += 1;
+          this.logger.warn(
+            `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
+          );
+        }
       }
     })();
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will allow the task worker to start the task again if a failure occurs. See issue https://github.com/backstage/backstage/issues/11526

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
