### PR TITLE
set default owner/repo when more than 1 allowed values defined

### DIFF
--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -89,12 +89,12 @@ export const RepoUrlPicker = (
 
   /* we deal with calling the repo setting here instead of in each components for ease */
   useEffect(() => {
-    if (allowedOwners.length === 1) {
+    if (allowedOwners.length > 0) {
       setState(prevState => ({ ...prevState, owner: allowedOwners[0] }));
     }
   }, [setState, allowedOwners]);
   useEffect(() => {
-    if (allowedRepos.length === 1) {
+    if (allowedRepos.length > 0) {
       setState(prevState => ({ ...prevState, repoName: allowedRepos[0] }));
     }
   }, [setState, allowedRepos]);


### PR DESCRIPTION
## Fix select fields for more than 1 `allowedOwner`/`allowedRepo` defined

Related issue: #12286 

Adding more than one `allowedOwner` or `allowedRepo` will now still set the first value as default in the `initialState`.

I was not able to write tests that proof the wrong behavior before implementation, as I am not familiar on how to mock React state in the component test. If someone could give me good advice I would add that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
