### PR TITLE
workflows: fix pr-sync approval

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,8 +21,9 @@ jobs:
     if: github.repository == 'backstage/backstage' && ( github.event.pull_request || github.event.issue.pull_request )
     steps:
       - name: PR sync
-        uses: backstage/actions/pr-sync@v0.4.0
+        uses: backstage/actions/pr-sync@v0.5.0
         with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN  }}
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}


### PR DESCRIPTION
Automatic renovate approvals are currently borked since apps can't be codeowners. Fix in 0.5.0 but waiting for https://github.com/backstage/actions/pull/43