### PR TITLE
feat: scaffolder Github repo drop down

### DIFF
--- a/.changeset/curly-gifts-hide.md
+++ b/.changeset/curly-gifts-hide.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Populate Github repositories possibility in software templates creation form dropdown.
+Backend contains new endpoint, which fetches all available Github repositories.

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -14,17 +14,39 @@
  * limitations under the License.
  */
 
-import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
-import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
-import { Router } from 'express';
-import { PluginEnvironment } from '../types';
+import {CatalogBuilder} from '@backstage/plugin-catalog-backend';
+import {ScaffolderEntitiesProcessor} from '@backstage/plugin-scaffolder-backend';
+import {Router} from 'express';
+import {PluginEnvironment} from '../types';
+import {
+  GithubDiscoveryProcessor,
+  GithubOrgReaderProcessor,
+} from '@backstage/plugin-catalog-backend-module-github';
+import {
+  ScmIntegrations,
+  DefaultGithubCredentialsProvider
+} from '@backstage/integration';
 
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   const builder = await CatalogBuilder.create(env);
+  const integrations = ScmIntegrations.fromConfig(env.config);
+  const githubCredentialsProvider = DefaultGithubCredentialsProvider.fromIntegrations(integrations);
+
+  builder.addProcessor(
+    GithubDiscoveryProcessor.fromConfig(env.config, {
+      logger: env.logger,
+      githubCredentialsProvider,
+    }),
+    GithubOrgReaderProcessor.fromConfig(env.config, {
+      logger: env.logger,
+      githubCredentialsProvider,
+    }),
+  );
   builder.addProcessor(new ScaffolderEntitiesProcessor());
-  const { processingEngine, router } = await builder.build();
+
+  const {processingEngine, router} = await builder.build();
   await processingEngine.start();
   return router;
 }

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -194,6 +194,18 @@ export class ScaffolderClient implements ScaffolderApi {
     return await response.json();
   }
 
+  async getGithubRepositories(organization: string): Promise<ScaffolderTask> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('scaffolder');
+    const url = `${baseUrl}/v2/repos-list/${encodeURIComponent(organization)}`;
+
+    const response = await this.fetchApi.fetch(url);
+    if (!response.ok) {
+      throw await ResponseError.fromResponse(response);
+    }
+
+    return await response.json();
+  }
+
   streamLogs(options: ScaffolderStreamLogsOptions): Observable<LogEvent> {
     if (this.useLongPollingLogs) {
       return this.streamLogsPolling(options);

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -40,6 +40,12 @@ import { useTemplateSecrets } from '../../secrets';
 export interface RepoUrlPickerUiOptions {
   allowedHosts?: string[];
   allowedOwners?: string[];
+  showRepoDropdown?: {
+    github?: boolean[];
+  };
+  pullReposFromBackend?: {
+    github?: boolean[];
+  };
   requestUserCredentials?: {
     secretsKey: string;
     additionalScopes?: {
@@ -134,6 +140,11 @@ export const RepoUrlPicker = (
   const hostType =
     (state.host && integrationApi.byHost(state.host)?.type) ?? null;
 
+  const repoSelectOptions = {
+    pullReposFromBackend: uiSchema?.['ui:options']?.pullReposFromBackend?.github,
+    showGithubRepoDropdown: uiSchema?.['ui:options']?.showRepoDropdown?.github
+  }
+
   return (
     <>
       <RepoUrlPickerHost
@@ -148,6 +159,7 @@ export const RepoUrlPicker = (
           rawErrors={rawErrors}
           state={state}
           onChange={updateLocalState}
+          repoSelectOptions={repoSelectOptions}
         />
       )}
       {hostType === 'gitlab' && (

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,1 @@
+test: pgp


### PR DESCRIPTION
## Feature: Github repositories select populated using apps config to call Github API

This PR adds Github repositories dropdown functionality that is handled by `ui:options` within `template.yaml` template.
Field example:
```yaml
    - title: Choose Github Repository
      required:
      - repoUrl
      properties:
        repoUrl:
          title: Repository Location
          type: string
          ui:field: RepoUrlPicker
          ui:options:
            allowedOwners: ['organisation-name-1', 'organisation-name-2']
            allowedHosts: ['github.com']
            showRepoDropdown:
              github: true
            pullReposFromBackend:
              github: true
```
- `showRepoDropdown` - converts free form text input to a select field with Github repos pre-populated, uses `smcAuthApi.getCredentials()` to get Github token to fetch Github repos by default.
- `pullReposFromBackend` - pre-populates drop down values using new API endpoint within Scaffolder Backend. Uses **Octokit** to make calls to Github, `appId` and `privateKey` config items used from Github integrations configuration defined in your `app-config.yaml`
- When `showRepoDropdown` option is not present, functionality should be intact as per original implementation.

Repository select drop-down preview below:
<img width="495" alt="image" src="https://user-images.githubusercontent.com/20816347/168846777-76245354-ce12-49e6-b1a5-1f62db54fa1d.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
