### PR TITLE
catalog-backend: disallow non-url location registration

### DIFF
--- a/.changeset/cuddly-pillows-press.md
+++ b/.changeset/cuddly-pillows-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Disallow anything but `'url'` locations from being registered via the location service.

--- a/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
@@ -17,6 +17,7 @@
 import { DefaultLocationService } from './DefaultLocationService';
 import { CatalogProcessingOrchestrator } from '../processing/types';
 import { LocationStore } from './types';
+import { InputError } from '@backstage/errors';
 
 describe('DefaultLocationServiceTest', () => {
   const orchestrator: jest.Mocked<CatalogProcessingOrchestrator> = {
@@ -250,6 +251,18 @@ describe('DefaultLocationServiceTest', () => {
         target: 'https://backstage.io/catalog-info.yaml',
         type: 'url',
       });
+    });
+
+    it('should not allow locations of unknown types', async () => {
+      await expect(
+        locationService.createLocation(
+          {
+            type: 'unknown',
+            target: 'https://backstage.io/catalog-info.yaml',
+          },
+          false,
+        ),
+      ).rejects.toThrow(InputError);
     });
   });
 

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -27,6 +27,7 @@ import {
 } from '../processing/types';
 import { LocationInput, LocationService, LocationStore } from './types';
 import { locationSpecToMetadataName } from '../util/conversion';
+import { InputError } from '@backstage/errors';
 
 export class DefaultLocationService implements LocationService {
   constructor(
@@ -38,6 +39,9 @@ export class DefaultLocationService implements LocationService {
     input: LocationInput,
     dryRun: boolean,
   ): Promise<{ location: Location; entities: Entity[]; exists?: boolean }> {
+    if (input.type !== 'url') {
+      throw new InputError(`Registered locations must be of type 'url'`);
+    }
     if (dryRun) {
       return this.dryRunCreateLocation(input);
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is the intended behavior and the only thing that is supported by the frontend.

A controversial point here is whether this should be considered a breaking change, or at least whether we should allow for some kind of configuration of this behavior in the backend. It's not impossible that there are scripts or workflows out there that register other location types, but that is not something we intend to support via the location service.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
