### PR TITLE
Revert "changeset: exit pre-release"

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "exit",
+  "mode": "pre",
   "tag": "next",
   "initialVersions": {
     "example-app": "0.2.73",


### PR DESCRIPTION
Reverts backstage/backstage#13047

Most recent next release failed, likely due to the yarn bump. We'll roll back this and do another next release today.