### PR TITLE
cli: update to support local development with Node16 module resolution

### DIFF
--- a/packages/cli/bin/backstage-cli
+++ b/packages/cli/bin/backstage-cli
@@ -24,14 +24,23 @@ const isLocal = require('fs').existsSync(path.resolve(__dirname, '../src'));
 if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
   require('..');
 } else {
-  require('ts-node').register({
-    transpileOnly: true,
-    /* eslint-disable-next-line no-restricted-syntax */
-    project: path.resolve(__dirname, '../../../tsconfig.json'),
-    compilerOptions: {
-      module: 'CommonJS',
-    },
-  });
-
-  require('../src');
+  try {
+    require('child_process').execFileSync(
+      'ts-node',
+      [
+        '--esm',
+        '--transpile-only',
+        '--project',
+        path.resolve(__dirname, '../../../tsconfig.json'),
+        path.resolve(__dirname, '../src/index.ts'),
+        ...process.argv.slice(2),
+      ],
+      {
+        stdio: 'inherit',
+      },
+    );
+  } catch (error) {
+    process.exit(error?.status || 1);
+  }
+  process.exit(0);
 }

--- a/packages/cli/bin/backstage-cli
+++ b/packages/cli/bin/backstage-cli
@@ -30,6 +30,8 @@ if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
       [
         '--esm',
         '--transpile-only',
+        '--compilerOptions',
+        '{"module":"Node16","moduleResolution":"Node16"}',
         '--project',
         path.resolve(__dirname, '../../../tsconfig.json'),
         path.resolve(__dirname, '../src/index.ts'),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,16 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
+  "exports": {
+    ".": "./dist/index.cjs.js",
+    "./asset-types": {
+      "types": "./asset-types/asset-types.d.ts",
+      "default": "./asset-types/asset-types.js"
+    },
+    "./config/tsconfig.json": "./config/tsconfig.json",
+    "./config/*": "./config/*.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",

--- a/packages/cli/src/commands/buildWorkspace.ts
+++ b/packages/cli/src/commands/buildWorkspace.ts
@@ -17,7 +17,7 @@
 import fs from 'fs-extra';
 import { createDistWorkspace } from '../lib/packager';
 
-export default async (dir: string, packages: string[]) => {
+export async function command(dir: string, packages: string[]) {
   if (!(await fs.pathExists(dir))) {
     throw new Error(`Target workspace directory doesn't exist, '${dir}'`);
   }
@@ -25,4 +25,4 @@ export default async (dir: string, packages: string[]) => {
   await createDistWorkspace(packages, {
     targetDir: dir,
   });
-};
+}

--- a/packages/cli/src/commands/clean/clean.ts
+++ b/packages/cli/src/commands/clean/clean.ts
@@ -17,7 +17,7 @@
 import fs from 'fs-extra';
 import { paths } from '../../lib/paths';
 
-export default async function clean() {
+export async function command() {
   await fs.remove(paths.resolveTarget('dist'));
   await fs.remove(paths.resolveTarget('dist-types'));
   await fs.remove(paths.resolveTarget('coverage'));

--- a/packages/cli/src/commands/config/docs.ts
+++ b/packages/cli/src/commands/config/docs.ts
@@ -23,7 +23,7 @@ import { loadCliConfig } from '../../lib/config';
 
 const DOCS_URL = 'https://config.backstage.io';
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   const { schema: appSchemas } = await loadCliConfig({
     args: [],
     fromPackage: opts.package,
@@ -37,4 +37,4 @@ export default async (opts: OptionValues) => {
   );
 
   openBrowser(`${DOCS_URL}#schema=${JSON.stringify(schema)}`);
-};
+}

--- a/packages/cli/src/commands/config/print.ts
+++ b/packages/cli/src/commands/config/print.ts
@@ -20,7 +20,7 @@ import { AppConfig, ConfigReader } from '@backstage/config';
 import { loadCliConfig } from '../../lib/config';
 import { ConfigSchema, ConfigVisibility } from '@backstage/config-loader';
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   const { schema, appConfigs } = await loadCliConfig({
     args: opts.config,
     fromPackage: opts.package,
@@ -35,7 +35,7 @@ export default async (opts: OptionValues) => {
   } else {
     process.stdout.write(`${stringifyYaml(data)}\n`);
   }
-};
+}
 
 function getVisibilityOption(opts: OptionValues): ConfigVisibility {
   if (opts.frontend && opts.withSecrets) {

--- a/packages/cli/src/commands/config/schema.ts
+++ b/packages/cli/src/commands/config/schema.ts
@@ -21,7 +21,7 @@ import { loadCliConfig } from '../../lib/config';
 import { JsonObject } from '@backstage/types';
 import { mergeConfigSchemas } from '@backstage/config-loader';
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   const { schema } = await loadCliConfig({
     args: [],
     fromPackage: opts.package,
@@ -43,4 +43,4 @@ export default async (opts: OptionValues) => {
   } else {
     process.stdout.write(`${stringifyYaml(merged)}\n`);
   }
-};
+}

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -17,7 +17,7 @@
 import { OptionValues } from 'commander';
 import { loadCliConfig } from '../../lib/config';
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   await loadCliConfig({
     args: opts.config,
     fromPackage: opts.package,
@@ -25,4 +25,4 @@ export default async (opts: OptionValues) => {
     fullVisibility: !opts.frontend,
     withDeprecatedKeys: opts.deprecated,
   });
-};
+}

--- a/packages/cli/src/commands/create-github-app/index.ts
+++ b/packages/cli/src/commands/create-github-app/index.ts
@@ -25,7 +25,7 @@ import openBrowser from 'react-dev-utils/openBrowser';
 // This is an experimental command that at this point does not support GitHub Enterprise
 // due to lacking support for creating apps from manifests.
 // https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-a-github-app-from-a-manifest
-export default async (org: string) => {
+export async function command(org: string) {
   const answers: Answers = await inquirer.prompt({
     name: 'appType',
     type: 'checkbox',
@@ -80,7 +80,7 @@ integrations:
       apps:
         - $include: ${fileName}`),
   );
-};
+}
 
 async function verifyGithubOrg(org: string): Promise<void> {
   let response;

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -161,16 +161,16 @@ async function buildPlugin(pluginFolder: string) {
     'yarn tsc',
     'yarn build',
   ];
-  for (const command of commands) {
+  for (const cmd of commands) {
     try {
-      await Task.forItem('executing', command, async () => {
+      await Task.forItem('executing', cmd, async () => {
         process.chdir(pluginFolder);
-        await exec(command);
+        await exec(cmd);
       }).catch(error => {
         process.stdout.write(error.stderr);
         process.stdout.write(error.stdout);
         throw new Error(
-          `Warning: Could not execute command ${chalk.cyan(command)}`,
+          `Warning: Could not execute command ${chalk.cyan(cmd)}`,
         );
       });
     } catch (error) {
@@ -195,7 +195,7 @@ export async function movePlugin(
   });
 }
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   const codeownersPath = await getCodeownersFilePath(paths.targetRoot);
 
   const questions: Question[] = [
@@ -337,4 +337,4 @@ export default async (opts: OptionValues) => {
     Task.error('🔥  Failed to create plugin!');
     Task.exit(1);
   }
-};
+}

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -40,7 +40,7 @@ function parseOptions(optionStrings: string[]): Record<string, string> {
   return options;
 }
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   const factory = await FactoryRegistry.interactiveSelect(opts.select);
 
   const providedOptions = parseOptions(opts.option);
@@ -130,4 +130,4 @@ export default async (opts: OptionValues) => {
       }
     }
   }
-};
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -43,7 +43,7 @@ export function registerRepoCommand(program: Command) {
       '--since <ref>',
       'Only build packages and their dev dependents that changed since the specified ref',
     )
-    .action(lazy(() => import('./repo/build').then(m => m.command)));
+    .action(lazy(() => import('./repo/build.js').then(m => m.command)));
 
   command
     .command('lint')
@@ -58,14 +58,14 @@ export function registerRepoCommand(program: Command) {
       'Only lint packages that changed since the specified ref',
     )
     .option('--fix', 'Attempt to automatically fix violations')
-    .action(lazy(() => import('./repo/lint').then(m => m.command)));
+    .action(lazy(() => import('./repo/lint.js').then(m => m.command)));
 
   command
     .command('list-deprecations', { hidden: true })
     .description('List deprecations. [EXPERIMENTAL]')
     .option('--json', 'Output as JSON')
     .action(
-      lazy(() => import('./repo/list-deprecations').then(m => m.command)),
+      lazy(() => import('./repo/list-deprecations.js').then(m => m.command)),
     );
 }
 
@@ -85,7 +85,7 @@ export function registerScriptCommand(program: Command) {
       '--inspect-brk',
       'Enable debugger in Node.js environments, breaking before code starts',
     )
-    .action(lazy(() => import('./start').then(m => m.command)));
+    .action(lazy(() => import('./start/index.js').then(m => m.command)));
 
   command
     .command('build')
@@ -113,7 +113,7 @@ export function registerScriptCommand(program: Command) {
       (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
       Array<string>(),
     )
-    .action(lazy(() => import('./build').then(m => m.command)));
+    .action(lazy(() => import('./build/index.js').then(m => m.command)));
 
   command
     .command('lint [directories...]')
@@ -124,35 +124,35 @@ export function registerScriptCommand(program: Command) {
     )
     .option('--fix', 'Attempt to automatically fix violations')
     .description('Lint a package')
-    .action(lazy(() => import('./lint').then(m => m.default)));
+    .action(lazy(() => import('./lint.js').then(m => m.command)));
 
   command
     .command('test')
     .allowUnknownOption(true) // Allows the command to run, but we still need to parse raw args
     .helpOption(', --backstage-cli-help') // Let Jest handle help
     .description('Run tests, forwarding args to Jest, defaulting to watch mode')
-    .action(lazy(() => import('./test').then(m => m.default)));
+    .action(lazy(() => import('./test.js').then(m => m.command)));
 
   command
     .command('fix', { hidden: true })
     .description('Applies automated fixes to the package. [EXPERIMENTAL]')
     .option('--deps', 'Only fix monorepo dependencies in package.json')
-    .action(lazy(() => import('./fix').then(m => m.command)));
+    .action(lazy(() => import('./fix.js').then(m => m.command)));
 
   command
     .command('clean')
     .description('Delete cache directories')
-    .action(lazy(() => import('./clean/clean').then(m => m.default)));
+    .action(lazy(() => import('./clean/clean.js').then(m => m.command)));
 
   command
     .command('prepack')
     .description('Prepares a package for packaging before publishing')
-    .action(lazy(() => import('./pack').then(m => m.pre)));
+    .action(lazy(() => import('./pack.js').then(m => m.pre)));
 
   command
     .command('postpack')
     .description('Restores the changes made by the prepack command')
-    .action(lazy(() => import('./pack').then(m => m.post)));
+    .action(lazy(() => import('./pack.js').then(m => m.post)));
 }
 
 export function registerMigrateCommand(program: Command) {
@@ -163,13 +163,15 @@ export function registerMigrateCommand(program: Command) {
   command
     .command('package-roles')
     .description(`Add package role field to packages that don't have it`)
-    .action(lazy(() => import('./migrate/packageRole').then(m => m.default)));
+    .action(
+      lazy(() => import('./migrate/packageRole.js').then(m => m.command)),
+    );
 
   command
     .command('package-scripts')
     .description('Set package scripts according to each package role')
     .action(
-      lazy(() => import('./migrate/packageScripts').then(m => m.command)),
+      lazy(() => import('./migrate/packageScripts.js').then(m => m.command)),
     );
 
   command
@@ -178,7 +180,9 @@ export function registerMigrateCommand(program: Command) {
       'Migrates all packages to use @backstage/cli/config/eslint-factory',
     )
     .action(
-      lazy(() => import('./migrate/packageLintConfigs').then(m => m.command)),
+      lazy(() =>
+        import('./migrate/packageLintConfigs.js').then(m => m.command),
+      ),
     );
 }
 
@@ -205,7 +209,7 @@ export function registerCommands(program: Command) {
       'The package registry to use for new packages',
     )
     .option('--no-private', 'Do not mark new packages as private')
-    .action(lazy(() => import('./create/create').then(m => m.default)));
+    .action(lazy(() => import('./create/create.js').then(m => m.command)));
 
   program
     .command('create-plugin')
@@ -218,7 +222,9 @@ export function registerCommands(program: Command) {
     .option('--npm-registry <URL>', 'npm registry URL')
     .option('--no-private', 'Public npm package')
     .action(
-      lazy(() => import('./create-plugin/createPlugin').then(m => m.default)),
+      lazy(() =>
+        import('./create-plugin/createPlugin.js').then(m => m.command),
+      ),
     );
 
   program
@@ -226,7 +232,7 @@ export function registerCommands(program: Command) {
     .option('--check', 'Fail if changes are required')
     .option('--yes', 'Apply all changes')
     .description('Diff an existing plugin with the creation template')
-    .action(lazy(() => import('./plugin/diff').then(m => m.default)));
+    .action(lazy(() => import('./plugin/diff.js').then(m => m.command)));
 
   // TODO(Rugvip): Deprecate in favor of package variant
   program
@@ -236,7 +242,7 @@ export function registerCommands(program: Command) {
     .description(
       'Run tests, forwarding args to Jest, defaulting to watch mode [DEPRECATED]',
     )
-    .action(lazy(() => import('./test').then(m => m.default)));
+    .action(lazy(() => import('./test.js').then(m => m.command)));
 
   program
     .command('config:docs')
@@ -245,7 +251,7 @@ export function registerCommands(program: Command) {
       'Only include the schema that applies to the given package',
     )
     .description('Browse the configuration reference documentation')
-    .action(lazy(() => import('./config/docs').then(m => m.default)));
+    .action(lazy(() => import('./config/docs.js').then(m => m.command)));
 
   program
     .command('config:print')
@@ -262,7 +268,7 @@ export function registerCommands(program: Command) {
     )
     .option(...configOption)
     .description('Print the app configuration for the current package')
-    .action(lazy(() => import('./config/print').then(m => m.default)));
+    .action(lazy(() => import('./config/print.js').then(m => m.command)));
 
   program
     .command('config:check')
@@ -277,7 +283,7 @@ export function registerCommands(program: Command) {
     .description(
       'Validate that the given configuration loads and matches schema',
     )
-    .action(lazy(() => import('./config/validate').then(m => m.default)));
+    .action(lazy(() => import('./config/validate.js').then(m => m.command)));
 
   program
     .command('config:schema')
@@ -290,7 +296,7 @@ export function registerCommands(program: Command) {
       'Format to print the schema in, either json or yaml [yaml]',
     )
     .description('Print configuration schema')
-    .action(lazy(() => import('./config/schema').then(m => m.default)));
+    .action(lazy(() => import('./config/schema.js').then(m => m.command)));
 
   registerRepoCommand(program);
   registerScriptCommand(program);
@@ -308,34 +314,36 @@ export function registerCommands(program: Command) {
       'main',
     )
     .description('Bump Backstage packages to the latest versions')
-    .action(lazy(() => import('./versions/bump').then(m => m.default)));
+    .action(lazy(() => import('./versions/bump.js').then(m => m.command)));
 
   program
     .command('versions:check')
     .option('--fix', 'Fix any auto-fixable versioning problems')
     .description('Check Backstage package versioning')
-    .action(lazy(() => import('./versions/lint').then(m => m.default)));
+    .action(lazy(() => import('./versions/lint.js').then(m => m.command)));
 
   // TODO(Rugvip): Deprecate in favor of package variant
   program
     .command('clean')
     .description('Delete cache directories [DEPRECATED]')
-    .action(lazy(() => import('./clean/clean').then(m => m.default)));
+    .action(lazy(() => import('./clean/clean.js').then(m => m.command)));
 
   program
     .command('build-workspace <workspace-dir> [packages...]')
     .description('Builds a temporary dist workspace from the provided packages')
-    .action(lazy(() => import('./buildWorkspace').then(m => m.default)));
+    .action(lazy(() => import('./buildWorkspace.js').then(m => m.command)));
 
   program
     .command('create-github-app <github-org>')
     .description('Create new GitHub App in your organization.')
-    .action(lazy(() => import('./create-github-app').then(m => m.default)));
+    .action(
+      lazy(() => import('./create-github-app/index.js').then(m => m.command)),
+    );
 
   program
     .command('info')
     .description('Show helpful information for debugging and reporting bugs')
-    .action(lazy(() => import('./info').then(m => m.default)));
+    .action(lazy(() => import('./info.js').then(m => m.command)));
 
   program
     .command('install [plugin-id]', { hidden: true })
@@ -344,7 +352,7 @@ export function registerCommands(program: Command) {
       'Install from a local package.json containing the installation recipe',
     )
     .description('Install a Backstage plugin [EXPERIMENTAL]')
-    .action(lazy(() => import('./install/install').then(m => m.default)));
+    .action(lazy(() => import('./install/install.js').then(m => m.command)));
 }
 
 // Wraps an action function so that it always exits and handles errors

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -43,7 +43,7 @@ export function registerRepoCommand(program: Command) {
       '--since <ref>',
       'Only build packages and their dev dependents that changed since the specified ref',
     )
-    .action(lazy(() => import('./repo/build.js').then(m => m.command)));
+    .action(lazy(() => import('./repo/build.js').then(m => m.default.command)));
 
   command
     .command('lint')
@@ -58,14 +58,16 @@ export function registerRepoCommand(program: Command) {
       'Only lint packages that changed since the specified ref',
     )
     .option('--fix', 'Attempt to automatically fix violations')
-    .action(lazy(() => import('./repo/lint.js').then(m => m.command)));
+    .action(lazy(() => import('./repo/lint.js').then(m => m.default.command)));
 
   command
     .command('list-deprecations', { hidden: true })
     .description('List deprecations. [EXPERIMENTAL]')
     .option('--json', 'Output as JSON')
     .action(
-      lazy(() => import('./repo/list-deprecations.js').then(m => m.command)),
+      lazy(() =>
+        import('./repo/list-deprecations.js').then(m => m.default.command),
+      ),
     );
 }
 
@@ -85,7 +87,9 @@ export function registerScriptCommand(program: Command) {
       '--inspect-brk',
       'Enable debugger in Node.js environments, breaking before code starts',
     )
-    .action(lazy(() => import('./start/index.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./start/index.js').then(m => m.default.command)),
+    );
 
   command
     .command('build')
@@ -113,7 +117,9 @@ export function registerScriptCommand(program: Command) {
       (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
       Array<string>(),
     )
-    .action(lazy(() => import('./build/index.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./build/index.js').then(m => m.default.command)),
+    );
 
   command
     .command('lint [directories...]')
@@ -124,35 +130,37 @@ export function registerScriptCommand(program: Command) {
     )
     .option('--fix', 'Attempt to automatically fix violations')
     .description('Lint a package')
-    .action(lazy(() => import('./lint.js').then(m => m.command)));
+    .action(lazy(() => import('./lint.js').then(m => m.default.command)));
 
   command
     .command('test')
     .allowUnknownOption(true) // Allows the command to run, but we still need to parse raw args
     .helpOption(', --backstage-cli-help') // Let Jest handle help
     .description('Run tests, forwarding args to Jest, defaulting to watch mode')
-    .action(lazy(() => import('./test.js').then(m => m.command)));
+    .action(lazy(() => import('./test.js').then(m => m.default.command)));
 
   command
     .command('fix', { hidden: true })
     .description('Applies automated fixes to the package. [EXPERIMENTAL]')
     .option('--deps', 'Only fix monorepo dependencies in package.json')
-    .action(lazy(() => import('./fix.js').then(m => m.command)));
+    .action(lazy(() => import('./fix.js').then(m => m.default.command)));
 
   command
     .command('clean')
     .description('Delete cache directories')
-    .action(lazy(() => import('./clean/clean.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./clean/clean.js').then(m => m.default.command)),
+    );
 
   command
     .command('prepack')
     .description('Prepares a package for packaging before publishing')
-    .action(lazy(() => import('./pack.js').then(m => m.pre)));
+    .action(lazy(() => import('./pack.js').then(m => m.default.pre)));
 
   command
     .command('postpack')
     .description('Restores the changes made by the prepack command')
-    .action(lazy(() => import('./pack.js').then(m => m.post)));
+    .action(lazy(() => import('./pack.js').then(m => m.default.post)));
 }
 
 export function registerMigrateCommand(program: Command) {
@@ -164,14 +172,18 @@ export function registerMigrateCommand(program: Command) {
     .command('package-roles')
     .description(`Add package role field to packages that don't have it`)
     .action(
-      lazy(() => import('./migrate/packageRole.js').then(m => m.command)),
+      lazy(() =>
+        import('./migrate/packageRole.js').then(m => m.default.command),
+      ),
     );
 
   command
     .command('package-scripts')
     .description('Set package scripts according to each package role')
     .action(
-      lazy(() => import('./migrate/packageScripts.js').then(m => m.command)),
+      lazy(() =>
+        import('./migrate/packageScripts.js').then(m => m.default.command),
+      ),
     );
 
   command
@@ -181,7 +193,7 @@ export function registerMigrateCommand(program: Command) {
     )
     .action(
       lazy(() =>
-        import('./migrate/packageLintConfigs.js').then(m => m.command),
+        import('./migrate/packageLintConfigs.js').then(m => m.default.command),
       ),
     );
 }
@@ -209,7 +221,9 @@ export function registerCommands(program: Command) {
       'The package registry to use for new packages',
     )
     .option('--no-private', 'Do not mark new packages as private')
-    .action(lazy(() => import('./create/create.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./create/create.js').then(m => m.default.command)),
+    );
 
   program
     .command('create-plugin')
@@ -223,7 +237,7 @@ export function registerCommands(program: Command) {
     .option('--no-private', 'Public npm package')
     .action(
       lazy(() =>
-        import('./create-plugin/createPlugin.js').then(m => m.command),
+        import('./create-plugin/createPlugin.js').then(m => m.default.command),
       ),
     );
 
@@ -232,7 +246,9 @@ export function registerCommands(program: Command) {
     .option('--check', 'Fail if changes are required')
     .option('--yes', 'Apply all changes')
     .description('Diff an existing plugin with the creation template')
-    .action(lazy(() => import('./plugin/diff.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./plugin/diff.js').then(m => m.default.command)),
+    );
 
   // TODO(Rugvip): Deprecate in favor of package variant
   program
@@ -242,7 +258,7 @@ export function registerCommands(program: Command) {
     .description(
       'Run tests, forwarding args to Jest, defaulting to watch mode [DEPRECATED]',
     )
-    .action(lazy(() => import('./test.js').then(m => m.command)));
+    .action(lazy(() => import('./test.js').then(m => m.default.command)));
 
   program
     .command('config:docs')
@@ -251,7 +267,9 @@ export function registerCommands(program: Command) {
       'Only include the schema that applies to the given package',
     )
     .description('Browse the configuration reference documentation')
-    .action(lazy(() => import('./config/docs.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./config/docs.js').then(m => m.default.command)),
+    );
 
   program
     .command('config:print')
@@ -268,7 +286,9 @@ export function registerCommands(program: Command) {
     )
     .option(...configOption)
     .description('Print the app configuration for the current package')
-    .action(lazy(() => import('./config/print.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./config/print.js').then(m => m.default.command)),
+    );
 
   program
     .command('config:check')
@@ -283,7 +303,9 @@ export function registerCommands(program: Command) {
     .description(
       'Validate that the given configuration loads and matches schema',
     )
-    .action(lazy(() => import('./config/validate.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./config/validate.js').then(m => m.default.command)),
+    );
 
   program
     .command('config:schema')
@@ -296,7 +318,9 @@ export function registerCommands(program: Command) {
       'Format to print the schema in, either json or yaml [yaml]',
     )
     .description('Print configuration schema')
-    .action(lazy(() => import('./config/schema.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./config/schema.js').then(m => m.default.command)),
+    );
 
   registerRepoCommand(program);
   registerScriptCommand(program);
@@ -314,36 +338,46 @@ export function registerCommands(program: Command) {
       'main',
     )
     .description('Bump Backstage packages to the latest versions')
-    .action(lazy(() => import('./versions/bump.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./versions/bump.js').then(m => m.default.command)),
+    );
 
   program
     .command('versions:check')
     .option('--fix', 'Fix any auto-fixable versioning problems')
     .description('Check Backstage package versioning')
-    .action(lazy(() => import('./versions/lint.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./versions/lint.js').then(m => m.default.command)),
+    );
 
   // TODO(Rugvip): Deprecate in favor of package variant
   program
     .command('clean')
     .description('Delete cache directories [DEPRECATED]')
-    .action(lazy(() => import('./clean/clean.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./clean/clean.js').then(m => m.default.command)),
+    );
 
   program
     .command('build-workspace <workspace-dir> [packages...]')
     .description('Builds a temporary dist workspace from the provided packages')
-    .action(lazy(() => import('./buildWorkspace.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./buildWorkspace.js').then(m => m.default.command)),
+    );
 
   program
     .command('create-github-app <github-org>')
     .description('Create new GitHub App in your organization.')
     .action(
-      lazy(() => import('./create-github-app/index.js').then(m => m.command)),
+      lazy(() =>
+        import('./create-github-app/index.js').then(m => m.default.command),
+      ),
     );
 
   program
     .command('info')
     .description('Show helpful information for debugging and reporting bugs')
-    .action(lazy(() => import('./info.js').then(m => m.command)));
+    .action(lazy(() => import('./info.js').then(m => m.default.command)));
 
   program
     .command('install [plugin-id]', { hidden: true })
@@ -352,7 +386,9 @@ export function registerCommands(program: Command) {
       'Install from a local package.json containing the installation recipe',
     )
     .description('Install a Backstage plugin [EXPERIMENTAL]')
-    .action(lazy(() => import('./install/install.js').then(m => m.command)));
+    .action(
+      lazy(() => import('./install/install.js').then(m => m.default.command)),
+    );
 }
 
 // Wraps an action function so that it always exits and handles errors

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -21,7 +21,7 @@ import { paths } from '../lib/paths';
 import { Lockfile } from '../lib/versioning';
 import fs from 'fs-extra';
 
-export default async () => {
+export async function command() {
   await new Promise(async () => {
     const yarnVersion = await runPlain('yarn --version');
     const isLocal = fs.existsSync(paths.resolveOwn('./src'));
@@ -56,4 +56,4 @@ export default async () => {
       console.log(`  ${dep.padEnd(maxLength)} ${[...versions].join(', ')}`);
     }
   });
-};
+}

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -154,7 +154,7 @@ async function loadPeerPluginDeps(
   }
 }
 
-export default async (pluginId?: string, cmd?: OptionValues) => {
+export async function command(pluginId?: string, cmd?: OptionValues) {
   const from = pluginId || cmd?.from;
   // TODO(himanshu): If no plugin id is provided, it should list all plugins available. Maybe in some other command?
   if (!from) {
@@ -164,4 +164,4 @@ export default async (pluginId?: string, cmd?: OptionValues) => {
   }
   const pkg = await loadPackageJson(from);
   await installPluginAndPeerPlugins(pkg);
-};
+}

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -18,7 +18,7 @@ import { OptionValues } from 'commander';
 import { paths } from '../lib/paths';
 import { ESLint } from 'eslint';
 
-export default async (directories: string[], opts: OptionValues) => {
+export async function command(directories: string[], opts: OptionValues) {
   const eslint = new ESLint({
     cwd: paths.targetDir,
     fix: opts.fix,
@@ -47,4 +47,4 @@ export default async (directories: string[], opts: OptionValues) => {
     console.log(resultText);
     process.exit(1);
   }
-};
+}

--- a/packages/cli/src/commands/migrate/packageRole.ts
+++ b/packages/cli/src/commands/migrate/packageRole.ts
@@ -20,7 +20,7 @@ import { getPackages } from '@manypkg/get-packages';
 import { paths } from '../../lib/paths';
 import { getRoleFromPackage, detectRoleFromPackage } from '../../lib/role';
 
-export default async () => {
+export async function command() {
   const { packages } = await getPackages(paths.targetDir);
 
   await Promise.all(
@@ -66,4 +66,4 @@ export default async () => {
       });
     }),
   );
-};
+}

--- a/packages/cli/src/commands/plugin/diff.ts
+++ b/packages/cli/src/commands/plugin/diff.ts
@@ -50,7 +50,7 @@ const fileHandlers = [
   },
 ];
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   let promptFunc = inquirerPromptFunc;
   let finalize = () => {};
 
@@ -64,7 +64,7 @@ export default async (opts: OptionValues) => {
   const templateFiles = await diffTemplateFiles('default-plugin', data);
   await handleAllFiles(fileHandlers, templateFiles, promptFunc);
   finalize();
-};
+}
 
 // Reads templating data from the existing plugin
 async function readPluginData(): Promise<PluginData> {

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -27,7 +27,7 @@ function includesAnyOf(hayStack: string[], ...needles: string[]) {
   return false;
 }
 
-export default async (_opts: OptionValues, cmd: Command) => {
+export async function command(_opts: OptionValues, cmd: Command) {
   // all args are forwarded to jest
   let parent = cmd;
   while (parent.parent) {
@@ -84,4 +84,4 @@ export default async (_opts: OptionValues, cmd: Command) => {
 
   // eslint-disable-next-line jest/no-jest-import
   await require('jest').run(args);
-};
+}

--- a/packages/cli/src/commands/versions/bump.test.ts
+++ b/packages/cli/src/commands/versions/bump.test.ts
@@ -20,7 +20,11 @@ import { Command } from 'commander';
 import { resolve as resolvePath } from 'path';
 import { paths } from '../../lib/paths';
 import * as runObj from '../../lib/run';
-import bump, { bumpBackstageJsonVersion, createVersionFinder } from './bump';
+import {
+  bumpBackstageJsonVersion,
+  createVersionFinder,
+  command as bump,
+} from './bump';
 import {
   setupRequestMockHandlers,
   withLogCollector,

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -56,7 +56,7 @@ type PkgVersionInfo = {
   location: string;
 };
 
-export default async (opts: OptionValues) => {
+export async function command(opts: OptionValues) {
   const lockfilePath = paths.resolveTargetRoot('yarn.lock');
   const lockfile = await Lockfile.load(lockfilePath);
   let pattern = opts.pattern;
@@ -324,7 +324,7 @@ export default async (opts: OptionValues) => {
         .join(', ')}`,
     );
   }
-};
+}
 
 export function createStrictVersionFinder(options: {
   releaseManifest: ReleaseManifest;

--- a/packages/cli/src/commands/versions/lint.ts
+++ b/packages/cli/src/commands/versions/lint.ts
@@ -47,7 +47,7 @@ export const forbiddenDuplicatesFilter = (name: string) =>
   FORBID_DUPLICATES.some(pattern => pattern.test(name)) &&
   !ALLOW_DUPLICATES.some(pattern => pattern.test(name));
 
-export default async (cmd: OptionValues) => {
+export async function command(cmd: OptionValues) {
   const fix = Boolean(cmd.fix);
 
   let success = true;
@@ -111,7 +111,7 @@ export default async (cmd: OptionValues) => {
   if (!success) {
     throw new Error('Failed versioning check');
   }
-};
+}
 
 function logArray<T>(arr: T[], header: string, each: (item: T) => string) {
   if (arr.length === 0) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #7926. This is one of the tricky pieces since the dynamic `import()`s in the CLI end up being treated as ESM when we switch resolution to Node16. The proposed solution is to switch the local development execution to use `ts-node` in ESM mode and refactor the imports.

We need to access the exported commands on the dynamically imported module via the `default` export. This is because we're relying on Node.js's built-in CJS compatibility layer, which is unable to find the named exports. As far as I can tell Node.js fails to do this because it tries to parse the exports from the source file rather than the transpiled code. It reads the `.ts` files from the filesystem and tries to parse `exports.<name> = ...` from those, which of course fails. A big downside of this is that type checks and runtime are inconsistent. TypeScript claims that `(await import('./build.js')).command` works just fine, but at runtime it does not. This still seems to be the best solution as far as I can tell.

Overall this PR is supposed to have no impact just yet, it's just making the future move to support Node16 resolution more smooth.

This is blocked by #12558

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
