### PR TITLE
core: remove usage of explicit type parameters for BackstagePlugin

### DIFF
--- a/.changeset/little-guests-sell.md
+++ b/.changeset/little-guests-sell.md
@@ -1,0 +1,7 @@
+---
+'@backstage/app-defaults': patch
+'@backstage/core-app-api': patch
+'@backstage/core-plugin-api': patch
+---
+
+Internal tweak removing usage of explicit type parameters for the `BackstagePlugin` type.

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -74,7 +74,7 @@ The extension type is a simple one:
 
 ```ts
 export type Extension<T> = {
-  expose(plugin: BackstagePlugin<any, any>): T;
+  expose(plugin: BackstagePlugin): T;
 };
 ```
 

--- a/packages/app-defaults/src/createApp.tsx
+++ b/packages/app-defaults/src/createApp.tsx
@@ -50,7 +50,7 @@ export function createApp(
       ...icons,
       ...options?.icons,
     },
-    plugins: (options?.plugins as BackstagePlugin<any, any>[]) ?? [],
+    plugins: (options?.plugins as BackstagePlugin[]) ?? [],
     themes: options?.themes ?? themes,
   });
 }

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -155,7 +155,7 @@ export type AppConfigLoader = () => Promise<AppConfig[]>;
 
 // @public
 export type AppContext = {
-  getPlugins(): BackstagePlugin<any, any>[];
+  getPlugins(): BackstagePlugin[];
   getSystemIcon(key: string): IconComponent | undefined;
   getComponents(): AppComponents;
 };
@@ -193,7 +193,7 @@ export type AppOptions = {
     [key in string]: IconComponent;
   };
   plugins?: Array<
-    BackstagePlugin<any, any> & {
+    BackstagePlugin & {
       output?(): Array<
         | {
             type: 'feature-flag';
@@ -254,7 +254,7 @@ export type AuthApiCreateOptions = {
 
 // @public
 export type BackstageApp = {
-  getPlugins(): BackstagePlugin<any, any>[];
+  getPlugins(): BackstagePlugin[];
   getSystemIcon(key: string): IconComponent | undefined;
   getProvider(): ComponentType<{}>;
   getRouter(): ComponentType<{}>;

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -82,8 +82,8 @@ import { resolveRouteBindings } from './resolveRouteBindings';
 import { BackstageRouteObject } from '../routing/types';
 
 type CompatiblePlugin =
-  | BackstagePlugin<any, any>
-  | (Omit<BackstagePlugin<any, any>, 'getFeatureFlags'> & {
+  | BackstagePlugin
+  | (Omit<BackstagePlugin, 'getFeatureFlags'> & {
       output(): Array<{ type: 'feature-flag'; name: string }>;
     });
 
@@ -145,7 +145,7 @@ function useConfigLoader(
 class AppContextImpl implements AppContext {
   constructor(private readonly app: AppManager) {}
 
-  getPlugins(): BackstagePlugin<any, any>[] {
+  getPlugins(): BackstagePlugin[] {
     return this.app.getPlugins();
   }
 
@@ -186,8 +186,8 @@ export class AppManager implements BackstageApp {
     this.apiFactoryRegistry = new ApiFactoryRegistry();
   }
 
-  getPlugins(): BackstagePlugin<any, any>[] {
-    return Array.from(this.plugins) as BackstagePlugin<any, any>[];
+  getPlugins(): BackstagePlugin[] {
+    return Array.from(this.plugins) as BackstagePlugin[];
   }
 
   getSystemIcon(key: string): IconComponent | undefined {
@@ -241,7 +241,7 @@ export class AppManager implements BackstageApp {
         validateRouteParameters(routing.paths, routing.parents);
         validateRouteBindings(
           routeBindings,
-          this.plugins as Iterable<BackstagePlugin<any, any>>,
+          this.plugins as Iterable<BackstagePlugin>,
         );
       }
 

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -206,7 +206,7 @@ export type AppOptions = {
    * A list of all plugins to include in the app.
    */
   plugins?: Array<
-    BackstagePlugin<any, any> & {
+    BackstagePlugin & {
       output?(): Array<
         { type: 'feature-flag'; name: string } | { type: string }
       >; // support for old plugins
@@ -291,7 +291,7 @@ export type BackstageApp = {
   /**
    * Returns all plugins registered for the app.
    */
-  getPlugins(): BackstagePlugin<any, any>[];
+  getPlugins(): BackstagePlugin[];
 
   /**
    * Get a common or custom icon for this app.
@@ -321,7 +321,7 @@ export type AppContext = {
   /**
    * Get a list of all plugins that are installed in the app.
    */
-  getPlugins(): BackstagePlugin<any, any>[];
+  getPlugins(): BackstagePlugin[];
 
   /**
    * Get a common or custom icon for this app.

--- a/packages/core-app-api/src/plugins/collectors.ts
+++ b/packages/core-app-api/src/plugins/collectors.ts
@@ -18,12 +18,9 @@ import { BackstagePlugin, getComponentData } from '@backstage/core-plugin-api';
 import { createCollector } from '../extensions/traversal';
 
 export const pluginCollector = createCollector(
-  () => new Set<BackstagePlugin<any, any>>(),
+  () => new Set<BackstagePlugin>(),
   (acc, node) => {
-    const plugin = getComponentData<BackstagePlugin<any, any>>(
-      node,
-      'core.plugin',
-    );
+    const plugin = getComponentData<BackstagePlugin>(node, 'core.plugin');
     if (plugin) {
       acc.add(plugin);
     }

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -147,7 +147,7 @@ export type AppComponents = {
 
 // @public
 export type AppContext = {
-  getPlugins(): BackstagePlugin_2<any, any>[];
+  getPlugins(): BackstagePlugin_2[];
   getSystemIcon(key: string): IconComponent_2 | undefined;
   getComponents(): AppComponents;
 };
@@ -401,7 +401,7 @@ export type ErrorBoundaryFallbackProps = {
 
 // @public
 export type Extension<T> = {
-  expose(plugin: BackstagePlugin<any, any>): T;
+  expose(plugin: BackstagePlugin): T;
 };
 
 // @public

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -225,7 +225,7 @@ export function createReactExtension<
     'Component';
 
   return {
-    expose(plugin: BackstagePlugin<any, any>) {
+    expose(plugin: BackstagePlugin) {
       const Result: any = (props: any) => {
         const app = useApp();
         const { Progress } = app.getComponents();

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -27,7 +27,7 @@ import { AnyApiFactory } from '../apis/system';
  * @public
  */
 export type Extension<T> = {
-  expose(plugin: BackstagePlugin<any, any>): T;
+  expose(plugin: BackstagePlugin): T;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Getting rid of these explicit type parameters as they're just adding noise.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
