### PR TITLE
Add configurable signing algorithm

### DIFF
--- a/.changeset/polite-spiders-pay.md
+++ b/.changeset/polite-spiders-pay.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-auth-node': minor
+---
+
+Added configurable algorithm field for IdentityClient and TokenFactory

--- a/.changeset/polite-spiders-pay.md
+++ b/.changeset/polite-spiders-pay.md
@@ -1,6 +1,5 @@
 ---
-'@backstage/plugin-auth-backend': minor
-'@backstage/plugin-auth-node': minor
+'@backstage/plugin-auth-backend': patch
 ---
 
-Added configurable algorithm field for IdentityClient and TokenFactory
+Added configurable algorithm field for TokenFactory

--- a/.changeset/tasty-snails-boil.md
+++ b/.changeset/tasty-snails-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Added configurable algorithms array for IdentityClient

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { TokenIssuer, TokenParams, KeyStore, AnyJWK } from './types';
-import { exportJWK, generateKeyPair, importJWK, JWK, SignJWT } from 'jose';
-import { Logger } from 'winston';
-import { v4 as uuid } from 'uuid';
-import { DateTime } from 'luxon';
 import { parseEntityRef } from '@backstage/catalog-model';
 import { AuthenticationError } from '@backstage/errors';
+import { exportJWK, generateKeyPair, importJWK, JWK, SignJWT } from 'jose';
+import { DateTime } from 'luxon';
+import { v4 as uuid } from 'uuid';
+import { Logger } from 'winston';
+
+import { AnyJWK, KeyStore, TokenIssuer, TokenParams } from './types';
 
 const MS_IN_S = 1000;
 
@@ -32,6 +32,10 @@ type Options = {
   keyStore: KeyStore;
   /** Expiration time of signing keys in seconds */
   keyDurationSeconds: number;
+  /** JWS "alg" (Algorithm) Header Parameter value. Defaults to ES256.
+   * Must match the algorithm defined in IdentityClient.
+   * More info on supported algorithms: https://github.com/panva/jose */
+  algorithm?: string;
 };
 
 /**
@@ -53,6 +57,7 @@ export class TokenFactory implements TokenIssuer {
   private readonly logger: Logger;
   private readonly keyStore: KeyStore;
   private readonly keyDurationSeconds: number;
+  private readonly algorithm: string;
 
   private keyExpiry?: Date;
   private privateKeyPromise?: Promise<JWK>;
@@ -62,6 +67,7 @@ export class TokenFactory implements TokenIssuer {
     this.logger = options.logger;
     this.keyStore = options.keyStore;
     this.keyDurationSeconds = options.keyDurationSeconds;
+    this.algorithm = options.algorithm ?? 'ES256';
   }
 
   async issueToken(params: TokenParams): Promise<string> {
@@ -156,11 +162,11 @@ export class TokenFactory implements TokenIssuer {
       .toJSDate();
     const promise = (async () => {
       // This generates a new signing key to be used to sign tokens until the next key rotation
-      const key = await generateKeyPair('ES256');
+      const key = await generateKeyPair(this.algorithm);
       const publicKey = await exportJWK(key.publicKey);
       const privateKey = await exportJWK(key.privateKey);
       publicKey.kid = privateKey.kid = uuid();
-      publicKey.alg = privateKey.alg = 'ES256';
+      publicKey.alg = privateKey.alg = this.algorithm;
 
       // We're not allowed to use the key until it has been successfully stored
       // TODO: some token verification implementations aggressively cache the list of keys, and

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -33,7 +33,7 @@ type Options = {
   /** Expiration time of signing keys in seconds */
   keyDurationSeconds: number;
   /** JWS "alg" (Algorithm) Header Parameter value. Defaults to ES256.
-   * Must match the algorithm defined in IdentityClient.
+   * Must match one of the algorithms defined for IdentityClient.
    * More info on supported algorithms: https://github.com/panva/jose */
   algorithm?: string;
 };

