### PR TITLE
scaffolder(next): Support `async` validation for `CustomFieldExtensions` and run validation for `type: object`

### DIFF
--- a/.changeset/sharp-swans-suffer.md
+++ b/.changeset/sharp-swans-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Added support for `async` validation for the `next` version of the plugin

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -91,7 +91,10 @@ import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';
 import { homePage } from './components/home/HomePage';
 import { Root } from './components/Root';
-import { LowerCaseValuePickerFieldExtension } from './components/scaffolder/customScaffolderExtensions';
+import {
+  DelayingComponentFieldExtension,
+  LowerCaseValuePickerFieldExtension,
+} from './components/scaffolder/customScaffolderExtensions';
 import { defaultPreviewTemplate } from './components/scaffolder/defaultPreviewTemplate';
 import { searchPage } from './components/search/SearchPage';
 import { providers } from './identityProviders';
@@ -228,7 +231,7 @@ const routes = (
       }
     >
       <ScaffolderFieldExtensions>
-        <LowerCaseValuePickerFieldExtension />
+        <DelayingComponentFieldExtension />
       </ScaffolderFieldExtensions>
     </Route>
     <Route path="/explore" element={<ExplorePage />} />

--- a/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
+++ b/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
@@ -62,3 +62,37 @@ export const LowerCaseValuePickerFieldExtension = scaffolderPlugin.provide(
     },
   }),
 );
+
+const MockDelayComponent = (
+  props: FieldExtensionComponentProps<{ test?: string }>,
+) => {
+  const { onChange, formData, rawErrors } = props;
+  return (
+    <TextField
+      label="test"
+      helperText="description"
+      value={formData?.test ?? ''}
+      onChange={({ target: { value } }) => onChange({ test: value })}
+      margin="normal"
+      error={rawErrors?.length > 0 && !formData}
+    />
+  );
+};
+
+export const DelayingComponentFieldExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'DelayingComponent',
+    component: MockDelayComponent,
+    validation: async (
+      value: { test?: string },
+      validation: FieldValidation,
+    ) => {
+      // delay 2 seconds
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      if (value.test !== 'pass') {
+        validation.addError('value was not equal to pass');
+      }
+    },
+  }),
+);

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -44,7 +44,7 @@ export type CustomFieldValidator<TFieldReturnValue> = (
   context: {
     apiHolder: ApiHolder;
   },
-) => void;
+) => void | Promise<void>;
 
 // @public
 export const EntityNamePickerFieldExtension: FieldExtensionComponent<

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -65,6 +65,7 @@
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.1",
     "json-schema": "^0.4.0",
+    "json-schema-library": "^6.0.0",
     "lodash": "^4.17.21",
     "luxon": "^3.0.0",
     "qs": "^6.9.4",

