### PR TITLE
Modify description column in entity tables to not have 'auto' width

### DIFF
--- a/.changeset/green-laws-greet.md
+++ b/.changeset/green-laws-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Modify description column to not use auto width.

--- a/plugins/catalog-react/src/components/EntityTable/columns.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/columns.tsx
@@ -147,7 +147,6 @@ export const columnFactories = Object.freeze({
           line={2}
         />
       ),
-      width: 'auto',
     };
   },
   createSpecLifecycleColumn<T extends Entity>(): TableColumn<T> {


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Having the auto flag makes the column smaller, even though it usually has the longest text. The most visible example of this is the 'hasSystems' card which renders the entity table with three columns only. 

See before/after screen shots on effects.
Catalog before: 
![image](https://user-images.githubusercontent.com/2392775/182607666-ba10334b-7cea-4dc8-b122-1679a8f3095e.png)
Catalog after:
![image](https://user-images.githubusercontent.com/2392775/182607763-09d50ac1-866a-44d4-a9c9-04523a097d14.png)


Has Systems card before:
![image](https://user-images.githubusercontent.com/2392775/182608380-d90bd2dd-323f-4d52-9d82-791c9d5bd987.png)

Has Systems card after:
![image](https://user-images.githubusercontent.com/2392775/182608201-13b1951c-d7f6-469d-9b17-1ea2798c93c3.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
