### PR TITLE
allow custom token parser provided to scaffolder

### DIFF
--- a/.changeset/olive-rats-exercise.md
+++ b/.changeset/olive-rats-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow scaffolder backend router be provided with a function to read the backend token from the request.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -444,6 +444,14 @@ export function fetchContents({
   outputPath: string;
 }): Promise<void>;
 
+// @public @deprecated
+export type GetTokenAndEntityRefFromRequestFunction = (
+  request: express.Request,
+) => {
+  token?: string;
+  entityRef?: string;
+};
+
 // @public (undocumented)
 export interface OctokitWithPullRequestPluginClient {
   // (undocumented)
@@ -467,6 +475,8 @@ export interface RouterOptions {
   config: Config;
   // (undocumented)
   database: PluginDatabaseManager;
+  // (undocumented)
+  getTokenAndEntityRefFromRequestFunction?: GetTokenAndEntityRefFromRequestFunction;
   // (undocumented)
   logger: Logger;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -48,7 +48,15 @@ import { createDryRunner } from '../scaffolder/dryrun';
 import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
 import { getEntityBaseUrl, getWorkingDirectory, findTemplate } from './helpers';
 
-type GetTokenAndEntityRefFromRequestFunction = (request: express.Request) => {
+/**
+ * GetTokenAndEntityRefFromRequestFunction
+ *
+ * @public
+ * @deprecated This type is a temporary stop gap fix before a more complete backend identity solution.
+ */
+export type GetTokenAndEntityRefFromRequestFunction = (
+  request: express.Request,
+) => {
   token?: string;
   entityRef?: string;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

*Note* This is one option of two to fix #12208

This allows the createRouter be optionally passed a function to parse
out the token from the request.

This is a minimal fix and would not be a long term solution.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
