### PR TITLE
Reseting the next run time when a TaskWorker gets repersisted.

### DIFF
--- a/.changeset/thick-snails-pump.md
+++ b/.changeset/thick-snails-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Resetting the next run time when a TaskWorker gets restarted. Was only overwriting the schedule settings, but now overwriting the next runtime as well

--- a/packages/backend-tasks/src/tasks/TaskWorker.test.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.test.ts
@@ -344,6 +344,7 @@ describe('TaskWorker', () => {
 
       const before = fn1.mock.calls.length;
       await promise2;
+      await new Promise(resolve => setTimeout(resolve, 350));
       expect(fn1.mock.calls.length).toBeGreaterThan(before);
     },
     60_000,

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -194,7 +194,7 @@ export class TaskWorker {
         next_run_start_at: startAt,
       })
       .onConflict('id')
-      .merge(['settings_json']);
+      .merge(['settings_json', 'next_run_start_at']);
   }
 
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When a task would get restarted, and thus the `persistTask` called again, it would still maintain the previous cadence, rather than resetting the cadence. 

This happens most often during development, and the server is hot reloaded. Will also occur if the 'initalDelayDuration' is modified in a deployed setting.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
