### PR TITLE
fix(scaffolder-backend): avoid double encoded cookiecutter URLs

### DIFF
--- a/.changeset/tiny-timers-flow.md
+++ b/.changeset/tiny-timers-flow.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Avoid double encoded cookiecutter URLs
+
+When using bitbucket and a relative cookiecutter URL with special characters, the fetch will fail
+due to a URL which is encoded twice. The fix ensures that the fetchContents will treat absolute
+and relative URLs the same way.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
@@ -119,4 +119,26 @@ describe('fetchContent helper', () => {
     expect(fs.ensureDir).toBeCalled();
     expect(dirFunction).toBeCalledWith({ targetDir: 'foo' });
   });
+
+  it('should not encode the URLs', async () => {
+    const baseUrl = 'https://github.com/backstage/foo/';
+    const nestedPath = '{{ nested }}';
+
+    // relative URL
+    await fetchContents({
+      ...options,
+      baseUrl,
+      fetchUrl: nestedPath,
+    });
+
+    // absolute URL
+    await fetchContents({
+      ...options,
+      fetchUrl: `${baseUrl}${nestedPath}`,
+    });
+
+    const expectedReadUrl = 'https://github.com/backstage/foo/{{ nested }}';
+    expect(readTree).toHaveBeenNthCalledWith(1, expectedReadUrl);
+    expect(readTree).toHaveBeenNthCalledWith(2, expectedReadUrl);
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.ts
@@ -64,10 +64,12 @@ export async function fetchContents({
         throw new InputError(`No integration found for location ${baseUrl}`);
       }
 
-      readUrl = integration.resolveUrl({
+      const resolvedUrl = integration.resolveUrl({
         url: fetchUrl,
         base: baseUrl,
       });
+
+      readUrl = decodeURIComponent(resolvedUrl);
     } else {
       throw new InputError(
         `Failed to fetch, template location could not be determined and the fetch URL is relative, ${fetchUrl}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When using bitbucket and a relative cookiecutter URL with special characters, the fetch will fail
due to a URL which is encoded twice. The fix ensures that the fetchContents will treat absolute
and relative URLs the same way.

For more details check: #11988

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes: #11988