### PR TITLE
Send Authorization headers in fetch requests in Code Climate plugin

### DIFF
--- a/.changeset/weak-drinks-report.md
+++ b/.changeset/weak-drinks-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-climate': patch
+---
+
+Send Authorization headers in fetch requests in Code Climate plugin to fix unauthorized requests to Backstage backends with authentication enabled as per https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md.

--- a/.changeset/weak-drinks-report.md
+++ b/.changeset/weak-drinks-report.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-code-climate': patch
 ---
 
-Send Authorization headers in fetch requests in Code Climate plugin to fix unauthorized requests to Backstage backends with authentication enabled as per https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md.
+Send Authorization headers in fetch requests using FetchApi in Code Climate plugin to fix unauthorized requests to Backstage backends with authentication enabled.

--- a/plugins/code-climate/api-report.md
+++ b/plugins/code-climate/api-report.md
@@ -8,6 +8,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/core-plugin-api';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // Warning: (ae-missing-release-tag) "CodeClimateApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -74,7 +75,8 @@ export const mockData: CodeClimateData;
 //
 // @public (undocumented)
 export class ProductionCodeClimateApi implements CodeClimateApi {
-  constructor(discoveryApi: DiscoveryApi);
+  // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts
+  constructor(options: Options);
   // (undocumented)
   fetchAllData(options: {
     apiUrl: string;

--- a/plugins/code-climate/api-report.md
+++ b/plugins/code-climate/api-report.md
@@ -8,7 +8,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
-import { IdentityApi } from '@backstage/core-plugin-api';
+import { FetchApi } from '@backstage/core-plugin-api';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // Warning: (ae-missing-release-tag) "CodeClimateApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/code-climate/src/plugin.ts
+++ b/plugins/code-climate/src/plugin.ts
@@ -39,7 +39,8 @@ export const codeClimatePlugin = createPlugin({
         discoveryApi: discoveryApiRef,
         identityApi: identityApiRef,
       },
-      factory: ({ discoveryApi }) => new ProductionCodeClimateApi(discoveryApi),
+      factory: ({ discoveryApi, identityApi }) =>
+        new ProductionCodeClimateApi({ discoveryApi, identityApi }),
     }),
   ],
   routes: {

--- a/plugins/code-climate/src/plugin.ts
+++ b/plugins/code-climate/src/plugin.ts
@@ -20,7 +20,7 @@ import {
   createPlugin,
   createRouteRef,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
   createComponentExtension,
 } from '@backstage/core-plugin-api';
 
@@ -37,10 +37,10 @@ export const codeClimatePlugin = createPlugin({
       api: codeClimateApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
+        fetchApi: fetchApiRef,
       },
-      factory: ({ discoveryApi, identityApi }) =>
-        new ProductionCodeClimateApi({ discoveryApi, identityApi }),
+      factory: ({ discoveryApi, fetchApi }) =>
+        new ProductionCodeClimateApi({ discoveryApi, fetchApi }),
     }),
   ],
   routes: {


### PR DESCRIPTION
Signed-off-by: Robert Cen <robert.cen@safetyculture.io>

## Hey, I just made a Pull Request!

Change to simply pass through the Authorization header using the token from the IdentityApi as part of the fetch requests from within the Code Climate plugins so that it is compatible with Backstage backends that have authentication enabled on the proxy endpoints. The changes made were based from https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
