### PR TITLE
feat: add support for `allowedOwners` at the `BitbucketRepoPicker`

### DIFF
--- a/.changeset/thick-shrimps-hammer.md
+++ b/.changeset/thick-shrimps-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Add support for `allowedOwners` to the `BitbucketRepoPicker` used for the workspace value.

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
@@ -19,6 +19,21 @@ import { BitbucketRepoPicker } from './BitbucketRepoPicker';
 import { render, fireEvent } from '@testing-library/react';
 
 describe('BitbucketRepoPicker', () => {
+  it('renders a select if there is a list of allowed owners', async () => {
+    const allowedOwners = ['owner1', 'owner2'];
+    const { findByText } = render(
+      <BitbucketRepoPicker
+        onChange={jest.fn()}
+        rawErrors={[]}
+        state={{ host: 'bitbucket.org', repoName: 'repo' }}
+        allowedOwners={allowedOwners}
+      />,
+    );
+
+    expect(await findByText('owner1')).toBeInTheDocument();
+    expect(await findByText('owner2')).toBeInTheDocument();
+  });
+
   it('renders workspace input when host is bitbucket.org', () => {
     const state = { host: 'bitbucket.org', workspace: 'lolsWorkspace' };
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -18,15 +18,20 @@ import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
+import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
 export const BitbucketRepoPicker = (props: {
+  allowedOwners?: string[];
   onChange: (state: RepoUrlPickerState) => void;
   state: RepoUrlPickerState;
   rawErrors: string[];
 }) => {
-  const { onChange, rawErrors, state } = props;
+  const { allowedOwners = [], onChange, rawErrors, state } = props;
   const { host, workspace, project } = state;
+  const ownerItems: SelectItem[] = allowedOwners
+    ? allowedOwners?.map(i => ({ label: i, value: i }))
+    : [];
   return (
     <>
       {host === 'bitbucket.org' && (
@@ -35,12 +40,27 @@ export const BitbucketRepoPicker = (props: {
           required
           error={rawErrors?.length > 0 && !workspace}
         >
-          <InputLabel htmlFor="workspaceInput">Workspace</InputLabel>
-          <Input
-            id="workspaceInput"
-            onChange={e => onChange({ workspace: e.target.value })}
-            value={workspace}
-          />
+          {allowedOwners?.length ? (
+            <Select
+              native
+              label="Allowed Workspaces"
+              onChange={s =>
+                onChange({ workspace: String(Array.isArray(s) ? s[0] : s) })
+              }
+              disabled={allowedOwners.length === 1}
+              selected={workspace}
+              items={ownerItems}
+            />
+          ) : (
+            <>
+              <InputLabel htmlFor="workspaceInput">Workspace</InputLabel>
+              <Input
+                id="workspaceInput"
+                onChange={e => onChange({ workspace: e.target.value })}
+                value={workspace}
+              />
+            </>
+          )}
           <FormHelperText>
             The Organization that this repo will belong to
           </FormHelperText>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -171,6 +171,7 @@ export const RepoUrlPicker = (
       )}
       {hostType === 'bitbucket' && (
         <BitbucketRepoPicker
+          allowedOwners={allowedOwners}
           rawErrors={rawErrors}
           state={state}
           onChange={updateLocalState}


### PR DESCRIPTION
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
