### PR TITLE
chore(backstage-common): Improve plural handling of log output for secrets

### DIFF
--- a/.changeset/quiet-pens-notice.md
+++ b/.changeset/quiet-pens-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Improve plural handling in logging output for secrets

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -53,7 +53,9 @@ const updateRedactionList = (
   );
 
   logger.info(
-    `${values.size} secrets found in the config which will be redacted`,
+    `${values.size} secret${
+      values.size > 1 ? 's' : ''
+    } found in the config which will be redacted`,
   );
 
   setRootLoggerRedactionList(Array.from(values));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When a test config I had ended up having only one secret, the log output ended up printing:

```text
[1] 2022-06-22T02:51:52.503Z backstage info Loaded config from app-config.yaml
[1] 2022-06-22T02:51:52.526Z backstage info 1 secrets found in the config which will be redacted
                                                    ^
```

This adds trivial handling to print "1 secret found" vs. "3 secrets found" in the log output.

Locally for me it now prints,

```text
[1] 2022-06-22T02:51:52.526Z backstage info 1 secret found in the config which will be redacted
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
