### PR TITLE
contextMenu prop passed through to ScaffolderPage from Router

### DIFF
--- a/.changeset/nervous-hounds-matter.md
+++ b/.changeset/nervous-hounds-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+contextMenu prop passed through to <ScaffolderPageContents /> from the <ScaffolderPage /> component

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -133,11 +133,13 @@ export const ScaffolderPageContents = ({
 export const ScaffolderPage = ({
   TemplateCardComponent,
   groups,
+  contextMenu,
 }: ScaffolderPageProps) => (
   <EntityListProvider>
     <ScaffolderPageContents
       TemplateCardComponent={TemplateCardComponent}
       groups={groups}
+      contextMenu={contextMenu}
     />
   </EntityListProvider>
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Passed the `contextMenu` prop through to `<ScaffolderPageContents />` from the `<ScaffolderPage />` component. Show/hide context menu items on the `<ScaffolderPage />` now working as expected

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
