### PR TITLE
just some :broom: api cleaning

### DIFF
--- a/.changeset/wild-sheep-roll.md
+++ b/.changeset/wild-sheep-roll.md
@@ -1,0 +1,8 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-adr': patch
+'@backstage/plugin-apache-airflow': patch
+'@backstage/plugin-api-docs': patch
+---
+
+Minor cleanup of the public API surface to reduce the number of warnings

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -987,13 +987,10 @@ export type SidebarOpenState = {
 };
 
 // @public
-export const SidebarOpenStateProvider: ({
-  children,
-  value,
-}: {
+export function SidebarOpenStateProvider(props: {
   children: ReactNode;
   value: SidebarOpenState;
-}) => JSX.Element;
+}): JSX.Element;
 
 // @public (undocumented)
 export type SidebarOptions = {
@@ -1034,13 +1031,10 @@ export type SidebarPinStateContextType = {
 };
 
 // @public
-export const SidebarPinStateProvider: ({
-  children,
-  value,
-}: {
+export function SidebarPinStateProvider(props: {
   children: ReactNode;
   value: SidebarPinStateContextType;
-}) => JSX.Element;
+}): JSX.Element;
 
 // @public (undocumented)
 export type SidebarProps = {

--- a/packages/core-components/src/layout/Sidebar/SidebarOpenStateContext.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarOpenStateContext.tsx
@@ -74,21 +74,21 @@ const VersionedSidebarContext = createVersionedContext<{
  *
  * @public
  */
-export const SidebarOpenStateProvider = ({
-  children,
-  value,
-}: {
+export function SidebarOpenStateProvider(props: {
   children: ReactNode;
   value: SidebarOpenState;
-}) => (
-  <LegacySidebarContext.Provider value={value}>
-    <VersionedSidebarContext.Provider
-      value={createVersionedValueMap({ 1: value })}
-    >
-      {children}
-    </VersionedSidebarContext.Provider>
-  </LegacySidebarContext.Provider>
-);
+}) {
+  const { children, value } = props;
+  return (
+    <LegacySidebarContext.Provider value={value}>
+      <VersionedSidebarContext.Provider
+        value={createVersionedValueMap({ 1: value })}
+      >
+        {children}
+      </VersionedSidebarContext.Provider>
+    </LegacySidebarContext.Provider>
+  );
+}
 
 /**
  * Hook to read and update the sidebar's open state, which controls whether or

--- a/packages/core-components/src/layout/Sidebar/SidebarPinStateContext.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarPinStateContext.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createVersionedContext,
   createVersionedValueMap,
@@ -22,8 +23,8 @@ import React, { createContext, ReactNode, useContext } from 'react';
 /**
  * Type of `SidebarPinStateContext`
  *
- * @public @deprecated
- * Use `SidebarPinState` instead.
+ * @public
+ * @deprecated Use `SidebarPinState` instead.
  */
 export type SidebarPinStateContextType = {
   isPinned: boolean;
@@ -80,21 +81,21 @@ const VersionedSidebarPinStateContext = createVersionedContext<{
  *
  * @public
  */
-export const SidebarPinStateProvider = ({
-  children,
-  value,
-}: {
+export function SidebarPinStateProvider(props: {
   children: ReactNode;
   value: SidebarPinStateContextType;
-}) => (
-  <LegacySidebarPinStateContext.Provider value={value}>
-    <VersionedSidebarPinStateContext.Provider
-      value={createVersionedValueMap({ 1: value })}
-    >
-      {children}
-    </VersionedSidebarPinStateContext.Provider>
-  </LegacySidebarPinStateContext.Provider>
-);
+}) {
+  const { children, value } = props;
+  return (
+    <LegacySidebarPinStateContext.Provider value={value}>
+      <VersionedSidebarPinStateContext.Provider
+        value={createVersionedValueMap({ 1: value })}
+      >
+        {children}
+      </VersionedSidebarPinStateContext.Provider>
+    </LegacySidebarPinStateContext.Provider>
+  );
+}
 
 /**
  * Hook to read and update sidebar pin state, which controls whether or not the

--- a/plugins/adr/api-report.md
+++ b/plugins/adr/api-report.md
@@ -31,13 +31,7 @@ export const adrPlugin: BackstagePlugin<
 
 // @public
 export const AdrReader: {
-  ({
-    adr,
-    decorators,
-  }: {
-    adr: string;
-    decorators?: AdrContentDecorator[] | undefined;
-  }): JSX.Element;
+  (props: { adr: string; decorators?: AdrContentDecorator[] }): JSX.Element;
   decorators: Readonly<{
     createRewriteRelativeLinksDecorator(): AdrContentDecorator;
     createRewriteRelativeEmbedsDecorator(): AdrContentDecorator;
@@ -45,23 +39,15 @@ export const AdrReader: {
 };
 
 // @public
-export const AdrSearchResultListItem: ({
-  lineClamp,
-  highlight,
-  rank,
-  result,
-}: {
-  lineClamp?: number | undefined;
-  highlight?: ResultHighlight | undefined;
-  rank?: number | undefined;
+export function AdrSearchResultListItem(props: {
+  lineClamp?: number;
+  highlight?: ResultHighlight;
+  rank?: number;
   result: AdrDocument;
-}) => JSX.Element;
+}): JSX.Element;
 
 // @public
-export const EntityAdrContent: ({
-  contentDecorators,
-  filePathFilterFn,
-}: {
+export const EntityAdrContent: (props: {
   contentDecorators?: AdrContentDecorator[] | undefined;
   filePathFilterFn?: AdrFilePathFilterFn | undefined;
 }) => JSX.Element;

--- a/plugins/adr/src/components/AdrReader/AdrReader.tsx
+++ b/plugins/adr/src/components/AdrReader/AdrReader.tsx
@@ -32,15 +32,14 @@ import { AdrContentDecorator } from './types';
 
 /**
  * Component to fetch and render an ADR.
+ *
  * @public
  */
-export const AdrReader = ({
-  adr,
-  decorators,
-}: {
+export const AdrReader = (props: {
   adr: string;
   decorators?: AdrContentDecorator[];
 }) => {
+  const { adr, decorators } = props;
   const { entity } = useEntity();
   const scmIntegrations = useApi(scmIntegrationsApiRef);
   const adrLocationUrl = getAdrLocationUrl(entity, scmIntegrations);

--- a/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
+++ b/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
@@ -58,13 +58,11 @@ const useStyles = makeStyles((theme: Theme) => ({
  * Component for browsing ADRs on an entity page.
  * @public
  */
-export const EntityAdrContent = ({
-  contentDecorators,
-  filePathFilterFn,
-}: {
+export const EntityAdrContent = (props: {
   contentDecorators?: AdrContentDecorator[];
   filePathFilterFn?: AdrFilePathFilterFn;
 }) => {
+  const { contentDecorators, filePathFilterFn } = props;
   const classes = useStyles();
   const { entity } = useEntity();
   const rootLink = useRouteRef(rootRouteRef);

--- a/plugins/adr/src/search/AdrSearchResultListItem.tsx
+++ b/plugins/adr/src/search/AdrSearchResultListItem.tsx
@@ -43,20 +43,16 @@ const useStyles = makeStyles({
 });
 
 /**
- * A component to display a ADR search result
+ * A component to display an ADR search result.
  * @public
  */
-export const AdrSearchResultListItem = ({
-  lineClamp = 5,
-  highlight,
-  rank,
-  result,
-}: {
+export function AdrSearchResultListItem(props: {
   lineClamp?: number;
   highlight?: ResultHighlight;
   rank?: number;
   result: AdrDocument;
-}) => {
+}) {
+  const { lineClamp = 5, highlight, rank, result } = props;
   const classes = useStyles();
   const analytics = useAnalytics();
 
@@ -122,4 +118,4 @@ export const AdrSearchResultListItem = ({
       <Divider component="li" />
     </Link>
   );
-};
+}

--- a/plugins/apache-airflow/api-report.md
+++ b/plugins/apache-airflow/api-report.md
@@ -9,9 +9,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public
-export const ApacheAirflowDagTable: ({
-  dagIds,
-}: {
+export const ApacheAirflowDagTable: (props: {
   dagIds?: string[] | undefined;
 }) => JSX.Element;
 

--- a/plugins/apache-airflow/src/components/DagTableComponent/DagTableComponent.tsx
+++ b/plugins/apache-airflow/src/components/DagTableComponent/DagTableComponent.tsx
@@ -134,7 +134,8 @@ type DagTableComponentProps = {
   dagIds?: string[];
 };
 
-export const DagTableComponent = ({ dagIds }: DagTableComponentProps) => {
+export const DagTableComponent = (props: DagTableComponentProps) => {
+  const { dagIds } = props;
   const apiClient = useApi(apacheAirflowApiRef);
 
   const { value, loading, error } = useAsync(async (): Promise<Dag[]> => {

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -58,21 +58,13 @@ export const ApiExplorerIndexPage: (
   props: DefaultApiExplorerPageProps,
 ) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "ApiExplorerPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const ApiExplorerPage: (
   props: DefaultApiExplorerPageProps,
 ) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "ApiTypeTitle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const ApiTypeTitle: ({
-  apiEntity,
-}: {
-  apiEntity: ApiEntity;
-}) => JSX.Element;
+export const ApiTypeTitle: (props: { apiEntity: ApiEntity }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "AsyncApiDefinitionWidget" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -88,17 +80,15 @@ export type AsyncApiDefinitionWidgetProps = {
   definition: string;
 };
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ConsumedApisCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const ConsumedApisCard: ({ variant }: Props) => JSX.Element;
+export const ConsumedApisCard: (props: {
+  variant?: InfoCardVariants;
+}) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ConsumingComponentsCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const ConsumingComponentsCard: ({ variant }: Props_4) => JSX.Element;
+export const ConsumingComponentsCard: (props: {
+  variant?: InfoCardVariants;
+}) => JSX.Element;
 
 // @public
 export const DefaultApiExplorerPage: ({
@@ -119,53 +109,31 @@ export type DefaultApiExplorerPageProps = {
 // @public (undocumented)
 export function defaultDefinitionWidgets(): ApiDefinitionWidget[];
 
-// Warning: (ae-missing-release-tag) "EntityApiDefinitionCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const EntityApiDefinitionCard: () => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "EntityConsumedApisCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const EntityConsumedApisCard: ({
-  variant,
-}: {
+export const EntityConsumedApisCard: (props: {
   variant?: InfoCardVariants | undefined;
 }) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "EntityConsumingComponentsCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const EntityConsumingComponentsCard: ({
-  variant,
-}: {
+export const EntityConsumingComponentsCard: (props: {
   variant?: InfoCardVariants | undefined;
 }) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "EntityHasApisCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const EntityHasApisCard: ({
-  variant,
-}: {
+export const EntityHasApisCard: (props: {
   variant?: InfoCardVariants | undefined;
 }) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "EntityProvidedApisCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const EntityProvidedApisCard: ({
-  variant,
-}: {
+export const EntityProvidedApisCard: (props: {
   variant?: InfoCardVariants | undefined;
 }) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "EntityProvidingComponentsCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const EntityProvidingComponentsCard: ({
-  variant,
-}: {
+export const EntityProvidingComponentsCard: (props: {
   variant?: InfoCardVariants | undefined;
 }) => JSX.Element;
 
@@ -183,11 +151,10 @@ export type GraphQlDefinitionWidgetProps = {
   definition: string;
 };
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "HasApisCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const HasApisCard: ({ variant }: Props_2) => JSX.Element;
+export const HasApisCard: (props: {
+  variant?: InfoCardVariants;
+}) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "OpenApiDefinitionWidget" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -218,15 +185,15 @@ export type PlainApiDefinitionWidgetProps = {
   language: string;
 };
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ProvidedApisCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export const ProvidedApisCard: ({ variant }: Props_3) => JSX.Element;
+export const ProvidedApisCard: (props: {
+  variant?: InfoCardVariants;
+}) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ProvidingComponentsCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const ProvidingComponentsCard: ({ variant }: Props_5) => JSX.Element;
+export const ProvidingComponentsCard: (props: {
+  variant?: InfoCardVariants;
+}) => JSX.Element;
 ```

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiTypeTitle.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiTypeTitle.tsx
@@ -19,7 +19,11 @@ import React from 'react';
 import { apiDocsConfigRef } from '../../config';
 import { useApi } from '@backstage/core-plugin-api';
 
-export const ApiTypeTitle = ({ apiEntity }: { apiEntity: ApiEntity }) => {
+/**
+ * @public
+ */
+export const ApiTypeTitle = (props: { apiEntity: ApiEntity }) => {
+  const { apiEntity } = props;
   const config = useApi(apiDocsConfigRef);
   const definition = config.getApiDefinitionWidget(apiEntity);
   const type = definition ? definition.title : apiEntity.spec.type;

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -32,11 +32,11 @@ import {
   WarningPanel,
 } from '@backstage/core-components';
 
-type Props = {
-  variant?: InfoCardVariants;
-};
-
-export const ConsumedApisCard = ({ variant = 'gridItem' }: Props) => {
+/**
+ * @public
+ */
+export const ConsumedApisCard = (props: { variant?: InfoCardVariants }) => {
+  const { variant = 'gridItem' } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_CONSUMES_API,

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -33,10 +33,6 @@ import {
   WarningPanel,
 } from '@backstage/core-components';
 
-type Props = {
-  variant?: InfoCardVariants;
-};
-
 const columns: TableColumn<ApiEntity>[] = [
   EntityTable.columns.createEntityRefColumn({ defaultKind: 'API' }),
   EntityTable.columns.createOwnerColumn(),
@@ -45,7 +41,11 @@ const columns: TableColumn<ApiEntity>[] = [
   EntityTable.columns.createMetadataDescriptionColumn(),
 ];
 
-export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
+/**
+ * @public
+ */
+export const HasApisCard = (props: { variant?: InfoCardVariants }) => {
+  const { variant = 'gridItem' } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_HAS_PART,

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -32,11 +32,11 @@ import {
   WarningPanel,
 } from '@backstage/core-components';
 
-type Props = {
-  variant?: InfoCardVariants;
-};
-
-export const ProvidedApisCard = ({ variant = 'gridItem' }: Props) => {
+/**
+ * @public
+ */
+export const ProvidedApisCard = (props: { variant?: InfoCardVariants }) => {
+  const { variant = 'gridItem' } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_PROVIDES_API,

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -34,11 +34,13 @@ import {
   WarningPanel,
 } from '@backstage/core-components';
 
-type Props = {
+/**
+ * @public
+ */
+export const ConsumingComponentsCard = (props: {
   variant?: InfoCardVariants;
-};
-
-export const ConsumingComponentsCard = ({ variant = 'gridItem' }: Props) => {
+}) => {
+  const { variant = 'gridItem' } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_API_CONSUMED_BY,

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -34,11 +34,10 @@ import {
   WarningPanel,
 } from '@backstage/core-components';
 
-type Props = {
+export const ProvidingComponentsCard = (props: {
   variant?: InfoCardVariants;
-};
-
-export const ProvidingComponentsCard = ({ variant = 'gridItem' }: Props) => {
+}) => {
+  const { variant = 'gridItem' } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_API_PROVIDED_BY,

--- a/plugins/api-docs/src/plugin.ts
+++ b/plugins/api-docs/src/plugin.ts
@@ -49,6 +49,7 @@ export const apiDocsPlugin = createPlugin({
   },
 });
 
+/** @public */
 export const ApiExplorerPage = apiDocsPlugin.provide(
   createRoutableExtension({
     name: 'ApiExplorerPage',
@@ -58,6 +59,7 @@ export const ApiExplorerPage = apiDocsPlugin.provide(
   }),
 );
 
+/** @public */
 export const EntityApiDefinitionCard = apiDocsPlugin.provide(
   createComponentExtension({
     name: 'EntityApiDefinitionCard',
@@ -68,6 +70,7 @@ export const EntityApiDefinitionCard = apiDocsPlugin.provide(
   }),
 );
 
+/** @public */
 export const EntityConsumedApisCard = apiDocsPlugin.provide(
   createComponentExtension({
     name: 'EntityConsumedApisCard',
@@ -78,6 +81,7 @@ export const EntityConsumedApisCard = apiDocsPlugin.provide(
   }),
 );
 
+/** @public */
 export const EntityConsumingComponentsCard = apiDocsPlugin.provide(
   createComponentExtension({
     name: 'EntityConsumingComponentsCard',
@@ -90,6 +94,7 @@ export const EntityConsumingComponentsCard = apiDocsPlugin.provide(
   }),
 );
 
+/** @public */
 export const EntityProvidedApisCard = apiDocsPlugin.provide(
   createComponentExtension({
     name: 'EntityProvidedApisCard',
@@ -100,6 +105,7 @@ export const EntityProvidedApisCard = apiDocsPlugin.provide(
   }),
 );
 
+/** @public */
 export const EntityProvidingComponentsCard = apiDocsPlugin.provide(
   createComponentExtension({
     name: 'EntityProvidingComponentsCard',
@@ -112,6 +118,7 @@ export const EntityProvidingComponentsCard = apiDocsPlugin.provide(
   }),
 );
 
+/** @public */
 export const EntityHasApisCard = apiDocsPlugin.provide(
   createComponentExtension({
     name: 'EntityHasApisCard',


### PR DESCRIPTION
Chasing after eager props unpacking in the public surfaces at least (effectively searching for `}: {` in api reports), and some other smol things slipped in too