### PR TITLE
scaffolder: temporary pin of @uiw/react-codemirror version

### DIFF
--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -59,7 +59,7 @@
     "@rjsf/core": "^3.2.1",
     "@rjsf/material-ui": "^3.2.1",
     "@types/json-schema": "^7.0.9",
-    "@uiw/react-codemirror": "^4.9.3",
+    "@uiw/react-codemirror": "^4.9.3 && <=4.11.1",
     "classnames": "^2.2.6",
     "git-url-parse": "^12.0.0",
     "humanize-duration": "^3.25.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,10 +1469,10 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@>=7.11.0":
-  version "7.17.9"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
-  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+"@babel/runtime@>=7.11.0", "@babel/runtime@^7.10.4", "@babel/runtime@^7.18.3":
+  version "7.18.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1480,13 +1480,6 @@
   version "7.17.7"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz#a5f3328dc41ff39d803f311cfe17703418cf9825"
   integrity sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.4", "@babel/runtime@^7.18.3":
-  version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
-  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -7530,7 +7523,7 @@
     "@typescript-eslint/types" "5.9.0"
     eslint-visitor-keys "^3.0.0"
 
-"@uiw/react-codemirror@^4.9.3":
+"@uiw/react-codemirror@^4.9.3 && <=4.11.1":
   version "4.11.1"
   resolved "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.11.1.tgz#be8e4f2c37b4ace3348773c5ba586b59656bdee8"
   integrity sha512-IeXxG9Sc73ZG03V1VK5wSzObGajAo+kuehkvi2cQVYse3lvkH2MGEHjnQ9zfu+dlFw5SQ9LVRe8a61thT9+ExA==


### PR DESCRIPTION
Temporary fix for the ongoing CI failures, also trying to get this fixed upstream. Figured we skip changeset as we don't want this to be part of the main release if possible.