### PR TITLE
feat: use same initial filter `owned` at TechDocsIndexPage as at CatalogPage

### DIFF
--- a/.changeset/wicked-dragons-brush.md
+++ b/.changeset/wicked-dragons-brush.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Use the same initial filter `owned` for the `TechDocsIndexPage` as for the `CatalogPage`.
+
+If you prefer to keep the previous behavior, you can change the default for the initial filter
+to `all` (or `starred` if you rather prefer that).
+
+```
+<TechDocsIndexPage initiallySelectedFilter="all" />
+```
+
+In general, with this change you will be able to set props at `TechDocsIndexPage`.

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -45,15 +45,11 @@ export type ContentStateTypes =
 
 // @public
 export const DefaultTechDocsHome: (
-  props: DefaultTechDocsHomeProps,
+  props: TechDocsIndexPageProps,
 ) => JSX.Element;
 
-// @public
-export type DefaultTechDocsHomeProps = {
-  initialFilter?: UserListFilterKind;
-  columns?: TableColumn<DocsTableRow>[];
-  actions?: TableProps<DocsTableRow>['actions'];
-};
+// @public @deprecated
+export type DefaultTechDocsHomeProps = TechDocsIndexPageProps;
 
 // @public
 export const DocsCardGrid: (props: DocsCardGridProps) => JSX.Element | null;
@@ -256,7 +252,14 @@ export type TechDocsCustomHomeProps = {
 export type TechDocsEntityMetadata = TechDocsEntityMetadata_2;
 
 // @public
-export const TechDocsIndexPage: () => JSX.Element;
+export const TechDocsIndexPage: (props: TechDocsIndexPageProps) => JSX.Element;
+
+// @public
+export type TechDocsIndexPageProps = {
+  initialFilter?: UserListFilterKind;
+  columns?: TableColumn<DocsTableRow>[];
+  actions?: TableProps<DocsTableRow>['actions'];
+};
 
 // @public @deprecated (undocumented)
 export type TechDocsMetadata = TechDocsMetadata_2;

--- a/plugins/techdocs/src/home/components/DefaultTechDocsHome.tsx
+++ b/plugins/techdocs/src/home/components/DefaultTechDocsHome.tsx
@@ -19,39 +19,34 @@ import {
   Content,
   ContentHeader,
   SupportButton,
-  TableColumn,
-  TableProps,
 } from '@backstage/core-components';
 import {
   CatalogFilterLayout,
   EntityListProvider,
   EntityOwnerPicker,
   EntityTagPicker,
-  UserListFilterKind,
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
 import { TechDocsPageWrapper } from './TechDocsPageWrapper';
 import { TechDocsPicker } from './TechDocsPicker';
-import { DocsTableRow, EntityListDocsTable } from './Tables';
+import { EntityListDocsTable } from './Tables';
+import { TechDocsIndexPageProps } from './TechDocsIndexPage';
 
 /**
  * Props for {@link DefaultTechDocsHome}
  *
  * @public
+ * @deprecated Please use `TechDocsIndexPageProps` instead.
  */
-export type DefaultTechDocsHomeProps = {
-  initialFilter?: UserListFilterKind;
-  columns?: TableColumn<DocsTableRow>[];
-  actions?: TableProps<DocsTableRow>['actions'];
-};
+export type DefaultTechDocsHomeProps = TechDocsIndexPageProps;
 
 /**
  * Component which renders a default documentation landing page.
  *
  * @public
  */
-export const DefaultTechDocsHome = (props: DefaultTechDocsHomeProps) => {
-  const { initialFilter = 'all', columns, actions } = props;
+export const DefaultTechDocsHome = (props: TechDocsIndexPageProps) => {
+  const { initialFilter = 'owned', columns, actions } = props;
   return (
     <TechDocsPageWrapper>
       <Content>

--- a/plugins/techdocs/src/home/components/TechDocsIndexPage.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsIndexPage.tsx
@@ -16,10 +16,24 @@
 
 import React from 'react';
 import { useOutlet } from 'react-router';
+import { TableColumn, TableProps } from '@backstage/core-components';
+import { UserListFilterKind } from '@backstage/plugin-catalog-react';
 import { DefaultTechDocsHome } from './DefaultTechDocsHome';
+import { DocsTableRow } from './Tables';
 
-export const TechDocsIndexPage = () => {
+/**
+ * Props for {@link TechDocsIndexPage}
+ *
+ * @public
+ */
+export type TechDocsIndexPageProps = {
+  initialFilter?: UserListFilterKind;
+  columns?: TableColumn<DocsTableRow>[];
+  actions?: TableProps<DocsTableRow>['actions'];
+};
+
+export const TechDocsIndexPage = (props: TechDocsIndexPageProps) => {
   const outlet = useOutlet();
 
-  return outlet || <DefaultTechDocsHome />;
+  return outlet || <DefaultTechDocsHome {...props} />;
 };

--- a/plugins/techdocs/src/home/components/index.ts
+++ b/plugins/techdocs/src/home/components/index.ts
@@ -24,5 +24,6 @@ export type {
   TabsConfig,
   TechDocsCustomHomeProps,
 } from './TechDocsCustomHome';
+export type { TechDocsIndexPageProps } from './TechDocsIndexPage';
 export * from './TechDocsPageWrapper';
 export * from './TechDocsPicker';


### PR DESCRIPTION
Aligns filter use of catalog page (and api page) with techdocs page.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
