### PR TITLE
workflows: migrate to triggered workflow for reacting to review comments

### DIFF
--- a/.github/workflows/pr-review-comment-trigger.yaml
+++ b/.github/workflows/pr-review-comment-trigger.yaml
@@ -1,0 +1,19 @@
+# This workflow is used to trigger the "PR Review Comment" workflow. This chaining is needed
+# because workflows triggered by pull_request_review_comment do not have access to secrets.
+
+name: PR Review Comment Trigger
+on:
+  pull_request_review_comment:
+    types:
+      - created
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    # The "PR Review Comment" workflow will check the success status of this workflow and only mark
+    # the PR for re-review if this workflow was successful, which is when the author leaves a review comment.
+    if: github.repository == 'backstage/backstage' && github.event.comment.user.id == github.event.pull_request.user.id
+
+    steps:
+      - run: echo "This PR needs another review"

--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -1,0 +1,24 @@
+# This workflow is triggered by "PR Review Comment Trigger"
+
+name: PR Review Comment
+on:
+  workflow_run:
+    workflows: [PR Review Comment Trigger]
+    types:
+      - completed
+
+jobs:
+  re-review:
+    runs-on: ubuntu-latest
+
+    # The triggering workflow will report success if the PR needs re-review
+    if: github.repository == 'backstage/backstage' && github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - uses: backstage/actions/re-review@v0.5.2
+        with:
+          app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
+          private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
+          installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
+          project-id: PVT_kwDOBFKqdc02LQ
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,9 +9,6 @@ on:
   issue_comment:
     types:
       - created
-  pull_request_review_comment:
-    types:
-      - created
 
 jobs:
   sync:


### PR DESCRIPTION
Workflows triggered by `pull_request_review_comment` on PRs from forks do not have access to secrets, so jumping through some hoops here to work around that. 🎪 