### PR TITLE
fix(catalog-backend): add entity ref within errors

### DIFF
--- a/.changeset/small-lemons-brake.md
+++ b/.changeset/small-lemons-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Include entity ref into error message when catalog policies fail

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -211,11 +211,18 @@ export class DefaultCatalogProcessingOrchestrator
     try {
       policyEnforcedEntity = await this.options.policy.enforce(entity);
     } catch (e) {
-      throw new InputError('Policy check failed', e);
+      throw new InputError(
+        `Policy check failed for ${stringifyEntityRef(entity)}`,
+        e,
+      );
     }
 
     if (!policyEnforcedEntity) {
-      throw new Error('Policy unexpectedly returned no data');
+      throw new Error(
+        `Policy unexpectedly returned no data for ${stringifyEntityRef(
+          entity,
+        )}`,
+      );
     }
 
     return policyEnforcedEntity;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


## What
- add entity ref into error when catalog processor validations fail

## Why

transform this

```txt
Policy check failed; caused by Error: "metadata.name" is not valid; expected a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total but found "somthing-". To learn more about catalog file format, visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md
```

into 

```txt
Policy check failed for ENTITY_REF ; caused by Error: "metadata.name" is not valid; expected a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total but found "somthing-". To learn more about catalog file format, visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md
```

It helps fix issues faster 