### PR TITLE
Add names to Group in Cost Insights

### DIFF
--- a/.changeset/plenty-timers-flow.md
+++ b/.changeset/plenty-timers-flow.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-cost-insights': patch
+'@backstage/plugin-cost-insights-common': patch
+---
+
+Add name property to Group

--- a/plugins/cost-insights-common/api-report.md
+++ b/plugins/cost-insights-common/api-report.md
@@ -44,6 +44,7 @@ export interface Entity {
 // @public (undocumented)
 export type Group = {
   id: string;
+  name?: string;
 };
 
 // @public (undocumented)

--- a/plugins/cost-insights-common/src/types/Group.ts
+++ b/plugins/cost-insights-common/src/types/Group.ts
@@ -19,4 +19,5 @@
  */
 export type Group = {
   id: string;
+  name?: string;
 };

--- a/plugins/cost-insights/src/components/CostInsightsTabs/CostInsightsTabs.test.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsTabs/CostInsightsTabs.test.tsx
@@ -32,6 +32,7 @@ const mockGroups: Group[] = [
   },
   {
     id: 'test-group-3',
+    name: 'Test Group 3',
   },
 ];
 
@@ -76,7 +77,7 @@ describe('<CostInsightsTabs />', () => {
     );
     await userEvent.click(rendered.getByTestId('cost-insights-groups-tab'));
     mockGroups.forEach(group =>
-      expect(rendered.getByText(group.id)).toBeInTheDocument(),
+      expect(rendered.getByText(group.name ?? group.id)).toBeInTheDocument(),
     );
   });
 });

--- a/plugins/cost-insights/src/components/CostInsightsTabs/CostInsightsTabs.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsTabs/CostInsightsTabs.tsx
@@ -100,7 +100,7 @@ export const CostInsightsTabs = ({ groups }: CostInsightsTabsProps) => {
             data-testid={g.id}
             onClick={updateGroupFilterAndCloseMenu(g)}
           >
-            {g.id}
+            {g.name ?? g.id}
           </MenuItem>
         ))}
       </Menu>

--- a/plugins/cost-insights/src/example/client.ts
+++ b/plugins/cost-insights/src/example/client.ts
@@ -52,7 +52,8 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
 
   async getUserGroups(userId: string): Promise<Group[]> {
     const groups: Group[] = await this.request({ userId }, [
-      { id: 'pied-piper' },
+      { id: 'group-a', name: 'Group A' },
+      { id: 'group-b', name: 'Group B' },
     ]);
 
     return groups;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `name` property to `Group` to make it more user-friendly, the same we do for `Project`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
