### PR TITLE
feat(MarkdownContent): Expose `transformLinkUri` and `transformImageUri`

### DIFF
--- a/.changeset/cool-toys-flow.md
+++ b/.changeset/cool-toys-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Add `transformLinkUri` and `transformImageUri` to `MarkdownContent`

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
@@ -62,4 +62,42 @@ describe('<MarkdownContent />', () => {
     expect(fp2).toBeInTheDocument();
     expect(rendered.getByText(');', { selector: 'span' })).toBeInTheDocument();
   });
+
+  it('render MarkdownContent component with transformed link', async () => {
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <MarkdownContent
+          content="[Title](https://backstage.io/link)"
+          transformLinkUri={href => {
+            return `${href}-modified`;
+          }}
+        />,
+      ),
+    );
+    const fp1 = rendered.getByText('Title', {
+      selector: 'a',
+    });
+    expect(fp1).toBeInTheDocument();
+    expect(fp1.getAttribute('href')).toEqual(
+      'https://backstage.io/link-modified',
+    );
+  });
+
+  it('render MarkdownContent component with transformed image', async () => {
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <MarkdownContent
+          content="![Image](https://backstage.io/blog/assets/6/header.png)"
+          transformImageUri={() => {
+            return `https://example.com/blog/assets/6/header.png`;
+          }}
+        />,
+      ),
+    );
+    const fp1 = rendered.getByAltText('Image');
+    expect(fp1).toBeInTheDocument();
+    expect(fp1.getAttribute('src')).toEqual(
+      'https://example.com/blog/assets/6/header.png',
+    );
+  });
 });

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -68,6 +68,8 @@ type Props = {
   content: string;
   dialect?: 'gfm' | 'common-mark';
   linkTarget?: Options['linkTarget'];
+  transformLinkUri?: Options['transformLinkUri'];
+  transformImageUri?: Options['transformImageUri'];
 };
 
 const components: Options['components'] = {
@@ -91,7 +93,13 @@ const components: Options['components'] = {
  * If you just want to render to plain [CommonMark](https://commonmark.org/), set the dialect to `'common-mark'`
  */
 export function MarkdownContent(props: Props) {
-  const { content, dialect = 'gfm', linkTarget } = props;
+  const {
+    content,
+    dialect = 'gfm',
+    linkTarget,
+    transformLinkUri,
+    transformImageUri,
+  } = props;
   const classes = useStyles();
   return (
     <ReactMarkdown
@@ -100,6 +108,8 @@ export function MarkdownContent(props: Props) {
       children={content}
       components={components}
       linkTarget={linkTarget}
+      transformLinkUri={transformLinkUri}
+      transformImageUri={transformImageUri}
     />
   );
 }

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -64,12 +64,7 @@ const useStyles = makeStyles<BackstageTheme>(
   { name: 'BackstageMarkdownContent' },
 );
 
-type TransformLink = (
-  href: string,
-  // Complex type from internal react-markdown dep library (hast)[./node_modules/@types/hast/index.d.ts]
-  children: any[],
-  title: string | null,
-) => string;
+type TransformLink = (href: string) => string;
 
 type Props = {
   content: string;

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -64,12 +64,23 @@ const useStyles = makeStyles<BackstageTheme>(
   { name: 'BackstageMarkdownContent' },
 );
 
+type TransformLink = (
+  href: string,
+  // Complex type from internal react-markdown dep library (hast)[./node_modules/@types/hast/index.d.ts]
+  children: any[],
+  title: string | null,
+) => string;
+
 type Props = {
   content: string;
   dialect?: 'gfm' | 'common-mark';
-  linkTarget?: Options['linkTarget'];
-  transformLinkUri?: Options['transformLinkUri'];
-  transformImageUri?: Options['transformImageUri'];
+  linkTarget?: React.HTMLAttributeAnchorTarget | TransformLink;
+  transformLinkUri?: TransformLink;
+  transformImageUri?: (
+    src: string,
+    alt: string,
+    title: string | null,
+  ) => string;
 };
 
 const components: Options['components'] = {

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -64,18 +64,12 @@ const useStyles = makeStyles<BackstageTheme>(
   { name: 'BackstageMarkdownContent' },
 );
 
-type TransformLink = (href: string) => string;
-
 type Props = {
   content: string;
   dialect?: 'gfm' | 'common-mark';
-  linkTarget?: React.HTMLAttributeAnchorTarget | TransformLink;
-  transformLinkUri?: TransformLink;
-  transformImageUri?: (
-    src: string,
-    alt: string,
-    title: string | null,
-  ) => string;
+  linkTarget?: Options['linkTarget'];
+  transformLinkUri?: (href: string) => string;
+  transformImageUri?: (href: string) => string;
 };
 
 const components: Options['components'] = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request exposes the `transformLinkUri` and `transformImageUri` props of react-markdown, this can be exceptionally useful to re-write URLs when using the `MarkdownContent` for internal content as well as images (ie changing relative imports to other URLs like a CDN or something else).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
