### PR TITLE
[Github Pull Requests Board] Show more than 10 PRs at one time

### DIFF
--- a/.changeset/sweet-fishes-taste.md
+++ b/.changeset/sweet-fishes-taste.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-github-pull-requests-board': patch
 ---
 
-Add optional `defaultLimit` prop to `EntityTeamPullRequestsCard` and `EntityTeamPullRequestsContent` to limit the number of PRs shown per repository. Excluding this prop will result in showing all PRs for each repository.
+Add optional `pullRequestLimit` prop to `EntityTeamPullRequestsCard` and `EntityTeamPullRequestsContent` to limit the number of PRs shown per repository. Excluding this prop will default the number of pull requests shown to 10 per repository (the existing functionality).

--- a/.changeset/sweet-fishes-taste.md
+++ b/.changeset/sweet-fishes-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-pull-requests-board': patch
+---
+
+The PR dashboard will now show more than 10 pull requests at one time.

--- a/.changeset/sweet-fishes-taste.md
+++ b/.changeset/sweet-fishes-taste.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-github-pull-requests-board': minor
+'@backstage/plugin-github-pull-requests-board': patch
 ---
 
 Add optional `defaultLimit` prop to `EntityTeamPullRequestsCard` and `EntityTeamPullRequestsContent` to limit the number of PRs shown per repository. Excluding this prop will result in showing all PRs for each repository.

--- a/.changeset/sweet-fishes-taste.md
+++ b/.changeset/sweet-fishes-taste.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-github-pull-requests-board': patch
+'@backstage/plugin-github-pull-requests-board': minor
 ---
 
-The PR dashboard will now show more than 10 pull requests at one time.
+Add optional `defaultLimit` prop to `EntityTeamPullRequestsCard` and `EntityTeamPullRequestsContent` to limit the number of PRs shown per repository. Excluding this prop will result in showing all PRs for each repository.

