### PR TITLE
[Search - ES module] possibility to set custom index template

### DIFF
--- a/.changeset/wet-icons-shout.md
+++ b/.changeset/wet-icons-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Now possible to set a custom index template on the elasticsearch search engine.

--- a/plugins/search-backend-module-elasticsearch/api-report.md
+++ b/plugins/search-backend-module-elasticsearch/api-report.md
@@ -137,6 +137,18 @@ export interface ElasticSearchConnectionConstructor {
   };
 }
 
+// @public
+export type ElasticSearchCustomIndexTemplate = {
+  name: string;
+  body: ElasticSearchCustomIndexTemplateBody;
+};
+
+// @public
+export type ElasticSearchCustomIndexTemplateBody = {
+  index_patterns: string[];
+  template: Record<string, any>;
+};
+
 // @public (undocumented)
 export type ElasticSearchHighlightConfig = {
   fragmentDelimiter: string;
@@ -211,9 +223,13 @@ export class ElasticSearchSearchEngine implements SearchEngine {
   }: ElasticSearchOptions): Promise<ElasticSearchSearchEngine>;
   // (undocumented)
   getIndexer(type: string): Promise<ElasticSearchSearchEngineIndexer>;
+  // (undocumented)
+  protected indexTemplate?: ElasticSearchCustomIndexTemplate;
   newClient<T>(create: (options: ElasticSearchClientOptions) => T): T;
   // (undocumented)
   query(query: SearchQuery): Promise<IndexableResultSet>;
+  // (undocumented)
+  setIndexTemplate(template: ElasticSearchCustomIndexTemplate): void;
   // (undocumented)
   setTranslator(translator: ElasticSearchQueryTranslator): void;
   // (undocumented)

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -42,15 +42,17 @@ export type { ElasticSearchClientOptions };
  */
 export type ElasticSearchCustomIndexTemplate = {
   name: string;
-  body: ElasticSearchIndexTemplateBody;
+  body: ElasticSearchCustomIndexTemplateBody;
 };
 
 /**
  * Elasticsearch specific index template body
  * @public
  */
-export type ElasticSearchIndexTemplateBody = {
+export type ElasticSearchCustomIndexTemplateBody = {
   index_patterns: string[];
+  // See available properties of template
+  // https://www.elastic.co/guide/en/elasticsearch/reference/7.15/indices-put-template.html#put-index-template-api-request-body
   template: Record<string, any>;
 };
 

--- a/plugins/search-backend-module-elasticsearch/src/engines/index.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/index.ts
@@ -30,6 +30,8 @@ export type {
   ElasticSearchQueryTranslator,
   ElasticSearchQueryTranslatorOptions,
   ElasticSearchOptions,
+  ElasticSearchCustomIndexTemplate,
+  ElasticSearchCustomIndexTemplateBody,
 } from './ElasticSearchSearchEngine';
 export type {
   ElasticSearchSearchEngineIndexer,

--- a/plugins/search-backend-module-elasticsearch/src/index.ts
+++ b/plugins/search-backend-module-elasticsearch/src/index.ts
@@ -36,4 +36,6 @@ export type {
   ElasticSearchAuth,
   ElasticSearchSearchEngineIndexer,
   ElasticSearchSearchEngineIndexerOptions,
+  ElasticSearchCustomIndexTemplate,
+  ElasticSearchCustomIndexTemplateBody,
 } from './engines';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes it possible for any adopter when setting up search in their app to set a custom index template when using elastic search. This is done by using the `setIndexTemplate` method. Something like:

```ts
  searchEngine.setIndexTemplate({
    name: 'custom-template',
    body: {
      index_patterns: ['*-index*'],
      template: {
        mappings: {},
        settings: {}
      }
    },
  });
```


Ref: https://www.elastic.co/guide/en/elasticsearch/reference/7.15/indices-put-template.html#put-index-template-api-request-body

### How to test:

1. Spin up local instances of elastic search and postgres 
2. Update your app-config with required configuration
```yaml
backend: 
  baseUrl: ...
  database:
    client: pg
    connection:
      host: ..
      port: ..
      user: ..
      password: ..
        
search:
  elasticsearch:
    node: # e.g. http://0.0.0.0:9200 
```

3. Set your custom index template as explained above

4. Start backstage locally `yarn dev`

5. You should be see logs like `Custom index template set` in your terminal.

6. To get your custom index template you should be able to make a request to `http://localhost:9200/_index_template/<name-of-your-custom-template>`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
