### PR TITLE
fix: allow frontend visibility for `integrations` itself

### DIFF
--- a/.changeset/sweet-plants-sparkle.md
+++ b/.changeset/sweet-plants-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Allow frontend visibility for `integrations` itself.

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -15,7 +15,10 @@
  */
 
 export interface Config {
-  /** Configuration for integrations towards various external repository provider systems */
+  /**
+   * Configuration for integrations towards various external repository provider systems
+   * @visibility frontend
+   */
   integrations?: {
     /** Integration configuration for Azure */
     azure?: Array<{


### PR DESCRIPTION
Currently, `integrations` is retrieved at catalog-import to check
configured integrations.

This could fail if there was no config below `integrations` which has `@visibility frontent`.

This happened if no integration or only non-Github integrations without
frontend visible properties like `integrations.bitbucketCloud` are used.

After this change, at least `integrations` will alway be visible to the frontend.

Closes: #11700
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
