### PR TITLE
Add filter property to MyGroupsSidebarItem

### DIFF
--- a/.changeset/spicy-forks-return.md
+++ b/.changeset/spicy-forks-return.md
@@ -2,4 +2,25 @@
 '@backstage/plugin-org': patch
 ---
 
-Added the ability to use an additional `filter` when fetching groups in `MyGroupsSidebarItem` component
+Added the ability to use an additional `filter` when fetching groups in `MyGroupsSidebarItem` component. Example:
+
+```diff
+// app/src/components/Root/Root.tsx
+<SidebarPage>
+    <Sidebar>
+      //...
+      <SidebarGroup label="Menu" icon={<MenuIcon />}>
+        {/* Global nav, not org-specific */}
+        //...
+        <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
+        <MyGroupsSidebarItem
+          singularTitle="My Squad"
+          pluralTitle="My Squads"
+          icon={GroupIcon}
++         filter={{ 'spec.type': 'team' }}
+        />
+       //...
+      </SidebarGroup>
+    </ Sidebar>
+</SidebarPage>
+```

--- a/.changeset/spicy-forks-return.md
+++ b/.changeset/spicy-forks-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Added the ability to use an additional `filter` when fetching groups in `MyGroupsSidebarItem` component

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -50,6 +50,7 @@ export const MyGroupsSidebarItem: (props: {
   singularTitle: string;
   pluralTitle: string;
   icon: IconComponent;
+  filter?: Record<string, string | symbol | (string | symbol)[]>;
 }) => JSX.Element | null;
 
 // @public (undocumented)

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
@@ -196,4 +196,92 @@ describe('MyGroupsSidebarItem Test', () => {
       expect(rendered.getByLabelText('My Squads')).toBeInTheDocument();
     });
   });
+
+  describe('When an additional filter is not provided', () => {
+    it('catalogApi.getEntities() should be called with the default filter', async () => {
+      const identityApi: Partial<IdentityApi> = {
+        getBackstageIdentity: async () => ({
+          type: 'user',
+          userEntityRef: 'user:default/guest',
+          ownershipEntityRefs: ['user:default/guest'],
+        }),
+      };
+      const mockCatalogApi: Partial<CatalogApi> = {
+        getEntities: jest.fn(),
+      };
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [identityApiRef, identityApi],
+            [catalogApiRef, mockCatalogApi],
+          ]}
+        >
+          <MyGroupsSidebarItem
+            singularTitle="My Squad"
+            pluralTitle="My Squads"
+            icon={GroupIcon}
+          />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+      expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
+        filter: [
+          {
+            kind: 'group',
+            'relations.hasMember': 'user:default/guest',
+          },
+        ],
+        fields: ['metadata', 'kind'],
+      });
+    });
+  });
+
+  describe('When an additional filter is provided', () => {
+    it('catalogApi.getEntities() should be called with an additional filter item', async () => {
+      const identityApi: Partial<IdentityApi> = {
+        getBackstageIdentity: async () => ({
+          type: 'user',
+          userEntityRef: 'user:default/guest',
+          ownershipEntityRefs: ['user:default/guest'],
+        }),
+      };
+      const mockCatalogApi: Partial<CatalogApi> = {
+        getEntities: jest.fn(),
+      };
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [identityApiRef, identityApi],
+            [catalogApiRef, mockCatalogApi],
+          ]}
+        >
+          <MyGroupsSidebarItem
+            singularTitle="My Squad"
+            pluralTitle="My Squads"
+            icon={GroupIcon}
+            filter={{ 'spec.type': 'team' }}
+          />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+      expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
+        filter: [
+          {
+            kind: 'group',
+            'relations.hasMember': 'user:default/guest',
+            'spec.type': 'team',
+          },
+        ],
+        fields: ['metadata', 'kind'],
+      });
+    });
+  });
 });

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
@@ -45,8 +45,9 @@ export const MyGroupsSidebarItem = (props: {
   singularTitle: string;
   pluralTitle: string;
   icon: IconComponent;
+  filter?: Record<string, string | symbol | (string | symbol)[]>;
 }) => {
-  const { singularTitle, pluralTitle, icon } = props;
+  const { singularTitle, pluralTitle, icon, filter } = props;
 
   const identityApi = useApi(identityApiRef);
   const catalogApi: CatalogApi = useApi(catalogApiRef);
@@ -56,7 +57,13 @@ export const MyGroupsSidebarItem = (props: {
     const profile = await identityApi.getBackstageIdentity();
 
     const response = await catalogApi.getEntities({
-      filter: [{ kind: 'group', 'relations.hasMember': profile.userEntityRef }],
+      filter: [
+        {
+          kind: 'group',
+          'relations.hasMember': profile.userEntityRef,
+          ...(filter ?? {}),
+        },
+      ],
       fields: ['metadata', 'kind'],
     });
 


### PR DESCRIPTION
Signed-off-by: kielosz <kielosz@gmail.com>

## Hey, I just made a Pull Request!

Added the possibility to provide an additional filter when using `MyGroupsSidebarItem`, so we can have a customized view, e.g. some companies may want to filter by `spec.type` to display only certain types of groups:

``` diff
// app/src/components/Root/Root.tsx
<SidebarPage>
    <Sidebar>
      //...
      <SidebarGroup label="Menu" icon={<MenuIcon />}>
        {/* Global nav, not org-specific */}
        //...
        <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
        <MyGroupsSidebarItem
          singularTitle="My Squad"
          pluralTitle="My Squads"
          icon={GroupIcon}
+         filter={{ 'spec.type': 'team' }}
        />
       //...
      </SidebarGroup>
    </ Sidebar>
</SidebarPage>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
