### PR TITLE
fix: Include bucketRootPath in AWS/GCS publisher for Techdocs

### DIFF
--- a/.changeset/big-spies-check.md
+++ b/.changeset/big-spies-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fix Techdocs S3 publisher to include bucketRootPath in requests. Currently, requests made to S3 are omitting this path and fail with a 404

--- a/.changeset/big-spies-check.md
+++ b/.changeset/big-spies-check.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-node': patch
 ---
 
-Fix Techdocs S3 publisher to include bucketRootPath in requests. Currently, requests made to S3 are omitting this path and fail with a 404
+Fix Techdocs S3 and GCS publisher to include bucketRootPath in requests

--- a/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
@@ -537,13 +537,13 @@ describe('AwsS3Publish', () => {
       app = express().use(publisher.docsRouter());
 
       const pngResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/img/with%20spaces.png`,
+        `/${entityTripletPath}/img/with%20spaces.png`,
       );
       expect(Buffer.from(pngResponse.body).toString('utf8')).toEqual(
         'found it',
       );
       const jsResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
+        `/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
       );
       expect(jsResponse.text).toEqual('found it too');
     });
@@ -558,13 +558,13 @@ describe('AwsS3Publish', () => {
       app = express().use(publisher.docsRouter());
 
       const pngResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/img/with%20spaces.png`,
+        `/${entityTripletPath}/img/with%20spaces.png`,
       );
       expect(Buffer.from(pngResponse.body).toString('utf8')).toEqual(
         'found it',
       );
       const jsResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
+        `/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
       );
       expect(jsResponse.text).toEqual('found it too');
     });

--- a/plugins/techdocs-node/src/stages/publish/awsS3.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.ts
@@ -370,19 +370,14 @@ export class AwsS3Publish implements PublisherBase {
    */
   docsRouter(): express.Handler {
     return async (req, res) => {
-      // Decode and trim the leading forward slash
       const decodedUri = decodeURI(req.path.replace(/^\//, ''));
-
-      // Root path is removed from the Uri so that legacy casing can be applied
-      // to the entity triplet without manipulating the root path
-      const decodedUriNoRoot = path.relative(this.bucketRootPath, decodedUri);
 
       // filePath example - /default/component/documented-component/index.html
       const filePathNoRoot = this.legacyPathCasing
-        ? decodedUriNoRoot
-        : lowerCaseEntityTripletInStoragePath(decodedUriNoRoot);
+        ? decodedUri
+        : lowerCaseEntityTripletInStoragePath(decodedUri);
 
-      // Re-prepend the root path to the relative file path
+      // Prepend the root path to the relative file path
       const filePath = path.posix.join(this.bucketRootPath, filePathNoRoot);
 
       // Files with different extensions (CSS, HTML) need to be served with different headers

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.test.ts
@@ -527,13 +527,13 @@ describe('GoogleGCSPublish', () => {
       app = express().use(publisher.docsRouter());
 
       const pngResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/img/with%20spaces.png`,
+        `/${entityTripletPath}/img/with%20spaces.png`,
       );
       expect(Buffer.from(pngResponse.body).toString('utf8')).toEqual(
         'found it',
       );
       const jsResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
+        `/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
       );
       expect(jsResponse.text).toEqual('found it too');
     });
@@ -548,13 +548,13 @@ describe('GoogleGCSPublish', () => {
       app = express().use(publisher.docsRouter());
 
       const pngResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/img/with%20spaces.png`,
+        `/${entityTripletPath}/img/with%20spaces.png`,
       );
       expect(Buffer.from(pngResponse.body).toString('utf8')).toEqual(
         'found it',
       );
       const jsResponse = await request(app).get(
-        `/${rootPath}/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
+        `/${entityTripletPath}/some%20folder/also%20with%20spaces.js`,
       );
       expect(jsResponse.text).toEqual('found it too');
     });

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.ts
@@ -274,18 +274,14 @@ export class GoogleGCSPublish implements PublisherBase {
    */
   docsRouter(): express.Handler {
     return (req, res) => {
-      // Decode and trim the leading forward slash
       const decodedUri = decodeURI(req.path.replace(/^\//, ''));
 
-      // Root path is removed from the Uri so that legacy casing can be applied
-      // to the entity triplet without manipulating the root path
-      const decodedUriNoRoot = path.relative(this.bucketRootPath, decodedUri);
-
+      // filePath example - /default/component/documented-component/index.html
       const filePathNoRoot = this.legacyPathCasing
-        ? decodedUriNoRoot
-        : lowerCaseEntityTripletInStoragePath(decodedUriNoRoot);
+        ? decodedUri
+        : lowerCaseEntityTripletInStoragePath(decodedUri);
 
-      // Re-prepend the root path to the relative file path
+      // Prepend the root path to the relative file path
       const filePath = path.posix.join(this.bucketRootPath, filePathNoRoot);
 
       // Files with different extensions (CSS, HTML) need to be served with different headers


### PR DESCRIPTION
Signed-off-by: aarontsharp <aaron.sharp@carta.com>

## Hey, I just made a Pull Request!
Currently, the S3 (and GCS) publisher for Techdocs' is not prepending the configured `rootBucketPath` to requests, meaning any request for Techdocs assets currently fail with a 404 if this configuration option is used.

The reason for this is that the existing implementation assumes that requests to Techdocs' backend will include the bucket prefix in the request URL e.g. `/static/docs/{rootBucketPath}/{namespace}/{kind}/{name}/${path}` (this is the request existing unit tests are making to test this). However, this is not what the plugin currently uses as seen [here](https://github.com/backstage/backstage/blob/6f70113b57804fbb0283003163dd60a1a4f859fe/plugins/techdocs/src/client.ts#L158) where the URL is formed as: `/static/docs/${namespace}/${kind}/${name}/${path}`.

Currently, when requests are received by this endpoint, this line in the current implementation:
`const decodedUriNoRoot = path.relative(this.bucketRootPath, decodedUri);`

returns a path like `../${decodedUri}`, because `bucketRootPath` is not a parent of the received url. Later in the flow, when `bucketRootPath` is prepended to this url, the result is `${bucketRootPath}/../${decodedUri}`, and `bucketRootPath` is dropped.

This change removes the assumption that the S3/GCS publisher will receive the bucket prefix in the path, which fixes the problem. Further, this assumption really doesn't make much sense, as the Techdocs frontend shouldn't be aware that S3/GCS in in use, nor should it need to provide the bucket prefix which is configured entirely in the backend plugin.

Fixes #10207

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
