### PR TITLE
Add field filters to useEntityList backend query

### DIFF
--- a/.changeset/moody-rocks-accept.md
+++ b/.changeset/moody-rocks-accept.md
@@ -1,0 +1,28 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-react': patch
+---
+
+The `useEntityList` hook has been updated to send a list of entity fields to the
+backend. This optimizes the catalog query, especially in the case of a catalog
+with many API definitions.
+
+This is a transparent change _unless_ you have added custom components that use
+the `useEntityList` hook. If this applies to you, you can update those
+components to use the new exported `addEntityFields` function to add any entity
+fields used by your component:
+
+```diff
+export function MyCustomPicker = () => {
+-    const { updateFilters, filters } = useEntityList();
++    const { updateFilters, filters, addEntityFields } = useEntityList();
+    const [values, setValues] = useState<string[]>([]);
+
++    useEffect(() => addEntityFields(['spec.otherfield']), [addEntityFields]);
+    useEffect(() => {
+        // filter implementation that uses spec.otherfield
+        updateFilters({ val: new MyCustomFilter(values) });
+    }, [values]);
+    ...
+}
+```

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -204,6 +204,7 @@ export type EntityListContextProps<
       | Partial<EntityFilters>
       | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
   ) => void;
+  addEntityFields: (fields: string[]) => void;
   queryParameters: Partial<Record<keyof EntityFilters, string | string[]>>;
   loading: boolean;
   error?: Error;

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -50,11 +50,14 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 export const EntityLifecyclePicker = () => {
   const classes = useStyles();
   const {
+    addEntityFields,
     updateFilters,
     backendEntities,
     filters,
     queryParameters: { lifecycles: lifecyclesParameter },
   } = useEntityList();
+
+  useEffect(() => addEntityFields(['spec.lifecycle']), [addEntityFields]);
 
   const queryParamLifecycles = useMemo(
     () => [lifecyclesParameter].flat().filter(Boolean) as string[],

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -52,11 +52,14 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 export const EntityOwnerPicker = () => {
   const classes = useStyles();
   const {
+    addEntityFields,
     updateFilters,
     backendEntities,
     filters,
     queryParameters: { owners: ownersParameter },
   } = useEntityList();
+
+  useEffect(() => addEntityFields(['spec.owner']), [addEntityFields]);
 
   const queryParamOwners = useMemo(
     () => [ownersParameter].flat().filter(Boolean) as string[],

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -52,10 +52,13 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 export const EntityTagPicker = () => {
   const classes = useStyles();
   const {
+    addEntityFields,
     updateFilters,
     filters,
     queryParameters: { tags: tagsParameter },
   } = useEntityList();
+
+  useEffect(() => addEntityFields(['metadata.tags']), [addEntityFields]);
 
   const catalogApi = useApi(catalogApiRef);
   const { value: availableTags } = useAsync(async () => {

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -133,10 +133,13 @@ export const UserListPicker = (props: UserListPickerProps) => {
   const {
     filters,
     updateFilters,
+    addEntityFields,
     backendEntities,
     queryParameters: { kind: kindParameter, user: userParameter },
     loading: loadingBackendEntities,
   } = useEntityList();
+
+  useEffect(() => addEntityFields(['relationships']), [addEntityFields]);
 
   // Remove group items that aren't in availableFilters and exclude
   // any now-empty groups.

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -40,7 +40,10 @@ export function useEntityTypeFilter(): {
     filters: { kind: kindFilter, type: typeFilter },
     queryParameters: { type: typeParameter },
     updateFilters,
+    addEntityFields,
   } = useEntityList();
+
+  useEffect(() => addEntityFields(['spec.type']), [addEntityFields]);
 
   const flattenedQueryTypes = useMemo(
     () => [typeParameter].flat().filter(Boolean) as string[],

--- a/plugins/catalog-react/src/testUtils/providers.tsx
+++ b/plugins/catalog-react/src/testUtils/providers.tsx
@@ -73,6 +73,7 @@ export const MockEntityListContextProvider = ({
       backendEntities: value?.backendEntities ?? defaultValues.backendEntities,
       updateFilters: value?.updateFilters ?? updateFilters,
       filters,
+      addEntityFields: jest.fn(),
       loading: value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
       error: value?.error,

--- a/plugins/catalog-react/src/utils/filters.ts
+++ b/plugins/catalog-react/src/utils/filters.ts
@@ -36,3 +36,8 @@ export function reduceEntityFilters(
       filter => !filter.filterEntity || filter.filterEntity(entity),
     );
 }
+
+export function uniqueEntityFields(fields: string[]) {
+  const uniqueFields = [...new Set(fields)];
+  return uniqueFields.sort();
+}


### PR DESCRIPTION
The `useEntityList` hook was not supplying `fields` in the `getEntities` query, which causes some performance issues with very large catalogs or those with heavy fields (such as the [definition field](https://backstage.io/docs/features/software-catalog/descriptor-format#specdefinition-required) on API kinds).

This adds an `addEntityFields` method in the hook that allows components to register additional entity fields for the query, and implements this for the UI pickers and CatalogTable.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
