### PR TITLE
Added changes to customize the node color

### DIFF
--- a/.changeset/smooth-jokes-begin.md
+++ b/.changeset/smooth-jokes-begin.md
@@ -1,0 +1,6 @@
+---
+'@backstage/theme': patch
+'@backstage/plugin-catalog-graph': patch
+---
+
+Added a way to customize the nodes color on the basis of kind

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -72,6 +72,17 @@ export type BackstagePaletteAdditions = {
     link: string;
     warning?: string;
   };
+  catalogGraph?: {
+    component?: string;
+    domain?: string;
+    system?: string;
+    location?: string;
+    resource?: string;
+    group?: string;
+    user?: string;
+    template?: string;
+    api?: string;
+  };
 };
 
 // @public

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -84,7 +84,7 @@ export type BackstagePaletteAdditions = {
     link: string;
     warning?: string;
   };
-  catalogGraph: {
+  catalogGraph?: {
     conponent: string;
     domain: string;
     system: string;

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -85,15 +85,15 @@ export type BackstagePaletteAdditions = {
     warning?: string;
   };
   catalogGraph?: {
-    conponent: string;
-    domain: string;
-    system: string;
-    location: string;
-    resource: string;
-    group: string;
-    user: string;
-    template: string;
-    api: string;
+    component?: string;
+    domain?: string;
+    system?: string;
+    location?: string;
+    resource?: string;
+    group?: string;
+    user?: string;
+    template?: string;
+    api?: string;
   };
 };
 

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -84,6 +84,17 @@ export type BackstagePaletteAdditions = {
     link: string;
     warning?: string;
   };
+  catalogGraph: {
+    conponent: string;
+    domain: string;
+    system: string;
+    location: string;
+    resource: string;
+    group: string;
+    user: string;
+    template: string;
+    api: string;
+  };
 };
 
 /**

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -21,26 +21,25 @@ import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { EntityKindIcon } from './EntityKindIcon';
 import { EntityNodeData } from './types';
-import { ALL_RELATION_PAIRS } from './relations';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   node: {
     fill: props =>
-      props?.kind
+      props?.kind && theme.palette.catalogGraph
         ? theme.palette.catalogGraph[props?.kind]
         : theme.palette.grey[300],
     stroke: theme.palette.grey[300],
 
     '&.primary': {
       fill: props =>
-        props?.kind
+        props?.kind && theme.palette.catalogGraph
           ? theme.palette.catalogGraph[props?.kind]
           : theme.palette.primary.light,
       stroke: theme.palette.primary.light,
     },
     '&.secondary': {
       fill: props =>
-        props?.kind
+        props?.kind && theme.palette.catalogGraph
           ? theme.palette.catalogGraph[props?.kind]
           : theme.palette.secondary.light,
       stroke: theme.palette.secondary.light,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -24,21 +24,21 @@ import { EntityNodeData } from './types';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   node: {
-    fill: props =>
+    fill: (props: { [key: string]: null }) =>
       props?.kind && theme.palette.catalogGraph
         ? theme.palette.catalogGraph[props?.kind]
         : theme.palette.grey[300],
     stroke: theme.palette.grey[300],
 
     '&.primary': {
-      fill: props =>
+      fill: (props: { [key: string]: null }) =>
         props?.kind && theme.palette.catalogGraph
           ? theme.palette.catalogGraph[props?.kind]
           : theme.palette.primary.light,
       stroke: theme.palette.primary.light,
     },
     '&.secondary': {
-      fill: props =>
+      fill: (props: { [key: string]: null }) =>
         props?.kind && theme.palette.catalogGraph
           ? theme.palette.catalogGraph[props?.kind]
           : theme.palette.secondary.light,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -75,7 +75,10 @@ export function CustomNode({
     onClick,
   },
 }: DependencyGraphTypes.RenderNodeProps<EntityNodeData>) {
-  const classes = useStyles({ kind: kind?.toLocaleLowerCase('en-US') });
+  const styleProps: any = {
+    kind: kind?.toLocaleLowerCase('en-US'),
+  };
+  const classes = useStyles({ ...styleProps });
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const idRef = useRef<SVGTextElement | null>(null);

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -50,10 +50,10 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
     fill: theme.palette.getContrastText(theme.palette.grey[300]),
 
     '&.primary': {
-      fill: '#fff',
+      fill: theme.palette.primary.contrastText,
     },
     '&.secondary': {
-      fill: '#fff',
+      fill: theme.palette.secondary.contrastText,
     },
     '&.focused': {
       fontWeight: 'bold',

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -24,21 +24,21 @@ import { EntityNodeData } from './types';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   node: {
-    fill: (props: { [key: string]: null }) =>
+    fill: (props: { [key: string]: undefined }) =>
       props?.kind && theme.palette.catalogGraph
         ? theme.palette.catalogGraph[props?.kind]
         : theme.palette.grey[300],
     stroke: theme.palette.grey[300],
 
     '&.primary': {
-      fill: (props: { [key: string]: null }) =>
+      fill: (props: { [key: string]: undefined }) =>
         props?.kind && theme.palette.catalogGraph
           ? theme.palette.catalogGraph[props?.kind]
           : theme.palette.primary.light,
       stroke: theme.palette.primary.light,
     },
     '&.secondary': {
-      fill: (props: { [key: string]: null }) =>
+      fill: (props: { [key: string]: undefined }) =>
         props?.kind && theme.palette.catalogGraph
           ? theme.palette.catalogGraph[props?.kind]
           : theme.palette.secondary.light,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -21,18 +21,28 @@ import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { EntityKindIcon } from './EntityKindIcon';
 import { EntityNodeData } from './types';
+import { ALL_RELATION_PAIRS } from './relations';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   node: {
-    fill: theme.palette.grey[300],
+    fill: props =>
+      props?.kind
+        ? theme.palette.catalogGraph[props?.kind]
+        : theme.palette.grey[300],
     stroke: theme.palette.grey[300],
 
     '&.primary': {
-      fill: theme.palette.primary.light,
+      fill: props =>
+        props?.kind
+          ? theme.palette.catalogGraph[props?.kind]
+          : theme.palette.primary.light,
       stroke: theme.palette.primary.light,
     },
     '&.secondary': {
-      fill: theme.palette.secondary.light,
+      fill: props =>
+        props?.kind
+          ? theme.palette.catalogGraph[props?.kind]
+          : theme.palette.secondary.light,
       stroke: theme.palette.secondary.light,
     },
   },
@@ -40,10 +50,10 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
     fill: theme.palette.getContrastText(theme.palette.grey[300]),
 
     '&.primary': {
-      fill: theme.palette.primary.contrastText,
+      fill: '#fff',
     },
     '&.secondary': {
-      fill: theme.palette.secondary.contrastText,
+      fill: '#fff',
     },
     '&.focused': {
       fontWeight: 'bold',
@@ -66,7 +76,7 @@ export function CustomNode({
     onClick,
   },
 }: DependencyGraphTypes.RenderNodeProps<EntityNodeData>) {
-  const classes = useStyles();
+  const classes = useStyles({ kind: kind?.toLocaleLowerCase('en-US') });
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const idRef = useRef<SVGTextElement | null>(null);


### PR DESCRIPTION
Signed-off-by: Shivam bisht <shvmbisht@gmail.com>

To increase readability on catalog graphs, I'd like to be able to customize the color of the node on the basis of kind (e.g team, component, service, resource, etc.)of my graph.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
