### PR TITLE
create-app: Add dockerfile.multistage

### DIFF
--- a/.changeset/tiny-carpets-give.md
+++ b/.changeset/tiny-carpets-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Create Dockerfile with create-app as well

--- a/packages/create-app/templates/default-app/Dockerfile.hbs
+++ b/packages/create-app/templates/default-app/Dockerfile.hbs
@@ -1,0 +1,59 @@
+# Stage 1 - Create yarn install skeleton layer
+FROM node:16-slim AS packages
+
+WORKDIR /app
+COPY package.json yarn.lock ./
+
+COPY packages packages
+
+# Comment this out if you don't have any internal plugins
+# COPY plugins plugins
+
+RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
+
+# Stage 2 - Install dependencies and build packages
+FROM node:16-slim AS build
+
+WORKDIR /app
+COPY --from=packages /app .
+
+# install sqlite3 dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
+    yarn config set python /usr/bin/python3
+
+RUN yarn install --frozen-lockfile --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+
+COPY . .
+
+RUN yarn tsc
+RUN yarn --cwd packages/backend build
+# If you have not yet migrated to package roles, use the following command instead:
+# RUN yarn --cwd packages/backend backstage-cli backend:bundle --build-dependencies
+
+# Stage 3 - Build the actual backend image and install production dependencies
+FROM node:16-slim
+
+WORKDIR /app
+
+# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
+# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    yarn config set python /usr/bin/python3
+
+# Copy the install dependencies from the build stage and context
+COPY --from=build /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton.tar.gz ./
+RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
+
+RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+
+# Copy the built packages from the build stage
+COPY --from=build /app/packages/backend/dist/bundle.tar.gz .
+RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
+
+# Copy any other files that we need at runtime
+COPY app-config.yaml ./
+
+CMD ["node", "packages/backend", "--config", "app-config.yaml"]


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a Dockerfile.multistage to create-app so that everytime a user creates a
new backstage application they have a production ready multistage
Dockerfile to go along their scaffold backstage. This way the users
don't have to worry about yarn build failures locally.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
