### PR TITLE
Kubernetes Plugin - Provide clearer documentation on correct RBAC permissions

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -373,23 +373,42 @@ view the Kubernetes API docs for your Kubernetes version (e.g.
 
 ### Role Based Access Control
 
-The current RBAC permissions required are read-only cluster wide, for the
-following objects:
+The current RBAC permissions required are read-only cluster wide, the below
+Kubernetes manifest describes which objects are required and will ensure
+the plugin functions correctly:
 
-- pods
-- services
-- configmaps
-- deployments
-- replicasets
-- horizontalpodautoscalers
-- ingresses
-- statefulsets
-
-The following RBAC permissions are required on the batch API group for the
-following objects:
-
-- jobs
-- cronjobs
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backstage-read-only
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - pods
+      - configmaps
+      - services
+      - deployments
+      - replicasets
+      - horizontalpodautoscalers
+      - ingresses
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+```
 
 ## Surfacing your Kubernetes components as part of an entity
 


### PR DESCRIPTION
Signed-off-by: Lucas Teligioridis <lucas@teligioridis.dev>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Rather than providing the objects and what permissions are required,
just provide a valid Kubernetes manifest that clearly shows this to the
developer setting this up. Will also prevent any ambiguity when applying
this directly against a Kubernetes API.

This potentially solves this issue:
https://github.com/backstage/backstage/issues/10035

Although some of those errors might be related to an AWS EKS cluster,
otherwise the assumption is that it might just be incorrect permissions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
