### PR TITLE
feat: add option to not protect the default branch

### DIFF
--- a/.changeset/shiny-windows-roll.md
+++ b/.changeset/shiny-windows-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add an option to not protect the default branch.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -270,6 +270,7 @@ export function createPublishGithubAction(options: {
   description?: string | undefined;
   access?: string | undefined;
   defaultBranch?: string | undefined;
+  protectDefaultBranch?: boolean | undefined;
   deleteBranchOnMerge?: boolean | undefined;
   gitCommitMessage?: string | undefined;
   gitAuthorName?: string | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -727,4 +727,26 @@ describe('publish:github', () => {
       requiredStatusCheckContexts: [],
     });
   });
+
+  it('should not call enableBranchProtectionOnDefaultRepoBranch with protectDefaultBranch disabled', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        name: 'repository',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        protectDefaultBranch: false,
+      },
+    });
+
+    expect(enableBranchProtectionOnDefaultRepoBranch).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -46,6 +46,7 @@ export function createPublishGithubAction(options: {
     description?: string;
     access?: string;
     defaultBranch?: string;
+    protectDefaultBranch?: boolean;
     deleteBranchOnMerge?: boolean;
     gitCommitMessage?: string;
     gitAuthorName?: string;
@@ -110,6 +111,11 @@ export function createPublishGithubAction(options: {
             title: 'Default Branch',
             type: 'string',
             description: `Sets the default branch on the repository. The default value is 'master'`,
+          },
+          protectDefaultBranch: {
+            title: 'Protect Default Branch',
+            type: 'boolean',
+            description: `Protect the default branch after creating the repository. The default value is 'true'`,
           },
           deleteBranchOnMerge: {
             title: 'Delete Branch On Merge',
@@ -209,6 +215,7 @@ export function createPublishGithubAction(options: {
         requiredStatusCheckContexts = [],
         repoVisibility = 'private',
         defaultBranch = 'master',
+        protectDefaultBranch = true,
         deleteBranchOnMerge = false,
         gitCommitMessage = 'initial commit',
         gitAuthorName,
@@ -360,21 +367,23 @@ export function createPublishGithubAction(options: {
         gitAuthorInfo,
       });
 
-      try {
-        await enableBranchProtectionOnDefaultRepoBranch({
-          owner,
-          client,
-          repoName: newRepo.name,
-          logger: ctx.logger,
-          defaultBranch,
-          requireCodeOwnerReviews,
-          requiredStatusCheckContexts,
-        });
-      } catch (e) {
-        assertError(e);
-        ctx.logger.warn(
-          `Skipping: default branch protection on '${newRepo.name}', ${e.message}`,
-        );
+      if (protectDefaultBranch) {
+        try {
+          await enableBranchProtectionOnDefaultRepoBranch({
+            owner,
+            client,
+            repoName: newRepo.name,
+            logger: ctx.logger,
+            defaultBranch,
+            requireCodeOwnerReviews,
+            requiredStatusCheckContexts,
+          });
+        } catch (e) {
+          assertError(e);
+          ctx.logger.warn(
+            `Skipping: default branch protection on '${newRepo.name}', ${e.message}`,
+          );
+        }
       }
 
       ctx.output('remoteUrl', remoteUrl);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a new parameter `protectDefaultBranch`, defaulting to `true`, to the `publish:github` action. This allows projects to be published without branch protection.

The need for this has arisen from some old projects we have created templates for, which need the default branch not to be protected.

This is my first PR to the project, so all feedback is welcome :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] N/A Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] N/A Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
