### PR TITLE
feat(backend-common): added ports range

### DIFF
--- a/.changeset/old-rockets-doubt.md
+++ b/.changeset/old-rockets-doubt.md
@@ -1,0 +1,11 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added port ranges in allowed hosts:
+
+```yaml
+reading:
+    allow:
+      - host: *.examples.org:900-1000
+```


### PR DESCRIPTION
Signed-off-by: Antonio Musolino <antoniomusolino007@gmail.com>

## Hey, I just made a Pull Request!

Hello, I added the possibility to specify a port range in the `backend.reading.allow` in the form: `.example.com:100-1000`; I need it because, in my company, we have services deployed under different ports internally. WDYT? 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
