### PR TITLE
backend-common: fix stuck s3 reading

### DIFF
--- a/.changeset/odd-baboons-buy.md
+++ b/.changeset/odd-baboons-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix a bug in the URL Reading towards AWS S3 where it would hang indefinitely.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

S3 reading of individual objects currently fails with a hanging request. This seems to be due to interactions between the order of calling `request.promise()` and `request.createReadStream()` which was changed in #11157.

This removes the `request.promise()` call for the `readUrl` method and refactors the tests to use MSW instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
