### PR TITLE
Add default feature flag in Scaffolder Plugin

### DIFF
--- a/.changeset/soft-fans-clap.md
+++ b/.changeset/soft-fans-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Add default feature flag to be used to toggle in WIP scaffolder templates

--- a/plugins/scaffolder/src/plugin.ts
+++ b/plugins/scaffolder/src/plugin.ts
@@ -41,7 +41,7 @@ import { EntityTagsPicker } from './components/fields/EntityTagsPicker/EntityTag
  */
 export const scaffolderPlugin = createPlugin({
   id: 'scaffolder',
-  featureFlags: [{ name: 'scaffolder-experimental-templates' }],
+  featureFlags: [{ name: 'scaffolder-show-experimental-templates' }],
   apis: [
     createApiFactory({
       api: scaffolderApiRef,

--- a/plugins/scaffolder/src/plugin.ts
+++ b/plugins/scaffolder/src/plugin.ts
@@ -41,6 +41,7 @@ import { EntityTagsPicker } from './components/fields/EntityTagsPicker/EntityTag
  */
 export const scaffolderPlugin = createPlugin({
   id: 'scaffolder',
+  featureFlags: [{ name: 'scaffolder-experimental-templates' }],
   apis: [
     createApiFactory({
       api: scaffolderApiRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added default flag to be shown in the UI to toggle WIP templates when deployed.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![image](https://user-images.githubusercontent.com/9360520/174231049-5ee8bb6c-b9f8-4846-b5bd-c3bf459ee70f.png)

