### PR TITLE
[Kubernetes Plugin] ability to configure refresh interval on Kubernetes tab

### DIFF
--- a/.changeset/khaki-shrimps-tell.md
+++ b/.changeset/khaki-shrimps-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+ability to configure refresh interval on Kubernetes tab

--- a/docs/features/kubernetes/installation.md
+++ b/docs/features/kubernetes/installation.md
@@ -33,9 +33,13 @@ const serviceEntityPage = (
   <EntityLayout>
     {/* other tabs... */}
     <EntityLayout.Route path="/kubernetes" title="Kubernetes">
-      <EntityKubernetesContent />
+      <EntityKubernetesContent refreshIntervalMs={30000} />
     </EntityLayout.Route>
 ```
+
+**Notes:**
+
+- The optional `refreshIntervalMs` property on the `EntityKubernetesContent` defines the interval in which the content automatically refreshes, if not set this will default to 10 seconds.
 
 That's it! But now, we need the Kubernetes Backend plugin for the frontend to
 work.

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -111,7 +111,14 @@ export interface DeploymentResources {
 // Warning: (ae-missing-release-tag) "EntityKubernetesContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const EntityKubernetesContent: (_props: {}) => JSX.Element;
+export const EntityKubernetesContent: (
+  props: EntityKubernetesContentProps,
+) => JSX.Element;
+
+// @public
+export type EntityKubernetesContentProps = {
+  refreshIntervalMs?: number;
+};
 
 // Warning: (ae-forgotten-export) The symbol "ErrorPanelProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ErrorPanel" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -300,6 +307,7 @@ export class KubernetesBackendClient implements KubernetesApi {
 // @public (undocumented)
 export const KubernetesContent: ({
   entity,
+  refreshIntervalMs,
 }: KubernetesContentProps) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "KubernetesDrawerable" needs to be exported by the entry point index.d.ts
@@ -370,11 +378,10 @@ export const PodsTable: ({
   extraColumns,
 }: PodsTablesProps) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Router" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const Router: (_props: Props) => JSX.Element;
+export const Router: (props: { refreshIntervalMs?: number }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "ServiceAccountKubernetesAuthProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/kubernetes/src/Router.tsx
+++ b/plugins/kubernetes/src/Router.tsx
@@ -32,9 +32,7 @@ export const isKubernetesAvailable = (entity: Entity) =>
     entity.metadata.annotations?.[KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION],
   );
 
-type Props = {};
-
-export const Router = (_props: Props) => {
+export const Router = (props: { refreshIntervalMs?: number }) => {
   const { entity } = useEntity();
 
   const kubernetesAnnotationValue =
@@ -49,7 +47,15 @@ export const Router = (_props: Props) => {
   ) {
     return (
       <Routes>
-        <Route path="/" element={<KubernetesContent entity={entity} />} />
+        <Route
+          path="/"
+          element={
+            <KubernetesContent
+              entity={entity}
+              refreshIntervalMs={props.refreshIntervalMs}
+            />
+          }
+        />
       </Routes>
     );
   }

--- a/plugins/kubernetes/src/components/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent.tsx
@@ -25,10 +25,20 @@ import EmptyStateImage from '../assets/emptystate.svg';
 import { useKubernetesObjects } from '../hooks';
 import { Content, Page, Progress } from '@backstage/core-components';
 
-type KubernetesContentProps = { entity: Entity; children?: React.ReactNode };
+type KubernetesContentProps = {
+  entity: Entity;
+  refreshIntervalMs?: number;
+  children?: React.ReactNode;
+};
 
-export const KubernetesContent = ({ entity }: KubernetesContentProps) => {
-  const { kubernetesObjects, error } = useKubernetesObjects(entity);
+export const KubernetesContent = ({
+  entity,
+  refreshIntervalMs,
+}: KubernetesContentProps) => {
+  const { kubernetesObjects, error } = useKubernetesObjects(
+    entity,
+    refreshIntervalMs,
+  );
 
   const clustersWithErrors =
     kubernetesObjects?.items.filter(r => r.errors.length > 0) ?? [];

--- a/plugins/kubernetes/src/index.ts
+++ b/plugins/kubernetes/src/index.ts
@@ -25,6 +25,7 @@ export {
   kubernetesPlugin as plugin,
   EntityKubernetesContent,
 } from './plugin';
+export type { EntityKubernetesContentProps } from './plugin';
 export { Router, isKubernetesAvailable } from './Router';
 export * from './api';
 export * from './kubernetes-auth-provider';

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -76,7 +76,21 @@ export const kubernetesPlugin = createPlugin({
   },
 });
 
-export const EntityKubernetesContent = kubernetesPlugin.provide(
+/**
+ * Props of EntityKubernetesContent
+ *
+ * @public
+ */
+export type EntityKubernetesContentProps = {
+  /**
+   * Sets the refresh interval in milliseconds. The default value is 10000 (10 seconds)
+   */
+  refreshIntervalMs?: number;
+};
+
+export const EntityKubernetesContent: (
+  props: EntityKubernetesContentProps,
+) => JSX.Element = kubernetesPlugin.provide(
   createRoutableExtension({
     name: 'EntityKubernetesContent',
     component: () => import('./Router').then(m => m.Router),


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Hey, I just made a Pull Request!

We have 6 clusters, so every time a user loads the Kubernetes tab, there are nearly 40 requests required to fetch all information required, which is quite a lot. On top of that, this tab currently refreshes every 10s, which might be far too often for something that doesn't change that often.

This PR introduces an optional refreshIntervalMs property to `EntityKubernetesContent` so integrators have the ability to decide how often it should refresh.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
