### PR TITLE
scaffolder: Fix empty string handling in `EntityPicker`

### DIFF
--- a/.changeset/dry-games-end.md
+++ b/.changeset/dry-games-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix bug with empty strings in `EntityPicker`

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -72,7 +72,7 @@ export const EntityPicker = (
 
   const onSelect = useCallback(
     (_: any, value: string | null) => {
-      onChange(value || '');
+      onChange(value ?? undefined);
     },
     [onChange],
   );


### PR DESCRIPTION
empty strings are still strings, so if it's not set default to undefined to throw the correct error.

Fixes #12037