--- a/plugins/auth-node/api-report.md
+++ b/plugins/auth-node/api-report.md
@@ -30,9 +30,13 @@ export function getBearerTokenFromAuthorizationHeader(
 // @public
 export class IdentityClient {
   authenticate(token: string | undefined): Promise<BackstageIdentityResponse>;
-  static create(options: {
-    discovery: PluginEndpointDiscovery;
-    issuer: string;
-  }): IdentityClient;
+  static create(options: IdentityClientOptions): IdentityClient;
 }
+
+// @public
+export type IdentityClientOptions = {
+  discovery: PluginEndpointDiscovery;
+  issuer: string;
+  algorithms?: string[];
+};
 ```

--- a/plugins/auth-node/src/IdentityClient.test.ts
+++ b/plugins/auth-node/src/IdentityClient.test.ts
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import {
-  SignJWT,
-  generateKeyPair,
   decodeProtectedHeader,
   exportJWK,
+  generateKeyPair,
+  SignJWT,
 } from 'jose';
 import { cloneDeep } from 'lodash';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { IdentityClient } from './IdentityClient';
 import { v4 as uuid } from 'uuid';
+
+import { IdentityClient } from './IdentityClient';
 
 interface AnyJWK extends Record<string, string> {
   use: 'sig';
@@ -109,6 +109,54 @@ describe('IdentityClient', () => {
     factory = new FakeTokenFactory({
       issuer: mockBaseUrl,
       keyDurationSeconds,
+    });
+  });
+
+  describe('identity client configuration', () => {
+    beforeEach(() => {
+      server.use(
+        rest.get(
+          `${mockBaseUrl}/.well-known/jwks.json`,
+          async (_, res, ctx) => {
+            const keys = await factory.listPublicKeys();
+            return res(ctx.json(keys));
+          },
+        ),
+      );
+    });
+
+    it('should defaults to ES256 when no algorithm is supplied', async () => {
+      const identityClient = IdentityClient.create({
+        discovery,
+        issuer: mockBaseUrl,
+      });
+
+      const token = await factory.issueToken({ claims: { sub: 'foo' } });
+      const response = await identityClient.authenticate(token);
+
+      // expect that the authenticate is able to validate a token with ES256, which is the one set to FakeTokenFactory.
+      // This means that IdentityClient set ES256 by default.
+      expect(response).toEqual({
+        token: token,
+        identity: {
+          type: 'user',
+          userEntityRef: 'foo',
+          ownershipEntityRefs: [],
+        },
+      });
+    });
+
+    it('should throw error on empty algorithm string', async () => {
+      const identityClient = IdentityClient.create({
+        discovery,
+        issuer: mockBaseUrl,
+        algorithm: '',
+      });
+
+      const token = await factory.issueToken({ claims: { sub: 'foo' } });
+      return expect(
+        async () => await identityClient.authenticate(token),
+      ).rejects.toThrow();
     });
   });
 

--- a/plugins/auth-node/src/IdentityClient.test.ts
+++ b/plugins/auth-node/src/IdentityClient.test.ts
@@ -146,11 +146,24 @@ describe('IdentityClient', () => {
       });
     });
 
+    it('should throw error on empty algorithms array', async () => {
+      const identityClient = IdentityClient.create({
+        discovery,
+        issuer: mockBaseUrl,
+        algorithms: [''],
+      });
+
+      const token = await factory.issueToken({ claims: { sub: 'foo' } });
+      return expect(
+        async () => await identityClient.authenticate(token),
+      ).rejects.toThrow();
+    });
+
     it('should throw error on empty algorithm string', async () => {
       const identityClient = IdentityClient.create({
         discovery,
         issuer: mockBaseUrl,
-        algorithm: '',
+        algorithms: [],
       });
 
       const token = await factory.issueToken({ claims: { sub: 'foo' } });

--- a/plugins/auth-node/src/IdentityClient.ts
+++ b/plugins/auth-node/src/IdentityClient.ts
@@ -29,6 +29,12 @@ import { BackstageIdentityResponse } from './types';
 
 const CLOCK_MARGIN_S = 10;
 
+/**
+ * An identity client options object which allows extra configurations
+ *
+ * @experimental This is not a stable API yet
+ * @public
+ */
 export type IdentityClientOptions = {
   discovery: PluginEndpointDiscovery;
   issuer: string;

--- a/plugins/auth-node/src/IdentityClient.ts
+++ b/plugins/auth-node/src/IdentityClient.ts
@@ -13,21 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { AuthenticationError } from '@backstage/errors';
 import {
   createRemoteJWKSet,
   decodeJwt,
-  jwtVerify,
+  decodeProtectedHeader,
   FlattenedJWSInput,
   JWSHeaderParameters,
-  decodeProtectedHeader,
+  jwtVerify,
 } from 'jose';
 import { GetKeyFunction } from 'jose/dist/types/types';
+
 import { BackstageIdentityResponse } from './types';
 
 const CLOCK_MARGIN_S = 10;
+
+export type IdentityClientOptions = {
+  discovery: PluginEndpointDiscovery;
+  issuer: string;
+
+  /** JWS "alg" (Algorithm) Header Parameter value. Defaults to ES256.
+   * Must match the algorithm defined in TokenFactory.
+   * More info on supported algorithms: https://github.com/panva/jose */
+  algorithm?: string;
+};
 
 /**
  * An identity client to interact with auth-backend and authenticate Backstage
@@ -39,25 +49,21 @@ const CLOCK_MARGIN_S = 10;
 export class IdentityClient {
   private readonly discovery: PluginEndpointDiscovery;
   private readonly issuer: string;
+  private readonly algorithm: string;
   private keyStore?: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>;
   private keyStoreUpdated: number = 0;
 
   /**
    * Create a new {@link IdentityClient} instance.
    */
-  static create(options: {
-    discovery: PluginEndpointDiscovery;
-    issuer: string;
-  }): IdentityClient {
+  static create(options: IdentityClientOptions): IdentityClient {
     return new IdentityClient(options);
   }
 
-  private constructor(options: {
-    discovery: PluginEndpointDiscovery;
-    issuer: string;
-  }) {
+  private constructor(options: IdentityClientOptions) {
     this.discovery = options.discovery;
     this.issuer = options.issuer;
+    this.algorithm = options.algorithm ?? 'ES256';
   }
 
   /**
@@ -82,7 +88,7 @@ export class IdentityClient {
       throw new AuthenticationError('No keystore exists');
     }
     const decoded = await jwtVerify(token, this.keyStore, {
-      algorithms: ['ES256'],
+      algorithms: [this.algorithm],
       audience: 'backstage',
       issuer: this.issuer,
     });

--- a/plugins/auth-node/src/IdentityClient.ts
+++ b/plugins/auth-node/src/IdentityClient.ts
@@ -33,10 +33,9 @@ export type IdentityClientOptions = {
   discovery: PluginEndpointDiscovery;
   issuer: string;
 
-  /** JWS "alg" (Algorithm) Header Parameter value. Defaults to ES256.
-   * Must match the algorithm defined in TokenFactory.
+  /** JWS "alg" (Algorithm) Header Parameter values. Defaults to an array containing just ES256.
    * More info on supported algorithms: https://github.com/panva/jose */
-  algorithm?: string;
+  algorithms?: string[];
 };
 
 /**
@@ -49,7 +48,7 @@ export type IdentityClientOptions = {
 export class IdentityClient {
   private readonly discovery: PluginEndpointDiscovery;
   private readonly issuer: string;
-  private readonly algorithm: string;
+  private readonly algorithms: string[];
   private keyStore?: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>;
   private keyStoreUpdated: number = 0;
 
@@ -63,7 +62,7 @@ export class IdentityClient {
   private constructor(options: IdentityClientOptions) {
     this.discovery = options.discovery;
     this.issuer = options.issuer;
-    this.algorithm = options.algorithm ?? 'ES256';
+    this.algorithms = options.algorithms ?? ['ES256'];
   }
 
   /**
@@ -88,7 +87,7 @@ export class IdentityClient {
       throw new AuthenticationError('No keystore exists');
     }
     const decoded = await jwtVerify(token, this.keyStore, {
-      algorithms: [this.algorithm],
+      algorithms: this.algorithms,
       audience: 'backstage',
       issuer: this.issuer,
     });

--- a/plugins/auth-node/src/index.ts
+++ b/plugins/auth-node/src/index.ts
@@ -22,6 +22,7 @@
 
 export { getBearerTokenFromAuthorizationHeader } from './getBearerTokenFromAuthorizationHeader';
 export { IdentityClient } from './IdentityClient';
+export type { IdentityClientOptions } from './IdentityClient';
 export type {
   BackstageIdentityResponse,
   BackstageSignInResult,


### PR DESCRIPTION
Signed-off-by: Manuel Scurti <manuel.scurti@agilelab.it>

## Hey, I just made a Pull Request!

To let IdentityClient and the default implementation of TokenIssuer (i.e. TokenFactory) be more flexible, I made few changes.
Now you can configure the signing algorithm used by the IdentityClient and TokenFactory through their constructors.

Example:
```ts  
const chosenSigningAlgorithm = 'RS384';

const tokenIssuer = new TokenFactory({
    issuer: authUrl,
    keyStore,
    keyDurationSeconds,
    logger: logger.child({ component: 'token-factory' }),
    algorithm: chosenSigningAlgorithm
  });

IdentityClient.create({
      discovery: env.discovery,
      issuer: await env.discovery.getExternalBaseUrl('auth'),
      algorithm: chosenSigningAlgorithm
})
```

Closes #11503 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
