### PR TITLE
added type predicates for entities

### DIFF
--- a/.changeset/pretty-masks-live.md
+++ b/.changeset/pretty-masks-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Added type predicates for all entity types, e.g. isUserEntity

--- a/.changeset/silent-coats-brake.md
+++ b/.changeset/silent-coats-brake.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Use entity type predicates from catalog-model

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -254,6 +254,36 @@ export { GroupEntityV1alpha1 };
 // @public
 export const groupEntityV1alpha1Validator: KindValidator;
 
+// @public (undocumented)
+export function isApiEntity(entity: Entity): entity is ApiEntityV1alpha1;
+
+// @public (undocumented)
+export function isComponentEntity(
+  entity: Entity,
+): entity is ComponentEntityV1alpha1;
+
+// @public (undocumented)
+export function isDomainEntity(entity: Entity): entity is DomainEntityV1alpha1;
+
+// @public (undocumented)
+export function isGroupEntity(entity: Entity): entity is GroupEntityV1alpha1;
+
+// @public (undocumented)
+export function isLocationEntity(
+  entity: Entity,
+): entity is LocationEntityV1alpha1;
+
+// @public (undocumented)
+export function isResourceEntity(
+  entity: Entity,
+): entity is ResourceEntityV1alpha1;
+
+// @public (undocumented)
+export function isSystemEntity(entity: Entity): entity is SystemEntityV1alpha1;
+
+// @public (undocumented)
+export function isUserEntity(entity: Entity): entity is UserEntityV1alpha1;
+
 // @public
 export type KindValidator = {
   check(entity: Entity): Promise<boolean>;

--- a/packages/catalog-model/src/entity/conditions.test.ts
+++ b/packages/catalog-model/src/entity/conditions.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from './Entity';
+import {
+  isApiEntity,
+  isComponentEntity,
+  isDomainEntity,
+  isGroupEntity,
+  isLocationEntity,
+  isResourceEntity,
+  isSystemEntity,
+  isUserEntity,
+} from './conditions';
+
+const apiEntity: Entity = {
+  apiVersion: '',
+  kind: 'api',
+  metadata: { name: 'api' },
+};
+const componentEntity: Entity = {
+  apiVersion: '',
+  kind: 'component',
+  metadata: { name: 'Component' },
+};
+const domainEntity: Entity = {
+  apiVersion: '',
+  kind: 'domain',
+  metadata: { name: 'Domain' },
+};
+const groupEntity: Entity = {
+  apiVersion: '',
+  kind: 'group',
+  metadata: { name: 'Group' },
+};
+const locationEntity: Entity = {
+  apiVersion: '',
+  kind: 'location',
+  metadata: { name: 'Location' },
+};
+const resourceEntity: Entity = {
+  apiVersion: '',
+  kind: 'resource',
+  metadata: { name: 'Resource' },
+};
+const systemEntity: Entity = {
+  apiVersion: '',
+  kind: 'system',
+  metadata: { name: 'System' },
+};
+const userEntity: Entity = {
+  apiVersion: '',
+  kind: 'user',
+  metadata: { name: 'User' },
+};
+
+describe('isApiEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isApiEntity(componentEntity)).not.toBeTruthy();
+    expect(isApiEntity(domainEntity)).not.toBeTruthy();
+    expect(isApiEntity(groupEntity)).not.toBeTruthy();
+    expect(isApiEntity(locationEntity)).not.toBeTruthy();
+    expect(isApiEntity(resourceEntity)).not.toBeTruthy();
+    expect(isApiEntity(systemEntity)).not.toBeTruthy();
+    expect(isApiEntity(userEntity)).not.toBeTruthy();
+    expect(isApiEntity(apiEntity)).toBeTruthy();
+  });
+});
+
+describe('isComponentEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isComponentEntity(apiEntity)).not.toBeTruthy();
+    expect(isComponentEntity(domainEntity)).not.toBeTruthy();
+    expect(isComponentEntity(groupEntity)).not.toBeTruthy();
+    expect(isComponentEntity(locationEntity)).not.toBeTruthy();
+    expect(isComponentEntity(resourceEntity)).not.toBeTruthy();
+    expect(isComponentEntity(systemEntity)).not.toBeTruthy();
+    expect(isComponentEntity(userEntity)).not.toBeTruthy();
+    expect(isComponentEntity(componentEntity)).toBeTruthy();
+  });
+});
+
+describe('isDomainEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isDomainEntity(apiEntity)).not.toBeTruthy();
+    expect(isDomainEntity(componentEntity)).not.toBeTruthy();
+    expect(isDomainEntity(groupEntity)).not.toBeTruthy();
+    expect(isDomainEntity(locationEntity)).not.toBeTruthy();
+    expect(isDomainEntity(resourceEntity)).not.toBeTruthy();
+    expect(isDomainEntity(systemEntity)).not.toBeTruthy();
+    expect(isDomainEntity(userEntity)).not.toBeTruthy();
+    expect(isDomainEntity(domainEntity)).toBeTruthy();
+  });
+});
+
+describe('isGroupEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isGroupEntity(apiEntity)).not.toBeTruthy();
+    expect(isGroupEntity(componentEntity)).not.toBeTruthy();
+    expect(isGroupEntity(domainEntity)).not.toBeTruthy();
+    expect(isGroupEntity(locationEntity)).not.toBeTruthy();
+    expect(isGroupEntity(resourceEntity)).not.toBeTruthy();
+    expect(isGroupEntity(systemEntity)).not.toBeTruthy();
+    expect(isGroupEntity(userEntity)).not.toBeTruthy();
+    expect(isGroupEntity(groupEntity)).toBeTruthy();
+  });
+});
+
+describe('isLocationEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isLocationEntity(apiEntity)).not.toBeTruthy();
+    expect(isLocationEntity(componentEntity)).not.toBeTruthy();
+    expect(isLocationEntity(domainEntity)).not.toBeTruthy();
+    expect(isLocationEntity(groupEntity)).not.toBeTruthy();
+    expect(isLocationEntity(resourceEntity)).not.toBeTruthy();
+    expect(isLocationEntity(systemEntity)).not.toBeTruthy();
+    expect(isLocationEntity(userEntity)).not.toBeTruthy();
+    expect(isLocationEntity(locationEntity)).toBeTruthy();
+  });
+});
+
+describe('isResourceEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isResourceEntity(apiEntity)).not.toBeTruthy();
+    expect(isResourceEntity(componentEntity)).not.toBeTruthy();
+    expect(isResourceEntity(domainEntity)).not.toBeTruthy();
+    expect(isResourceEntity(groupEntity)).not.toBeTruthy();
+    expect(isResourceEntity(locationEntity)).not.toBeTruthy();
+    expect(isResourceEntity(systemEntity)).not.toBeTruthy();
+    expect(isResourceEntity(userEntity)).not.toBeTruthy();
+    expect(isResourceEntity(resourceEntity)).toBeTruthy();
+  });
+});
+
+describe('isSystemEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isSystemEntity(apiEntity)).not.toBeTruthy();
+    expect(isSystemEntity(componentEntity)).not.toBeTruthy();
+    expect(isSystemEntity(domainEntity)).not.toBeTruthy();
+    expect(isSystemEntity(groupEntity)).not.toBeTruthy();
+    expect(isSystemEntity(locationEntity)).not.toBeTruthy();
+    expect(isSystemEntity(resourceEntity)).not.toBeTruthy();
+    expect(isSystemEntity(userEntity)).not.toBeTruthy();
+    expect(isSystemEntity(systemEntity)).toBeTruthy();
+  });
+});
+
+describe('isUserEntity', () => {
+  it('should check for the intended type', () => {
+    expect(isUserEntity(apiEntity)).not.toBeTruthy();
+    expect(isUserEntity(componentEntity)).not.toBeTruthy();
+    expect(isUserEntity(domainEntity)).not.toBeTruthy();
+    expect(isUserEntity(groupEntity)).not.toBeTruthy();
+    expect(isUserEntity(locationEntity)).not.toBeTruthy();
+    expect(isUserEntity(resourceEntity)).not.toBeTruthy();
+    expect(isUserEntity(systemEntity)).not.toBeTruthy();
+    expect(isUserEntity(userEntity)).toBeTruthy();
+  });
+});

