### PR TITLE
[Search]: Fix search modal context scope

### DIFF
--- a/.changeset/search-turtles-itch.md
+++ b/.changeset/search-turtles-itch.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-search': patch
+---
+
+To allow people to use a global search context in the search modal, the code for the search modal has been changed to only create a local search context if there is no parent context already defined.
+
+If you want to continue using a local context even if you define a global one, you will have to wrap the modal in a new local context manually:
+
+```tsx
+<SearchContextProvider>
+  <SearchModal toggleModal={toggleModal} />
+</SearchContextProvider>
+```

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import {
   Dialog,
   DialogActions,
@@ -170,6 +170,17 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
   );
 };
 
+const Context = ({ children }: PropsWithChildren<{}>) => {
+  // Checks if there is a parent context already defined and, if not, creates a new local context.
+  try {
+    // Throws an exception if there is no parent context already defined
+    useSearch();
+    return <>{children}</>;
+  } catch {
+    return <SearchContextProvider>{children}</SearchContextProvider>;
+  }
+};
+
 /**
  * @public
  */
@@ -194,11 +205,11 @@ export const SearchModal = ({
       hidden={hidden}
     >
       {open && (
-        <SearchContextProvider>
+        <Context>
           {(children && children({ toggleModal })) ?? (
             <Modal toggleModal={toggleModal} />
           )}
-        </SearchContextProvider>
+        </Context>
       )}
     </Dialog>
   );

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -35,6 +35,7 @@ import {
   SearchResult,
   SearchResultPager,
   useSearch,
+  useSearchContextCheck,
 } from '@backstage/plugin-search-react';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { Link, useContent } from '@backstage/core-components';
@@ -172,13 +173,11 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
 
 const Context = ({ children }: PropsWithChildren<{}>) => {
   // Checks if there is a parent context already defined and, if not, creates a new local context.
-  try {
-    // Throws an exception if there is no parent context already defined
-    useSearch();
+  const hasParentContext = useSearchContextCheck();
+  if (hasParentContext) {
     return <>{children}</>;
-  } catch {
-    return <SearchContextProvider>{children}</SearchContextProvider>;
   }
+  return <SearchContextProvider>{children}</SearchContextProvider>;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To allow people to use a global search context in the search modal, this pull request changes the search modal code to only create a local search context for the modal if there is no parent context already defined.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
