### PR TITLE
Defer to the techdocs preparer to tidy tmp files

### DIFF
--- a/.changeset/fast-glasses-shop.md
+++ b/.changeset/fast-glasses-shop.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Defer to implementation of techdocs preparer to delete the temporary directory. _Note_ previously, there was a comment mentioning that docs retrieved from github should be kept and docs retrieved otherwise should not. However the logic appeared to be incorrect. This change chooses to delete the files in any scenario.

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -24,6 +24,8 @@ export class DirectoryPreparer implements PreparerBase {
     { logger, reader }: PreparerConfig,
   ): DirectoryPreparer;
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+  // (undocumented)
+  tidy(preparerResponse: PreparerResponse): Promise<void>;
 }
 
 // @public
@@ -106,6 +108,7 @@ export const parseReferenceAnnotation: (
 // @public
 export type PreparerBase = {
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+  tidy?(preparerResponse: PreparerResponse): Promise<void>;
 };
 
 // @public
@@ -248,5 +251,7 @@ export const transformDirLocation: (
 export class UrlPreparer implements PreparerBase {
   static fromConfig({ reader, logger }: PreparerConfig): UrlPreparer;
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+  // (undocumented)
+  tidy(preparerResponse: PreparerResponse): Promise<void>;
 }
 ```

--- a/plugins/techdocs-node/src/stages/prepare/types.ts
+++ b/plugins/techdocs-node/src/stages/prepare/types.ts
@@ -78,6 +78,12 @@ export type PreparerBase = {
    * @throws `NotModifiedError` when the prepared directory has not been changed since the last build.
    */
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+
+  /**
+   * Given a Preparer response then tidy anything left over.
+   * @param preparerResponse - This allows the preparer what to tidy up.
+   **/
+  tidy?(preparerResponse: PreparerResponse): Promise<void>;
 };
 
 /**

--- a/plugins/techdocs-node/src/stages/prepare/url.ts
+++ b/plugins/techdocs-node/src/stages/prepare/url.ts
@@ -25,6 +25,7 @@ import {
   PreparerOptions,
   PreparerResponse,
 } from './types';
+import fs from 'fs-extra';
 
 /**
  * Preparer used to retrieve documentation files from a remote repository
@@ -69,6 +70,19 @@ export class UrlPreparer implements PreparerBase {
       }
 
       throw error;
+    }
+  }
+
+  async tidy(preparerResponse: PreparerResponse) {
+    this.logger.debug(
+      `Removing prepared directory ${preparerResponse.preparedDir} since the site has been generated`,
+    );
+    try {
+      // Not a blocker hence no need to await this.
+      fs.remove(preparerResponse.preparedDir);
+    } catch (error) {
+      assertError(error);
+      this.logger.debug(`Error removing prepared directory ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change adds a new function to the PreparerBase type called
tidy. It is used by techdocs-backend to defer to the preparer to
delete the temporary files. The Preparer may then use its own logic
to decide whether files need to be deleted or not.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
