### PR TITLE
Add projectId config option to GCS techdocs publisher

### DIFF
--- a/.changeset/gold-laws-attend.md
+++ b/.changeset/gold-laws-attend.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Add projectId config option to GCP Cloud Storage techdocs publisher. This will allow users to override the project ID, instead of implicitly using the same one as found in a credentials bundle.

--- a/.changeset/gold-laws-attend.md
+++ b/.changeset/gold-laws-attend.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-techdocs-node': minor
 ---
 
-Add projectId config option to GCP Cloud Storage techdocs publisher. This will allow users to override the project ID, instead of implicitly using the same one as found in a credentials bundle.
+Add `projectId` config option to GCP Cloud Storage techdocs publisher. This will allow users to override the project ID, instead of implicitly using the same one as found in a credentials bundle.

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -235,6 +235,7 @@ preconfigured
 prepack
 Preprarer
 productional
+projectId
 Protobuf
 proxying
 Proxying

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -235,7 +235,6 @@ preconfigured
 prepack
 Preprarer
 productional
-projectId
 Protobuf
 proxying
 Proxying

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -38,7 +38,9 @@ files from here to serve documentation in Backstage. Note that the bucket names
 are globally unique.
 
 Set the config `techdocs.publisher.googleGcs.bucketName` in your
-`app-config.yaml` to the name of the bucket you just created.
+`app-config.yaml` to the name of the bucket you just created. Set
+`techdocs.publisher.googleGcs.projectId` to the ID of the Google Cloud project
+that contains your bucket.
 
 ```yaml
 techdocs:
@@ -46,6 +48,7 @@ techdocs:
     type: 'googleGcs'
     googleGcs:
       bucketName: 'name-of-techdocs-storage-bucket'
+      projectId: 'name-of-project'
 ```
 
 **3a. (Recommended) Authentication using environment variable**
@@ -96,6 +99,20 @@ techdocs:
     googleGcs:
       bucketName: 'name-of-techdocs-storage-bucket'
       credentials: ${GOOGLE_APPLICATION_CREDENTIALS}
+```
+
+Assuming the service account you are using was created in the same project as
+the bucket, you do not need to set the `projectId` field. If not, you will
+have to override it as with default credentials:
+
+```yaml
+techdocs:
+  publisher:
+    type: 'googleGcs'
+    googleGcs:
+      bucketName: 'name-of-techdocs-storage-bucket'
+      credentials: ${GOOGLE_APPLICATION_CREDENTIALS}
+      projectId: 'name-of-project'
 ```
 
 **4. That's it!**

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -233,6 +233,13 @@ export interface Config {
              * @visibility secret
              */
             credentials?: string;
+            /**
+             * (Optional) GCP project ID that contains the bucket. Should be
+             * set if credentials is not set, or if the service account in
+             * the credentials belongs to a different project to the bucket.
+             * @visibility backend
+             */
+            projectId?: string;
           };
         };
 

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.ts
@@ -16,7 +16,12 @@
 import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { assertError } from '@backstage/errors';
-import { File, FileExistsResponse, Storage } from '@google-cloud/storage';
+import {
+  File,
+  FileExistsResponse,
+  Storage,
+  StorageOptions,
+} from '@google-cloud/storage';
 import express from 'express';
 import JSON5 from 'json5';
 import path from 'path';
@@ -83,6 +88,9 @@ export class GoogleGCSPublish implements PublisherBase {
     const credentials = config.getOptionalString(
       'techdocs.publisher.googleGcs.credentials',
     );
+    const projectId = config.getOptionalString(
+      'techdocs.publisher.googleGcs.projectId',
+    );
     let credentialsJson: any = {};
     if (credentials) {
       try {
@@ -94,11 +102,17 @@ export class GoogleGCSPublish implements PublisherBase {
       }
     }
 
+    const clientOpts: StorageOptions = {};
+    if (projectId) {
+      clientOpts.projectId = projectId;
+    }
+
     const storageClient = new Storage({
       ...(credentials && {
         projectId: credentialsJson.project_id,
         credentials: credentialsJson,
       }),
+      ...clientOpts,
     });
 
     const legacyPathCasing =


### PR DESCRIPTION
Fixes #13049

## Hey, I just made a Pull Request!

Add `projectId` config option to GCP Cloud Storage techdocs publisher. This will allow users to override the project ID, instead of implicitly using the same one as found in a credentials bundle.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))