### PR TITLE
create-app: Add empty locations list to production config

### DIFF
--- a/.changeset/nice-yaks-tie.md
+++ b/.changeset/nice-yaks-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated `app-config.production.yaml` to specify an empty list of catalog locations. This is done to prevent example locations stored in `app-config.yaml` from being loaded as these are examples.

--- a/packages/create-app/templates/default-app/app-config.production.yaml
+++ b/packages/create-app/templates/default-app/app-config.production.yaml
@@ -32,3 +32,9 @@ backend:
       # ssl:
       #   ca: # if you have a CA file and want to verify it you can uncomment this section
       #     $file: <file-path>/ca/server.crt
+
+catalog:
+  # Overrides the default list locations from app-config.yaml as these contain example data.
+  # See https://backstage.io/docs/features/software-catalog/software-catalog-overview#adding-components-to-the-catalog for more details
+  # on how to get entities into the catalog.
+  locations: []


### PR DESCRIPTION
Updated `app-config.production.yaml` to specify an empty list of catalog locations. This is done to prevent example locations stored in `app-config.yaml` from being loaded as these are examples.