### PR TITLE
Permission framework docs: fix condition exports

### DIFF
--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -163,8 +163,8 @@ import { createConditionExports } from '@backstage/plugin-permission-node';
 import { permissionRules } from './service/rules';
 
 const { conditions, createConditionalDecision } = createConditionExports({
-  pluginId: 'catalog',
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  pluginId: 'todolist',
+  resourceType: TODO_LIST_RESOURCE_TYPE,
   rules: permissionRules,
 });
 


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <vincenzos@spotify.com>

## Hey, I just made a Pull Request!

This PR fix a typo in the permission docs for plugin author's documentation which is preventing the users to perform conditional decisions

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
