### PR TITLE
Include stack trace on startup errors in create app

### DIFF
--- a/.changeset/twenty-terms-dress.md
+++ b/.changeset/twenty-terms-dress.md
@@ -2,4 +2,4 @@
 '@backstage/create-app': patch
 ---
 
-Updated backend to include stack trace in stderr when the backend fails to start up.
+Updated backend to write stack trace when the backend fails to start up.

--- a/.changeset/twenty-terms-dress.md
+++ b/.changeset/twenty-terms-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated backend to include stack trace in stderr when the backend fails to start up.

--- a/.changeset/twenty-terms-dress.md
+++ b/.changeset/twenty-terms-dress.md
@@ -3,3 +3,12 @@
 ---
 
 Updated backend to write stack trace when the backend fails to start up.
+
+To apply this change to your Backstage installation, make the following change to `packages/backend/src/index.ts`
+
+```diff
+    cors:
+    origin: http://localhost:3000
+-    console.error(`Backend failed to start up, ${error}`);
++    console.error('Backend failed to start up', error);
+```

--- a/packages/create-app/templates/default-app/packages/backend/src/index.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/index.ts
@@ -104,6 +104,6 @@ async function main() {
 
 module.hot?.accept();
 main().catch(error => {
-  console.error(`Backend failed to start up, ${error}`);
+  console.error('Backend failed to start up', error);
   process.exit(1);
 });


### PR DESCRIPTION
Signed-off-by: Alex Crome <afscrome@users.noreply.github.com>

Updated the index.ts of the backend in create-app to log the error as an object, rather than a string.  This causes the error to include a stack trace, along with the error message.

This change also brings the behaviour in line with `plugins/backend/src/index.ts`
https://github.com/backstage/backstage/blob/4b90d70893a3b84e37a98bf7deef71ee7f143476/packages/backend/src/index.ts#L172

![image](https://user-images.githubusercontent.com/289860/184127638-7fc3226a-bb4a-4066-bf3d-c826bf5bcc7d.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
