### PR TITLE
Fix issues with optional directories and files

### DIFF
--- a/.changeset/orange-deers-marry.md
+++ b/.changeset/orange-deers-marry.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Fix issues with optional directories and files

--- a/.changeset/orange-deers-marry.md
+++ b/.changeset/orange-deers-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Fix issues with optional directories and files

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -165,7 +165,7 @@ describe('fetch:template', () => {
             showDummyFile: false,
             skipRootDirectory: true,
             skipSubdirectory: true,
-            skipMultiplesDirectories: true
+            skipMultiplesDirectories: true,
           },
         });
 
@@ -178,21 +178,22 @@ describe('fetch:template', () => {
               '${{ "dummy-file2.txt" if values.showDummyFile else "" }}':
                 'some dummy file',
               '${{ "dummy-dir" if not values.skipRootDirectory else "" }}': {
-                'file.txt':
-                  'file inside optional directory',
-              subdir: {
-                '${{ "dummy-subdir" if not values.skipSubdirectory else "" }}':
-                  'file inside optional subdirectory'
-                }
+                'file.txt': 'file inside optional directory',
+                subdir: {
+                  '${{ "dummy-subdir" if not values.skipSubdirectory else "" }}':
+                    'file inside optional subdirectory',
+                },
               },
               subdir2: {
-                '${{ "dummy-subdir" if not values.skipMultiplesDirectories else "" }}': {
-                  '${{ "dummy-subdir" if not values.skipMultiplesDirectories else "" }}': {
-                    'multipleDirectorySkippedFile.txt':
-                      'file inside multiple optional subdirectories'
-                  }
-                }
-              }
+                '${{ "dummy-subdir" if not values.skipMultiplesDirectories else "" }}':
+                  {
+                    '${{ "dummy-subdir" if not values.skipMultiplesDirectories else "" }}':
+                      {
+                        'multipleDirectorySkippedFile.txt':
+                          'file inside multiple optional subdirectories',
+                      },
+                  },
+              },
             },
           });
 
@@ -222,12 +223,16 @@ describe('fetch:template', () => {
 
       it('skips content of empty subdirectory', async () => {
         await expect(
-          fs.pathExists(`${workspacePath}/target/subdir2/multipleDirectorySkippedFile.txt`),
+          fs.pathExists(
+            `${workspacePath}/target/subdir2/multipleDirectorySkippedFile.txt`,
+          ),
         ).resolves.toEqual(false);
 
         await expect(
-          fs.pathExists(`${workspacePath}/target/subdir2/dummy-subdir/dummy-subdir/multipleDirectorySkippedFile.txt`),
-        ).resolves.toEqual(false);        
+          fs.pathExists(
+            `${workspacePath}/target/subdir2/dummy-subdir/dummy-subdir/multipleDirectorySkippedFile.txt`,
+          ),
+        ).resolves.toEqual(false);
       });
     });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -226,6 +226,12 @@ describe('fetch:template', () => {
         ).resolves.toEqual(false);
       });
 
+      it('skips empty filename inside directory', async () => {
+        await expect(
+          fs.pathExists(`${workspacePath}/target/subdir3/fileSkippedInsideDirectory.txt`),
+        ).resolves.toEqual(false);
+      });      
+
       it('skips content of empty subdirectory', async () => {
         await expect(
           fs.pathExists(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -220,10 +220,14 @@ describe('fetch:template', () => {
         ).resolves.toEqual(false);
       });
 
-      it('skips content of empty directory', async () => {
+      it('skips content of empty subdirectory', async () => {
         await expect(
           fs.pathExists(`${workspacePath}/target/subdir2/multipleDirectorySkippedFile.txt`),
         ).resolves.toEqual(false);
+
+        await expect(
+          fs.pathExists(`${workspacePath}/target/subdir2/dummy-subdir/dummy-subdir/multipleDirectorySkippedFile.txt`),
+        ).resolves.toEqual(false);        
       });
     });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -166,6 +166,7 @@ describe('fetch:template', () => {
             skipRootDirectory: true,
             skipSubdirectory: true,
             skipMultiplesDirectories: true,
+            skipFileInsideDirectory: true
           },
         });
 
@@ -194,6 +195,10 @@ describe('fetch:template', () => {
                       },
                   },
               },
+              subdir3: {
+                '${{ "fileSkippedInsideDirectory.txt" if not values.skipFileInsideDirectory else "" }}':
+                  'skipped file inside directory',
+              },              
             },
           });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -166,7 +166,7 @@ describe('fetch:template', () => {
             skipRootDirectory: true,
             skipSubdirectory: true,
             skipMultiplesDirectories: true,
-            skipFileInsideDirectory: true
+            skipFileInsideDirectory: true,
           },
         });
 
@@ -198,7 +198,7 @@ describe('fetch:template', () => {
               subdir3: {
                 '${{ "fileSkippedInsideDirectory.txt" if not values.skipFileInsideDirectory else "" }}':
                   'skipped file inside directory',
-              },              
+              },
             },
           });
 
