### PR TITLE
Limit the length of errors that get written to the database

### DIFF
--- a/.changeset/spotty-points-build.md
+++ b/.changeset/spotty-points-build.md
@@ -1,0 +1,6 @@
+---
+'@backstage/errors': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Limit the length of error messages that get written to the database and logs - to prevent performance issues

--- a/.changeset/spotty-points-build.md
+++ b/.changeset/spotty-points-build.md
@@ -1,5 +1,4 @@
 ---
-'@backstage/errors': patch
 '@backstage/plugin-catalog-backend': patch
 ---
 

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
@@ -97,7 +97,10 @@ export class UrlReaderProcessor implements CatalogProcessor {
       emit(processingResult.refresh(`${location.type}:${location.target}`));
     } catch (error) {
       assertError(error);
-      const message = `Unable to read ${location.type}, ${error}`;
+      const message = `Unable to read ${location.type}, ${error}`.substring(
+        0,
+        5000,
+      );
       if (error.name === 'NotModifiedError' && cacheItem) {
         for (const parseResult of cacheItem.value) {
           emit(parseResult);


### PR DESCRIPTION
Signed-off-by: Gudmundur Orn Johannsson <gudmundur.orn@gmail.com>

## Hey, I just made a Pull Request!

In some scenarios, catalog processors may throw huge errors. These errors are then written to the `final_entities` and `refresh_state` tables of the catalog plugin's database, causing the database to grow unreasonably large and may cause all sorts of performance issues when loading a collection of entities into memory.

The resiliency of the system can be improved by enforcing a reasonable limit on the length of the error messages.

Here's how I came across this problem:

I have a Backstage installation that uses the catalog plugin and it scans around 500 repositories from our Github Enterprise server. When the Github server was taken down for maintenance, it responded to all api requests with a status 500 and a huge html page (700k). The error message that contains the full html of that page gets printed in the logs and it gets saved in the `final_entities` and `refresh_state` tables of the catalog plugin's database, and some actions in the frontend load all these entities in one go without any pagination, causing Backstage to run out of heap space (500mb) and crash. The huge Backstage logs in our log storage was also a problem, since it prints the huge html multiple times per second.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
