### PR TITLE
feat: updating catalog client entity getters to use generic typings

### DIFF
--- a/.changeset/lovely-rice-hug.md
+++ b/.changeset/lovely-rice-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Updated catalog-client getEntities and getEntityByRef functions to optionally use generic typings. This prevents the need for consumers to cast the result to the specific entity sub-type (Kind).

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -92,10 +92,10 @@ export class CatalogClient implements CatalogApi {
   /**
    * {@inheritdoc CatalogApi.getEntities}
    */
-  async getEntities(
+  async getEntities<EntityKind extends Entity = Entity>(
     request?: GetEntitiesRequest,
     options?: CatalogRequestOptions,
-  ): Promise<GetEntitiesResponse> {
+  ): Promise<GetEntitiesResponse<EntityKind>> {
     const { filter = [], fields = [], offset, limit, after } = request ?? {};
     const params: string[] = [];
 
@@ -137,7 +137,7 @@ export class CatalogClient implements CatalogApi {
     }
 
     const query = params.length ? `?${params.join('&')}` : '';
-    const entities: Entity[] = await this.requestRequired(
+    const entities: EntityKind[] = await this.requestRequired(
       'GET',
       `/entities${query}`,
       options,
@@ -171,10 +171,10 @@ export class CatalogClient implements CatalogApi {
   /**
    * {@inheritdoc CatalogApi.getEntityByRef}
    */
-  async getEntityByRef(
+  async getEntityByRef<EntityKind extends Entity = Entity>(
     entityRef: string | CompoundEntityRef,
     options?: CatalogRequestOptions,
-  ): Promise<Entity | undefined> {
+  ): Promise<EntityKind | undefined> {
     const { kind, namespace, name } = parseEntityRef(entityRef);
     return this.requestOptional(
       'GET',

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -116,8 +116,8 @@ export interface GetEntitiesRequest {
  *
  * @public
  */
-export interface GetEntitiesResponse {
-  items: Entity[];
+export interface GetEntitiesResponse<EntityKind = Entity> {
+  items: EntityKind[];
 }
 
 /**


### PR DESCRIPTION
Hi team, this is my first time attempting to contribute so apologies in case I forgot to do something described in the contributing guidelines.

I want to propose this tiny change that adds generic types to the entity retrieval functions on our catalog-client. We started implementing `cost-insights` in our company, and as we progressed through the development, we ended up with a few utilities that wrapped the `catalog-client` functions just to cast the result to the specific entity kind(s).

Thought about proposing this change upstream as it could be beneficial to others. Please advise, thanks in advance!

Signed-off-by: Daniel Figueiredo <dfigueiredo@wealthsimple.com>

## Hey, I just made a Pull Request!

Updated `@backstage/catalog-client` entity retrieval functions to optionally use generic typings.
This prevents the need for consumers to force cast the result into the specific `Entity` sub-type (Kind).

Functions changes:

* `getEntities`: defaults to `Entity` but accepts anything that extends `Entity` (e.g. `ComponentEntity`, `UserEntity`, `GroupEntity`, etc). As `getEntities` can be queried to return multiple kinds, optionally consumers can provide a union of the expected entity kinds returned for better type safety.
* `getEntityByRef`: similar to above, accepts anything that extends from or defaults `Entity`.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes - N/A
- [x] Screenshots attached (for UI changes) - N/A
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
