### PR TITLE
[SearchModal]: Fix parent context usage

### DIFF
--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -136,7 +136,7 @@ export function useSearchModal(initialState = false) {
   );
 
   // Inherit from parent context, if set.
-  return parentContextValue
+  return parentContextValue?.state
     ? parentContextValue
     : { state, toggleModal, setOpen };
 }


### PR DESCRIPTION
Co-authored-by: Anders Näsman <andersn@spotify.com>
Signed-off-by: Camila Belo <camilaibs@gmail.com>

## Hey, I just made a Pull Request!

The search modal was always open before because a parent context value is created independently of using `SearchModalProvider`.
In this pull request, we start by checking the internal state of the parent context and returning it only when the internal state is set.

Bug fix for [[Search] Allow modal to be controlled externally #11525](https://github.com/backstage/backstage/pull/11525), containing changeset.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
