### PR TITLE
Docs: Remove markdown version constraint for mkdocs-techdocs-core

### DIFF
--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -278,10 +278,7 @@ Note: We recommend Python version 3.7 or higher.
 
 > Caveat: Please install the `mkdocs-techdocs-core` package after all other
 > Python packages. The order is important to make sure we get correct version of
-> some of the dependencies. For example, we want `Markdown` version to be
-> [3.2.2](https://github.com/backstage/backstage/blob/f9f70c225548017b6a14daea75b00fbd399c11eb/packages/techdocs-container/techdocs-core/requirements.txt#L11).
-> You can also explicitly install `Markdown==3.2.2` after installing all other
-> Python packages.
+> some of the dependencies.
 
 ## Running Backstage locally
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* The latest version of [mkdocs-techdocs-core](https://github.com/backstage/mkdocs-techdocs-core) (1.1.4) support markdown version >=3.2, <4.0 as this [PR](https://github.com/backstage/mkdocs-techdocs-core/pull/74) has been merged
* Backstage techdocs documentation has been modified to reflect this change

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
