### PR TITLE
Catalog: fix conditional decision based on properties of type array

### DIFF
--- a/.changeset/strange-moles-design.md
+++ b/.changeset/strange-moles-design.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix issue for conditional decisions based on properties stored as arrays, like tags.
+
+Before this change, having a permission policy returning conditional decisions based on metadata like tags, such like `createCatalogConditionalDecision(permission, catalogConditions.hasMetadata('tags', 'java'),)`, was producing wrong results. The issue occurred when authorizing entities already loaded from the database, for example when authorizing `catalogEntityDeletePermission`.

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.test.ts
@@ -46,6 +46,22 @@ describe('createPropertyRule', () => {
         ).toBe(false);
       });
 
+      it('returns false when specified key is an empty array', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                tags: [],
+              },
+            },
+            'tags',
+          ),
+        ).toBe(false);
+      });
+
       it('returns true when specified key is present', () => {
         expect(
           apply(
@@ -60,6 +76,22 @@ describe('createPropertyRule', () => {
               },
             },
             'org.name',
+          ),
+        ).toBe(true);
+      });
+
+      it('returns true when specified key is an array containing more than an element', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                tags: ['java'],
+              },
+            },
+            'tags',
           ),
         ).toBe(true);
       });
@@ -101,6 +133,23 @@ describe('createPropertyRule', () => {
         ).toBe(false);
       });
 
+      it(`returns false when key is an array and doesn't contain the specified value`, () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                tags: ['java'],
+              },
+            },
+            'tags',
+            'python',
+          ),
+        ).toBe(false);
+      });
+
       it('returns true when specified key and value is present', () => {
         expect(
           apply(
@@ -116,6 +165,23 @@ describe('createPropertyRule', () => {
             },
             'org.name',
             'test-org',
+          ),
+        ).toBe(true);
+      });
+
+      it(`returns true when key is an array and contains the specified value`, () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                tags: ['java', 'java11'],
+              },
+            },
+            'tags',
+            'java',
           ),
         ).toBe(true);
       });

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -26,6 +26,13 @@ export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
     apply: (resource: Entity, key: string, value?: string) => {
       const foundValue = get(resource[propertyType], key);
+
+      if (Array.isArray(foundValue)) {
+        if (value !== undefined) {
+          return foundValue.includes(value);
+        }
+        return foundValue.length > 0;
+      }
       if (value !== undefined) {
         return value === foundValue;
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue when using conditional decisions based on properties stored as arrays, like tags.

Let’s say we would like to show and authorize operations only to entities having a `java` tag. To do that, we would need to use the following permission policy:

```typescript
class MyPolicy implements PermissionPolicy {
  async handle({ permission }: PolicyQuery): Promise<PolicyDecision> {
    if (isResourcePermission(permission, 'catalog-entity')) {
      return createCatalogConditionalDecision(
        permission,
        catalogConditions.hasMetadata('tags', 'java'),
      );
    }
    return {
      result: AuthorizeResult.ALLOW,
    };
  }
}
```

This works well when listing entities, but doesn’t work properly when authorizing entities already loaded from the database, specifically when authorizing `catalogEntityDeletePermission`.
When using the policy above in the example backstage instance, the "Unregister entity" button in http://localhost:3000/catalog/default/component/artist-lookup should be enabled instead of disabled.

This PR fixes the issue mentioned above, introducing support for conditional decisions based on properties stored as arrays, like tags.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
