### PR TITLE
root: nicer workaround for yarn --cwd bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "release": "node scripts/prepare-release.js && changeset version && yarn diff --yes && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install",
     "prettier:check": "prettier --check .",
     "lerna": "lerna",
-    "storybook": "(cd storybook && yarn start)",
+    "storybook": "yarn ./storybook run start",
     "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
     "snyk:test:package": "yarn snyk:test --include",
-    "build-storybook": "(cd storybook && yarn build-storybook)",
+    "build-storybook": "yarn ./storybook run build-storybook",
     "techdocs-cli": "node scripts/techdocs-cli.js",
     "techdocs-cli:dev": "cross-env TECHDOCS_CLI_DEV_MODE=true node scripts/techdocs-cli.js",
     "prepare": "husky install"


### PR DESCRIPTION
🧹 , the recommended workaround for `yarn --cwd <path>` not working within scripts