### PR TITLE
workflows/pr-review-comment: debug time

### DIFF
--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -15,6 +15,7 @@ jobs:
     if: github.repository == 'backstage/backstage' && github.event.workflow_run.conclusion == 'success'
 
     steps:
+      - uses: hmarr/debug-action@v2
       - uses: backstage/actions/re-review@v0.5.3
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}


### PR DESCRIPTION
It's debug time 🤦 

For some reason the PR number isn't present the same way it was in the actions repo