### PR TITLE
Adding back the edit and feedback buttons on Techdocs pages

### DIFF
--- a/.changeset/nice-seas-jam.md
+++ b/.changeset/nice-seas-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fixed issue with git feedback buttons not appearing automatically in docs pages. This was done by appending repo_url to the helper function getRepoUrlFromLocationAnnotation.

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -98,13 +98,13 @@ describe('helpers', () => {
 
   describe('getRepoUrlFromLocationAnnotation', () => {
     it.each`
-      url                                                                        | repo_url                                    | edit_uri
-      ${'https://github.com/backstage/backstage'}                                | ${'https://github.com/backstage/backstage'} | ${undefined}
-      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${undefined}                                | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/docs'}
-      ${'https://github.com/backstage/backstage/tree/main/'}                     | ${undefined}                                | ${'https://github.com/backstage/backstage/edit/main/docs'}
-      ${'https://gitlab.com/backstage/backstage'}                                | ${'https://gitlab.com/backstage/backstage'} | ${undefined}
-      ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${undefined}                                | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/docs'}
-      ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${undefined}                                | ${'https://gitlab.com/backstage/backstage/-/edit/main/docs'}
+      url                                                                        | repo_url                                                                   | edit_uri
+      ${'https://github.com/backstage/backstage'}                                | ${'https://github.com/backstage/backstage'}                                | ${undefined}
+      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/docs'}
+      ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/edit/main/docs'}
+      ${'https://gitlab.com/backstage/backstage'}                                | ${'https://gitlab.com/backstage/backstage'}                                | ${undefined}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/docs'}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${'https://gitlab.com/backstage/backstage/-/edit/main/docs'}
     `('should convert $url', ({ url: target, repo_url, edit_uri }) => {
       const parsedLocationAnnotation: ParsedLocationAnnotation = {
         type: 'url',
@@ -120,14 +120,14 @@ describe('helpers', () => {
     });
 
     it.each`
-      url                                                                        | edit_uri
-      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/custom/folder'}
-      ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/edit/main/custom/folder'}
-      ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/custom/folder'}
-      ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${'https://gitlab.com/backstage/backstage/-/edit/main/custom/folder'}
+      url                                                                        | repo_url                                                                   | edit_uri
+      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/custom/folder'}
+      ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/edit/main/custom/folder'}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/custom/folder'}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${'https://gitlab.com/backstage/backstage/-/edit/main/custom/folder'}
     `(
       'should convert $url with custom docsFolder',
-      ({ url: target, edit_uri }) => {
+      ({ url: target, repo_url, edit_uri }) => {
         const parsedLocationAnnotation: ParsedLocationAnnotation = {
           type: 'url',
           target,
@@ -139,7 +139,7 @@ describe('helpers', () => {
             scmIntegrations,
             './custom/folder',
           ),
-        ).toEqual({ edit_uri });
+        ).toEqual({ repo_url, edit_uri });
       },
     );
 

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -114,7 +114,10 @@ export const getRepoUrlFromLocationAnnotation = (
         url: `./${docsFolder}`,
         base: target,
       });
-      return { edit_uri: integration.resolveEditUrl(sourceFolder) };
+      return {
+        repo_url: target,
+        edit_uri: integration.resolveEditUrl(sourceFolder),
+      };
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In reference to the issue: https://github.com/backstage/backstage/issues/11026

Essentially the edit and feedback buttons stopped automatically appearing from the techdocs pages at some point recently, and this issue was created in reference to that. After digging into it a bit, the helper function [getRepoUrlFromLocationAnnotation](https://github.com/backstage/backstage/blob/c938e0d61dbe74f126e5e347413addba8bcd3698/plugins/techdocs-node/src/stages/generate/helpers.ts#L94) in techdocs-node isn't returning a `repo_url`. Both a `repo_url` and a `edit_uri` are needed in order to render the buttons, so adding it in the helper function seems like an easy fix. The method seems to only be called from [mkDocsPatchers](https://github.com/backstage/backstage/blob/c938e0d61dbe74f126e5e347413addba8bcd3698/plugins/techdocs-node/src/stages/generate/mkDocsPatchers.ts#L104), so it seems like a safe change, unless I'm missing some context. We've also been running a patch with this change on our backstage instance for about a month now with no issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
