### PR TITLE
Fix settings page not displaying sing in properly

### DIFF
--- a/.changeset/soft-falcons-love.md
+++ b/.changeset/soft-falcons-love.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-user-settings': patch
+'@backstage/plugin-user-settings': minor
 ---
 
-Fixed settings page showing providers as logged out when the user is using more than one provider, and displayed some additional login information.
+**BREAKING** Fixed settings page showing providers as logged out when the user is using more than one provider, and displayed some additional login information.

--- a/.changeset/soft-falcons-love.md
+++ b/.changeset/soft-falcons-love.md
@@ -2,4 +2,10 @@
 '@backstage/plugin-user-settings': minor
 ---
 
-**BREAKING** Fixed settings page showing providers as logged out when the user is using more than one provider, and displayed some additional login information.
+**BREAKING**: The `apiRef` passed to `ProviderSettingsItem` now needs to
+implement `ProfileInfoApi & SessionApi`, rather than just the latter. This is
+unlikely to have an effect on most users though, since the builtin auth
+providers generally implement both.
+
+Fixed settings page showing providers as logged out when the user is using more
+than one provider, and displayed some additional login information.

--- a/.changeset/soft-falcons-love.md
+++ b/.changeset/soft-falcons-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Fixed settings page showing providers as logged out when the user is using more than one provider, and displayed some additional login information.

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { BackstageUserIdentity } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { ProfileInfo } from '@backstage/core-plugin-api';
+import { ProfileInfoApi } from '@backstage/core-plugin-api';
 import { PropsWithChildren } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
