### PR TITLE
fix: return refresh keys if item is cached

### DIFF
--- a/.changeset/great-cats-sit.md
+++ b/.changeset/great-cats-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixes a bug to be able to utilize refresh keys after the entity is loaded from cache

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -145,20 +145,22 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       BATCH_SIZE,
     );
 
-    // Delete old refresh keys
-    await tx<DbRefreshKeysRow>('refresh_keys')
-      .where({ entity_id: id })
-      .delete();
+    if (refreshKeys && refreshKeys.length > 0) {
+      // Delete old refresh keys
+      await tx<DbRefreshKeysRow>('refresh_keys')
+        .where({ entity_id: id })
+        .delete();
 
-    // Insert the refresh keys for the processed entity
-    await tx.batchInsert(
-      'refresh_keys',
-      refreshKeys.map(k => ({
-        entity_id: id,
-        key: k.key,
-      })),
-      BATCH_SIZE,
-    );
+      // Insert the refresh keys for the processed entity
+      await tx.batchInsert(
+        'refresh_keys',
+        refreshKeys.map(k => ({
+          entity_id: id,
+          key: k.key,
+        })),
+        BATCH_SIZE,
+      );
+    }
 
     return {
       previous: {

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -145,22 +145,20 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       BATCH_SIZE,
     );
 
-    if (refreshKeys && refreshKeys.length > 0) {
-      // Delete old refresh keys
-      await tx<DbRefreshKeysRow>('refresh_keys')
-        .where({ entity_id: id })
-        .delete();
+    // Delete old refresh keys
+    await tx<DbRefreshKeysRow>('refresh_keys')
+      .where({ entity_id: id })
+      .delete();
 
-      // Insert the refresh keys for the processed entity
-      await tx.batchInsert(
-        'refresh_keys',
-        refreshKeys.map(k => ({
-          entity_id: id,
-          key: k.key,
-        })),
-        BATCH_SIZE,
-      );
-    }
+    // Insert the refresh keys for the processed entity
+    await tx.batchInsert(
+      'refresh_keys',
+      refreshKeys.map(k => ({
+        entity_id: id,
+        key: k.key,
+      })),
+      BATCH_SIZE,
+    );
 
     return {
       previous: {

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
@@ -127,19 +127,25 @@ describe('UrlReaderProcessor', () => {
     mockCache.get.mockResolvedValue(cacheItem);
     const processor = new UrlReaderProcessor({ reader, logger });
 
-    const generated = (await new Promise<CatalogProcessorResult>(emit =>
-      processor.readLocation(
-        spec,
-        false,
-        emit,
-        defaultEntityDataParser,
-        mockCache,
-      ),
-    )) as CatalogProcessorEntityResult;
+    const emitted = new Array<CatalogProcessorResult>();
+    await processor.readLocation(
+      spec,
+      false,
+      r => emitted.push(r),
+      defaultEntityDataParser,
+      mockCache,
+    );
 
-    expect(generated.type).toBe('entity');
-    expect(generated.location).toEqual(spec);
-    expect(generated.entity).toEqual({ mock: 'entity' });
+    const entity = emitted[0];
+    const refresh = emitted[1];
+
+    expect(entity.type).toBe('entity');
+    expect(entity.location).toEqual(spec);
+    expect(entity.entity).toEqual({ mock: 'entity' });
+
+    expect(refresh.type).toBe('refresh');
+    expect(refresh.key).toBe('url:http://localhost/component.yaml');
+
     expect(mockCache.get).toBeCalledWith('v1');
     expect(mockCache.get).toBeCalledTimes(1);
     expect(mockCache.set).toBeCalledTimes(0);

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
@@ -27,6 +27,7 @@ import {
   CatalogProcessorCache,
   CatalogProcessorEntityResult,
   CatalogProcessorErrorResult,
+  CatalogProcessorRefreshKeysResult,
   CatalogProcessorResult,
 } from '@backstage/plugin-catalog-node';
 import { defaultEntityDataParser } from '../util/parse';
@@ -136,8 +137,8 @@ describe('UrlReaderProcessor', () => {
       mockCache,
     );
 
-    const entity = emitted[0];
-    const refresh = emitted[1];
+    const entity = emitted[0] as CatalogProcessorEntityResult;
+    const refresh = emitted[1] as CatalogProcessorRefreshKeysResult;
 
     expect(entity.type).toBe('entity');
     expect(entity.location).toEqual(spec);

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
@@ -102,6 +102,7 @@ export class UrlReaderProcessor implements CatalogProcessor {
         for (const parseResult of cacheItem.value) {
           emit(parseResult);
         }
+        emit(processingResult.refresh(`${location.type}:${location.target}`));
       } else if (error.name === 'NotFoundError') {
         if (!optional) {
           emit(processingResult.notFoundError(location, message));


### PR DESCRIPTION
Signed-off-by: Kiss Miklos <miklos@roadie.io>

## Hey, I just made a Pull Request!
It solves a bug with the current refresh based on keys implementation. In the initial implementation I missed to return refresh keys in cases where the result is loaded from cache. It means that with the current behaviour if you add a new entity to the catalog it can be refreshed until the catalog runs the processing loop on it, because in that case it will load the entity from cache, won't return a refresh key and the refresh key will be deleted from the DB table

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
