### PR TITLE
Avoid double encoding in bitbucket integration

### DIFF
--- a/.changeset/pretty-gifts-do.md
+++ b/.changeset/pretty-gifts-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Avoid double encoding of the file path in `getBitbucketDownloadUrl`

--- a/packages/integration/src/bitbucket/core.test.ts
+++ b/packages/integration/src/bitbucket/core.test.ts
@@ -139,6 +139,20 @@ describe('bitbucket core', () => {
       );
     });
 
+    it('does not double encode the filepath', async () => {
+      const config: BitbucketIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+      };
+      const result = await getBitbucketDownloadUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/%2Fdocs?at=some-branch',
+        config,
+      );
+      expect(result).toEqual(
+        'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive?format=tgz&at=some-branch&prefix=backstage-mock&path=%2Fdocs',
+      );
+    });
+
     it('do not add path param if no path is specified for Bitbucket Server', async () => {
       const defaultBranchResponse = {
         displayId: 'main',

--- a/packages/integration/src/bitbucket/core.ts
+++ b/packages/integration/src/bitbucket/core.ts
@@ -100,7 +100,9 @@ export async function getBitbucketDownloadUrl(
   // path will limit the downloaded content
   // /docs will only download the docs folder and everything below it
   // /docs/index.md will download the docs folder and everything below it
-  const path = filepath ? `&path=${encodeURIComponent(filepath)}` : '';
+  const path = filepath
+    ? `&path=${encodeURIComponent(decodeURIComponent(filepath))}`
+    : '';
   const archiveUrl = isHosted
     ? `${protocol}://${resource}/${project}/${repoName}/get/${branch}.tar.gz`
     : `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${branch}&prefix=${project}-${repoName}${path}`;


### PR DESCRIPTION
Signed-off-by: Namco <namco1992@gmail.com>

## Hey, I just made a Pull Request!

Follow up fix for this PR https://github.com/backstage/backstage/pull/12430.
The original PR https://github.com/backstage/backstage/pull/12430 avoided double encoding in `bitbucketServer` integration, but not `bitbucket` integration. This PR fixes it for consistency.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
