### PR TITLE
feat(scaffolder-backend): allow to create Gerrit project using default owner

### DIFF
--- a/.changeset/witty-ladybugs-laugh.md
+++ b/.changeset/witty-ladybugs-laugh.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow to create Gerrit project using default owner

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gerrit.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gerrit.test.ts
@@ -65,13 +65,6 @@ describe('publish:gerrit', () => {
     await expect(
       action.handler({
         ...mockContext,
-        input: { repoUrl: 'gerrithost.org?workspace=w&repo=repo', description },
-      }),
-    ).rejects.toThrow(/missing owner/);
-
-    await expect(
-      action.handler({
-        ...mockContext,
         input: { repoUrl: 'gerrithost.org?workspace=w&owner=o', description },
       }),
     ).rejects.toThrow(/missing repo/);
@@ -164,6 +157,56 @@ describe('publish:gerrit', () => {
       input: {
         ...mockContext.input,
         repoUrl: 'gerrithost.org?workspace=workspace&owner=owner&repo=repo',
+        sourcePath: 'repository/',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: `${mockContext.workspacePath}/repository/`,
+      remoteUrl: 'https://gerrithost.org/a/repo',
+      defaultBranch: 'master',
+      auth: { username: 'gerrituser', password: 'usertoken' },
+      logger: mockContext.logger,
+      commitMessage: expect.stringContaining('initial commit\n\nChange-Id:'),
+      gitAuthorInfo: {},
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://gerrithost.org/a/repo',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repoContentsUrl',
+      'https://gerrithost.org/repo/+/refs/heads/master',
+    );
+  });
+
+  it('can correctly create a new project without specifying owner', async () => {
+    expect.assertions(5);
+    server.use(
+      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
+        expect(req.headers.get('Authorization')).toBe(
+          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+        );
+        expect(req.body).toEqual({
+          create_empty_commit: false,
+          owners: [],
+          description,
+          parent: 'workspace',
+        });
+        return res(
+          ctx.status(201),
+          ctx.set('Content-Type', 'application/json'),
+          ctx.json({}),
+        );
+      }),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        repoUrl: 'gerrithost.org?workspace=workspace&repo=repo',
         sourcePath: 'repository/',
       },
     });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gerrit.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gerrit.ts
@@ -31,7 +31,7 @@ const createGerritProject = async (
   options: {
     projectName: string;
     parent: string;
-    owner: string;
+    owner?: string;
     description: string;
   },
 ): Promise<void> => {
@@ -42,7 +42,7 @@ const createGerritProject = async (
     body: JSON.stringify({
       parent,
       description,
-      owners: [owner],
+      owners: owner ? [owner] : [],
       create_empty_commit: false,
     }),
     headers: {
@@ -174,11 +174,6 @@ export function createPublishGerritAction(options: {
         );
       }
 
-      if (!owner) {
-        throw new InputError(
-          `Invalid URL provider was included in the repo URL to create ${ctx.input.repoUrl}, missing owner`,
-        );
-      }
       if (!workspace) {
         throw new InputError(
           `Invalid URL provider was included in the repo URL to create ${ctx.input.repoUrl}, missing workspace`,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts
@@ -85,7 +85,7 @@ export const parseRepoUrl = (
       );
     }
   } else {
-    if (!owner) {
+    if (!owner && type !== 'gerrit') {
       throw new InputError(
         `Invalid repo URL passed to publisher: ${repoUrl}, missing owner`,
       );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { GerritRepoPicker } from './GerritRepoPicker';
 import { render, fireEvent } from '@testing-library/react';
 
-describe('BitbucketRepoPicker', () => {
+describe('GerritRepoPicker', () => {
   describe('owner input field', () => {
     it('calls onChange when the owner input changes', () => {
       const onChange = jest.fn();

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
@@ -29,18 +29,14 @@ export const GerritRepoPicker = (props: {
   const { workspace, owner } = state;
   return (
     <>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !workspace}
-      >
+      <FormControl margin="normal" error={rawErrors?.length > 0 && !workspace}>
         <InputLabel htmlFor="ownerInput">Owner</InputLabel>
         <Input
           id="ownerInput"
           onChange={e => onChange({ owner: e.target.value })}
           value={owner}
         />
-        <FormHelperText>The owner of the project</FormHelperText>
+        <FormHelperText>The owner of the project (optional)</FormHelperText>
       </FormControl>
       <FormControl
         margin="normal"

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.ts
@@ -54,8 +54,8 @@ export const repoPickerValidation = (
           );
         }
       }
-      // For anything other than bitbucket
-      else {
+      // For anything other than bitbucket and gerrit
+      else if (integrationApi?.byHost(host)?.type !== 'gerrit') {
         if (!searchParams.get('owner')) {
           validation.addError(
             'Incomplete repository location provided, owner not provided',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `gerrit:publish` actions throws an `InputError` if the repoUrl doesn't have the owner param.
However this field is optional in the Gerrit REST API ([documentation reference here](https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#project-input)).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
