### PR TITLE
Use username password or token for bitbucket server

### DIFF
--- a/.changeset/rude-tips-argue.md
+++ b/.changeset/rude-tips-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+have token take precedence over username and password in the bitbucketServer integration according to documentation

--- a/.changeset/rude-tips-argue.md
+++ b/.changeset/rude-tips-argue.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-have token take precedence over username and password in the bitbucketServer integration according to documentation
+Fixed bug in the `bitbucketServer` integration where token did not take precedence over supplied username and password which is described in the documentation.

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -42,13 +42,14 @@ describe('bitbucketServer core', () => {
         username: 'u',
         password: 'p',
       };
-      const withBasicAuthAndTokenPrecedence: BitbucketServerIntegrationConfig = {
-        host: '',
-        apiBaseUrl: '',
-        token: 'A',
-        username: 'u',
-        password: 'p',
-      };
+      const withBasicAuthAndTokenPrecedence: BitbucketServerIntegrationConfig =
+        {
+          host: '',
+          apiBaseUrl: '',
+          token: 'A',
+          username: 'u',
+          password: 'p',
+        };
       const withoutCredentials: BitbucketServerIntegrationConfig = {
         host: '',
         apiBaseUrl: '',
@@ -62,8 +63,10 @@ describe('bitbucketServer core', () => {
           .Authorization,
       ).toEqual('Basic dTpw');
       expect(
-        (getBitbucketServerRequestOptions(withBasicAuthAndTokenPrecedence).headers as any)
-          .Authorization,
+        (
+          getBitbucketServerRequestOptions(withBasicAuthAndTokenPrecedence)
+            .headers as any
+        ).Authorization,
       ).toEqual('Bearer A');
       expect(
         (getBitbucketServerRequestOptions(withoutCredentials).headers as any)

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -42,6 +42,13 @@ describe('bitbucketServer core', () => {
         username: 'u',
         password: 'p',
       };
+      const withBasicAuthAndTokenPrecedence: BitbucketServerIntegrationConfig = {
+        host: '',
+        apiBaseUrl: '',
+        token: 'A',
+        username: 'u',
+        password: 'p',
+      };
       const withoutCredentials: BitbucketServerIntegrationConfig = {
         host: '',
         apiBaseUrl: '',
@@ -54,6 +61,10 @@ describe('bitbucketServer core', () => {
         (getBitbucketServerRequestOptions(withBasicAuth).headers as any)
           .Authorization,
       ).toEqual('Basic dTpw');
+      expect(
+        (getBitbucketServerRequestOptions(withBasicAuthAndTokenPrecedence).headers as any)
+          .Authorization,
+      ).toEqual('Bearer A');
       expect(
         (getBitbucketServerRequestOptions(withoutCredentials).headers as any)
           .Authorization,

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -139,8 +139,7 @@ export function getBitbucketServerRequestOptions(
 
   if (config.token) {
     headers.Authorization = `Bearer ${config.token}`;
-  }
-  if (config.username && config.password) {
+  } else if (config.username && config.password) {
     const buffer = Buffer.from(`${config.username}:${config.password}`, 'utf8');
     headers.Authorization = `Basic ${buffer.toString('base64')}`;
   }


### PR DESCRIPTION
The bitbucket server publish action allows setting the token like other platforms, if the integration has a username and password configured though, not the token but the credentials are used

In config.ts the docs claim token takes precedence which only holds true if username & password are not set

Signed-off-by: Robert Schuh <github@eneticum.de>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
