### PR TITLE
Aggregate catalog permissions

### DIFF
--- a/.changeset/lovely-walls-brush.md
+++ b/.changeset/lovely-walls-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-common': patch
+---
+
+Export aggregated list of all catalog permissions

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -91,7 +91,10 @@ import {
 } from '@backstage/plugin-permission-node';
 import { AuthorizedEntitiesCatalog } from './AuthorizedEntitiesCatalog';
 import { basicEntityFilter } from './request/basicEntityFilter';
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import {
+  catalogPermissions,
+  RESOURCE_TYPE_CATALOG_ENTITY,
+} from '@backstage/plugin-catalog-common';
 import { AuthorizedLocationService } from './AuthorizedLocationService';
 
 /** @public */
@@ -435,6 +438,7 @@ export class CatalogBuilder {
             entitiesByRef[stringifyEntityRef(parseEntityRef(resourceRef))],
         );
       },
+      permissions: catalogPermissions,
       rules: this.permissionRules,
     });
     const stitcher = new Stitcher(dbClient, logger);

--- a/plugins/catalog-common/api-report.md
+++ b/plugins/catalog-common/api-report.md
@@ -50,5 +50,11 @@ export const catalogLocationDeletePermission: BasicPermission;
 export const catalogLocationReadPermission: BasicPermission;
 
 // @alpha
+export const catalogPermissions: (
+  | BasicPermission
+  | ResourcePermission<'catalog-entity'>
+)[];
+
+// @alpha
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
 ```

--- a/plugins/catalog-common/src/index.ts
+++ b/plugins/catalog-common/src/index.ts
@@ -30,6 +30,7 @@ export {
   catalogLocationReadPermission,
   catalogLocationCreatePermission,
   catalogLocationDeletePermission,
+  catalogPermissions,
 } from './permissions';
 export type { CatalogEntityPermission } from './permissions';
 

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -129,3 +129,17 @@ export const catalogLocationDeletePermission = createPermission({
     action: 'delete',
   },
 });
+
+/**
+ * List of all catalog permissions.
+ * @alpha
+ */
+export const catalogPermissions = [
+  catalogEntityReadPermission,
+  catalogEntityCreatePermission,
+  catalogEntityDeletePermission,
+  catalogEntityRefreshPermission,
+  catalogLocationReadPermission,
+  catalogLocationCreatePermission,
+  catalogLocationDeletePermission,
+];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As a follow up to https://github.com/backstage/backstage/pull/11695, the catalog permissions will now be aggregated and made available on the `/.well-known/backstage/permissions/metadata/` endpoint.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
