### PR TITLE
fix(sidebarItem): only add arrow icon to items with a submenu

### DIFF
--- a/.changeset/mean-turtles-reply.md
+++ b/.changeset/mean-turtles-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix issue where right arrow icon was incorrectly added to side bar items without a sub-menu

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -259,6 +259,7 @@ type SidebarItemBaseProps = {
   icon: IconComponent;
   text?: string;
   hasNotifications?: boolean;
+  hasSubmenu?: boolean;
   disableHighlight?: boolean;
   className?: string;
 };
@@ -356,6 +357,7 @@ const SidebarItemBase = forwardRef<any, SidebarItemProps>((props, ref) => {
     icon: Icon,
     text,
     hasNotifications = false,
+    hasSubmenu = false,
     disableHighlight = false,
     onClick,
     children,
@@ -370,12 +372,12 @@ const SidebarItemBase = forwardRef<any, SidebarItemProps>((props, ref) => {
   const { isOpen } = useContext(SidebarContext);
 
   const divStyle =
-    !isOpen && children ? { display: 'flex', marginLeft: '24px' } : {};
+    !isOpen && hasSubmenu ? { display: 'flex', marginLeft: '24px' } : {};
 
   const displayItemIcon = (
     <div style={divStyle}>
       <Icon fontSize="small" />
-      {!isOpen && children ? <ArrowRightIcon /> : <></>}
+      {!isOpen && hasSubmenu ? <ArrowRightIcon /> : <></>}
     </div>
   );
 
@@ -492,6 +494,7 @@ const SidebarItemWithSubmenu = ({
         className={classnames(isHoveredOn && classes.highlighted)}
       >
         <SidebarItemBase
+          hasSubmenu
           className={isActive ? classes.selected : ''}
           {...props}
         >


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Fixes an issue from this [change](https://github.com/backstage/backstage/pull/11038) where the right arrow icon is incorrectly being applied to shortcut items:

| Before | After |
| --- | --- |
| ![Screen Shot 2022-05-19 at 4 57 50 PM](https://user-images.githubusercontent.com/6998196/169404189-905349c0-1eb7-4a1f-bf60-56bfd8ffcb2e.png) | ![Screen Shot 2022-05-19 at 4 57 26 PM](https://user-images.githubusercontent.com/6998196/169404207-4312093a-9515-43b8-815b-a5493e549076.png) |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
