### PR TITLE
Handle incorrect return type from Octokit paginate plugin

### DIFF
--- a/.changeset/dull-starfishes-chew.md
+++ b/.changeset/dull-starfishes-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Handle incorrect return type from Octokit paginate plugin to resolve reading URLs from GitHub

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -119,7 +119,10 @@ class GithubAppManager {
         const repos = await installationClient.paginate(
           installationClient.apps.listReposAccessibleToInstallation,
         );
-        const hasRepo = repos.repositories.some(repository => {
+        // The return type of the paginate method is incorrect.
+        const repositories: RestEndpointMethodTypes['apps']['listReposAccessibleToInstallation']['response']['data']['repositories'] =
+          repos.repositories ?? repos;
+        const hasRepo = repositories.some(repository => {
           return repository.name === repo;
         });
         if (!hasRepo) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Handle an issue with an incorrect return type from the Octokit paginate plugin. This fixes #12761.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
