### PR TITLE
refactor(MyGroupsSidebarItem): Render namespaced teams within dropdown items

### DIFF
--- a/.changeset/shiny-turkeys-doubt.md
+++ b/.changeset/shiny-turkeys-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Render namespaced teams within dropdown items in `MyGroupsSidebarItem`


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This changes the rendering of namespaced groups to show them as dropdown items. This improves the UI when groups have long namespaces/names.

| Before | After |
| --- | --- |
| ![Screen Shot 2022-06-16 at 3 38 34 PM](https://user-images.githubusercontent.com/6998196/174153645-370c3077-ef58-44ca-b7f0-328bb926106e.png) | ![Screen Shot 2022-06-16 at 3 37 27 PM](https://user-images.githubusercontent.com/6998196/174153681-5f6572bf-5e1a-45d8-9266-35218001f970.png) |



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