--- a/packages/catalog-model/src/entity/conditions.ts
+++ b/packages/catalog-model/src/entity/conditions.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ApiEntity,
+  ComponentEntity,
+  DomainEntity,
+  GroupEntity,
+  LocationEntity,
+  ResourceEntity,
+  SystemEntity,
+  UserEntity,
+} from '../kinds';
+import { Entity } from './Entity';
+
+/**
+ * @public
+ */
+export function isApiEntity(entity: Entity): entity is ApiEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'API';
+}
+/**
+ * @public
+ */
+export function isComponentEntity(entity: Entity): entity is ComponentEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'COMPONENT';
+}
+/**
+ * @public
+ */
+export function isDomainEntity(entity: Entity): entity is DomainEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'DOMAIN';
+}
+/**
+ * @public
+ */
+export function isGroupEntity(entity: Entity): entity is GroupEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
+}
+/**
+ * @public
+ */
+export function isLocationEntity(entity: Entity): entity is LocationEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'LOCATION';
+}
+/**
+ * @public
+ */
+export function isResourceEntity(entity: Entity): entity is ResourceEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'RESOURCE';
+}
+/**
+ * @public
+ */
+export function isSystemEntity(entity: Entity): entity is SystemEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'SYSTEM';
+}
+/**
+ * @public
+ */
+export function isUserEntity(entity: Entity): entity is UserEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'USER';
+}

