### PR TITLE
[Techdocs] Reorder tab title to have the site name first

### DIFF
--- a/.changeset/tender-weeks-help.md
+++ b/.changeset/tender-weeks-help.md
@@ -2,5 +2,5 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-Updated `swagger-ui-react` to 4.11.1 in order to address a [XSS 
+Updated `swagger-ui-react` to 4.11.1 in order to address a [XSS
 vulnerability](https://github.com/advisories/GHSA-hqq7-2q2v-82xq) in `@braintree/sanitize-url`

--- a/.changeset/tender-weeks-help.md
+++ b/.changeset/tender-weeks-help.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Updated `swagger-ui-react` to 4.11.1 in order to address a [XSS 
+vulnerability](https://github.com/advisories/GHSA-hqq7-2q2v-82xq) in `@braintree/sanitize-url`

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -50,7 +50,7 @@
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4",
-    "swagger-ui-react": "^4.1.3"
+    "swagger-ui-react": "^4.11.1"
   },
   "peerDependencies": {
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -91,7 +91,7 @@ export const TechDocsReaderPageHeader = (
   }, [metadata, setTitle, setSubtitle]);
 
   const appTitle = configApi.getOptional('app.title') || 'Backstage';
-  const tabTitle = [subtitle, title, appTitle].filter(Boolean).join(' | ');
+  const tabTitle = [title, subtitle, appTitle].filter(Boolean).join(' | ');
 
   const { locationMetadata, spec } = entityMetadata || {};
   const lifecycle = spec?.lifecycle;

--- a/yarn.lock
+++ b/yarn.lock
@@ -24157,7 +24157,7 @@ swagger-client@^3.18.5:
     traverse "~0.6.6"
     url "~0.11.0"
 
-swagger-ui-react@^4.1.3:
+swagger-ui-react@^4.11.1:
   version "4.12.0"
   resolved "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-4.12.0.tgz#bfdf67bd0679fdd62ec3fb98bd827afb81fb7fe6"
   integrity sha512-pkSkUe4WVb7omoScK8GG2qgD6LxwZEIA+fKcxeACC7PCW52vFEjle6WO6lFOLj1JmfWriL7Ngi0+wJtVjfhnWw==


### PR DESCRIPTION
Fixes https://github.com/backstage/backstage/issues/11468

Makes sense to have the Site name first and also be consistent with the entity pages