### PR TITLE
chore(cost-insights): update readme with updated sidebar path

### DIFF
--- a/.changeset/angry-jobs-serve.md
+++ b/.changeset/angry-jobs-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+In the README, a old path of the `sidebar` was updated to the current path.

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -72,37 +72,50 @@ import { CostInsightsPage } from '@backstage/plugin-cost-insights';
 To expose the plugin to your users, you can integrate the `cost-insights` route anyway that suits your application, but most commonly it is added to the Sidebar.
 
 ```diff
-// packages/app/src/sidebar.tsx
+// packages/app/src/components/Root/Root.tsx
 + import MoneyIcon from '@material-ui/icons/MonetizationOn';
 
  ...
 
- export const AppSidebar = () => (
-   <Sidebar>
-     <SidebarLogo />
-     <SidebarGroup icon={<SearchIcon />} to="/search">
-       <SidebarSearch />
-     </SidebarGroup>
-     <SidebarDivider />
-     {/* Global nav, not org-specific */}
-     <SidebarGroup label="Menu" icon={<MenuIcon />}>
-       <SidebarItem icon={HomeIcon} to="./" text="Home" />
-       <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
-       <SidebarItem icon={LibraryBooks} to="/docs" text="Docs" />
-       <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
-       <SidebarDivider />
-       <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
-+      <SidebarItem icon={MoneyIcon} to="cost-insights" text="Cost Insights" />
-     </SidebarGroup>
-     {/* End global nav */}
-     <SidebarDivider />
-     <SidebarSpace />
-     <SidebarDivider />
-     <SidebarGroup icon={<UserSettingsSignInAvatar />} to="/settings">
-       <SidebarSettings />
-     </SidebarGroup>
-   </Sidebar>
- );
+ export const Root = ({ children }: PropsWithChildren<{}>) => (
+  <SidebarPage>
+    <Sidebar>
+      <SidebarLogo />
+      <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+        <SidebarSearchModal>
+          {({ toggleModal }) => <SearchModal toggleModal={toggleModal} />}
+        </SidebarSearchModal>
+      </SidebarGroup>
+      <SidebarDivider />
+        <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
+        <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
+        <SidebarItem icon={LayersIcon} to="explore" text="Explore" />
+        <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
+        {/* End global nav */}
+        <SidebarDivider />
+        <SidebarScrollWrapper>
++          <SidebarItem
++            icon={MoneyIcon}
++            to="cost-insights"
++            text="Cost Insights"
++          />
+        </SidebarScrollWrapper>
+        <SidebarDivider />
+        <Shortcuts />
+      </SidebarGroup>
+      <SidebarSpace />
+      <SidebarDivider />
+      <SidebarGroup
+        label="Settings"
+        icon={<UserSettingsSignInAvatar />}
+        to="/settings"
+      >
+        <SidebarSettings />
+      </SidebarGroup>
+    </Sidebar>
+    {children}
+  </SidebarPage>
+);
 ```
 
 ## Configuration
@@ -157,7 +170,7 @@ costInsights:
 
 ### Currencies (Optional)
 
-In the `Cost Overview` panel, users can choose from a dropdown of currencies to see costs in, such as Engineers or USD. Currencies must be defined as keys on the `currencies` field. A user-friendly label and unit are **required**. If not set, the `defaultCurrencies` in `currenc.ts` will be used.
+In the `Cost Overview` panel, users can choose from a dropdown of currencies to see costs in, such as Engineers or USD. Currencies must be defined as keys on the `currencies` field. A user-friendly label and unit are **required**. If not set, the `defaultCurrencies` in `currency.ts` will be used.
 
 A currency without `kind` is reserved to calculate cost for `engineers`. There should only be one currency without `kind`.
 


### PR DESCRIPTION
Signed-off-by: djamaile <rdjamaile@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

 // packages/app/src/sidebar.tsx (old) -> // packages/app/src/components/Root/Root.tsx (new)
Was implementing cost insights last week and noticed this outdated path. A quick update to reflect the current reality. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