--- a/packages/catalog-model/src/entity/index.ts
+++ b/packages/catalog-model/src/entity/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from './conditions';
 export {
   DEFAULT_NAMESPACE,
   ANNOTATION_EDIT_URL,

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -20,8 +20,8 @@ import {
 } from '@backstage/backend-common';
 import {
   Entity,
+  isUserEntity,
   stringifyEntityRef,
-  UserEntity,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -93,13 +93,9 @@ export class DefaultCatalogCollator {
     return formatted.toLowerCase();
   }
 
-  private isUserEntity(entity: Entity): entity is UserEntity {
-    return entity.kind.toLocaleUpperCase('en-US') === 'USER';
-  }
-
   private getDocumentText(entity: Entity): string {
     let documentText = entity.metadata.description || '';
-    if (this.isUserEntity(entity)) {
+    if (isUserEntity(entity)) {
       if (entity.spec?.profile?.displayName && documentText) {
         // combine displayName and description
         const displayName = entity.spec?.profile?.displayName;

--- a/plugins/catalog-backend/src/search/util.ts
+++ b/plugins/catalog-backend/src/search/util.ts
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, UserEntity, GroupEntity } from '@backstage/catalog-model';
-
-function isUserEntity(entity: Entity): entity is UserEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'USER';
-}
-
-function isGroupEntity(entity: Entity): entity is GroupEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
-}
+import { Entity, isUserEntity, isGroupEntity } from '@backstage/catalog-model';
 
 export function getDocumentText(entity: Entity): string {
   const documentTexts: string[] = [];

--- a/plugins/catalog/src/components/EntitySwitch/conditions.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.ts
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ApiEntity,
-  ComponentEntity,
-  DomainEntity,
-  Entity,
-  GroupEntity,
-  LocationEntity,
-  ResourceEntity,
-  SystemEntity,
-  UserEntity,
-} from '@backstage/catalog-model';
+import { ComponentEntity, Entity } from '@backstage/catalog-model';
 
 function strCmp(a: string | undefined, b: string | undefined): boolean {
   return Boolean(
@@ -66,53 +56,4 @@ export function isComponentType(types: string | string[]) {
  */
 export function isNamespace(namespaces: string | string[]) {
   return (entity: Entity) => strCmpAll(entity.metadata?.namespace, namespaces);
-}
-
-/**
- * @public
- */
-export function isApiEntity(entity: Entity): entity is ApiEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'API';
-}
-/**
- * @public
- */
-export function isComponentEntity(entity: Entity): entity is ComponentEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'COMPONENT';
-}
-/**
- * @public
- */
-export function isDomainEntity(entity: Entity): entity is DomainEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'DOMAIN';
-}
-/**
- * @public
- */
-export function isGroupEntity(entity: Entity): entity is GroupEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
-}
-/**
- * @public
- */
-export function isLocationEntity(entity: Entity): entity is LocationEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'LOCATION';
-}
-/**
- * @public
- */
-export function isResourceEntity(entity: Entity): entity is ResourceEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'RESOURCE';
-}
-/**
- * @public
- */
-export function isSystemEntity(entity: Entity): entity is SystemEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'SYSTEM';
-}
-/**
- * @public
- */
-export function isUserEntity(entity: Entity): entity is UserEntity {
-  return entity.kind.toLocaleUpperCase('en-US') === 'USER';
 }

