### PR TITLE
scaffolder: reduce max file size for dry-run content

### DIFF
--- a/.changeset/strange-trains-collect.md
+++ b/.changeset/strange-trains-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+The max content size for dry-run files has been reduced from 256k to 64k.

--- a/plugins/scaffolder/src/components/TemplateEditorPage/DryRunContext.tsx
+++ b/plugins/scaffolder/src/components/TemplateEditorPage/DryRunContext.tsx
@@ -29,8 +29,8 @@ import React, {
 import { scaffolderApiRef } from '../../api';
 import { ScaffolderDryRunResponse } from '../../types';
 
-const MAX_CONTENT_SIZE = 256 * 1024;
-const CHUNK_SIZE = 0x8000;
+const MAX_CONTENT_SIZE = 64 * 1024;
+const CHUNK_SIZE = 32 * 1024;
 
 interface DryRunOptions {
   templateContent: string;


### PR DESCRIPTION
Fix for the other issue in #12075. This should make it much more difficult to hit the request size limit.