### PR TITLE
Scaffolder: Renders path templates when copyWithoutRender is used

### DIFF
--- a/.changeset/five-falcons-destroy.md
+++ b/.changeset/five-falcons-destroy.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Add `copyWithoutTemplating` to the fetch template action input. `copyWithoutTemplating` also accepts an array of glob patterns. Contents of matched files or directories are copied without being processed, but paths are subject to rendering.
+
+Deprecate `copyWithoutRender` in favor of `copyWithoutTemplating`.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -106,6 +106,7 @@ export function createFetchTemplateAction(options: {
   values: any;
   templateFileExtension?: string | boolean | undefined;
   copyWithoutRender?: string[] | undefined;
+  copyWithoutTemplating?: string[] | undefined;
   cookiecutterCompat?: boolean | undefined;
 }>;
 


### PR DESCRIPTION
When putting templated paths in `copyWithoutRender` filter, like
`{{project}}/something`, the path template won't get rendered and the
files are copied to the exact `{{project}}/something` instead of
`someproject/something`.

Cookiecutter has fixed this issue in https://github.com/cookiecutter/cookiecutter/issues/456. For users who come from the Cookiecutter world, this inconsistency between Cookiecutter and Backstage is unexpected and could lead to some confusion. 

I believe the behaviour in Backstage should be consistent with Cookiecutter. Note that this change affects templating even not in `cookiecutterCompat` mode, I'm not sure if this would be considered as a breaking change. However, I think having different behaviours (render paths in `cookiecutterCompat` mode, otherwise ignore it) might be even more confusing, and I can't really think of a use case that you actually want to have untemplated paths in your end result.

Signed-off-by: Mengnan Gong <namco1992@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
