### PR TITLE
Document how to use a GitHub App integration config file for auth

### DIFF
--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -55,6 +55,31 @@ The GitHub provider is a structure with three configuration keys:
   `https://your-intermediate-service.com/handler`. Only needed if Backstage is
   not the immediate receiver (e.g. one OAuth app for many backstage instances).
 
+### Using a GitHub App integrations config file
+
+When using a GitHub App with an integration configuration file, as described in the [GitHub integration documentation](docs/auth/github/provider.md), you cannot use a generic include as you [can use](docs/auth/github/provider.md) with the generic GitHub integration.
+
+You can re-use the integration file by including each individual field in the file as the GitHub auth provider configuration:
+
+```yaml
+auth:
+  providers:
+    github:
+      development:
+        appId: 
+          $include: example-backstage-app-credentials.yaml#appId
+        webhookUrl: 
+          $include: example-backstage-app-credentials.yaml#webhookUrl
+        clientId: 
+          $include: example-backstage-app-credentials.yaml#clientId
+        clientSecret: 
+          $include: example-backstage-app-credentials.yaml#clientSecret
+        webhookSecret: 
+          $include: example-backstage-app-credentials.yaml#webhookSecret
+        privateKey:
+          $include: example-backstage-app-credentials.yaml#privateKey
+```
+
 ## Adding the provider to the Backstage frontend
 
 To add the provider to the frontend, add the `githubAuthApi` reference and

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -66,15 +66,15 @@ auth:
   providers:
     github:
       development:
-        appId: 
+        appId:
           $include: example-backstage-app-credentials.yaml#appId
-        webhookUrl: 
+        webhookUrl:
           $include: example-backstage-app-credentials.yaml#webhookUrl
-        clientId: 
+        clientId:
           $include: example-backstage-app-credentials.yaml#clientId
-        clientSecret: 
+        clientSecret:
           $include: example-backstage-app-credentials.yaml#clientSecret
-        webhookSecret: 
+        webhookSecret:
           $include: example-backstage-app-credentials.yaml#webhookSecret
         privateKey:
           $include: example-backstage-app-credentials.yaml#privateKey

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -57,7 +57,7 @@ The GitHub provider is a structure with three configuration keys:
 
 ### Using a GitHub App integrations config file
 
-When using a GitHub App with an integration configuration file, as described in the [GitHub integration documentation](docs/auth/github/provider.md), you cannot use a generic include as you [can use](docs/auth/github/provider.md) with the generic GitHub integration.
+When using a GitHub App with an integration configuration file, as described in the [GitHub integration documentation](../../integrations/github/github-apps.md#github-enterprise), you cannot use a generic include as you [can use](../../integrations/github/github-apps.md#github-enterprise) with the generic GitHub integration.
 
 You can re-use the integration file by including each individual field in the file as the GitHub auth provider configuration:
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The configuration of a GitHub integration configuration file for the GitHub auth provider was not mentioned in the documentation.

I found a discussion which raised the same issue, without any replies: https://github.com/backstage/backstage/discussions/8170 

I eventually figured out a way to use the individual field include which seems to work. Due to a lack of an alternative, I've described this method in the documentation.

Do I need to generate a changeset for this documentation-only PR?

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
