### PR TITLE
Added Backstage version to info command

### DIFF
--- a/.changeset/modern-shrimps-wave.md
+++ b/.changeset/modern-shrimps-wave.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Added Backstage version to output of `yarn backstage-clie info` command
+Added Backstage version to output of `yarn backstage-cli info` command

--- a/.changeset/modern-shrimps-wave.md
+++ b/.changeset/modern-shrimps-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added Backstage version to output of `yarn backstage-clie info` command

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -24,7 +24,6 @@ import fs from 'fs-extra';
 export default async () => {
   await new Promise(async () => {
     const yarnVersion = await runPlain('yarn --version');
-    // eslint-disable-next-line no-restricted-syntax
     const isLocal = fs.existsSync(paths.resolveOwn('./src'));
 
     const backstageFile = paths.resolveTargetRoot('backstage.json');
@@ -34,7 +33,8 @@ export default async () => {
         const backstageJson = await fs.readJSON(backstageFile);
         backstageVersion = backstageJson.version ?? 'N/A';
       } catch (error) {
-        backstageVersion = 'N/A';
+        console.warn('The "backstage.json" file is not in the expected format');
+        console.log();
       }
     }
 

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -28,21 +28,21 @@ export default async () => {
     const isLocal = fs.existsSync(paths.resolveOwn('./src'));
 
     const backstageFile = paths.resolveTargetRoot('backstage.json');
-    let backstageJson = undefined;
+    let backstageVersion = 'N/A';
     if (fs.existsSync(backstageFile)) {
-      const buffer = await fs.readFile(backstageFile);
-      backstageJson = JSON.parse(buffer.toString());
+      try {
+        const backstageJson = await fs.readJSON(backstageFile);
+        backstageVersion = backstageJson.version ?? 'N/A';
+      } catch (error) {
+        backstageVersion = 'N/A';
+      }
     }
 
     console.log(`OS:   ${os.type} ${os.release} - ${os.platform}/${os.arch}`);
     console.log(`node: ${process.version}`);
     console.log(`yarn: ${yarnVersion}`);
     console.log(`cli:  ${cliVersion} (${isLocal ? 'local' : 'installed'})`);
-    console.log(
-      `backstage:  ${
-        backstageJson && backstageJson.version ? backstageJson.version : 'N/A'
-      }`,
-    );
+    console.log(`backstage:  ${backstageVersion}`);
     console.log();
     console.log('Dependencies:');
     const lockfilePath = paths.resolveTargetRoot('yarn.lock');

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -26,10 +26,22 @@ export default async () => {
     // eslint-disable-next-line no-restricted-syntax
     const isLocal = require('fs').existsSync(paths.resolveOwn('./src'));
 
+    const backstageFile = paths.resolveTargetRoot('backstage.json');
+    let backstageJson = undefined;
+    if (require('fs').existsSync(backstageFile)) {
+      const buffer = await require('fs').readFile(backstageFile);
+      backstageJson = JSON.parse(buffer.toString());
+    }
+
     console.log(`OS:   ${os.type} ${os.release} - ${os.platform}/${os.arch}`);
     console.log(`node: ${process.version}`);
     console.log(`yarn: ${yarnVersion}`);
     console.log(`cli:  ${cliVersion} (${isLocal ? 'local' : 'installed'})`);
+    console.log(
+      `backstage:  ${
+        backstageJson && backstageJson.version ? backstageJson.version : 'N/A'
+      }`,
+    );
     console.log();
     console.log('Dependencies:');
     const lockfilePath = paths.resolveTargetRoot('yarn.lock');

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -19,17 +19,18 @@ import os from 'os';
 import { runPlain } from '../lib/run';
 import { paths } from '../lib/paths';
 import { Lockfile } from '../lib/versioning';
+import fs from 'fs-extra';
 
 export default async () => {
   await new Promise(async () => {
     const yarnVersion = await runPlain('yarn --version');
     // eslint-disable-next-line no-restricted-syntax
-    const isLocal = require('fs').existsSync(paths.resolveOwn('./src'));
+    const isLocal = fs.existsSync(paths.resolveOwn('./src'));
 
     const backstageFile = paths.resolveTargetRoot('backstage.json');
     let backstageJson = undefined;
-    if (require('fs').existsSync(backstageFile)) {
-      const buffer = await require('fs').readFile(backstageFile);
+    if (fs.existsSync(backstageFile)) {
+      const buffer = await fs.readFile(backstageFile);
       backstageJson = JSON.parse(buffer.toString());
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added Backstage version to `yarn backstage-cli info` command output:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/67169551/180502368-db714020-ba83-40fc-a084-a398906bf8a9.png">

If there is no `backstage.json` this will fallback to "N/A"

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
