### PR TITLE
[TechInsights] Export TechInsightsClient so it can be extended

### DIFF
--- a/.changeset/heavy-carrots-cheer.md
+++ b/.changeset/heavy-carrots-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Export TechInsightsClient so it may be extended by custom implementations

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -10,6 +10,8 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { BulkCheckResponse } from '@backstage/plugin-tech-insights-common';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { CompoundEntityRef } from '@backstage/catalog-model';
+import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
@@ -77,6 +79,35 @@ export interface TechInsightsApi {
 
 // @public
 export const techInsightsApiRef: ApiRef<TechInsightsApi>;
+
+// Warning: (ae-missing-release-tag) "TechInsightsClient" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class TechInsightsClient implements TechInsightsApi {
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    identityApi: IdentityApi;
+  });
+  // (undocumented)
+  getAllChecks(): Promise<Check[]>;
+  // (undocumented)
+  getScorecardsDefinition(
+    type: string,
+    value: CheckResult[],
+    title?: string,
+    description?: string,
+  ): CheckResultRenderer | undefined;
+  // (undocumented)
+  runBulkChecks(
+    entities: CompoundEntityRef[],
+    checks?: Check[],
+  ): Promise<BulkCheckResponse>;
+  // (undocumented)
+  runChecks(
+    entityParams: CompoundEntityRef,
+    checks?: string[],
+  ): Promise<CheckResult[]>;
+}
 
 // @public (undocumented)
 export const techInsightsPlugin: BackstagePlugin<

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -29,16 +29,14 @@ import {
   defaultCheckResultRenderers,
 } from '../components/CheckResultRenderer';
 
-export type Options = {
-  discoveryApi: DiscoveryApi;
-  identityApi: IdentityApi;
-};
-
 export class TechInsightsClient implements TechInsightsApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
 
-  constructor(options: Options) {
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    identityApi: IdentityApi;
+  }) {
     this.discoveryApi = options.discoveryApi;
     this.identityApi = options.identityApi;
   }

--- a/plugins/tech-insights/src/api/index.ts
+++ b/plugins/tech-insights/src/api/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './TechInsightsApi';
 export * from './TechInsightsClient';
+export * from './types';

--- a/plugins/tech-insights/src/index.ts
+++ b/plugins/tech-insights/src/index.ts
@@ -19,7 +19,6 @@ export {
   EntityTechInsightsScorecardCard,
 } from './plugin';
 
-export { techInsightsApiRef } from './api/TechInsightsApi';
-export type { TechInsightsApi } from './api/TechInsightsApi';
-export type { Check } from './api/types';
+export { techInsightsApiRef, TechInsightsClient } from './api';
+export type { TechInsightsApi, Check } from './api';
 export type { CheckResultRenderer } from './components/CheckResultRenderer';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed that `TechInsightsClient` is not exported while figuring out how to introduce a custom `CheckResultRenderer`. 

My approach would be to overwrite the TechInsights api with `new TechInsightsClient(...)` and consequently overwriting the `getScorecardsDefinition()` method. However, without this change it is not possible to get the `TechInsightsClient` from the plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
