### PR TITLE
added initial storage api subscription in Shortcuts plugin 

### DIFF
--- a/.changeset/violet-trees-play.md
+++ b/.changeset/violet-trees-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+fixed shortcuts initialization when using firestore

--- a/.changeset/violet-trees-play.md
+++ b/.changeset/violet-trees-play.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-shortcuts': patch
+'@backstage/plugin-shortcuts': minor
 ---
 
-fixed shortcuts initialization when using firestore
+Fixed shortcuts initialization when using firestore

--- a/.changeset/violet-trees-play.md
+++ b/.changeset/violet-trees-play.md
@@ -2,4 +2,13 @@
 '@backstage/plugin-shortcuts': minor
 ---
 
-Fixed shortcuts initialization when using firestore
+Internal observable replaced with a mapping from the storage API. This fixes shortcuts initialization when using firestore.
+
+`ShortcutApi.get` method, that returns an immediate snapshot of shortcuts, made public.
+
+Example of how to get and observe `shortcuts`:
+
+```typescript
+const shortcutApi = useApi(shortcutsApiRef);
+const shortcuts = useObservable(shortcutApi.shortcut$(), shortcutApi.get());
+```

--- a/plugins/shortcuts/api-report.md
+++ b/plugins/shortcuts/api-report.md
@@ -20,13 +20,13 @@ export class LocalStoredShortcuts implements ShortcutApi {
   // (undocumented)
   add(shortcut: Omit<Shortcut, 'id'>): Promise<void>;
   // (undocumented)
+  get(): Shortcut[];
+  // (undocumented)
   getColor(url: string): string;
   // (undocumented)
   remove(id: string): Promise<void>;
   // (undocumented)
   shortcut$(): Observable_2<Shortcut[]>;
-  // (undocumented)
-  snapshot(): Shortcut[];
   // (undocumented)
   update(shortcut: Shortcut): Promise<void>;
 }
@@ -45,10 +45,10 @@ export type Shortcut = {
 // @public (undocumented)
 export interface ShortcutApi {
   add(shortcut: Omit<Shortcut, 'id'>): Promise<void>;
+  get(): Shortcut[];
   getColor(url: string): string;
   remove(id: string): Promise<void>;
   shortcut$(): Observable<Shortcut[]>;
-  snapshot(): Shortcut[];
   update(shortcut: Shortcut): Promise<void>;
 }
 

--- a/plugins/shortcuts/api-report.md
+++ b/plugins/shortcuts/api-report.md
@@ -9,7 +9,7 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { Observable } from '@backstage/types';
-import ObservableImpl from 'zen-observable';
+import { default as Observable_2 } from 'zen-observable';
 import { StorageApi } from '@backstage/core-plugin-api';
 
 // Warning: (ae-missing-release-tag) "LocalStoredShortcuts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -24,7 +24,9 @@ export class LocalStoredShortcuts implements ShortcutApi {
   // (undocumented)
   remove(id: string): Promise<void>;
   // (undocumented)
-  shortcut$(): ObservableImpl<Shortcut[]>;
+  shortcut$(): Observable_2<Shortcut[]>;
+  // (undocumented)
+  snapshot(): Shortcut[];
   // (undocumented)
   update(shortcut: Shortcut): Promise<void>;
 }
@@ -46,6 +48,7 @@ export interface ShortcutApi {
   getColor(url: string): string;
   remove(id: string): Promise<void>;
   shortcut$(): Observable<Shortcut[]>;
+  snapshot(): Shortcut[];
   update(shortcut: Shortcut): Promise<void>;
 }
 

