### PR TITLE
fix: EntityPage tab scrolling overflow bug on Firefox

### DIFF
--- a/.changeset/lovely-gifts-itch.md
+++ b/.changeset/lovely-gifts-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix EntityPage tab scrolling overflow bug on Firefox

--- a/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
+++ b/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
@@ -35,6 +35,7 @@ const useStyles = makeStyles(
       gridArea: 'pageSubheader',
       backgroundColor: theme.palette.background.paper,
       paddingLeft: theme.spacing(3),
+      minWidth: 0,
     },
     defaultTab: {
       padding: theme.spacing(3, 3),


### PR DESCRIPTION
## Hey, I just made a Pull Request!
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/1923679/171007648-8adfe220-4edd-43e0-99a0-403031c3d768.png">

- [fix: HeaderTabs Firefox overflow scroll bug with min-width: 0](https://github.com/backstage/backstage/commit/a69690f4009061bf59342af19feb59e76e0ae322)
  - Fixes #11694


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
