### PR TITLE
[tech-insights] Fix maxItems lifecycle condition

### DIFF
--- a/.changeset/warm-lions-retire.md
+++ b/.changeset/warm-lions-retire.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+'@backstage/plugin-tech-insights-node': patch
+---
+
+Introduce additional JsonValue types to be storable as facts. This enables the possibility to store more complex objects for fact checking purposes. The rules engine supports walking keyed object values directly to create rules and checks
+
+Modify facts database table to have a more restricted timestamp precision for cases where the postgres server isn't configured to contain such value. This fixes the issue where in some cases `maxItems` lifecycle condition didn't work as expected.

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -301,6 +301,7 @@ superfences
 Superfences
 superset
 supertype
+storable
 talkdesk
 Talkdesk
 tasklist

--- a/plugins/tech-insights-backend/migrations/2022060100821_facts_timestamp_precision.js
+++ b/plugins/tech-insights-backend/migrations/2022060100821_facts_timestamp_precision.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('facts', table => {
+    table
+      .dateTime('timestamp', { precision: 0 })
+      .defaultTo(knex.fn.now())
+      .notNullable()
+      .comment('The timestamp when this entry was created')
+      .alter();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} _knex
+ */
+exports.down = async function down(_knex) {};

--- a/plugins/tech-insights-node/api-report.md
+++ b/plugins/tech-insights-node/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import { DateTime } from 'luxon';
 import { Duration } from 'luxon';
 import { DurationLike } from 'luxon';
+import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { TokenManager } from '@backstage/backend-common';
@@ -76,7 +77,14 @@ export type FactRetrieverRegistration = {
 // @public
 export type FactSchema = {
   [name: string]: {
-    type: 'integer' | 'float' | 'string' | 'boolean' | 'datetime' | 'set';
+    type:
+      | 'integer'
+      | 'float'
+      | 'string'
+      | 'boolean'
+      | 'datetime'
+      | 'set'
+      | 'object';
     description: string;
     since?: string;
     metadata?: Record<string, any>;
@@ -136,6 +144,7 @@ export type TechInsightFact = {
     | string[]
     | boolean[]
     | DateTime[]
+    | JsonValue
   >;
   timestamp?: DateTime;
 };

--- a/plugins/tech-insights-node/package.json
+++ b/plugins/tech-insights-node/package.json
@@ -36,6 +36,7 @@
     "@backstage/backend-common": "^0.14.0-next.2",
     "@backstage/config": "^1.0.1",
     "@backstage/plugin-tech-insights-common": "^0.2.4",
+    "@backstage/types": "^1.0.0",
     "@types/luxon": "^2.0.5",
     "luxon": "^2.0.2",
     "winston": "^3.2.1"

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -15,6 +15,7 @@
  */
 import { DateTime, Duration, DurationLike } from 'luxon';
 import { Config } from '@backstage/config';
+import { JsonValue } from '@backstage/types';
 import {
   PluginEndpointDiscovery,
   TokenManager,
@@ -55,6 +56,7 @@ export type TechInsightFact = {
     | string[]
     | boolean[]
     | DateTime[]
+    | JsonValue
   >;
 
   /**
@@ -94,9 +96,16 @@ export type FactSchema = {
      * Type of the individual fact value
      *
      * Numbers are split into integers and floating point values.
-     * `set` indicates a collection of values
+     * `set` indicates a collection of values, `object` indicates JSON serializable value
      */
-    type: 'integer' | 'float' | 'string' | 'boolean' | 'datetime' | 'set';
+    type:
+      | 'integer'
+      | 'float'
+      | 'string'
+      | 'boolean'
+      | 'datetime'
+      | 'set'
+      | 'object';
 
     /**
      * A description of this individual fact value


### PR DESCRIPTION
Modify facts database table to have a more restricted timestamp precision for cases where the postgres server isn't configured to contain such value. This fixes the issue where in some cases `maxItems` lifecycle condition didn't work as expected.

Introduce additional JsonValue types to be storable as facts. This enables the possibility to store more complex objects for fact checking purposes. The rules engine supports walking keyed object values directly to create rules and checks

resolves #11595

Signed-off-by: Jussi Hallila <jussi@hallila.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
