### PR TITLE
fix(search): close modal when toggled

### DIFF
--- a/.changeset/quick-badgers-fetch.md
+++ b/.changeset/quick-badgers-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': minor
+---
+
+toggle open so that when the search modal is closed, the scrolling behavior will not change

--- a/plugins/search/src/components/SearchModal/useSearchModal.test.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.test.tsx
@@ -30,7 +30,7 @@ describe('useSearchModal', () => {
     },
   );
 
-  it('should keep open forever to true once modal is toggled', () => {
+  it('should toggle open once modal is toggled', () => {
     const rendered = renderHook(() => useSearchModal());
     act(() => rendered.result.current.toggleModal());
 
@@ -41,7 +41,7 @@ describe('useSearchModal', () => {
 
     act(() => rendered.result.current.toggleModal());
     expect(rendered.result.current.state).toEqual({
-      open: true,
+      open: false,
       hidden: true,
     });
   });
@@ -55,7 +55,7 @@ describe('useSearchModal', () => {
     });
   });
 
-  it('should keep open forever to true even when the modal transition from opened to closed', () => {
+  it('should toggle open and hidden when the modal transition from opened to closed', () => {
     const rendered = renderHook(() => useSearchModal());
 
     act(() => rendered.result.current.setOpen(true));
@@ -66,7 +66,7 @@ describe('useSearchModal', () => {
 
     act(() => rendered.result.current.setOpen(false));
     expect(rendered.result.current.state).toEqual({
-      open: true,
+      open: false,
       hidden: true,
     });
   });

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -120,7 +120,7 @@ export function useSearchModal(initialState = false) {
   const toggleModal = useCallback(
     () =>
       setState(prevState => ({
-        open: true,
+        open: !prevState.open,
         hidden: !prevState.hidden,
       })),
     [],
@@ -128,8 +128,8 @@ export function useSearchModal(initialState = false) {
 
   const setOpen = useCallback(
     (open: boolean) =>
-      setState(prevState => ({
-        open: prevState.open || open,
+      setState(() => ({
+        open: open,
         hidden: !open,
       })),
     [],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Toggled open in useSearchModal.  The as is behavior was preventing scrolling when the modal was closed by keeping the modal style on the <body> element.
![image](https://user-images.githubusercontent.com/42561077/181037134-287010a0-16bb-4760-b762-acb223f325b9.png)
By setting open to false, this allows material UI to remove the style from <body> and allows scrolling when the modal is closed.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
