### PR TITLE
[techdocs/cli] Use light theme if it's not dark

### DIFF
--- a/.changeset/purple-games-think.md
+++ b/.changeset/purple-games-think.md
@@ -1,5 +1,0 @@
----
-'techdocs-cli-embedded-app': patch
----
-
-Theme selector in `npx @techdocs/cli serve` would break if localstorage had a non-light-or-dark value for theme.

--- a/.changeset/purple-games-think.md
+++ b/.changeset/purple-games-think.md
@@ -1,0 +1,5 @@
+---
+'techdocs-cli-embedded-app': patch
+---
+
+Theme selector in `npx @techdocs/cli serve` would break if localstorage had a non-light-or-dark value for theme.

--- a/packages/techdocs-cli-embedded-app/src/components/TechDocsPage/TechDocsPage.tsx
+++ b/packages/techdocs-cli-embedded-app/src/components/TechDocsPage/TechDocsPage.tsx
@@ -55,7 +55,7 @@ export const TechDocsThemeToggle = () => {
   const appThemeApi = useApi(appThemeApiRef);
   const classes = useStyles();
   const [theme, setTheme] = useState<Themes>(
-    (appThemeApi.getActiveThemeId() as Themes) || Themes.LIGHT,
+    appThemeApi.getActiveThemeId() === Themes.DARK ? Themes.DARK : Themes.LIGHT,
   );
 
   const themes = {


### PR DESCRIPTION
Use light theme if it's not dark, to avoid breaking the theme selector on other values in local storage

Fixes #12995

Signed-off-by: Axel Hecht <axel@pike.org>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
