### PR TITLE
Add wrap-around for tool lists in Home Plugin

### DIFF
--- a/.changeset/dull-owls-grab.md
+++ b/.changeset/dull-owls-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Add wrap-around for the listing of tools to prevent increasing width with name length.

--- a/plugins/home/src/homePageComponents/Toolkit/Content.tsx
+++ b/plugins/home/src/homePageComponents/Toolkit/Content.tsx
@@ -35,8 +35,10 @@ const useStyles = makeStyles(theme => ({
   },
   label: {
     marginTop: theme.spacing(1),
+    width: '72px',
     fontSize: '0.9em',
     lineHeight: '1.25',
+    overflowWrap: 'break-word',
     color: theme.palette.text.secondary,
   },
   icon: {


### PR DESCRIPTION
Signed-off-by: Parth Shukla <theparthshukla@gmail.com>

## Hey, I just made a Pull Request!
#12751 

A wrap-around has been added for tool lists as earlier, the width would increase with the length of the tool name. For eg:- 
<img width="725" alt="Screenshot 2022-07-27 at 14 10 11" src="https://user-images.githubusercontent.com/36262397/181248241-52de6e7c-5fa3-4407-a572-bb27c49ac968.png">

With the new changes, if lines are long, then they're broken apart with slight tolerance for long words.
<img width="707" alt="Screenshot 2022-07-27 at 14 08 46" src="https://user-images.githubusercontent.com/36262397/181248858-f0e26aee-3e74-48db-a97a-fb76af752d7e.png">

This was done to increase uniformity in the tools menu.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
