### PR TITLE
(fix): bind 'this' properly for getKey function in ALB auth provider

### DIFF
--- a/.changeset/tricky-hounds-cry.md
+++ b/.changeset/tricky-hounds-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fix improper binding of 'this' in ALB Auth provider

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -189,7 +189,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
     };
   }
 
-  async getKey(header: JWTHeaderParameters): Promise<KeyObject> {
+  getKey = async (header: JWTHeaderParameters): Promise<KeyObject> => {
     if (!header.kid) {
       throw new AuthenticationError('No key id was specified in header');
     }
@@ -208,7 +208,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
       keyValue.export({ format: 'pem', type: 'spki' }),
     );
     return keyValue;
-  }
+  };
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

## Hey, I just made a Pull Request!
This changes the getKey function in the ALB provider to an arrow function. This is needed to properly bind 'this' - otherwise, this provider complains about 'this' being undefined in getKey, since it is passed as a function to the jose library and called with a different context.
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