@@ -24,7 +25,7 @@ export const ProviderSettingsItem: (props: {
   title: string;
   description: string;
   icon: IconComponent;
-  apiRef: ApiRef<SessionApi>;
+  apiRef: ApiRef<ProfileInfoApi & SessionApi>;
 }) => JSX.Element;
 
 // @public (undocumented)

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsAvatar.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsAvatar.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { BackstageTheme } from '@backstage/theme';
+import { makeStyles, Avatar } from '@material-ui/core';
+import { sidebarConfig } from '@backstage/core-components';
+
+const useStyles = makeStyles<BackstageTheme, { size: number }>(theme => ({
+  avatar: {
+    width: ({ size }) => size,
+    height: ({ size }) => size,
+    fontSize: ({ size }) => size * 0.7,
+    border: `1px solid ${theme.palette.textSubtle}`,
+  },
+}));
+
+type Props = { size?: number; picture: string | undefined };
+
+export const ProviderSettingsAvatar = ({ size, picture }: Props) => {
+  const { iconSize } = sidebarConfig;
+  const classes = useStyles(size ? { size } : { size: iconSize });
+
+  return <Avatar src={picture} className={classes.avatar} />;
+};

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -62,10 +62,10 @@ export const ProviderSettingsItem = (props: {
             .then((profileResponse: ProfileInfo | undefined) => {
               if (sessionState === SessionState.SignedIn) {
                 setSignedIn(true);
-              } else {
-                setSignedIn(profileResponse !== undefined);
               }
-              setProfile(profileResponse ?? {});
+              if (profileResponse) {
+                setProfile(profileResponse);
+              }
             });
         }
       });

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -26,6 +26,7 @@ import {
 import {
   ApiRef,
   SessionApi,
+  SessionState,
   ProfileInfoApi,
   ProfileInfo,
   useApi,
@@ -48,16 +49,22 @@ export const ProviderSettingsItem = (props: {
   useEffect(() => {
     let didCancel = false;
 
-    const subscription = api.sessionState$().subscribe(() => {
-      if (!didCancel) {
-        api
-          .getProfile({ optional: true })
-          .then((profile: ProfileInfo | undefined) => {
-            setSignedIn(profile !== undefined);
-            setProfileEmail(profile?.email ?? '');
-          });
-      }
-    });
+    const subscription = api
+      .sessionState$()
+      .subscribe((sessionState: SessionState) => {
+        if (!didCancel) {
+          api
+            .getProfile({ optional: true })
+            .then((profile: ProfileInfo | undefined) => {
+              if (sessionState === SessionState.SignedIn) {
+                setSignedIn(true);
+              } else {
+                setSignedIn(profile !== undefined);
+              }
+              setProfileEmail(profile?.email ?? '');
+            });
+        }
+      });
 
     return () => {
       didCancel = true;

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -51,7 +51,7 @@ export const ProviderSettingsItem = (props: {
     const subscription = api.sessionState$().subscribe(() => {
       if (!didCancel) {
         api
-          .getProfile({ optional: false })
+          .getProfile({ optional: true })
           .then((profile: ProfileInfo | undefined) => {
             setSignedIn(profile !== undefined);
             setProfileEmail(profile?.email ?? '');

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -17,11 +17,13 @@
 import React, { useEffect, useState } from 'react';
 import {
   Button,
+  Grid,
   ListItem,
   ListItemIcon,
   ListItemSecondaryAction,
   ListItemText,
   Tooltip,
+  Typography,
 } from '@material-ui/core';
 import {
   ApiRef,
@@ -32,6 +34,7 @@ import {
   useApi,
   IconComponent,
 } from '@backstage/core-plugin-api';
+import { ProviderSettingsAvatar } from './ProviderSettingsAvatar';
 
 /** @public */
 export const ProviderSettingsItem = (props: {
@@ -44,7 +47,8 @@ export const ProviderSettingsItem = (props: {
 
   const api = useApi(apiRef);
   const [signedIn, setSignedIn] = useState(false);
-  const [profileEmail, setProfileEmail] = useState('');
+  const emptyProfile: ProfileInfo = {};
+  const [profile, setProfile] = useState(emptyProfile);
 
   useEffect(() => {
     let didCancel = false;
@@ -55,13 +59,13 @@ export const ProviderSettingsItem = (props: {
         if (!didCancel) {
           api
             .getProfile({ optional: true })
-            .then((profile: ProfileInfo | undefined) => {
+            .then((profileResponse: ProfileInfo | undefined) => {
               if (sessionState === SessionState.SignedIn) {
                 setSignedIn(true);
               } else {
-                setSignedIn(profile !== undefined);
+                setSignedIn(profileResponse !== undefined);
               }
-              setProfileEmail(profile?.email ?? '');
+              setProfile(profileResponse ?? {});
             });
         }
       });
@@ -82,7 +86,30 @@ export const ProviderSettingsItem = (props: {
         secondary={
           <Tooltip placement="top" arrow title={description}>
             <span>
-              {description}. Signed in as {profileEmail}
+              <Grid container spacing={6}>
+                <Grid item>
+                  <ProviderSettingsAvatar size={48} picture={profile.picture} />
+                </Grid>
+                <Grid item xs={12} sm container>
+                  <Grid item xs container direction="column" spacing={2}>
+                    <Grid item xs>
+                      <Typography
+                        variant="subtitle1"
+                        color="textPrimary"
+                        gutterBottom
+                      >
+                        {profile.displayName}
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
+                        {profile.email}
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
+                        {description}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                </Grid>
+              </Grid>
             </span>
           </Tooltip>
         }

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -60,11 +60,13 @@ export const ProviderSettingsItem = (props: {
           api
             .getProfile({ optional: true })
             .then((profileResponse: ProfileInfo | undefined) => {
-              if (sessionState === SessionState.SignedIn) {
-                setSignedIn(true);
-              }
-              if (profileResponse) {
-                setProfile(profileResponse);
+              if (!didCancel) {
+                if (sessionState === SessionState.SignedIn) {
+                  setSignedIn(true);
+                }
+                if (profileResponse) {
+                  setProfile(profileResponse);
+                }
               }
             });
         }


### PR DESCRIPTION
Resolves #13091
When the user has two providers, the settings page checks only for one, and the others are considered signed out, although the user is signed in properly.

This fix uses `getProfile` to check on whether the user is signed in, instead of the session information, as per what was suggested in the issue.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