--- a/plugins/scaffolder/src/extensions/types.ts
+++ b/plugins/scaffolder/src/extensions/types.ts
@@ -25,7 +25,7 @@ export type CustomFieldValidator<TFieldReturnValue> = (
   data: TFieldReturnValue,
   field: FieldValidation,
   context: { apiHolder: ApiHolder },
-) => void;
+) => void | Promise<void>;
 
 /**
  * Type for the Custom Field Extension with the

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { TemplateParameterSchema } from '../../../types';
 import { Stepper } from './Stepper';
 import { renderInTestApp } from '@backstage/test-utils';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 
 describe('Stepper', () => {
   it('should render the step titles for each step of the manifest', async () => {
@@ -53,7 +53,9 @@ describe('Stepper', () => {
 
     expect(getByText('Next')).toBeInTheDocument();
 
-    await fireEvent.click(getByText('Next'));
+    await act(async () => {
+      await fireEvent.click(getByText('Next'));
+    });
 
     expect(getByText('Review')).toBeInTheDocument();
   });
@@ -93,9 +95,13 @@ describe('Stepper', () => {
       target: { value: 'im a test value' },
     });
 
-    await fireEvent.click(getByText('Next'));
+    await act(async () => {
+      await fireEvent.click(getByText('Next'));
+    });
 
-    await fireEvent.click(getByText('Back'));
+    await act(async () => {
+      await fireEvent.click(getByText('Back'));
+    });
 
     expect(getByRole('textbox', { name: 'name' })).toHaveValue(
       'im a test value',

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -88,11 +88,6 @@ export const Stepper = (props: StepperProps) => {
   const handleNext = async ({ formData }: { formData: JsonObject }) => {
     setErrors(undefined);
 
-    const errorContext: any = {};
-    for (const [key] of Object.entries(formData)) {
-      errorContext[key] = createFieldValidation();
-    }
-
     const returnedValidation = await validator(formData);
 
     const hasErrors = Object.values(returnedValidation).some(i => {

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -27,8 +27,7 @@ import { Theme as MuiTheme } from '@rjsf/material-ui';
 import React, { useMemo, useState } from 'react';
 import { FieldExtensionOptions } from '../../../extensions';
 import { TemplateParameterSchema } from '../../../types';
-import { createAsyncValidator } from './createAsyncValidators';
-import { createFieldValidation } from './schema';
+import { createAsyncValidators } from './createAsyncValidators';
 import { useTemplateSchema } from './useTemplateSchema';
 
 const useStyles = makeStyles(theme => ({
@@ -74,9 +73,9 @@ export const Stepper = (props: StepperProps) => {
     );
   }, [props.extensions]);
 
-  const validator = useMemo(() => {
+  const validation = useMemo(() => {
     const { mergedSchema } = steps[activeStep];
-    return createAsyncValidator(mergedSchema, validators, {
+    return createAsyncValidators(mergedSchema, validators, {
       apiHolder,
     });
   }, [steps, activeStep, validators, apiHolder]);
@@ -86,9 +85,11 @@ export const Stepper = (props: StepperProps) => {
   };
 
   const handleNext = async ({ formData }: { formData: JsonObject }) => {
+    // TODO(blam): What do we do about loading states, does each field extension get a chance
+    // to display it's own loading? Or should we grey out the entire form.
     setErrors(undefined);
 
-    const returnedValidation = await validator(formData);
+    const returnedValidation = await validation(formData);
 
     const hasErrors = Object.values(returnedValidation).some(i => {
       return i.__errors.length > 0;

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.test.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { JsonObject } from '@backstage/types';
+import { CustomFieldValidator } from '../../../extensions';
+import { createAsyncValidator } from './createAsyncValidators';
+
+describe('createAsyncValidators', () => {
+  it('should call the correct functions for validation', async () => {
+    const schema: JsonObject = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          'ui:field': 'NameField',
+        },
+        address: {
+          type: 'object',
+          'ui:field': 'AddressField',
+          properties: {
+            street: {
+              type: 'string',
+            },
+            postcode: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    };
+
+    const validators = { NameField: jest.fn(), AddressField: jest.fn() };
+
+    const validate = createAsyncValidator(schema, validators, {
+      apiHolder: { get: jest.fn() },
+    });
+
+    await validate({
+      name: 'asd',
+      address: { street: 'street', postcode: 'postcode' },
+    });
+
+    expect(validators.NameField).toHaveBeenCalled();
+    expect(validators.AddressField).toHaveBeenCalled();
+  });
+
+  it('should return the correct errors to the frontend', async () => {
+    const schema: JsonObject = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          'ui:field': 'NameField',
+        },
+        address: {
+          type: 'object',
+          'ui:field': 'AddressField',
+          properties: {
+            street: {
+              type: 'string',
+            },
+            postcode: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    };
+
+    const NameField: CustomFieldValidator<string> = (value, { addError }) => {
+      if (!value) {
+        addError('something is broken here!');
+      }
+    };
+
+    const AddressField: CustomFieldValidator<{
+      street?: string;
+      postcode?: string;
+    }> = (value, { addError }) => {
+      if (!value.postcode) {
+        addError('postcode is missing!');
+      }
+
+      if (!value.street) {
+        addError('street is missing here!');
+      }
+    };
+
+    const validate = createAsyncValidator(
+      schema,
+      {
+        NameField: NameField as CustomFieldValidator<unknown>,
+        AddressField: AddressField as CustomFieldValidator<unknown>,
+      },
+      {
+        apiHolder: { get: jest.fn() },
+      },
+    );
+
+    await expect(
+      validate({
+        name: 'asd',
+        address: { street: 'street', postcode: 'postcode' },
+      }),
+    ).resolves.toEqual({
+      name: expect.objectContaining({
+        __errors: [],
+      }),
+      address: expect.objectContaining({
+        __errors: [],
+      }),
+    });
+
+    await expect(
+      validate({
+        name: 'asd',
+        address: { street: '', postcode: 'postcode' },
+      }),
+    ).resolves.toEqual({
+      name: expect.objectContaining({
+        __errors: [],
+      }),
+      address: expect.objectContaining({
+        __errors: ['street is missing here!'],
+      }),
+    });
+
+    await expect(
+      validate({
+        name: '',
+        address: { street: '', postcode: '' },
+      }),
+    ).resolves.toEqual({
+      name: expect.objectContaining({
+        __errors: ['something is broken here!'],
+      }),
+      address: expect.objectContaining({
+        __errors: ['postcode is missing!', 'street is missing here!'],
+      }),
+    });
+  });
+});

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.test.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.test.ts
@@ -15,7 +15,7 @@
  */
 import { JsonObject } from '@backstage/types';
 import { CustomFieldValidator } from '../../../extensions';
