### PR TITLE
Feat/allow to post into auth refresh

### DIFF
--- a/.changeset/ten-cobras-wash.md
+++ b/.changeset/ten-cobras-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Allowed post method on /refresh path

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -350,6 +350,7 @@ router.get('/auth/providerA/handler/frame');
 router.post('/auth/providerA/handler/frame');
 router.post('/auth/providerA/logout');
 router.get('/auth/providerA/refresh'); // if supported
+router.post('/auth/providerA/refresh'); // if supported
 ```
 
 As you can see each endpoint is prefixed with both `/auth` and its provider

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -140,6 +140,7 @@ export async function createRouter(
         }
         if (provider.refresh) {
           r.get('/refresh', provider.refresh.bind(provider));
+          r.post('/refresh', provider.refresh.bind(provider));
         }
 
         router.use(`/${providerId}`, r);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allowed `post` on `/refresh` path.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
