### PR TITLE
chore: Exporting KubernetesClientProvider as requested in issue #10457

### DIFF
--- a/.changeset/brave-steaks-lay.md
+++ b/.changeset/brave-steaks-lay.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-chore: Exporting KubernetesClientProvider as requested in issue #10457
+chore: Exporting KubernetesClientProvider and everything in kubernetes-auth-translator as requested in issue #10457

--- a/.changeset/brave-steaks-lay.md
+++ b/.changeset/brave-steaks-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+chore: Exporting KubernetesClientProvider as requested in issue #10457

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -32,17 +32,12 @@ export interface AWSClusterDetails extends ClusterDetails {
   externalId?: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "KubernetesAuthTranslator" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "AwsIamKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class AwsIamKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {
   // (undocumented)
   awsGetCredentials: () => Promise<Credentials>;
-  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "AWSClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   decorateClusterDetailsWithAuth(
     clusterDetails: AWSClusterDetails,
@@ -58,8 +53,6 @@ export class AwsIamKubernetesAuthTranslator
     assumeRole?: string,
     externalId?: string,
   ): Promise<SigningCreds>;
-  // Warning: (ae-forgotten-export) The symbol "SigningCreds" needs to be exported by the entry point index.d.ts
-  //
   // (undocumented)
   validCredentials(creds: SigningCreds): boolean;
 }
@@ -67,15 +60,11 @@ export class AwsIamKubernetesAuthTranslator
 // @alpha (undocumented)
 export interface AzureClusterDetails extends ClusterDetails {}
 
-// Warning: (ae-missing-release-tag) "AzureIdentityKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class AzureIdentityKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {
   constructor(logger: Logger, tokenCredential?: TokenCredential);
-  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "AzureClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   decorateClusterDetailsWithAuth(
     clusterDetails: AzureClusterDetails,
@@ -135,14 +124,10 @@ export interface FetchResponseWrapper {
 // @alpha (undocumented)
 export interface GKEClusterDetails extends ClusterDetails {}
 
-// Warning: (ae-missing-release-tag) "GoogleKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class GoogleKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {
-  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "GKEClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   decorateClusterDetailsWithAuth(
     clusterDetails: GKEClusterDetails,
@@ -150,23 +135,26 @@ export class GoogleKubernetesAuthTranslator
   ): Promise<GKEClusterDetails>;
 }
 
-// Warning: (ae-missing-release-tag) "GoogleServiceAccountAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class GoogleServiceAccountAuthTranslator
   implements KubernetesAuthTranslator
 {
-  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "GKEClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   decorateClusterDetailsWithAuth(
     clusterDetails: GKEClusterDetails,
   ): Promise<GKEClusterDetails>;
 }
 
-// Warning: (ae-missing-release-tag) "KubernetesAuthTranslatorGenerator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
+export interface KubernetesAuthTranslator {
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: ClusterDetails,
+    authConfig: KubernetesRequestAuth,
+  ): Promise<ClusterDetails>;
+}
+
+// @alpha (undocumented)
 export class KubernetesAuthTranslatorGenerator {
   // (undocumented)
   static getKubernetesAuthTranslatorInstance(
@@ -247,24 +235,14 @@ export type KubernetesBuilderReturn = Promise<{
   serviceLocator: KubernetesServiceLocator;
 }>;
 
-// Warning: (ae-missing-release-tag) "KubernetesClientProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class KubernetesClientProvider {
-  // Warning: (ae-incompatible-release-tags) The symbol "getCoreClientByClusterDetails" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   getCoreClientByClusterDetails(clusterDetails: ClusterDetails): CoreV1Api;
-  // Warning: (ae-incompatible-release-tags) The symbol "getCustomObjectsClient" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   getCustomObjectsClient(clusterDetails: ClusterDetails): CustomObjectsApi;
-  // Warning: (ae-incompatible-release-tags) The symbol "getKubeConfig" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   getKubeConfig(clusterDetails: ClusterDetails): KubeConfig;
-  // Warning: (ae-incompatible-release-tags) The symbol "getMetricsClient" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   getMetricsClient(clusterDetails: ClusterDetails): Metrics;
 }
@@ -355,12 +333,8 @@ export interface KubernetesServiceLocator {
   }>;
 }
 
-// Warning: (ae-missing-release-tag) "NoopKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class NoopKubernetesAuthTranslator implements KubernetesAuthTranslator {
-  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "ServiceAccountClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   decorateClusterDetailsWithAuth(
     clusterDetails: ServiceAccountClusterDetails,
