### PR TITLE
Implement EntityKindPicker allowing to filter on multiple kinds

### DIFF
--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -28,14 +28,19 @@ import { getEntityRelations } from './utils';
  * @public
  */
 export class EntityKindFilter implements EntityFilter {
-  constructor(readonly value: string) {}
+  constructor(readonly value: string | string[]) {}
 
-  getCatalogFilters(): Record<string, string | string[]> {
-    return { kind: this.value };
+  // Simplify `string | string[]` for consumers, always returns an array
+  getKinds(): string[] {
+    return Array.isArray(this.value) ? this.value : [this.value];
   }
 
-  toQueryValue(): string {
-    return this.value;
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { kind: this.getKinds() };
+  }
+
+  toQueryValue(): string[] {
+    return this.getKinds();
   }
 }
 

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -34,6 +34,7 @@ import {
   EntityTypePicker,
   UserListFilterKind,
   UserListPicker,
+  EntityKindPicker,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { createComponentRouteRef } from '../../routes';
@@ -83,6 +84,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
           </ContentHeader>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
+              <EntityKindPicker />
               <EntityTypePicker />
               <UserListPicker initialFilter={initiallySelectedFilter} />
               <EntityOwnerPicker />

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -70,7 +70,12 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const defaultColumns: TableColumn<CatalogTableRow>[] = useMemo(() => {
     return [
       columnFactories.createTitleColumn({ hidden: true }),
-      columnFactories.createNameColumn({ defaultKind: filters.kind?.value }),
+      columnFactories.createNameColumn({
+        defaultKind:
+          filters.kind?.getKinds()?.length === 1
+            ? filters.kind?.getKinds()[0]
+            : undefined,
+      }),
       ...createEntitySpecificColumns(),
       columnFactories.createMetadataDescriptionColumn(),
       columnFactories.createTagsColumn(),
@@ -100,7 +105,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
           ];
       }
     }
-  }, [filters.kind?.value]);
+  }, [filters.kind]);
 
   const showTypeColumn = filters.type === undefined;
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar


### PR DESCRIPTION
This change implements the EntityKindPicker allowing for selecting multiple kinds.

This is a draft of implementing a more clear kind picker that also support multiple kinds at once.

It is currently breaking any logic based on filter kind which needs to be considered more carefully.

More discussion can be found at https://github.com/backstage/backstage/issues/9616#issuecomment-1205412715

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

![image](https://user-images.githubusercontent.com/6881694/182887659-f5992397-6d44-4783-b52d-a008b41421f6.png)

![image](https://user-images.githubusercontent.com/6881694/182887697-7339ef4f-e940-44af-b8a5-fc3e31d9939c.png)
![image](https://user-images.githubusercontent.com/6881694/182887735-29e50c5c-0a99-4f2d-9b8c-7f68bb731e00.png)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
