### PR TITLE
feat: techdocs-cli extra Docker options for serve/serve:mkdocs

### DIFF
--- a/.changeset/weak-shrimps-deny.md
+++ b/.changeset/weak-shrimps-deny.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Added CLI option `--docker-option` to allow passing additional options to the `docker run` command executed my `serve` and `serve:mkdocs`.

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -83,6 +83,8 @@ Serve a documentation project locally in a Backstage app-like environment
 Options:
   -i, --docker-image <DOCKER_IMAGE>        The mkdocs docker container to use (default: "spotify/techdocs")
   --docker-entrypoint <DOCKER_ENTRYPOINT>  Override the image entrypoint
+  --docker-option <DOCKER_OPTION...>       Extra options to pass to the docker run command, e.g. "--add-host=internal.host:192.168.11.12"
+                                           (can be added multiple times).
   --no-docker                              Do not use Docker, use MkDocs executable in current user environment.
   --mkdocs-port <PORT>                     Port for MkDocs server to use (default: "8000")
   -v --verbose                             Enable verbose output. (default: false)

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -96,6 +96,7 @@ Usage: techdocs-cli serve [options]
 Options:
   -i, --docker-image <DOCKER_IMAGE>
   --docker-entrypoint <DOCKER_ENTRYPOINT>
+  --docker-option <DOCKER_OPTION...>
   --no-docker
   --mkdocs-port <PORT>
   -v --verbose
@@ -110,6 +111,7 @@ Usage: techdocs-cli serve:mkdocs [options]
 Options:
   -i, --docker-image <DOCKER_IMAGE>
   --docker-entrypoint <DOCKER_ENTRYPOINT>
+  --docker-option <DOCKER_OPTION...>
   --no-docker
   -p, --port <PORT>
   -v --verbose

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -216,6 +216,10 @@ export function registerCommands(program: Command) {
       'Override the image entrypoint',
     )
     .option(
+      '--docker-option <DOCKER_OPTION...>',
+      'Extra options to pass to the docker run command, e.g. "--add-host=internal.host:192.168.11.12" (can be added multiple times).',
+    )
+    .option(
       '--no-docker',
       'Do not use Docker, run `mkdocs serve` in current user environment.',
     )
@@ -236,6 +240,10 @@ export function registerCommands(program: Command) {
     .option(
       '--docker-entrypoint <DOCKER_ENTRYPOINT>',
       'Override the image entrypoint',
+    )
+    .option(
+      '--docker-option <DOCKER_OPTION...>',
+      'Extra options to pass to the docker run command, e.g. "--add-host=internal.host:192.168.11.12" (can be added multiple times).',
     )
     .option(
       '--no-docker',

--- a/packages/techdocs-cli/src/commands/serve/mkdocs.ts
+++ b/packages/techdocs-cli/src/commands/serve/mkdocs.ts
@@ -62,6 +62,7 @@ export default async function serveMkdocs(opts: OptionValues) {
     port: opts.port,
     dockerImage: opts.dockerImage,
     dockerEntrypoint: opts.dockerEntrypoint,
+    dockerOptions: opts.dockerOption,
     useDocker: opts.docker,
     stdoutLogFunc: logFunc,
     stderrLogFunc: logFunc,

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -93,6 +93,7 @@ export default async function serve(opts: OptionValues) {
     port: opts.mkdocsPort,
     dockerImage: opts.dockerImage,
     dockerEntrypoint: opts.dockerEntrypoint,
+    dockerOptions: opts.dockerOption,
     useDocker: opts.docker,
     stdoutLogFunc: mkdocsLogFunc,
     stderrLogFunc: mkdocsLogFunc,

--- a/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
@@ -64,6 +64,39 @@ describe('runMkdocsServer', () => {
         expect.objectContaining({}),
       );
     });
+
+    it('should accept custom docker options', async () => {
+      await runMkdocsServer({
+        dockerOptions: [
+          '--add-host=internal.host:192.168.11.12',
+          '--name',
+          'my-techdocs-container',
+        ],
+      });
+
+      expect(run).toHaveBeenCalledWith(
+        'docker',
+        expect.arrayContaining([
+          'run',
+          '--rm',
+          '-w',
+          '/content',
+          '-v',
+          `${process.cwd()}:/content`,
+          '-p',
+          '8000:8000',
+          '-it',
+          '--add-host=internal.host:192.168.11.12',
+          '--name',
+          'my-techdocs-container',
+          'spotify/techdocs',
+          'serve',
+          '--dev-addr',
+          '0.0.0.0:8000',
+        ]),
+        expect.objectContaining({}),
+      );
+    });
   });
 
   describe('mkdocs', () => {

--- a/packages/techdocs-cli/src/lib/mkdocsServer.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.ts
@@ -22,6 +22,7 @@ export const runMkdocsServer = async (options: {
   useDocker?: boolean;
   dockerImage?: string;
   dockerEntrypoint?: string;
+  dockerOptions?: string[];
   stdoutLogFunc?: LogFunc;
   stderrLogFunc?: LogFunc;
 }): Promise<ChildProcess> => {
@@ -45,6 +46,7 @@ export const runMkdocsServer = async (options: {
         ...(options.dockerEntrypoint
           ? ['--entrypoint', options.dockerEntrypoint]
           : []),
+        ...(options.dockerOptions || []),
         dockerImage,
         'serve',
         '--dev-addr',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows to add additional Docker CLI options when running `@techdocs/cli serve` and `@techdocs/cli serve:mkdocs`. This can be useful when it's necessary to override networking features due to local environment constraints, such as adding `--add-host` or `--dns` options.

The new variadic `--docker-option` can be passed multiple times to the `serve` and `serve:mkdocs` commands:

```shell
$ npx @techdocs/cli serve --help
Usage: techdocs-cli serve [options]

Serve a documentation project locally in a Backstage app-like environment

Options:
  -i, --docker-image <DOCKER_IMAGE>        The mkdocs docker container to use (default: "spotify/techdocs:v1.0.3")
  --docker-entrypoint <DOCKER_ENTRYPOINT>  Override the image entrypoint
  --docker-option <DOCKER_OPTION...>       Extra options to pass to the docker run command, e.g.
                                           "--add-host=internal.host:192.168.11.12" (can be added multiple times).
  --no-docker                              Do not use Docker, use MkDocs executable in current user environment.
  --mkdocs-port <PORT>                     Port for MkDocs server to use (default: "8000")
  -v --verbose                             Enable verbose output. (default: false)
  -h, --help                               display help for command
```

Examples:

```shell
$ npx @techdocs/cli serve  \
  --docker-option '--name=my-techdocs-container'   \
  --docker-option '--add-host=my.custom.kroki.host:1.2.3.4'  \
  --docker-option '--add-host=another.host:2.3.4.5'

$ npx @techdocs/cli serve:mkdocs \
  --docker-option '--name=my-techdocs-container'  \
  --docker-option '--add-host=my.custom.kroki.host:1.2.3.4'  \
  --docker-option '--add-host=another.host:2.3.4.5'
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) - added CLI output instead
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
