### PR TITLE
feat(techdocs): use entity title as label in header

### DIFF
--- a/.changeset/polite-ligers-hang.md
+++ b/.changeset/polite-ligers-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Use entity title as label in `TechDocsReaderPageHeader` if available

--- a/.changeset/ten-wombats-reply.md
+++ b/.changeset/ten-wombats-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Update default mock

--- a/plugins/techdocs-addons-test-utils/src/test-utils.tsx
+++ b/plugins/techdocs-addons-test-utils/src/test-utils.tsx
@@ -82,7 +82,7 @@ type TechDocsAddonTesterOptions = {
 
 const defaultOptions: TechDocsAddonTesterOptions = {
   dom: <></>,
-  entity: {},
+  entity: { metadata: { name: '' } },
   metadata: {},
   componentId: 'docs',
   apis: [],

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -110,6 +110,7 @@ export const TechDocsReaderPageHeader = (
           <EntityRefLink
             color="inherit"
             entityRef={entityRef}
+            title={entityMetadata?.metadata.title}
             defaultKind="Component"
           />
         }


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

| Before | After |
| ------- | ---- |
| ![Screen Shot 2022-06-01 at 10 50 17 AM](https://user-images.githubusercontent.com/6998196/171436535-44f89bcd-8ac5-446e-b11d-555b043b8612.png) | ![Screen Shot 2022-06-01 at 10 49 57 AM](https://user-images.githubusercontent.com/6998196/171436593-49ee0a9c-0c77-4514-bf10-a24745968a8a.png) |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
