### PR TITLE
fix(github-pull-requests-board): filter out github accounts that have…

### DIFF
--- a/.changeset/silver-poets-push.md
+++ b/.changeset/silver-poets-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-pull-requests-board': patch
+---
+
+Fixed rendering when PR contains references to deleted Github accounts

--- a/plugins/github-pull-requests-board/src/utils/functions.test.ts
+++ b/plugins/github-pull-requests-board/src/utils/functions.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { filterSameUser } from './functions';
+
+import { Author } from './types';
+
+const users = [
+  null,
+  {
+    login: 'myuserlogin',
+    avatarUrl: '',
+    id: '',
+    email: '',
+    name: '',
+  },
+  {
+    login: 'anotheruserlogin',
+    avatarUrl: '',
+    id: '',
+    email: '',
+    name: '',
+  },
+  {
+    login: 'myuserlogin',
+    avatarUrl: '',
+    id: '',
+    email: '',
+    name: '',
+  },
+] as Author[];
+
+describe('filterSameUser', () => {
+  it('should return distinct users', () => {
+    expect(filterSameUser(users).length).toEqual(2);
+  });
+
+  // null users a.k.a. Ghost users are accounts that have been deleted
+  it('should contain null user', () => {
+    expect(filterSameUser(users)).not.toContain(null);
+  });
+});

--- a/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -42,7 +42,11 @@ export const getChangeRequests = (reviews: Reviews = []): Reviews => {
 };
 
 export const filterSameUser = (users: Author[]): Author[] => {
-  return users.reduce((acc, curr) => {
+  const filterGhostUsers = (usersToFilter: Author[]): Author[] => {
+    return usersToFilter.filter(user => user !== null);
+  };
+
+  return filterGhostUsers(users).reduce((acc, curr) => {
     const containsUser = acc.find(({ login }) => login === curr.login);
 
     if (!containsUser) {


### PR DESCRIPTION
… been deleted

Pull request that contain interactions with user accounts that have been
deleted are null in the response from the graphql API. This change prevents
deleted accounts from breaking the rendering of the PR.

Signed-off-by: Niall McCullagh <niallmccullagh@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
