### PR TITLE
Add Component Dependency

### DIFF
--- a/docs/features/software-catalog/system-model.md
+++ b/docs/features/software-catalog/system-model.md
@@ -33,7 +33,7 @@ tracked in source control, or use some existing open source or commercial
 software.
 
 A component can implement APIs for other components to consume. In turn it might
-depend on APIs implemented by other components, or resources that are attached
+depend on Components or APIs implemented by other components, or resources that are attached
 to it at runtime.
 
 ### API


### PR DESCRIPTION
## Add documentation for component dependency

A component can depend on another component according to [the YAML spec](https://backstage.io/docs/features/software-catalog/descriptor-format#specdependson-optional).

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
