### PR TITLE
Add `reviewers` and `teamReviewers` params to `publish:github:pull-request` action

### DIFF
--- a/.changeset/tricky-ligers-move.md
+++ b/.changeset/tricky-ligers-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added `reviewers` and `teamReviewers` parameters to `publish:github:pull-request` action to add reviewers on the pull request created by the action

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -20,6 +20,7 @@ import { Knex } from 'knex';
 import { LocationSpec } from '@backstage/plugin-catalog-backend';
 import { Logger } from 'winston';
 import { Observable } from '@backstage/types';
+import { Octokit } from 'octokit';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { Schema } from 'jsonschema';
 import { ScmIntegrationRegistry } from '@backstage/integration';
@@ -391,6 +392,8 @@ export const createPublishGithubPullRequestAction: ({
   targetPath?: string | undefined;
   sourcePath?: string | undefined;
   token?: string | undefined;
+  reviewers?: string[] | undefined;
+  teamReviewers?: string[] | undefined;
 }>;
 
 // @public
@@ -419,7 +422,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   branchName: string;
   targetPath: string;
   token?: string | undefined;
-  commitAction?: 'update' | 'create' | 'delete' | undefined;
+  commitAction?: 'update' | 'delete' | 'create' | undefined;
   projectid?: string | undefined;
   removeSourceBranch?: boolean | undefined;
   assignee?: string | undefined;
@@ -523,15 +526,14 @@ export function fetchContents({
 }): Promise<void>;
 
 // @public (undocumented)
-export interface OctokitWithPullRequestPluginClient {
-  // (undocumented)
+export type OctokitWithPullRequestPluginClient = Octokit & {
   createPullRequest(options: createPullRequest.Options): Promise<{
     data: {
       html_url: string;
       number: number;
     };
   } | null>;
-}
+};
 
 // @public
 export interface RouterOptions {

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -422,7 +422,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   branchName: string;
   targetPath: string;
   token?: string | undefined;
-  commitAction?: 'update' | 'delete' | 'create' | undefined;
+  commitAction?: 'update' | 'create' | 'delete' | undefined;
   projectid?: string | undefined;
   removeSourceBranch?: boolean | undefined;
   assignee?: string | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -287,6 +287,8 @@ describe('createPublishGithubPullRequestAction', () => {
         teamReviewers: ['team-foo'],
       };
 
+      mockFs({ [workspacePath]: {} });
+
       ctx = {
         createTemporaryDirectory: jest.fn(),
         output: jest.fn(),
@@ -336,6 +338,8 @@ describe('createPublishGithubPullRequestAction', () => {
         branchName: 'new-app',
         description: 'This PR is really good',
       };
+
+      mockFs({ [workspacePath]: {} });
 
       ctx = {
         createTemporaryDirectory: jest.fn(),

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -26,7 +26,6 @@ import { resolve as resolvePath } from 'path';
 import { Writable } from 'stream';
 import { ActionContext, TemplateAction } from '../../types';
 import {
-  CreateGithubPullRequestClientFactoryInput,
   createPublishGithubPullRequestAction,
   OctokitWithPullRequestPluginClient,
 } from './githubPullRequest';
@@ -42,11 +41,12 @@ type GithubPullRequestActionInput = ReturnType<
 
 describe('createPublishGithubPullRequestAction', () => {
   let instance: TemplateAction<GithubPullRequestActionInput>;
-  let fakeClient: OctokitWithPullRequestPluginClient;
-
-  let clientFactory: (
-    input: CreateGithubPullRequestClientFactoryInput,
-  ) => Promise<OctokitWithPullRequestPluginClient>;
+  let fakeClient: {
+    createPullRequest: jest.Mock;
+    rest: {
+      pulls: { requestReviewers: jest.Mock };
+    };
+  };
 
   beforeEach(() => {
     const integrations = ScmIntegrations.fromConfig(new ConfigReader({}));
@@ -64,11 +64,13 @@ describe('createPublishGithubPullRequestAction', () => {
       }),
       rest: {
         pulls: {
-          requestReviewers: jest.fn(async (_: any) => ({ data: {} }))
-        }
-      }
+          requestReviewers: jest.fn(async (_: any) => ({ data: {} })),
+        },
+      },
     };
-    clientFactory = jest.fn(async () => fakeClient);
+    const clientFactory = jest.fn(
+      async () => fakeClient as unknown as OctokitWithPullRequestPluginClient,
+    );
     const githubCredentialsProvider: GithubCredentialsProvider = {
       getCredentials: jest.fn(),
     };
@@ -78,6 +80,11 @@ describe('createPublishGithubPullRequestAction', () => {
       githubCredentialsProvider,
       clientFactory,
     });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+    jest.resetAllMocks();
   });
 
   describe('with no sourcePath', () => {
@@ -106,6 +113,7 @@ describe('createPublishGithubPullRequestAction', () => {
         workspacePath,
       };
     });
+
     it('creates a pull request', async () => {
       await instance.handler(ctx);
 
@@ -140,10 +148,6 @@ describe('createPublishGithubPullRequestAction', () => {
       );
       expect(ctx.output).toHaveBeenCalledWith('pullRequestNumber', 123);
     });
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
-    });
   });
 
   describe('with sourcePath', () => {
@@ -174,11 +178,6 @@ describe('createPublishGithubPullRequestAction', () => {
         input,
         workspacePath,
       };
-    });
-
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
     });
 
     it('creates a pull request with only relevant files', async () => {
@@ -272,10 +271,6 @@ describe('createPublishGithubPullRequestAction', () => {
       );
       expect(ctx.output).toHaveBeenCalledWith('pullRequestNumber', 123);
     });
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
-    });
   });
 
   describe('with reviewers and teamReviewers', () => {
@@ -289,7 +284,7 @@ describe('createPublishGithubPullRequestAction', () => {
         branchName: 'new-app',
         description: 'This PR is really good',
         reviewers: ['foobar'],
-        teamReviewers: ['team-foo']
+        teamReviewers: ['team-foo'],
       };
 
       ctx = {
@@ -312,12 +307,14 @@ describe('createPublishGithubPullRequestAction', () => {
         pull_number: 123,
         reviewers: ['foobar'],
         team_reviewers: ['team-foo'],
-      })
+      });
     });
 
     it('creates outputs for the pull request url and number even if requesting reviewers fails', async () => {
-      fakeClient.rest.pulls.requestReviewers.mockImplementation(() => { throw new Error('a random error') })
-      
+      fakeClient.rest.pulls.requestReviewers.mockImplementation(() => {
+        throw new Error('a random error');
+      });
+
       await instance.handler(ctx);
 
       expect(ctx.output).toHaveBeenCalledWith(
@@ -326,12 +323,7 @@ describe('createPublishGithubPullRequestAction', () => {
       );
       expect(ctx.output).toHaveBeenCalledWith('pullRequestNumber', 123);
     });
-
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
-    });
-  })
+  });
 
   describe('with no reviewers and teamReviewers', () => {
     let input: GithubPullRequestActionInput;
@@ -361,12 +353,7 @@ describe('createPublishGithubPullRequestAction', () => {
       expect(fakeClient.createPullRequest).toBeCalled();
       expect(fakeClient.rest.pulls.requestReviewers).not.toBeCalled();
     });
-
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
-    });
-  })
+  });
 
   describe('with executable file mode 755', () => {
     let input: GithubPullRequestActionInput;
@@ -430,10 +417,6 @@ describe('createPublishGithubPullRequestAction', () => {
         'https://github.com/myorg/myrepo/pull/123',
       );
       expect(ctx.output).toHaveBeenCalledWith('pullRequestNumber', 123);
-    });
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
     });
   });
 
