### PR TITLE
tech-insights: Factretriever timeout support

### DIFF
--- a/.changeset/strong-planes-return.md
+++ b/.changeset/strong-planes-return.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-tech-insights-backend': minor
-'@backstage/plugin-tech-insights-node': minor
+'@backstage/plugin-tech-insights-backend': patch
+'@backstage/plugin-tech-insights-node': patch
 ---
 
 Support for timeout in FactRetrieverRegistrationOptions

--- a/.changeset/strong-planes-return.md
+++ b/.changeset/strong-planes-return.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-tech-insights-backend': minor
+'@backstage/plugin-tech-insights-node': minor
+---
+
+Support for timeout in FactRetrieverRegistrationOptions

--- a/plugins/tech-insights-backend/api-report.md
+++ b/plugins/tech-insights-backend/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { Config } from '@backstage/config';
+import { Duration } from 'luxon';
 import express from 'express';
 import { FactChecker } from '@backstage/plugin-tech-insights-node';
 import { FactCheckerFactory } from '@backstage/plugin-tech-insights-node';
@@ -12,6 +13,7 @@ import { FactLifecycle } from '@backstage/plugin-tech-insights-node';
 import { FactRetriever } from '@backstage/plugin-tech-insights-node';
 import { FactRetrieverRegistration } from '@backstage/plugin-tech-insights-node';
 import { FactSchema } from '@backstage/plugin-tech-insights-node';
+import { HumanDuration } from '@backstage/backend-tasks';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -50,6 +52,7 @@ export type FactRetrieverRegistrationOptions = {
   cadence: string;
   factRetriever: FactRetriever;
   lifecycle?: FactLifecycle;
+  timeout?: Duration | HumanDuration;
 };
 
 // @public (undocumented)

--- a/plugins/tech-insights-backend/package.json
+++ b/plugins/tech-insights-backend/package.json
@@ -43,6 +43,7 @@
     "@backstage/plugin-tech-insights-common": "^0.2.6",
     "@backstage/plugin-tech-insights-node": "^0.3.3",
     "@types/express": "^4.17.6",
+    "@types/luxon": "^3.0.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "knex": "^2.0.0",
@@ -56,8 +57,8 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^0.1.27",
     "@backstage/cli": "^0.18.1",
-    "@types/supertest": "^2.0.8",
     "@types/semver": "^7.3.8",
+    "@types/supertest": "^2.0.8",
     "supertest": "^6.1.3",
     "wait-for-expect": "^3.0.2"
   },

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -34,7 +34,7 @@ export type FactRetrieverRegistrationOptions = {
   cadence: string;
   factRetriever: FactRetriever;
   lifecycle?: FactLifecycle;
-  timeout: Duration | HumanDuration;
+  timeout?: Duration | HumanDuration;
 };
 
 /**

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -27,6 +27,7 @@ import { Duration } from 'luxon';
  * @param cadence - cron expression to indicate when the fact retriever should be triggered
  * @param factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
  * @param lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
+ * @param timeout - Optional duration to determine how long the fact retriever should be allowed to run, defaults to 5 minutes
  *
  */
 export type FactRetrieverRegistrationOptions = {
@@ -40,10 +41,10 @@ export type FactRetrieverRegistrationOptions = {
  * @public
  *
  * A helper function to construct fact retriever registrations.
- *
- * @param cadence - cron expression to indicate when the fact retriever should be triggered
- * @param factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
- * @param lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
+ * @param options.cadence - Cron expression to indicate when the fact retriever should be triggered
+ * @param options.factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
+ * @param options.lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
+ * @param options.timeout - Optional duration to determine how long the fact retriever should be allowed to run, defaults to 5 minutes
  *
  *
  * @remarks

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HumanDuration } from '@backstage/backend-tasks';
 import {
   FactLifecycle,
   FactRetriever,
   FactRetrieverRegistration,
 } from '@backstage/plugin-tech-insights-node';
+import { Duration } from 'luxon';
 
 /**
  * @public
@@ -31,6 +33,7 @@ export type FactRetrieverRegistrationOptions = {
   cadence: string;
   factRetriever: FactRetriever;
   lifecycle?: FactLifecycle;
+  timeout: Duration | HumanDuration;
 };
 
 /**
@@ -64,10 +67,11 @@ export type FactRetrieverRegistrationOptions = {
 export function createFactRetrieverRegistration(
   options: FactRetrieverRegistrationOptions,
 ): FactRetrieverRegistration {
-  const { cadence, factRetriever, lifecycle } = options;
+  const { cadence, factRetriever, lifecycle, timeout } = options;
   return {
     cadence,
     factRetriever,
     lifecycle,
+    timeout,
   };
 }

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -41,10 +41,10 @@ export type FactRetrieverRegistrationOptions = {
  * @public
  *
  * A helper function to construct fact retriever registrations.
- * @param options.cadence - Cron expression to indicate when the fact retriever should be triggered
- * @param options.factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
- * @param options.lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
- * @param options.timeout - Optional duration to determine how long the fact retriever should be allowed to run, defaults to 5 minutes
+ * @param cadence - Cron expression to indicate when the fact retriever should be triggered
+ * @param factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
+ * @param lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
+ * @param timeout - Optional duration to determine how long the fact retriever should be allowed to run, defaults to 5 minutes
  *
  *
  * @remarks

--- a/plugins/tech-insights-node/api-report.md
+++ b/plugins/tech-insights-node/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import { DateTime } from 'luxon';
 import { Duration } from 'luxon';
 import { DurationLike } from 'luxon';
+import { HumanDuration } from '@backstage/backend-tasks';
 import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -72,7 +73,7 @@ export type FactRetrieverContext = {
 export type FactRetrieverRegistration = {
   factRetriever: FactRetriever;
   cadence?: string;
-  timeout?: Duration;
+  timeout?: Duration | HumanDuration;
   lifecycle?: FactLifecycle;
 };
 

--- a/plugins/tech-insights-node/package.json
+++ b/plugins/tech-insights-node/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.15.0",
+    "@backstage/backend-tasks": "^0.3.4",
     "@backstage/config": "^1.0.1",
     "@backstage/plugin-tech-insights-common": "^0.2.6",
     "@backstage/types": "^1.0.0",

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -21,6 +21,7 @@ import {
   TokenManager,
 } from '@backstage/backend-common';
 import { Logger } from 'winston';
+import { HumanDuration } from '@backstage/backend-tasks';
 
 /**
  * A container for facts. The shape of the fact records needs to correspond to the FactSchema with same `ref` value.
@@ -270,7 +271,7 @@ export type FactRetrieverRegistration = {
    * defaults to 5 minutes.
    *
    */
-  timeout?: Duration;
+  timeout?: Duration | HumanDuration;
 
   /**
    * Fact lifecycle definition


### PR DESCRIPTION
Signed-off-by: Niek te Grootenhuis <niek.te.grootenhuis@alliander.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I noticed that the way tech-insights factretrievers are registered does not support a timeout, despite being implemented further  down the line in the [factretrieverEngine](https://github.com/backstage/backstage/blob/master/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts#L99).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
