### PR TITLE
respect `ensureExists` when `pluginDivisionMode` is set to `schema`.

### DIFF
--- a/.changeset/purple-apricots-build.md
+++ b/.changeset/purple-apricots-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+**BREAKING** The config prop `ensureExists` now applies to schema creation when `pluginDivisionMode` is set to `schema`. This means schemas will no longer be automatically created when `ensureExists` is set to `false`. In this case the `pg` database as well as each `schema` must be created out of band.

--- a/.changeset/purple-apricots-build.md
+++ b/.changeset/purple-apricots-build.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': patch
 ---
 
-**BREAKING** The config prop `ensureExists` now applies to schema creation when `pluginDivisionMode` is set to `schema`. This means schemas will no longer be automatically created when `ensureExists` is set to `false`. In this case the `pg` database as well as each `schema` must be created out of band.
+The config prop `ensureExists` now applies to schema creation when `pluginDivisionMode` is set to `schema`. This means schemas will no longer accidentally be automatically created when `ensureExists` is set to `false`.

--- a/packages/backend-common/src/database/DatabaseManager.test.ts
+++ b/packages/backend-common/src/database/DatabaseManager.test.ts
@@ -612,6 +612,31 @@ describe('DatabaseManager', () => {
       );
     });
 
+    it('ensureExists does not create database or schema when false', async () => {
+      const testManager = DatabaseManager.fromConfig(
+        new ConfigReader({
+          backend: {
+            database: {
+              client: 'pg',
+              pluginDivisionMode: 'schema',
+              ensureExists: false,
+              connection: {
+                host: 'localhost',
+                user: 'foo',
+                password: 'bar',
+                database: 'foodb',
+              },
+            },
+          },
+        }),
+      );
+      const pluginId = 'testdbname';
+      await testManager.forPlugin(pluginId).getClient();
+
+      expect(mocked(ensureDatabaseExists)).toHaveBeenCalledTimes(0);
+      expect(mocked(ensureSchemaExists)).toHaveBeenCalledTimes(0);
+    });
+
     it('fetches and merges additional knex config', async () => {
       const testManager = DatabaseManager.fromConfig(
         new ConfigReader({

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -321,13 +321,15 @@ export class DatabaseManager {
 
     let schemaOverrides;
     if (this.getPluginDivisionModeConfig() === 'schema') {
-      try {
-        schemaOverrides = this.getSchemaOverrides(pluginId);
-        await ensureSchemaExists(pluginConfig, pluginId);
-      } catch (error) {
-        throw new Error(
-          `Failed to connect to the database to make sure that schema for plugin '${pluginId}' exists, ${error}`,
-        );
+      schemaOverrides = this.getSchemaOverrides(pluginId);
+      if (this.getEnsureExistsConfig(pluginId)) {
+        try {
+          await ensureSchemaExists(pluginConfig, pluginId);
+        } catch (error) {
+          throw new Error(
+            `Failed to connect to the database to make sure that schema for plugin '${pluginId}' exists, ${error}`,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Andrew Duckett <andrew.duckett@gmail.com>

## Hey, I just made a Pull Request!

Updated the database manager so the config prop `ensureExists` now applies to schema creation when `pluginDivisionMode` is set to `schema`.  This means schemas will _no longer_ be automatically created when `ensureExists` is set to `false`.  

I marked the change set as BREAKING as this change may surprise those that:
- Are using a `pluginDivisionMode` of `schema`
- Have set `ensureExists` to `false` because they do not have permission to create databases
- But do have permission to create `schemas`, so expect them to be created automatically

When using `pg` this change requires that both the database _and_ schema(s) be created out of band when `ensureExists` is `false.

fixes #12626 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
