### PR TITLE
Patch release of #11617: luxon dependency fix as v1.2.1

### DIFF
--- a/.changeset/itchy-avocados-hug.md
+++ b/.changeset/itchy-avocados-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fixed potential crash by bumping the `luxon` dependency to `^2.3.1`.

--- a/.changeset/itchy-avocados-hug.md
+++ b/.changeset/itchy-avocados-hug.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-common': patch
----
-
-Fixed potential crash by bumping the `luxon` dependency to `^2.3.1`.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.17.11",

--- a/packages/backend-common/CHANGELOG.md
+++ b/packages/backend-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-common
 
+## 0.13.4
+
+### Patch Changes
+
+- 739be2b079: Fixed potential crash by bumping the `luxon` dependency to `^2.3.1`.
+
 ## 0.13.3
 
 ### Patch Changes

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-common",
   "description": "Common functionality library for Backstage backends",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "private": false,

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -68,7 +68,7 @@
     "knex": "^1.0.2",
     "lodash": "^4.17.21",
     "logform": "^2.3.2",
-    "luxon": "^2.0.2",
+    "luxon": "^2.3.1",
     "minimatch": "^5.0.0",
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16730,7 +16730,7 @@ lunr@^2.3.9:
   resolved "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-luxon@^2.0.2, luxon@^2.3.0:
+luxon@^2.0.2, luxon@^2.3.0, luxon@^2.3.1:
   version "2.4.0"
   resolved "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz#9435806545bb32d4234dab766ab8a3d54847a765"
   integrity sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==


### PR DESCRIPTION
This release fixes a potential crash where `@backstage/backend-common` declared an outdated `luxon` version dependency range.