### PR TITLE
fix: check for `integrations.github` without retrieving `integrations`

### DIFF
--- a/.changeset/unlucky-stingrays-juggle.md
+++ b/.changeset/unlucky-stingrays-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Support use without `integrations` or only integrations without frontend visible properties (e.g., `bitbucketCloud`) being configured by checking `integrations.github` directly without attempting to load `integrations`.

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -46,8 +46,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
   const appTitle = configApi.getOptional('app.title') || 'Backstage';
   const catalogImportApi = useApi(catalogImportApiRef);
 
-  const integrations = configApi.getConfig('integrations');
-  const hasGithubIntegration = integrations.has('github');
+  const hasGithubIntegration = configApi.has('integrations.github');
 
   const catalogFilename = useCatalogFilename();
 


### PR DESCRIPTION
Support use without `integrations` or only integrations without frontend visible properties
(e.g., `bitbucketCloud`) being configured by checking `integrations.github` directly
without attempting to load `integrations`.

Previously, `integrations` was retrieved first and then the existence of the
key `github` was checked.

This could fail if there was no config below `integrations` which has `@visibility frontend`.

This happened if no integration or only non-Github integrations without
frontend visible properties like `integrations.bitbucketCloud` are used.

After this change, we will check `integrations.github` directly.

Closes: #11700
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
