### PR TITLE
[Techdocs] Reorder tab title

### DIFF
--- a/.changeset/techdocs-gorgeous-plants-sniff.md
+++ b/.changeset/techdocs-gorgeous-plants-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Reorder browser tab title in Techdocs pages to have the site name first.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -91,7 +91,7 @@ export const TechDocsReaderPageHeader = (
   }, [metadata, setTitle, setSubtitle]);
 
   const appTitle = configApi.getOptional('app.title') || 'Backstage';
-  const tabTitle = [subtitle, title, appTitle].filter(Boolean).join(' | ');
+  const tabTitle = [title, subtitle, appTitle].filter(Boolean).join(' | ');
 
   const { locationMetadata, spec } = entityMetadata || {};
   const lifecycle = spec?.lifecycle;


### PR DESCRIPTION
Fixes https://github.com/backstage/backstage/issues/11468

Makes sense to have the Site name first and also be consistent with the entity pages