### PR TITLE
Add Rootly plugin

### DIFF
--- a/microsite/data/plugins/rootly.yaml
+++ b/microsite/data/plugins/rootly.yaml
@@ -6,4 +6,4 @@ category: Incident Management
 description: Import your Backstage entities into Rootly services and view incidents & analytics.
 documentation: https://github.com/rootlyhq/backstage-plugin/blob/master/README.md
 iconUrl: https://raw.githubusercontent.com/rootlyhq/backstage-plugin/master/docs/logo.png
-npmPackageName: '@rootlyhq/backstage-plugin'
+npmPackageName: '@rootly/backstage-plugin'

--- a/microsite/data/plugins/rootly.yaml
+++ b/microsite/data/plugins/rootly.yaml
@@ -4,6 +4,6 @@ author: Rootly
 authorUrl: https://rootly.com/
 category: Incident Management
 description: Import your Backstage entities into Rootly services and view incidents & analytics.
-documentation: https://github.com/backstage/backstage/blob/master/plugins/rootly/README.md
-iconUrl: https://raw.githubusercontent.com/backstage/backstage/master/plugins/rootly/doc/logo.png
-npmPackageName: '@backstage/plugin-rootly'
+documentation: https://github.com/rootlyhq/backstage-plugin/blob/master/README.md
+iconUrl: https://raw.githubusercontent.com/rootlyhq/backstage-plugin/master/docs/logo.png
+npmPackageName: '@rootlyhq/backstage-plugin'

--- a/microsite/data/plugins/rootly.yaml
+++ b/microsite/data/plugins/rootly.yaml
@@ -1,0 +1,9 @@
+---
+title: Rootly
+author: Rootly
+authorUrl: https://rootly.com/
+category: Incident Management
+description: Import your Backstage entities into Rootly services and view incidents & analytics.
+documentation: https://github.com/backstage/backstage/blob/master/plugins/rootly/README.md
+iconUrl: https://raw.githubusercontent.com/backstage/backstage/master/plugins/rootly/doc/logo.png
+npmPackageName: '@backstage/plugin-rootly'


### PR DESCRIPTION
# Rootly plugin for Backstage

Cf. https://github.com/rootlyhq/backstage-plugin

The [Rootly](https://rootly.com) plugin is a frontend plugin that displays Rootly services, incidents in Backstage. The plugin includes three components that can be integrated into Backstage:

- The `RootlyPage` routable extension component which produces a standalone page with the following capabilities:
  - View and search a list of entities and import/link them to rootly services
  - View and search a list of services
  - View and search a list of incidents

- The `RootlyOverviewCard` component which produces a summary of your entity with incidents over last 30 days and ongoing incidents.

- The `RootlyIncidentsPage` component which produces a dedicated page within your entity with details about ongoing and past incidents.