### PR TITLE
Include aria label for copy button

### DIFF
--- a/.changeset/tender-cycles-shout.md
+++ b/.changeset/tender-cycles-shout.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-components': minor
+'@backstage/core-components': patch
 ---
 
 Improve accessibility for CopyTextButton

--- a/.changeset/tender-cycles-shout.md
+++ b/.changeset/tender-cycles-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Improve accessibility for CopyTextButton

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -190,6 +190,7 @@ export function CopyTextButton(props: CopyTextButtonProps): JSX.Element;
 
 // @public
 export interface CopyTextButtonProps {
+  'aria-label'?: string;
   text: string;
   tooltipDelay?: number;
   tooltipText?: string;

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.stories.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.stories.tsx
@@ -44,6 +44,6 @@ export const LongerTooltipDelay = () => (
 export const WithAriaLabel = () => (
   <CopyTextButton
     text="The text to copy to clipboard"
-    ariaLabel="This is an aria label"
+    aria-label="This is an aria label"
   />
 );

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.stories.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.stories.tsx
@@ -40,3 +40,10 @@ export const LongerTooltipDelay = () => (
     tooltipDelay={3000}
   />
 );
+
+export const WithAriaLabel = () => (
+  <CopyTextButton
+    text="The text to copy to clipboard"
+    ariaLabel="This is an aria label"
+  />
+);

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
@@ -104,7 +104,7 @@ describe('<CopyTextButton />', () => {
   it('aria-label', async () => {
     const { getByLabelText } = await renderInTestApp(
       <TestApiProvider apis={apis}>
-        <CopyTextButton {...props} ariaLabel="text for aria-label" />
+        <CopyTextButton {...props} aria-label="text for aria-label" />
       </TestApiProvider>,
     );
     expect(getByLabelText('text for aria-label')).toBeInTheDocument();

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
@@ -55,13 +55,14 @@ const apis = [[errorApiRef, mockErrorApi] as const] as const;
 
 describe('<CopyTextButton />', () => {
   it('renders without exploding', async () => {
-    const { getByTitle, queryByText } = await renderInTestApp(
+    const { getByTitle, queryByText, getByLabelText } = await renderInTestApp(
       <TestApiProvider apis={apis}>
         <CopyTextButton {...props} />
       </TestApiProvider>,
     );
     expect(getByTitle('mockTooltip')).toBeInTheDocument();
     expect(queryByText('mockTooltip')).not.toBeInTheDocument();
+    expect(getByLabelText('Copy text')).toBeInTheDocument();
   });
 
   it('displays tooltip and copy the text on click', async () => {
@@ -98,5 +99,14 @@ describe('<CopyTextButton />', () => {
       </TestApiProvider>,
     );
     expect(mockErrorApi.post).toHaveBeenCalledWith(error);
+  });
+
+  it('aria-label', async () => {
+    const { getByLabelText } = await renderInTestApp(
+      <TestApiProvider apis={apis}>
+        <CopyTextButton {...props} ariaLabel="text for aria-label" />
+      </TestApiProvider>,
+    );
+    expect(getByLabelText('text for aria-label')).toBeInTheDocument();
   });
 });

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
@@ -47,11 +47,16 @@ export interface CopyTextButtonProps {
    * Default: "Text copied to clipboard"
    */
   tooltipText?: string;
-}
 
-type LabelledCopyTextButtonProps = CopyTextButtonProps & {
+  /**
+   * Text to use as aria-label prop on the button
+   *
+   * @remarks
+   *
+   * Default: "Copy text"
+   */
   'aria-label'?: string;
-};
+}
 
 /**
  * Copy text button with visual feedback
@@ -72,7 +77,7 @@ type LabelledCopyTextButtonProps = CopyTextButtonProps & {
  *   arial-label="Accessible label for this button" />
  * ```
  */
-export function CopyTextButton(props: LabelledCopyTextButtonProps) {
+export function CopyTextButton(props: CopyTextButtonProps) {
   const {
     text,
     tooltipDelay = 1000,

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
@@ -49,6 +49,10 @@ export interface CopyTextButtonProps {
   tooltipText?: string;
 }
 
+type LabelledCopyTextButtonProps = CopyTextButtonProps & {
+  ariaLabel?: string;
+};
+
 /**
  * Copy text button with visual feedback
  *
@@ -62,13 +66,18 @@ export interface CopyTextButtonProps {
  *
  * @example
  *
- * `<CopyTextButton text="My text that I want to be copied to the clipboard" />`
+ * ```
+ * <CopyTextButton
+ *   text="My text that I want to be copied to the clipboard"
+ *   ariaLabel="Accessible label for this button" />
+ * ```
  */
-export function CopyTextButton(props: CopyTextButtonProps) {
+export function CopyTextButton(props: LabelledCopyTextButtonProps) {
   const {
     text,
     tooltipDelay = 1000,
     tooltipText = 'Text copied to clipboard',
+    ariaLabel = 'Copy text',
   } = props;
   const errorApi = useApi(errorApiRef);
   const [open, setOpen] = useState(false);
@@ -96,7 +105,7 @@ export function CopyTextButton(props: CopyTextButtonProps) {
         onClose={() => setOpen(false)}
         open={open}
       >
-        <IconButton onClick={handleCopyClick}>
+        <IconButton onClick={handleCopyClick} aria-label={ariaLabel}>
           <CopyIcon />
         </IconButton>
       </Tooltip>

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
@@ -50,7 +50,7 @@ export interface CopyTextButtonProps {
 }
 
 type LabelledCopyTextButtonProps = CopyTextButtonProps & {
-  ariaLabel?: string;
+  'aria-label'?: string;
 };
 
 /**
@@ -69,7 +69,7 @@ type LabelledCopyTextButtonProps = CopyTextButtonProps & {
  * ```
  * <CopyTextButton
  *   text="My text that I want to be copied to the clipboard"
- *   ariaLabel="Accessible label for this button" />
+ *   arial-label="Accessible label for this button" />
  * ```
  */
 export function CopyTextButton(props: LabelledCopyTextButtonProps) {
@@ -77,7 +77,7 @@ export function CopyTextButton(props: LabelledCopyTextButtonProps) {
     text,
     tooltipDelay = 1000,
     tooltipText = 'Text copied to clipboard',
-    ariaLabel = 'Copy text',
+    'aria-label': ariaLabel = 'Copy text',
   } = props;
   const errorApi = useApi(errorApiRef);
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
Signed-off-by: Omar Babativa <obabativa@vmware.com>

## Add attribute in CopyTextButton to handle aria label 

Addresses a small part of https://github.com/backstage/backstage/issues/7124

![CopyTextButton aria-label usage](https://user-images.githubusercontent.com/89466662/178076596-28e6a9c8-ff1a-4992-beaa-133269fc50b2.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
