### PR TITLE
errors: add ConsumedResponse type + use for ResponseError

### DIFF
--- a/.changeset/sharp-numbers-taste.md
+++ b/.changeset/sharp-numbers-taste.md
@@ -1,0 +1,7 @@
+---
+'@backstage/errors': minor
+---
+
+The `ResponseError.fromResponse` now accepts a more narrow response type, in order to avoid incompatibilities between different fetch implementations.
+
+The `response` property of `ResponseError` has also been narrowed to a new `ConsumedResponse` type that omits all the properties for consuming the body of the response. This is not considered a breaking change as it was always an error to try to consume the body of the response.

--- a/packages/errors/api-report.md
+++ b/packages/errors/api-report.md
@@ -15,6 +15,17 @@ export class AuthenticationError extends CustomErrorBase {}
 export class ConflictError extends CustomErrorBase {}
 
 // @public
+export type ConsumedResponse = {
+  readonly headers: Headers;
+  readonly ok: boolean;
+  readonly redirected: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType;
+  readonly url: string;
+};
+
+// @public
 export class CustomErrorBase extends Error {
   constructor(message?: string, cause?: Error | unknown);
   readonly cause?: Error | undefined;
@@ -67,15 +78,21 @@ export class NotModifiedError extends CustomErrorBase {}
 
 // @public
 export function parseErrorResponseBody(
-  response: Response,
+  response: ConsumedResponse & {
+    text(): Promise<string>;
+  },
 ): Promise<ErrorResponseBody>;
 
 // @public
 export class ResponseError extends Error {
   readonly body: ErrorResponseBody;
   readonly cause: Error;
-  static fromResponse(response: Response): Promise<ResponseError>;
-  readonly response: Response;
+  static fromResponse(
+    response: ConsumedResponse & {
+      text(): Promise<string>;
+    },
+  ): Promise<ResponseError>;
+  readonly response: ConsumedResponse;
 }
 
 // @public

--- a/packages/errors/src/errors/ResponseError.ts
+++ b/packages/errors/src/errors/ResponseError.ts
@@ -19,6 +19,7 @@ import {
   ErrorResponseBody,
   parseErrorResponseBody,
 } from '../serialization/response';
+import { ConsumedResponse } from './types';
 
 /**
  * An error thrown as the result of a failed server request.
@@ -34,7 +35,7 @@ export class ResponseError extends Error {
    * Note that the body of this response is always consumed. Its parsed form is
    * in the `body` field.
    */
-  readonly response: Response;
+  readonly response: ConsumedResponse;
 
   /**
    * The parsed JSON error body, as sent by the server.
@@ -59,7 +60,9 @@ export class ResponseError extends Error {
    * function consumes the body of the response, and assumes that it hasn't
    * been consumed before.
    */
-  static async fromResponse(response: Response): Promise<ResponseError> {
+  static async fromResponse(
+    response: ConsumedResponse & { text(): Promise<string> },
+  ): Promise<ResponseError> {
     const data = await parseErrorResponseBody(response);
 
     const status = data.response.statusCode || response.status;
@@ -77,7 +80,7 @@ export class ResponseError extends Error {
 
   private constructor(props: {
     message: string;
-    response: Response;
+    response: ConsumedResponse;
     data: ErrorResponseBody;
     cause: Error;
   }) {

--- a/packages/errors/src/errors/types.ts
+++ b/packages/errors/src/errors/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-export { assertError, isError } from './assertion';
-export type { ErrorLike } from './assertion';
-export {
-  AuthenticationError,
-  ConflictError,
-  ForwardedError,
-  InputError,
-  NotAllowedError,
-  NotFoundError,
-  NotModifiedError,
-} from './common';
-export { CustomErrorBase } from './CustomErrorBase';
-export { ResponseError } from './ResponseError';
-export type { ConsumedResponse } from './types';
+/**
+ * ConsumedResponse represents a Response that is known to have been consumed.
+ * The methods and properties used to read the body contents are therefore omitted.
+ *
+ * @public
+ */
+export type ConsumedResponse = {
+  readonly headers: Headers;
+  readonly ok: boolean;
+  readonly redirected: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType;
+  readonly url: string;
+};

--- a/packages/errors/src/serialization/response.ts
+++ b/packages/errors/src/serialization/response.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ConsumedResponse } from '../errors/types';
 import { SerializedError } from './error';
 
 /**
@@ -53,7 +54,7 @@ export type ErrorResponseBody = {
  * @param response - The response of a failed request
  */
 export async function parseErrorResponseBody(
-  response: Response,
+  response: ConsumedResponse & { text(): Promise<string> },
 ): Promise<ErrorResponseBody> {
   try {
     const text = await response.text();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #12166

Also feel it makes the usage of `ResponseError` safer, since trying to consume the body again in any way would always lead to an error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
