### PR TITLE
feat(kubernetes): add namespace to k8s error reporting table

### DIFF
--- a/.changeset/flat-zebras-draw.md
+++ b/.changeset/flat-zebras-draw.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-kubernetes': minor
+'@backstage/plugin-kubernetes': patch
 ---
 
 Adds namespace column to Kubernetes error reporting table

--- a/.changeset/flat-zebras-draw.md
+++ b/.changeset/flat-zebras-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': minor
+---
+
+Adds namespace column to Kubernetes error reporting table

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -109,6 +109,8 @@ export interface DetectedError {
   // (undocumented)
   names: string[];
   // (undocumented)
+  namespace: string;
+  // (undocumented)
   severity: ErrorSeverity;
 }
 

--- a/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
+++ b/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
@@ -26,12 +26,17 @@ type ErrorReportingProps = {
 const columns: TableColumn<DetectedError>[] = [
   {
     title: 'cluster',
-    width: '15%',
+    width: '10%',
     render: (detectedError: DetectedError) => detectedError.cluster,
   },
   {
+    title: 'namespace',
+    width: '10%',
+    render: (detectedError: DetectedError) => detectedError.namespace,
+  },
+  {
     title: 'kind',
-    width: '15%',
+    width: '10%',
     render: (detectedError: DetectedError) => detectedError.kind,
   },
   {

--- a/plugins/kubernetes/src/error-detection/common.ts
+++ b/plugins/kubernetes/src/error-detection/common.ts
@@ -45,6 +45,7 @@ export const detectErrorsInObjects = <T extends ErrorDetectable>(
         const value = errors.get(dedupKey);
 
         const name = object.metadata?.name ?? 'unknown';
+        const namespace = object.metadata?.namespace ?? 'unknown';
 
         if (value !== undefined) {
           // This gets translated into the Chip "+5 others"
@@ -60,6 +61,7 @@ export const detectErrorsInObjects = <T extends ErrorDetectable>(
             names: [name],
             message: message,
             severity: errorMapper.severity,
+            namespace,
           });
         }
       }

--- a/plugins/kubernetes/src/error-detection/error-detection.test.ts
+++ b/plugins/kubernetes/src/error-detection/error-detection.test.ts
@@ -154,6 +154,7 @@ describe('detectErrors', () => {
         'container=side-car restarted 38 times',
       ],
       names: ['dice-roller-canary-7d64cd756c-55rfq'],
+      namespace: 'default',
       severity: 4,
     });
 
@@ -165,6 +166,7 @@ describe('detectErrors', () => {
         'containers with unready status: [side-car other-side-car]',
       ],
       names: ['dice-roller-canary-7d64cd756c-55rfq'],
+      namespace: 'default',
       severity: 5,
     });
 
@@ -176,6 +178,7 @@ describe('detectErrors', () => {
         'back-off 5m0s restarting failed container=side-car pod=dice-roller-canary-7d64cd756c-55rfq_default(65ad28e3-5d51-4b4b-9bf8-4cb069803034)',
       ],
       names: ['dice-roller-canary-7d64cd756c-55rfq'],
+      namespace: 'default',
       severity: 6,
     });
 
@@ -187,6 +190,7 @@ describe('detectErrors', () => {
         'container=side-car exited with error code (1)',
       ],
       names: ['dice-roller-canary-7d64cd756c-55rfq'],
+      namespace: 'default',
       severity: 4,
     });
   });
@@ -210,6 +214,7 @@ describe('detectErrors', () => {
         'containers with unready status: [nginx]',
       ],
       names: ['dice-roller-bad-cm-855bf85464-mg6xb'],
+      namespace: 'default',
       severity: 5,
     });
 
@@ -218,6 +223,7 @@ describe('detectErrors', () => {
       kind: 'Pod',
       message: ['configmap "some-cm" not found'],
       names: ['dice-roller-bad-cm-855bf85464-mg6xb'],
+      namespace: 'default',
       severity: 6,
     });
   });
@@ -248,6 +254,7 @@ describe('detectErrors', () => {
       kind: 'Deployment',
       message: ['Deployment does not have minimum availability.'],
       names: ['dice-roller-canary'],
+      namespace: 'default',
       severity: 6,
     });
   });
@@ -280,6 +287,7 @@ describe('detectErrors', () => {
         'Current number of replicas (10) is equal to the configured max number of replicas (10)',
       ],
       names: ['dice-roller'],
+      namespace: 'default',
       severity: 8,
     });
   });

--- a/plugins/kubernetes/src/error-detection/types.ts
+++ b/plugins/kubernetes/src/error-detection/types.ts
@@ -55,6 +55,7 @@ export type DetectedErrorsByCluster = Map<string, DetectedError[]>;
 export interface DetectedError {
   severity: ErrorSeverity;
   cluster: string;
+  namespace: string;
   kind: ErrorDetectableKind;
   names: string[];
   message: string[];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the namespace field to the Kubernetes error reporting table. Closes https://github.com/backstage/backstage/issues/12565

<img width="939" alt="image" src="https://user-images.githubusercontent.com/627654/182351514-3847299d-3473-425c-b65f-5f3b35995180.png">


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~ Not neccessary
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
