### PR TITLE
Add PATCH and HEAD to the Access-Control-Allow-Methods

### DIFF
--- a/.changeset/wicked-knives-wink.md
+++ b/.changeset/wicked-knives-wink.md
@@ -3,3 +3,13 @@
 ---
 
 Add `PATCH` and `HEAD` to the `Access-Control-Allow-Methods`.
+
+
+To apply this change to your Backstage installation make the following change to your `app-config.yaml`
+
+```diff
+   cors:
+     origin: http://localhost:3000
+-    methods: [GET, POST, PUT, DELETE]
++    methods: [GET, POST, PUT, DELETE, PATCH, HEAD]
+```

--- a/.changeset/wicked-knives-wink.md
+++ b/.changeset/wicked-knives-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Add `PATCH` and `HEAD` to the `Access-Control-Allow-Methods`.

--- a/.changeset/wicked-knives-wink.md
+++ b/.changeset/wicked-knives-wink.md
@@ -4,7 +4,6 @@
 
 Add `PATCH` and `HEAD` to the `Access-Control-Allow-Methods`.
 
-
 To apply this change to your Backstage installation make the following change to your `app-config.yaml`
 
 ```diff

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -39,7 +39,7 @@ backend:
     store: memory
   cors:
     origin: http://localhost:3000
-    methods: [GET, POST, PUT, DELETE]
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
   csp:
     connect-src: ["'self'", 'http:', 'https:']

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -24,7 +24,7 @@ backend:
     # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   cors:
     origin: http://localhost:3000
-    methods: [GET, POST, PUT, DELETE]
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
   # This is for local developement only, it is not recommended to use this in production
   # The production database configuration is stored in app-config.production.yaml


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <vincenzos@spotify.com>

## Hey, I just made a Pull Request!

This PR adds the `PATCH` and `HEAD` to the `Access-Control-Allow-Methods`.

Since Backstage uses [cors](https://www.npmjs.com/package/cors), it could make sense to allow the same methods that are allowed in the cors default configuration.

Feel free to discard this PR in case there was any specific reason why the two new methods weren't allowed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