@@ -402,12 +376,8 @@ export interface ObjectToFetch {
   plural: string;
 }
 
-// Warning: (ae-missing-release-tag) "OidcKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export class OidcKubernetesAuthTranslator implements KubernetesAuthTranslator {
-  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
-  //
   // (undocumented)
   decorateClusterDetailsWithAuth(
     clusterDetails: ClusterDetails,
@@ -434,4 +404,11 @@ export interface ServiceAccountClusterDetails extends ClusterDetails {}
 
 // @alpha (undocumented)
 export type ServiceLocatorMethod = 'multiTenant' | 'http';
+
+// @alpha (undocumented)
+export type SigningCreds = {
+  accessKeyId: string | undefined;
+  secretAccessKey: string | undefined;
+  sessionToken: string | undefined;
+};
 ```

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -6,6 +6,7 @@
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { CoreV1Api } from '@kubernetes/client-node';
+import { Credentials } from 'aws-sdk';
 import { CustomObjectsApi } from '@kubernetes/client-node';
 import { Duration } from 'luxon';
 import { Entity } from '@backstage/catalog-model';
@@ -14,13 +15,14 @@ import type { FetchResponse } from '@backstage/plugin-kubernetes-common';
 import type { JsonObject } from '@backstage/types';
 import { KubeConfig } from '@kubernetes/client-node';
 import type { KubernetesFetchError } from '@backstage/plugin-kubernetes-common';
-import type { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
+import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 import type { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { Logger } from 'winston';
 import { Metrics } from '@kubernetes/client-node';
 import type { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { PodStatus } from '@kubernetes/client-node/dist/top';
+import { TokenCredential } from '@azure/identity';
 
 // @alpha (undocumented)
 export interface AWSClusterDetails extends ClusterDetails {
@@ -30,8 +32,55 @@ export interface AWSClusterDetails extends ClusterDetails {
   externalId?: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "KubernetesAuthTranslator" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "AwsIamKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class AwsIamKubernetesAuthTranslator
+  implements KubernetesAuthTranslator
+{
+  // (undocumented)
+  awsGetCredentials: () => Promise<Credentials>;
+  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "AWSClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: AWSClusterDetails,
+  ): Promise<AWSClusterDetails>;
+  // (undocumented)
+  getBearerToken(
+    clusterName: string,
+    assumeRole?: string,
+    externalId?: string,
+  ): Promise<string>;
+  // (undocumented)
+  getCredentials(
+    assumeRole?: string,
+    externalId?: string,
+  ): Promise<SigningCreds>;
+  // Warning: (ae-forgotten-export) The symbol "SigningCreds" needs to be exported by the entry point index.d.ts
+  //
+  // (undocumented)
+  validCredentials(creds: SigningCreds): boolean;
+}
+
 // @alpha (undocumented)
 export interface AzureClusterDetails extends ClusterDetails {}
+
+// Warning: (ae-missing-release-tag) "AzureIdentityKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class AzureIdentityKubernetesAuthTranslator
+  implements KubernetesAuthTranslator
+{
+  constructor(logger: Logger, tokenCredential?: TokenCredential);
+  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "AzureClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: AzureClusterDetails,
+  ): Promise<AzureClusterDetails>;
+}
 
 // @alpha (undocumented)
 export interface ClusterDetails {
@@ -85,6 +134,48 @@ export interface FetchResponseWrapper {
 
 // @alpha (undocumented)
 export interface GKEClusterDetails extends ClusterDetails {}
+
+// Warning: (ae-missing-release-tag) "GoogleKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class GoogleKubernetesAuthTranslator
+  implements KubernetesAuthTranslator
+{
+  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "GKEClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: GKEClusterDetails,
+    authConfig: KubernetesRequestAuth,
+  ): Promise<GKEClusterDetails>;
+}
+
+// Warning: (ae-missing-release-tag) "GoogleServiceAccountAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class GoogleServiceAccountAuthTranslator
+  implements KubernetesAuthTranslator
+{
+  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "GKEClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: GKEClusterDetails,
+  ): Promise<GKEClusterDetails>;
+}
+
+// Warning: (ae-missing-release-tag) "KubernetesAuthTranslatorGenerator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class KubernetesAuthTranslatorGenerator {
+  // (undocumented)
+  static getKubernetesAuthTranslatorInstance(
+    authProvider: string,
+    options: {
+      logger: Logger;
+    },
+  ): KubernetesAuthTranslator;
+}
 
 // @alpha (undocumented)
 export class KubernetesBuilder {
@@ -264,6 +355,18 @@ export interface KubernetesServiceLocator {
   }>;
 }
 
+// Warning: (ae-missing-release-tag) "NoopKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class NoopKubernetesAuthTranslator implements KubernetesAuthTranslator {
+  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "ServiceAccountClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: ServiceAccountClusterDetails,
+  ): Promise<ServiceAccountClusterDetails>;
+}
+
 // @alpha (undocumented)
 export interface ObjectFetchParams {
   // (undocumented)
@@ -297,6 +400,19 @@ export interface ObjectToFetch {
   objectType: KubernetesObjectTypes;
   // (undocumented)
   plural: string;
+}
+
+// Warning: (ae-missing-release-tag) "OidcKubernetesAuthTranslator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class OidcKubernetesAuthTranslator implements KubernetesAuthTranslator {
+  // Warning: (ae-incompatible-release-tags) The symbol "decorateClusterDetailsWithAuth" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: ClusterDetails,
+    authConfig: KubernetesRequestAuth,
+  ): Promise<ClusterDetails>;
 }
 
 // @alpha (undocumented)

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -5,15 +5,19 @@
 ```ts
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
+import { CoreV1Api } from '@kubernetes/client-node';
+import { CustomObjectsApi } from '@kubernetes/client-node';
 import { Duration } from 'luxon';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
 import type { FetchResponse } from '@backstage/plugin-kubernetes-common';
 import type { JsonObject } from '@backstage/types';
+import { KubeConfig } from '@kubernetes/client-node';
 import type { KubernetesFetchError } from '@backstage/plugin-kubernetes-common';
 import type { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 import type { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { Logger } from 'winston';
+import { Metrics } from '@kubernetes/client-node';
 import type { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { PodStatus } from '@kubernetes/client-node/dist/top';
@@ -151,6 +155,28 @@ export type KubernetesBuilderReturn = Promise<{
   objectsProvider: KubernetesObjectsProvider;
   serviceLocator: KubernetesServiceLocator;
 }>;
+
+// Warning: (ae-missing-release-tag) "KubernetesClientProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class KubernetesClientProvider {
+  // Warning: (ae-incompatible-release-tags) The symbol "getCoreClientByClusterDetails" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  getCoreClientByClusterDetails(clusterDetails: ClusterDetails): CoreV1Api;
+  // Warning: (ae-incompatible-release-tags) The symbol "getCustomObjectsClient" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  getCustomObjectsClient(clusterDetails: ClusterDetails): CustomObjectsApi;
+  // Warning: (ae-incompatible-release-tags) The symbol "getKubeConfig" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  getKubeConfig(clusterDetails: ClusterDetails): KubeConfig;
+  // Warning: (ae-incompatible-release-tags) The symbol "getMetricsClient" is marked as @public, but its signature references "ClusterDetails" which is marked as @alpha
+  //
+  // (undocumented)
+  getMetricsClient(clusterDetails: ClusterDetails): Metrics;
+}
 
 // @alpha
 export interface KubernetesClustersSupplier {

--- a/plugins/kubernetes-backend/src/index.ts
+++ b/plugins/kubernetes-backend/src/index.ts
@@ -22,6 +22,7 @@
 
 export * from './service/router';
 export * from './service/KubernetesBuilder';
+export * from './service/KubernetesClientProvider';
 export * from './types/types';
 
 export { DEFAULT_OBJECTS } from './service/KubernetesFanOutHandler';

--- a/plugins/kubernetes-backend/src/index.ts
+++ b/plugins/kubernetes-backend/src/index.ts
@@ -27,6 +27,7 @@ export * from './kubernetes-auth-translator/GoogleServiceAccountAuthProvider';
 export * from './kubernetes-auth-translator/KubernetesAuthTranslatorGenerator';
 export * from './kubernetes-auth-translator/NoopKubernetesAuthTranslator';
 export * from './kubernetes-auth-translator/OidcKubernetesAuthTranslator';
+export * from './kubernetes-auth-translator/types';
 
 export * from './service/router';
 export * from './service/KubernetesBuilder';

--- a/plugins/kubernetes-backend/src/index.ts
+++ b/plugins/kubernetes-backend/src/index.ts
@@ -20,9 +20,18 @@
  * @packageDocumentation
  */
 
+export * from './kubernetes-auth-translator/AwsIamKubernetesAuthTranslator';
+export * from './kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator';
+export * from './kubernetes-auth-translator/GoogleKubernetesAuthTranslator';
+export * from './kubernetes-auth-translator/GoogleServiceAccountAuthProvider';
+export * from './kubernetes-auth-translator/KubernetesAuthTranslatorGenerator';
+export * from './kubernetes-auth-translator/NoopKubernetesAuthTranslator';
+export * from './kubernetes-auth-translator/OidcKubernetesAuthTranslator';
+
 export * from './service/router';
 export * from './service/KubernetesBuilder';
 export * from './service/KubernetesClientProvider';
+
 export * from './types/types';
 
 export { DEFAULT_OBJECTS } from './service/KubernetesFanOutHandler';

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
@@ -18,12 +18,20 @@ import { sign } from 'aws4';
 import { AWSClusterDetails } from '../types/types';
 import { KubernetesAuthTranslator } from './types';
 
-type SigningCreds = {
+/**
+ *
+ * @alpha
+ */
+export type SigningCreds = {
   accessKeyId: string | undefined;
   secretAccessKey: string | undefined;
   sessionToken: string | undefined;
 };
 
+/**
+ *
+ * @alpha
+ */
 export class AwsIamKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator.ts
@@ -25,6 +25,10 @@ import {
 
 const aksScope = '6dae42f8-4368-4678-94ff-3960e28e3630/.default'; // This scope is the same for all Azure Managed Kubernetes
 
+/**
+ *
+ * @alpha
+ */
 export class AzureIdentityKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/GoogleKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/GoogleKubernetesAuthTranslator.ts
@@ -18,6 +18,10 @@ import { KubernetesAuthTranslator } from './types';
 import { GKEClusterDetails } from '../types/types';
 import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 
+/**
+ *
+ * @alpha
+ */
 export class GoogleKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/GoogleServiceAccountAuthProvider.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/GoogleServiceAccountAuthProvider.ts
@@ -17,6 +17,10 @@ import { KubernetesAuthTranslator } from './types';
 import { GKEClusterDetails } from '../types/types';
 import * as container from '@google-cloud/container';
 
+/**
+ *
+ * @alpha
+ */
 export class GoogleServiceAccountAuthTranslator
   implements KubernetesAuthTranslator
 {

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
@@ -23,6 +23,10 @@ import { GoogleServiceAccountAuthTranslator } from './GoogleServiceAccountAuthPr
 import { AzureIdentityKubernetesAuthTranslator } from './AzureIdentityKubernetesAuthTranslator';
 import { OidcKubernetesAuthTranslator } from './OidcKubernetesAuthTranslator';
 
+/**
+ *
+ * @alpha
+ */
 export class KubernetesAuthTranslatorGenerator {
   static getKubernetesAuthTranslatorInstance(
     authProvider: string,

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/NoopKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/NoopKubernetesAuthTranslator.ts
@@ -17,6 +17,10 @@
 import { KubernetesAuthTranslator } from './types';
 import { ServiceAccountClusterDetails } from '../types/types';
 
+/**
+ *
+ * @alpha
+ */
 export class NoopKubernetesAuthTranslator implements KubernetesAuthTranslator {
   async decorateClusterDetailsWithAuth(
     clusterDetails: ServiceAccountClusterDetails,

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
@@ -18,6 +18,10 @@ import { KubernetesAuthTranslator } from './types';
 import { ClusterDetails } from '../types/types';
 import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 
+/**
+ *
+ * @alpha
+ */
 export class OidcKubernetesAuthTranslator implements KubernetesAuthTranslator {
   async decorateClusterDetailsWithAuth(
     clusterDetails: ClusterDetails,

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/types.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/types.ts
@@ -17,6 +17,10 @@
 import { ClusterDetails } from '../types/types';
 import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
 
+/**
+ *
+ * @alpha
+ */
 export interface KubernetesAuthTranslator {
   decorateClusterDetailsWithAuth(
     clusterDetails: ClusterDetails,

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -22,6 +22,10 @@ import {
 } from '@kubernetes/client-node';
 import { ClusterDetails } from '../types/types';
 
+/**
+ *
+ * @alpha
+ */
 export class KubernetesClientProvider {
   // visible for testing
   getKubeConfig(clusterDetails: ClusterDetails) {


### PR DESCRIPTION
Signed-off-by: Carlos Esteban Lopez <luchillo17@gmail.com>

## Hey, I just made a Pull Request!

As requested in issue #10457 the KubernetesClientProvider is now exported as well from the `@backstage/plugin-kubernetes-backend` package.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
