### PR TITLE
backend-common: bump luxon to match usage

### DIFF
--- a/.changeset/itchy-avocados-hug.md
+++ b/.changeset/itchy-avocados-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fixed potential crash by bumping the `luxon` dependency to `^2.3.1`.

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -68,7 +68,7 @@
     "knex": "^1.0.2",
     "lodash": "^4.17.21",
     "logform": "^2.3.2",
-    "luxon": "^2.0.2",
+    "luxon": "^2.3.1",
     "minimatch": "^5.0.0",
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16760,7 +16760,7 @@ lunr@^2.3.9:
   resolved "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-luxon@^2.0.2, luxon@^2.3.0:
+luxon@^2.0.2, luxon@^2.3.0, luxon@^2.3.1:
   version "2.4.0"
   resolved "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz#9435806545bb32d4234dab766ab8a3d54847a765"
   integrity sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some recent changes require a newer version of `luxon`. Fixes #11584 

There's a separate discussion to be had whether we should change our version bump strategy to avoid this kind of issues, although that might be at the cost of a lot more noise and forced upgrades for users of our packages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
