### PR TITLE
[Home] Fix Homepage template - mock the catalog api

### DIFF
--- a/packages/app/src/components/home/templates/DefaultTemplate.stories.tsx
+++ b/packages/app/src/components/home/templates/DefaultTemplate.stories.tsx
@@ -27,6 +27,7 @@ import {
   starredEntitiesApiRef,
   MockStarredEntitiesApi,
   entityRouteRef,
+  catalogApiRef,
 } from '@backstage/plugin-catalog-react';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { ConfigReader } from '@backstage/config';

--- a/packages/app/src/components/home/templates/DefaultTemplate.stories.tsx
+++ b/packages/app/src/components/home/templates/DefaultTemplate.stories.tsx
@@ -39,6 +39,45 @@ import { HomePageStackOverflowQuestions } from '@backstage/plugin-stack-overflow
 import { Grid, makeStyles } from '@material-ui/core';
 import React, { ComponentType } from 'react';
 
+const entities = [
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'mock-starred-entity',
+      title: 'Mock Starred Entity!',
+    },
+  },
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'mock-starred-entity-2',
+      title: 'Mock Starred Entity 2!',
+    },
+  },
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'mock-starred-entity-3',
+      title: 'Mock Starred Entity 3!',
+    },
+  },
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'mock-starred-entity-4',
+      title: 'Mock Starred Entity 4!',
+    },
+  },
+];
+
+const mockCatalogApi = {
+  getEntities: async () => ({ items: entities }),
+};
+
 const starredEntitiesApi = new MockStarredEntitiesApi();
 starredEntitiesApi.toggleStarred('component:default/example-starred-entity');
 starredEntitiesApi.toggleStarred('component:default/example-starred-entity-2');
@@ -53,6 +92,7 @@ export default {
         <>
           <TestApiProvider
             apis={[
+              [catalogApiRef, mockCatalogApi],
               [starredEntitiesApiRef, starredEntitiesApi],
               [searchApiRef, { query: () => Promise.resolve({ results: [] }) }],
               [


### PR DESCRIPTION
Signed-off-by: Emma Indal <emma.indahl@gmail.com>

## Hey, I just made a Pull Request!

The change introduced here https://github.com/backstage/backstage/pull/11343 require access to the catalog api and it was mocked for the starredEntities home page component story, but not for the homepage template. 

<img width="1728" alt="Screenshot 2022-05-26 at 15 05 06" src="https://user-images.githubusercontent.com/25153114/170493322-75bb9b8c-9ce2-4787-8a26-efa27f219a28.png">

**After**

<img width="1726" alt="Screenshot 2022-05-26 at 15 10 15" src="https://user-images.githubusercontent.com/25153114/170494311-072478be-8309-4e4c-8ef1-930d5208f282.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
