### PR TITLE
Align common.schema.json with Entity type

### DIFF
--- a/packages/catalog-model/src/schema/shared/common.schema.json
+++ b/packages/catalog-model/src/schema/shared/common.schema.json
@@ -43,6 +43,12 @@
         },
         "target": {
           "$ref": "#reference"
+        },
+        "targetRef": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\w+$",
+          "description": "The entity ref of the target of this relation."        
         }
       }
     },


### PR DESCRIPTION
Added the field `targetRef` to match the Typescript type. 

Fixes #11565