### PR TITLE
Update documentation of catalog readonly mode

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -106,8 +106,7 @@ with [Static Location Configuration](#static-location-configuration) or a
 discovery processor like
 [GitHub Discovery](../../integrations/github/discovery.md). To enforce usage of
 processors to locate entities we can configure the catalog into `readonly` mode.
-This configuration disables the mutating backend catalog APIs and disallows
-users from registering new entities at run-time.
+This configuration disables registering and deleting locations with the catalog APIs.
 
 ```yaml
 catalog:
@@ -116,6 +115,8 @@ catalog:
 
 > **Note that any plugin relying on the catalog API for creating, updating and
 > deleting entities will not work in this mode.**
+
+Deleting an entity by UUID, `DELETE /entities/by-uid/:uid`, is allowed when using this mode. It may be rediscovered as noted in [explicit deletion](life-of-an-entity.md#explicit-deletion).
 
 A common use case for this configuration is when organizations have a remote
 source that should be mirrored into Backstage. To make Backstage a mirror of


### PR DESCRIPTION
Signed-off-by: Patrick Schilling <pschilli@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Update the [documentation of the catalog readonly mode](https://backstage.io/docs/features/software-catalog/configuration#readonly-mode) to clarify behavior based on discussion in #12146.

Clarify that it's just the location that is readonly.  Also added details on delete by UUID.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
