### PR TITLE
cli: Add warning when app.baseUrl and backend.baseUrl are identical

### DIFF
--- a/.changeset/fuzzy-colts-enjoy.md
+++ b/.changeset/fuzzy-colts-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Added console warning to frontend start when the `app.baseUrl` and `backend.baseUrl` are identical

--- a/.changeset/shiny-clocks-joke.md
+++ b/.changeset/shiny-clocks-joke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/cli': minor
+'@backstage/cli': patch
 ---
 
 Added console warning to frontend start when the `app.baseUrl` and `backend.baseUrl` are identical

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -44,7 +44,7 @@ export async function startFrontend(options: StartAppOptions) {
     if (problemPackages.length > 1) {
       console.log(
         chalk.yellow(
-          `⚠️ Some of the following packages may be outdated or have duplicate installations:
+          `⚠️   Some of the following packages may be outdated or have duplicate installations:
 
           ${uniq(problemPackages).join(', ')}
         `,
@@ -52,7 +52,7 @@ export async function startFrontend(options: StartAppOptions) {
       );
       console.log(
         chalk.yellow(
-          `⚠️ This can be resolved using the following command:
+          `⚠️   This can be resolved using the following command:
 
           yarn backstage-cli versions:check --fix
       `,
@@ -73,10 +73,14 @@ export async function startFrontend(options: StartAppOptions) {
   if (appBaseUrl === backendBaseUrl) {
     console.log(
       chalk.yellow(
-        `⚠️ Conflict between app baseUrl and backend baseUrl:
+        `⚠️   Conflict between app baseUrl and backend baseUrl:
 
-  app.baseUrl:     ${appBaseUrl}
-  backend.baseUrl: ${appBaseUrl}
+    app.baseUrl:     ${appBaseUrl}
+    backend.baseUrl: ${appBaseUrl}
+
+    Must have unique hostname and/or ports.
+
+    This can be resolved by changing app.baseUrl and backend.baseUrl to point to their respective local development ports.
 `,
       ),
     );

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -62,14 +62,30 @@ export async function startFrontend(options: StartAppOptions) {
   }
 
   const { name } = await fs.readJson(paths.resolveTarget('package.json'));
+  const config = await loadCliConfig({
+    args: options.configPaths,
+    fromPackage: name,
+    withFilteredKeys: true,
+  });
+
+  const appBaseUrl = config.frontendConfig.getString('app.baseUrl');
+  const backendBaseUrl = config.frontendConfig.getString('backend.baseUrl');
+  if (appBaseUrl === backendBaseUrl) {
+    console.log(
+      chalk.yellow(
+        `⚠️ Conflict between app baseUrl and backend baseUrl:
+
+  app.baseUrl:     ${appBaseUrl}
+  backend.baseUrl: ${appBaseUrl}
+`,
+      ),
+    );
+  }
+
   const waitForExit = await serveBundle({
     entry: options.entry,
     checksEnabled: options.checksEnabled,
-    ...(await loadCliConfig({
-      args: options.configPaths,
-      fromPackage: name,
-      withFilteredKeys: true,
-    })),
+    ...config,
   });
 
   await waitForExit();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- cli: `startFrontend` - Add warning when app.baseUrl and backend.baseUrl are identical
  - Fixes: https://github.com/backstage/backstage/issues/8251

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/1923679/169288164-a2f7e62e-e8ba-4b19-b1be-176629d93a75.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
