### PR TITLE
Fix level of App Registration header in MS Graph docs

### DIFF
--- a/docs/integrations/azure/org.md
+++ b/docs/integrations/azure/org.md
@@ -69,7 +69,7 @@ Alternatively you can use VSCode with the Azure extension if you install `@azure
 When these are set up, the plugin will authenticate with the Microsoft Graph API without you needing to configure any credentials, or granting any special permissions.
 If you can't do this, you'll have to create an App Registration.
 
-## App Registration
+### App Registration
 
 If none of the other authentication methods work, you can create an app registration in the azure portal.  
 By default the graph plugin requires the following Application permissions (not Delegated) for Microsoft Graph:


### PR DESCRIPTION
# Hey, I just made a Pull Request!

I just noticed a small typo in the documentation I introduced with #12490 - the "App Registration" header should have been a sub heading of "Authenticating with Microsoft Graph".  This PR corrects that

![image](https://user-images.githubusercontent.com/289860/179287410-df631c2b-3aab-4c0f-95d1-5e18c7ec2236.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
