### PR TITLE
scaffolder-backend: fs delete action isDisabled flag

### DIFF
--- a/.changeset/kind-terms-tickle.md
+++ b/.changeset/kind-terms-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added optional isDisabled input to fs:delete action

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.test.ts
@@ -124,4 +124,53 @@ describe('fs:delete', () => {
       expect(fileExists).toBe(false);
     });
   });
+
+  describe('isDisabled', () => {
+    it('should call fs.rm when not disabled', async () => {
+      const files = ['unit-test-a.js', 'unit-test-b.js'];
+
+      files.forEach(file => {
+        const filePath = resolvePath(workspacePath, file);
+        const fileExists = fs.existsSync(filePath);
+        expect(fileExists).toBe(true);
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          isDisabled: false,
+        }
+      });
+
+      files.forEach(file => {
+        const filePath = resolvePath(workspacePath, file);
+        const fileExists = fs.existsSync(filePath);
+        expect(fileExists).toBe(false);
+      });
+    });
+    it('should skip fs.rm when disabled', async () => {
+      const files = ['unit-test-a.js', 'unit-test-b.js'];
+
+      files.forEach(file => {
+        const filePath = resolvePath(workspacePath, file);
+        const fileExists = fs.existsSync(filePath);
+        expect(fileExists).toBe(true);
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          isDisabled: true,
+        }
+      });
+
+      files.forEach(file => {
+        const filePath = resolvePath(workspacePath, file);
+        const fileExists = fs.existsSync(filePath);
+        expect(fileExists).toBe(true);
+      });
+    });
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
@@ -23,7 +23,7 @@ import fs from 'fs-extra';
  * @public
  */
 export const createFilesystemDeleteAction = () => {
-  return createTemplateAction<{ files: string[] }>({
+  return createTemplateAction<{ files: string[], isDisabled?: boolean }>({
     id: 'fs:delete',
     description: 'Deletes files and directories from the workspace',
     schema: {
@@ -39,6 +39,11 @@ export const createFilesystemDeleteAction = () => {
               type: 'string',
             },
           },
+          isDisabled: {
+            title: 'Is Disabled',
+            description: 'Flag to skip this action',
+            type: 'boolean',
+          },
         },
       },
     },
@@ -46,6 +51,9 @@ export const createFilesystemDeleteAction = () => {
     async handler(ctx) {
       if (!Array.isArray(ctx.input?.files)) {
         throw new InputError('files must be an Array');
+      }
+      if (ctx.input.isDisabled) {
+        return;
       }
 
       for (const file of ctx.input.files) {


### PR DESCRIPTION
Signed-off-by: Michael Short <michael@bison.dev>

## Hey, I just made a Pull Request!

Added optional flag `isDisabled` to the `fs:delete` action to skip it. This adds customization to the action for utilizing input fields in the scaffolder form to optionally delete files based on project setup. 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
