### PR TITLE
Fix replacing hosted gitlab relative path in repo url.

### DIFF
--- a/.changeset/hot-cooks-enjoy.md
+++ b/.changeset/hot-cooks-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-common': minor
+'@backstage/backend-common': patch
 ---
 
 Fix edge case bug when gitlab relativePath is repeated in the target URL.

--- a/.changeset/hot-cooks-enjoy.md
+++ b/.changeset/hot-cooks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+Fix edge case bug when gitlab relativePath is repeated in the target URL.

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -125,8 +125,12 @@ export class GitlabUrlReader implements UrlReader {
     );
 
     // Considering self hosted gitlab with relative
+    // assuming '/gitlab' is the relative path
+    // from: /gitlab/repo/project
+    // to: repo/project
     if (relativePath) {
-      repoFullName = trimStart(full_name, relativePath);
+      const rectifiedRelativePath = `${trimStart(relativePath, '/')}/`;
+      repoFullName = full_name.replace(rectifiedRelativePath, '');
     }
 
     // Use GitLab API to get the default branch


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bug reported after #12403, we should limit replacing the subpath to the first occurrence at the start of the repo path.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
