### PR TITLE
use the right msw version

### DIFF
--- a/plugins/catalog-backend-module-bitbucket-server/package.json
+++ b/plugins/catalog-backend-module-bitbucket-server/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^0.1.27-next.0",
     "@backstage/cli": "^0.18.1-next.0",
-    "msw": "^0.35.0"
+    "msw": "^0.44.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This fixes the impure lockfile in master. Intentionally skipping changeset because of unreleased package