### PR TITLE
fix references to search-backend-node

### DIFF
--- a/.changeset/reject-failed-index-tasks.md
+++ b/.changeset/reject-failed-index-tasks.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/search-backend-node': patch
+'@backstage/plugin-search-backend-node': patch
 ---
 
 propagate indexing errors so they don't appear successful to the task scheduler

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -495,7 +495,7 @@
 - 022507c860: A `DefaultCatalogCollatorFactory`, which works with the new stream-based
   search indexing subsystem, is now available. The `DefaultCatalogCollator` will
   continue to be available for those unable to upgrade to the stream-based
-  `@backstage/search-backend-node` (and related packages), however it is now
+  `@backstage/plugin-search-backend-node` (and related packages), however it is now
   marked as deprecated and will be removed in a future version.
 
   To upgrade this plugin and the search indexing subsystem in one go, check

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -37,7 +37,7 @@ import { Permission } from '@backstage/plugin-permission-common';
 
 /**
  * @public
- * @deprecated Upgrade to a more recent `@backstage/search-backend-node` and
+ * @deprecated Upgrade to a more recent `@backstage/plugin-search-backend-node` and
  * use `DefaultCatalogCollatorFactory` instead.
  */
 export class DefaultCatalogCollator {

--- a/plugins/search-backend-module-elasticsearch/CHANGELOG.md
+++ b/plugins/search-backend-module-elasticsearch/CHANGELOG.md
@@ -91,10 +91,10 @@
 - 022507c860: **BREAKING**
 
   The `ElasticSearchSearchEngine` implements the new stream-based indexing
-  process expected by the latest `@backstage/search-backend-node`.
+  process expected by the latest `@backstage/plugin-search-backend-node`.
 
   When updating to this version, you must also update to the latest version of
-  `@backstage/search-backend-node`. Check [this upgrade guide](https://backstage.io/docs/features/search/how-to-guides#how-to-migrate-from-search-alpha-to-beta)
+  `@backstage/plugin-search-backend-node`. Check [this upgrade guide](https://backstage.io/docs/features/search/how-to-guides#how-to-migrate-from-search-alpha-to-beta)
   for further details.
 
 ### Patch Changes

--- a/plugins/search-backend-module-pg/CHANGELOG.md
+++ b/plugins/search-backend-module-pg/CHANGELOG.md
@@ -83,10 +83,10 @@
 - 022507c860: **BREAKING**
 
   The `PgSearchEngine` implements the new stream-based indexing process expected
-  by the latest `@backstage/search-backend-node`.
+  by the latest `@backstage/plugin-search-backend-node`.
 
   When updating to this version, you must also update to the latest version of
-  `@backstage/search-backend-node`. Check [this upgrade guide](https://backstage.io/docs/features/search/how-to-guides#how-to-migrate-from-search-alpha-to-beta)
+  `@backstage/plugin-search-backend-node`. Check [this upgrade guide](https://backstage.io/docs/features/search/how-to-guides#how-to-migrate-from-search-alpha-to-beta)
   for further details.
 
 ### Patch Changes

--- a/plugins/search-common/src/types.ts
+++ b/plugins/search-common/src/types.ts
@@ -134,7 +134,7 @@ export type IndexableDocument = SearchDocument & {
 
 /**
  * Information about a specific document type. Intended to be used in the
- * {@link @backstage/search-backend-node#IndexBuilder} to collect information
+ * {@link @backstage/plugin-search-backend-node#IndexBuilder} to collect information
  * about the types stored in the index.
  * @beta
  */

--- a/plugins/techdocs-backend/CHANGELOG.md
+++ b/plugins/techdocs-backend/CHANGELOG.md
@@ -190,7 +190,7 @@
 - 022507c860: A `DefaultTechDocsCollatorFactory`, which works with the new stream-based
   search indexing subsystem, is now available. The `DefaultTechDocsCollator` will
   continue to be available for those unable to upgrade to the stream-based
-  `@backstage/search-backend-node` (and related packages), however it is now
+  `@backstage/plugin-search-backend-node` (and related packages), however it is now
   marked as deprecated and will be removed in a future version.
 
   To upgrade this plugin and the search indexing subsystem in one go, check

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -69,7 +69,7 @@ type EntityInfo = {
  * A search collator responsible for gathering and transforming TechDocs documents.
  *
  * @public
- * @deprecated Upgrade to a more recent `@backstage/search-backend-node` and
+ * @deprecated Upgrade to a more recent `@backstage/plugin-search-backend-node` and
  * use `DefaultTechDocsCollatorFactory` instead.
  */
 export class DefaultTechDocsCollator {


### PR DESCRIPTION
Main change here is the changeset fix, but figured the other references could be replaced as well. Feeling it's not worth creating changesets for these though, not worth the noise.