### PR TITLE
always create a keystore

### DIFF
--- a/.changeset/polite-jokes-matter.md
+++ b/.changeset/polite-jokes-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Address corner cases where the key store was not being created at startup

--- a/plugins/auth-node/src/IdentityClient.ts
+++ b/plugins/auth-node/src/IdentityClient.ts
@@ -141,7 +141,7 @@ export class IdentityClient {
     // Add a small margin in case clocks are out of sync
     const issuedAfterLastRefresh =
       payload?.iat && payload.iat > this.keyStoreUpdated - CLOCK_MARGIN_S;
-    if (!keyStoreHasKey && issuedAfterLastRefresh) {
+    if (!this.keyStore || (!keyStoreHasKey && issuedAfterLastRefresh)) {
       const url = await this.discovery.getBaseUrl('auth');
       const endpoint = new URL(`${url}/.well-known/jwks.json`);
       this.keyStore = createRemoteJWKSet(endpoint);


### PR DESCRIPTION
Context: https://discord.com/channels/687207715902193673/978977570852835379/984479004172115998

It seems to me that we'd always want to generate a keystore if there wasn't one, no matter what.