### PR TITLE
Cli/server: Fix webpack deprecation warnings

### DIFF
--- a/.changeset/purple-beans-march.md
+++ b/.changeset/purple-beans-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix `webpack-dev-server` deprecations.

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -43,7 +43,6 @@ export async function serveBundle(options: ServeOptions) {
   const compiler = webpack(config);
 
   const server = new WebpackDevServer(
-    compiler as any,
     {
       hot: !process.env.CI,
       devMiddleware: {
@@ -71,10 +70,11 @@ export async function serveBundle(options: ServeOptions) {
         webSocketURL: 'auto://0.0.0.0:0/ws',
       },
     } as any,
+    compiler as any,
   );
 
   await new Promise<void>((resolve, reject) => {
-    server.listen(port, host, (err?: Error) => {
+    server.startCallback((err?: Error) => {
       if (err) {
         reject(err);
         return;


### PR DESCRIPTION
Running the development dev server results in the following deprecation
warnings from "webpack-dev-server".

* [DEP_WEBPACK_DEV_SERVER_CONSTRUCTOR] DeprecationWarning: Using 'compiler'
as the first argument is deprecated. Please use 'options' as the first
argument and 'compiler' as the second argument.
* [DEP_WEBPACK_DEV_SERVER_LISTEN] DeprecationWarning: 'listen' is deprecated.
Please use the async 'start' or 'startCallback' method.

Signed-off-by: Niklas Aronsson <niklasar@axis.com>

## Hey, I just made a Pull Request!

Links the the relevant places in the "webpack-dev-server" souruce:
[DEP_WEBPACK_DEV_SERVER_CONSTRUCTOR](https://github.com/webpack/webpack-dev-server/blob/049b153b87ab908ae53b71356e0716bb3fc5bf07/lib/Server.js#L219)
[DEP_WEBPACK_DEV_SERVER_LISTEN](https://github.com/webpack/webpack-dev-server/blob/049b153b87ab908ae53b71356e0716bb3fc5bf07/lib/Server.js#L3358)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
