### PR TITLE
chore: Make docstrings MDX compatible

### DIFF
--- a/.changeset/curvy-weeks-matter.md
+++ b/.changeset/curvy-weeks-matter.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-common': patch
+'@backstage/catalog-model': patch
+'@backstage/core-components': patch
+'@backstage/plugin-techdocs-react': patch
+---
+
+Updated docstring to be MDX compatible.

--- a/.changeset/curvy-weeks-matter.md
+++ b/.changeset/curvy-weeks-matter.md
@@ -5,4 +5,4 @@
 '@backstage/plugin-techdocs-react': patch
 ---
 
-Updated docstring to be MDX compatible.
+Updated JSDoc to be MDX compatible.

--- a/packages/backend-common/src/reading/FetchUrlReader.ts
+++ b/packages/backend-common/src/reading/FetchUrlReader.ts
@@ -39,8 +39,8 @@ export class FetchUrlReader implements UrlReader {
    * targets to allow, containing the following fields:
    *
    * `host`:
-   *   Either full hostnames to match, or subdomain wildcard matchers with a leading `*`.
-   *   For example `example.com` and `*.example.com` are valid values, `prod.*.example.com` is not.
+   *   Either full hostnames to match, or subdomain wildcard matchers with a leading '*'.
+   *   For example 'example.com' and '*.example.com' are valid values, 'prod.*.example.com' is not.
    *
    * `paths`:
    *   An optional list of paths which are allowed. If the list is omitted all paths are allowed.

--- a/packages/catalog-model/src/validation/CommonValidatorFunctions.ts
+++ b/packages/catalog-model/src/validation/CommonValidatorFunctions.ts
@@ -24,7 +24,7 @@ import lodash from 'lodash';
  */
 export class CommonValidatorFunctions {
   /**
-   * Checks that the value is on the form <suffix> or <prefix><separator><suffix>, and validates
+   * Checks that the value is on the form `<suffix>` or `<prefix><separator><suffix>`, and validates
    * those parts separately.
    *
    * @param value - The value to check

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -40,7 +40,7 @@ import { ARROW_MARKER_ID } from './constants';
  *
  * @public
  * @remarks
- * <NodeData> and <EdgeData> are useful when rendering custom or edge labels
+ * `<NodeData>` and `<EdgeData>` are useful when rendering custom or edge labels
  */
 export interface DependencyGraphProps<NodeData, EdgeData>
   extends React.SVGProps<SVGSVGElement> {

--- a/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
@@ -64,7 +64,7 @@ export type ItemCardHeaderProps = Partial<WithStyles<typeof styles>> & {
  * A simple card header, rendering a default look for "item cards" - cards that
  * are arranged in a grid for users to select among several options.
  *
- * This component expects to be placed within a MUI <CardMedia>.
+ * This component expects to be placed within a MUI `<CardMedia>`.
  *
  * Styles for the header can be overridden using the `classes` prop, e.g.:
  *

--- a/plugins/techdocs-react/src/addons.tsx
+++ b/plugins/techdocs-react/src/addons.tsx
@@ -30,7 +30,7 @@ import { TechDocsAddonLocations, TechDocsAddonOptions } from './types';
 export const TECHDOCS_ADDONS_KEY = 'techdocs.addons.addon.v1';
 
 /**
- * Marks the <TechDocsAddons> registry component.
+ * Marks the `<TechDocsAddons>` registry component.
  * @public
  */
 export const TECHDOCS_ADDONS_WRAPPER_KEY = 'techdocs.addons.wrapper.v1';


### PR DESCRIPTION
Update docstrings to be compatible with MDX so that references work on docusaurus 2.0