### PR TITLE
Upgrade git-url-parse to 12.0.0

### DIFF
--- a/.changeset/short-deers-remember.md
+++ b/.changeset/short-deers-remember.md
@@ -1,0 +1,21 @@
+---
+'@backstage/backend-common': patch
+'@backstage/integration': patch
+'@backstage/plugin-adr': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Upgrade git-url-parse to 12.0.0.
+
+Motivation for upgrade is transitively upgrading parse-url which is vulnerable
+to several CVEs detected by Snyk.
+
+- SNYK-JS-PARSEURL-2935944
+- SNYK-JS-PARSEURL-2935947
+- SNYK-JS-PARSEURL-2936249

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -58,7 +58,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "helmet": "^5.0.2",
     "isomorphic-git": "^1.8.0",
     "jose": "^4.6.0",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -36,7 +36,7 @@
     "@backstage/config": "^1.0.1",
     "@backstage/errors": "^1.1.0-next.0",
     "cross-fetch": "^3.1.5",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "@octokit/rest": "^18.5.3",
     "@octokit/auth-app": "^3.4.0",
     "luxon": "^2.0.2",

--- a/plugins/adr/package.json
+++ b/plugins/adr/package.json
@@ -33,7 +33,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "octokit": "^1.7.1",
     "react-markdown": "^8.0.0",
     "react-router-dom": "6.0.0-beta.0",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -53,7 +53,7 @@
     "express-promise-router": "^4.1.0",
     "fast-json-stable-stringify": "^2.1.0",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "glob": "^7.1.6",
     "knex": "^2.0.0",
     "lodash": "^4.17.21",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -47,7 +47,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^18.5.3",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "js-base64": "^3.6.0",
     "lodash": "^4.17.21",
     "react-hook-form": "^7.12.2",

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -54,7 +54,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "globby": "^11.0.0",
     "isbinaryfile": "^5.0.0",
     "isomorphic-git": "^1.8.0",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -61,7 +61,7 @@
     "@types/json-schema": "^7.0.9",
     "@uiw/react-codemirror": "^4.9.3",
     "classnames": "^2.2.6",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.1",
     "json-schema": "^0.4.0",

--- a/plugins/techdocs-module-addons-contrib/package.json
+++ b/plugins/techdocs-module-addons-contrib/package.json
@@ -44,7 +44,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@react-hookz/web": "^14.0.0",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -54,7 +54,7 @@
     "aws-sdk": "^2.840.0",
     "express": "^4.17.1",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "js-yaml": "^4.0.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -53,7 +53,7 @@
     "@material-ui/styles": "^4.10.0",
     "dompurify": "^2.2.9",
     "event-source-polyfill": "1.0.25",
-    "git-url-parse": "^11.6.0",
+    "git-url-parse": "^12.0.0",
     "jss": "~10.8.2",
     "lodash": "^4.17.21",
     "react-helmet": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13821,12 +13821,27 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
+git-up@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/git-up/-/git-up-6.0.0.tgz#dbd6e4eee270338be847a0601e6d0763c90b74db"
+  integrity sha512-6RUFSNd1c/D0xtGnyWN2sxza2bZtZ/EmI9448n6rCZruFwV/ezeEn2fJP7XnUQGwf0RAtd/mmUCbtH6JPYA2SA==
+  dependencies:
+    is-ssh "^1.4.0"
+    parse-url "^7.0.2"
+
 git-url-parse@^11.4.4, git-url-parse@^11.6.0:
   version "11.6.0"
   resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
   integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
   dependencies:
     git-up "^4.0.0"
+
+git-url-parse@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-12.0.0.tgz#4ba70bc1e99138321c57e3765aaf7428e5abb793"
+  integrity sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==
+  dependencies:
+    git-up "^6.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -15646,6 +15661,13 @@ is-ssh@^1.3.0:
   integrity sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==
   dependencies:
     protocols "^1.1.0"
+
+is-ssh@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz#4f8220601d2839d8fa624b3106f8e8884f01b8b2"
+  integrity sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==
+  dependencies:
+    protocols "^2.0.1"
 
 is-stream-ended@^0.1.4:
   version "0.1.4"
@@ -19297,7 +19319,7 @@ normalize-url@^4.1.0:
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
-normalize-url@^6.0.1:
+normalize-url@^6.0.1, normalize-url@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
@@ -20221,6 +20243,13 @@ parse-path@^4.0.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
+parse-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz#f933152f3c6d34f4cf36cfc3d07b138ac113649d"
+  integrity sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==
+  dependencies:
+    protocols "^2.0.0"
+
 parse-url@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
@@ -20230,6 +20259,16 @@ parse-url@^5.0.0:
     normalize-url "^3.3.0"
     parse-path "^4.0.0"
     protocols "^1.4.0"
+
+parse-url@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/parse-url/-/parse-url-7.0.2.tgz#d21232417199b8d371c6aec0cedf1406fd6393f0"
+  integrity sha512-PqO4Z0eCiQ08Wj6QQmrmp5YTTxpYfONdOEamrtvK63AmzXpcavIVQubGHxOEwiIoDZFb8uDOoQFS0NCcjqIYQg==
+  dependencies:
+    is-ssh "^1.4.0"
+    normalize-url "^6.1.0"
+    parse-path "^5.0.0"
+    protocols "^2.0.1"
 
 parse5@6.0.1:
   version "6.0.1"
@@ -21348,6 +21387,11 @@ protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.7"
   resolved "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
   integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
+
+protocols@^2.0.0, protocols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz#8f155da3fc0f32644e83c5782c8e8212ccf70a86"
+  integrity sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
 
 proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
This change upgrades git-url-parse to 12.0.0. This is a major upgrade but it
changes nothing to our usage.

- https://github.com/IonicaBizau/git-url-parse/releases/tag/12.0.0
- https://github.com/IonicaBizau/git-up/releases/tag/6.0.0
- https://github.com/IonicaBizau/parse-url/releases/tag/7.0.0

Motivation for upgrade is transitively upgrading parse-url which is vulnerable
to several CVEs detected by Snyk.

- closes #12273
- closes #12274
- closes #12300

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
