### PR TITLE
Revert "chore(deps): update helm release postgresql to v11"

### DIFF
--- a/contrib/chart/backstage/Chart.lock
+++ b/contrib/chart/backstage/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.2.4
-digest: sha256:782c8593a80e332b19f736d48f4635e424bbf0575ed9d587c0a301cccfcedce8
-generated: "2022-05-19T10:46:51.441725486Z"
+  version: 9.8.12
+digest: sha256:549b9a0cdf7b2e0ad949ebad853a467bf320928970a946fb0ef7e13e9bdb7a10
+generated: "2022-05-20T08:15:48.301491565Z"

--- a/contrib/chart/backstage/Chart.yaml
+++ b/contrib/chart/backstage/Chart.yaml
@@ -18,7 +18,7 @@ sources:
 dependencies:
   - name: postgresql
     condition: postgresql.enabled
-    version: 11.2.4
+    version: 9.8.12
     repository: https://charts.bitnami.com/bitnami
 
 maintainers:


### PR DESCRIPTION
## Description

This reverts commit d0b04813ab991e0701495e1015c3b386be14ced9.

I am reverting this automatic upgrade of the chart dependency because it has breaking changes and needs more
work and testing.

closes #11522

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
