### PR TITLE
Disable octokit throttling

### DIFF
--- a/.changeset/tame-trainers-rule.md
+++ b/.changeset/tame-trainers-rule.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Add throttling option to publish:github:pull-request
+Disable octokit throttling in publish:github:pull-request

--- a/.changeset/tame-trainers-rule.md
+++ b/.changeset/tame-trainers-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Add throttling option to publish:github:pull-request

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -169,7 +169,6 @@ export type CreateGithubPullRequestClientFactoryInput = {
   owner: string;
   repo: string;
   token?: string;
-  throttling?: boolean;
 };
 
 // @public
@@ -392,7 +391,6 @@ export const createPublishGithubPullRequestAction: ({
   token?: string | undefined;
   reviewers?: string[] | undefined;
   teamReviewers?: string[] | undefined;
-  throttling?: boolean | undefined;
 }>;
 
 // @public

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -169,6 +169,7 @@ export type CreateGithubPullRequestClientFactoryInput = {
   owner: string;
   repo: string;
   token?: string;
+  throttling?: boolean;
 };
 
 // @public
@@ -391,6 +392,7 @@ export const createPublishGithubPullRequestAction: ({
   token?: string | undefined;
   reviewers?: string[] | undefined;
   teamReviewers?: string[] | undefined;
+  throttling?: boolean | undefined;
 }>;
 
 // @public

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -57,6 +57,7 @@ export type CreateGithubPullRequestClientFactoryInput = {
   owner: string;
   repo: string;
   token?: string;
+  throttling?: boolean;
 };
 
 export const defaultClientFactory = async ({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -57,7 +57,6 @@ export type CreateGithubPullRequestClientFactoryInput = {
   owner: string;
   repo: string;
   token?: string;
-  throttling?: boolean;
 };
 
 export const defaultClientFactory = async ({
@@ -67,7 +66,6 @@ export const defaultClientFactory = async ({
   repo,
   host = 'github.com',
   token: providedToken,
-  throttling,
 }: CreateGithubPullRequestClientFactoryInput): Promise<OctokitWithPullRequestPluginClient> => {
   const [encodedHost, encodedOwner, encodedRepo] = [host, owner, repo].map(
     encodeURIComponent,
@@ -83,7 +81,7 @@ export const defaultClientFactory = async ({
   const OctokitPR = Octokit.plugin(createPullRequest);
   return new OctokitPR({
     ...octokitOptions,
-    ...(!throttling && { throttle: { enabled: false } }),
+    ...{ throttle: { enabled: false } },
   });
 };
 
@@ -134,7 +132,6 @@ export const createPublishGithubPullRequestAction = ({
     token?: string;
     reviewers?: string[];
     teamReviewers?: string[];
-    throttling?: boolean;
   }>({
     id: 'publish:github:pull-request',
     schema: {
@@ -201,11 +198,6 @@ export const createPublishGithubPullRequestAction = ({
             description:
               'The teams that will be added as reviewers to the pull request',
           },
-          throttling: {
-            title: 'Github Throttling',
-            type: 'boolean',
-            description: 'Whether to enable Github request throttling',
-          },
         },
       },
       output: {
@@ -237,7 +229,6 @@ export const createPublishGithubPullRequestAction = ({
         token: providedToken,
         reviewers,
         teamReviewers,
-        throttling,
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -255,7 +246,6 @@ export const createPublishGithubPullRequestAction = ({
         owner,
         repo,
         token: providedToken,
-        throttling,
       });
 
       const fileRoot = sourcePath


### PR DESCRIPTION
This adds a throttling option to enable/disable the octokit throttling feature. With throttling, `publish:github:pull-request` becomes (unusably) slow.