### PR TITLE
more verbose logging on publish:github error

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -263,7 +263,22 @@ export function createPublishGithubAction(options: {
               allow_rebase_merge: allowRebaseMerge,
             });
 
-      const { data: newRepo } = await repoCreationPromise;
+      let newRepo;
+
+      try {
+        newRepo = (await repoCreationPromise).data;
+      } catch (e) {
+        assertError(e);
+        if (e.message === 'Resource not accessible by integration') {
+          ctx.logger.warn(
+            'The GitHub app or token provided to Backstage may not have the required permissions to create the repository.',
+          );
+        }
+        throw new Error(
+          `Failed to create the ${user.data.type} repository ${owner}/${repo}: ${e.message}`,
+        );
+      }
+
       if (access?.startsWith(`${owner}/`)) {
         const [, team] = access.split('/');
         await client.rest.teams.addOrUpdateRepoPermissionsInOrg({


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This change improves (IMHO) the error message when the github credentials do not have the required permissions to create a repository.

Previously it would show the following output:

```
2022-05-17T17:17:10.000Z Beginning step publish:github
22022-05-17T17:17:11.000Z HttpError: Resource not accessible by integration
3    at /Users/brianfletcher/git-repos/backstage/node_modules/@octokit/request/dist-node/index.js:86:21
4    at processTicksAndRejections (internal/process/task_queues.js:95:5)
5    at async Job.doExecute (/Users/brianfletcher/git-repos/backstage/node_modules/bottleneck/light.js:405:18)
```

After my proposed change, it would show the following error:

```
12022-05-17T17:40:59.000Z Beginning step publish:github
22022-05-17T17:41:00.000Z warn: The GitHub app or token provided to Backstage may not have the required permissions to create the repository. {"timestamp":"2022-05-17T17:41:00.862Z"}
32022-05-17T17:41:00.000Z Error: Failed to create the Organization repository AcmeInc/asfwef: Resource not accessible by integration
4    at Object.handler (webpack-internal:///../../plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts:283:15)
5    at async NunjucksWorkflowRunner.execute (webpack-internal:///../../plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts:281:11)
6    at async TaskWorker.runOneTask (webpack-internal:///../../plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts:106:26)
7    at async eval (webpack-internal:///../../plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts:93:9)
```

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