--- a/plugins/github-pull-requests-board/api-report.md
+++ b/plugins/github-pull-requests-board/api-report.md
@@ -13,7 +13,7 @@ export const EntityTeamPullRequestsCard: (
 // @public (undocumented)
 export interface EntityTeamPullRequestsCardProps {
   // (undocumented)
-  defaultLimit?: number;
+  pullRequestLimit?: number;
 }
 
 // @public (undocumented)
@@ -24,7 +24,7 @@ export const EntityTeamPullRequestsContent: (
 // @public (undocumented)
 export interface EntityTeamPullRequestsContentProps {
   // (undocumented)
-  defaultLimit?: number;
+  pullRequestLimit?: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/github-pull-requests-board/api-report.md
+++ b/plugins/github-pull-requests-board/api-report.md
@@ -8,7 +8,7 @@
 // @public (undocumented)
 export const EntityTeamPullRequestsCard: (
   props: EntityTeamPullRequestsCardProps,
-) => JSX.Element | null;
+) => JSX.Element;
 
 // @public (undocumented)
 export interface EntityTeamPullRequestsCardProps {
@@ -19,7 +19,7 @@ export interface EntityTeamPullRequestsCardProps {
 // @public (undocumented)
 export const EntityTeamPullRequestsContent: (
   props: EntityTeamPullRequestsContentProps,
-) => JSX.Element | null;
+) => JSX.Element;
 
 // @public (undocumented)
 export interface EntityTeamPullRequestsContentProps {

--- a/plugins/github-pull-requests-board/api-report.md
+++ b/plugins/github-pull-requests-board/api-report.md
@@ -5,13 +5,27 @@
 ```ts
 /// <reference types="react" />
 
-import { FunctionComponent } from 'react';
+// @public (undocumented)
+export const EntityTeamPullRequestsCard: (
+  props: EntityTeamPullRequestsCardProps,
+) => JSX.Element | null;
 
 // @public (undocumented)
-export const EntityTeamPullRequestsCard: FunctionComponent<{}>;
+export interface EntityTeamPullRequestsCardProps {
+  // (undocumented)
+  defaultLimit?: number;
+}
 
 // @public (undocumented)
-export const EntityTeamPullRequestsContent: FunctionComponent<{}>;
+export const EntityTeamPullRequestsContent: (
+  props: EntityTeamPullRequestsContentProps,
+) => JSX.Element | null;
+
+// @public (undocumented)
+export interface EntityTeamPullRequestsContentProps {
+  // (undocumented)
+  defaultLimit?: number;
+}
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -45,7 +45,6 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^19.0.3",
-    "@types/react": "^16.13.1 || ^17.0.0",
     "moment": "^2.29.1",
     "react-use": "^17.2.4"
   },
@@ -58,6 +57,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.11.26",
+    "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "msw": "^0.45.0"
   },

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -57,11 +57,11 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.11.26",
+    "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "msw": "^0.45.0"
   },
   "peerDependencies": {
-    "@types/react": "^16.13.1 || ^17.0.0",
     "react": "^16.13.1 || ^17.0.0",
     "react-dom": "^16.13.1 || ^17.0.0"
   },

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -45,6 +45,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^19.0.3",
+    "@types/react": "^16.13.1 || ^17.0.0",
     "moment": "^2.29.1",
     "react-use": "^17.2.4"
   },
@@ -61,7 +62,6 @@
     "msw": "^0.45.0"
   },
   "peerDependencies": {
-    "@types/react": "^16.13.1 || ^17.0.0",
     "react": "^16.13.1 || ^17.0.0",
     "react-dom": "^16.13.1 || ^17.0.0"
   },

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -57,11 +57,11 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.11.26",
-    "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "msw": "^0.45.0"
   },
   "peerDependencies": {
+    "@types/react": "^16.13.1 || ^17.0.0",
     "react": "^16.13.1 || ^17.0.0",
     "react-dom": "^16.13.1 || ^17.0.0"
   },

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FunctionComponent, useState } from 'react';
+import React, { useState } from 'react';
 import { Grid, Typography } from '@material-ui/core';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -30,16 +30,16 @@ import { useUserRepositories } from '../../hooks/useUserRepositories';
 
 /** @public */
 export interface EntityTeamPullRequestsCardProps {
-  defaultLimit?: number;
+  pullRequestLimit?: number;
 }
 
 const EntityTeamPullRequestsCard = (props: EntityTeamPullRequestsCardProps) => {
-  const { defaultLimit = 100 } = props;
+  const { pullRequestLimit } = props;
   const [infoCardFormat, setInfoCardFormat] = useState<PRCardFormating[]>([]);
   const { repositories } = useUserRepositories();
   const { loading, pullRequests, refreshPullRequests } = usePullRequestsByTeam(
     repositories,
-    defaultLimit,
+    pullRequestLimit,
   );
 
   const header = (

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -28,6 +28,7 @@ import { PRCardFormating } from '../../utils/types';
 import { DraftPrIcon } from '../icons/DraftPr';
 import { useUserRepositories } from '../../hooks/useUserRepositories';
 
+/** @public */
 export interface EntityTeamPullRequestsCardProps {
   defaultLimit?: number;
 }

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -33,9 +33,7 @@ export interface EntityTeamPullRequestsCardProps {
   defaultLimit?: number;
 }
 
-const EntityTeamPullRequestsCard: FunctionComponent<
-  EntityTeamPullRequestsCardProps
-> = (props: EntityTeamPullRequestsCardProps) => {
+const EntityTeamPullRequestsCard = (props: EntityTeamPullRequestsCardProps) => {
   const { defaultLimit = 100 } = props;
   const [infoCardFormat, setInfoCardFormat] = useState<PRCardFormating[]>([]);
   const { repositories } = useUserRepositories();

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -28,11 +28,20 @@ import { PRCardFormating } from '../../utils/types';
 import { DraftPrIcon } from '../icons/DraftPr';
 import { useUserRepositories } from '../../hooks/useUserRepositories';
 
-const EntityTeamPullRequestsCard: FunctionComponent = () => {
+export interface EntityTeamPullRequestsCardProps {
+  defaultLimit?: number;
+}
+
+const EntityTeamPullRequestsCard: FunctionComponent<
+  EntityTeamPullRequestsCardProps
+> = (props: EntityTeamPullRequestsCardProps) => {
+  const { defaultLimit = 100 } = props;
   const [infoCardFormat, setInfoCardFormat] = useState<PRCardFormating[]>([]);
   const { repositories } = useUserRepositories();
-  const { loading, pullRequests, refreshPullRequests } =
-    usePullRequestsByTeam(repositories);
+  const { loading, pullRequests, refreshPullRequests } = usePullRequestsByTeam(
+    repositories,
+    defaultLimit,
+  );
 
   const header = (
     <InfoCardHeader onRefresh={refreshPullRequests}>

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/index.ts
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { default as EntityTeamPullRequestsCard } from './EntityTeamPullRequestsCard';
+export type { EntityTeamPullRequestsCardProps } from './EntityTeamPullRequestsCard';

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -31,9 +31,9 @@ export interface EntityTeamPullRequestsContentProps {
   defaultLimit?: number;
 }
 
-const EntityTeamPullRequestsContent: FunctionComponent<
-  EntityTeamPullRequestsContentProps
-> = (props: EntityTeamPullRequestsContentProps) => {
+const EntityTeamPullRequestsContent = (
+  props: EntityTeamPullRequestsContentProps,
+) => {
   const { defaultLimit } = props;
   const [infoCardFormat, setInfoCardFormat] = useState<PRCardFormating[]>([]);
   const { repositories } = useUserRepositories();

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -28,18 +28,18 @@ import { useUserRepositories } from '../../hooks/useUserRepositories';
 
 /** @public */
 export interface EntityTeamPullRequestsContentProps {
-  defaultLimit?: number;
+  pullRequestLimit?: number;
 }
 
 const EntityTeamPullRequestsContent = (
   props: EntityTeamPullRequestsContentProps,
 ) => {
-  const { defaultLimit } = props;
+  const { pullRequestLimit } = props;
   const [infoCardFormat, setInfoCardFormat] = useState<PRCardFormating[]>([]);
   const { repositories } = useUserRepositories();
   const { loading, pullRequests, refreshPullRequests } = usePullRequestsByTeam(
     repositories,
-    defaultLimit,
+    pullRequestLimit,
   );
 
   const header = (

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -26,6 +26,7 @@ import { PRCardFormating } from '../../utils/types';
 import { DraftPrIcon } from '../icons/DraftPr';
 import { useUserRepositories } from '../../hooks/useUserRepositories';
 
+/** @public */
 export interface EntityTeamPullRequestsContentProps {
   defaultLimit?: number;
 }

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FunctionComponent, useState } from 'react';
+import React, { useState } from 'react';
 import { Grid, Typography } from '@material-ui/core';
 import { Progress, InfoCard } from '@backstage/core-components';
 

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -26,11 +26,20 @@ import { PRCardFormating } from '../../utils/types';
 import { DraftPrIcon } from '../icons/DraftPr';
 import { useUserRepositories } from '../../hooks/useUserRepositories';
 
-const EntityTeamPullRequestsContent: FunctionComponent = () => {
+export interface EntityTeamPullRequestsContentProps {
+  defaultLimit?: number;
+}
+
+const EntityTeamPullRequestsContent: FunctionComponent<
+  EntityTeamPullRequestsContentProps
+> = (props: EntityTeamPullRequestsContentProps) => {
+  const { defaultLimit } = props;
   const [infoCardFormat, setInfoCardFormat] = useState<PRCardFormating[]>([]);
   const { repositories } = useUserRepositories();
-  const { loading, pullRequests, refreshPullRequests } =
-    usePullRequestsByTeam(repositories);
+  const { loading, pullRequests, refreshPullRequests } = usePullRequestsByTeam(
+    repositories,
+    defaultLimit,
+  );
 
   const header = (
     <InfoCardHeader onRefresh={refreshPullRequests}>

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/index.ts
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { default as EntityTeamPullRequestsContent } from './EntityTeamPullRequestsContent';
+export type { EntityTeamPullRequestsContentProps } from './EntityTeamPullRequestsContent';

--- a/plugins/github-pull-requests-board/src/hooks/usePullRequestsByTeam.tsx
+++ b/plugins/github-pull-requests-board/src/hooks/usePullRequestsByTeam.tsx
@@ -19,7 +19,10 @@ import { PullRequests, PullRequestsColumn } from '../utils/types';
 import { useGetPullRequestsFromRepository } from '../api/useGetPullRequestsFromRepository';
 import { useGetPullRequestDetails } from '../api/useGetPullRequestDetails';
 
-export function usePullRequestsByTeam(repositories: string[]) {
+export function usePullRequestsByTeam(
+  repositories: string[],
+  defaultLimit?: number,
+) {
   const [pullRequests, setPullRequests] = useState<PullRequestsColumn[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const getPullRequests = useGetPullRequestsFromRepository();
@@ -27,7 +30,10 @@ export function usePullRequestsByTeam(repositories: string[]) {
 
   const getPRsPerRepository = useCallback(
     async (repository: string): Promise<PullRequests> => {
-      const pullRequestsNumbers = await getPullRequests(repository);
+      const pullRequestsNumbers = await getPullRequests(
+        repository,
+        defaultLimit,
+      );
 
       const pullRequestsWithDetails = await Promise.all(
         pullRequestsNumbers.map(({ node }) =>
@@ -37,7 +43,7 @@ export function usePullRequestsByTeam(repositories: string[]) {
 
       return pullRequestsWithDetails;
     },
-    [getPullRequests, getPullRequestDetails],
+    [getPullRequests, getPullRequestDetails, defaultLimit],
   );
 
   const getPRsFromTeam = useCallback(

--- a/plugins/github-pull-requests-board/src/hooks/usePullRequestsByTeam.tsx
+++ b/plugins/github-pull-requests-board/src/hooks/usePullRequestsByTeam.tsx
@@ -21,7 +21,7 @@ import { useGetPullRequestDetails } from '../api/useGetPullRequestDetails';
 
 export function usePullRequestsByTeam(
   repositories: string[],
-  defaultLimit?: number,
+  pullRequestLimit?: number,
 ) {
   const [pullRequests, setPullRequests] = useState<PullRequestsColumn[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -32,7 +32,7 @@ export function usePullRequestsByTeam(
     async (repository: string): Promise<PullRequests> => {
       const pullRequestsNumbers = await getPullRequests(
         repository,
-        defaultLimit,
+        pullRequestLimit,
       );
 
       const pullRequestsWithDetails = await Promise.all(
@@ -43,7 +43,7 @@ export function usePullRequestsByTeam(
 
       return pullRequestsWithDetails;
     },
-    [getPullRequests, getPullRequestDetails, defaultLimit],
+    [getPullRequests, getPullRequestDetails, pullRequestLimit],
   );
 
   const getPRsFromTeam = useCallback(

--- a/plugins/github-pull-requests-board/src/index.ts
+++ b/plugins/github-pull-requests-board/src/index.ts
@@ -17,3 +17,5 @@ export {
   EntityTeamPullRequestsCard,
   EntityTeamPullRequestsContent,
 } from './plugin';
+export type { EntityTeamPullRequestsCardProps } from './components/EntityTeamPullRequestsCard';
+export type { EntityTeamPullRequestsContentProps } from './components/EntityTeamPullRequestsContent';

--- a/plugins/github-pull-requests-board/src/plugin.ts
+++ b/plugins/github-pull-requests-board/src/plugin.ts
@@ -18,6 +18,8 @@ import {
   createComponentExtension,
   createRoutableExtension,
 } from '@backstage/core-plugin-api';
+import { EntityTeamPullRequestsCardProps } from './components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard';
+import { EntityTeamPullRequestsContentProps } from './components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent';
 import { rootRouteRef } from './routes';
 
 const githubPullRequestsBoardPlugin = createPlugin({
@@ -28,7 +30,9 @@ const githubPullRequestsBoardPlugin = createPlugin({
 });
 
 /** @public */
-export const EntityTeamPullRequestsCard = githubPullRequestsBoardPlugin.provide(
+export const EntityTeamPullRequestsCard: (
+  props: EntityTeamPullRequestsCardProps,
+) => JSX.Element | null = githubPullRequestsBoardPlugin.provide(
   createComponentExtension({
     name: 'EntityTeamPullRequestsCard',
     component: {
@@ -41,14 +45,15 @@ export const EntityTeamPullRequestsCard = githubPullRequestsBoardPlugin.provide(
 );
 
 /** @public */
-export const EntityTeamPullRequestsContent =
-  githubPullRequestsBoardPlugin.provide(
-    createRoutableExtension({
-      name: 'PullRequestPage',
-      component: () =>
-        import('./components/EntityTeamPullRequestsContent').then(
-          m => m.EntityTeamPullRequestsContent,
-        ),
-      mountPoint: rootRouteRef,
-    }),
-  );
+export const EntityTeamPullRequestsContent: (
+  props: EntityTeamPullRequestsContentProps,
+) => JSX.Element | null = githubPullRequestsBoardPlugin.provide(
+  createRoutableExtension({
+    name: 'PullRequestPage',
+    component: () =>
+      import('./components/EntityTeamPullRequestsContent').then(
+        m => m.EntityTeamPullRequestsContent,
+      ),
+    mountPoint: rootRouteRef,
+  }),
+);

--- a/plugins/github-pull-requests-board/src/plugin.ts
+++ b/plugins/github-pull-requests-board/src/plugin.ts
@@ -30,9 +30,7 @@ const githubPullRequestsBoardPlugin = createPlugin({
 });
 
 /** @public */
-export const EntityTeamPullRequestsCard: (
-  props: EntityTeamPullRequestsCardProps,
-) => JSX.Element | null = githubPullRequestsBoardPlugin.provide(
+export const EntityTeamPullRequestsCard = githubPullRequestsBoardPlugin.provide(
   createComponentExtension({
     name: 'EntityTeamPullRequestsCard',
     component: {
@@ -45,15 +43,14 @@ export const EntityTeamPullRequestsCard: (
 );
 
 /** @public */
-export const EntityTeamPullRequestsContent: (
-  props: EntityTeamPullRequestsContentProps,
-) => JSX.Element | null = githubPullRequestsBoardPlugin.provide(
-  createRoutableExtension({
-    name: 'PullRequestPage',
-    component: () =>
-      import('./components/EntityTeamPullRequestsContent').then(
-        m => m.EntityTeamPullRequestsContent,
-      ),
-    mountPoint: rootRouteRef,
-  }),
-);
+export const EntityTeamPullRequestsContent =
+  githubPullRequestsBoardPlugin.provide(
+    createRoutableExtension({
+      name: 'PullRequestPage',
+      component: () =>
+        import('./components/EntityTeamPullRequestsContent').then(
+          m => m.EntityTeamPullRequestsContent,
+        ),
+      mountPoint: rootRouteRef,
+    }),
+  );

--- a/plugins/github-pull-requests-board/src/plugin.ts
+++ b/plugins/github-pull-requests-board/src/plugin.ts
@@ -18,8 +18,6 @@ import {
   createComponentExtension,
   createRoutableExtension,
 } from '@backstage/core-plugin-api';
-import { EntityTeamPullRequestsCardProps } from './components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard';
-import { EntityTeamPullRequestsContentProps } from './components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent';
 import { rootRouteRef } from './routes';
 
 const githubPullRequestsBoardPlugin = createPlugin({

--- a/plugins/github-pull-requests-board/src/utils/types.tsx
+++ b/plugins/github-pull-requests-board/src/utils/types.tsx
@@ -23,6 +23,10 @@ export type GraphQlPullRequests<T> = {
   repository: {
     pullRequests: {
       edges: T;
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor?: string;
+      };
     };
   };
 };


### PR DESCRIPTION
Signed-off-by: Jake Crews <jake.crews@daveramsey.com>

## Hey, I just made a Pull Request!

Currently the GitHub PR Board plugin only will display 10 PRs at a time. For the vast majority of our use cases for this plugin a group has more than 10 PRs open at a given time. I modified the plugin to show all PRs available by paginating through the results.

[I created an issue for this](https://github.com/backstage/backstage/issues/13290) with no response since it looks like the creator of this plugin has not been active recently.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
