### PR TITLE
Add type to EntityLinks

### DIFF
--- a/.changeset/shaggy-melons-drive.md
+++ b/.changeset/shaggy-melons-drive.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/catalog-model': patch
+'@backstage/catalog-model': minor
 ---
 
 Adding an optional type field to entity links to group and categorize links

--- a/.changeset/shaggy-melons-drive.md
+++ b/.changeset/shaggy-melons-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Adding an optional type field to entity links to group and categorize links

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -365,6 +365,8 @@ Backstage integrator will ultimately be left to provide the appropriate icon
 component mappings. A generic fallback icon would be provided if a mapping
 cannot be resolved.
 
+The semantics of the `type` field are undefined. The adopter is free to define their own set of types and utilize them as they wish. Some potential use cases can be to utilize the type field to validate certain links exist on entities or to create customized UI components for specific link types.
+
 ## Common to All Kinds: Relations
 
 The `relations` root field is a read-only list of relations, between the current

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -55,6 +55,7 @@ metadata:
     - url: https://admin.example-org.com
       title: Admin Dashboard
       icon: dashboard
+      type: admin-dashboard
 spec:
   type: website
   lifecycle: production
@@ -83,7 +84,8 @@ This is the same entity as returned in JSON from the software catalog API:
       {
         "url": "https://admin.example-org.com",
         "title": "Admin Dashboard",
-        "icon": "dashboard"
+        "icon": "dashboard",
+        "type": "admin-dashboard"
       }
     ],
     "tags": ["java"],
@@ -353,6 +355,7 @@ Fields of a link are:
 | `url`   | String | [Required] A `url` in a standard `uri` format (e.g. `https://example.com/some/page`) |
 | `title` | String | [Optional] A user friendly display name for the link.                                |
 | `icon`  | String | [Optional] A key representing a visual icon to be displayed in the UI.               |
+| `type`  | String | [Optional] An optional value to categorize links into specific groups.               |
 
 _NOTE_: The `icon` field value is meant to be a semantic key that will map to a
 specific icon that may be provided by an icon library (e.g. `material-ui`

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -159,6 +159,7 @@ export type EntityLink = {
   url: string;
   title?: string;
   icon?: string;
+  type?: string;
 };
 
 // @public

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -210,4 +210,9 @@ export type EntityLink = {
    * An optional semantic key that represents a visual icon.
    */
   icon?: string;
+
+  /**
+   * An optional value to categorize links into specific groups
+   */
+  type?: string;
 };

--- a/packages/catalog-model/src/schema/EntityMeta.schema.json
+++ b/packages/catalog-model/src/schema/EntityMeta.schema.json
@@ -108,6 +108,12 @@
             "description": "A key representing a visual icon to be displayed in the UI.",
             "examples": ["dashboard"],
             "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "description": "An optional value to categorize links into specific groups.",
+            "examples": ["runbook", "documentation", "logs", "dashboard"],
+            "minLength": 1
           }
         }
       }


### PR DESCRIPTION
Add an optional type field to entity links that will allow developers
to group and categorize links based on types.

closes #10404

Signed-off-by: James Russo <jrusso@brex.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
