### PR TITLE
[Kubernetes plugin] CRDs are configurable per cluster

### DIFF
--- a/.changeset/long-pumpkins-walk.md
+++ b/.changeset/long-pumpkins-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Added a new `customResources` field to the ClusterDetails interface, in order to specify (override) custom resources per cluster

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -31,6 +31,10 @@ kubernetes:
           dashboardUrl: http://127.0.0.1:64713 # url copied from running the command: minikube service kubernetes-dashboard -n kubernetes-dashboard
           dashboardApp: standard
           caData: ${K8S_CONFIG_CA_DATA}
+          customResources:
+            - group: 'argoproj.io'
+              apiVersion: 'v1alpha1'
+              plural: 'rollouts'
         - url: http://127.0.0.2:9999
           name: aws-cluster-1
           authProvider: 'aws'
@@ -254,6 +258,11 @@ See also
 https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud
 for complete docs about GKE without `gcloud`.
 
+##### `clusters.\*.customResources` (optional)
+
+Configures which [custom resources][3] to look for when returning an entity's
+Kubernetes resources belonging to the cluster. Same specification as [`customResources`](#customresources-optional)
+
 #### `gke`
 
 This cluster locator is designed to work with Kubernetes clusters running in
@@ -327,8 +336,12 @@ it is also possible to implement a
 
 ### `customResources` (optional)
 
-Configures which [custom resources][3] to look for when returning an entity's
+Configures which [custom resources][3] to look for by default when returning an entity's
 Kubernetes resources.
+
+**Notes:**
+
+- The optional `kubernetes.customResources` property is overrode by `customResources` at the [clusters level](#clusterscustomresources-optional).
 
 Defaults to empty array. Example:
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -35,6 +35,7 @@ export interface ClusterDetails {
   authProvider: string;
   // (undocumented)
   caData?: string | undefined;
+  customResources?: CustomResourceMatcher[];
   dashboardApp?: string;
   dashboardParameters?: JsonObject;
   dashboardUrl?: string;

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -211,19 +211,14 @@ export class KubernetesFanOutHandler {
     entity,
     auth,
   }: KubernetesObjectsByEntity): Promise<ObjectsByEntityResponse> {
-    return this.fanOutRequests(
-      entity,
-      auth,
-      this.objectTypesToFetch,
-      this.customResources,
-    );
+    return this.fanOutRequests(entity, auth, this.objectTypesToFetch);
   }
 
   private async fanOutRequests(
     entity: Entity,
     auth: KubernetesRequestAuth,
     objectTypesToFetch: Set<ObjectToFetch>,
-    customResources: CustomResourceMatcher[],
+    customResources?: CustomResourceMatcher[],
   ) {
     const entityName =
       entity.metadata?.annotations?.['backstage.io/kubernetes-id'] ||
@@ -254,7 +249,11 @@ export class KubernetesFanOutHandler {
             clusterDetails: clusterDetailsItem,
             objectTypesToFetch: objectTypesToFetch,
             labelSelector,
-            customResources: customResources.map(c => ({
+            customResources: (
+              customResources ||
+              clusterDetailsItem.customResources ||
+              this.customResources
+            ).map(c => ({
               ...c,
               objectType: 'customresources',
             })),

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -193,6 +193,11 @@ export interface ClusterDetails {
    * @see dashboardApp
    */
   dashboardParameters?: JsonObject;
+  /**
+   * Specifies which custom resources to look for when returning an entity's
+   * Kubernetes resources.
+   */
+  customResources?: CustomResourceMatcher[];
 }
 
 /**


### PR DESCRIPTION
## Hey, we just made a Pull Request! @jamieklassen

* Added a new customResources field to the ClusterDetails interface, to be able to specify (override) CRDs per cluster. Resolves #10513.

* We have refactored KubernetesFanOutHandler.test.ts to remove some duplicated code

* We have not modified the docs, first we want to validate this approach @mclarke47 @jamieklassen

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
