### PR TITLE
Autogenerate ids for headings in markdown content

### DIFF
--- a/.changeset/lazy-snakes-film.md
+++ b/.changeset/lazy-snakes-film.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': minor
 ---
 
-Adds code to autogenerate ids for headers parsed through the MarkdownContent component.
+Adds code to generate ids for headers parsed through the MarkdownContent component.

--- a/.changeset/lazy-snakes-film.md
+++ b/.changeset/lazy-snakes-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Adds code to autogenerate ids for headers parsed through the MarkdownContent component.

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
@@ -100,4 +100,34 @@ describe('<MarkdownContent />', () => {
       'https://example.com/blog/assets/6/header.png',
     );
   });
+
+  it('render MarkdownContent component with headings given proper ids', async () => {
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <MarkdownContent
+          content={
+            '# Lorem ipsum\n' +
+            '## bing bong\n' +
+            '### The FitnessGram Pacer Test is a multistage aerobic capacity test'
+          }
+        />,
+      ),
+    );
+
+    expect(rendered.getByText('Lorem ipsum').getAttribute('id')).toEqual(
+      'lorem-ipsum',
+    );
+    expect(rendered.getByText('bing bong').getAttribute('id')).toEqual(
+      'bing-bong',
+    );
+    expect(
+      rendered
+        .getByText(
+          'The FitnessGram Pacer Test is a multistage aerobic capacity test',
+        )
+        .getAttribute('id'),
+    ).toEqual(
+      'the-fitnessgram-pacer-test-is-a-multistage-aerobic-capacity-test',
+    );
+  });
 });

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -73,6 +73,19 @@ type Props = {
   className?: string;
 };
 
+const flatten = (text, child) => {
+  return typeof child === 'string'
+    ? text + child
+    : React.Children.toArray(child.props.children).reduce(flatten, text);
+};
+
+const headingRenderer = ({ level, children }) => {
+  const childrenArray = React.Children.toArray(children);
+  const text = childrenArray.reduce(flatten, '');
+  const slug = text.toLocaleLowerCase('en-US').replace(/\W/g, '-');
+  return React.createElement(`h${level}`, { id: slug }, children);
+};
+
 const components: Options['components'] = {
   code: ({ inline, className, children, ...props }) => {
     const text = String(children).replace(/\n+$/, '');
@@ -85,6 +98,12 @@ const components: Options['components'] = {
       </code>
     );
   },
+  h1: headingRenderer,
+  h2: headingRenderer,
+  h3: headingRenderer,
+  h4: headingRenderer,
+  h5: headingRenderer,
+  h6: headingRenderer,
 };
 
 /**

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -20,6 +20,7 @@ import gfm from 'remark-gfm';
 import React from 'react';
 import { BackstageTheme } from '@backstage/theme';
 import { CodeSnippet } from '../CodeSnippet';
+import { HeadingProps } from 'react-markdown/lib/ast-to-react';
 
 export type MarkdownContentClassKey = 'markdown';
 
@@ -73,13 +74,15 @@ type Props = {
   className?: string;
 };
 
-const flatten = (text, child) => {
+const flatten = (text: string, child: any): string => {
+  if (!child) return text;
+
   return typeof child === 'string'
     ? text + child
     : React.Children.toArray(child.props.children).reduce(flatten, text);
 };
 
-const headingRenderer = ({ level, children }) => {
+const headingRenderer = ({ level, children }: HeadingProps) => {
   const childrenArray = React.Children.toArray(children);
   const text = childrenArray.reduce(flatten, '');
   const slug = text.toLocaleLowerCase('en-US').replace(/\W/g, '-');


### PR DESCRIPTION
Signed-off-by: John Philip <johnphilip283@gmail.com>

## Hey, I just made a Pull Request!

Added custom renderers for h1 - h6 elements in the MarkdownContent component that autogenerate ids for these elements when rendered (see screenshots for examples).

Before:

<img width="868" alt="before" src="https://user-images.githubusercontent.com/23266343/185272299-a2351bbf-e683-4493-9cc0-8359ae8da8fe.png">

After:

<img width="881" alt="after" src="https://user-images.githubusercontent.com/23266343/185272316-798d011f-f8eb-4cf6-bda4-c689e61eec0c.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
