### PR TITLE
Add support for FreeIPA as a LDAP vendor

### DIFF
--- a/.changeset/hungry-cougars-press.md
+++ b/.changeset/hungry-cougars-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Fix mapping between users and groups for FreeIPA when using the LdapOrgProcessor

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -14,11 +14,7 @@ entities that mirror your org setup.
 
 ## Supported vendors
 
-Currently, Backstage only supports the following LDAP vendors:
-
-1. OpenLDAP (default)
-2. Active Directory
-3. FreeIPA
+Backstage in general supports OpenLDAP compatible vendors, as well as Active Directory and FreeIPA. If you are using a vendor that does not seem to be supported, please [file an issue](https://github.com/backstage/backstage/issues/new?assignees=&labels=enhancement&template=feature_template.md).
 
 ## Installation
 

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -12,7 +12,7 @@ groups - directly from an LDAP compatible service. The result is a hierarchy of
 [`Group`](../../features/software-catalog/descriptor-format.md#kind-group) kind
 entities that mirror your org setup.
 
-## Suported vendors
+## Supported vendors
 
 Currently, Backstage only supports the following LDAP vendors:
 

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -12,6 +12,14 @@ groups - directly from an LDAP compatible service. The result is a hierarchy of
 [`Group`](../../features/software-catalog/descriptor-format.md#kind-group) kind
 entities that mirror your org setup.
 
+## Suported vendors
+
+Currently, Backstage only supports the following LDAP vendors:
+
+1. OpenLDAP (default)
+2. Active Directory
+3. FreeIPA
+
 ## Installation
 
 This guide will use the Entity Provider method. If you for some reason prefer

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -23,6 +23,7 @@ import { errorString } from './util';
 import {
   ActiveDirectoryVendor,
   DefaultLdapVendor,
+  FreeIpaVendor,
   LdapVendor,
 } from './vendors';
 
@@ -199,6 +200,8 @@ export class LdapClient {
       .then(root => {
         if (root && root.raw?.forestFunctionality) {
           return ActiveDirectoryVendor;
+        } else if (root && root.raw?.ipaDomainLevel) {
+          return FreeIpaVendor;
         }
         return DefaultLdapVendor;
       })

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
@@ -32,7 +32,11 @@ import {
   resolveRelations,
 } from './read';
 import { RecursivePartial } from './util';
-import { ActiveDirectoryVendor, DefaultLdapVendor, FreeIpaVendor } from './vendors';
+import {
+  ActiveDirectoryVendor,
+  DefaultLdapVendor,
+  FreeIpaVendor,
+} from './vendors';
 
 function user(data: RecursivePartial<UserEntity>): UserEntity {
   return merge(
@@ -252,7 +256,6 @@ describe('readLdapUsers', () => {
     );
   });
 });
-
 
 describe('readLdapGroups', () => {
   const client: jest.Mocked<LdapClient> = {

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
@@ -32,7 +32,7 @@ import {
   resolveRelations,
 } from './read';
 import { RecursivePartial } from './util';
-import { ActiveDirectoryVendor, DefaultLdapVendor } from './vendors';
+import { ActiveDirectoryVendor, DefaultLdapVendor, FreeIpaVendor } from './vendors';
 
 function user(data: RecursivePartial<UserEntity>): UserEntity {
   return merge(
@@ -195,7 +195,64 @@ describe('readLdapUsers', () => {
       new Map([['dn-value', new Set(['x', 'y', 'z'])]]),
     );
   });
+
+  it('transfers all attributes from FreeIPA', async () => {
+    client.getVendor.mockResolvedValue(FreeIpaVendor);
+    client.searchStreaming.mockImplementation(async (_dn, _opts, fn) => {
+      await fn(
+        searchEntry({
+          uid: ['uid-value'],
+          description: ['description-value'],
+          cn: ['cn-value'],
+          mail: ['mail-value'],
+          avatarUrl: ['avatarUrl-value'],
+          memberOf: ['x', 'y', 'z'],
+          dn: ['dn-value'],
+          ipaUniqueID: ['uuid-value'],
+        }),
+      );
+    });
+    const config: UserConfig = {
+      dn: 'ddd',
+      options: {},
+      map: {
+        rdn: 'uid',
+        name: 'uid',
+        description: 'description',
+        displayName: 'cn',
+        email: 'mail',
+        picture: 'avatarUrl',
+        memberOf: 'memberOf',
+      },
+    };
+    const { users, userMemberOf } = await readLdapUsers(client, config);
+    expect(users).toEqual([
+      expect.objectContaining({
+        metadata: {
+          name: 'uid-value',
+          description: 'description-value',
+          annotations: {
+            [LDAP_DN_ANNOTATION]: 'dn-value',
+            [LDAP_RDN_ANNOTATION]: 'uid-value',
+            [LDAP_UUID_ANNOTATION]: 'uuid-value',
+          },
+        },
+        spec: {
+          profile: {
+            displayName: 'cn-value',
+            email: 'mail-value',
+            picture: 'avatarUrl-value',
+          },
+          memberOf: [],
+        },
+      }),
+    ]);
+    expect(userMemberOf).toEqual(
+      new Map([['dn-value', new Set(['x', 'y', 'z'])]]),
+    );
+  });
 });
+
 
 describe('readLdapGroups', () => {
   const client: jest.Mocked<LdapClient> = {

--- a/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
@@ -63,6 +63,16 @@ export const ActiveDirectoryVendor: LdapVendor = {
   },
 };
 
+export const FreeIpaVendor: LdapVendor = {
+  dnAttributeName: 'dn',
+  uuidAttributeName: 'ipaUniqueID',
+  decodeStringAttribute: (entry, name) => {
+    return decode(entry, name, value => {
+      return value.toString();
+    });
+  },
+};
+
 // Decode an attribute to a consumer
 function decode(
   entry: SearchEntry,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As discussed in #12493 I've added a LDAP vendor for FreeIPA.

I've based the change in `getVendor` on the `getRootDSE` output from FreeIPA:

```text
# extended LDIF
#
# LDAPv3
# base <> (default) with scope baseObject
# filter: (objectclass=*)
# requesting: ALL
#

#
dn:
objectClass: top
namingContexts: dc=intra,dc=organization,dc=io
namingContexts: cn=changelog
namingContexts: o=ipaca
defaultnamingcontext: dc=intra,dc=organization,dc=io
supportedExtension: 2.16.840.1.113730.3.5.7
...ommitted additional supportedExtension...
supportedControl: 2.16.840.1.113730.3.4.2
...ommitted additional supportedControl...
supportedSASLMechanisms: EXTERNAL
supportedSASLMechanisms: GSS-SPNEGO
supportedSASLMechanisms: GSSAPI
supportedSASLMechanisms: DIGEST-MD5
supportedSASLMechanisms: CRAM-MD5
supportedSASLMechanisms: LOGIN
supportedSASLMechanisms: PLAIN
supportedSASLMechanisms: ANONYMOUS
supportedLDAPVersion: 2
supportedLDAPVersion: 3
vendorName: 389 Project
vendorVersion: 389-Directory/1.4.3.231 B2022.061.1818
dataversion: 020220516125028020220516125028020220516125028
netscapemdsuffix: <redacted>
lastusn: 1593209
changeLog: cn=changelog
firstchangenumber: 0
lastchangenumber: 0
ipatopologypluginversion: 1.0
ipatopologyismanaged: on
ipaDomainLevel: 1

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1
```

I'm still looking into how to test my change against the actual FreeIPA instance that we have. I couldn't find any documentation on how to use a dev version of Backstage to test specific features. Any pointers would be welcome.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
