### PR TITLE
More member exports from azure-devops

### DIFF
--- a/.changeset/smooth-sheep-hide.md
+++ b/.changeset/smooth-sheep-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops': patch
+---
+
+Exporting azureDevOpsApiRef, AzureGitTagsIcon, and all hooks for the benefit of other plugins.

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -178,6 +178,11 @@ export const azureDevOpsPlugin: BackstagePlugin<{}, {}>;
 // @public (undocumented)
 export const AzureGitTagsIcon: (props: SvgIconProps) => JSX.Element;
 
+// Warning: (ae-missing-release-tag) "AzurePipelinesIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const AzurePipelinesIcon: (props: SvgIconProps) => JSX.Element;
+
 // Warning: (ae-missing-release-tag) "AzurePullRequestsIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -16,7 +16,6 @@ import { GitTag } from '@backstage/plugin-azure-devops-common';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { PullRequest } from '@backstage/plugin-azure-devops-common';
 import { PullRequestOptions } from '@backstage/plugin-azure-devops-common';
-import { PullRequestStatus } from '@backstage/plugin-azure-devops-common';
 import { RepoBuild } from '@backstage/plugin-azure-devops-common';
 import { RepoBuildOptions } from '@backstage/plugin-azure-devops-common';
 import { SvgIconProps } from '@material-ui/core';
@@ -172,16 +171,6 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
 //
 // @public (undocumented)
 export const azureDevOpsPlugin: BackstagePlugin<{}, {}>;
-
-// Warning: (ae-missing-release-tag) "AzureGitTagsIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const AzureGitTagsIcon: (props: SvgIconProps) => JSX.Element;
-
-// Warning: (ae-missing-release-tag) "AzurePipelinesIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const AzurePipelinesIcon: (props: SvgIconProps) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "AzurePullRequestsIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -348,74 +337,6 @@ export interface PullRequestColumnConfig {
 //
 // @public (undocumented)
 export type PullRequestFilter = (pullRequest: DashboardPullRequest) => boolean;
-
-// Warning: (ae-missing-release-tag) "useAllTeams" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function useAllTeams(): {
-  teams?: Team[];
-  loading: boolean;
-  error?: Error;
-};
-
-// Warning: (ae-missing-release-tag) "useDashboardPullRequests" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function useDashboardPullRequests(
-  project?: string,
-  pollingInterval?: number,
-): {
-  pullRequests?: DashboardPullRequest[];
-  loading: boolean;
-  error?: Error;
-};
-
-// Warning: (ae-missing-release-tag) "useProjectRepoFromEntity" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function useProjectRepoFromEntity(entity: Entity): {
-  project: string;
-  repo: string;
-};
-
-// Warning: (ae-missing-release-tag) "usePullRequests" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function usePullRequests(
-  entity: Entity,
-  defaultLimit?: number,
-  requestedStatus?: PullRequestStatus,
-): {
-  items?: PullRequest[];
-  loading: boolean;
-  error?: Error;
-};
-
-// Warning: (ae-missing-release-tag) "useRepoBuilds" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function useRepoBuilds(
-  entity: Entity,
-  defaultLimit?: number,
-): {
-  items?: RepoBuild[];
-  loading: boolean;
-  error?: Error;
-};
-
-// Warning: (ae-missing-release-tag) "useUserEmail" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function useUserEmail(): string | undefined;
-
-// Warning: (ae-missing-release-tag) "useUserTeamIds" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function useUserTeamIds(userId: string | undefined): {
-  teamIds?: string[];
-  loading: boolean;
-  error?: Error;
-};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -5,10 +5,22 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { BuildRun } from '@backstage/plugin-azure-devops-common';
+import { BuildRunOptions } from '@backstage/plugin-azure-devops-common';
 import { DashboardPullRequest } from '@backstage/plugin-azure-devops-common';
