### PR TITLE
Allow unknown typed location from being registered via the location service by configuration settings

### DIFF
--- a/.changeset/flat-plums-shout.md
+++ b/.changeset/flat-plums-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow unknown typed location from being registered via the location service by configuration settings

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -55,6 +55,23 @@ export interface Config {
     readonly?: boolean;
 
     /**
+     * Allow unknown type when create location.
+     *
+     * Setting 'locationService.create.allowUnknownType=false' forbids to create
+     * location with unknown type through location service.
+     * This is the default value.
+     *
+     * Setting 'locationService.create.allowUnknownType=true' allows to create
+     * location with unknown type through location service.
+     *
+     */
+    locationService?: {
+      create?: {
+        allowUnknownType: boolean;
+      };
+    };
+
+    /**
      * A set of static locations that the catalog shall always keep itself
      * up-to-date with. This is commonly used for large, permanent integrations
      * that are defined by the Backstage operators at an organization, rather

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -465,7 +465,7 @@ export class CatalogBuilder {
     const locationAnalyzer =
       this.locationAnalyzer ?? new RepoLocationAnalyzer(logger, integrations);
     const locationService = new AuthorizedLocationService(
-      new DefaultLocationService(locationStore, orchestrator),
+      new DefaultLocationService(locationStore, orchestrator, config),
       permissionEvaluator,
     );
     const refreshService = new AuthorizedRefreshService(

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -26,18 +26,26 @@ import { LocationInput, LocationService, LocationStore } from './types';
 import { locationSpecToMetadataName } from '../util/conversion';
 import { InputError } from '@backstage/errors';
 import { DeferredEntity } from '@backstage/plugin-catalog-node';
+import { Config } from '@backstage/config';
 
 export class DefaultLocationService implements LocationService {
   constructor(
     private readonly store: LocationStore,
     private readonly orchestrator: CatalogProcessingOrchestrator,
+    private readonly config: Config,
   ) {}
 
   async createLocation(
     input: LocationInput,
     dryRun: boolean,
   ): Promise<{ location: Location; entities: Entity[]; exists?: boolean }> {
-    if (input.type !== 'url') {
+    const allowUnknownTypeConfigName =
+      'catalog.locationService.create.allowUnknownType';
+    const allowUnknownType =
+      this.config.has(allowUnknownTypeConfigName) &&
+      this.config.getBoolean(allowUnknownTypeConfigName);
+
+    if (!allowUnknownType && input.type !== 'url') {
       throw new InputError(`Registered locations must be of type 'url'`);
     }
     if (dryRun) {


### PR DESCRIPTION
Allow unknown typed location from being registered via the location service by configuration settings

Signed-off-by: Stéphane MORI <stephane.mori@gmail.com>

The following commit add a check to control location type : https://github.com/backstage/backstage/commit/8838b13038cf86ef90e6ce1506097a8fc4047dcb 
This check exists for security reason. But I use this method to create location with custom type. 
So I submit a solution to allow unknown location type even if default configuration doesn't allow it.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