--- a/plugins/catalog/src/components/EntitySwitch/conditions.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
-import { Entity, ComponentEntity } from '@backstage/catalog-model';
+import {
+  ApiEntity,
+  ComponentEntity,
+  DomainEntity,
+  Entity,
+  GroupEntity,
+  LocationEntity,
+  ResourceEntity,
+  SystemEntity,
+  UserEntity,
+} from '@backstage/catalog-model';
 
 function strCmp(a: string | undefined, b: string | undefined): boolean {
   return Boolean(
@@ -56,4 +66,53 @@ export function isComponentType(types: string | string[]) {
  */
 export function isNamespace(namespaces: string | string[]) {
   return (entity: Entity) => strCmpAll(entity.metadata?.namespace, namespaces);
+}
+
+/**
+ * @public
+ */
+export function isApiEntity(entity: Entity): entity is ApiEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'API';
+}
+/**
+ * @public
+ */
+export function isComponentEntity(entity: Entity): entity is ComponentEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'COMPONENT';
+}
+/**
+ * @public
+ */
+export function isDomainEntity(entity: Entity): entity is DomainEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'DOMAIN';
+}
+/**
+ * @public
+ */
+export function isGroupEntity(entity: Entity): entity is GroupEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
+}
+/**
+ * @public
+ */
+export function isLocationEntity(entity: Entity): entity is LocationEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'LOCATION';
+}
+/**
+ * @public
+ */
+export function isResourceEntity(entity: Entity): entity is ResourceEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'RESOURCE';
+}
+/**
+ * @public
+ */
+export function isSystemEntity(entity: Entity): entity is SystemEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'SYSTEM';
+}
+/**
+ * @public
+ */
+export function isUserEntity(entity: Entity): entity is UserEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'USER';
 }

--- a/plugins/catalog/src/components/EntitySwitch/index.ts
+++ b/plugins/catalog/src/components/EntitySwitch/index.ts
@@ -16,4 +16,4 @@
 
 export { EntitySwitch } from './EntitySwitch';
 export type { EntitySwitchProps, EntitySwitchCaseProps } from './EntitySwitch';
-export * from './conditions';
+export { isKind, isNamespace, isComponentType } from './conditions';

--- a/plugins/catalog/src/components/EntitySwitch/index.ts
+++ b/plugins/catalog/src/components/EntitySwitch/index.ts
@@ -16,4 +16,4 @@
 
 export { EntitySwitch } from './EntitySwitch';
 export type { EntitySwitchProps, EntitySwitchCaseProps } from './EntitySwitch';
-export { isKind, isNamespace, isComponentType } from './conditions';
+export * from './conditions';


### PR DESCRIPTION
Signed-off-by: Alex Rybchenko <arybchenko@box.com>

## Hey, I just made a Pull Request!
These type predicates are already used in couple plugins, maybe we could just add single source of truth (maybe `catalog-common` will be a better place).
I will also add tests if you approve this idea :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
