### PR TITLE
scaffolder: change how we lookup the ui:schema for properties in the form for validation

### DIFF
--- a/.changeset/forty-waves-breathe.md
+++ b/.changeset/forty-waves-breathe.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Fixing validation for arrays, objects and other parts of the `jsonschema` with `anyOf` and `allOf`
+- Fixing validation for arrays, objects and other parts of the `jsonschema` with `anyOf` and `allOf`
+- Correctly handle different states for the form, so that the review step renders correctly when using `dependencies` in the templates.

--- a/.changeset/forty-waves-breathe.md
+++ b/.changeset/forty-waves-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixing validation for arrays, objects and other parts of the `jsonschema` with `anyOf` and `allOf`

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -270,6 +270,9 @@ catalog:
     # Backstage end-to-end tests of TechDocs
     - type: file
       target: ../../cypress/e2e-fixture.catalog.info.yaml
+
+    - type: url
+      target: https://github.com/benjdlambert/software-templates/blob/main/scaffolder-templates/dependencies/template.yaml
 scaffolder:
   # Use to customize default commit author info used when new components are created
   # defaultAuthor:

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -84,14 +84,17 @@ import {
 } from '@backstage/plugin-user-settings';
 import { AdvancedSettings } from './components/advancedSettings';
 import AlarmIcon from '@material-ui/icons/Alarm';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { hot } from 'react-hot-loader/root';
 import { Navigate, Route } from 'react-router';
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';
 import { homePage } from './components/home/HomePage';
 import { Root } from './components/Root';
-import { LowerCaseValuePickerFieldExtension } from './components/scaffolder/customScaffolderExtensions';
+import {
+  CustomFieldExtension,
+  LowerCaseValuePickerFieldExtension,
+} from './components/scaffolder/customScaffolderExtensions';
 import { defaultPreviewTemplate } from './components/scaffolder/defaultPreviewTemplate';
 import { searchPage } from './components/search/SearchPage';
 import { providers } from './identityProviders';
@@ -101,6 +104,7 @@ import { techDocsPage } from './components/techdocs/TechDocsPage';
 import { ApacheAirflowPage } from '@backstage/plugin-apache-airflow';
 import { PermissionedRoute } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
+import useMountedState from 'react-use/lib/useMountedState';
 
 const app = createApp({
   apis,
@@ -210,6 +214,7 @@ const routes = (
       }
     >
       <ScaffolderFieldExtensions>
+        <CustomFieldExtension />
         <LowerCaseValuePickerFieldExtension />
       </ScaffolderFieldExtensions>
     </Route>

--- a/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
+++ b/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
@@ -62,3 +62,45 @@ export const LowerCaseValuePickerFieldExtension = scaffolderPlugin.provide(
     },
   }),
 );
+
+const CustomFieldComponent = (props: FieldExtensionComponentProps<string>) => {
+  const {
+    idSchema,
+    schema: { title, description },
+    formData,
+    onChange,
+    required,
+    rawErrors,
+  } = props;
+
+  return (
+    <TextField
+      id={idSchema?.$id}
+      label={title}
+      value={formData || ''}
+      fullWidth
+      onChange={({ target: { value } }) => onChange(value)}
+      required={required}
+      error={rawErrors?.length > 0 && !formData}
+      helperText={description}
+    />
+  );
+};
+
+export const CustomFieldExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'CustomField',
+    component: CustomFieldComponent,
+    validation: (value: string, validation: FieldValidation) => {
+      try {
+        if (!value) {
+          validation.addError('Properties is required');
+        } else {
+          // TODO
+        }
+      } catch (error) {
+        validation.addError('Ops! Something wrong');
+      }
+    },
+  }),
+);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -28,7 +28,6 @@ import {
   SecureTemplater,
 } from '../../../../lib/templating/SecureTemplater';
 import path from 'path';
