### PR TITLE
core-plugin-api: enable /alpha entrypoint

### DIFF
--- a/.changeset/warm-monkeys-study.md
+++ b/.changeset/warm-monkeys-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Enabled the `@backstage/core-plugin-api/alpha` entry point.

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -31,26 +31,26 @@ export type AlertMessage = {
   severity?: 'success' | 'info' | 'warning' | 'error';
 };
 
-// @alpha
+// @public
 export type AnalyticsApi = {
   captureEvent(event: AnalyticsEvent): void;
 };
 
-// @alpha
+// @public
 export const analyticsApiRef: ApiRef<AnalyticsApi>;
 
-// @alpha
+// @public
 export const AnalyticsContext: (options: {
   attributes: Partial<AnalyticsContextValue>;
   children: ReactNode;
 }) => JSX.Element;
 
-// @alpha
+// @public
 export type AnalyticsContextValue = CommonAnalyticsContext & {
   [param in string]: string | boolean | number | undefined;
 };
 
-// @alpha
+// @public
 export type AnalyticsEvent = {
   action: string;
   subject: string;
@@ -59,12 +59,12 @@ export type AnalyticsEvent = {
   context: AnalyticsContextValue;
 };
 
-// @alpha
+// @public
 export type AnalyticsEventAttributes = {
   [attribute in string]: string | boolean | number;
 };
 
-// @alpha
+// @public
 export type AnalyticsTracker = {
   captureEvent: (
     action: string,
@@ -241,7 +241,7 @@ export type BootErrorPageProps = {
   error: Error;
 };
 
-// @alpha
+// @public
 export type CommonAnalyticsContext = {
   pluginId: string;
   routeRef: string;
@@ -715,7 +715,7 @@ export type TypesToApiRefs<T> = {
   [key in keyof T]: ApiRef<T[key]>;
 };
 
-// @alpha
+// @public
 export function useAnalytics(): AnalyticsTracker;
 
 // @public

--- a/packages/core-plugin-api/package.json
+++ b/packages/core-plugin-api/package.json
@@ -6,7 +6,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "alphaTypes": "dist/index.alpha.d.ts"
   },
   "backstage": {
     "role": "web-library"
@@ -24,7 +25,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli package build",
+    "build": "backstage-cli package build --experimental-type-build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
@@ -61,6 +62,7 @@
     "msw": "^0.43.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "alpha"
   ]
 }

--- a/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
+++ b/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
@@ -61,7 +61,7 @@ export const useAnalyticsContext = (): AnalyticsContextValue => {
  * Analytics contexts are additive, meaning the context ultimately emitted with
  * an event is the combination of all contexts in the parent tree.
  *
- * @alpha
+ * @public
  */
 export const AnalyticsContext = (options: {
   attributes: Partial<AnalyticsContextValue>;

--- a/packages/core-plugin-api/src/analytics/types.ts
+++ b/packages/core-plugin-api/src/analytics/types.ts
@@ -17,7 +17,7 @@
 /**
  * Common analytics context attributes.
  *
- * @alpha
+ * @public
  */
 export type CommonAnalyticsContext = {
   /**
@@ -39,7 +39,7 @@ export type CommonAnalyticsContext = {
 /**
  * Analytics context envelope.
  *
- * @alpha
+ * @public
  */
 export type AnalyticsContextValue = CommonAnalyticsContext & {
   [param in string]: string | boolean | number | undefined;

--- a/packages/core-plugin-api/src/analytics/useAnalytics.tsx
+++ b/packages/core-plugin-api/src/analytics/useAnalytics.tsx
@@ -35,7 +35,7 @@ function useAnalyticsApi(): AnalyticsApi {
 /**
  * Gets a pre-configured analytics tracker.
  *
- * @alpha
+ * @public
  */
 export function useAnalytics(): AnalyticsTracker {
   const trackerRef = useRef<Tracker | null>(null);

--- a/packages/core-plugin-api/src/apis/definitions/AnalyticsApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/AnalyticsApi.ts
@@ -21,7 +21,7 @@ import { AnalyticsContextValue } from '../../analytics/types';
  * Represents an event worth tracking in an analytics system that could inform
  * how users of a Backstage instance are using its features.
  *
- * @alpha
+ * @public
  */
 export type AnalyticsEvent = {
   /**
@@ -79,7 +79,7 @@ export type AnalyticsEvent = {
  * A structure allowing other arbitrary metadata to be provided by analytics
  * event emitters.
  *
- * @alpha
+ * @public
  */
 export type AnalyticsEventAttributes = {
   [attribute in string]: string | boolean | number;
@@ -89,7 +89,7 @@ export type AnalyticsEventAttributes = {
  * Represents a tracker with methods that can be called to track events in a
  * configured analytics service.
  *
- * @alpha
+ * @public
  */
 export type AnalyticsTracker = {
   captureEvent: (
@@ -103,8 +103,6 @@ export type AnalyticsTracker = {
 };
 
 /**
- * **EXPERIMENTAL**
- *
  * The Analytics API is used to track user behavior in a Backstage instance.
  *
  * @remarks
@@ -113,7 +111,7 @@ export type AnalyticsTracker = {
  * useAnalytics() hook. This will return a pre-configured AnalyticsTracker
  * with relevant methods for instrumentation.
  *
- * @alpha
+ * @public
  */
 export type AnalyticsApi = {
   /**
@@ -124,11 +122,9 @@ export type AnalyticsApi = {
 };
 
 /**
- * **EXPERIMENTAL**
- *
  * The {@link ApiRef} of {@link AnalyticsApi}.
  *
- * @alpha
+ * @public
  */
 export const analyticsApiRef: ApiRef<AnalyticsApi> = createApiRef({
   id: 'core.analytics',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enabling the `/alpha` entry point for `@backstage/core-plugin-api`.

@iamEAP do you think we should mark the analytics API as stable or move it over to the `/alpha` entrypoint? I'm feeling we're at the point were we should just mark it stable as it's been out for a long time and the `@alpha` in docs doesn't really do much by itself.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
