### PR TITLE
create-app: move better-sqlite3 back to dependencies

### DIFF
--- a/.changeset/loud-ears-taste.md
+++ b/.changeset/loud-ears-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+The `better-sqlite3` dependency has been moved back to production `"dependencies"` in `packages/backend/package.json`, with instructions in the Dockerfile to move it to `"devDependencies"` if desired. There is no need to apply this change to existing apps, unless you want your production image to have SQLite available as a database option.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -60,7 +60,8 @@ FROM node:16-bullseye-slim
 
 WORKDIR /app
 
-# install sqlite3 dependencies, you can skip this if you don't use sqlite3 in the image
+# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
+# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
     rm -rf /var/lib/apt/lists/* && \
@@ -178,7 +179,8 @@ FROM node:16-bullseye-slim
 
 WORKDIR /app
 
-# install sqlite3 dependencies, you can skip this if you don't use sqlite3 in the image
+# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
+# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
     rm -rf /var/lib/apt/lists/* && \

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -13,7 +13,8 @@ FROM node:16-bullseye-slim
 
 WORKDIR /app
 
-# install sqlite3 dependencies, you can skip this if you don't use sqlite3 in the image
+# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
+# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
     rm -rf /var/lib/apt/lists/* && \

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -13,7 +13,8 @@ FROM node:16-bullseye-slim
 
 WORKDIR /app
 
-# install sqlite3 dependencies, you can skip this if you don't use sqlite3 in the image
+# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
+# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
     rm -rf /var/lib/apt/lists/* && \

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -33,6 +33,7 @@
     "@backstage/plugin-search-backend-module-pg": "^{{version '@backstage/plugin-search-backend-module-pg'}}",
     "@backstage/plugin-search-backend-node": "^{{version '@backstage/plugin-search-backend-node'}}",
     "@backstage/plugin-techdocs-backend": "^{{version '@backstage/plugin-techdocs-backend'}}",
+    "better-sqlite3": "^7.5.0",
     "dockerode": "^3.3.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
@@ -44,8 +45,7 @@
     "@types/dockerode": "^3.3.0",
     "@types/express-serve-static-core": "^4.17.5",
     "@types/express": "^4.17.6",
-    "@types/luxon": "^2.0.4",
-    "better-sqlite3": "^7.5.0"
+    "@types/luxon": "^2.0.4"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Split this out from #13073 so that we can merge it ahead of main-line release. Fixes #11651 and replaces #13021
