### PR TITLE
Add missing res.end in scaffolder backend EventStream usage

### DIFF
--- a/.changeset/strange-crabs-confess.md
+++ b/.changeset/strange-crabs-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Add missing res.end() in scaffolder backend EventStream usage

--- a/.changeset/strange-crabs-confess.md
+++ b/.changeset/strange-crabs-confess.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Add missing res.end() in scaffolder backend EventStream usage
+Add missing `res.end()` in scaffolder backend `EventStream` usage

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -311,6 +311,7 @@ export async function createRouter(
           logger.error(
             `Received error from event stream when observing taskId '${taskId}', ${error}`,
           );
+          res.end();
         },
         next: ({ events }) => {
           let shouldUnsubscribe = false;
@@ -324,7 +325,10 @@ export async function createRouter(
           }
           // res.flush() is only available with the compression middleware
           res.flush?.();
-          if (shouldUnsubscribe) subscription.unsubscribe();
+          if (shouldUnsubscribe) {
+            subscription.unsubscribe();
+            res.end();
+          }
         },
       });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This is related to [this Discord thread](https://discord.com/channels/687207715902193673/996771410359898196) with @benjdlambert on the scaffolder appearing to hang.

Observations:

1. I noticed the scaffolder backend `EventStream` logs were not showing up in my deployed (k8s with Kong ingress) environment.
2. They did however show up up in local dev
3. Our docs backend also uses `EventStream` to build/publish/serve docs on demand, and those *do* show up in the deployed environment, so I realized there must be some difference in the usage. Note: we use a custom docs backend that's essentially a fork of TechDocs.


This commit https://github.com/backstage/backstage/commit/f43192207 changeset explicitly says:

> remove usage of res.send() for use of res.json() and res.end()

yet no `res.end()` calls were actually introduced.

I tested this change which adds the missing `.end()` calls and verified that it works.

I suspect the ingress proxy does not send the response to the client until it is fully flushed, which is why it worked in local dev, where the browser client is hitting the dev server directly, and therefore streams the data even if the connection is never flushed and ended.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
