### PR TITLE
Patch release of #11630, S3 UrlReader fix

### DIFF
--- a/.changeset/odd-baboons-buy.md
+++ b/.changeset/odd-baboons-buy.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-common': patch
----
-
-Fix a bug in the URL Reading towards AWS S3 where it would hang indefinitely.

--- a/.changeset/odd-baboons-buy.md
+++ b/.changeset/odd-baboons-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix a bug in the URL Reading towards AWS S3 where it would hang indefinitely.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.17.11",

--- a/packages/backend-common/CHANGELOG.md
+++ b/packages/backend-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-common
 
+## 0.13.5
+
+### Patch Changes
+
+- 667d2ed6f8: Fix a bug in the URL Reading towards AWS S3 where it would hang indefinitely.
+
 ## 0.13.4
 
 ### Patch Changes

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-common",
   "description": "Common functionality library for Backstage backends",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "private": false,


### PR DESCRIPTION
This release fixes a issue in `@backstage/backend-common` where reading of S3 object would hang indefinitely