### PR TITLE
index a null for large values as well

### DIFF
--- a/.changeset/gold-hounds-vanish.md
+++ b/.changeset/gold-hounds-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+The search index now does retain fields that have a very long value, but in the form of just a null. This makes it possible to at least filter for their existence.

--- a/plugins/catalog-backend/src/stitching/buildEntitySearch.test.ts
+++ b/plugins/catalog-backend/src/stitching/buildEntitySearch.test.ts
@@ -109,10 +109,10 @@ describe('buildEntitySearch', () => {
       expect(output).toEqual([]);
     });
 
-    it('skips very large values', () => {
+    it('replaces very large values with null', () => {
       const input = [{ key: 'foo', value: 'a'.repeat(10000) }];
       const output = mapToRows(input, 'eid');
-      expect(output).toEqual([]);
+      expect(output).toEqual([{ entity_id: 'eid', key: 'foo', value: null }]);
     });
   });
 

--- a/plugins/catalog-backend/src/stitching/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/stitching/buildEntitySearch.ts
@@ -137,8 +137,12 @@ export function mapToRows(input: Kv[], entityId: string): DbSearchRow[] {
       result.push({ entity_id: entityId, key, value: null });
     } else {
       const value = String(rawValue).toLocaleLowerCase('en-US');
-      if (key.length <= MAX_KEY_LENGTH && value.length <= MAX_VALUE_LENGTH) {
-        result.push({ entity_id: entityId, key, value });
+      if (key.length <= MAX_KEY_LENGTH) {
+        result.push({
+          entity_id: entityId,
+          key,
+          value: value.length <= MAX_VALUE_LENGTH ? value : null,
+        });
       }
     }
   }


### PR DESCRIPTION
Fixes #13191

I did consider whether it would be better to store the empty string or a placeholder like `<value too large>`. It felt like null was the one with the fewest potential side effects elsewhere.