### PR TITLE
Update docs link to current techdocs-cli

### DIFF
--- a/docs/features/techdocs/README.md
+++ b/docs/features/techdocs/README.md
@@ -95,7 +95,7 @@ See [TechDocs Architecture](architecture.md) to get an overview of where the bel
 [techdocs/frontend-library]: https://github.com/backstage/backstage/blob/master/plugins/techdocs-react
 [techdocs/backend]: https://github.com/backstage/backstage/blob/master/plugins/techdocs-backend
 [techdocs/container]: https://github.com/backstage/techdocs-container
-[techdocs/cli]: https://github.com/backstage/techdocs-cli
+[techdocs/cli]: https://github.com/backstage/backstage/blob/master/packages/techdocs-cli
 
 ## Get involved
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the link from the [archived repo](https://github.com/backstage/techdocs-cli) to the [current location of the techdocs-cli](https://github.com/backstage/backstage/blob/master/packages/techdocs-cli)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