-import { parseRepoUrl } from '../publish/util';
 
 /**
  * Downloads a skeleton, templates variables into file and directory names and content.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -220,13 +220,6 @@ export function createFetchTemplateAction(options: {
       const renderTemplate = await SecureTemplater.loadRenderer({
         cookiecutterCompat: ctx.input.cookiecutterCompat,
         additionalTemplateFilters,
-        // TODO(blam): let's work out how we can deprecate this.
-        // We shouldn't really need to be exposing these now we can deal with
-        // objects in the params block.
-        // Maybe we can expose a new RepoUrlPicker with secrets for V3 that provides an object already.
-        parseRepoUrl(url: string) {
-          return parseRepoUrl(url, integrations);
-        },
       });
 
       for (const location of allEntriesInTemplate) {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -28,6 +28,7 @@ import {
   SecureTemplater,
 } from '../../../../lib/templating/SecureTemplater';
 import path from 'path';
+import { parseRepoUrl } from '../publish/util';
 
 /**
  * Downloads a skeleton, templates variables into file and directory names and content.
@@ -219,6 +220,13 @@ export function createFetchTemplateAction(options: {
       const renderTemplate = await SecureTemplater.loadRenderer({
         cookiecutterCompat: ctx.input.cookiecutterCompat,
         additionalTemplateFilters,
+        // TODO(blam): let's work out how we can deprecate this.
+        // We shouldn't really need to be exposing these now we can deal with
+        // objects in the params block.
+        // Maybe we can expose a new RepoUrlPicker with secrets for V3 that provides an object already.
+        parseRepoUrl(url: string) {
+          return parseRepoUrl(url, integrations);
+        },
       });
 
       for (const location of allEntriesInTemplate) {

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -65,6 +65,7 @@
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.1",
     "json-schema": "^0.4.0",
+    "json-schema-library": "^6.0.0",
     "lodash": "^4.17.21",
     "luxon": "^3.0.0",
     "qs": "^6.9.4",

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -29,7 +29,7 @@ import {
   useApi,
   featureFlagsApiRef,
 } from '@backstage/core-plugin-api';
-import { FormProps, IChangeEvent, UiSchema, withTheme } from '@rjsf/core';
+import { FormProps, IChangeEvent, withTheme } from '@rjsf/core';
 import { Theme as MuiTheme } from '@rjsf/material-ui';
 import React, { useState } from 'react';
 import { transformSchemaToProps } from './schema';

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -31,7 +31,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { FormProps, IChangeEvent, withTheme } from '@rjsf/core';
 import { Theme as MuiTheme } from '@rjsf/material-ui';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { transformSchemaToProps } from './schema';
 import { Content, StructuredMetadataTable } from '@backstage/core-components';
 import cloneDeep from 'lodash/cloneDeep';
@@ -51,7 +51,7 @@ type Props = {
    * Steps for the form, each contains title and form schema
    */
   steps: Step[];
