### PR TITLE
fix(stack-overflow-question-plugin): Adjust link icon alignment

### DIFF
--- a/.changeset/fifty-yaks-visit.md
+++ b/.changeset/fifty-yaks-visit.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-stack-overflow-backend': patch
+'@backstage/plugin-stack-overflow': patch
 ---
 
 Fixed a layout bug where the external link icon button was not positioned at the end of the container

--- a/.changeset/poor-readers-allow.md
+++ b/.changeset/poor-readers-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow-backend': patch
+---
+
+Fixed a layout bug where the external link icon button was not positioned at the end of the container

--- a/plugins/stack-overflow/src/home/StackOverflowQuestions/Content.tsx
+++ b/plugins/stack-overflow/src/home/StackOverflowQuestions/Content.tsx
@@ -74,12 +74,14 @@ export const Content = (props: StackOverflowQuestionsContentProps) => {
               primary={question.title}
               secondary={getSecondaryText(question.answer_count)}
             />
-            <ListItemSecondaryAction>
+          </Link>
+          <ListItemSecondaryAction>
+            <Link to={question.link}>
               <IconButton edge="end" aria-label="external-link">
                 <OpenInNewIcon />
               </IconButton>
-            </ListItemSecondaryAction>
-          </Link>
+            </Link>
+          </ListItemSecondaryAction>
         </ListItem>
       ))}
     </List>


### PR DESCRIPTION
Signed-off-by: Austin Berry <austin.berry@docker.com>

## Hey, I just made a Pull Request!
**Cause:**
The `<link>` component was wrapping the whole row and getting it's width changed due to the parent being `display: flex` ( this would also cause the whole row to be clickable ), the `<ListItemSecondaryAction>` component uses position absolute and due to the width change of its parent it's not able to make it to the end of the container.
![stackoverflow-question-plugin-broken](https://user-images.githubusercontent.com/103646487/173640677-c063d21f-15c4-4fa2-a5c2-53e078fab150.png)

**Fix:**
Wrap the `<IconButton>` and `<ListItemText>` separately.
![stackoverflow-question-plugin-fixed](https://user-images.githubusercontent.com/103646487/173641069-baa8586f-46de-49d4-a66c-f09db9d8243e.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
