### PR TITLE
Fix function name in docs

### DIFF
--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -207,7 +207,7 @@ of lower-level calls:
 
 ```ts
 // File: packages/backend/src/plugins/auth.ts
-import { getDefaultOwnershipRefs } from '@backstage/plugin-auth-backend';
+import { getDefaultOwnershipEntityRefs } from '@backstage/plugin-auth-backend';
 
 export default async function createPlugin(
   // ...
@@ -236,7 +236,7 @@ export default async function createPlugin(
         // an entity you will need to replace this step as well.
         //
         // You might also replace it if you for example want to filter out certain groups.
-        const ownershipRefs = getDefaultOwnershipRefs(entity);
+        const ownershipRefs = getDefaultOwnershipEntityRefs(entity);
 
         // The last step is to issue the token, where we might provide more options in the future.
         return ctx.issueToken({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`getDefaultOwnershipRefs` isn't available in the package, [getDefaultOwnershipEntityRefs](https://backstage.io/docs/reference/plugin-auth-backend.getdefaultownershipentityrefs) works in this example.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
