### PR TITLE
chore(catalog): deprecate `AwsS3DiscoveryProcessor`

### DIFF
--- a/.changeset/olive-tips-camp.md
+++ b/.changeset/olive-tips-camp.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Deprecate `AwsS3DiscoveryProcessor` in favor of `AwsS3EntityProvider` (since v0.1.4).
+
+You can find a migration guide at
+[the release notes for v0.1.4](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-aws/CHANGELOG.md#014).

--- a/docs/integrations/aws-s3/discovery.md
+++ b/docs/integrations/aws-s3/discovery.md
@@ -76,27 +76,3 @@ builder.addEntityProvider(
   }),
 );
 ```
-
-## Alternative Processor
-
-As alternative to the entity provider `AwsS3EntityProvider`
-you can still use the `AwsS3DiscoveryProcessor`.
-
-```yaml
-# app-config.yaml
-
-catalog:
-  locations:
-    - type: s3-discovery
-      target: https://sample-bucket.s3.us-east-2.amazonaws.com/prefix/
-```
-
-```ts
-/* packages/backend/src/plugins/catalog.ts */
-
-import { AwsS3DiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-aws';
-
-const builder = await CatalogBuilder.create(env);
-/** ... other processors ... */
-builder.addProcessor(new AwsS3DiscoveryProcessor(env.reader));
-```

--- a/plugins/catalog-backend-module-aws/api-report.md
+++ b/plugins/catalog-backend-module-aws/api-report.md
@@ -54,7 +54,7 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
-// @public
+// @public @deprecated
 export class AwsS3DiscoveryProcessor implements CatalogProcessor {
   constructor(reader: UrlReader);
   // (undocumented)

--- a/plugins/catalog-backend-module-aws/src/processors/AwsS3DiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsS3DiscoveryProcessor.ts
@@ -31,6 +31,7 @@ import limiterFactory from 'p-limit';
  * `https://testbucket.s3.us-east-2.amazonaws.com`.
  *
  * @public
+ * @deprecated Use the `AwsS3EntityProvider` instead (see https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-aws/CHANGELOG.md#014).
  */
 export class AwsS3DiscoveryProcessor implements CatalogProcessor {
   constructor(private readonly reader: UrlReader) {}


### PR DESCRIPTION
Deprecate `AwsS3DiscoveryProcessor` in favor of `AwsS3EntityProvider` (since v0.1.4).

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
