### PR TITLE
Add warning label to generated Docker images

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and push Docker Hub image
+name: Build and push Docker image
 on:
   repository_dispatch:
     types: [release-published]
@@ -87,3 +87,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/backstage:latest
             ghcr.io/${{ github.repository_owner }}/backstage:${{ github.event.client_payload.version }}
+          labels: |
+            org.opencontainers.image.description=Docker image generated from the latest Backstage release; this contains what you would get out of the box by running npx @backstage/create-app and building a Docker image from the generated source. This is meant to ease the process of evaluating Backstage for the first time, but also has the severe limitation that there is no way to install additional plugins relevant to your infrastructure.


### PR DESCRIPTION
The [Docker images](https://github.com/backstage/backstage/pkgs/container/backstage) generated by the workflow added in #11696 have no description. This adds a short description (max length 512 chars) using the supported opencontainers spec. Unfortunately there doesn't seem to be a way to modify the main package page which just shows the Backstage README.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
