### PR TITLE
chore(scaffolder): remove projectId from gitlab publish mr action because it is redundant

### DIFF
--- a/.changeset/forty-timers-cheer.md
+++ b/.changeset/forty-timers-cheer.md
@@ -1,5 +1,6 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': major
 ---
 
-refactored the gitlab publish merge request action to not use the `projectId` property. Instead use the `host` and `owner` property from the `RepoUrlPicker`. This decreases the amount of fields the user has to fill in.
+**DEPRECATION**: The `projectid` input parameters to the `publish:gitlab:merge-request`, it's no longer required as it can be decoded from the `repoUrl` input parameter.
+**DEPRECATION**: The `projectid` output of the action in favour of `projectPath`

--- a/.changeset/forty-timers-cheer.md
+++ b/.changeset/forty-timers-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+refactored the gitlab publish merge request action to not use the `projectId` property. Instead use the `host` and `owner` property from the `RepoUrlPicker`. This decreases the amount of fields the user has to fill in.

--- a/.changeset/forty-timers-cheer.md
+++ b/.changeset/forty-timers-cheer.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': major
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
 **DEPRECATION**: The `projectid` input parameters to the `publish:gitlab:merge-request`, it's no longer required as it can be decoded from the `repoUrl` input parameter.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -338,7 +338,6 @@ export function createPublishGitlabAction(options: {
 export const createPublishGitlabMergeRequestAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<{
-  projectid: string;
   repoUrl: string;
   title: string;
   description: string;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -344,6 +344,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   branchName: string;
   targetPath: string;
   token?: string | undefined;
+  projectid?: string | undefined;
 }>;
 
 // @public
