### PR TITLE
fix: (plugin-tech-radar): Move CSS overflow property to quadrant block element

### DIFF
--- a/.changeset/witty-seas-tie.md
+++ b/.changeset/witty-seas-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Move CSS overflow property to quadrant block element (i.e. to a div element) in RadarLegend component.

--- a/plugins/tech-radar/src/components/RadarLegend/RadarLegend.tsx
+++ b/plugins/tech-radar/src/components/RadarLegend/RadarLegend.tsx
@@ -32,15 +32,11 @@ export type Props = {
 };
 
 const useStyles = makeStyles<Theme>(theme => ({
-  quadrantLegend: {
-    overflowY: 'auto',
-    scrollbarWidth: 'thin',
-  },
   quadrant: {
     height: '100%',
     width: '100%',
+    overflowY: 'auto',
     scrollbarWidth: 'thin',
-    pointerEvents: 'none',
   },
   quadrantHeading: {
     pointerEvents: 'none',
@@ -229,7 +225,6 @@ const RadarLegend = (props: Props): JSX.Element => {
         y={quadrant.legendY}
         width={quadrant.legendWidth}
         height={quadrant.legendHeight}
-        className={classes.quadrantLegend}
         data-testid="radar-quadrant"
       >
         <div className={classes.quadrant}>


### PR DESCRIPTION
Signed-off-by: Vincent Lam <vincent.lam@ingka.com>

## Hey, I just made a Pull Request!

Issue link: https://github.com/backstage/backstage/issues/7664

As described in the issue above: when there are too many entries in the tech radar quadrants, some of the sections disappears/renders weirdly. Over time this issue has been somewhat "solved", i.e. the tech radar works great with Google Chrome and Microsoft Edge. However, in the case of other browsers such as Firefox and Safari, the issue still persist:

<img width="376" alt="Screenshot 2022-08-10 at 13 09 21" src="https://user-images.githubusercontent.com/44773696/184006741-63013f1b-cb30-48d2-8b2e-4c3dfd8c3a50.png">
Image captured in Firefox. <br/>
In the quadrant "Process" above, I have added 50+ entries. As we all can see the entries and sections are overflowing into one another.
<br/><br/>
While debugging this issue I noticed that the tech radar quadrants, i.e. the foreignObject SVG element behaves/renders differently in different browsers. For some reason the foreignObject is being rendered as an inline-element in Firefox and Safari:

<img width="387" alt="Screenshot 2022-08-10 at 16 04 45" src="https://user-images.githubusercontent.com/44773696/184009809-2eaabb85-eaac-43f3-84ac-7851afce17a7.png">

while in Chrome and Edge the foreignObject is being rendered as a block-element:

<img width="340" alt="Screenshot 2022-08-10 at 16 04 20" src="https://user-images.githubusercontent.com/44773696/184010004-6090c48b-af40-48d9-90bd-df06da8326d5.png">

I strongly suspect that this is the reason why the tech radar quadrants is rendered "correctly" in some browsers and for some other browsers the entries overflows. The reason for this is that the CSS "overflow" property requires/only works with block elements and that the block element has a defined height.

Hence, this pull request will move the CSS overflow property (in this case: "overflow-y" property) to a quadrant block-level child element of the foreignObject SVG element in the "RadarLegend" component (i.e. in this case a regular div element which in turn is also known as block-level elements). By doing so the CSS overflow property will make it possible to render and scroll each tech radar quadrants properly in all the aforementioned browsers.

<img width="365" alt="Screenshot 2022-08-10 at 16 02 11" src="https://user-images.githubusercontent.com/44773696/184013832-5ac35a33-f2a9-4a42-a0f0-e11557a3abc2.png">
Image captured in Firefox.

<br/><br/>

**My browser version list:**
- Google Chrome Version 104.0.5112.79
- Microsoft Edge Version 104.0.1293.47
- Firefox Version 103.0.2
- Safari Version 14.1.2


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