@@ -228,9 +228,11 @@ describe('fetch:template', () => {
 
       it('skips empty filename inside directory', async () => {
         await expect(
-          fs.pathExists(`${workspacePath}/target/subdir3/fileSkippedInsideDirectory.txt`),
+          fs.pathExists(
+            `${workspacePath}/target/subdir3/fileSkippedInsideDirectory.txt`,
+          ),
         ).resolves.toEqual(false);
-      });      
+      });
 
       it('skips content of empty subdirectory', async () => {
         await expect(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -27,7 +27,7 @@ import {
   TemplateFilter,
   SecureTemplater,
 } from '../../../../lib/templating/SecureTemplater';
-import path from 'node:path';
+import path from 'path';
 
 /**
  * Downloads a skeleton, templates variables into file and directory names and content.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -27,6 +27,7 @@ import {
   TemplateFilter,
   SecureTemplater,
 } from '../../../../lib/templating/SecureTemplater';
+import path from 'node:path';
 
 /**
  * Downloads a skeleton, templates variables into file and directory names and content.
@@ -260,12 +261,12 @@ export function createFetchTemplateAction(options: {
 }
 
 function containsSkippedContent(localOutputPath: string): boolean {
-  // if the path starts with / means that the root directory has been skipped
+  // if the path is absolute means that the root directory has been skipped
   // if the path is empty means that there is a file skipped in the root
   // if the path includes // means that there is a subdirectory skipped
   return (
-    localOutputPath.startsWith('/') ||
     localOutputPath === '' ||
-    localOutputPath.includes('//')
+    path.isAbsolute(localOutputPath) ||
+    localOutputPath.includes(`${path.sep}${path.sep}`)
   );
 }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -217,6 +217,9 @@ export function createFetchTemplateAction(options: {
         }
 
         const outputPath = resolveSafeChildPath(outputDir, localOutputPath);
+        if (fs.existsSync(outputPath)) {
+          continue;
+        }
 
         if (!renderContents && !extension) {
           ctx.logger.info(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -263,7 +263,9 @@ function containsSkippedContent(localOutputPath: string): boolean {
   // if the path starts with / means that the root directory has been skipped
   // if the path is empty means that there is a file skipped in the root
   // if the path includes // means that there is a subdirectory skipped
-  return localOutputPath.startsWith('/')
-    || localOutputPath === ''
-    || localOutputPath.includes('//');
+  return (
+    localOutputPath.startsWith('/') ||
+    localOutputPath === '' ||
+    localOutputPath.includes('//')
+  );
 }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -206,15 +206,16 @@ export function createFetchTemplateAction(options: {
         } else {
           renderFilename = renderContents = !nonTemplatedEntries.has(location);
         }
+
         if (renderFilename) {
           localOutputPath = renderTemplate(localOutputPath, context);
         }
-        const outputPath = resolveSafeChildPath(outputDir, localOutputPath);
-        // variables have been expanded to make an empty file name
-        // this is due to a conditional like if values.my_condition then file-name.txt else empty string so skip
-        if (outputDir === outputPath) {
+
+        if (containsSkippedContent(localOutputPath)) {
           continue;
         }
+
+        const outputPath = resolveSafeChildPath(outputDir, localOutputPath);
 
         if (!renderContents && !extension) {
           ctx.logger.info(
@@ -256,4 +257,13 @@ export function createFetchTemplateAction(options: {
       ctx.logger.info(`Template result written to ${outputDir}`);
     },
   });
+}
+
+function containsSkippedContent(localOutputPath: string): boolean {
+  // if the path starts with / means that the root directory has been skipped
+  // if the path is empty means that there is a file skipped in the root
+  // if the path includes // means that there is a subdirectory skipped
+  return localOutputPath.startsWith('/')
+    || localOutputPath === ''
+    || localOutputPath.includes('//');
 }


### PR DESCRIPTION
Signed-off-by: Manuel Cañete <mcaneteubeda@gmail.com>

## Hey, I just made a Pull Request!

There are three issues that I have could find working with optional files/folders in the template action.

- If there is an optional folder in the root including a file and the condition to create it is false the template fails
	- e.g: `${{ values.condition }}/file.txt` ->`localOutputPath` will be `/file.txt` and it will throw an error`NotAllowedError: Relative path is not allowed to refer to a directory outside its parent`.
- If there is an optional file inside a subfolder then the action tries to create the file even when the condition is false and it throws an error when it is going to write the file content in a directory.
	- e.g: `src/${{ "subDir" if values.myCondition else "" }}/${{ "file.md" if values.myCondition else "" }}` -> `EISDIR: illegal operation on a directory, open `
- If there is an optional folder with subfolders or files and the condition to create the folder is false then the included folders and files are written to the parent folder instead of skip it.
	- e.g: `src/${{ "subDir" if values.myCondition else "" }}/file.txt` will be copied to `src/file.txt` when `myCondition` is false. I think the expected behaviour is to skip the files included in the optional folder.

This PR is related to:
- [Discord: dynamic template folders](https://discord.com/channels/687207715902193673/925716323772825610/925826692663107694)
- [Discord: empty-scaffolder discussion](https://discord.com/channels/687207715902193673/908724374981468212)
- [PR Skip empty file names during scaffolder](https://github.com/backstage/backstage/pull/8028)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
