### PR TITLE
[Scaffolder] Get data of other fields in Form from a custom field

### DIFF
--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -198,6 +198,7 @@ export const MultistepJsonForm = (props: Props) => {
                   widgets={widgets}
                   noHtml5Validate
                   formData={formData}
+                  formContext={formData}
                   onChange={onChange}
                   onSubmit={e => {
                     if (e.errors.length === 0) handleNext();


### PR DESCRIPTION
[Scaffolder] Get data of other fields in Form from a custom field

Allows to use e.g.
```TypeScript
const CustomFieldExtensionComponent(props: FieldExtensionComponentProps<string[]>) => {
     const { formContext } = props;
     ....
};

const CustomFieldExtension = scaffolderPlugin.provide(
  createScaffolderFieldExtension({
    name: ...,
    component: CustomFieldExtensionComponent,
    validation: ....
  })
);
```

Related Issue: https://github.com/backstage/backstage/discussions/11413

Signed-off-by: Minh Trí <tritri251214@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
