### PR TITLE
[Search] Properly name versioned search modal context

### DIFF
--- a/.changeset/search-generals-gathered.md
+++ b/.changeset/search-generals-gathered.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fixed a bug that could cause analytics events in other parts of Backstage to capture nonsensical values resembling search modal state under some circumstances.

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -37,7 +37,7 @@ export type SearchModalValue = {
 
 const SearchModalContext = createVersionedContext<{
   1: SearchModalValue | undefined;
-}>('analytics-context');
+}>('search-modal-context');
 
 /**
  * Props for the SearchModalProvider.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

An internal Backstage user reported strange analytics behavior, which upon investigation appears to have stemmed from a badly named versioned context.  Whoops!

This is a follow-up to #11525 and #11541

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
