### PR TITLE
tabs: dont push navigate twice

### DIFF
--- a/.changeset/honest-ligers-care.md
+++ b/.changeset/honest-ligers-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Work around a bug calling `onChange` twice in `mui` for `RoutedTab` so you don't have to press back twice to navigate through tabs

--- a/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
+++ b/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
@@ -20,7 +20,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import TabUI, { TabProps } from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 /** @public */
 export type HeaderTabsClassKey =
@@ -80,12 +80,15 @@ export function HeaderTabs(props: HeaderTabsProps) {
   const [selectedTab, setSelectedTab] = useState<number>(selectedIndex ?? 0);
   const styles = useStyles();
 
-  const handleChange = (_: React.ChangeEvent<{}>, index: number) => {
-    if (selectedIndex === undefined) {
-      setSelectedTab(index);
-    }
-    if (onChange) onChange(index);
-  };
+  const handleChange = useCallback(
+    (_: React.ChangeEvent<{}>, index: number) => {
+      if (selectedIndex === undefined) {
+        setSelectedTab(index);
+      }
+      if (onChange && selectedIndex !== index) onChange(index);
+    },
+    [selectedIndex, onChange],
+  );
 
   useEffect(() => {
     if (selectedIndex !== undefined) {


### PR DESCRIPTION
Seems like there's a bug in MUI tabs which means that the tabs `onChange` get's called twice.

So we work around it by only pushing the navigate if the index is different.

Fixes #12654
