### PR TITLE
Fix/knex signing keys length

### DIFF
--- a/.changeset/fifty-planes-dream.md
+++ b/.changeset/fifty-planes-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Increased key field size for signing_keys table to account for larger signature keys

--- a/plugins/auth-backend/migrations/20200619125845_init.js
+++ b/plugins/auth-backend/migrations/20200619125845_init.js
@@ -20,6 +20,13 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function up(knex) {
+  /**
+   * key field length. must be enough for the chosen JWT signing algorithm.
+   * the default value is set to be enough for all supported algorithms of the
+   * `jose` library.
+   */
+  const SIGNING_KEY_MAX_LENGTH = 512;
+
   return knex.schema.createTable('signing_keys', table => {
     table.comment(
       'Signing keys that are currently in use or have recently been used to issue tokens',
@@ -34,7 +41,10 @@ exports.up = async function up(knex) {
       .notNullable()
       .defaultTo(knex.fn.now())
       .comment('The creation time of the key');
-    table.string('key').notNullable().comment('The serialized signing key');
+    table
+      .string('key', SIGNING_KEY_MAX_LENGTH)
+      .notNullable()
+      .comment('The serialized signing key');
   });
 };
 

--- a/plugins/auth-backend/migrations/20220522100910_key_field_size.js
+++ b/plugins/auth-backend/migrations/20220522100910_key_field_size.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/auth-backend/migrations/20220522100910_key_field_size.js
+++ b/plugins/auth-backend/migrations/20220522100910_key_field_size.js
@@ -20,27 +20,30 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function up(knex) {
-  return knex.schema.createTable('signing_keys', table => {
-    table.comment(
-      'Signing keys that are currently in use or have recently been used to issue tokens',
-    );
-    table
-      .string('kid')
-      .primary()
-      .notNullable()
-      .comment('ID of the signing key');
-    table
-      .timestamp('created_at', { useTz: false, precision: 0 })
-      .notNullable()
-      .defaultTo(knex.fn.now())
-      .comment('The creation time of the key');
-    table.string('key').notNullable().comment('The serialized signing key');
-  });
+  // Sqlite does not support alter column.
+  if (!knex.client.config.client.includes('sqlite3')) {
+    await knex.schema.alterTable('signing_keys', table => {
+      table
+        .text('key')
+        .notNullable()
+        .comment('The serialized signing key')
+        .alter({ alterType: true });
+    });
+  }
 };
 
 /**
  * @param {import('knex').Knex} knex
  */
 exports.down = async function down(knex) {
-  return knex.schema.dropTable('auth_keystore');
+  // Sqlite does not support alter column.
+  if (!knex.client.config.client.includes('sqlite3')) {
+    await knex.schema.alterTable('signing_keys', table => {
+      table
+        .string('key')
+        .notNullable()
+        .comment('The serialized signing key')
+        .alter({ alterType: true });
+    });
+  }
 };

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -34,6 +34,9 @@ type Options = {
   keyDurationSeconds: number;
   /** JWS "alg" (Algorithm) Header Parameter value. Defaults to ES256.
    * Must match one of the algorithms defined for IdentityClient.
+   * When setting a different algorithm, check if the `key` field
+   * of the `signing_keys` table can fit the length of the generated keys.
+   * If not, modify the migration file in the migrations folder.
    * More info on supported algorithms: https://github.com/panva/jose */
   algorithm?: string;
 };

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -36,7 +36,7 @@ type Options = {
    * Must match one of the algorithms defined for IdentityClient.
    * When setting a different algorithm, check if the `key` field
    * of the `signing_keys` table can fit the length of the generated keys.
-   * If not, modify the migration file in the migrations folder.
+   * If not, add a knex migration file in the migrations folder.
    * More info on supported algorithms: https://github.com/panva/jose */
   algorithm?: string;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since now developers of backstage can customize the signing algorithm for the IdentityClient and the TokenFactory, there can be cases in which the `key` field of the `signing_keys` table does not fit the size of the generated key. 
This PR sets the `key` field size to 512 so that it can fit all the algorithms supported by the jose library.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
