### PR TITLE
cli: fix missing trailing / in public path output config

### DIFF
--- a/.changeset/calm-timers-wonder.md
+++ b/.changeset/calm-timers-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix the public path configuration of the frontend app build so that a trailing `/` is always appended when needed.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -89,6 +89,7 @@ export async function createConfig(
 
   const baseUrl = frontendConfig.getString('app.baseUrl');
   const validBaseUrl = new URL(baseUrl);
+  const publicPath = validBaseUrl.pathname.replace(/\/$/, '');
   if (checksEnabled) {
     plugins.push(
       new ForkTsCheckerWebpackPlugin({
@@ -121,7 +122,7 @@ export async function createConfig(
     new HtmlWebpackPlugin({
       template: paths.targetHtml,
       templateParameters: {
-        publicPath: validBaseUrl.pathname.replace(/\/$/, ''),
+        publicPath,
         config: frontendConfig,
       },
     }),
@@ -194,7 +195,7 @@ export async function createConfig(
     },
     output: {
       path: paths.targetDist,
-      publicPath: validBaseUrl.pathname,
+      publicPath: `${publicPath}/`,
       filename: isDev ? '[name].js' : 'static/[name].[fullhash:8].js',
       chunkFilename: isDev
         ? '[name].chunk.js'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Right now you have to have a trailing `/` in the `app.baseUrl` if you host the app on a path other than `/`, or chunk fetches for e.g. a baseUrl of `https://localhost/foo` will end up being `/foostatic/...`. This makes sure the public path always ends with a `/` in the output config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
