### PR TITLE
[TechDocs] Fix docker pull default on cli generate command

### DIFF
--- a/.changeset/techdocs-the-whole-pulse.md
+++ b/.changeset/techdocs-the-whole-pulse.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Fixed a bug that prevented docker images from being pulled by default when generating TechDocs.

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -38,7 +38,7 @@ export function registerCommands(program: Command) {
       'The mkdocs docker container to use',
       defaultDockerImage,
     )
-    .option('--no-pull', 'Do not pull the latest docker image', false)
+    .option('--no-pull', 'Do not pull the latest docker image')
     .option(
       '--no-docker',
       'Do not use Docker, use MkDocs executable and plugins in current user environment.',


### PR DESCRIPTION
## What / Why

Looks like a regression may have been introduced in the major version upgrade of `commander` in #10617, which caused `techdocs-cli generate` to _never_ pull the latest image, rather than respecting the `--no-pull` flag (relevant upstream change here https://github.com/tj/commander.js/pull/1652).

Closes #11553

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
