### PR TITLE
Explain how to enable techdocs cache

### DIFF
--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -160,7 +160,8 @@ techdocs:
 
   # techdocs.cache is optional, and is only recommended when you've configured
   # an external techdocs.publisher.type above. Also requires backend.cache to
-  # be configured with a valid cache store.
+  # be configured with a valid cache store. Configure techdocs.cache.ttl to
+  # enable caching of techdocs assets.
   cache:
     # Represents the number of milliseconds a statically built asset should
     # stay cached. Cache invalidation is handled automatically by the frontend,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For dummies like me, it took me a while to figure out that even if you
have configured the backend cache, the TechDocs cache is not enabled
until you set a value for the TTL. My interpretation was that it was
just configured by default, and the fact that a default value for ttl
seems to appear here points to that as well.

This change hopes to make this explicit, to avoid others spinning their
wheels like I have.

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
