### PR TITLE
Kubernetes Docs - Add instructions to prevent 403 on API read

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -395,6 +395,7 @@ rules:
       - horizontalpodautoscalers
       - ingresses
       - statefulsets
+      - limitranges
     verbs:
       - get
       - list


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The latest plugin requires the `limitranges` API to be available for
read-only otherwise a 403 error will return on the Kubernetes pane.

Fixes https://github.com/backstage/backstage/issues/12842

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
