### PR TITLE
fix: cost-insights api docs warnings

### DIFF
--- a/plugins/cost-insights/api-report.md
+++ b/plugins/cost-insights/api-report.md
@@ -272,7 +272,6 @@ export type BarChartTooltipProps = {
   actions?: ReactNode;
 };
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "ChangeStatistic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -296,7 +295,6 @@ export type ChartData = {
   [key: string]: number;
 };
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Cost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -450,7 +448,6 @@ export enum DataKey {
   Previous = 'previous',
 }
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "DateAggregation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -478,7 +475,6 @@ export enum Duration {
 // @public (undocumented)
 export const EngineerThreshold = 0.5;
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Entity" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -506,7 +502,6 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
   getUserGroups(userId: string): Promise<Group[]>;
 }
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Group" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -574,19 +569,16 @@ export type LegendItemProps = {
 // @public (undocumented)
 export type Loading = Record<string, boolean>;
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Maybe" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
 export type Maybe<T> = common.Maybe<T>;
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Metric" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
 export type Metric = common.Metric;
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "MetricData" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -622,7 +614,6 @@ export interface PageFilters {
   project: Maybe_2<string>;
 }
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Product" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -649,7 +640,6 @@ export interface ProductPeriod {
   productType: string;
 }
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Project" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)
@@ -711,7 +701,6 @@ export type TooltipItem = {
   value: string;
 };
 
-// Warning: (tsdoc-characters-after-block-tag) The token "@backstage" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // Warning: (ae-missing-release-tag) "Trendline" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public @deprecated (undocumented)

--- a/plugins/cost-insights/src/types/index.ts
+++ b/plugins/cost-insights/src/types/index.ts
@@ -14,30 +14,6 @@
  * limitations under the License.
  */
 
-import * as common from '@backstage/plugin-cost-insights-common';
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type ChangeStatistic = common.ChangeStatistic;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Cost = common.Cost;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type DateAggregation = common.DateAggregation;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Entity = common.Entity;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Group = common.Group;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Maybe<T> = common.Maybe<T>;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Metric = common.Metric;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type MetricData = common.MetricData;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Product = common.Product;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Project = common.Project;
-/** * @deprecated use the same type from @backstage/plugin-cost-insights-common instead */
-export type Trendline = common.Trendline;
-
 // TODO: Split some of these up into `@backstage/plugin-cost-insights-react` for presentation types
 //       and `@backstage/plugin-cost-insights-common` for data transfer object types.
 export * from './Alert';
@@ -51,3 +27,53 @@ export * from './Filters';
 export * from './Icon';
 export * from './Loading';
 export * from './Theme';
+
+/**
+ * Deprecated types moved to `@backstage/plugin-cost-insights-common`
+ */
+import * as common from '@backstage/plugin-cost-insights-common';
+
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type ChangeStatistic = common.ChangeStatistic;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Cost = common.Cost;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type DateAggregation = common.DateAggregation;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Entity = common.Entity;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Group = common.Group;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Maybe<T> = common.Maybe<T>;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Metric = common.Metric;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type MetricData = common.MetricData;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Product = common.Product;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Project = common.Project;
+/**
+ * @deprecated use the same type from `@backstage/plugin-cost-insights-common` instead
+ */
+export type Trendline = common.Trendline;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow up to #12298, which fixes the `cost-insights` api docs report & ensures the deprecation warnings work properly in a supported editor (e.g. `vscode`).

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
