### PR TITLE
Trim newlines in $file placeholder

### DIFF
--- a/.changeset/hip-pets-glow.md
+++ b/.changeset/hip-pets-glow.md
@@ -2,4 +2,4 @@
 '@backstage/config-loader': patch
 ---
 
-From now on the \$file placeholder will trim the the whitespaces and newline characters from the end of the file it reads.
+From now on the \$file placeholder will trim the whitespaces and newline characters from the end of the file it reads.

--- a/.changeset/hip-pets-glow.md
+++ b/.changeset/hip-pets-glow.md
@@ -2,4 +2,4 @@
 '@backstage/config-loader': patch
 ---
 
-From now on the \$file placeholder will trim the whitespaces and newline characters from the end of the file it reads.
+From now on the `$file` placeholder will trim the whitespaces and newline characters from the end of the file it reads.

--- a/.changeset/hip-pets-glow.md
+++ b/.changeset/hip-pets-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+From now on the \$file placeholder will trim the the whitespaces and newline characters from the end of the file it reads.

--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -50,7 +50,7 @@ const readFile = jest.fn(async (path: string) => {
     {
       [resolvePath(root, 'my-secret')]: 'secret',
       [resolvePath(root, 'with-newline-at-the-end')]:
-        'value without newline at the end\n',
+        'value without newline at the end\n\n',
       [resolvePath(root, 'my-data.json')]: '{"a":{"b":{"c":42}}}',
       [resolvePath(root, 'my-data.yaml')]: 'some:\n yaml:\n  key: 7',
       [resolvePath(root, 'my-data.yml')]: 'different: { key: hello }',
@@ -94,12 +94,12 @@ describe('includeTransform', () => {
       includeTransform({ $file: 'no-secret' }, root),
     ).rejects.toThrow('File not found!');
   });
-  it('should trim new lines from end of file', async () => {
+  it('should trim newlines from end of file', async () => {
     await expect(
       includeTransform({ $file: 'with-newline-at-the-end' }, root),
     ).resolves.toEqual({
       applied: true,
-      value: 'value without new line at the end',
+      value: 'value without newline at the end',
     });
   });
 

--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -49,6 +49,8 @@ const readFile = jest.fn(async (path: string) => {
   const content = (
     {
       [resolvePath(root, 'my-secret')]: 'secret',
+      [resolvePath(root, 'with-newline-at-the-end')]:
+        'value without newline at the end\n',
       [resolvePath(root, 'my-data.json')]: '{"a":{"b":{"c":42}}}',
       [resolvePath(root, 'my-data.yaml')]: 'some:\n yaml:\n  key: 7',
       [resolvePath(root, 'my-data.yml')]: 'different: { key: hello }',
@@ -91,6 +93,14 @@ describe('includeTransform', () => {
     await expect(
       includeTransform({ $file: 'no-secret' }, root),
     ).rejects.toThrow('File not found!');
+  });
+  it('should trim new lines from end of file', async () => {
+    await expect(
+      includeTransform({ $file: 'with-newline-at-the-end' }, root),
+    ).resolves.toEqual({
+      applied: true,
+      value: 'value without new line at the end',
+    });
   });
 
   it('should include env vars', async () => {

--- a/packages/config-loader/src/lib/transform/include.ts
+++ b/packages/config-loader/src/lib/transform/include.ts
@@ -73,7 +73,7 @@ export function createIncludeTransform(
       case '$file':
         try {
           const value = await readFile(resolvePath(baseDir, includeValue));
-          return { applied: true, value };
+          return { applied: true, value: value.trimEnd() };
         } catch (error) {
           throw new Error(`failed to read file ${includeValue}, ${error}`);
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://github.com/backstage/backstage/issues/12553

Trims the newline characters from the end of the file when it is read by the $file placeholder

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
