### PR TITLE
Scaffolder Gitlab Merge Requests - added assignee as an optional field

### DIFF
--- a/.changeset/itchy-needles-think.md
+++ b/.changeset/itchy-needles-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added optional assignee parameter for Gitlab Merge Request action

--- a/.changeset/selfish-moles-compete.md
+++ b/.changeset/selfish-moles-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Gitlab MR assignee - log Gitlab user search failures and proceed with MR creation

--- a/.changeset/selfish-moles-compete.md
+++ b/.changeset/selfish-moles-compete.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder-backend': patch
----
-
-Gitlab MR assignee - log Gitlab user search failures and proceed with MR creation

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -406,6 +406,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   token?: string | undefined;
   projectid?: string | undefined;
   removeSourceBranch?: boolean | undefined;
+  assignee?: string | undefined;
 }>;
 
 // @public

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.test.ts
@@ -336,5 +336,45 @@ describe('createGitLabMergeRequest', () => {
         },
       );
     });
+
+    it('merge request is successfully created without an assignee when assignee is not found in Gitlab', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        title: 'Create my new MR',
+        branchName: 'new-mr',
+        description: 'This is an important change',
+        removeSourceBranch: false,
+        draft: true,
+        targetPath: 'Subdirectory',
+        assignee: 'Unknown',
+      };
+      mockFs({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'new-mr',
+        'main',
+        'Create my new MR',
+        {
+          description: 'This is an important change',
+          removeSourceBranch: false,
+        },
+      );
+    });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.test.ts
@@ -53,6 +53,15 @@ const mockGitlabClient = {
   },
   Users: {
     current: jest.fn(),
+    username: jest.fn(async (user: string) => {
+      if (user !== 'John Smith') throw new Error('user does not exist');
+      else
+        return [
+          {
+            id: 123,
+          },
+        ];
+    }),
   },
 };
 
@@ -199,6 +208,130 @@ describe('createGitLabMergeRequest', () => {
         'Create my new MR',
         {
           description: 'other MR description',
+          removeSourceBranch: false,
+        },
+      );
+    });
+  });
+
+  describe('createGitLabMergeRequestWithAssignee', () => {
+    it('assignee is set correcly when a valid assignee username is passed in options', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        title: 'Create my new MR',
+        branchName: 'new-mr',
+        description: 'This is an important change',
+        removeSourceBranch: false,
+        draft: true,
+        targetPath: 'Subdirectory',
+        assignee: 'John Smith',
+      };
+      mockFs({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'new-mr',
+        'main',
+        'Create my new MR',
+        {
+          description: 'This is an important change',
+          removeSourceBranch: false,
+          assigneeId: 123,
+        },
+      );
+    });
+
+    it('assignee is not set when a valid assignee username is not passed in options', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        title: 'Create my new MR',
+        branchName: 'new-mr',
+        description: 'This is an important change',
+        removeSourceBranch: false,
+        draft: true,
+        targetPath: 'Subdirectory',
+        assingnee: 'John Doe',
+      };
+      mockFs({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'new-mr',
+        'main',
+        'Create my new MR',
+        {
+          description: 'This is an important change',
+          removeSourceBranch: false,
+          assigneeId: undefined,
+        },
+      );
+    });
+  });
+  describe('createGitLabMergeRequestWithoutAssignee', () => {
+    it('merge request is successfully created without an assignee when assignee username is not passed in options', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        title: 'Create my new MR',
+        branchName: 'new-mr',
+        description: 'This is an important change',
+        removeSourceBranch: false,
+        draft: true,
+        targetPath: 'Subdirectory',
+      };
+      mockFs({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'new-mr',
+        'main',
+        'Create my new MR',
+        {
+          description: 'This is an important change',
           removeSourceBranch: false,
         },
       );

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -161,8 +161,8 @@ export const createPublishGitlabMergeRequestAction = (options: {
           const assigneeUser = await api.Users.username(assignee);
           assigneeId = assigneeUser[0].id;
         } catch (e) {
-          throw new InputError(
-            `Failed to find gitlab user id for ${assignee}: ${e}`,
+          console.warn(
+            `Failed to find gitlab user id for ${assignee}: ${e}. Proceeding with MR creation without an assignee.`,
           );
         }
       }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -43,6 +43,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
     /** @deprecated Use projectPath instead */
     projectid?: string;
     removeSourceBranch?: boolean;
+    assignee?: string;
   }>({
     id: 'publish:gitlab:merge-request',
     schema: {
@@ -91,6 +92,11 @@ export const createPublishGitlabMergeRequestAction = (options: {
             type: 'boolean',
             description:
               'Option to delete source branch once the MR has been merged. Default: false',
+          },
+          assignee: {
+            title: 'Merge Request Assignee',
+            type: 'string',
+            description: 'User this merge request will be assigned to',
           },
         },
       },
@@ -146,6 +152,21 @@ export const createPublishGitlabMergeRequestAction = (options: {
         [tokenType]: token,
       });
 
+      const assignee = ctx.input.assignee;
+
+      let assigneeId = undefined;
+
+      if (assignee !== undefined) {
+        try {
+          const assigneeUser = await api.Users.username(assignee);
+          assigneeId = assigneeUser[0].id;
+        } catch (e) {
+          throw new InputError(
+            `Failed to find gitlab user id for ${assignee}: ${e}`,
+          );
+        }
+      }
+
       const targetPath = resolveSafeChildPath(
         ctx.workspacePath,
         ctx.input.targetPath,
@@ -199,6 +220,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
             removeSourceBranch: ctx.input.removeSourceBranch
               ? ctx.input.removeSourceBranch
               : false,
+            assigneeId: assigneeId,
           },
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -161,7 +161,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
           const assigneeUser = await api.Users.username(assignee);
           assigneeId = assigneeUser[0].id;
         } catch (e) {
-          console.warn(
+          ctx.logger.warn(
             `Failed to find gitlab user id for ${assignee}: ${e}. Proceeding with MR creation without an assignee.`,
           );
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added assignee as an optional input to Gitlab Merge Request action. 
Gitlab expects this field to be a Gitlab-specific user id, so we first perform a Gitlab User lookup based on the passed username and then use the returned id to identify MR assignee. 
If a user with a given username does not exist, the error message is written in the log, and the MR creation process will proceed. 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
