### PR TITLE
[Kubernetes Plugin] Show more details on Requests/Limits

### DIFF
--- a/.changeset/fluffy-wasps-chew.md
+++ b/.changeset/fluffy-wasps-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+show request/limit CPU and Memory on the UI

--- a/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
@@ -108,10 +108,10 @@ describe('PodsTable', () => {
     expect(getByText('1/1')).toBeInTheDocument();
     expect(getByText('0')).toBeInTheDocument();
     expect(getByText('OK')).toBeInTheDocument();
-    expect(getByText('requests: 99%')).toBeInTheDocument();
-    expect(getByText('limits: 99%')).toBeInTheDocument();
-    expect(getByText('requests: 1%')).toBeInTheDocument();
-    expect(getByText('limits: 0%')).toBeInTheDocument();
+    expect(getByText('requests: 99% of 50m')).toBeInTheDocument();
+    expect(getByText('limits: 99% of 50m')).toBeInTheDocument();
+    expect(getByText('requests: 1% of 64MiB')).toBeInTheDocument();
+    expect(getByText('limits: 0% of 128MiB')).toBeInTheDocument();
   });
   it('should render placehoplder when empty metrics context', async () => {
     const podNameToClientPodStatus = new Map<string, ClientPodStatus>();

--- a/plugins/kubernetes/src/utils/pod.test.tsx
+++ b/plugins/kubernetes/src/utils/pod.test.tsx
@@ -15,7 +15,11 @@
  */
 
 import React from 'react';
-import { currentToDeclaredResourceToPerc, podStatusToCpuUtil } from './pod';
+import {
+  currentToDeclaredResourceToPerc,
+  podStatusToCpuUtil,
+  podStatusToMemoryUtil,
+} from './pod';
 import { SubvalueCell } from '@backstage/core-components';
 
 describe('pod', () => {
@@ -46,7 +50,30 @@ describe('pod', () => {
         },
       } as any);
       expect(result).toStrictEqual(
-        <SubvalueCell subvalue="limits: 50%" value="requests: 99%" />,
+        <SubvalueCell
+          subvalue="limits: 50% of 100m"
+          value="requests: 99% of 50m"
+        />,
+      );
+    });
+  });
+  describe('podStatusToMemoryUtil', () => {
+    it('does use correct units', () => {
+      const result = podStatusToMemoryUtil({
+        memory: {
+          // ~91.5 MiB
+          currentUsage: '95948800',
+          // 320 MiB
+          limitTotal: '335544320',
+          // 192 MiB
+          requestTotal: '201326592',
+        },
+      } as any);
+      expect(result).toStrictEqual(
+        <SubvalueCell
+          subvalue="limits: 28% of 320MiB"
+          value="requests: 47% of 192MiB"
+        />,
       );
     });
   });

--- a/plugins/kubernetes/src/utils/pod.tsx
+++ b/plugins/kubernetes/src/utils/pod.tsx
@@ -130,6 +130,10 @@ export const currentToDeclaredResourceToPerc = (
   return `${(numerator * BigInt(100)) / denominator}%`;
 };
 
+const formatMilicores = (value: string | number): string => {
+  return `${parseFloat(value.toString()) * 1000}m`;
+};
+
 export const podStatusToCpuUtil = (podStatus: ClientPodStatus): ReactNode => {
   const cpuUtil = podStatus.cpu;
 
@@ -146,13 +150,17 @@ export const podStatusToCpuUtil = (podStatus: ClientPodStatus): ReactNode => {
       value={`requests: ${currentToDeclaredResourceToPerc(
         currentUsage,
         cpuUtil.requestTotal,
-      )}`}
+      )} of ${formatMilicores(cpuUtil.requestTotal)}`}
       subvalue={`limits: ${currentToDeclaredResourceToPerc(
         currentUsage,
         cpuUtil.limitTotal,
-      )}`}
+      )} of ${formatMilicores(cpuUtil.limitTotal)}`}
     />
   );
+};
+
+const bytesToMiB = (value: string | number): string => {
+  return `${parseFloat(value.toString()) / 1024 / 1024}MiB`;
 };
 
 export const podStatusToMemoryUtil = (
@@ -165,11 +173,11 @@ export const podStatusToMemoryUtil = (
       value={`requests: ${currentToDeclaredResourceToPerc(
         memUtil.currentUsage,
         memUtil.requestTotal,
-      )}`}
+      )} of ${bytesToMiB(memUtil.requestTotal)}`}
       subvalue={`limits: ${currentToDeclaredResourceToPerc(
         memUtil.currentUsage,
         memUtil.limitTotal,
-      )}`}
+      )} of ${bytesToMiB(memUtil.limitTotal)}`}
     />
   );
 };


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Hey, I just made a Pull Request!

Implementation of #11588

This PR essentially adds more details about what is the current Request/Limit, for both CPU and Memory.

Before:

![](https://user-images.githubusercontent.com/94755/169075566-2f7e70a5-a69c-4a94-9cc6-b49f4f9cfe67.png)

After:

![](https://user-images.githubusercontent.com/94755/169075942-43da3bb6-5589-4be8-a397-79d481ad14ed.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
