### PR TITLE
[GitlabDiscoveryEntityProvider] Add possibility to scan all the groups in the project

### DIFF
--- a/.changeset/two-crews-accept.md
+++ b/.changeset/two-crews-accept.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-gitlab': minor
+'@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
 Add the possibility in the `GitlabDiscoveryEntityProvider` to scan the whole project instead of concrete groups. For that, use a configuration like this one, where the group parameter is omitted (not mandatory anymore):

--- a/.changeset/two-crews-accept.md
+++ b/.changeset/two-crews-accept.md
@@ -2,13 +2,14 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-Add the possibility in the `GitlabDiscoveryEntityProvider` to scan the whole project instead of concrete groups. For that, use a configuration like this one:
+Add the possibility in the `GitlabDiscoveryEntityProvider` to scan the whole project instead of concrete groups. For that, use a configuration like this one, where the group parameter is omitted (not mandatory anymore):
 
 ```yaml
 catalog:
   providers:
     gitlab:
-      host: gitlab-host # Identifies one of the hosts set up in the integrations
-      branch: main # Optional. Uses `master` as default
-      entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
+      yourProviderId:
+        host: gitlab-host # Identifies one of the hosts set up in the integrations
+        branch: main # Optional. Uses `master` as default
+        entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
 ```

--- a/.changeset/two-crews-accept.md
+++ b/.changeset/two-crews-accept.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': minor
+---
+
+Add the possibility in the `GitlabDiscoveryEntityProvider` to scan the whole project instead of concrete groups. For that, use a configuration like this one:
+
+```yaml
+catalog:
+  providers:
+    gitlab:
+      host: gitlab-host # Identifies one of the hosts set up in the integrations
+      branch: main # Optional. Uses `master` as default
+      entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
+```

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -22,20 +22,8 @@ catalog:
       yourProviderId:
         host: gitlab-host # Identifies one of the hosts set up in the integrations
         branch: main # Optional. Uses `master` as default
-        group: example-group # Group and subgroup (if needed) to look for repositories
+        group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole project will be scanned
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
-```
-
-If you desire so, it's also possible to execute the gitlab discovery in your entire
-project. In order to do that, use this catalog configuration instead:
-
-```yaml
-catalog:
-  providers:
-    gitlab:
-      host: gitlab-host # Identifies one of the hosts set up in the integrations
-      branch: main # Optional. Uses `master` as default
-      entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
 ```
 
 As this provider is not one of the default providers, you will first need to install

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -26,6 +26,18 @@ catalog:
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
 ```
 
+If you desire so, it's also possible to execute the gitlab discovery in your entire
+project. In order to do that, use this catalog configuration instead:
+
+```yaml
+catalog:
+  providers:
+    gitlab:
+      host: gitlab-host # Identifies one of the hosts set up in the integrations
+      branch: main # Optional. Uses `master` as default
+      entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
+```
+
 As this provider is not one of the default providers, you will first need to install
 the gitlab catalog plugin:
 

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -23,33 +23,53 @@ export interface Config {
       /**
        * GitlabDiscoveryEntityProvider configuration
        */
-      gitlab?: Record<
-        string,
-        {
-          /**
-           * (Required) Gitlab's host name.
-           * @visibility backend
-           */
-          host: string;
-          /**
-           * (Required) Gitlab's group[/subgroup] where the discovery is done.
-           * @visibility backend
-           */
-          group: string;
-          /**
-           * (Optional) Default branch to read the catalog-info.yaml file.
-           * If not set, 'master' will be used.
-           * @visibility backend
-           */
-          branch?: string;
-          /**
-           * (Optional) The name used for the catalog file.
-           * If not set, 'catalog-info.yaml' will be used.
-           * @visibility backend
-           */
-          entityFilename?: string;
-        }
-      >;
+      gitlab?:
+        | {
+            /**
+             * (Required) Gitlab's host name.
+             * @visibility backend
+             */
+            host: string;
+            /**
+             * (Optional) Default branch to read the catalog-info.yaml file.
+             * If not set, 'master' will be used.
+             * @visibility backend
+             */
+            branch?: string;
+            /**
+             * (Optional) The name used for the catalog file.
+             * If not set, 'catalog-info.yaml' will be used.
+             * @visibility backend
+             */
+            entityFilename?: string;
+          }
+        | Record<
+            string,
+            {
+              /**
+               * (Required) Gitlab's host name.
+               * @visibility backend
+               */
+              host: string;
+              /**
+               * (Required) Gitlab's group[/subgroup] where the discovery is done.
+               * @visibility backend
+               */
+              group: string;
+              /**
+               * (Optional) Default branch to read the catalog-info.yaml file.
+               * If not set, 'master' will be used.
+               * @visibility backend
+               */
+              branch?: string;
+              /**
+               * (Optional) The name used for the catalog file.
+               * If not set, 'catalog-info.yaml' will be used.
+               * @visibility backend
+               */
+              entityFilename?: string;
+            }
+          >;
     };
   };
 }

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -23,53 +23,34 @@ export interface Config {
       /**
        * GitlabDiscoveryEntityProvider configuration
        */
-      gitlab?:
-        | {
-            /**
-             * (Required) Gitlab's host name.
-             * @visibility backend
-             */
-            host: string;
-            /**
-             * (Optional) Default branch to read the catalog-info.yaml file.
-             * If not set, 'master' will be used.
-             * @visibility backend
-             */
-            branch?: string;
-            /**
-             * (Optional) The name used for the catalog file.
-             * If not set, 'catalog-info.yaml' will be used.
-             * @visibility backend
-             */
-            entityFilename?: string;
-          }
-        | Record<
-            string,
-            {
-              /**
-               * (Required) Gitlab's host name.
-               * @visibility backend
-               */
-              host: string;
-              /**
-               * (Required) Gitlab's group[/subgroup] where the discovery is done.
-               * @visibility backend
-               */
-              group: string;
-              /**
-               * (Optional) Default branch to read the catalog-info.yaml file.
-               * If not set, 'master' will be used.
-               * @visibility backend
-               */
-              branch?: string;
-              /**
-               * (Optional) The name used for the catalog file.
-               * If not set, 'catalog-info.yaml' will be used.
-               * @visibility backend
-               */
-              entityFilename?: string;
-            }
-          >;
+      gitlab?: Record<
+        string,
+        {
+          /**
+           * (Required) Gitlab's host name.
+           * @visibility backend
+           */
+          host: string;
+          /**
+           * (Optional) Gitlab's group[/subgroup] where the discovery is done.
+           * If not defined the whole project will be scanned.
+           * @visibility backend
+           */
+          group?: string;
+          /**
+           * (Optional) Default branch to read the catalog-info.yaml file.
+           * If not set, 'master' will be used.
+           * @visibility backend
+           */
+          branch?: string;
+          /**
+           * (Optional) The name used for the catalog file.
+           * If not set, 'catalog-info.yaml' will be used.
+           * @visibility backend
+           */
+          entityFilename?: string;
+        }
+      >;
     };
   };
 }

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -103,4 +103,21 @@ describe('config', () => {
       "Missing required config value at 'catalog.providers.gitlab.test.group'",
     );
   });
