### PR TITLE
Add highlight to active techdocs navigation item and parents

### DIFF
--- a/.changeset/itchy-mice-kiss.md
+++ b/.changeset/itchy-mice-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add highlight to active navigation item and navigation parents.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -47,6 +47,11 @@ export default ({ theme, sidebar }: RuleOptions) => `
   height: 20px !important;
 }
 
+.md-nav__item--active > .md-nav__link, a.md-nav__link--active {
+  text-decoration: underline;
+  color: var(--md-typeset-a-color);
+}
+
 .md-main__inner {
   margin-top: 0;
 }


### PR DESCRIPTION
This change adds highlighting to navigation items in tech docs. It highlights
the whole nav tree with the same color and an underline.

I figured this a patch as we already have some highlighting, but this "fixes"
it with color-blind assistance, ie. underline, and highlights the full tree.

Fixes #5596.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

## Light mode

<img width="263" alt="image" src="https://user-images.githubusercontent.com/6881694/179402525-961c4598-de26-4aa7-988d-6038598dc2b8.png">

## Dark mode

<img width="253" alt="image" src="https://user-images.githubusercontent.com/6881694/179402546-cb9fe802-c2a7-4fd5-bda8-2d5ab9f3acfb.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
