### PR TITLE
Added transient AlertMessage

### DIFF
--- a/.changeset/chilled-ladybugs-cough.md
+++ b/.changeset/chilled-ladybugs-cough.md
@@ -1,0 +1,20 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Added a new `display` property to the `AlertMessage` which can accept the values `permanent` or `transient`.
+
+Here's a rough example of how to trigger an alert using the new `display` property:
+
+```ts
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+
+const ExampleTransient = () => {
+  const alertApi = useApi(alertApiRef);
+  alertApi.post({
+    message: 'Example of Transient Alert',
+    severity: 'success',
+    display: 'transient',
+  });
+};
+```

--- a/.changeset/chilled-ladybugs-cough.md
+++ b/.changeset/chilled-ladybugs-cough.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-plugin-api': patch
+'@backstage/core-plugin-api': minor
 ---
 
 Added a new `display` property to the `AlertMessage` which can accept the values `permanent` or `transient`.

--- a/.changeset/strong-rice-warn.md
+++ b/.changeset/strong-rice-warn.md
@@ -18,3 +18,18 @@ Added option to allow the `AlertMessage` to be self-closing. This is done with a
 ```
 
 The above example will set the transient timeout to 2500ms from the default of 5000ms
+
+Here's a rough example of how to trigger an alert using the new `transient` boolean:
+
+```ts
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+
+const exampleTransient = () => {
+  const alertApi = useApi(alertApiRef);
+  alertApi.post({
+    message: 'Example of Transient Alert',
+    severity: 'success',
+    transient: true,
+  });
+};
+```

--- a/.changeset/strong-rice-warn.md
+++ b/.changeset/strong-rice-warn.md
@@ -3,18 +3,18 @@
 '@backstage/core-plugin-api': patch
 ---
 
-Added option to allow the `AlertMessage` to be self-closing. This is done with a new `transient` boolean that is set on the `AlertMessage`. The length of time that these transient message stay open for can be set using the `transientTimeoutMs` prop on the `AlertDisplay` in the `App.tsx`. Here is an example:
+Added an option to allow the `AlertMessage` to be self-closing. This is done with a new `display` property that is set to `transient` on the `AlertMessage`. The length of time that these transient message stay open for can be set using the `transientTimeoutMs` prop on the `AlertDisplay` in the `App.tsx`. Here is an example:
 
 ```diff
- const App = () => (
-   <AppProvider>
-+    <AlertDisplay transientTimeoutMs={2500} />
-     <OAuthRequestDialog />
-     <AppRouter>
-       <Root>{routes}</Root>
-     </AppRouter>
-   </AppProvider>
- );
+  const App = () => (
+    <AppProvider>
++     <AlertDisplay transientTimeoutMs={2500} />
+      <OAuthRequestDialog />
+      <AppRouter>
+        <Root>{routes}</Root>
+      </AppRouter>
+    </AppProvider>
+  );
 ```
 
 The above example will set the transient timeout to 2500ms from the default of 5000ms
@@ -29,7 +29,7 @@ const exampleTransient = () => {
   alertApi.post({
     message: 'Example of Transient Alert',
     severity: 'success',
-    transient: true,
+    display: 'transient',
   });
 };
 ```

--- a/.changeset/strong-rice-warn.md
+++ b/.changeset/strong-rice-warn.md
@@ -1,9 +1,8 @@
 ---
 '@backstage/core-components': patch
-'@backstage/core-plugin-api': patch
 ---
 
-Added an option to allow the `AlertMessage` to be self-closing. This is done with a new `display` property that is set to `transient` on the `AlertMessage`. The length of time that these transient message stay open for can be set using the `transientTimeoutMs` prop on the `AlertDisplay` in the `App.tsx`. Here is an example:
+Added an option to allow the `AlertMessage` to be self-closing. This is done with a new `display` property that is set to `transient` on the `AlertMessage` when triggering a message to the `AlertApi`. The length of time that these transient messages stay open for can be set using the `transientTimeoutMs` prop on the `AlertDisplay` in the `App.tsx`. Here is an example:
 
 ```diff
   const App = () => (
@@ -18,18 +17,3 @@ Added an option to allow the `AlertMessage` to be self-closing. This is done wit
 ```
 
 The above example will set the transient timeout to 2500ms from the default of 5000ms
-
-Here's a rough example of how to trigger an alert using the new `transient` boolean:
-
-```ts
-import { alertApiRef, useApi } from '@backstage/core-plugin-api';
-
-const exampleTransient = () => {
-  const alertApi = useApi(alertApiRef);
-  alertApi.post({
-    message: 'Example of Transient Alert',
-    severity: 'success',
-    display: 'transient',
-  });
-};
-```

