### PR TITLE
Remove hardcoded color icon link vertical

### DIFF
--- a/.changeset/bright-balloons-hide.md
+++ b/.changeset/bright-balloons-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Change BackstageIconLinkVertical style to use pallette instead of explicit color

--- a/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
@@ -47,7 +47,7 @@ const useIconStyles = makeStyles(
       textAlign: 'center',
     },
     disabled: {
-      color: 'gray',
+      color: theme.palette.text.secondary,
       cursor: 'default',
     },
     primary: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
When viewing a component, the _overview_ tab includes a row of icons to View Techdocs, as well as View Source code.  An accessibility scan shows that when these icons are disabled, there is not enough contrast between the foreground and background of the labels:

<img width="898" alt="image" src="https://user-images.githubusercontent.com/2686352/175536628-5c62dd3a-467f-4a75-8858-8b0c6f3ffe0a.png">

The style in use for these icons explicitly uses 'gray' as the color for disabled text, regardless of theme in use.  This should use the current theme palette instead.  This will fix the contrast issues and also allow adopters to change this style      based on their themes.

I chose `theme.palette.text.secondary` as that is used for other "disabled" text, such as in the "Overview", "CI/CD"... row above.

Related to #7124


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
