### PR TITLE
feat: support Bearer auth header at git commands

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -83,15 +83,17 @@ export async function initRepoAndPush({
 }: {
   dir: string;
   remoteUrl: string;
-  auth: { username: string; password: string };
+  // For use cases where token has to be used with Basic Auth
+  // it has to be provided as password together with a username
+  // which may be a fixed value defined by the provider.
+  auth: { username: string; password: string } | { token: string };
   logger: Logger;
   defaultBranch?: string;
   commitMessage?: string;
   gitAuthorInfo?: { name?: string; email?: string };
 }): Promise<void> {
   const git = Git.fromAuth({
-    username: auth.username,
-    password: auth.password,
+    ...auth,
     logger,
   });
 
@@ -137,7 +139,10 @@ export async function commitAndPushRepo({
   remoteRef,
 }: {
   dir: string;
-  auth: { username: string; password: string };
+  // For use cases where token has to be used with Basic Auth
+  // it has to be provided as password together with a username
+  // which may be a fixed value defined by the provider.
+  auth: { username: string; password: string } | { token: string };
   logger: Logger;
   commitMessage: string;
   gitAuthorInfo?: { name?: string; email?: string };
@@ -145,8 +150,7 @@ export async function commitAndPushRepo({
   remoteRef?: string;
 }): Promise<void> {
   const git = Git.fromAuth({
-    username: auth.username,
-    password: auth.password,
+    ...auth,
     logger,
   });
 


### PR DESCRIPTION
Support Bearer-based Authorization header for auth
with token only (no username).

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
