### PR TITLE
[TechDocs] Fix large headings

### DIFF
--- a/.changeset/dull-fans-hug.md
+++ b/.changeset/dull-fans-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Added back reduction in size, this fixes the extermly large TeachDocs headings

--- a/.changeset/dull-fans-hug.md
+++ b/.changeset/dull-fans-hug.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-Added back reduction in size, this fixes the extermly large TeachDocs headings
+Added back reduction in size, this fixes the extremely large TeachDocs headings

--- a/plugins/techdocs/src/reader/transformers/styles/rules/typeset.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/typeset.ts
@@ -47,7 +47,8 @@ ${headings.reduce<string>((style, heading) => {
     let factor: number | string = 1;
     if (typeof value === 'number') {
       // convert px to rem
-      factor = value / htmlFontSize;
+      // 60% of the size defined because it is too big
+      factor = (value / htmlFontSize) * 0.6;
     }
     if (typeof value === 'string') {
       factor = value.replace('rem', '');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the large TechDocs headings and closes #12891 

Before:

![Screen Shot 2022-08-10 at 10 11 40 AM](https://user-images.githubusercontent.com/67169551/183941851-8a0e205d-acfd-4aea-a39f-15871f852b6e.png)

After:

![Screen Shot 2022-08-10 at 10 12 07 AM](https://user-images.githubusercontent.com/67169551/183941900-b292b1b5-291d-440b-aefa-44be9c236654.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
