### PR TITLE
Add edit url to GitHub teams

### DIFF
--- a/.changeset/modern-pandas-agree.md
+++ b/.changeset/modern-pandas-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Adds an edit url to the GitHub Teams Group entities.

--- a/.changeset/modern-pandas-agree.md
+++ b/.changeset/modern-pandas-agree.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-Adds an edit url to the GitHub Teams Group entities.
+Adds an edit URL to the GitHub Teams Group entities.

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -86,6 +86,7 @@ describe('github', () => {
                 name: 'Team',
                 description: 'The one and only team',
                 avatarUrl: 'http://example.com/team.jpeg',
+                editTeamUrl: 'http://example.com/orgs/blah/teams/team/edit',
                 parentTeam: {
                   slug: 'parent',
                   combinedSlug: '',
@@ -109,6 +110,11 @@ describe('github', () => {
             metadata: expect.objectContaining({
               name: 'team',
               description: 'The one and only team',
+              annotations: {
+                'github.com/team-slug': 'blah/team',
+                'backstage.io/edit-url':
+                  'http://example.com/orgs/blah/teams/team/edit',
+              },
             }),
             spec: {
               type: 'team',

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -52,6 +52,7 @@ export type Team = {
   name?: string;
   description?: string;
   avatarUrl?: string;
+  editTeamUrl: string;
   parentTeam?: Team;
   members: Connection<User>;
 };
@@ -165,6 +166,7 @@ export async function getOrganizationTeams(
             name
             description
             avatarUrl
+            editTeamUrl
             parentTeam { slug }
             members(first: 100, membership: IMMEDIATE) {
               pageInfo { hasNextPage }
@@ -186,6 +188,7 @@ export async function getOrganizationTeams(
         name: team.slug,
         annotations: {
           'github.com/team-slug': team.combinedSlug,
+          'backstage.io/edit-url': team.editTeamUrl,
         },
       },
       spec: {

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -52,7 +52,7 @@ export type Team = {
   name?: string;
   description?: string;
   avatarUrl?: string;
-  editTeamUrl: string;
+  editTeamUrl?: string;
   parentTeam?: Team;
   members: Connection<User>;
 };
@@ -181,15 +181,20 @@ export async function getOrganizationTeams(
   const groupMemberUsers = new Map<string, string[]>();
 
   const mapper = async (team: Team) => {
+    const annotations: { [annotationName: string]: string } = {
+      'github.com/team-slug': team.combinedSlug,
+    };
+
+    if (team.editTeamUrl) {
+      annotations['backstage.io/edit-url'] = team.editTeamUrl;
+    }
+
     const entity: GroupEntity = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Group',
       metadata: {
         name: team.slug,
-        annotations: {
-          'github.com/team-slug': team.combinedSlug,
-          'backstage.io/edit-url': team.editTeamUrl,
-        },
+        annotations,
       },
       spec: {
         type: 'team',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the edit team link to the backstage group entity for teams loaded from GitHub.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
