### PR TITLE
Fix OpenAPI HTML descriptions in darkmode

### DIFF
--- a/.changeset/stale-needles-applaud.md
+++ b/.changeset/stale-needles-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Set font colors correctly for descriptions containing HTML

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -53,6 +53,7 @@ const useStyles = makeStyles(theme => ({
           .opblock-summary-operation-id,
           .opblock-summary-path,
           .opblock-summary-path__deprecated,
+          .opblock-description-wrapper,
           .opblock-external-docs-wrapper,
           .opblock-section-header .btn,
           .opblock-section-header>label,
@@ -66,7 +67,7 @@ const useStyles = makeStyles(theme => ({
         fontFamily: theme.typography.fontFamily,
         color: theme.palette.text.primary,
       },
-      [`& .opblock .opblock-section-header, 
+      [`& .opblock .opblock-section-header,
           .model-box,
           section.models .model-container`]: {
         background: theme.palette.background.default,
@@ -75,7 +76,7 @@ const useStyles = makeStyles(theme => ({
           .parameter__in`]: {
         color: theme.palette.text.disabled,
       },
-      [`& table.model, 
+      [`& table.model,
           .parameter__type,
           .model.model-title,
           .model-title,
@@ -91,7 +92,7 @@ const useStyles = makeStyles(theme => ({
       [`& .parameter__name.required:after`]: {
         color: theme.palette.warning.dark,
       },
-      [`& table.model, 
+      [`& table.model,
           table.model .model,
           .opblock-external-docs-wrapper`]: {
         fontSize: theme.typography.fontSize,
@@ -104,7 +105,7 @@ const useStyles = makeStyles(theme => ({
         color: theme.palette.text.hint,
         backgroundColor: theme.palette.background.paper,
       },
-      [`& .opblock-summary-method, 
+      [`& .opblock-summary-method,
           .info a`]: {
         fontFamily: theme.typography.fontFamily,
       },


### PR DESCRIPTION
Currently when an OpenAPI specification contains HTML in the description fields
it is not rendered with the correct theme font colors making the description
unreadable in darkmode.

This change adds an additional selector to the style theme that correctly
selects the description block and ensures colors follows the theme.

Some trailing whitespace was removed as well while I was in the file.

Closes #12243

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

### Darkmode

<img width="841" alt="image" src="https://user-images.githubusercontent.com/6881694/178060928-d33cb0ea-df83-4f69-9520-b184cf0e0181.png">

### Lightmode

<img width="810" alt="image" src="https://user-images.githubusercontent.com/6881694/178061018-dd1e6c04-63e7-42e1-bb67-71391dcb13cd.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