+import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { GitTag } from '@backstage/plugin-azure-devops-common';
+import { IdentityApi } from '@backstage/core-plugin-api';
+import { PullRequest } from '@backstage/plugin-azure-devops-common';
+import { PullRequestOptions } from '@backstage/plugin-azure-devops-common';
+import { PullRequestStatus } from '@backstage/plugin-azure-devops-common';
+import { RepoBuild } from '@backstage/plugin-azure-devops-common';
+import { RepoBuildOptions } from '@backstage/plugin-azure-devops-common';
 import { SvgIconProps } from '@material-ui/core';
+import { Team } from '@backstage/plugin-azure-devops-common';
 
 // Warning: (ae-missing-release-tag) "AllFilter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -55,10 +67,116 @@ export type AssignedToUserFilter = BaseFilter &
       }
   );
 
+// Warning: (ae-missing-release-tag) "AzureDevOpsApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AzureDevOpsApi {
+  // (undocumented)
+  getAllTeams(): Promise<Team[]>;
+  // (undocumented)
+  getBuildRuns(
+    projectName: string,
+    repoName?: string,
+    definitionName?: string,
+    options?: BuildRunOptions,
+  ): Promise<{
+    items: BuildRun[];
+  }>;
+  // (undocumented)
+  getDashboardPullRequests(
+    projectName: string,
+  ): Promise<DashboardPullRequest[]>;
+  // (undocumented)
+  getGitTags(
+    projectName: string,
+    repoName: string,
+  ): Promise<{
+    items: GitTag[];
+  }>;
+  // (undocumented)
+  getPullRequests(
+    projectName: string,
+    repoName: string,
+    options?: PullRequestOptions,
+  ): Promise<{
+    items: PullRequest[];
+  }>;
+  // (undocumented)
+  getRepoBuilds(
+    projectName: string,
+    repoName: string,
+    options?: RepoBuildOptions,
+  ): Promise<{
+    items: RepoBuild[];
+  }>;
+  // (undocumented)
+  getUserTeamIds(userId: string): Promise<string[]>;
+}
+
+// Warning: (ae-missing-release-tag) "azureDevOpsApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const azureDevOpsApiRef: ApiRef<AzureDevOpsApi>;
+
+// Warning: (ae-missing-release-tag) "AzureDevOpsClient" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class AzureDevOpsClient implements AzureDevOpsApi {
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    identityApi: IdentityApi;
+  });
+  // (undocumented)
+  getAllTeams(): Promise<Team[]>;
+  // (undocumented)
+  getBuildRuns(
+    projectName: string,
+    repoName?: string,
+    definitionName?: string,
+    options?: BuildRunOptions,
+  ): Promise<{
+    items: BuildRun[];
+  }>;
+  // (undocumented)
+  getDashboardPullRequests(
+    projectName: string,
+  ): Promise<DashboardPullRequest[]>;
+  // (undocumented)
+  getGitTags(
+    projectName: string,
+    repoName: string,
+  ): Promise<{
+    items: GitTag[];
+  }>;
+  // (undocumented)
+  getPullRequests(
+    projectName: string,
+    repoName: string,
+    options?: PullRequestOptions,
+  ): Promise<{
+    items: PullRequest[];
+  }>;
+  // (undocumented)
+  getRepoBuilds(
+    projectName: string,
+    repoName: string,
+    options?: RepoBuildOptions,
+  ): Promise<{
+    items: RepoBuild[];
+  }>;
+  // (undocumented)
+  getUserTeamIds(userId: string): Promise<string[]>;
+}
+
 // Warning: (ae-missing-release-tag) "azureDevOpsPlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const azureDevOpsPlugin: BackstagePlugin<{}, {}>;
+
+// Warning: (ae-missing-release-tag) "AzureGitTagsIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const AzureGitTagsIcon: (props: SvgIconProps) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "AzurePullRequestsIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -225,6 +343,74 @@ export interface PullRequestColumnConfig {
 //
 // @public (undocumented)
 export type PullRequestFilter = (pullRequest: DashboardPullRequest) => boolean;
