### PR TITLE
techdocs-cli: fix the legacyCopyReadmeMdToIndexMd flag in techdocs-cli generate

### DIFF
--- a/.changeset/happy-boxes-melt.md
+++ b/.changeset/happy-boxes-melt.md
@@ -1,0 +1,6 @@
+---
+'@techdocs/cli': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fix the flag parsing for `legacyCopyReadmeMdToIndexMd` in `techdocs-cli generate` command, and decouple it's logic from the `techdocs-ref` flag.

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -57,8 +57,8 @@ export default async function generate(opts: OptionValues) {
         runIn: opts.docker ? 'docker' : 'local',
         dockerImage,
         pullImage,
-        legacyCopyReadmeMdToIndexMd,
         mkdocs: {
+          legacyCopyReadmeMdToIndexMd,
           omitTechdocsCorePlugin,
         },
       },

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -111,10 +111,10 @@ export class TechdocsGenerator implements GeneratorBase {
         parsedLocationAnnotation,
         this.scmIntegrations,
       );
+    }
 
-      if (this.options.legacyCopyReadmeMdToIndexMd) {
-        await patchIndexPreBuild({ inputDir, logger: childLogger, docsDir });
-      }
+    if (this.options.legacyCopyReadmeMdToIndexMd) {
+      await patchIndexPreBuild({ inputDir, logger: childLogger, docsDir });
     }
 
     if (!this.options.omitTechdocsCoreMkdocsPlugin) {


### PR DESCRIPTION
Fix #11838.

Signed-off-by: Mengnan Gong <namco1992@gmail.com>

## Hey, I just made a Pull Request!

As the problem described in #11838, the `legacyCopyReadmeMdToIndexMd` is misplaced in the config, therefore the value provided is not picked up when initializing the generator.

We also moved the corresponding logic out from `if (parsedLocationAnnotation)` because:
1. The description of the `techdocs-ref` flag says "It is completely fine to skip this as it is only being used to set repo_url in mkdocs.yml if not found.", which is not true in this case, because it also controls whether the `legacyCopyReadmeMdToIndexMd` takes effect or not.
2. `legacyCopyReadmeMdToIndexMd` should have nothing to do with the `parsedLocationAnnotation` logic

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
