### PR TITLE
fix(elasticSearch): use more precise matching for query filters

### DIFF
--- a/.changeset/search-eight-hounds-worry.md
+++ b/.changeset/search-eight-hounds-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Use more precise matching for query filters

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.test.ts
@@ -153,7 +153,7 @@ describe('ElasticSearchSearchEngine', () => {
             },
             filter: {
               match: {
-                kind: 'testKind',
+                'kind.keyword': 'testKind',
               },
             },
           },
@@ -204,7 +204,12 @@ describe('ElasticSearchSearchEngine', () => {
       const actualTranslatedQuery = translatorUnderTest({
         types: ['indexName'],
         term: 'testTerm',
-        filters: { kind: 'testKind', namespace: 'testNameSpace' },
+        filters: {
+          kind: 'testKind',
+          namespace: 'testNameSpace',
+          foo: 123,
+          bar: true,
+        },
       }) as ConcreteElasticSearchQuery;
 
       expect(actualTranslatedQuery).toMatchObject({
@@ -228,12 +233,22 @@ describe('ElasticSearchSearchEngine', () => {
             filter: [
               {
                 match: {
-                  kind: 'testKind',
+                  'kind.keyword': 'testKind',
                 },
               },
               {
                 match: {
-                  namespace: 'testNameSpace',
+                  'namespace.keyword': 'testNameSpace',
+                },
+              },
+              {
+                match: {
+                  foo: '123',
+                },
+              },
+              {
+                match: {
+                  bar: 'true',
                 },
               },
             ],

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -168,7 +168,9 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       .filter(([_, value]) => Boolean(value))
       .map(([key, value]: [key: string, value: any]) => {
         if (['string', 'number', 'boolean'].includes(typeof value)) {
-          return esb.matchQuery(key, value.toString());
+          // Use exact matching for string datatype fields
+          const keyword = typeof value === 'string' ? `${key}.keyword` : key;
+          return esb.matchQuery(keyword, value.toString());
         }
         if (Array.isArray(value)) {
           return esb


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This fixes an obscure issue that can be observed in some TechDocs search scenarios. For example if you using the search in the TechDocs site of `component:default/web-project` and you have another TechDocs site for `component:default/foo-web`, the search results may contain results from both sites. This is due to loose matching on the `name` field filter so `web-project` and `foo-web` are close enough to both match. This fix uses a [`Match Phrase Query`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html) that results in a more exact match ([ref](https://www.oreilly.com/library/view/learning-elasticsearch/9781787128453/9940b606-36b2-467c-81ff-4282c4138298.xhtml#:~:text=Match%20phrase%20query%20is%20similar,the%20search%20input%20are%20matched.)) 

Alternatively, if we wanted to ensure we're always using an exact match, we could use a [Term Query](https://www.elastic.co/guide/en/elasticsearch/guide/current/_finding_exact_values.html#_term_query_with_text) but that would require setting the `name` field to be `not_analyzed` which I believe will prevent intentional fuzzy matching on this field (eg. general queries for "web" will no longer match the `component:default/web-project` document) 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
