### PR TITLE
cli/create-github-app: Add members to permission selection list

### DIFF
--- a/.changeset/green-parents-pay.md
+++ b/.changeset/green-parents-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Improved the `create-github-app` permissions selection prompt by converting it into a multi-select with clearer descriptions. The `members` permission is now also included in the list which is required for ingesting user data into the catalog.


### PR DESCRIPTION
Improved the `create-github-app` permissions selection prompt by converting it into a multi-select with clearer descriptions. The `members` permission is now also included in the list which is required for ingesting user data into the catalog.