### PR TITLE
fix: awsalb provider fix AuthenticationError

### DIFF
--- a/.changeset/tender-shrimps-warn.md
+++ b/.changeset/tender-shrimps-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Revert code used to get the aws-alb public key


### PR DESCRIPTION
Signed-off-by: Marco Crivellaro <marco.crive@gmail.com>

## Hey, I just made a Pull Request!

Fixes a bug introduced with [Update jose to 4.6.0](https://github.com/backstage/backstage/commit/1624b52168f32978a5d87ad5c0f931fc1e70c6fa) where all calls to `/api/auth/awsalb/refresh` return `401` with following response body:

```json
{"error":{"name":"AuthenticationError","message":"Exception occurred during AWS ALB token refresh; caused by Error: Exception occurred during JWT processing: TypeError: Cannot read properties of undefined (reading 'keyCache')","cause":{"name":"Error","message":"Exception occurred during JWT processing: TypeError: Cannot read properties of undefined (reading 'keyCache')","stack":"Error: Exception occurred during JWT processing: TypeError: Cannot read properties of undefined (reading 'keyCache')\n    at AwsAlbAuthProvider.getResult (/app/node_modules/@backstage/plugin-auth-backend/dist/index.cjs.js:822:13)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at runNextTicks (node:internal/process/task_queues:65:3)\n    at processImmediate (node:internal/timers:437:9)\n    at async AwsAlbAuthProvider.refresh (/app/node_modules/@backstage/plugin-auth-backend/dist/index.cjs.js:779:22)"}},"request":{"method":"GET","url":"/api/auth/awsalb/refresh"},"response":{"statusCode":401}}
```

This fix reverts the code used to get the key

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
