### PR TITLE
Remove flex-wrap when the site is rendered on smaller devices

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -1227,3 +1227,13 @@ code {
 h3.collapsible span.arrow {
   margin-right: 4px;
 }
+
+@media only screen and (max-width: 767px) {
+  .navigationSlider .slidingNav ul {
+    flex-wrap: nowrap;
+  }
+
+  .navPusher {
+    padding-top: 50px;
+  }
+}


### PR DESCRIPTION
Signed-off-by: liverday <vitor.medeiro10@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
Improved the mobile experience on Microsite navigation menu, following the issue: https://github.com/backstage/backstage/issues/10557

|Before|After|
|-|-|
|![Before change menu](https://user-images.githubusercontent.com/9805744/171448736-c7fdb0b5-b6f6-422b-94ce-6c520557e071.png)|![After Change Menu](https://user-images.githubusercontent.com/9805744/171449003-b266333a-1ee7-424c-a60b-61f1044d31e7.png)|

This make the `overflow: auto` works like a charm with horizontal scroll. The hamburger menu is harder because Docusaurus doesn't have support for this change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