-  intialFormData: Record<string, any>;
+  intialFormData?: Record<string, any>;
   widgets?: FormProps<any>['widgets'];
   fields?: FormProps<any>['fields'];
   finishButtonLabel?: string;

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JsonObject } from '@backstage/types';
+import { JsonObject, JsonValue } from '@backstage/types';
 import {
   Box,
   Button,
@@ -110,12 +110,7 @@ export const MultistepJsonForm = (props: Props) => {
 
   const [formState, setFormState] = useState({});
   useEffect(() => {
-    setFormState(
-      Array.from(stepsState.values()).reduce((curr, next) => ({
-        ...curr,
-        ...next,
-      })),
-    );
+    setFormState(Object.assign({}, ...stepsState.values()));
   }, [stepsState]);
 
   const [disableButtons, setDisableButtons] = useState(false);
@@ -214,7 +209,7 @@ export const MultistepJsonForm = (props: Props) => {
                   widgets={widgets}
                   noHtml5Validate
                   formData={formChangeData}
-                  formContext={{ formData: formChangeData }}
+                  formContext={{ formData: formState }}
                   onChange={onChange}
                   onSubmit={e => {
                     if (e.errors.length === 0) handleNext(e);

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -107,11 +107,7 @@ export const MultistepJsonForm = (props: Props) => {
   const [activeStep, setActiveStep] = useState(0);
   const [formChangeData, setFormChangeData] = useState(intialFormData);
   const stepsState = useMap();
-
   const [formState, setFormState] = useState({});
-  useEffect(() => {
-    setFormState(Object.assign({}, ...stepsState.values()));
-  }, [stepsState]);
 
   const [disableButtons, setDisableButtons] = useState(false);
   const errorApi = useApi(errorApiRef);
@@ -163,6 +159,15 @@ export const MultistepJsonForm = (props: Props) => {
   const handleNext = (e: IChangeEvent) => {
     stepsState.set(activeStep, e.formData);
     setActiveStep(Math.min(activeStep + 1, steps.length));
+    setFormState(
+      Array.from(stepsState.values()).reduce(
+        (curr, next) => ({
+          ...curr,
+          ...next,
+        }),
+        {},
+      ),
+    );
   };
 
   const onChange = (e: IChangeEvent) => {

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -208,13 +208,12 @@ export const MultistepJsonForm = (props: Props) => {
               </StepLabel>
               <StepContent key={title}>
                 <Form
-                  omitExtraData
                   showErrorList={false}
                   fields={{ ...fieldOverrides, ...fields }}
                   widgets={widgets}
-                  noHtml5Validate
                   formData={formChangeData}
                   formContext={{ formData: formState }}
+                  key={activeStep}
                   onChange={onChange}
                   onSubmit={e => {
                     if (e.errors.length === 0) handleNext(e);

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -37,6 +37,7 @@ import { Content, StructuredMetadataTable } from '@backstage/core-components';
 import cloneDeep from 'lodash/cloneDeep';
 import * as fieldOverrides from './FieldOverrides';
 import { Draft07 as JSONSchema } from 'json-schema-library';
+import { utils } from '@rjsf/core';
 
 const Form = withTheme(MuiTheme);
 type Step = {
@@ -60,7 +61,9 @@ type Props = {
 
 export function getReviewData(formData: Record<string, any>, steps: Step[]) {
   const reviewData: Record<string, any> = {};
-  const schemas = steps.map(step => new JSONSchema(step.schema));
+  const schemas = steps.map(
+    step => new JSONSchema(utils.retrieveSchema(step.schema, {}, formData)),
+  );
 
   for (const [key] of Object.entries(formData)) {
     const uiSchema = schemas
@@ -191,7 +194,6 @@ export const MultistepJsonForm = (props: Props) => {
               </StepLabel>
               <StepContent key={title}>
                 <Form
-                  liveOmit
                   showErrorList={false}
                   fields={{ ...fieldOverrides, ...fields }}
                   widgets={widgets}

--- a/plugins/scaffolder/src/components/TemplateEditorPage/TemplateEditorForm.tsx
+++ b/plugins/scaffolder/src/components/TemplateEditorPage/TemplateEditorForm.tsx
@@ -179,7 +179,6 @@ export function TemplateEditorForm(props: TemplateEditorFormProps) {
           <MultistepJsonForm
             steps={steps}
             fields={fields}
-            intialFormData={{}}
             finishButtonLabel={onDryRun && 'Try It'}
             onFinish={onDryRun && (formState => onDryRun(formState))}
           />

--- a/plugins/scaffolder/src/components/TemplateEditorPage/TemplateEditorForm.tsx
+++ b/plugins/scaffolder/src/components/TemplateEditorPage/TemplateEditorForm.tsx
@@ -77,8 +77,6 @@ interface TemplateEditorFormProps {
   content?: string;
   /** Setting this to true will cause the content to be parsed as if it is the template entity spec */
   contentIsSpec?: boolean;
-  data: JsonObject;
-  onUpdate: (data: JsonObject) => void;
   setErrorText: (errorText?: string) => void;
 
   onDryRun?: (data: JsonObject) => Promise<void>;
@@ -94,8 +92,6 @@ export function TemplateEditorForm(props: TemplateEditorFormProps) {
   const {
     content,
     contentIsSpec,
-    data,
-    onUpdate,
     onDryRun,
     setErrorText,
     fieldExtensions = [],
@@ -183,11 +179,9 @@ export function TemplateEditorForm(props: TemplateEditorFormProps) {
           <MultistepJsonForm
             steps={steps}
             fields={fields}
-            formData={data}
-            onChange={e => onUpdate(e.formData)}
-            onReset={() => onUpdate({})}
+            intialFormData={{}}
             finishButtonLabel={onDryRun && 'Try It'}
-            onFinish={onDryRun && (() => onDryRun(data))}
+            onFinish={onDryRun && (formState => onDryRun(formState))}
           />
         </ErrorBoundary>
       </div>
@@ -205,9 +199,7 @@ export function TemplateEditorFormDirectoryEditorDryRun(
   const directoryEditor = useDirectoryEditor();
   const { selectedFile } = directoryEditor;
 
-  const [data, setData] = useState<JsonObject>({});
-
-  const handleDryRun = async () => {
+  const handleDryRun = async (formState: JsonObject) => {
     if (!selectedFile) {
       return;
     }
@@ -215,7 +207,7 @@ export function TemplateEditorFormDirectoryEditorDryRun(
     try {
       await dryRun.execute({
         templateContent: selectedFile.content,
-        values: data,
+        values: formState,
         files: directoryEditor.files,
       });
       setErrorText();
@@ -236,8 +228,6 @@ export function TemplateEditorFormDirectoryEditorDryRun(
       fieldExtensions={fieldExtensions}
       setErrorText={setErrorText}
       content={content}
-      data={data}
-      onUpdate={setData}
     />
   );
 }

--- a/plugins/scaffolder/src/components/TemplateEditorPage/TemplateFormPreviewer.tsx
+++ b/plugins/scaffolder/src/components/TemplateEditorPage/TemplateFormPreviewer.tsx
@@ -122,7 +122,6 @@ export const TemplateFormPreviewer = ({
   const [errorText, setErrorText] = useState<string>();
   const [templateOptions, setTemplateOptions] = useState<TemplateOption[]>([]);
   const [templateYaml, setTemplateYaml] = useState(defaultPreviewTemplate);
-  const [formState, setFormState] = useState({});
 
   const { loading } = useAsync(
     () =>
@@ -205,8 +204,6 @@ export const TemplateFormPreviewer = ({
             content={templateYaml}
             contentIsSpec
             fieldExtensions={customFieldExtensions}
-            data={formState}
-            onUpdate={setFormState}
             setErrorText={setErrorText}
           />
         </div>

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.test.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.test.tsx
@@ -195,28 +195,43 @@ describe('TemplatePage', () => {
         {
           title: 'Fill in some steps',
           schema: {
-            oneOf: [
-              {
-                title: 'First',
-                properties: {
-                  name: {
-                    title: 'Name',
-                    type: 'string',
-                  },
-                },
-                required: ['name'],
+            properties: {
+              option: {
+                type: 'string',
+                enum: ['first', 'second'],
+                default: 'first',
               },
-              {
-                title: 'Second',
-                properties: {
-                  something: {
-                    title: 'Something',
-                    type: 'string',
+            },
+            dependences: {
+              option: {
+                oneOf: [
+                  {
+                    properties: {
+                      option: {
+                        const: 'first',
+                      },
+                      name: {
+                        title: 'Name',
+                        type: 'string',
+                      },
+                    },
+                    required: ['name'],
                   },
-                },
-                required: ['something'],
+                  {
+                    properties: {
+                      option: {
+                        const: 'second',
+                      },
+                      something: {
+                        title: 'Something',
+                        type: 'string',
+                      },
+                    },
+                    required: ['something'],
+                  },
+                ],
               },
-            ],
+            },
           },
         },
       ],
@@ -247,11 +262,13 @@ describe('TemplatePage', () => {
     fireEvent.click(listbox.getByText(/Second/i));
 
     // Fill the second option
-    fireEvent.change(await findByLabelText('Something', { exact: false }), {
-      target: { value: 'my-something' },
-    });
+    await fireEvent.change(
+      await findByLabelText('Something', { exact: false }),
+      {
+        target: { value: 'my-something' },
+      },
+    );
 
-    // Go to the final page
     fireEvent.click(await findByText('Next step'));
     expect(await findByText('Reset')).toBeInTheDocument();
   });

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -130,7 +130,7 @@ export const TemplatePage = ({
             titleTypographyProps={{ component: 'h2' }}
           >
             <MultistepJsonForm
-              initialFormData={initialFormData}
+              intialFormData={initialFormData}
               fields={customFieldComponents}
               onFinish={handleCreate}
               steps={schema.steps.map(step => {

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { LinearProgress } from '@material-ui/core';
-import { IChangeEvent } from '@rjsf/core';
 import qs from 'qs';
 import React, { useCallback, useContext, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router';
@@ -35,6 +34,7 @@ import {
   useRouteRef,
 } from '@backstage/core-plugin-api';
 import { stringifyEntityRef } from '@backstage/catalog-model';
+import { JsonValue } from '@backstage/types';
 
 const useTemplateParameterSchema = (templateRef: string) => {
   const scaffolderApi = useApi(scaffolderApiRef);
@@ -64,7 +64,7 @@ export const TemplatePage = ({
   const scaffolderTaskRoute = useRouteRef(scaffolderTaskRouteRef);
   const rootRoute = useRouteRef(rootRouteRef);
   const { schema, loading, error } = useTemplateParameterSchema(templateRef);
-  const [formState, setFormState] = useState<Record<string, any>>(() => {
+  const [initialFormData] = useState<Record<string, any>>(() => {
     const query = qs.parse(window.location.search, {
       ignoreQueryPrefix: true,
     });
@@ -75,13 +75,8 @@ export const TemplatePage = ({
       return query.formData ?? {};
     }
   });
-  const handleFormReset = () => setFormState({});
-  const handleChange = useCallback(
-    (e: IChangeEvent) => setFormState(e.formData),
-    [setFormState],
-  );
 
-  const handleCreate = async () => {
+  const handleCreate = async (formState: Record<string, JsonValue>) => {
     const { taskId } = await scaffolderApi.scaffold({
       templateRef,
       values: formState,
@@ -135,10 +130,8 @@ export const TemplatePage = ({
             titleTypographyProps={{ component: 'h2' }}
           >
             <MultistepJsonForm
-              formData={formState}
+              initialFormData={initialFormData}
               fields={customFieldComponents}
-              onChange={handleChange}
-              onReset={handleFormReset}
               onFinish={handleCreate}
               steps={schema.steps.map(step => {
                 return {

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -15,7 +15,7 @@
  */
 import { LinearProgress } from '@material-ui/core';
 import qs from 'qs';
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import useAsync from 'react-use/lib/useAsync';

--- a/plugins/scaffolder/src/components/TemplatePage/createValidator.ts
+++ b/plugins/scaffolder/src/components/TemplatePage/createValidator.ts
@@ -19,6 +19,7 @@ import { FormValidation } from '@rjsf/core';
 import { JsonObject } from '@backstage/types';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { Draft07 as JSONSchema } from 'json-schema-library';
+import { utils } from '@rjsf/core';
 
 export const createValidator = (
   rootSchema: JsonObject,
@@ -28,7 +29,9 @@ export const createValidator = (
   },
 ) => {
   function validate(formData: JsonObject, errors: FormValidation) {
-    const parsedSchema = new JSONSchema(rootSchema);
+    const parsedSchema = new JSONSchema(
+      utils.retrieveSchema(rootSchema, {}, formData),
+    );
     for (const [key, value] of Object.entries(formData)) {
       const definitionInSchema = parsedSchema.getSchema(`#/${key}`, formData);
       if (definitionInSchema && 'ui:field' in definitionInSchema) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12380,6 +12380,11 @@ easy-table@1.1.0:
   optionalDependencies:
     wcwidth ">=1.0.1"
 
+ebnf@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/ebnf/-/ebnf-1.9.0.tgz#9c2dd6052f3ed43a69c1f0b07b15bd03cefda764"
+  integrity sha512-LKK899+j758AgPq00ms+y90mo+2P86fMKUWD28sH0zLKUj7aL6iIH2wy4jejAMM9I2BawJ+2kp6C3mMXj+Ii5g==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -14797,6 +14802,25 @@ grpc-docs@^1.0.6, grpc-docs@^1.1.2:
     rollup-plugin-smart-asset "^2.1.2"
     styled-components "^5.3.3"
 
+gson-conform@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/gson-conform/-/gson-conform-1.0.3.tgz#6f982f98ea84199280bd48b6bfbcd0ae7447f1e2"
+  integrity sha512-gaZQN/5ZbohkLBOs4JKHkg/IdOB9kuuEr5SVLAjHUs+Q+Nl746DRe18GgQy4oxxVXStO//Zga2wg4eWL9Mfshw==
+
+gson-pointer@4.1.1, gson-pointer@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/gson-pointer/-/gson-pointer-4.1.1.tgz#088d6aa38d52753530288d13b5a75b6a43170e9b"
+  integrity sha512-rOS/zCLUI8BT0+/U+p5nzI0RfhIyRmzkpwzyCj8gcLoRl3rHuysk6ci1IQ955AQQZDSNN3mVec26Sx9wRZ0EjA==
+
+gson-query@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/gson-query/-/gson-query-5.1.0.tgz#8f34a062849f8c08be0c35eddaa2ad18a4326a49"
+  integrity sha512-xKb/90XfmLLKGgX8Y7LRF4yKnMR/ckV5WOQ/Ip0pRXuDh7jUhdY1UYjPvQnF7/UMbNsAo0168j2j0yt9+4QdaA==
+  dependencies:
+    ebnf "^1.9.0"
+    gson-conform "^1.0.3"
+    gson-pointer "4.1.1"
+
 gtoken@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/gtoken/-/gtoken-6.0.1.tgz#1276371d51e93c4eface76e3f30f9e8f1cad3f1a"
@@ -17151,6 +17175,17 @@ json-schema-compare@^0.2.2:
   integrity sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==
   dependencies:
     lodash "^4.17.4"
+
+json-schema-library@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/json-schema-library/-/json-schema-library-6.0.0.tgz#2a823d850031842c6917f41a8c576af3b603ab48"
+  integrity sha512-1nTpSmyfmgJpaNPIBO1SnHpXiMUh76hZnqSuCrJr7Lcu2N2SB55UPgf5F790r4dy4i4o/Moaw7OdqDhEmxP/Rw==
+  dependencies:
+    deepmerge "^4.2.2"
+    fast-deep-equal "^3.1.3"
+    gson-pointer "^4.1.1"
+    gson-query "^5.1.0"
+    valid-url "^1.0.9"
 
 json-schema-merge-allof@^0.6.0:
   version "0.6.0"
@@ -26129,6 +26164,11 @@ v8-to-istanbul@^8.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Hopefully should supersede  #12947.

Basically removing our custom logic for parsing jsonschema to grab out bits of the ui:schema, we can use a library and look up the data instead.

Found this library as a replacement for a lot of logic in #12952 and think it's good to start using this in places already/

@tritri251214 can you test this PR to see if it works for the dependencies?

Closes #12948
Closes #12947 