### PR TITLE
errors: inline headers type

### DIFF
--- a/.changeset/warm-paws-sneeze.md
+++ b/.changeset/warm-paws-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': patch
+---
+
+Inline the type of `ConsumedResponse.headers` and tweaked it to be the intersection of the built-in type and `node-fetch` type.

--- a/packages/errors/api-report.md
+++ b/packages/errors/api-report.md
@@ -16,7 +16,18 @@ export class ConflictError extends CustomErrorBase {}
 
 // @public
 export type ConsumedResponse = {
-  readonly headers: Headers;
+  readonly headers: {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    forEach(callback: (value: string, name: string) => void): void;
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): Iterator<[string, string]>;
+  };
   readonly ok: boolean;
   readonly redirected: boolean;
   readonly status: number;

--- a/packages/errors/src/errors/types.ts
+++ b/packages/errors/src/errors/types.ts
@@ -21,7 +21,19 @@
  * @public
  */
 export type ConsumedResponse = {
-  readonly headers: Headers;
+  readonly headers: {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    forEach(callback: (value: string, name: string) => void): void;
+
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): Iterator<[string, string]>;
+  };
   readonly ok: boolean;
   readonly redirected: boolean;
   readonly status: number;


### PR DESCRIPTION
Fixes a type incompatibility between `node-fetch` and the built-in fetch API. It's a tweak to #12237, which hasn't been shipped in a main line release yet.