### PR TITLE
Bump `git-url-parse`

### DIFF
--- a/.changeset/cuddly-needles-marry.md
+++ b/.changeset/cuddly-needles-marry.md
@@ -1,0 +1,14 @@
+---
+'@backstage/backend-common': patch
+'@backstage/integration': patch
+'@backstage/plugin-adr': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Bump `git-url-parse` version to `^13.0.0`

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -59,7 +59,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "helmet": "^6.0.0",
     "isomorphic-git": "^1.8.0",
     "jose": "^4.6.0",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -36,7 +36,7 @@
     "@backstage/config": "^1.0.1",
     "@backstage/errors": "^1.1.0",
     "cross-fetch": "^3.1.5",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "@octokit/rest": "^19.0.3",
     "@octokit/auth-app": "^4.0.0",
     "luxon": "^3.0.0",

--- a/plugins/adr/package.json
+++ b/plugins/adr/package.json
@@ -34,7 +34,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "octokit": "^2.0.0",
     "react-markdown": "^8.0.0",
     "react-use": "^17.2.4",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -55,7 +55,7 @@
     "express-promise-router": "^4.1.0",
     "fast-json-stable-stringify": "^2.1.0",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "glob": "^7.1.6",
     "knex": "^2.0.0",
     "lodash": "^4.17.21",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -47,7 +47,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^19.0.3",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "js-base64": "^3.6.0",
     "lodash": "^4.17.21",
     "react-hook-form": "^7.12.2",

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -57,7 +57,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "globby": "^11.0.0",
     "isbinaryfile": "^5.0.0",
     "isomorphic-git": "^1.8.0",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -61,7 +61,7 @@
     "@types/json-schema": "^7.0.9",
     "@uiw/react-codemirror": "^4.9.3",
     "classnames": "^2.2.6",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.1",
     "json-schema": "^0.4.0",

--- a/plugins/techdocs-module-addons-contrib/package.json
+++ b/plugins/techdocs-module-addons-contrib/package.json
@@ -44,7 +44,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@react-hookz/web": "^15.0.0",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -54,7 +54,7 @@
     "aws-sdk": "^2.840.0",
     "express": "^4.17.1",
     "fs-extra": "10.1.0",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "js-yaml": "^4.0.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -53,7 +53,7 @@
     "@material-ui/styles": "^4.10.0",
     "dompurify": "^2.2.9",
     "event-source-polyfill": "1.0.25",
-    "git-url-parse": "^12.0.0",
+    "git-url-parse": "^13.0.0",
     "jss": "~10.8.2",
     "lodash": "^4.17.21",
     "react-helmet": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14625,6 +14625,14 @@ git-up@^6.0.0:
     is-ssh "^1.4.0"
     parse-url "^7.0.2"
 
+git-up@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz#bace30786e36f56ea341b6f69adfd83286337467"
+  integrity sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==
+  dependencies:
+    is-ssh "^1.4.0"
+    parse-url "^8.1.0"
+
 git-url-parse@^11.4.4:
   version "11.6.0"
   resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
@@ -14638,6 +14646,13 @@ git-url-parse@^12.0.0:
   integrity sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==
   dependencies:
     git-up "^6.0.0"
+
+git-url-parse@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-13.0.0.tgz#9a18d0eaec579fb6379c368aecb09f00b544669c"
+  integrity sha512-X1kozCqKL82dMrCLi4vie9SHDC+QugKskAMs4VUbIkhURKg5yDwxDmf6Ixg73J+/xVgK5TXKhzn8a94nHJHpnA==
+  dependencies:
+    git-up "^7.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -20891,6 +20906,13 @@ parse-path@^5.0.0:
   dependencies:
     protocols "^2.0.0"
 
+parse-path@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz#605a2d58d0a749c8594405d8cc3a2bf76d16099b"
+  integrity sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==
+  dependencies:
+    protocols "^2.0.0"
+
 parse-url@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
@@ -20910,6 +20932,13 @@ parse-url@^7.0.2:
     normalize-url "^6.1.0"
     parse-path "^5.0.0"
     protocols "^2.0.1"
+
+parse-url@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz#972e0827ed4b57fc85f0ea6b0d839f0d8a57a57d"
+  integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
+  dependencies:
+    parse-path "^7.0.0"
 
 parse5@6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Fixes #6039 finally! :pray:

Other plugin maintainers will also need to bump to grab the latest verisons of our packages, and `git-url-parse` to be fixed everywhere.