### PR TITLE
fix(docs-like-code): Patched Techdocs Sidebar layout for medium devices.

### DIFF
--- a/.changeset/mighty-penguins-tap.md
+++ b/.changeset/mighty-penguins-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed techdocs sidebar layout bug for medium devices.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -16,6 +16,8 @@
 
 import { RuleOptions } from './types';
 
+const SIDEBAR_WIDTH = '224px';
+
 export default ({ theme, sidebar }: RuleOptions) => `
 /*==================  Layout  ==================*/
 
@@ -169,7 +171,9 @@ export default ({ theme, sidebar }: RuleOptions) => `
     width: 12.1rem !important;
     z-index: 200;
     left: ${
-      sidebar.isPinned ? 'calc(-12.1rem + 224px)' : 'calc(-12.1rem + 72px)'
+      sidebar.isPinned
+        ? `calc(-12.1rem + ${SIDEBAR_WIDTH})`
+        : 'calc(-12.1rem + 72px)'
     } !important;
   }
   .md-sidebar--secondary:not([hidden]) {

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -61,7 +61,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
   scrollbar-width: thin;
 }
 .md-sidebar .md-sidebar__scrollwrap {
-  width: calc(16rem - 10px);
+  width: calc(12.1rem);
 }
 .md-sidebar--secondary {
   right: ${theme.spacing(3)}px;
@@ -169,7 +169,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
     width: 12.1rem !important;
     z-index: 200;
     left: ${
-      sidebar.isPinned ? 'calc(-12.1rem + 242px)' : 'calc(-12.1rem + 72px)'
+      sidebar.isPinned ? 'calc(-12.1rem + 224px)' : 'calc(-12.1rem + 72px)'
     } !important;
   }
   .md-sidebar--secondary:not([hidden]) {


### PR DESCRIPTION
## Techdocs layout bug fix

Hello world, this is my first pull request here!

This pull request fixes the bug reported at #12552. It ended up being a sidebar that was causing the header layout to overlap so I guess the issue name should say "Sidebar" instead of "Header".

Before the fix the sidebar was overlapping with the Header on any tech docs documentation: 
![image](https://user-images.githubusercontent.com/36337762/179077558-c347457f-62e7-41d0-8ed1-e0e4ec5095b6.png)

Final result with sidebar both sidebar pinned on and off:
![image](https://user-images.githubusercontent.com/36337762/179077810-30cfedc9-2f2b-4b98-9de1-1615f2032973.png)
![image](https://user-images.githubusercontent.com/36337762/179077850-4aa5bde4-33da-40bf-8bf9-659d0a3c8f9f.png)

#### :heavy_check_mark: Checklist
<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
