### PR TITLE
cli: add json and wasm extensions to webpack resolve config

### DIFF
--- a/.changeset/popular-starfishes-bow.md
+++ b/.changeset/popular-starfishes-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added resolution of `.json` and `.wasm` files to the Webpack configuration in order to match defaults.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -162,7 +162,7 @@ export async function createConfig(
     context: paths.targetPath,
     entry: [require.resolve('react-hot-loader/patch'), paths.targetEntry],
     resolve: {
-      extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],
+      extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json', '.wasm'],
       mainFields: ['browser', 'module', 'main'],
       fallback: {
         ...pickBy(require('node-libs-browser')),
@@ -272,7 +272,7 @@ export async function createBackendConfig(
       paths.targetRunFile ? paths.targetRunFile : paths.targetEntry,
     ],
     resolve: {
-      extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],
+      extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json'],
       mainFields: ['main'],
       modules: [paths.rootNodeModules, ...moduleDirs],
       plugins: [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the underlying issue in #12893

Aligning with https://webpack.js.org/configuration/resolve/#resolveextensions and Node.js behavior.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
