### PR TITLE
Use webpack esmodule detection for React Refresh

### DIFF
--- a/.changeset/purple-plums-travel.md
+++ b/.changeset/purple-plums-travel.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Use the `webpack` `esmodule` detection for React Refresh
+Fixed a misconfiguration where all modules where treated as ESM by the React Refresh plugin for Webpack.

--- a/.changeset/purple-plums-travel.md
+++ b/.changeset/purple-plums-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Use the `webpack` `esmodule` detection for React Refresh

--- a/packages/cli/src/lib/bundler/transforms.ts
+++ b/packages/cli/src/lib/bundler/transforms.ts
@@ -190,7 +190,6 @@ export const transforms = (options: TransformOptions): Transforms => {
   if (isDev) {
     plugins.push(
       new ReactRefreshPlugin({
-        esModule: true,
         overlay: { sockProtocol: 'ws' },
       }),
     );


### PR DESCRIPTION
- use the webpack detection for `esmodule` with React Refresh
- chore: add changeset

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
