### PR TITLE
scaffolder: Save workspace form state when using `bitbucket` and predefined list

### DIFF
--- a/.changeset/funny-hounds-obey.md
+++ b/.changeset/funny-hounds-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixing bug when the workspace would not be automatically saved when using `allowedOwners`

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Input from '@material-ui/core/Input';
@@ -32,6 +32,13 @@ export const BitbucketRepoPicker = (props: {
   const ownerItems: SelectItem[] = allowedOwners
     ? allowedOwners?.map(i => ({ label: i, value: i }))
     : [];
+
+  useEffect(() => {
+    if (host === 'bitbucket.org' && allowedOwners.length) {
+      onChange({ workspace: allowedOwners[0] });
+    }
+  }, [allowedOwners, host, onChange]);
+
   return (
     <>
       {host === 'bitbucket.org' && (

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -90,9 +90,13 @@ export const RepoUrlPicker = (
   /* we deal with calling the repo setting here instead of in each components for ease */
   useEffect(() => {
     if (allowedOwners.length > 0) {
-      setState(prevState => ({ ...prevState, owner: allowedOwners[0] }));
+      setState(prevState => ({
+        ...prevState,
+        owner: allowedOwners[0],
+      }));
     }
   }, [setState, allowedOwners]);
+
   useEffect(() => {
     if (allowedRepos.length > 0) {
       setState(prevState => ({ ...prevState, repoName: allowedRepos[0] }));


### PR DESCRIPTION
Fixes #13226