### PR TITLE
feat(catalog): add capability to refresh entity providers.

### DIFF
--- a/.changeset/sweet-dots-search.md
+++ b/.changeset/sweet-dots-search.md
@@ -1,0 +1,39 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-backend-module-aws': patch
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+'@backstage/plugin-catalog-backend-module-github': patch
+'@backstage/plugin-catalog-backend-module-ldap': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Add capability to refresh entity providers.
+
+Entity providers can implement `getTaskId?(): string` in order to participate
+in this feature.
+
+Existing entity providers were enabled.
+
+The refresh for providers can be triggered using the `/api/catalog/refresh` endpoint.
+
+Example: _refresh all entity providers_
+
+```
+POST /api/catalog/refresh
+{
+  "providers": "all"
+}
+```
+
+Example: _refresh selected entity providers_
+
+```
+POST /api/catalog/refresh
+{
+  "providers": ["providerName", "anotherProviderName"]
+}
+```
+
+Non-existent or non-supporting (== no `getTaskId`) entity providers will be ignored.
+
+**The permission plugin is not yet supported and all such requests will be rejected.**

--- a/plugins/catalog-backend-module-aws/api-report.md
+++ b/plugins/catalog-backend-module-aws/api-report.md
@@ -62,6 +62,8 @@ export class AwsS3EntityProvider implements EntityProvider {
   // (undocumented)
   getProviderName(): string;
   // (undocumented)
+  getTaskId(): string;
+  // (undocumented)
   refresh(logger: Logger): Promise<void>;
 }
 ```

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
@@ -104,7 +104,7 @@ export class AwsS3EntityProvider implements EntityProvider {
 
   private createScheduleFn(schedule: TaskRunner): () => Promise<void> {
     return async () => {
-      const taskId = `${this.getProviderName()}:refresh`;
+      const taskId = this.getTaskId();
       return schedule.run({
         id: taskId,
         fn: async () => {
@@ -127,6 +127,11 @@ export class AwsS3EntityProvider implements EntityProvider {
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getProviderName} */
   getProviderName(): string {
     return `awsS3-provider:${this.config.id}`;
+  }
+
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getTaskId} */
+  getTaskId(): string {
+    return `${this.getProviderName()}:refresh`;
   }
 
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */

--- a/plugins/catalog-backend-module-gerrit/api-report.md
+++ b/plugins/catalog-backend-module-gerrit/api-report.md
@@ -24,6 +24,8 @@ export class GerritEntityProvider implements EntityProvider {
   // (undocumented)
   getProviderName(): string;
   // (undocumented)
+  getTaskId(): string;
+  // (undocumented)
   refresh(logger: Logger): Promise<void>;
 }
 

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
@@ -89,10 +89,17 @@ export class GerritEntityProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(schedule);
   }
 
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getProviderName} */
   getProviderName(): string {
     return `gerrit-provider:${this.config.id}`;
   }
 
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getTaskId} */
+  getTaskId(): string {
+    return `${this.getProviderName()}:refresh`;
+  }
+
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */
   async connect(connection: EntityProviderConnection): Promise<void> {
     this.connection = connection;
     await this.scheduleFn();
@@ -100,7 +107,7 @@ export class GerritEntityProvider implements EntityProvider {
 
   private createScheduleFn(schedule: TaskRunner): () => Promise<void> {
     return async () => {
-      const taskId = `${this.getProviderName()}:refresh`;
+      const taskId = this.getTaskId();
       return schedule.run({
         id: taskId,
         fn: async () => {

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -91,6 +91,8 @@ export class GitHubOrgEntityProvider implements EntityProvider {
   ): GitHubOrgEntityProvider;
   // (undocumented)
   getProviderName(): string;
+  // (undocumented)
+  getTaskId(): string;
   read(options?: { logger?: Logger }): Promise<void>;
 }
 

--- a/plugins/catalog-backend-module-github/src/GitHubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/GitHubOrgEntityProvider.ts
@@ -149,6 +149,11 @@ export class GitHubOrgEntityProvider implements EntityProvider {
     return `GitHubOrgEntityProvider:${this.options.id}`;
   }
 
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getTaskId} */
+  getTaskId(): string {
+    return `${this.getProviderName()}:refresh`;
+  }
+
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */
   async connect(connection: EntityProviderConnection) {
     this.connection = connection;
@@ -208,7 +213,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
     }
 
     this.scheduleFn = async () => {
-      const id = `${this.getProviderName()}:refresh`;
+      const id = this.getTaskId();
       await schedule.run({
         id,
         fn: async () => {

--- a/plugins/catalog-backend-module-ldap/api-report.md
+++ b/plugins/catalog-backend-module-ldap/api-report.md
@@ -112,6 +112,8 @@ export class LdapOrgEntityProvider implements EntityProvider {
   ): LdapOrgEntityProvider;
   // (undocumented)
   getProviderName(): string;
+  // (undocumented)
+  getTaskId(): string;
   read(options?: { logger?: Logger }): Promise<void>;
 }
 

--- a/plugins/catalog-backend-module-ldap/src/processors/LdapOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-ldap/src/processors/LdapOrgEntityProvider.ts
@@ -154,6 +154,11 @@ export class LdapOrgEntityProvider implements EntityProvider {
     return `LdapOrgEntityProvider:${this.options.id}`;
   }
 
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getTaskId} */
+  getTaskId(): string {
+    return `${this.getProviderName()}:refresh`;
+  }
+
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */
   async connect(connection: EntityProviderConnection) {
     this.connection = connection;
@@ -212,7 +217,7 @@ export class LdapOrgEntityProvider implements EntityProvider {
     }
 
     this.scheduleFn = async () => {
-      const id = `${this.getProviderName()}:refresh`;
+      const id = this.getTaskId();
       await schedule.run({
         id,
         fn: async () => {

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -128,6 +128,8 @@ export class MicrosoftGraphOrgEntityProvider implements EntityProvider {
   ): MicrosoftGraphOrgEntityProvider;
   // (undocumented)
   getProviderName(): string;
+  // (undocumented)
+  getTaskId(): string;
   read(options?: { logger?: Logger }): Promise<void>;
 }
 

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
@@ -157,6 +157,11 @@ export class MicrosoftGraphOrgEntityProvider implements EntityProvider {
     return `MicrosoftGraphOrgEntityProvider:${this.options.id}`;
   }
 
+  /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getTaskId} */
+  getTaskId(): string {
+    return `${this.getProviderName()}:refresh`;
+  }
+
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */
   async connect(connection: EntityProviderConnection) {
     this.connection = connection;
@@ -215,7 +220,7 @@ export class MicrosoftGraphOrgEntityProvider implements EntityProvider {
     }
 
     this.scheduleFn = async () => {
-      const id = `${this.getProviderName()}:refresh`;
+      const id = this.getTaskId();
       await schedule.run({
         id,
         fn: async () => {

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -26,6 +26,7 @@ import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Readable } from 'stream';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { Router } from 'express';
@@ -193,6 +194,7 @@ export type CatalogEnvironment = {
   config: Config;
   reader: UrlReader;
   permissions: PermissionEvaluator | PermissionAuthorizer;
+  scheduler: PluginTaskScheduler;
 };
 
 // @alpha
@@ -416,6 +418,7 @@ export type EntityFilter =
 export interface EntityProvider {
   connect(connection: EntityProviderConnection): Promise<void>;
   getProviderName(): string;
+  getTaskId?(): string;
 }
 
 // @public

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.13.6-next.0",
+    "@backstage/backend-tasks": "^0.3.2-next.0",
     "@backstage/catalog-client": "^1.0.2",
     "@backstage/catalog-model": "^1.0.2",
     "@backstage/config": "^1.0.1",

--- a/plugins/catalog-backend/src/api/provider.ts
+++ b/plugins/catalog-backend/src/api/provider.ts
@@ -46,6 +46,8 @@ export interface EntityProviderConnection {
 export interface EntityProvider {
   /** Unique provider name used internally for caching. */
   getProviderName(): string;
+  /** Optional. ID of the scheduled task which can be used to trigger/find/... it. */
+  getTaskId?(): string;
   /** Connect is called upon initialization by the catalog engine. */
   connect(connection: EntityProviderConnection): Promise<void>;
 }

--- a/plugins/catalog-backend/src/service/AuthorizedRefreshService.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedRefreshService.ts
@@ -29,12 +29,16 @@ export class AuthorizedRefreshService implements RefreshService {
   ) {}
 
   async refresh(options: RefreshOptions) {
+    if (!options.entityRef) {
+      throw new NotAllowedError();
+    }
+
     const authorizeDecision = (
       await this.permissionApi.authorize(
         [
           {
             permission: catalogEntityRefreshPermission,
-            resourceRef: options.entityRef,
+            resourceRef: options.entityRef!,
           },
         ],
         { token: options.authorizationToken },

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -15,6 +15,7 @@
  */
 
 import { PluginDatabaseManager, UrlReader } from '@backstage/backend-common';
+import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import {
   DefaultNamespaceEntityPolicy,
   EntityPolicies,
@@ -100,6 +101,7 @@ export type CatalogEnvironment = {
   config: Config;
   reader: UrlReader;
   permissions: PermissionEvaluator | PermissionAuthorizer;
+  scheduler: PluginTaskScheduler;
 };
 
 /**
@@ -456,7 +458,11 @@ export class CatalogBuilder {
       permissionEvaluator,
     );
     const refreshService = new AuthorizedRefreshService(
-      new DefaultRefreshService({ database: processingDatabase }),
+      new DefaultRefreshService({
+        database: processingDatabase,
+        entityProviders: entityProviders,
+        scheduler: this.env.scheduler,
+      }),
       permissionEvaluator,
     );
     const router = await createRouter({

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -23,6 +23,7 @@ import {
   UrlReaders,
   useHotMemoize,
 } from '@backstage/backend-common';
+import { TaskScheduler } from '@backstage/backend-tasks';
 import { ConfigReader } from '@backstage/config';
 import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 import { Server } from 'http';
@@ -61,6 +62,7 @@ export async function startStandaloneServer(
     discovery,
     tokenManager,
   });
+  const scheduler = TaskScheduler.fromConfig(config).forPlugin('catalog');
 
   logger.debug('Creating application...');
   await applyDatabaseMigrations(await database.getClient());
@@ -70,6 +72,7 @@ export async function startStandaloneServer(
     config,
     reader,
     permissions,
+    scheduler,
   });
   const catalog = await builder.build();
 

--- a/plugins/catalog-backend/src/service/types.ts
+++ b/plugins/catalog-backend/src/service/types.ts
@@ -55,11 +55,19 @@ export interface LocationService {
  *
  * @public
  */
-export type RefreshOptions = {
-  /** The reference to a single entity that should be refreshed */
-  entityRef: string;
-  authorizationToken?: string;
-};
+export type RefreshOptions =
+  | {
+      /** The reference to a single entity that should be refreshed */
+      entityRef: string;
+      providers?: never;
+      authorizationToken?: string;
+    }
+  | {
+      entityRef?: never;
+      /** The reference to a set of to be refreshed providers or all providers. */
+      providers: 'all' | string[];
+      authorizationToken?: string;
+    };
 
 /**
  * A service that manages refreshes of entities in the catalog.


### PR DESCRIPTION
Entity providers can implement `getTaskId?(): string` in order to participate
in this feature.

Existing entity providers were enabled.

The refresh for providers can be triggered using the `/api/catalog/refresh` endpoint.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