--- a/.changeset/strong-rice-warn.md
+++ b/.changeset/strong-rice-warn.md
@@ -1,0 +1,20 @@
+---
+'@backstage/core-components': patch
+'@backstage/core-plugin-api': patch
+---
+
+Added option to allow the `AlertMessage` to be self-closing. This is done with a new `transient` boolean that is set on the `AlertMessage`. The length of time that these transient message stay open for can be set using the `transientTimeoutMs` prop on the `AlertDisplay` in the `App.tsx`. Here is an example:
+
+```diff
+ const App = () => (
+   <AppProvider>
++    <AlertDisplay transientTimeoutMs={2500} />
+     <OAuthRequestDialog />
+     <AppRouter>
+       <Root>{routes}</Root>
+     </AppRouter>
+   </AppProvider>
+ );
+```
+
+The above example will set the transient timeout to 2500ms from the default of 5000ms

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -280,7 +280,7 @@ const routes = (
 
 const App = () => (
   <AppProvider>
-    <AlertDisplay />
+    <AlertDisplay transientTimeoutMs={2500} />
     <OAuthRequestDialog />
     <AppRouter>
       <Root>{routes}</Root>

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -55,9 +55,6 @@ import { WithStyles } from '@material-ui/core/styles';
 // @public
 export function AlertDisplay(props: AlertDisplayProps): JSX.Element | null;
 
-// Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-//
 // @public
 export type AlertDisplayProps = {
   anchorOrigin?: {

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -55,7 +55,10 @@ import { WithStyles } from '@material-ui/core/styles';
 // @public
 export function AlertDisplay(props: AlertDisplayProps): JSX.Element | null;
 
-// @public (undocumented)
+// Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
+// Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
+//
+// @public
 export type AlertDisplayProps = {
   anchorOrigin?: {
     vertical: 'top' | 'bottom';

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -61,6 +61,7 @@ export type AlertDisplayProps = {
     vertical: 'top' | 'bottom';
     horizontal: 'left' | 'center' | 'right';
   };
+  transientTimeoutMs?: number;
 };
 
 // @public

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.test.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.test.tsx
@@ -214,6 +214,39 @@ describe('<AlertDisplay />', () => {
       expect(queryByText('transient message')).not.toBeInTheDocument();
       jest.useRealTimers();
     });
+
+    it('renders 3 different messages with overlapping timeout', async () => {
+      jest.useFakeTimers();
+      const { queryByText } = await renderInTestApp(
+        <TestApiProvider apis={apis}>
+          <AlertDisplay transientTimeoutMs={1500} />
+        </TestApiProvider>,
+      );
+
+      // 3 messages stacked with 1.5s each, display times: 0-1.5, 1.5-3, 3-4.5
+
+      // 0s in, only message 1
+      expect(queryByText('transient message one')).toBeInTheDocument();
+
+      // 1s in, message 1 still shown, message 2 added in background
+      act(() => jest.advanceTimersByTime(1000));
+      expect(queryByText('transient message one')).toBeInTheDocument();
+      expect(queryByText('(1 older message)')).toBeInTheDocument();
+
+      // 2s in, message 2 now shown, message 3 added
+      act(() => jest.advanceTimersByTime(1000));
+      expect(queryByText('transient message two')).toBeInTheDocument();
+      expect(queryByText('(1 older message)')).toBeInTheDocument();
+
+      // 3.5s in, message 3 now shown
+      act(() => jest.advanceTimersByTime(1500));
+      expect(queryByText('transient message three')).toBeInTheDocument();
+
+      // 5s in, all messages gone
+      act(() => jest.advanceTimersByTime(1500));
+      expect(queryByText('transient message three')).not.toBeInTheDocument();
+      jest.useRealTimers();
+    });
   });
 
   describe('with multiple messages of mixed display', () => {

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.test.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.test.tsx
@@ -247,6 +247,43 @@ describe('<AlertDisplay />', () => {
       expect(queryByText('transient message three')).not.toBeInTheDocument();
       jest.useRealTimers();
     });
+
+    it('renders 3 different messages with overlapping timeout and manual removal', async () => {
+      jest.useFakeTimers();
+      const { queryByText } = await renderInTestApp(
+        <TestApiProvider apis={apis}>
+          <AlertDisplay transientTimeoutMs={1500} />
+        </TestApiProvider>,
+      );
+
+      // 3 messages stacked with 1.5s each, display times: 0-1.5, 1.5-3, 3-4.5
+
+      // 0s in, only message 1
+      expect(queryByText('transient message one')).toBeInTheDocument();
+
+      // 1s in, message 1 still shown, message 2 added in background
+      act(() => jest.advanceTimersByTime(1000));
+      expect(queryByText('transient message one')).toBeInTheDocument();
+      expect(queryByText('(1 older message)')).toBeInTheDocument();
+
+      // manually remove message 1
+      fireEvent.click(screen.getByTestId('error-button-close'));
+      expect(screen.getByText('transient message two')).toBeInTheDocument();
+
+      // 2s in, message 2 now shown, message 3 added
+      act(() => jest.advanceTimersByTime(1000));
+      expect(queryByText('transient message two')).toBeInTheDocument();
+      expect(queryByText('(1 older message)')).toBeInTheDocument();
+
+      // 3s in, message 3 now shown
+      act(() => jest.advanceTimersByTime(1500));
+      expect(queryByText('transient message three')).toBeInTheDocument();
+
+      // 4s in, all messages gone
+      act(() => jest.advanceTimersByTime(1500));
+      expect(queryByText('transient message three')).not.toBeInTheDocument();
+      jest.useRealTimers();
+    });
   });
 
   describe('with multiple messages of mixed display', () => {

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -29,6 +29,21 @@ import React, { useEffect, useState } from 'react';
  * @remarks
  *
  * Shown as SnackBar at the center top of the page by default. Configurable with props.
+ *
+ * @param anchorOrigin.vertical - Vertical orientation of where the AlertDisplay will be located
+ * @param anchorOrigin.horizontal - Horizontal orientation of where the AlertDisplay will be located
+ * @param transientTimeoutMs - Number of milliseconds a transient alert will stay open for. Default value is 5000
+ *
+ * @example
+ *
+ * // This example shows the default usage, the SnackBar will show up at the top in the center and any transient messages will stay open for 5000ms
+ * <AlertDisplay />
+ *
+ * // With this example the SnackBar will show up in the bottom right hand corner and any transient messages will stay open for 2500ms
+ * <AlertDisplay transientTimeoutMs={2500} anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}/>
+ *
+ * // If you want to just set the time a transientTimeoutMs, you can do that like this:
+ * <AlertDisplay transientTimeoutMs={10000} />
  */
 
 // TODO: improve on this and promote to a shared component for use by all apps.

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -81,10 +81,13 @@ export function AlertDisplay(props: AlertDisplayProps) {
 
   useEffect(() => {
     const [current] = messages;
-    if (current && current.display === 'transient')
-      setTimeout(() => {
+    if (current && current.display === 'transient') {
+      const timer = setTimeout(() => {
         setMessages(msgs => msgs.filter(msg => msg !== current));
       }, timeoutMs);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
   }, [messages, timeoutMs]);
 
   if (messages.length === 0) {

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -35,7 +35,8 @@ import React, { useEffect, useState } from 'react';
  * @param transientTimeoutMs - Number of milliseconds a transient alert will stay open for. Default value is 5000
  *
  * @example
- *
+ * Here's some examples:
+ * ```
  * // This example shows the default usage, the SnackBar will show up at the top in the center and any transient messages will stay open for 5000ms
  * <AlertDisplay />
  *
@@ -44,6 +45,7 @@ import React, { useEffect, useState } from 'react';
  *
  * // If you want to just set the time a transientTimeoutMs, you can do that like this:
  * <AlertDisplay transientTimeoutMs={10000} />
+ * ```
  */
 
 // TODO: improve on this and promote to a shared component for use by all apps.

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -19,6 +19,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import { Alert } from '@material-ui/lab';
+import { useIsMounted } from '@react-hookz/web';
 import pluralize from 'pluralize';
 import React, { useEffect, useState } from 'react';
 
@@ -62,6 +63,7 @@ export type AlertDisplayProps = {
 export function AlertDisplay(props: AlertDisplayProps) {
   const [messages, setMessages] = useState<Array<AlertMessage>>([]);
   const alertApi = useApi(alertApiRef);
+  const isMounted = useIsMounted();
 
   const {
     anchorOrigin = { vertical: 'top', horizontal: 'center' },
@@ -82,13 +84,14 @@ export function AlertDisplay(props: AlertDisplayProps) {
   useEffect(() => {
     const [current] = messages;
     if (current && current.display === 'transient') {
-      const timer = setTimeout(() => {
-        setMessages(msgs => msgs.filter(msg => msg !== current));
+      setTimeout(() => {
+        if (isMounted()) {
+          setMessages(msgs => msgs.filter(msg => msg !== current));
+        }
       }, timeoutMs);
-      return () => clearTimeout(timer);
     }
     return undefined;
-  }, [messages, timeoutMs]);
+  }, [messages, timeoutMs, isMounted]);
 
   if (messages.length === 0) {
     return null;

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -64,7 +64,7 @@ export function AlertDisplay(props: AlertDisplayProps) {
 
   useEffect(() => {
     const [current] = messages;
-    if (current && current.transient)
+    if (current && current.display === 'transient')
       setTimeout(() => {
         setMessages(msgs => msgs.filter(msg => msg !== current));
       }, timeoutMs);

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -23,6 +23,19 @@ import pluralize from 'pluralize';
 import React, { useEffect, useState } from 'react';
 
 /**
+ * Properties for {@link AlertDisplay}
+ *
+ * @public
+ */
+export type AlertDisplayProps = {
+  anchorOrigin?: {
+    vertical: 'top' | 'bottom';
+    horizontal: 'left' | 'center' | 'right';
+  };
+  transientTimeoutMs?: number;
+};
+
+/**
  * Displays alerts from {@link @backstage/core-plugin-api#AlertApi}
  *
  * @public
@@ -47,18 +60,6 @@ import React, { useEffect, useState } from 'react';
  * <AlertDisplay transientTimeoutMs={10000} />
  * ```
  */
-
-// TODO: improve on this and promote to a shared component for use by all apps.
-
-export type AlertDisplayProps = {
-  anchorOrigin?: {
-    vertical: 'top' | 'bottom';
-    horizontal: 'left' | 'center' | 'right';
-  };
-  transientTimeoutMs?: number;
-};
-
-/** @public */
 export function AlertDisplay(props: AlertDisplayProps) {
   const [messages, setMessages] = useState<Array<AlertMessage>>([]);
   const alertApi = useApi(alertApiRef);

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -30,8 +30,8 @@ import React, { useEffect, useState } from 'react';
  *
  * Shown as SnackBar at the center top of the page by default. Configurable with props.
  *
- * @param anchorOrigin.vertical - Vertical orientation of where the AlertDisplay will be located
- * @param anchorOrigin.horizontal - Horizontal orientation of where the AlertDisplay will be located
+ * @param anchorOrigin - The `vertical` property will set the vertical orientation of where the AlertDisplay will be located
+ * and the `horizontal` property will set the horizontal orientation of where the AlertDisplay will be located
  * @param transientTimeoutMs - Number of milliseconds a transient alert will stay open for. Default value is 5000
  *
  * @example

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -29,6 +29,7 @@ export const alertApiRef: ApiRef<AlertApi>;
 export type AlertMessage = {
   message: string;
   severity?: 'success' | 'info' | 'warning' | 'error';
+  transient?: boolean;
 };
 
 // @public

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -29,7 +29,7 @@ export const alertApiRef: ApiRef<AlertApi>;
 export type AlertMessage = {
   message: string;
   severity?: 'success' | 'info' | 'warning' | 'error';
-  transient?: boolean;
+  display?: 'permanent' | 'transient';
 };
 
 // @public

--- a/packages/core-plugin-api/src/apis/definitions/AlertApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/AlertApi.ts
@@ -26,6 +26,7 @@ export type AlertMessage = {
   message: string;
   // Severity will default to success since that is what material ui defaults the value to.
   severity?: 'success' | 'info' | 'warning' | 'error';
+  transient?: boolean;
 };
 
 /**

--- a/packages/core-plugin-api/src/apis/definitions/AlertApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/AlertApi.ts
@@ -26,7 +26,7 @@ export type AlertMessage = {
   message: string;
   // Severity will default to success since that is what material ui defaults the value to.
   severity?: 'success' | 'info' | 'warning' | 'error';
-  transient?: boolean;
+  display?: 'permanent' | 'transient';
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Added option to allow the `AlertMessage` to be self-closing. This is done with a new `transient` boolean that is set on the `AlertMessage`. The length of time that these transient message stay open for can be set using the `transientTimeoutMs` prop on the `AlertDisplay` in the `App.tsx`. Here is an example:

```diff
 const App = () => (
   <AppProvider>
+    <AlertDisplay transientTimeoutMs={2500} />
     <OAuthRequestDialog />
     <AppRouter>
       <Root>{routes}</Root>
     </AppRouter>
   </AppProvider>
 );
```

The above example will set the transient timeout to 2500ms from the default of 5000ms

Here's a rough example of how to trigger an alert using the new `transient` boolean:

```ts
import { alertApiRef, useApi } from '@backstage/core-plugin-api';

const exampleTransient = () => {
  const alertApi = useApi(alertApiRef);
  alertApi.post({
    message: 'Example of Transient Alert',
    severity: 'success',
    transient: true,
  });
};
```

Here's a video of this in use:

https://user-images.githubusercontent.com/67169551/188206525-50e672a3-0f79-480f-9886-3024a1cf77eb.mov

Closes #13205 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
