### PR TITLE
Fix a complex case where uiSchema loses previous values

### DIFF
--- a/.changeset/slimy-stingrays-type.md
+++ b/.changeset/slimy-stingrays-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+fix uiSchema generation when using complex dependencies

--- a/plugins/scaffolder/src/components/MultistepJsonForm/schema.test.ts
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/schema.test.ts
@@ -347,6 +347,128 @@ describe('transformSchemaToProps', () => {
     });
   });
 
+  it('transforms schema with complex dependencies', () => {
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        conditional: {
+          title: 'Person',
+          type: 'object',
+          properties: {
+            'Do you have any pets?': {
+              type: 'string',
+              enum: ['No', 'Yes: One', 'Yes: More than one'],
+              default: 'No',
+              'ui:widget': 'radio',
+            },
+          },
+          required: ['Do you have any pets?'],
+          dependencies: {
+            'Do you have any pets?': {
+              oneOf: [
+                {
+                  properties: {
+                    'Do you have any pets?': {
+                      enum: ['No'],
+                    },
+                  },
+                },
+                {
+                  properties: {
+                    'Do you have any pets?': {
+                      enum: ['Yes: One'],
+                    },
+                    'How old is your pet?': {
+                      type: 'number',
+                    },
+                  },
+                  required: ['How old is your pet?'],
+                },
+                {
+                  properties: {
+                    'Do you have any pets?': {
+                      enum: ['Yes: More than one'],
+                    },
+                    'Do you want to get rid of any?': {
+                      type: 'boolean',
+                    },
+                  },
+                  required: ['Do you want to get rid of any?'],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const expectedSchema = {
+      type: 'object',
+      properties: {
+        conditional: {
+          title: 'Person',
+          type: 'object',
+          properties: {
+            'Do you have any pets?': {
+              type: 'string',
+              enum: ['No', 'Yes: One', 'Yes: More than one'],
+              default: 'No',
+            },
+          },
+          required: ['Do you have any pets?'],
+          dependencies: {
+            'Do you have any pets?': {
+              oneOf: [
+                {
+                  properties: {
+                    'Do you have any pets?': {
+                      enum: ['No'],
+                    },
+                  },
+                },
+                {
+                  properties: {
+                    'Do you have any pets?': {
+                      enum: ['Yes: One'],
+                    },
+                    'How old is your pet?': {
+                      type: 'number',
+                    },
+                  },
+                  required: ['How old is your pet?'],
+                },
+                {
+                  properties: {
+                    'Do you have any pets?': {
+                      enum: ['Yes: More than one'],
+                    },
+                    'Do you want to get rid of any?': {
+                      type: 'boolean',
+                    },
+                  },
+                  required: ['Do you want to get rid of any?'],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const expectedUiSchema = {
+      conditional: {
+        'Do you have any pets?': {
+          'ui:widget': 'radio',
+        },
+        'Do you want to get rid of any?': {},
+        'How old is your pet?': {},
+      },
+    };
+
+    expect(transformSchemaToProps(inputSchema)).toEqual({
+      schema: expectedSchema,
+      uiSchema: expectedUiSchema,
+    });
+  });
+
   it('transforms schema with array items', () => {
     const inputSchema = {
       type: 'object',

--- a/plugins/scaffolder/src/components/MultistepJsonForm/schema.ts
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/schema.ts
@@ -50,7 +50,7 @@ function extractUiSchema(schema: JsonObject, uiSchema: JsonObject) {
         continue;
       }
       const innerUiSchema = {};
-      uiSchema[propName] = innerUiSchema;
+      uiSchema[propName] = uiSchema[propName] || innerUiSchema;
       extractUiSchema(schemaNode, innerUiSchema);
     }
   }


### PR DESCRIPTION
In non trivial cases of using eg a schema with dependencies,
the extractUiSchema function could reset ui properties previously
set by the recursive call.

Signed-off-by: Eric Bottard <bottarde@vmware.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
