### PR TITLE
move register new component into context menu

### DIFF
--- a/.changeset/little-mayflies-compete.md
+++ b/.changeset/little-mayflies-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Move Register New Component in context menu

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -17,14 +17,12 @@
 import {
   Content,
   ContentHeader,
-  CreateButton,
   Header,
   Page,
   SupportButton,
 } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
-import { useRouteRef } from '@backstage/core-plugin-api';
 import {
   CatalogFilterLayout,
   EntityKindPicker,
@@ -34,7 +32,6 @@ import {
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
 import React, { ComponentType } from 'react';
-import { registerComponentRouteRef } from '../../routes';
 import { TemplateList } from '../TemplateList';
 import { TemplateTypePicker } from '../TemplateTypePicker';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
@@ -60,7 +57,6 @@ export const ScaffolderPageContents = ({
   groups,
   contextMenu,
 }: ScaffolderPageProps) => {
-  const registerComponentLink = useRouteRef(registerComponentRouteRef);
   const otherTemplatesGroup = {
     title: groups ? 'Other Templates' : 'Templates',
     filter: (entity: Entity) => {
@@ -80,16 +76,10 @@ export const ScaffolderPageContents = ({
         title="Create a New Component"
         subtitle="Create new software components using standard templates"
       >
-        <ScaffolderPageContextMenu {...contextMenu} />
+        <ScaffolderPageContextMenu {...contextMenu} registerNew={allowed} />
       </Header>
       <Content>
         <ContentHeader title="Available Templates">
-          {allowed && (
-            <CreateButton
-              title="Register Existing Component"
-              to={registerComponentLink && registerComponentLink()}
-            />
-          )}
           <SupportButton>
             Create new software components using standard templates. Different
             templates create different kinds of components (services, websites,

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPageContextMenu.test.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPageContextMenu.test.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { renderInTestApp } from '@backstage/test-utils';
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { rootRouteRef } from '../../routes';
+import { registerComponentRouteRef, rootRouteRef } from '../../routes';
 import { ScaffolderPageContextMenu } from './ScaffolderPageContextMenu';
 
 describe('ScaffolderPageContextMenu', () => {
@@ -31,6 +31,23 @@ describe('ScaffolderPageContextMenu', () => {
     );
 
     expect(screen.getByTestId('container')).toBeEmptyDOMElement();
+  });
+
+  it('renders the add template option', async () => {
+    await renderInTestApp(
+      <div data-testid="container">
+        <ScaffolderPageContextMenu actions={false} />
+      </div>,
+      {
+        mountedRoutes: {
+          '/': rootRouteRef,
+          '/register': registerComponentRouteRef,
+        },
+      },
+    );
+
+    await userEvent.click(screen.getByTestId('container').firstElementChild!);
+    expect(screen.queryByText('Add Template')).toBeInTheDocument();
   });
 
   it('renders the editor option', async () => {

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPageContextMenu.tsx
@@ -22,12 +22,13 @@ import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
 import Popover from '@material-ui/core/Popover';
 import { makeStyles } from '@material-ui/core/styles';
+import Add from '@material-ui/icons/Add';
 import Description from '@material-ui/icons/Description';
 import Edit from '@material-ui/icons/Edit';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
-import { rootRouteRef } from '../../routes';
+import { rootRouteRef, registerComponentRouteRef } from '../../routes';
 
 const useStyles = makeStyles({
   button: {
@@ -36,6 +37,7 @@ const useStyles = makeStyles({
 });
 
 export type ScaffolderPageContextMenuProps = {
+  registerNew?: boolean;
   editor?: boolean;
   actions?: boolean;
 };
@@ -48,6 +50,9 @@ export function ScaffolderPageContextMenu(
   const pageLink = useRouteRef(rootRouteRef);
   const navigate = useNavigate();
 
+  const registerComponentLink = useRouteRef(registerComponentRouteRef);
+
+  const showRegister = props.registerNew !== false && registerComponentLink;
   const showEditor = props.editor !== false;
   const showActions = props.actions !== false;
 
@@ -84,6 +89,14 @@ export function ScaffolderPageContextMenu(
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
         <MenuList>
+          {showRegister && (
+            <MenuItem onClick={() => navigate(registerComponentLink())}>
+              <ListItemIcon>
+                <Add fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Add Template" />
+            </MenuItem>
+          )}
           {showEditor && (
             <MenuItem onClick={() => navigate(`${pageLink()}/edit`)}>
               <ListItemIcon>


### PR DESCRIPTION
We noticed that less than 1% of our users are creating new templates.
Thus I don't think this button should use such a prime real state

We also performed a small usability test and we observed that
users expect the search box to be in this area.

So I would like to move the "Register New Component" button inside
the context menu, and call it "Add Template" instead.
This will also clear the space for the search box.

## Hey, I just made a Pull Request!

<img width="771" alt="Screen Shot 2022-05-19 at 10 20 19 AM" src="https://user-images.githubusercontent.com/466007/169333993-bc51e969-7d84-40f5-bc9c-010e7f38d45c.png">

<img width="774" alt="Screen Shot 2022-05-19 at 10 20 26 AM" src="https://user-images.githubusercontent.com/466007/169334047-89f617ca-7fdc-458d-b202-3affb11425e3.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
