### PR TITLE
TechInsightsBackend/README: Added 'scheduler' to code examples

### DIFF
--- a/.changeset/breezy-poems-grab.md
+++ b/.changeset/breezy-poems-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+---
+
+TechInsightsBackend: Added missing 'scheduler' to code examples

--- a/plugins/tech-insights-backend/README.md
+++ b/plugins/tech-insights-backend/README.md
@@ -106,6 +106,7 @@ const builder = buildTechInsightsContext({
   database: env.database,
   discovery: env.discovery,
   tokenManager: env.tokenManager,
+  scheduler: env.scheduler,
 - factRetrievers: [],
 + factRetrievers: [myFactRetrieverRegistration],
 });
@@ -122,6 +123,7 @@ const builder = buildTechInsightsContext({
   database: env.database,
   discovery: env.discovery,
   tokenManager: env.tokenManager,
+  scheduler: env.scheduler,
 - factRetrievers: [],
 + factRetrievers: process.env.MAIN_FACT_RETRIEVER_INSTANCE ? [myFactRetrieverRegistration] : [],
 });
@@ -281,6 +283,7 @@ export default async function createPlugin(
     database: env.database,
     discovery: env.discovery,
     tokenManager: env.tokenManager,
+    scheduler: env.scheduler,
     factRetrievers: [
       createFactRetrieverRegistration({
         cadence: '0 */6 * * *', // Run every 6 hours - https://crontab.guru/#0_*/6_*_*_*


### PR DESCRIPTION
Signed-off-by: Niklas Aronsson <niklasar@axis.com>

## Hey, I just made a Pull Request!

Some code examples for "buildTechInsightsContext" were missing the "scheduler" argument that were added in 0.3.0. Copy pasting from the README should now work.

[CHANGELOG 0.3.0](https://github.com/backstage/backstage/blob/master/plugins/tech-insights-backend/CHANGELOG.md#minor-changes-2)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
