### PR TITLE
workflows: use latest version of cron action with app auth

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -8,4 +8,8 @@ jobs:
   cron:
     runs-on: ubuntu-latest
     steps:
-      - uses: backstage/actions/cron@v0.1.8
+      - uses: backstage/actions/cron@v0.1.12
+        with:
+          app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
+          private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
+          installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}


### PR DESCRIPTION
Latest version of cron action uses app auth rather than a token, so that we get org access