+
+// Warning: (ae-missing-release-tag) "useAllTeams" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useAllTeams(): {
+  teams?: Team[];
+  loading: boolean;
+  error?: Error;
+};
+
+// Warning: (ae-missing-release-tag) "useDashboardPullRequests" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useDashboardPullRequests(
+  project?: string,
+  pollingInterval?: number,
+): {
+  pullRequests?: DashboardPullRequest[];
+  loading: boolean;
+  error?: Error;
+};
+
+// Warning: (ae-missing-release-tag) "useProjectRepoFromEntity" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useProjectRepoFromEntity(entity: Entity): {
+  project: string;
+  repo: string;
+};
+
+// Warning: (ae-missing-release-tag) "usePullRequests" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function usePullRequests(
+  entity: Entity,
+  defaultLimit?: number,
+  requestedStatus?: PullRequestStatus,
+): {
+  items?: PullRequest[];
+  loading: boolean;
+  error?: Error;
+};
+
+// Warning: (ae-missing-release-tag) "useRepoBuilds" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useRepoBuilds(
+  entity: Entity,
+  defaultLimit?: number,
+): {
+  items?: RepoBuild[];
+  loading: boolean;
+  error?: Error;
+};
+
+// Warning: (ae-missing-release-tag) "useUserEmail" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useUserEmail(): string | undefined;
+
+// Warning: (ae-missing-release-tag) "useUserTeamIds" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useUserTeamIds(userId: string | undefined): {
+  teamIds?: string[];
+  loading: boolean;
+  error?: Error;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/azure-devops/src/index.ts
+++ b/plugins/azure-devops/src/index.ts
@@ -27,7 +27,7 @@ export {
 export { AzurePullRequestsIcon } from './components/AzurePullRequestsIcon';
 export { AzureGitTagsIcon } from './components/AzureGitTagsIcon';
 
-export { azureDevOpsApiRef } from './api';
+export * from './api';
 export * from './hooks';
 
 export { FilterType } from './components/PullRequestsPage';

--- a/plugins/azure-devops/src/index.ts
+++ b/plugins/azure-devops/src/index.ts
@@ -25,6 +25,10 @@ export {
 } from './plugin';
 
 export { AzurePullRequestsIcon } from './components/AzurePullRequestsIcon';
+export { AzureGitTagsIcon } from './components/AzureGitTagsIcon';
+
+export { azureDevOpsApiRef } from './api';
+export * from './hooks';
 
 export { FilterType } from './components/PullRequestsPage';
 export type {

--- a/plugins/azure-devops/src/index.ts
+++ b/plugins/azure-devops/src/index.ts
@@ -26,6 +26,7 @@ export {
 
 export { AzurePullRequestsIcon } from './components/AzurePullRequestsIcon';
 export { AzureGitTagsIcon } from './components/AzureGitTagsIcon';
+export { AzurePipelinesIcon } from './components/AzurePipelinesIcon';
 
 export * from './api';
 export * from './hooks';

--- a/plugins/azure-devops/src/index.ts
+++ b/plugins/azure-devops/src/index.ts
@@ -25,11 +25,8 @@ export {
 } from './plugin';
 
 export { AzurePullRequestsIcon } from './components/AzurePullRequestsIcon';
-export { AzureGitTagsIcon } from './components/AzureGitTagsIcon';
-export { AzurePipelinesIcon } from './components/AzurePipelinesIcon';
 
 export * from './api';
-export * from './hooks';
 
 export { FilterType } from './components/PullRequestsPage';
 export type {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

My org is developing an internal plugin that leans on the `azure-devops` plugin, and it could use a few more exported members, in particular azureDevOpsApiRef and some react hooks. It looks like the `catalog-react` plugin and others make similar exports, which leads me to think this is safe and proper.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
