### PR TITLE
[Search] Fix page cursor cleanup

### DIFF
--- a/.changeset/search-boats-double.md
+++ b/.changeset/search-boats-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Fix search pagination to reset page cursor also when a term is cleared.

--- a/plugins/search-react/src/context/SearchContext.test.tsx
+++ b/plugins/search-react/src/context/SearchContext.test.tsx
@@ -108,40 +108,58 @@ describe('SearchContext', () => {
     expect(result.current).toEqual(expect.objectContaining(initialState));
   });
 
-  it('Resets cursor when term is set (and different from previous)', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSearch(), {
-      wrapper,
-      initialProps: {
-        initialState: {
-          ...initialState,
-          pageCursor: 'SOMEPAGE',
+  describe('Resets cursor', () => {
+    it('When term is cleared', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useSearch(), {
+        wrapper,
+        initialProps: {
+          initialState: {
+            ...initialState,
+            term: 'first term',
+            pageCursor: 'SOMEPAGE',
+          },
         },
-      },
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.term).toEqual('first term');
+      expect(result.current.pageCursor).toEqual('SOMEPAGE');
+
+      act(() => {
+        result.current.setTerm('');
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.pageCursor).toBeUndefined();
     });
 
-    await waitForNextUpdate();
+    it('When term is set (and different from previous)', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useSearch(), {
+        wrapper,
+        initialProps: {
+          initialState: {
+            ...initialState,
+            term: 'first term',
+            pageCursor: 'SOMEPAGE',
+          },
+        },
+      });
 
-    expect(result.current.pageCursor).toEqual('SOMEPAGE');
+      await waitForNextUpdate();
 
-    act(() => {
-      result.current.setTerm('first term');
+      expect(result.current.term).toEqual('first term');
+      expect(result.current.pageCursor).toEqual('SOMEPAGE');
+
+      act(() => {
+        result.current.setTerm('second term');
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.pageCursor).toBeUndefined();
     });
-
-    act(() => {
-      result.current.setPageCursor('OTHERPAGE');
-    });
-
-    await waitForNextUpdate();
-
-    expect(result.current.pageCursor).toEqual('OTHERPAGE');
-
-    act(() => {
-      result.current.setTerm('second term');
-    });
-
-    await waitForNextUpdate();
-
-    expect(result.current.pageCursor).toEqual(undefined);
   });
 
   describe('Performs search (and sets results)', () => {

--- a/plugins/search-react/src/context/SearchContext.tsx
+++ b/plugins/search-react/src/context/SearchContext.tsx
@@ -150,10 +150,11 @@ export const SearchContextProvider = (props: SearchContextProviderProps) => {
 
   useEffect(() => {
     // Any time a term is reset, we want to start from page 0.
-    if (term && prevTerm && term !== prevTerm) {
+    // Only reset the term if it has been modified by the user at least once, the initial state must not reset the term.
+    if (prevTerm !== undefined && term !== prevTerm) {
       setPageCursor(undefined);
     }
-  }, [term, prevTerm, initialState.pageCursor]);
+  }, [term, prevTerm, setPageCursor]);
 
   const value: SearchContextValue = {
     result,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #9907

Fix search pagination to reset page cursor also when a term is cleared.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
