### PR TITLE
feat: Make okta scopes configurable

### DIFF
--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -43,6 +43,7 @@ auth:
         audience: ${AUTH_OKTA_DOMAIN}
         authServerId: ${AUTH_OKTA_AUTH_SERVER_ID} # Optional
         idp: ${AUTH_OKTA_IDP} # Optional
+        scopes: ['openid', 'email', 'profile', 'offline_access', 'groups'] # Optional
 ```
 
 The values referenced are found on the Application page on your Okta site.
@@ -54,6 +55,7 @@ The values referenced are found on the Application page on your Okta site.
   `https://company.okta.com`
 - `authServerId`: The authorization server ID for the Application
 - `idp`: The identity provider for the application, e.g. `0oaulob4BFVa4zQvt0g3`
+- `scopes`: List of Okta defined scopes. Must be a subset of the `OKTA_OIDC_SCOPES`.
 
 ## Adding the provider to the Backstage frontend
 

--- a/packages/app-defaults/src/defaults/apis.ts
+++ b/packages/app-defaults/src/defaults/apis.ts
@@ -175,9 +175,11 @@ export const apis = [
         discoveryApi,
         oauthRequestApi,
         environment,
-        defaultScopes: configApi.getOptionalStringArray(`auth.providers.okta.${environment}.scopes`),
+        defaultScopes: configApi.getOptionalStringArray(
+          `auth.providers.okta.${environment}.scopes`,
+        ),
       });
-    }
+    },
   }),
   createApiFactory({
     api: gitlabAuthApiRef,

--- a/packages/app-defaults/src/defaults/apis.ts
+++ b/packages/app-defaults/src/defaults/apis.ts
@@ -169,12 +169,15 @@ export const apis = [
       oauthRequestApi: oauthRequestApiRef,
       configApi: configApiRef,
     },
-    factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
-      OktaAuth.create({
+    factory: ({ discoveryApi, oauthRequestApi, configApi }) => {
+      const environment = configApi.getOptionalString('auth.environment');
+      return OktaAuth.create({
         discoveryApi,
         oauthRequestApi,
-        environment: configApi.getOptionalString('auth.environment'),
-      }),
+        environment,
+        defaultScopes: configApi.getOptionalStringArray(`auth.providers.okta.${environment}.scopes`),
+      });
+    }
   }),
   createApiFactory({
     api: gitlabAuthApiRef,


### PR DESCRIPTION
Right now, there's a default list of scopes available, but we want to make it configurable for users to add scopes if wanted.
Related to this comment: https://github.com/backstage/backstage/pull/12359#issuecomment-1183826172

To add your own scopes, add a list of `scopes` to your `app-config.yaml`. Users cannot add scopes that are not a part of this list: https://github.com/backstage/backstage/blob/master/packages/core-app-api/src/apis/implementations/auth/okta/OktaAuth.ts#L27-L35.

Example of `app-config` dict:
```
auth:
  environment: development
  providers:
    github:
      development:
        clientId: ${AUTH_GITHUB_CLIENT_ID}
        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
    okta:
      development:
        clientId: ${AUTH_OKTA_CLIENT_ID}
        clientSecret: ${AUTH_OKTA_CLIENT_SECRET}
        audience: ${AUTH_OKTA_AUDIENCE}
        scopes: ['openid', 'email', 'profile', 'offline_access', 'groups']
```

For those needing `prettier` instructions (this is my first time contributing to backstage):
1. Run `yarn install` at the root directory `backstage/`
2. Run `yarn prettier --write .` in the directory of where your changed files are, or you can run at root and fix globally (will take some time but fool proof).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
