### PR TITLE
graphiql: switch GraphiQLPage to .jsx

### DIFF
--- a/.changeset/shaggy-buses-juggle.md
+++ b/.changeset/shaggy-buses-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphiql': patch
+---
+
+Internal refactor

--- a/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.jsx
+++ b/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.jsx
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// @ts-check
+// NOTE: This file is intentionally .jsx, so that there is one file in this repo where we make sure .jsx files work.
+
 import React from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/lib/useAsync';
@@ -33,7 +37,8 @@ export const GraphiQLPage = () => {
   const graphQlBrowseApi = useApi(graphQlBrowseApiRef);
   const endpoints = useAsync(() => graphQlBrowseApi.getEndpoints());
 
-  let content: JSX.Element;
+  /** @type JSX.Element */
+  let content;
 
   if (endpoints.loading) {
     content = (
@@ -53,7 +58,7 @@ export const GraphiQLPage = () => {
   } else {
     content = (
       <Content noPadding>
-        <GraphiQLBrowser endpoints={endpoints.value!} />
+        <GraphiQLBrowser endpoints={endpoints.value} />
       </Content>
     );
   }


### PR DESCRIPTION
Another failing test for #13502

I'd like to keep this change permanently once we've fixed the compilation issue, so that we discover `.jsx` compatibility issues earlier.