-import { createAsyncValidator } from './createAsyncValidators';
+import { createAsyncValidators } from './createAsyncValidators';
 
 describe('createAsyncValidators', () => {
   it('should call the correct functions for validation', async () => {
@@ -43,7 +43,7 @@ describe('createAsyncValidators', () => {
 
     const validators = { NameField: jest.fn(), AddressField: jest.fn() };
 
-    const validate = createAsyncValidator(schema, validators, {
+    const validate = createAsyncValidators(schema, validators, {
       apiHolder: { get: jest.fn() },
     });
 
@@ -98,7 +98,7 @@ describe('createAsyncValidators', () => {
       }
     };
 
-    const validate = createAsyncValidator(
+    const validate = createAsyncValidators(
       schema,
       {
         NameField: NameField as CustomFieldValidator<unknown>,

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormValidation } from '@rjsf/core';
+import { JsonObject, JsonValue } from '@backstage/types';
+import { ApiHolder } from '@backstage/core-plugin-api';
+import { CustomFieldValidator } from '../../../extensions';
+
+function isObject(obj: unknown): obj is JsonObject {
+  return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
+}
+
+export const createAsyncValidator = (
+  rootSchema: JsonObject,
+  validators: Record<string, undefined | CustomFieldValidator<unknown>>,
+  context: {
+    apiHolder: ApiHolder;
+  },
+) => {
+  async function validate(
+    schema: JsonObject,
+    formData: JsonObject,
+    errors: FormValidation,
+  ) {
+    const schemaProps = schema.properties;
+    const customObject = schema.type === 'object' && schemaProps === undefined;
+
+    if (!isObject(schemaProps) && !customObject) {
+      return;
+    }
+
+    if (schemaProps) {
+      for (const [key, propData] of Object.entries(formData)) {
+        const propValidation = errors[key];
+
+        if (isObject(propData)) {
+          const propSchemaProps = schemaProps[key];
+          if (isObject(propSchemaProps)) {
+            await validate(
+              propSchemaProps,
+              propData as JsonObject,
+              propValidation as FormValidation,
+            );
+          }
+        } else {
+          const propSchema = schemaProps[key];
+          const fieldName =
+            isObject(propSchema) && (propSchema['ui:field'] as string);
+          if (fieldName && typeof validators[fieldName] === 'function') {
+            await validators[fieldName]!(
+              propData as JsonValue,
+              propValidation,
+              context,
+            );
+          }
+        }
+      }
+    } else if (customObject) {
+      const fieldName = schema['ui:field'] as string;
+      if (fieldName && typeof validators[fieldName] === 'function') {
+        await validators[fieldName]!(formData, errors, context);
+      }
+    }
+  }
+
+  return async (formData: JsonObject, errors: FormValidation) => {
+    await validate(rootSchema, formData, errors);
+    return errors;
+  };
+};

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.ts
@@ -21,7 +21,7 @@ import { CustomFieldValidator } from '../../../extensions';
 import { Draft07 as JSONSchema } from 'json-schema-library';
 import { createFieldValidation } from './schema';
 
-export const createAsyncValidator = (
+export const createAsyncValidators = (
   rootSchema: JsonObject,
   validators: Record<string, undefined | CustomFieldValidator<unknown>>,
   context: {
@@ -41,7 +41,11 @@ export const createAsyncValidator = (
         const validator = validators[definitionInSchema['ui:field']];
         if (validator) {
           const fieldValidation = createFieldValidation();
-          await validator(value, fieldValidation, context);
+          try {
+            await validator(value, fieldValidation, context);
+          } catch (ex) {
+            fieldValidation.addError(ex.message);
+          }
           formValidation[key] = fieldValidation;
         }
       }

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/createAsyncValidators.ts
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import { FieldValidation, FormValidation } from '@rjsf/core';
+import { FieldValidation } from '@rjsf/core';
 import { JsonObject } from '@backstage/types';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { CustomFieldValidator } from '../../../extensions';
 import { Draft07 as JSONSchema } from 'json-schema-library';
-
-function isObject(obj: unknown): obj is JsonObject {
-  return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
-}
+import { createFieldValidation } from './schema';
 
 export const createAsyncValidator = (
   rootSchema: JsonObject,
@@ -43,12 +40,7 @@ export const createAsyncValidator = (
       if (definitionInSchema && 'ui:field' in definitionInSchema) {
         const validator = validators[definitionInSchema['ui:field']];
         if (validator) {
-          const fieldValidation = {
-            __errors: [] as string[],
-            addError: (message: string) => {
-              fieldValidation.__errors.push(message);
-            },
-          };
+          const fieldValidation = createFieldValidation();
           await validator(value, fieldValidation, context);
           formValidation[key] = fieldValidation;
         }

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/schema.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/schema.ts
@@ -114,7 +114,6 @@ export const extractSchemaFromStep = (
 /**
  * @alpha
  * Creates a field validation object for use in react jsonschema form
- * @returns {FieldValidation} A field validation object that can be used to validate a field
  */
 export const createFieldValidation = (): FieldValidation => {
   const fieldValidation: FieldValidation = {

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/schema.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/schema.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { JsonObject } from '@backstage/types';
-import { UiSchema } from '@rjsf/core';
+import { FieldValidation, UiSchema } from '@rjsf/core';
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -109,4 +109,20 @@ export const extractSchemaFromStep = (
   const returnSchema: JsonObject = JSON.parse(JSON.stringify(inputStep));
   extractUiSchema(returnSchema, uiSchema);
   return { uiSchema, schema: returnSchema };
+};
+
+/**
+ * @alpha
+ * Creates a field validation object for use in react jsonschema form
+ * @returns {FieldValidation} A field validation object that can be used to validate a field
+ */
+export const createFieldValidation = (): FieldValidation => {
+  const fieldValidation: FieldValidation = {
+    __errors: [] as string[],
+    addError: (message: string) => {
+      fieldValidation.__errors.push(message);
+    },
+  };
+
+  return fieldValidation;
 };

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/useTemplateSchema.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/useTemplateSchema.ts
@@ -24,6 +24,7 @@ export const useTemplateSchema = (
 ): {
   steps: {
     uiSchema: UiSchema;
+    originalSchema: JsonObject;
     schema: JsonObject;
     title: string;
     description?: string;
@@ -33,6 +34,7 @@ export const useTemplateSchema = (
   const steps = manifest.steps.map(({ title, description, schema }) => ({
     title,
     description,
+    originalSchema: schema,
     ...extractSchemaFromStep(schema),
   }));
 
@@ -45,6 +47,7 @@ export const useTemplateSchema = (
     // Then filter out the properties that are not enabled with feature flag
     .map(step => ({
       ...step,
+
       schema: {
         ...step.schema,
         // Title is rendered at the top of the page, so let's ignore this from jsonschemaform

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/useTemplateSchema.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/useTemplateSchema.ts
@@ -24,7 +24,7 @@ export const useTemplateSchema = (
 ): {
   steps: {
     uiSchema: UiSchema;
-    originalSchema: JsonObject;
+    mergedSchema: JsonObject;
     schema: JsonObject;
     title: string;
     description?: string;
@@ -34,7 +34,7 @@ export const useTemplateSchema = (
   const steps = manifest.steps.map(({ title, description, schema }) => ({
     title,
     description,
-    originalSchema: schema,
+    mergedSchema: schema,
     ...extractSchemaFromStep(schema),
   }));
 

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/useTemplateSchema.ts
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/useTemplateSchema.ts
@@ -47,7 +47,6 @@ export const useTemplateSchema = (
     // Then filter out the properties that are not enabled with feature flag
     .map(step => ({
       ...step,
-
       schema: {
         ...step.schema,
         // Title is rendered at the top of the page, so let's ignore this from jsonschemaform

--- a/yarn.lock
+++ b/yarn.lock
@@ -12254,6 +12254,11 @@ easy-table@1.1.0:
   optionalDependencies:
     wcwidth ">=1.0.1"
 
+ebnf@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/ebnf/-/ebnf-1.9.0.tgz#9c2dd6052f3ed43a69c1f0b07b15bd03cefda764"
+  integrity sha512-LKK899+j758AgPq00ms+y90mo+2P86fMKUWD28sH0zLKUj7aL6iIH2wy4jejAMM9I2BawJ+2kp6C3mMXj+Ii5g==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -14651,6 +14656,25 @@ grpc-docs@^1.0.6, grpc-docs@^1.1.2:
     rollup-plugin-smart-asset "^2.1.2"
     styled-components "^5.3.3"
 
+gson-conform@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/gson-conform/-/gson-conform-1.0.3.tgz#6f982f98ea84199280bd48b6bfbcd0ae7447f1e2"
+  integrity sha512-gaZQN/5ZbohkLBOs4JKHkg/IdOB9kuuEr5SVLAjHUs+Q+Nl746DRe18GgQy4oxxVXStO//Zga2wg4eWL9Mfshw==
+
+gson-pointer@4.1.1, gson-pointer@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/gson-pointer/-/gson-pointer-4.1.1.tgz#088d6aa38d52753530288d13b5a75b6a43170e9b"
+  integrity sha512-rOS/zCLUI8BT0+/U+p5nzI0RfhIyRmzkpwzyCj8gcLoRl3rHuysk6ci1IQ955AQQZDSNN3mVec26Sx9wRZ0EjA==
+
+gson-query@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/gson-query/-/gson-query-5.1.0.tgz#8f34a062849f8c08be0c35eddaa2ad18a4326a49"
+  integrity sha512-xKb/90XfmLLKGgX8Y7LRF4yKnMR/ckV5WOQ/Ip0pRXuDh7jUhdY1UYjPvQnF7/UMbNsAo0168j2j0yt9+4QdaA==
+  dependencies:
+    ebnf "^1.9.0"
+    gson-conform "^1.0.3"
+    gson-pointer "4.1.1"
+
 gtoken@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/gtoken/-/gtoken-6.0.1.tgz#1276371d51e93c4eface76e3f30f9e8f1cad3f1a"
@@ -16988,6 +17012,17 @@ json-schema-compare@^0.2.2:
   integrity sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==
   dependencies:
     lodash "^4.17.4"
+
+json-schema-library@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/json-schema-library/-/json-schema-library-6.0.0.tgz#2a823d850031842c6917f41a8c576af3b603ab48"
+  integrity sha512-1nTpSmyfmgJpaNPIBO1SnHpXiMUh76hZnqSuCrJr7Lcu2N2SB55UPgf5F790r4dy4i4o/Moaw7OdqDhEmxP/Rw==
+  dependencies:
+    deepmerge "^4.2.2"
+    fast-deep-equal "^3.1.3"
+    gson-pointer "^4.1.1"
+    gson-query "^5.1.0"
+    valid-url "^1.0.9"
 
 json-schema-merge-allof@^0.6.0:
   version "0.6.0"
@@ -25925,6 +25960,11 @@ v8-to-istanbul@^8.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Fixes #7868
Fixes #8420