### PR TITLE
Add allowArbitraryValues in OwnedEntityPicker

### DIFF
--- a/.changeset/weak-jeans-cry.md
+++ b/.changeset/weak-jeans-cry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Add allowArbitraryValues to ui:options in OwnedEntityPicker uiSchema, similar to allowArbitraryValues in EntityPicker
+Add `allowArbitraryValues` to `ui:options` in `OwnedEntityPicker`, similar to `allowArbitraryValues` in `EntityPicker`

--- a/.changeset/weak-jeans-cry.md
+++ b/.changeset/weak-jeans-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Add allowArbitraryValues to ui:options in OwnedEntityPicker uiSchema, similar to allowArbitraryValues in EntityPicker

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -154,6 +154,8 @@ export const OwnedEntityPickerFieldExtension: FieldExtensionComponent<
 // @public
 export interface OwnedEntityPickerUiOptions {
   // (undocumented)
+  allowArbitraryValues?: boolean;
+  // (undocumented)
   allowedKinds?: string[];
   // (undocumented)
   defaultKind?: string;

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -60,6 +60,8 @@ export const OwnedEntityPicker = (
 
   const allowedKinds = uiSchema['ui:options']?.allowedKinds;
   const defaultKind = uiSchema['ui:options']?.defaultKind;
+  const allowArbitraryValues =
+    uiSchema['ui:options']?.allowArbitraryValues ?? true;
   const { ownedEntities, loading } = useOwnedEntities(allowedKinds);
 
   const entityRefs = ownedEntities?.items
@@ -83,7 +85,7 @@ export const OwnedEntityPicker = (
         onChange={onSelect}
         options={entityRefs || []}
         autoSelect
-        freeSolo
+        freeSolo={allowArbitraryValues}
         renderInput={params => (
           <TextField
             {...params}

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -37,6 +37,7 @@ import { FieldExtensionComponentProps } from '../../../extensions';
 export interface OwnedEntityPickerUiOptions {
   allowedKinds?: string[];
   defaultKind?: string;
+  allowArbitraryValues?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `allowArbitraryValues` was added in Pull Request #8441 for `EntityPicker`. This feature does not exist in `OwnedEntityPicker`.
Also a comment from @GoFightNguyen was asking about this:
> @GoFightNguyen are we able to also add this to the new OwnedEntityPicker as well?
> 
> _Originally posted by @regicsolutions in https://github.com/backstage/backstage/issues/8441#issuecomment-997299196_

Based on the mentioned PR, I added this option to `OwnedEntityPicker`. I don't have a typescript or js background so anything wrong please let me know :slightly_smiling_face: 

The current behaviour can be check using the Template Editor:
![image](https://user-images.githubusercontent.com/4191538/176164725-86db76c8-e0a8-4369-9b60-6dac23378391.png)

The allowArbitraryValues set to false behaviour working with this patch:
![image](https://user-images.githubusercontent.com/4191538/176165749-1b2a991e-6b6f-4f62-a9e3-261adb5ed3e3.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
