### PR TITLE
remove disclaimer from addons.md now that backstage 1.2 is out

### DIFF
--- a/docs/features/techdocs/addons.md
+++ b/docs/features/techdocs/addons.md
@@ -4,11 +4,6 @@ title: TechDocs Addons
 description: How to find, use, or create TechDocs Addons.
 ---
 
-> Note: This page contains documentation for features that have not yet been
-> released on a [main-line version](https://backstage.io/docs/overview/versioning-policy#main-release-line)
-> of Backstage and TechDocs. We plan to make Addons generally available in
-> Backstage v1.2.
-
 ## Concepts
 
 TechDocs is a centralized platform for publishing, viewing, and discovering


### PR DESCRIPTION
1.2 release is out, so should this disclaimer be removed?

```
Note: This page contains documentation for features that have not yet been released on a [main-line version](https://backstage.io/docs/overview/versioning-policy#main-release-line) of Backstage and TechDocs. We plan to make Addons generally available in Backstage v1.2.
```

## Hey, I just made a Pull Request!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] Removed a disclaimer from the docs
(https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
