### PR TITLE
docs: update code sample for custom processors

### DIFF
--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -377,6 +377,10 @@ import {
 export class SystemXReaderProcessor implements CatalogProcessor {
   constructor(private readonly reader: UrlReader) {}
 
+  getProcessorName(): string {
+    return 'SystemXReaderProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     _optional: boolean,


### PR DESCRIPTION
`getProcessorName` is a required method.