### PR TITLE
[TechDocs] Fix Entity Docs Routes

### DIFF
--- a/.changeset/techdocs-dancers-battle.md
+++ b/.changeset/techdocs-dancers-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add a `sub-route` path on the EntityDocs page to fix the blank screen error when navigating using sidebar links.

--- a/plugins/techdocs/src/Router.tsx
+++ b/plugins/techdocs/src/Router.tsx
@@ -69,7 +69,9 @@ export const EmbeddedDocsRouter = (props: PropsWithChildren<{}>) => {
 
   return (
     <Routes>
-      <Route element={<EntityPageDocs entity={entity} />}>{children}</Route>
+      <Route path="*" element={<EntityPageDocs entity={entity} />}>
+        {children}
+      </Route>
     </Routes>
   );
 };


### PR DESCRIPTION
Co-authored-by: Anders Näsman <andersn@spotify.com>
Co-authored-by: Otto Sichert <git@ottosichert.de>
Signed-off-by: Camila Belo <camilaibs@gmail.com>

## Hey, I just made a Pull Request!

Fixes: https://github.com/backstage/backstage/issues/11536

Add a sub-routes path on the EntityDocs page for fixing the blank screen error when navigating using sidebar links.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