--- a/plugins/shortcuts/src/Shortcuts.tsx
+++ b/plugins/shortcuts/src/Shortcuts.tsx
@@ -39,10 +39,7 @@ export interface ShortcutsProps {
 
 export const Shortcuts = (props: ShortcutsProps) => {
   const shortcutApi = useApi(shortcutsApiRef);
-  const shortcuts = useObservable(
-    shortcutApi.shortcut$(),
-    shortcutApi.snapshot(),
-  );
+  const shortcuts = useObservable(shortcutApi.shortcut$(), shortcutApi.get());
   const [anchorEl, setAnchorEl] = React.useState<Element | undefined>();
   const loading = Boolean(!shortcuts);
 

--- a/plugins/shortcuts/src/Shortcuts.tsx
+++ b/plugins/shortcuts/src/Shortcuts.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import PlayListAddIcon from '@material-ui/icons/PlaylistAdd';
 import { ShortcutItem } from './ShortcutItem';

--- a/plugins/shortcuts/src/Shortcuts.tsx
+++ b/plugins/shortcuts/src/Shortcuts.tsx
@@ -40,7 +40,8 @@ export interface ShortcutsProps {
 export const Shortcuts = (props: ShortcutsProps) => {
   const shortcutApi = useApi(shortcutsApiRef);
   const shortcuts = useObservable(
-    useMemo(() => shortcutApi.shortcut$(), [shortcutApi]),
+    shortcutApi.shortcut$(),
+    shortcutApi.snapshot(),
   );
   const [anchorEl, setAnchorEl] = React.useState<Element | undefined>();
   const loading = Boolean(!shortcuts);

--- a/plugins/shortcuts/src/api/LocalStoredShortcuts.test.ts
+++ b/plugins/shortcuts/src/api/LocalStoredShortcuts.test.ts
@@ -27,17 +27,22 @@ describe('LocalStoredShortcuts', () => {
     );
     const shortcut: Shortcut = { id: 'id', title: 'title', url: '/url' };
 
-    await shortcutApi.add(shortcut);
+    const observerNextHandler = jest.fn();
 
     await new Promise<void>(resolve => {
-      const subscription = shortcutApi.shortcut$().subscribe(data => {
-        expect(data).toEqual(
-          expect.arrayContaining([{ ...shortcut, id: expect.anything() }]),
-        );
-        subscription.unsubscribe();
-        resolve();
+      shortcutApi.shortcut$().subscribe({
+        next: data => {
+          observerNextHandler(data);
+          resolve();
+        },
       });
+      shortcutApi.add(shortcut);
     });
+
+    expect(observerNextHandler).toHaveBeenCalledTimes(1);
+    expect(observerNextHandler).toHaveBeenCalledWith(
+      expect.arrayContaining([{ ...shortcut, id: expect.anything() }]),
+    );
   });
 
   it('should add shortcuts with ids', async () => {

--- a/plugins/shortcuts/src/api/LocalStoredShortcuts.ts
+++ b/plugins/shortcuts/src/api/LocalStoredShortcuts.ts
@@ -33,27 +33,27 @@ export class LocalStoredShortcuts implements ShortcutApi {
     );
   }
 
-  snapshot() {
+  get() {
     return Array.from(
       this.storageApi.snapshot<Shortcut[]>('items').value ?? [],
     ).sort((a, b) => (a.title >= b.title ? 1 : -1));
   }
 
   async add(shortcut: Omit<Shortcut, 'id'>) {
-    const shortcuts = this.snapshot();
+    const shortcuts = this.get();
     shortcuts.push({ ...shortcut, id: uuid() });
 
     await this.storageApi.set('items', shortcuts);
   }
 
   async remove(id: string) {
-    const shortcuts = this.snapshot().filter(s => s.id !== id);
+    const shortcuts = this.get().filter(s => s.id !== id);
 
     await this.storageApi.set('items', shortcuts);
   }
 
   async update(shortcut: Shortcut) {
-    const shortcuts = this.snapshot().filter(s => s.id !== shortcut.id);
+    const shortcuts = this.get().filter(s => s.id !== shortcut.id);
     shortcuts.push(shortcut);
 
     await this.storageApi.set('items', shortcuts);

--- a/plugins/shortcuts/src/api/LocalStoredShortcuts.ts
+++ b/plugins/shortcuts/src/api/LocalStoredShortcuts.ts
@@ -25,7 +25,11 @@ import { StorageApi } from '@backstage/core-plugin-api';
  * Implementation of the ShortcutApi that uses the StorageApi to store shortcuts.
  */
 export class LocalStoredShortcuts implements ShortcutApi {
-  constructor(private readonly storageApi: StorageApi) {}
+  constructor(private readonly storageApi: StorageApi) {
+    this.storageApi.observe$<Shortcut[]>('items').subscribe({
+      next: () => this.notify(),
+    });
+  }
 
   shortcut$() {
     return this.observable;
@@ -36,14 +40,12 @@ export class LocalStoredShortcuts implements ShortcutApi {
     shortcuts.push({ ...shortcut, id: uuid() });
 
     await this.storageApi.set('items', shortcuts);
-    this.notify();
   }
 
   async remove(id: string) {
     const shortcuts = this.get().filter(s => s.id !== id);
 
     await this.storageApi.set('items', shortcuts);
-    this.notify();
   }
 
   async update(shortcut: Shortcut) {
@@ -51,7 +53,6 @@ export class LocalStoredShortcuts implements ShortcutApi {
     shortcuts.push(shortcut);
 
     await this.storageApi.set('items', shortcuts);
-    this.notify();
   }
 
   getColor(url: string) {

--- a/plugins/shortcuts/src/api/ShortcutApi.ts
+++ b/plugins/shortcuts/src/api/ShortcutApi.ts
@@ -29,6 +29,11 @@ export interface ShortcutApi {
   shortcut$(): Observable<Shortcut[]>;
 
   /**
+   * Returns an immediate snapshot of shortcuts, sorted by title
+   */
+  snapshot(): Shortcut[];
+
+  /**
    * Generates a unique id for the shortcut and then saves it.
    */
   add(shortcut: Omit<Shortcut, 'id'>): Promise<void>;

--- a/plugins/shortcuts/src/api/ShortcutApi.ts
+++ b/plugins/shortcuts/src/api/ShortcutApi.ts
@@ -31,7 +31,7 @@ export interface ShortcutApi {
   /**
    * Returns an immediate snapshot of shortcuts, sorted by title
    */
-  snapshot(): Shortcut[];
+  get(): Shortcut[];
 
   /**
    * Generates a unique id for the shortcut and then saves it.


### PR DESCRIPTION
## Hey, I just made a Pull Request!
There was a problem when with Shortcuts plugin when using Firestore - notify event was called only for add/update/remove actions, but not when Firestore initialised, so no stored links are shown on page load (only after adding new item). This PR adds subscription in ShortcutsApi constructor to fix this

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
