### PR TITLE
Added edit button to UserProfileCard

### DIFF
--- a/.changeset/lucky-points-wash.md
+++ b/.changeset/lucky-points-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Added an edit button to the `UserProfileCard` that is enabled when the `backstage.io/edit-url` is present, this matches how the `GroupProfileCard` works

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
@@ -75,7 +75,7 @@ describe('UserSummary Test', () => {
 });
 
 describe('Edit Button', () => {
-  it('Should default to disabled', async () => {
+  it('Should not be present by default', async () => {
     const userEntity: UserEntity = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'User',
@@ -111,10 +111,10 @@ describe('Edit Button', () => {
       ),
     );
 
-    expect(rendered.getByRole('button')).toBeDisabled();
+    expect(rendered.queryByTitle('Edit Metadata')).not.toBeInTheDocument();
   });
 
-  it('Should be enabled when edit URL annotation is present', async () => {
+  it('Should be visible when edit URL annotation is present', async () => {
     const annotations: Record<string, string> = {
       'backstage.io/edit-url': 'https://example.com/user.yaml',
     };
@@ -153,6 +153,6 @@ describe('Edit Button', () => {
         },
       ),
     );
-    expect(rendered.getByRole('button')).toBeEnabled();
+    expect(rendered.getByRole('button')).toBeInTheDocument();
   });
 });

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
@@ -73,3 +73,86 @@ describe('UserSummary Test', () => {
     expect(rendered.getByText('Super awesome human')).toBeInTheDocument();
   });
 });
+
+describe('Edit Button', () => {
+  it('Should default to disabled', async () => {
+    const userEntity: UserEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        name: 'calum.leavy',
+        description: 'Super awesome human',
+      },
+      spec: {
+        profile: {
+          displayName: 'Calum Leavy',
+          email: 'calum-leavy@example.com',
+        },
+        memberOf: ['ExampleGroup'],
+      },
+      relations: [
+        {
+          type: 'memberOf',
+          targetRef: 'group:default/examplegroup',
+        },
+      ],
+    };
+
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <EntityProvider entity={userEntity}>
+          <UserProfileCard variant="gridItem" />
+        </EntityProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      ),
+    );
+
+    expect(rendered.getByRole('button')).toBeDisabled();
+  });
+
+  it('Should be enabled when edit URL annotation is present', async () => {
+    const annotations: Record<string, string> = {
+      'backstage.io/edit-url': 'https://example.com/user.yaml',
+    };
+    const userEntity: UserEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        name: 'calum.leavy',
+        description: 'Super awesome human',
+        annotations,
+      },
+      spec: {
+        profile: {
+          displayName: 'Calum Leavy',
+          email: 'calum-leavy@example.com',
+        },
+        memberOf: ['ExampleGroup'],
+      },
+      relations: [
+        {
+          type: 'memberOf',
+          targetRef: 'group:default/examplegroup',
+        },
+      ],
+    };
+
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <EntityProvider entity={userEntity}>
+          <UserProfileCard variant="gridItem" />
+        </EntityProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      ),
+    );
+    expect(rendered.getByRole('button')).toBeEnabled();
+  });
+});

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -75,27 +75,25 @@ export const UserProfileCard = (props: { variant?: InfoCardVariants }) => {
     kind: 'Group',
   });
 
-  const infoCardAction = entityMetadataEditUrl ? (
-    <IconButton
-      aria-label="Edit"
-      title="Edit Metadata"
-      component={Link}
-      to={entityMetadataEditUrl}
-    >
-      <EditIcon />
-    </IconButton>
-  ) : (
-    <IconButton aria-label="Edit" disabled title="Edit Metadata">
-      <EditIcon />
-    </IconButton>
-  );
-
   return (
     <InfoCard
       title={<CardTitle title={displayName} />}
       subheader={description}
       variant={props.variant}
-      action={infoCardAction}
+      action={
+        <>
+          {entityMetadataEditUrl && (
+            <IconButton
+              aria-label="Edit"
+              title="Edit Metadata"
+              component={Link}
+              to={entityMetadataEditUrl}
+            >
+              <EditIcon />
+            </IconButton>
+          )}
+        </>
+      }
     >
       <Grid container spacing={3} alignItems="flex-start">
         <Grid item xs={12} sm={2} xl={1}>

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { RELATION_MEMBER_OF, UserEntity } from '@backstage/catalog-model';
+import {
+  RELATION_MEMBER_OF,
+  UserEntity,
+  ANNOTATION_EDIT_URL,
+} from '@backstage/catalog-model';
 import {
   EntityRefLinks,
   getEntityRelations,
@@ -23,12 +27,14 @@ import {
 import {
   Box,
   Grid,
+  IconButton,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
   Tooltip,
 } from '@material-ui/core';
+import EditIcon from '@material-ui/icons/Edit';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
 import PersonIcon from '@material-ui/icons/Person';
@@ -56,6 +62,9 @@ export const UserProfileCard = (props: { variant?: InfoCardVariants }) => {
     return <Alert severity="error">User not found</Alert>;
   }
 
+  const entityMetadataEditUrl =
+    user.metadata.annotations?.[ANNOTATION_EDIT_URL];
+
   const {
     metadata: { name: metaName, description },
     spec: { profile },
@@ -66,11 +75,27 @@ export const UserProfileCard = (props: { variant?: InfoCardVariants }) => {
     kind: 'Group',
   });
 
+  const infoCardAction = entityMetadataEditUrl ? (
+    <IconButton
+      aria-label="Edit"
+      title="Edit Metadata"
+      component={Link}
+      to={entityMetadataEditUrl}
+    >
+      <EditIcon />
+    </IconButton>
+  ) : (
+    <IconButton aria-label="Edit" disabled title="Edit Metadata">
+      <EditIcon />
+    </IconButton>
+  );
+
   return (
     <InfoCard
       title={<CardTitle title={displayName} />}
       subheader={description}
       variant={props.variant}
+      action={infoCardAction}
     >
       <Grid container spacing={3} alignItems="flex-start">
         <Grid item xs={12} sm={2} xl={1}>


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Added an edit button to the `UserProfileCard` that is enabled when the `backstage.io/edit-url` is present, this matches how the `GroupProfileCard` works

Default, no annotation:

![Screen Shot 2022-08-17 at 12 53 33 PM](https://user-images.githubusercontent.com/67169551/185208796-a9058a79-2bc3-4a4e-8953-531fd33bb92e.png)

Enabled with annotation:

![Screen Shot 2022-08-15 at 2 51 15 PM](https://user-images.githubusercontent.com/67169551/184713051-81f0d27e-3104-40da-8395-490264c71f15.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
