### PR TITLE
kubernetes: fix merge conflict of getMatchingHpa call

### DIFF
--- a/plugins/kubernetes/src/components/StatefulSetsAccordions/StatefulSetsAccordions.tsx
+++ b/plugins/kubernetes/src/components/StatefulSetsAccordions/StatefulSetsAccordions.tsx
@@ -183,8 +183,11 @@ export const StatefulSetsAccordions = ({}: StatefulSetsAccordionsProps) => {
           <Grid item xs>
             <StatefulSetAccordion
               matchingHpa={getMatchingHpa(
-                statefulset.metadata?.name,
-                'statefulset',
+                {
+                  name: statefulset.metadata?.name,
+                  namespace: statefulset.metadata?.namespace,
+                  kind: 'statefulset',
+                },
                 groupedResponses.horizontalPodAutoscalers,
               )}
               ownedPods={getOwnedResources(statefulset, groupedResponses.pods)}


### PR DESCRIPTION
Two concurrent changes that ended up incompatible 🧹 
