### PR TITLE
docs: fix cost insights example app config

### DIFF
--- a/.changeset/good-squids-rest.md
+++ b/.changeset/good-squids-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fix broken app-config in the example in the README

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -26,6 +26,8 @@ yarn add --cwd packages/app @backstage/plugin-cost-insights
 
 2. Create a CostInsights client. Clients must implement the [CostInsightsApi](https://github.com/backstage/backstage/blob/master/plugins/cost-insights/src/api/CostInsightsApi.ts) interface. Create your own or [use a template](https://github.com/backstage/backstage/blob/master/plugins/cost-insights/src/example/templates/CostInsightsClient.ts) to get started.
 
+Tip: You can also use the `ExampleCostInsightsClient` from `@backstage/plugin-cost-insights` to see how the plugin looks with some mock data.
+
 ```ts
 // path/to/CostInsightsClient.ts
 import { CostInsightsApi } from '@backstage/plugin-cost-insights';

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -171,16 +171,15 @@ costInsights:
       name: Some Other Cloud Product
       icon: data
   currencies:
-    metricA:
-      currencyA:
-        label: Currency A
-        unit: Unit A
-      currencyB:
-        label: Currency B
-        kind: CURRENCY_B
-        unit: Unit B
-        prefix: B
-        rate: 3.5
+    currencyA:
+      label: Currency A
+      unit: Unit A
+    currencyB:
+      label: Currency B
+      kind: CURRENCY_B
+      unit: Unit B
+      prefix: B
+      rate: 3.5
 ```
 
 ## Alerts


### PR DESCRIPTION
The current config doesn't match with the schema. This is the error we get when we use the example as it is

```
Error: Configuration does not match schema

  Config must have required property 'label' { missingProperty=label } at /costInsights/currencies/metricA
  Config must have required property 'unit' { missingProperty=unit } at /costInsights/currencies/metricA
```