### PR TITLE
Prevent typing warnings/errors by creating a Duration object

### DIFF
--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -39,6 +39,7 @@ schedule it:
 ```diff
  // packages/backend/src/plugins/catalog.ts
 +import { GitHubOrgEntityProvider } from '@backstage/plugin-catalog-backend-module-github';
++import {Duration} from 'luxon';
 
  export default async function createPlugin(
    env: PluginEnvironment,
@@ -53,8 +54,8 @@ schedule it:
 +      orgUrl: 'https://github.com/backstage',
 +      logger: env.logger,
 +      schedule: env.scheduler.createScheduledTaskRunner({
-+        frequency: { minutes: 60 },
-+        timeout: { minutes: 15 },
++        frequency: Duration.fromObject({minutes: 60}),
++        timeout: Duration.fromObject({minutes: 15})
 +      }),
 +    }),
 +  );


### PR DESCRIPTION
When using the current code, linters seem to be complaining about the frequency and timeout objects passed to `createScheduledTaskRunner`. When we create the Duration objects the way proposed, these errors disappear.

## Hey, I just made a Pull Request!

Updated docs

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
