### PR TITLE
Fix Error Code in Register Component DryRun

### DIFF
--- a/.changeset/breezy-spiders-eat.md
+++ b/.changeset/breezy-spiders-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix Error Code in Register Component DryRun

--- a/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
@@ -197,7 +197,7 @@ describe('DefaultLocationServiceTest', () => {
           { type: 'url', target: 'https://backstage.io/catalog-info.yaml' },
           true,
         ),
-      ).rejects.toThrowError('Duplicate nested entity: location:default/foo');
+      ).rejects.toThrow(InputError);
     });
 
     it('should return exists false when the location does not exist beforehand', async () => {
@@ -261,6 +261,25 @@ describe('DefaultLocationServiceTest', () => {
             target: 'https://backstage.io/catalog-info.yaml',
           },
           false,
+        ),
+      ).rejects.toThrow(InputError);
+    });
+
+    it('should return default InputError for failed processed entities in dryRun mode', async () => {
+      store.listLocations.mockResolvedValueOnce([]);
+
+      orchestrator.process.mockResolvedValueOnce({
+        ok: false,
+        errors: [new Error('Error: Unable to read url')],
+      });
+
+      await expect(
+        locationService.createLocation(
+          {
+            type: 'url',
+            target: 'https://backstage.io/wrong-url/catalog-info.yaml',
+          },
+          true,
         ),
       ).rejects.toThrow(InputError);
     });

--- a/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
@@ -197,7 +197,7 @@ describe('DefaultLocationServiceTest', () => {
           { type: 'url', target: 'https://backstage.io/catalog-info.yaml' },
           true,
         ),
-      ).rejects.toThrow(InputError);
+      ).rejects.toThrow('Duplicate nested entity: location:default/foo');
     });
 
     it('should return exists false when the location does not exist beforehand', async () => {

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -81,7 +81,7 @@ export class DefaultLocationService implements LocationService {
               stringifyEntityRef(processed.completedEntity),
           )
         ) {
-          throw new Error(
+          throw new InputError(
             `Duplicate nested entity: ${stringifyEntityRef(
               processed.completedEntity,
             )}`,
@@ -90,7 +90,7 @@ export class DefaultLocationService implements LocationService {
         unprocessedEntities.push(...processed.deferredEntities);
         entities.push(processed.completedEntity);
       } else {
-        throw Error(processed.errors.map(String).join(', '));
+        throw new InputError(processed.errors.map(String).join(', '));
       }
     }
     return entities;


### PR DESCRIPTION


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The error code for input validation in API POST `/api/catalog/locations` should not default to error code 500. There is existing InputError that I can re-use instead of creating new Error type.

Close https://github.com/backstage/backstage/issues/12072 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
~- [ ] Added or updated documentation~
~- [ ] Tests for new functionality and regression tests for bug fixes~
~- [ ] Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
