### PR TITLE
feat(adrs): track discover event and result rank in AdrSearchResultListItem

### DIFF
--- a/.changeset/thick-radios-drive.md
+++ b/.changeset/thick-radios-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+Track discover event and result rank for `AdrSearchResultListItem`

--- a/plugins/adr/api-report.md
+++ b/plugins/adr/api-report.md
@@ -47,10 +47,12 @@ export const AdrReader: {
 export const AdrSearchResultListItem: ({
   lineClamp,
   highlight,
+  rank,
   result,
 }: {
   lineClamp?: number | undefined;
   highlight?: ResultHighlight | undefined;
+  rank?: number | undefined;
   result: AdrDocument;
 }) => JSX.Element;
 

--- a/plugins/adr/src/search/AdrSearchResultListItem.tsx
+++ b/plugins/adr/src/search/AdrSearchResultListItem.tsx
@@ -24,6 +24,7 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import { Link } from '@backstage/core-components';
+import { useAnalytics } from '@backstage/core-plugin-api';
 import { AdrDocument } from '@backstage/plugin-adr-common';
 import { ResultHighlight } from '@backstage/plugin-search-common';
 import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
@@ -46,16 +47,26 @@ const useStyles = makeStyles({
 export const AdrSearchResultListItem = ({
   lineClamp = 5,
   highlight,
+  rank,
   result,
 }: {
   lineClamp?: number;
   highlight?: ResultHighlight;
+  rank?: number;
   result: AdrDocument;
 }) => {
   const classes = useStyles();
+  const analytics = useAnalytics();
+
+  const handleClick = () => {
+    analytics.captureEvent('discover', result.title, {
+      attributes: { to: result.location },
+      value: rank,
+    });
+  };
 
   return (
-    <Link to={result.location}>
+    <Link noTrack to={result.location} onClick={handleClick}>
       <ListItem alignItems="flex-start" className={classes.flexContainer}>
         <ListItemText
           className={classes.itemText}


### PR DESCRIPTION

Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Follow up to https://github.com/backstage/backstage/pull/11951 to add rank tracking to `AdrSearchResultListItem`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
