### PR TITLE
cli: make versions:bump always update version ranges

### DIFF
--- a/.changeset/famous-pianos-kick.md
+++ b/.changeset/famous-pianos-kick.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-The `versions:bump` command will no update dependency ranges in `package.json`, even if the new version is within the current range.
+The `versions:bump` command will now update dependency ranges in `package.json`, even if the new version is within the current range.

--- a/.changeset/famous-pianos-kick.md
+++ b/.changeset/famous-pianos-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `versions:bump` command will no update dependency ranges in `package.json`, even if the new version is within the current range.

--- a/packages/cli/src/commands/versions/bump.test.ts
+++ b/packages/cli/src/commands/versions/bump.test.ts
@@ -174,6 +174,8 @@ describe('bump', () => {
       'unlocking @backstage/core@^1.0.3 ~> 1.0.6',
       'unlocking @backstage/core-api@^1.0.6 ~> 1.0.7',
       'unlocking @backstage/core-api@^1.0.3 ~> 1.0.7',
+      'bumping @backstage/core in a to ^1.0.6',
+      'bumping @backstage/core in b to ^1.0.6',
       'bumping @backstage/theme in b to ^2.0.0',
       'Running yarn install to install new versions',
       '⚠️  The following packages may have breaking changes:',
@@ -210,15 +212,15 @@ describe('bump', () => {
     expect(packageA).toEqual({
       name: 'a',
       dependencies: {
-        '@backstage/core': '^1.0.5', // not bumped since new version is within range
+        '@backstage/core': '^1.0.6',
       },
     });
     const packageB = await fs.readJson('/packages/b/package.json');
     expect(packageB).toEqual({
       name: 'b',
       dependencies: {
-        '@backstage/core': '^1.0.3', // not bumped
-        '@backstage/theme': '^2.0.0', // bumped since newer
+        '@backstage/core': '^1.0.6',
+        '@backstage/theme': '^2.0.0',
       },
     });
   });
@@ -297,6 +299,8 @@ describe('bump', () => {
       'unlocking @backstage/core-api@^1.0.6 ~> 1.0.7',
       'unlocking @backstage/core-api@^1.0.3 ~> 1.0.7',
       'bumping @backstage/theme in b to ^5.0.0',
+      'bumping @backstage/core in b to ^1.0.6',
+      'bumping @backstage/core in a to ^1.0.6',
       'Your project is now at version 0.0.1, which has been written to backstage.json',
       'Running yarn install to install new versions',
       '⚠️  The following packages may have breaking changes:',
@@ -333,15 +337,15 @@ describe('bump', () => {
     expect(packageA).toEqual({
       name: 'a',
       dependencies: {
-        '@backstage/core': '^1.0.5', // not bumped since new version is within range
+        '@backstage/core': '^1.0.6',
       },
     });
     const packageB = await fs.readJson('/packages/b/package.json');
     expect(packageB).toEqual({
       name: 'b',
       dependencies: {
-        '@backstage/core': '^1.0.3', // not bumped
-        '@backstage/theme': '^5.0.0', // bumped since newer
+        '@backstage/core': '^1.0.6',
+        '@backstage/theme': '^5.0.0',
       },
     });
   });
@@ -544,6 +548,8 @@ describe('bump', () => {
       'unlocking @backstage/core-api@^1.0.6 ~> 1.0.7',
       'unlocking @backstage/core-api@^1.0.3 ~> 1.0.7',
       'bumping @backstage/theme in b to ^5.0.0',
+      'bumping @backstage/core in b to ^1.0.6',
+      'bumping @backstage/core in a to ^1.0.6',
       'Your project is now at version 1.0.0, which has been written to backstage.json',
       'Running yarn install to install new versions',
       '⚠️  The following packages may have breaking changes:',
@@ -650,7 +656,11 @@ describe('bump', () => {
       'unlocking @backstage-extra/custom@^1.0.1 ~> 1.1.0',
       'unlocking @backstage/core-api@^1.0.6 ~> 1.0.7',
       'unlocking @backstage/core-api@^1.0.3 ~> 1.0.7',
+      'bumping @backstage/core in a to ^1.0.6',
+      'bumping @backstage-extra/custom in a to ^1.1.0',
       'bumping @backstage-extra/custom-two in a to ^2.0.0',
+      'bumping @backstage/core in b to ^1.0.6',
+      'bumping @backstage-extra/custom in b to ^1.1.0',
       'bumping @backstage-extra/custom-two in b to ^2.0.0',
       'bumping @backstage/theme in b to ^2.0.0',
       'Skipping backstage.json update as custom pattern is used',
@@ -690,9 +700,9 @@ describe('bump', () => {
     expect(packageA).toEqual({
       name: 'a',
       dependencies: {
-        '@backstage-extra/custom': '^1.0.1',
+        '@backstage-extra/custom': '^1.1.0',
         '@backstage-extra/custom-two': '^2.0.0',
-        '@backstage/core': '^1.0.5', // not bumped since new version is within range
+        '@backstage/core': '^1.0.6',
       },
     });
     const packageB = await fs.readJson('/packages/b/package.json');
@@ -701,8 +711,8 @@ describe('bump', () => {
       dependencies: {
         '@backstage-extra/custom': '^1.1.0',
         '@backstage-extra/custom-two': '^2.0.0',
-        '@backstage/core': '^1.0.3', // not bumped
-        '@backstage/theme': '^2.0.0', // bumped since newer
+        '@backstage/core': '^1.0.6',
+        '@backstage/theme': '^2.0.0',
       },
     });
   });

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -124,13 +124,6 @@ export default async (opts: OptionValues) => {
       }
 
       for (const pkg of pkgs) {
-        if (semver.satisfies(target, pkg.range)) {
-          if (semver.minVersion(pkg.range)?.version !== target) {
-            unlocked.push({ name, range: pkg.range, target });
-          }
-
-          continue;
-        }
         versionBumps.set(
           pkg.name,
           (versionBumps.get(pkg.name) ?? []).concat({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This switches the `versions:bump` logic to always update version ranges in local `packages.json` files, even if the existing version range satisfies the new dependency version. Fixes #13443

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
