### PR TITLE
Cloudify Plugin metadata updates

### DIFF
--- a/microsite/data/plugins/cloudify.yaml
+++ b/microsite/data/plugins/cloudify.yaml
@@ -3,7 +3,7 @@ title: Cloudify
 author: Cloudify
 authorUrl: https://cloudify.co/
 category: Orchestration
-description: Load blueprints from desired Cloudify Manager instance
-documentation: https://github.com/Cloudify-PS/backstage-cloudify-plugin#readme
+description: Cloudify provides a remote execution and environment management backend that handles the provisioning and continuous update of Kubernetes, Terraform, Ansible, CloudFormation, Azure ARM, VRO based environments through a single API endpoint.
+documentation: https://github.com/cloudify-cosmo/backstage-cloudify-plugin#readme
 iconUrl: https://avatars.githubusercontent.com/u/6260555?s=200&v=4
 npmPackageName: 'plugin-cloudify'


### PR DESCRIPTION
Cloudify Plugin metadata was aligned to Cloudify's requirements:

- _description_ - updated description to align with the suggestions of Cloudify's Founder and CTO.
- _documentation_ - the repository was migrated to [cloudify-cosmo](https://github.com/cloudify-cosmo/backstage-cloudify-plugin) where all official public repositories are stored.
