### PR TITLE
chore: fix for the time tests

### DIFF
--- a/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.test.tsx
+++ b/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.test.tsx
@@ -113,7 +113,6 @@ describe('HeaderWorldClock with custom Time Format', () => {
       </ThemeProvider>,
     );
 
-    const currentTime = `09:10`;
-    expect(rendered.getByText(currentTime)).toBeInTheDocument();
+    expect(rendered.getByText('09:10')).toBeInTheDocument();
   });
 });

--- a/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.test.tsx
+++ b/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.test.tsx
@@ -89,6 +89,8 @@ describe('HeaderWorldClock with invalid Time Zone', () => {
 
 describe('HeaderWorldClock with custom Time Format', () => {
   it('uses 24hr clock from custom Time Format', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-06-28T09:10:13.502Z'));
+
     const clockConfigs: ClockConfig[] = [
       {
         label: 'UTC',
@@ -111,7 +113,7 @@ describe('HeaderWorldClock with custom Time Format', () => {
       </ThemeProvider>,
     );
 
-    const currentTime = `${new Date().getHours()}:${new Date().getMinutes()}`;
+    const currentTime = `09:10`;
     expect(rendered.getByText(currentTime)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The test was looking for `9:9` depending on if you ran this at 11:09 EST, when in the document `09:09` it would be so mocked out the time and assert that the correct time is displayed.
