### PR TITLE
Added back support for when no branch is provided

### DIFF
--- a/.changeset/dull-pumas-hope.md
+++ b/.changeset/dull-pumas-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added back support for when no branch is provided to the `UrlReader` for Bitbucket Server

--- a/.changeset/dull-pumas-hope.md
+++ b/.changeset/dull-pumas-hope.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-common': patch
+'@backstage/backend-common': minor
 ---
 
 Added back support for when no branch is provided to the `UrlReader` for Bitbucket Server

--- a/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
@@ -205,8 +205,19 @@ export class BitbucketServerUrlReader implements UrlReader {
 
     const commits = await commitResponse.json();
 
+    // Handles case when a branch is provided in the URL
     if (commits && commits.id) {
       return commits.id.substring(0, 12);
+    }
+
+    // Handles case when no branch is provided in the URL
+    if (
+      commits &&
+      commits.values &&
+      commits.values.length > 0 &&
+      commits.values[0].id
+    ) {
+      return commits.values[0].id.substring(0, 12);
     }
 
     throw new Error(`Failed to read response from ${commitApiUrl}`);


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

This adds back support for when no branch is provided to the `UrlReader` for Bitbucket Server

Closes #12740 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
