### PR TITLE
Avoid double encoding in `bitbucketServer` integration

### DIFF
--- a/.changeset/tender-terms-flash.md
+++ b/.changeset/tender-terms-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Avoid double encoding of the filepath in `getBitbucketServerDownloadUrl`

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -108,6 +108,20 @@ describe('bitbucketServer core', () => {
       );
     });
 
+    it('does not double encode the filepath', async () => {
+      const config: BitbucketServerIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+      };
+      const result = await getBitbucketServerDownloadUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/%2Fdocs?at=some-branch',
+        config,
+      );
+      expect(result).toEqual(
+        'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive?format=tgz&at=some-branch&prefix=backstage-mock&path=%2Fdocs',
+      );
+    });
+
     it('do not add path param if no path is specified for Bitbucket Server', async () => {
       const defaultBranchResponse = {
         displayId: 'main',

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -83,7 +83,9 @@ export async function getBitbucketServerDownloadUrl(
   // path will limit the downloaded content
   // /docs will only download the docs folder and everything below it
   // /docs/index.md will download the docs folder and everything below it
-  const path = filepath ? `&path=${encodeURIComponent(filepath)}` : '';
+  const path = filepath
+    ? `&path=${encodeURIComponent(decodeURIComponent(filepath))}`
+    : '';
   return `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${branch}&prefix=${project}-${repoName}${path}`;
 }
 


### PR DESCRIPTION
- chore: avoid double encoding of filepath
- chore: added changeset Signed-off-by: blam <ben@blam.sh>

Follow up fix from the stale PR #11989
