### PR TITLE
backstage-create-app doesn't add vital init() piece automatically

### DIFF
--- a/docs/integrations/datadog-rum/installation.md
+++ b/docs/integrations/datadog-rum/installation.md
@@ -24,6 +24,8 @@ app:
   #   env: 'staging'
 ```
 
+If during [`yarn backstage-create-app`](https://github.com/backstage/backstage/tree/master/packages/create-app) time your [`app-config.yaml`](https://github.com/backstage/backstage/blob/master/app-config.yaml#L5) file did not have this configuration, you have to adjust your [`packages/app/public/index.html`](https://github.com/backstage/backstage/blob/master/packages/app/public/index.html#L64) to include the Datadog RUM `init()` section manually.
+
 The `clientToken` and `applicationId` are generated from the Datadog RUM page
 following
 [these instructions](https://docs.datadoghq.com/real_user_monitoring/browser/).

--- a/docs/integrations/datadog-rum/installation.md
+++ b/docs/integrations/datadog-rum/installation.md
@@ -24,7 +24,7 @@ app:
   #   env: 'staging'
 ```
 
-If during [`yarn backstage-create-app`](https://github.com/backstage/backstage/tree/master/packages/create-app) time your [`app-config.yaml`](https://github.com/backstage/backstage/blob/master/app-config.yaml#L5) file did not have this configuration, you have to adjust your [`packages/app/public/index.html`](https://github.com/backstage/backstage/blob/master/packages/app/public/index.html#L64) to include the Datadog RUM `init()` section manually.
+If your [`app-config.yaml`](https://github.com/backstage/backstage/blob/master/app-config.yaml#L5) file does not have this configuration, you may have to adjust your [`packages/app/public/index.html`](https://github.com/backstage/backstage/blob/master/packages/app/public/index.html#L64) to include the Datadog RUM `init()` section manually.
 
 The `clientToken` and `applicationId` are generated from the Datadog RUM page
 following


### PR DESCRIPTION
You have to adjust your `index.html` template file manually.

Signed-off-by: Stephan Schielke <401815+stephanschielke@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     Unsure if this intended behavior, but it took me a while to understand the `DD_RUM.init()` is missing in my app after following the installation docs for Datadog RUM.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

~- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [X] Added or updated documentation
~- [ ] Tests for new functionality and regression tests for bug fixes~
~- [ ] Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
