### PR TITLE
workflows: use actions/stale@v5

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@main
+      - uses: actions/stale@v5
         id: stale
         with:
           stale-issue-message: >


### PR DESCRIPTION
Been having issues with stale labels not being added properly, thinking that rolling back to v5 might fix it