### PR TITLE
Add Cloudify plugin

### DIFF
--- a/microsite/data/plugins/cloudify.yaml
+++ b/microsite/data/plugins/cloudify.yaml
@@ -1,0 +1,9 @@
+---
+title: Cloudify
+author: Cloudify
+authorUrl: https://cloudify.co/
+category: Orchestration
+description: Load blueprints from desired Cloudify Manager instance
+documentation: https://github.com/Cloudify-PS/backstage-cloudify-plugin#readme
+iconUrl: https://avatars.githubusercontent.com/u/6260555?s=200&v=4
+npmPackageName: 'plugin-cloudify'


### PR DESCRIPTION
## Add Cloudify plugin

Backstage plugin that connects with the Cloudify Manager instance and pulls all available blueprints.
Blueprints are listed in a table and accesible via a link to the Cloudify Manager.

![image](https://user-images.githubusercontent.com/60732113/170265189-6031a8d9-6272-48c4-8502-faaa3adf0ef9.png)

