### PR TITLE
unescape html entities from stackoverflow api response

### DIFF
--- a/.changeset/tender-ladybugs-relax.md
+++ b/.changeset/tender-ladybugs-relax.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-stack-overflow': patch
 ---
 
-Unescape html entity references from the stackoverflow API response before rendering the question title to the list component.
+Support showing HTML entity references from the API response before rendering the question title to the list component.

--- a/.changeset/tender-ladybugs-relax.md
+++ b/.changeset/tender-ladybugs-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow': patch
+---
+
+Unescape html entity references from the stackoverflow API response before rendering the question title to the list component.

--- a/plugins/stack-overflow/src/home/StackOverflowQuestions/Content.tsx
+++ b/plugins/stack-overflow/src/home/StackOverflowQuestions/Content.tsx
@@ -26,6 +26,7 @@ import {
 } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import useAsync from 'react-use/lib/useAsync';
+import _unescape from 'lodash/unescape';
 import qs from 'qs';
 import React from 'react';
 import {
@@ -73,7 +74,7 @@ export const Content = (props: StackOverflowQuestionsContentProps) => {
           <ListItem key={question.link}>
             {props.icon && <ListItemIcon>{props.icon}</ListItemIcon>}
             <ListItemText
-              primary={question.title}
+              primary={_unescape(question.title)}
               secondary={getSecondaryText(question.answer_count)}
             />
             <ListItemSecondaryAction>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

unescape html entities from stackoverflow api response

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