@@ -499,10 +482,6 @@ describe('createPublishGithubPullRequestAction', () => {
         'https://github.com/myorg/myrepo/pull/123',
       );
       expect(ctx.output).toHaveBeenCalledWith('pullRequestNumber', 123);
-    });
-    afterEach(() => {
-      mockFs.restore();
-      jest.resetAllMocks();
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -180,7 +180,8 @@ export const createPublishGithubPullRequestAction = ({
             items: {
               type: 'string',
             },
-            description: 'Pull Request Reviewers',
+            description:
+              'The users that will be added as reviewers to the pull request',
           },
           teamReviewers: {
             title: 'Pull Request Team Reviewers',
@@ -188,7 +189,8 @@ export const createPublishGithubPullRequestAction = ({
             items: {
               type: 'string',
             },
-            description: 'Pull Request Team Reviewers',
+            description:
+              'The teams that will be added as reviewers to the pull request',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -280,7 +280,7 @@ export const createPublishGithubPullRequestAction = ({
         }
 
         const pullRequestNumber = response.data.number;
-        if (reviewers !== null || teamReviewers !== null) {
+        if (reviewers || teamReviewers) {
           try {
             const result = await client.rest.pulls.requestReviewers({
               owner,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds two new parameters to the `publish:github:pull-request` scaffolder action to specify the users and the teams that will be added as reviewers to the created PR.
Reviewers are added to the PR via an extra API call. We've decided not to make the action fail if the latter call fails, since the PR creation is the main goal of the action (but any error is logged).  

Closes #9571 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
