### PR TITLE
scaffolder-backend: deprecate publish:file action

### DIFF
--- a/.changeset/fresh-rockets-yell.md
+++ b/.changeset/fresh-rockets-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+The `publish:file` action has been deprecated in favor of testing templates using the template editor instead. Note that this action is not and was never been installed by default.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -303,7 +303,7 @@ export function createPublishBitbucketServerAction(options: {
   token?: string | undefined;
 }>;
 
-// @public
+// @public @deprecated
 export function createPublishFileAction(): TemplateAction<{
   path: string;
 }>;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/file.ts
@@ -29,6 +29,7 @@ import { createTemplateAction } from '../../createTemplateAction';
  * production, as it writes the files to the local filesystem of the scaffolder.
  *
  * @public
+ * @deprecated This action will be removed, prefer testing templates using the template editor instead.
  */
 export function createPublishFileAction() {
   return createTemplateAction<{ path: string }>({
@@ -47,6 +48,10 @@ export function createPublishFileAction() {
       },
     },
     async handler(ctx) {
+      ctx.logger.warn(
+        '[DEPRECATED] This action will be removed, prefer testing templates using the template editor instead.',
+      );
+
       const { path } = ctx.input;
 
       const exists = await fs.pathExists(path);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There are better ways to test templates now, and this action is a little bit scary to have as something that is easy to install.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
