### PR TITLE
Bazaar plugin: The project member link will now target the user catalog page.

### DIFF
--- a/.changeset/seven-pillows-approve.md
+++ b/.changeset/seven-pillows-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': minor
+---
+
+Include user ref when adding a member. The member link will point to the catalog if possible.

--- a/.changeset/tough-seahorses-learn.md
+++ b/.changeset/tough-seahorses-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar-backend': minor
+---
+
+Added user entity ref to the members table

--- a/plugins/bazaar-backend/migrations/20220817150443_add_member_entity_ref.js
+++ b/plugins/bazaar-backend/migrations/20220817150443_add_member_entity_ref.js
@@ -22,6 +22,6 @@ exports.up = async function up(knex) {
 
 exports.down = async function down(knex) {
   return knex.schema.table('members', table => {
-    t.dropColumn('user_ref');
+    table.dropColumn('user_ref');
   });
 };

--- a/plugins/bazaar-backend/migrations/20220817150443_add_member_entity_ref.js
+++ b/plugins/bazaar-backend/migrations/20220817150443_add_member_entity_ref.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('members', table => {
+    table.string('user_ref').nullable();
+  });
+};
+
+exports.down = async function down(knex) {
+  return knex.schema.table('members', table => {
+    t.dropColumn('user_ref');
+  });
+};

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
@@ -75,6 +75,13 @@ describe('DatabaseHandler', () => {
         responsible: bazaarProject.responsible,
       });
 
+      // Add a member to the project
+      await knex('members').insert({
+        item_id: 1,
+        user_ref: 'user:default/thehulk',
+        user_id: 'Bruce Banner',
+      });
+
       const res = await dbHandler.getMetadataByRef('ref1');
 
       expect(res).toHaveLength(1);
@@ -85,6 +92,7 @@ describe('DatabaseHandler', () => {
       expect(res[0].end_date).toEqual(null);
       expect(res[0].size).toEqual('small');
       expect(res[0].responsible).toEqual('r');
+      expect(res[0].members_count).toEqual(1);
     },
     60_000,
   );

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
@@ -92,7 +92,9 @@ describe('DatabaseHandler', () => {
       expect(res[0].end_date).toEqual(null);
       expect(res[0].size).toEqual('small');
       expect(res[0].responsible).toEqual('r');
-      expect(res[0].members_count).toEqual(1);
+      expect(
+        res[0].members_count === '1' || res[0].members_count === 1,
+      ).toBeTruthy();
     },
     60_000,
   );

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.ts
@@ -67,11 +67,17 @@ export class DatabaseHandler {
     return await this.client.select('*').from('members').where({ item_id: id });
   }
 
-  async addMember(id: number, userId: string, picture?: string) {
+  async addMember(
+    id: number,
+    userId: string,
+    userRef?: string,
+    picture?: string,
+  ) {
     await this.client
       .insert({
         item_id: id,
         user_id: userId,
+        user_ref: userRef,
         picture: picture,
       })
       .into('members');

--- a/plugins/bazaar-backend/src/service/router.ts
+++ b/plugins/bazaar-backend/src/service/router.ts
@@ -51,12 +51,20 @@ export async function createRouter(
     }
   });
 
-  router.put('/projects/:id/member/:userId', async (request, response) => {
-    const { id, userId } = request.params;
-    await dbHandler.addMember(parseInt(id, 10), userId, request.body?.picture);
+  router.put(
+    '/projects/:id/member/:userId/:userRef?',
+    async (request, response) => {
+      const { id, userId, userRef } = request.params;
+      await dbHandler.addMember(
+        parseInt(id, 10),
+        userId,
+        userRef,
+        request.body?.picture,
+      );
 
-    response.json({ status: 'ok' });
-  });
+      response.json({ status: 'ok' });
+    },
+  );
 
   router.delete('/projects/:id/member/:userId', async (request, response) => {
     const { id, userId } = request.params;

--- a/plugins/bazaar/src/api.ts
+++ b/plugins/bazaar/src/api.ts
@@ -121,11 +121,14 @@ export class BazaarClient implements BazaarApi {
   async addMember(id: number, userId: string): Promise<void> {
     const baseUrl = await this.discoveryApi.getBaseUrl('bazaar');
     const { picture } = await this.identityApi.getProfileInfo();
+    const { userEntityRef } = await this.identityApi.getBackstageIdentity();
 
     await this.fetchApi.fetch(
       `${baseUrl}/projects/${encodeURIComponent(
         id,
-      )}/member/${encodeURIComponent(userId)}`,
+      )}/member/${encodeURIComponent(userId)}/${encodeURIComponent(
+        userEntityRef,
+      )}`,
       {
         method: 'PUT',
         headers: {

--- a/plugins/bazaar/src/components/CardContentFields/CardContentFields.tsx
+++ b/plugins/bazaar/src/components/CardContentFields/CardContentFields.tsx
@@ -23,6 +23,8 @@ import {
   Typography,
   GridSize,
 } from '@material-ui/core';
+import { generatePath } from 'react-router-dom';
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Avatar, Link } from '@backstage/core-components';
 import { AboutField } from '@backstage/plugin-catalog';
 import { StatusTag } from '../StatusTag';
@@ -111,7 +113,14 @@ export const CardContentFields = ({
                         />
                         <Link
                           className={classes.break}
-                          to={`http://github.com/${member.userId}`}
+                          to={
+                            member.userRef
+                              ? generatePath(
+                                  '/catalog/:namespace/:kind/:name',
+                                  parseEntityRef(member.userRef),
+                                )
+                              : `http://github.com/${member.userId}`
+                          }
                           target="_blank"
                         >
                           {member?.userId}

--- a/plugins/bazaar/src/types.ts
+++ b/plugins/bazaar/src/types.ts
@@ -17,6 +17,7 @@
 export type Member = {
   itemId: number;
   userId: string;
+  userRef?: string;
   joinDate?: string;
   picture?: string;
 };

--- a/plugins/bazaar/src/util/parseMethods.ts
+++ b/plugins/bazaar/src/util/parseMethods.ts
@@ -37,6 +37,7 @@ export const parseMember = (member: any): Member => {
   return {
     itemId: member.item_id,
     userId: member.user_id,
+    userRef: member.user_ref,
     joinDate: member.join_date,
     picture: member.picture,
   } as Member;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The url for a project member is currently hard coded as "httpx://github.com/${backstage_display_name}", this PR changes the url to instead target the backstage catalog page of the user. Not sure if current url is valid for orgs that are using github as their identity provider but it is a bit confusing for non github setups.

Changes:

* Backend: Added a migration to add a field ("user_ref") to the member table. This will contain the user entity ref.
* Backend: The "add_member" api call now accepts an optional "user entity ref" parameter.
* Front end: When a user presses the "Join project" the backstage user entity ref of the current user is included in the api call.
* Front end: If the 'userRef' field is set on a member, the url will link to the catalog page of the user.

#### :heavy_check_mark: Checklist
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #13190
