### PR TITLE
microsite: fix release page

### DIFF
--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -1,6 +1,7 @@
 {
   "releases": {
     "Release Notes": [
+      "releases/v1.5.0",
       "releases/v1.4.0",
       "releases/v1.3.0",
       "releases/v1.2.0",


### PR DESCRIPTION
The left sidebar is currently missing if you head to the release page, this should bring it back