### PR TITLE
[pagerduty] Use IdentityApi to provide auth token for pagerduty API calls

### DIFF
--- a/.changeset/eight-ducks-beg.md
+++ b/.changeset/eight-ducks-beg.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-pagerduty': patch
+'@backstage/plugin-pagerduty': minor
 ---
 
-Use identityApi to provide auth token for pagerduty API calls.
+**Breaking**: Use identityApi to provide auth token for pagerduty API calls.

--- a/.changeset/eight-ducks-beg.md
+++ b/.changeset/eight-ducks-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-pagerduty': patch
+---
+
+Use identityApi to provide auth token for pagerduty API calls.

--- a/plugins/pagerduty/api-report.md
+++ b/plugins/pagerduty/api-report.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ConfigApi } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { IdentityApi } from '@backstage/core-plugin-api';
 import { ReactNode } from 'react';
 
 // Warning: (ae-missing-release-tag) "EntityPagerDutyCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -45,6 +46,7 @@ export class PagerDutyClient implements PagerDutyApi {
   static fromConfig(
     configApi: ConfigApi,
     discoveryApi: DiscoveryApi,
+    identityApi: IdentityApi,
   ): PagerDutyClient;
   // Warning: (ae-forgotten-export) The symbol "ChangeEvent" needs to be exported by the entry point index.d.ts
   //

--- a/plugins/pagerduty/src/api/types.ts
+++ b/plugins/pagerduty/src/api/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { Incident, ChangeEvent, OnCall, Service } from '../components/types';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
 
 export type TriggerAlarmRequest = {
   integrationKey: string;
@@ -74,6 +74,7 @@ export type OnCallsResponse = {
 export type ClientApiConfig = {
   eventsBaseUrl?: string;
   discoveryApi: DiscoveryApi;
+  identityApi: IdentityApi;
 };
 
 export type RequestOptions = {

--- a/plugins/pagerduty/src/plugin.ts
+++ b/plugins/pagerduty/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   discoveryApiRef,
   configApiRef,
   createComponentExtension,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({
@@ -32,9 +33,13 @@ export const pagerDutyPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: pagerDutyApiRef,
-      deps: { discoveryApi: discoveryApiRef, configApi: configApiRef },
-      factory: ({ configApi, discoveryApi }) =>
-        PagerDutyClient.fromConfig(configApi, discoveryApi),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+        identityApi: identityApiRef,
+      },
+      factory: ({ configApi, discoveryApi, identityApi }) =>
+        PagerDutyClient.fromConfig(configApi, discoveryApi, identityApi),
     }),
   ],
 });


### PR DESCRIPTION
Signed-off-by: Isaiah Thiessen <isaiah.thiessen@telus.com>
Co-authored-by: Joel Cayne <joel.cayne@telus.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Currently the pagerduty plugin doesn't send an auth token for API requests. This adds IdentityApi support to the pagerduty plugin to enable it to pass auth tokens to pagerduty API calls through the backstage proxy.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

(re-creating https://github.com/backstage/backstage/pull/11678)