@@ -709,4 +710,8 @@ export class TemplateActionRegistry {
 
 // @public (undocumented)
 export type TemplateFilter = (...args: JsonValue[]) => JsonValue | undefined;
+
+// Warnings were encountered during analysis:
+//
+// src/scaffolder/actions/builtin/publish/gitlabMergeRequest.d.ts:16:9 - (tsdoc-missing-deprecation-message) The @deprecated block must include a deprecation message, e.g. describing the recommended alternative
 ```

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -710,8 +710,4 @@ export class TemplateActionRegistry {
 
 // @public (undocumented)
 export type TemplateFilter = (...args: JsonValue[]) => JsonValue | undefined;
-
-// Warnings were encountered during analysis:
-//
-// src/scaffolder/actions/builtin/publish/gitlabMergeRequest.d.ts:16:9 - (tsdoc-missing-deprecation-message) The @deprecated block must include a deprecation message, e.g. describing the recommended alternative
 ```

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -40,6 +40,8 @@ export const createPublishGitlabMergeRequestAction = (options: {
     branchName: string;
     targetPath: string;
     token?: string;
+    /** @deprecated */
+    projectid?: string;
   }>({
     id: 'publish:gitlab:merge-request',
     schema: {
@@ -51,6 +53,12 @@ export const createPublishGitlabMergeRequestAction = (options: {
             type: 'string',
             title: 'Repository Location',
             description: `Accepts the format 'gitlab.com/group_name/project_name' where 'project_name' is the repository name and 'group_name' is a group or username`,
+          },
+          /** @deprecated */
+          projectid: {
+            type: 'string',
+            title: 'projectid',
+            description: 'Project ID/Name(slug) of the Gitlab Project',
           },
           title: {
             type: 'string',
@@ -82,6 +90,10 @@ export const createPublishGitlabMergeRequestAction = (options: {
       output: {
         type: 'object',
         properties: {
+          projectid: {
+            title: 'Gitlab Project id/Name(slug)',
+            type: 'string',
+          },
           projectPath: {
             title: 'Gitlab Project path',
             type: 'string',
@@ -173,7 +185,8 @@ export const createPublishGitlabMergeRequestAction = (options: {
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;
         });
-        ctx.output('project path: ', projectPath);
+        ctx.output('projectid', projectPath);
+        ctx.output('projectPath', projectPath);
         ctx.output('mergeRequestUrl', mergeRequestUrl);
       } catch (e) {
         throw new InputError(`Merge request creation failed${e}`);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -185,7 +185,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;
         });
-        /** @deprecated Use projectPath instead */
+        /** @deprecated */
         ctx.output('projectid', projectPath);
         ctx.output('projectPath', projectPath);
         ctx.output('mergeRequestUrl', mergeRequestUrl);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -185,6 +185,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;
         });
+        /** @deprecated */
         ctx.output('projectid', projectPath);
         ctx.output('projectPath', projectPath);
         ctx.output('mergeRequestUrl', mergeRequestUrl);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -40,7 +40,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
     branchName: string;
     targetPath: string;
     token?: string;
-    /** @deprecated */
+    /** @deprecated Use projectPath instead */
     projectid?: string;
   }>({
     id: 'publish:gitlab:merge-request',
@@ -54,7 +54,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
             title: 'Repository Location',
             description: `Accepts the format 'gitlab.com/group_name/project_name' where 'project_name' is the repository name and 'group_name' is a group or username`,
           },
-          /** @deprecated */
+          /** @deprecated Use projectPath instead */
           projectid: {
             type: 'string',
             title: 'projectid',
@@ -185,7 +185,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;
         });
-        /** @deprecated */
+        /** @deprecated Use projectPath instead */
         ctx.output('projectid', projectPath);
         ctx.output('projectPath', projectPath);
         ctx.output('mergeRequestUrl', mergeRequestUrl);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -34,7 +34,6 @@ export const createPublishGitlabMergeRequestAction = (options: {
   const { integrations } = options;
 
   return createTemplateAction<{
-    projectid: string;
     repoUrl: string;
     title: string;
     description: string;
@@ -45,18 +44,13 @@ export const createPublishGitlabMergeRequestAction = (options: {
     id: 'publish:gitlab:merge-request',
     schema: {
       input: {
-        required: ['projectid', 'repoUrl', 'targetPath', 'branchName'],
+        required: ['repoUrl', 'targetPath', 'branchName'],
         type: 'object',
         properties: {
           repoUrl: {
             type: 'string',
             title: 'Repository Location',
             description: `Accepts the format 'gitlab.com/group_name/project_name' where 'project_name' is the repository name and 'group_name' is a group or username`,
-          },
-          projectid: {
-            type: 'string',
-            title: 'projectid',
-            description: 'Project ID/Name(slug) of the Gitlab Project',
           },
           title: {
             type: 'string',
@@ -88,8 +82,8 @@ export const createPublishGitlabMergeRequestAction = (options: {
       output: {
         type: 'object',
         properties: {
-          projectid: {
-            title: 'Gitlab Project id/Name(slug)',
+          projectPath: {
+            title: 'Gitlab Project path',
             type: 'string',
           },
           mergeRequestURL: {
@@ -102,7 +96,9 @@ export const createPublishGitlabMergeRequestAction = (options: {
     },
     async handler(ctx) {
       const repoUrl = ctx.input.repoUrl;
-      const { host } = parseRepoUrl(repoUrl, integrations);
+      const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
+      const projectPath = `${owner}/${repo}`;
+
       const integrationConfig = integrations.gitlab.byHost(host);
 
       const destinationBranch = ctx.input.branchName;
@@ -140,14 +136,13 @@ export const createPublishGitlabMergeRequestAction = (options: {
         content: file.content.toString('base64'),
         execute_filemode: file.executable,
       }));
-
-      const projects = await api.Projects.show(ctx.input.projectid);
+      const projects = await api.Projects.show(projectPath);
 
       const { default_branch: defaultBranch } = projects;
 
       try {
         await api.Branches.create(
-          ctx.input.projectid,
+          projectPath,
           destinationBranch,
           String(defaultBranch),
         );
@@ -157,7 +152,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
 
       try {
         await api.Commits.create(
-          ctx.input.projectid,
+          projectPath,
           destinationBranch,
           ctx.input.title,
           actions,
@@ -170,7 +165,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
 
       try {
         const mergeRequestUrl = await api.MergeRequests.create(
-          ctx.input.projectid,
+          projectPath,
           destinationBranch,
           String(defaultBranch),
           ctx.input.title,
@@ -178,7 +173,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;
         });
-        ctx.output('projectid', ctx.input.projectid);
+        ctx.output('project path: ', projectPath);
         ctx.output('mergeRequestUrl', mergeRequestUrl);
       } catch (e) {
         throw new InputError(`Merge request creation failed${e}`);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -111,6 +111,12 @@ export const createPublishGitlabMergeRequestAction = (options: {
       const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
       const projectPath = `${owner}/${repo}`;
 
+      if (ctx.input.projectid) {
+        const deprecationWarning = `Property "projectid" is deprecated and no longer to needed to create a MR`;
+        ctx.logger.warn(deprecationWarning);
+        console.warn(deprecationWarning);
+      }
+
       const integrationConfig = integrations.gitlab.byHost(host);
 
       const destinationBranch = ctx.input.branchName;


### PR DESCRIPTION
Signed-off-by: djamaile <rdjamaile@gmail.com>

## Hey, I just made a Pull Request!

`projectId` in this case doesn't seem necessary because we can already fetch the project path from `RepoUrlPicker`  and use that to query the gitlab API.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
