### PR TITLE
Add support for other `hosts` in `GitHubEntityProvider`

### DIFF
--- a/.changeset/smooth-yaks-hug.md
+++ b/.changeset/smooth-yaks-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added the ability to configure the host for the `GitHubEntityProvider` to use against GitHub Enterprise

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.test.ts
@@ -75,6 +75,29 @@ describe('GitHubEntityProvider', () => {
     expect(providers[0].getProviderName()).toEqual('github-provider:default');
   });
 
+  it('throws when the integration config does not exist', () => {
+    const schedule = new PersistingTaskRunner();
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          github: {
+            organization: 'test-org',
+            host: 'ghe.internal.com',
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      GitHubEntityProvider.fromConfig(config, {
+        logger,
+        schedule,
+      }),
+    ).toThrowError(
+      /There is no GitHub config that matches host ghe.internal.com/,
+    );
+  });
+
   it('multiple provider configs', () => {
     const schedule = new PersistingTaskRunner();
     const config = new ConfigReader({

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.ts
@@ -63,23 +63,24 @@ export class GitHubEntityProvider implements EntityProvider {
     },
   ): GitHubEntityProvider[] {
     const integrations = ScmIntegrations.fromConfig(config);
-    const integration = integrations.github.byHost('github.com');
 
-    if (!integration) {
-      throw new Error(
-        `There is no GitHub config that matches github. Please add a configuration entry for it under integrations.github`,
+    return readProviderConfigs(config).map(providerConfig => {
+      const integrationHost = providerConfig.host;
+      const integration = integrations.github.byHost(integrationHost);
+
+      if (!integration) {
+        throw new Error(
+          `There is no GitHub config that matches host ${integrationHost}. Please add a configuration entry for it under integrations.github`,
+        );
+      }
+
+      return new GitHubEntityProvider(
+        providerConfig,
+        integration,
+        options.logger,
+        options.schedule,
       );
-    }
-
-    return readProviderConfigs(config).map(
-      providerConfig =>
-        new GitHubEntityProvider(
-          providerConfig,
-          integration,
-          options.logger,
-          options.schedule,
-        ),
-    );
+    });
   }
 
   private constructor(

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.test.ts
@@ -68,17 +68,22 @@ describe('readProviderConfigs', () => {
                 branch: 'branch-name',
               },
             },
+            providerWithHost: {
+              organization: 'test-org1',
+              host: 'ghe.internal.com',
+            },
           },
         },
       },
     });
     const providerConfigs = readProviderConfigs(config);
 
-    expect(providerConfigs).toHaveLength(4);
+    expect(providerConfigs).toHaveLength(5);
     expect(providerConfigs[0]).toEqual({
       id: 'providerOrganizationOnly',
       organization: 'test-org1',
       catalogPath: '/catalog-info.yaml',
+      host: 'github.com',
       filters: {
         repository: undefined,
         branch: undefined,
@@ -88,6 +93,7 @@ describe('readProviderConfigs', () => {
       id: 'providerCustomCatalogPath',
       organization: 'test-org2',
       catalogPath: 'custom/path/catalog-info.yaml',
+      host: 'github.com',
       filters: {
         repository: undefined,
         branch: undefined,
@@ -97,6 +103,7 @@ describe('readProviderConfigs', () => {
       id: 'providerWithRepositoryFilter',
       organization: 'test-org3', // organization
       catalogPath: '/catalog-info.yaml', // file
+      host: 'github.com',
       filters: {
         repository: /^repository.*filter$/, // repo
         branch: undefined, // branch
@@ -106,9 +113,20 @@ describe('readProviderConfigs', () => {
       id: 'providerWithBranchFilter',
       organization: 'test-org4',
       catalogPath: '/catalog-info.yaml',
+      host: 'github.com',
       filters: {
         repository: undefined,
         branch: 'branch-name',
+      },
+    });
+    expect(providerConfigs[4]).toEqual({
+      id: 'providerWithHost',
+      organization: 'test-org1',
+      catalogPath: '/catalog-info.yaml',
+      host: 'ghe.internal.com',
+      filters: {
+        repository: undefined,
+        branch: undefined,
       },
     });
   });

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.ts
@@ -23,6 +23,7 @@ export type GitHubEntityProviderConfig = {
   id: string;
   catalogPath: string;
   organization: string;
+  host: string;
   filters?: {
     repository?: RegExp;
     branch?: string;
@@ -56,6 +57,7 @@ function readProviderConfig(
   const organization = config.getString('organization');
   const catalogPath =
     config.getOptionalString('catalogPath') ?? DEFAULT_CATALOG_PATH;
+  const host = config.getOptionalString('host') ?? 'github.com';
   const repositoryPattern = config.getOptionalString('filters.repository');
   const branchPattern = config.getOptionalString('filters.branch');
 
@@ -63,6 +65,7 @@ function readProviderConfig(
     id,
     catalogPath,
     organization,
+    host,
     filters: {
       repository: repositoryPattern
         ? compileRegExp(repositoryPattern)


### PR DESCRIPTION
After a brief chat this morning we settled on `host` as an extra option to fall inline with other providers that have the same pattern.

Fixes #13373 