### PR TITLE
clarify caData field

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -236,10 +236,12 @@ kubernetes:
 
 ##### `clusters.\*.caData` (optional)
 
-PEM-encoded certificate authority certificates.
+Base64-encoded certificate authority bundle in PEM format. The Kubernetes client
+will verify that TLS certificate presented by the API server is signed by this
+CA.
 
-This values could be obtained via inspecting the Kubernetes config file (usually
-at `~/.kube/config`) under `clusters.cluster.certificate-authority-data`. For
+This value could be obtained via inspecting the kubeconfig file (usually
+at `~/.kube/config`) under `clusters[*].cluster.certificate-authority-data`. For
 GKE, execute the following command to obtain the value
 
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change affects the docs only!

The code in `@kubernetes/client-node` will decode this value, as seen here:

https://github.com/kubernetes-client/javascript/blob/2b6813f99a85605f691973d6bc43f291ac072fc7/src/config.ts#L518-L520

I have seen a casual reader insert the multi-line raw contents of a PEM file in this field, so it seems worth mentioning the extra layer of encoding explicitly.

#### :heavy_check_mark: Checklist

I skipped the changeset since there are no code changes here -- I hope that's the right thing to do!

- [x] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [x] Added or updated documentation
- [x] ~Tests for new functionality and regression tests for bug fixes~
- [x] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
