### PR TITLE
Auth Backend: Add JWT to CloudflareAccessResult

### DIFF
--- a/.changeset/rich-cooks-camp.md
+++ b/.changeset/rich-cooks-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Cloudflare Access Provider: Add JWT to CloudflareAccessResult

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -204,7 +204,7 @@ export type CloudflareAccessResult = {
   claims: CloudflareAccessClaims;
   cfIdentity: CloudflareAccessIdentityProfile;
   expiresInSeconds?: number;
-  jwt: string;
+  token: string;
 };
 
 // @public

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -204,6 +204,7 @@ export type CloudflareAccessResult = {
   claims: CloudflareAccessClaims;
   cfIdentity: CloudflareAccessIdentityProfile;
   expiresInSeconds?: number;
+  jwt: string;
 };
 
 // @public

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.test.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.test.ts
@@ -138,12 +138,24 @@ describe('CloudflareAccessAuthProvider', () => {
   const provider = new CloudflareAccessAuthProvider({
     teamName: 'foobar',
     resolverContext: {} as AuthResolverContext,
-    authHandler: async ({ claims }) => ({
-      profile: {
-        email: claims.email,
-      },
-    }),
-    signInResolver: async () => {
+    authHandler: async (result) => {
+      expect(result).toEqual(expect.objectContaining({
+        claims: mockClaims,
+        cfIdentity: mockCfIdentity,
+        token: mockJwt,
+      }));
+      return {
+        profile: {
+          email: result.claims.email,
+        },
+      };
+    },
+    signInResolver: async ({result}) => {
+      expect(result).toEqual(expect.objectContaining({
+        claims: mockClaims,
+        cfIdentity: mockCfIdentity,
+        token: mockJwt,
+      }));
       return {
         token:
           'eyblob.eyJzdWIiOiJ1c2VyOmRlZmF1bHQvamltbXltYXJrdW0iLCJlbnQiOlsidXNlcjpkZWZhdWx0L2ppbW15bWFya3VtIl19.eyblob',

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.test.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.test.ts
@@ -138,24 +138,28 @@ describe('CloudflareAccessAuthProvider', () => {
   const provider = new CloudflareAccessAuthProvider({
     teamName: 'foobar',
     resolverContext: {} as AuthResolverContext,
-    authHandler: async (result) => {
-      expect(result).toEqual(expect.objectContaining({
-        claims: mockClaims,
-        cfIdentity: mockCfIdentity,
-        token: mockJwt,
-      }));
+    authHandler: async result => {
+      expect(result).toEqual(
+        expect.objectContaining({
+          claims: mockClaims,
+          cfIdentity: mockCfIdentity,
+          token: mockJwt,
+        }),
+      );
       return {
         profile: {
           email: result.claims.email,
         },
       };
     },
-    signInResolver: async ({result}) => {
-      expect(result).toEqual(expect.objectContaining({
-        claims: mockClaims,
-        cfIdentity: mockCfIdentity,
-        token: mockJwt,
-      }));
+    signInResolver: async ({ result }) => {
+      expect(result).toEqual(
+        expect.objectContaining({
+          claims: mockClaims,
+          cfIdentity: mockCfIdentity,
+          token: mockJwt,
+        }),
+      );
       return {
         token:
           'eyblob.eyJzdWIiOiJ1c2VyOmRlZmF1bHQvamltbXltYXJrdW0iLCJlbnQiOlsidXNlcjpkZWZhdWx0L2ppbW15bWFya3VtIl19.eyblob',

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
@@ -267,7 +267,7 @@ export class CloudflareAccessAuthProvider implements AuthProviderRouteHandlers {
       return {
         ...result,
         token: jwt,
-      }
+      };
     }
     const claims = verifyResult.payload as CloudflareAccessClaims;
     // Builds a passport profile from JWT claims first

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
@@ -153,6 +153,7 @@ export type CloudflareAccessResult = {
   claims: CloudflareAccessClaims;
   cfIdentity: CloudflareAccessIdentityProfile;
   expiresInSeconds?: number;
+  jwt: string;
 };
 
 /**
@@ -277,6 +278,7 @@ export class CloudflareAccessAuthProvider implements AuthProviderRouteHandlers {
         claims,
         cfIdentity,
         expiresInSeconds: claims.exp - claims.iat,
+        jwt,
       };
       this.cache?.set(`${CACHE_PREFIX}/${sub}`, JSON.stringify(cfAccessResult));
       return cfAccessResult;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow up to https://github.com/backstage/backstage/pull/12234. It's a small change so I'd just open a PR directly to get feedback.

The change adds the request JWT to the `CloudflareAccessResult` so that it can then be accessed by the `authHandler()` and `signIn` `resolver()` functions. My use case for this is so that I can make calls to enrich the User's `ProfileInfo` and related entities on behalf of the user using their own JWT.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