+
+  it('read full gitlab project', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          gitlab: {
+            host: 'host',
+            branch: 'main',
+          },
+        },
+      },
+    });
+
+    const result = readGitlabConfigs(config);
+    expect(result).toHaveLength(1);
+    expect(result[0].group).toEqual('');
+  });
 });

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -100,7 +100,7 @@ describe('config', () => {
     });
 
     expect(() => readGitlabConfigs(config)).toThrow(
-      "Missing required config value at 'catalog.providers.gitlab.test.group'",
+      "Missing required config value at 'catalog.providers.gitlab.test.host'",
     );
   });
 
@@ -109,8 +109,10 @@ describe('config', () => {
       catalog: {
         providers: {
           gitlab: {
-            host: 'host',
-            branch: 'main',
+            test: {
+              host: 'host',
+              branch: 'main',
+            },
           },
         },
       },

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -48,6 +48,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
  * @param config - The config object to extract from
  */
 export function readGitlabConfigs(config: Config): GitlabProviderConfig[] {
+  const reservedParams = ['host', 'group', 'branch', 'catalogFile'];
   const configs: GitlabProviderConfig[] = [];
 
   const providerConfigs = config.getOptionalConfig('catalog.providers.gitlab');
@@ -56,8 +57,20 @@ export function readGitlabConfigs(config: Config): GitlabProviderConfig[] {
     return configs;
   }
 
-  for (const id of providerConfigs.keys()) {
-    configs.push(readGitlabConfig(id, providerConfigs.getConfig(id)));
+  if (providerConfigs.keys().some(r => reservedParams.indexOf(r) >= 0)) {
+    configs.push({
+      id: 'full-check',
+      group: '',
+      branch: providerConfigs.getOptionalString('branch') ?? 'master',
+      host: providerConfigs.getString('host'),
+      catalogFile:
+        providerConfigs.getOptionalString('entityFilename') ??
+        'catalog-info.yaml',
+    });
+  } else {
+    for (const id of providerConfigs.keys()) {
+      configs.push(readGitlabConfig(id, providerConfigs.getConfig(id)));
+    }
   }
 
   return configs;

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -25,7 +25,7 @@ import { GitlabProviderConfig } from '../lib/types';
  * @param config - The config object to extract from
  */
 function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
-  const group = config.getString('group');
+  const group = config.getOptionalString('group') ?? '';
   const host = config.getString('host');
   const branch = config.getOptionalString('branch') ?? 'master';
   const catalogFile =
@@ -48,7 +48,6 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
  * @param config - The config object to extract from
  */
 export function readGitlabConfigs(config: Config): GitlabProviderConfig[] {
-  const reservedParams = ['host', 'group', 'branch', 'catalogFile'];
   const configs: GitlabProviderConfig[] = [];
 
   const providerConfigs = config.getOptionalConfig('catalog.providers.gitlab');
@@ -57,20 +56,8 @@ export function readGitlabConfigs(config: Config): GitlabProviderConfig[] {
     return configs;
   }
 
-  if (providerConfigs.keys().some(r => reservedParams.indexOf(r) >= 0)) {
-    configs.push({
-      id: 'full-check',
-      group: '',
-      branch: providerConfigs.getOptionalString('branch') ?? 'master',
-      host: providerConfigs.getString('host'),
-      catalogFile:
-        providerConfigs.getOptionalString('entityFilename') ??
-        'catalog-info.yaml',
-    });
-  } else {
-    for (const id of providerConfigs.keys()) {
-      configs.push(readGitlabConfig(id, providerConfigs.getConfig(id)));
-    }
+  for (const id of providerConfigs.keys()) {
+    configs.push(readGitlabConfig(id, providerConfigs.getConfig(id)));
   }
 
   return configs;


### PR DESCRIPTION
Signed-off-by: ivgo <ivgo@spreadgroup.com>

## Hey, I just made a Pull Request!

As discussed in the PR #11886, I'm adding the possibility to scan the whole project instead of concrete groups, as it was designed at first. The idea to do it is pretty similar to the one in the AWS Entity Provider as well. So if you just skip the `providerId` and define the host and optional parameters, the entity provider will automatically scan all the repositories in your gitlab instance. 

I have just added a test for the config file, as I haven't changed any other function, and the `listProjects` is already designed for this purpose.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
