### PR TITLE
workflows: new method for signaling PR number of review comments

### DIFF
--- a/.github/workflows/pr-review-comment-trigger.yaml
+++ b/.github/workflows/pr-review-comment-trigger.yaml
@@ -16,4 +16,13 @@ jobs:
     if: github.repository == 'backstage/backstage' && github.event.comment.user.id == github.event.pull_request.user.id
 
     steps:
-      - run: echo "This PR needs another review"
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number-${{ github.event.pull_request.number }}
+          path: pr/

--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -15,11 +15,30 @@ jobs:
     if: github.repository == 'backstage/backstage' && github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: hmarr/debug-action@v2
+      # Inspired by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Read PR Number
+        id: pr-number
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const [artifact] = allArtifacts.data.artifacts.filter(artifact => artifact.name.startsWith('pr_number-'))
+            if (!artifact) {
+              throw new Error('No PR Number artifact available')
+            }
+
+            const prNumber = artifact.name.slice('pr_number-'.length)
+            console.log(`::set-output name=pr-number::${prNumber}`);
+
       - uses: backstage/actions/re-review@v0.5.3
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
           project-id: PVT_kwDOBFKqdc02LQ
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.pr-number.outputs.pr-number }}


### PR DESCRIPTION
`github.event.workflow_run.pull_requests[0].number` is not available on PRs comments from forks, so now we have this