### PR TITLE
Header Hierarchy Jump on Catalog Import Page

### DIFF
--- a/.changeset/violet-apples-repair.md
+++ b/.changeset/violet-apples-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': minor
+---
+
+Updated catalog import page text so they go in the correct hierarchy order

--- a/.changeset/violet-apples-repair.md
+++ b/.changeset/violet-apples-repair.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-import': minor
+'@backstage/plugin-catalog-import': patch
 ---
 
 Updated catalog import page text so they go in the correct hierarchy order

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -54,6 +54,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
   return (
     <InfoCard
       title="Register an existing component"
+      titleTypographyProps={{ component: 'h3' }}
       deepLink={{
         title: 'Learn more about the Software Catalog',
         link: 'https://backstage.io/docs/features/software-catalog/software-catalog-overview',
@@ -62,7 +63,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
       <Typography variant="body2" paragraph>
         Enter the URL to your source code repository to add it to {appTitle}.
       </Typography>
-      <Typography variant="h6">Link to an existing entity file</Typography>
+      <Typography variant="h4">Link to an existing entity file</Typography>
       <Typography variant="subtitle2" color="textSecondary" paragraph>
         Example: <code>{exampleLocationUrl}</code>
       </Typography>
@@ -72,7 +73,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
       </Typography>
       {hasGithubIntegration && (
         <>
-          <Typography variant="h6">
+          <Typography variant="h4">
             Link to a repository{' '}
             <Chip label="GitHub only" variant="outlined" size="small" />
           </Typography>

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -63,7 +63,9 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
       <Typography variant="body2" paragraph>
         Enter the URL to your source code repository to add it to {appTitle}.
       </Typography>
-      <Typography variant="h4">Link to an existing entity file</Typography>
+      <Typography component="h4" variant="h6">
+        Link to an existing entity file
+      </Typography>
       <Typography variant="subtitle2" color="textSecondary" paragraph>
         Example: <code>{exampleLocationUrl}</code>
       </Typography>
@@ -73,7 +75,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
       </Typography>
       {hasGithubIntegration && (
         <>
-          <Typography variant="h4">
+          <Typography component="h4" variant="h6">
             Link to a repository{' '}
             <Chip label="GitHub only" variant="outlined" size="small" />
           </Typography>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

On the catalog-import page, I've updated the hierarchy order for accessibility standards. I've added a header to the `infocard` title to be `<h3>` and changed the text section headers to be `<h4>`

<img width="759" alt="import component new" src="https://user-images.githubusercontent.com/51958813/169412741-c2521776-4a45-48e4-ab63-8d053f9811b1.png">

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
