### PR TITLE
core-app-api: allow path props in route elements

### DIFF
--- a/.changeset/cool-cameras-count.md
+++ b/.changeset/cool-cameras-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+When using React Router v6 stable, it is now possible for components within the `Route` element tree to have `path` props, although they will be ignored.

--- a/packages/core-app-api/src/routing/collectors.stable.test.tsx
+++ b/packages/core-app-api/src/routing/collectors.stable.test.tsx
@@ -453,18 +453,19 @@ describe('discovery', () => {
     );
   });
 
-  it('should throw elements within element prop contains a path', () => {
-    expect(() => {
-      traverseElementTree({
-        root: <Route path="foo" element={<Extension3 path="bar" />} />,
-        discoverers: [childDiscoverer, routeElementDiscoverer],
-        collectors: {
-          routing: routingV2Collector,
-        },
-      });
-    }).toThrow(
-      'Elements within the element prop tree may not have paths, found "bar"',
-    );
+  it('should ignore path props within route elements', () => {
+    const { routing } = traverseElementTree({
+      root: <Route path="foo" element={<Extension1 path="bar" />} />,
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+    expect(sortedEntries(routing.paths)).toEqual([[ref1, 'foo']]);
+    expect(sortedEntries(routing.parents)).toEqual([[ref1, undefined]]);
+    expect(routing.objects).toEqual([
+      routeObj('foo', [ref1], [], undefined, plugin),
+    ]);
   });
 
   it('should throw when a routable extension does not have a path set', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Tried out React Router v6 stable in our internal project, and it turned out that this is a very unnecessary check that is mostly in the way. I think it's safe for us to ignore these paths as they're located in a place where it would be very surprising if they were taken into account.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
