### PR TITLE
backend-plugin-api: properly forward lack of feature options

### DIFF
--- a/.changeset/famous-cups-roll.md
+++ b/.changeset/famous-cups-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Updated `createBackendPlugin` and `createBackendModule` to properly forward lack of options.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -72,14 +72,26 @@ export const cacheServiceRef: ServiceRef<PluginCacheManager>;
 export const configServiceRef: ServiceRef<Config>;
 
 // @public (undocumented)
-export function createBackendModule<TOptions>(
+export function createBackendModule<
+  TOptions extends
+    | {
+        [name: string]: unknown;
+      }
+    | undefined = undefined,
+>(
   config: BackendModuleConfig<TOptions>,
 ): undefined extends TOptions
   ? (options?: TOptions) => BackendFeature
   : (options: TOptions) => BackendFeature;
 
 // @public (undocumented)
-export function createBackendPlugin<TOptions>(
+export function createBackendPlugin<
+  TOptions extends
+    | {
+        [name: string]: unknown;
+      }
+    | undefined = undefined,
+>(
   config: BackendPluginConfig<TOptions>,
 ): undefined extends TOptions
   ? (options?: TOptions) => BackendFeature

--- a/packages/backend-plugin-api/src/wiring/factories.test.ts
+++ b/packages/backend-plugin-api/src/wiring/factories.test.ts
@@ -56,6 +56,18 @@ describe('createBackendPlugin', () => {
     // @ts-expect-error
     expect(plugin({ b: 'b' })).toBeDefined();
   });
+
+  it('should create plugins without options', () => {
+    const plugin = createBackendPlugin({
+      id: 'x',
+      register() {},
+    });
+    expect(plugin).toBeDefined();
+    // @ts-expect-error
+    expect(plugin({ a: 'a' })).toBeDefined();
+    // @ts-expect-error
+    expect(plugin({})).toBeDefined();
+  });
 });
 
 describe('createBackendModule', () => {
@@ -85,5 +97,18 @@ describe('createBackendModule', () => {
     expect(mod()).toBeDefined();
     // @ts-expect-error
     expect(mod({ b: 'b' })).toBeDefined();
+  });
+
+  it('should create modules without options', () => {
+    const mod = createBackendModule({
+      pluginId: 'x',
+      moduleId: 'y',
+      register() {},
+    });
+    expect(mod).toBeDefined();
+    // @ts-expect-error
+    expect(mod({ a: 'a' })).toBeDefined();
+    // @ts-expect-error
+    expect(mod({})).toBeDefined();
   });
 });

--- a/packages/backend-plugin-api/src/wiring/factories.ts
+++ b/packages/backend-plugin-api/src/wiring/factories.ts
@@ -43,7 +43,9 @@ export interface BackendPluginConfig<TOptions> {
 }
 
 /** @public */
-export function createBackendPlugin<TOptions>(
+export function createBackendPlugin<
+  TOptions extends { [name: string]: unknown } | undefined = undefined,
+>(
   config: BackendPluginConfig<TOptions>,
 ): undefined extends TOptions
   ? (options?: TOptions) => BackendFeature
@@ -67,7 +69,9 @@ export interface BackendModuleConfig<TOptions> {
 }
 
 /** @public */
-export function createBackendModule<TOptions>(
+export function createBackendModule<
+  TOptions extends { [name: string]: unknown } | undefined = undefined,
+>(
   config: BackendModuleConfig<TOptions>,
 ): undefined extends TOptions
   ? (options?: TOptions) => BackendFeature

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
@@ -89,7 +89,7 @@ describe('TestBackend', () => {
 
     await startTestBackend({
       services: [sf],
-      features: [testModule({})],
+      features: [testModule()],
     });
 
     expect(testFn).toHaveBeenCalledWith('winning');

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -225,7 +225,7 @@ export type CatalogPermissionRule<TParams extends unknown[] = unknown[]> =
   PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 // @alpha
-export const catalogPlugin: (options?: unknown) => BackendFeature;
+export const catalogPlugin: (options?: undefined) => BackendFeature;
 
 // @public (undocumented)
 export interface CatalogProcessingEngine {

--- a/plugins/catalog-node/src/catalogService.test.ts
+++ b/plugins/catalog-node/src/catalogService.test.ts
@@ -53,7 +53,7 @@ describe('catalogServiceRef', () => {
 
     await startTestBackend({
       services: [mockDiscoveryFactory],
-      features: [testModule({})],
+      features: [testModule()],
     });
   });
 });

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -556,7 +556,7 @@ export type RunCommandOptions = {
 };
 
 // @alpha
-export const scaffolderCatalogModule: (options?: unknown) => BackendFeature;
+export const scaffolderCatalogModule: (options?: undefined) => BackendFeature;
 
 // @public (undocumented)
 export class ScaffolderEntitiesProcessor implements CatalogProcessor {

--- a/plugins/scaffolder-backend/src/extension/ScaffolderCatalogModule.test.ts
+++ b/plugins/scaffolder-backend/src/extension/ScaffolderCatalogModule.test.ts
@@ -24,7 +24,7 @@ describe('ScaffolderCatalogModule', () => {
     const extensionPoint = { addProcessor: jest.fn() };
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
-      features: [scaffolderCatalogModule({})],
+      features: [scaffolderCatalogModule()],
     });
 
     expect(extensionPoint.addProcessor).toHaveBeenCalledWith(


### PR DESCRIPTION
🧹, right now if you have a plugin that doesn't accept options, the actual plugin factory function will instead accept any options.