### PR TITLE
GitHub Entity Provider - Improved support for wildcards in `catalogPath`

### DIFF
--- a/.changeset/tall-mugs-press.md
+++ b/.changeset/tall-mugs-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Improved support for wildcards in `catalogPath`

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -74,6 +74,12 @@ catalog:
         filters: # optional filters
           branch: 'develop' # optional string
           repository: '.*' # optional Regex
+      wildcardProviderId:
+        organization: 'new-org' # string
+        catalogPath: '/groups/**/*.yaml' # this will search all folders for files that end in .yaml
+        filters: # optional filters
+          branch: 'develop' # optional string
+          repository: '.*' # optional Regex
 ```
 
 This provider supports multiple organizations via unique provider IDs.
@@ -84,7 +90,7 @@ This provider supports multiple organizations via unique provider IDs.
 - **`catalogPath`** _(optional)_:
   Default: `/catalog-info.yaml`.
   Path where to look for `catalog-info.yaml` files.
-  When started with `/`, it is an absolute path from the repo root.
+  You can use wildcards - `*` or `**` - to search the path and/or the filename
 - **filters** _(optional)_:
   - **branch** _(optional)_:
     String used to filter results based on the branch name.

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.test.ts
@@ -153,7 +153,7 @@ describe('GitHubEntityProvider', () => {
     expect(taskDef.id).toEqual('github-provider:myProvider:refresh');
     await (taskDef.fn as () => Promise<void>)();
 
-    const url = `https://github.com/test-org/test-repo/blob/main/catalog-custom.yaml`;
+    const url = `https://github.com/test-org/test-repo/blob/main/custom/path/catalog-custom.yaml`;
     const expectedEntities = [
       {
         entity: {
@@ -164,7 +164,7 @@ describe('GitHubEntityProvider', () => {
               'backstage.io/managed-by-location': `url:${url}`,
               'backstage.io/managed-by-origin-location': `url:${url}`,
             },
-            name: 'generated-21936a3d1e926b8bb3b00ac4398dc9a8dbb90b45',
+            name: 'generated-5e4b9498097f15434e88c477cfba6c079aa8ca7f',
           },
           spec: {
             presence: 'optional',

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.ts
@@ -195,9 +195,9 @@ export class GitHubEntityProvider implements EntityProvider {
   private createLocationUrl(repository: Repository): string {
     const branch =
       this.config.filters?.branch || repository.defaultBranchRef?.name || '-';
-    const catalogFile = this.config.catalogPath.substring(
-      this.config.catalogPath.lastIndexOf('/') + 1,
-    );
+    const catalogFile = this.config.catalogPath.startsWith('/')
+      ? this.config.catalogPath.substring(1)
+      : this.config.catalogPath;
     return `${repository.url}/blob/${branch}/${catalogFile}`;
   }
 


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Improved support for wildcards in `catalogPath` for the GitHub Entity Provider 

**Note:** This fixes the issue we are experiencing in #12992 but I worry it breaks the absolute path functionality mentioned in the docs here: https://github.com/backstage/backstage/blob/08ba32c80711cfe622802ce1058e5c8a9cd76bd3/docs/integrations/github/discovery.md?plain=1#L87

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
