### PR TITLE
cli: remove last dependencies on Lerna

### DIFF
--- a/.changeset/purple-wolves-confess.md
+++ b/.changeset/purple-wolves-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Removed internal dependencies on Lerna. It is now no longer necessary to have Lerna installed in a project to use all features of the Backstage CLI.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:all": "backstage-cli repo lint",
     "lint:type-deps": "node scripts/check-type-dependencies.js",
     "docker-build": "yarn tsc && yarn workspace example-backend build --build-dependencies && yarn workspace example-backend build-image",
-    "new": "backstage-cli new --scope backstage --no-private",
+    "new": "backstage-cli new --scope backstage --baseVersion 0.0.0 --no-private",
     "create-plugin": "echo \"use 'yarn new' instead\"",
     "release": "node scripts/prepare-release.js && changeset version && yarn diff --yes && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",
     "prettier:check": "prettier --check .",

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -179,6 +179,7 @@ Options:
   --option <name>=<value>
   --scope <scope>
   --npm-registry <URL>
+  --baseVersion <version>
   --no-private
   -h, --help
 ```

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -301,6 +301,7 @@ export default async (opts: OptionValues) => {
         npmRegistry,
       },
       createPackageVersionProvider(lockfile),
+      isMonoRepo,
     );
 
     Task.section('Moving to final location');

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -218,6 +218,10 @@ export function registerCommands(program: Command) {
       '--npm-registry <URL>',
       'The package registry to use for new packages',
     )
+    .option(
+      '--baseVersion <version>',
+      'The version to use for any new packages (default: 0.1.0)',
+    )
     .option('--no-private', 'Do not mark new packages as private')
     .action(lazy(() => import('./new/new').then(m => m.default)));
 

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -22,6 +22,7 @@ import { FactoryRegistry } from '../../lib/new/FactoryRegistry';
 import { paths } from '../../lib/paths';
 import { assertError } from '@backstage/errors';
 import { Task } from '../../lib/tasks';
+import { isMonoRepo } from '../../lib/monorepo/isMonoRepo';
 
 function parseOptions(optionStrings: string[]): Record<string, string> {
   const options: Record<string, string> = {};
@@ -49,21 +50,6 @@ export default async (opts: OptionValues) => {
     providedOptions,
   );
 
-  let isMonoRepo = false;
-  try {
-    const rootPackageJson = await fs.readJson(
-      paths.resolveTargetRoot('package.json'),
-    );
-    if (rootPackageJson.workspaces) {
-      isMonoRepo = true;
-    }
-  } catch (error) {
-    assertError(error);
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
   let defaultVersion = '0.1.0';
   try {
     const rootLernaJson = await fs.readJson(
@@ -89,7 +75,7 @@ export default async (opts: OptionValues) => {
   let modified = false;
   try {
     await factory.create(options, {
-      isMonoRepo,
+      isMonoRepo: await isMonoRepo(),
       defaultVersion,
       scope: opts.scope?.replace(/^@/, ''),
       npmRegistry: opts.npmRegistry,

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -51,17 +51,15 @@ export default async (opts: OptionValues) => {
   );
 
   let defaultVersion = '0.1.0';
-  try {
-    const rootLernaJson = await fs.readJson(
-      paths.resolveTargetRoot('lerna.json'),
-    );
-    if (rootLernaJson.version) {
-      defaultVersion = rootLernaJson.version;
-    }
-  } catch (error) {
-    assertError(error);
-    if (error.code !== 'ENOENT') {
-      throw error;
+  if (opts.baseVersion) {
+    defaultVersion = opts.baseVersion;
+  } else {
+    const lernaVersion = await fs
+      .readJson(paths.resolveTargetRoot('lerna.json'))
+      .then(pkg => pkg.version)
+      .catch(() => undefined);
+    if (lernaVersion) {
+      defaultVersion = lernaVersion;
     }
   }
 

--- a/packages/cli/src/lib/monorepo/isMonoRepo.ts
+++ b/packages/cli/src/lib/monorepo/isMonoRepo.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { paths } from '../paths';
+import fs from 'fs-extra';
+
+export async function isMonoRepo(): Promise<boolean> {
+  const rootPackageJsonPath = paths.resolveTargetRoot('package.json');
+  try {
+    const pkg = await fs.readJson(rootPackageJsonPath);
+    return Boolean(pkg?.workspaces?.packages);
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/cli/src/lib/monorepo/isMonorepo.test.ts
+++ b/packages/cli/src/lib/monorepo/isMonorepo.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isMonoRepo } from './isMonoRepo';
+import mockFs from 'mock-fs';
+
+describe('isMonoRepo', () => {
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it('should detect a monorepo', async () => {
+    mockFs({
+      'package.json': JSON.stringify({
+        name: 'foo',
+        workspaces: {
+          packages: ['packages/*'],
+        },
+      }),
+    });
+    await expect(isMonoRepo()).resolves.toBe(true);
+  });
+
+  it('should detect a non- monorepo', async () => {
+    mockFs({
+      'package.json': JSON.stringify({
+        name: 'foo',
+      }),
+    });
+    await expect(isMonoRepo()).resolves.toBe(false);
+  });
+
+  it('should return false if package.json is missing', async () => {
+    mockFs({});
+    await expect(isMonoRepo()).resolves.toBe(false);
+  });
+});

--- a/packages/cli/src/lib/new/factories/common/tasks.ts
+++ b/packages/cli/src/lib/new/factories/common/tasks.ts
@@ -62,6 +62,7 @@ export async function executePluginPackageTemplate(
     tempDir,
     options.values,
     createPackageVersionProvider(lockfile),
+    ctx.isMonoRepo,
   );
 
   // Format package.json if it exists

--- a/packages/cli/src/lib/tasks.test.ts
+++ b/packages/cli/src/lib/tasks.test.ts
@@ -53,6 +53,7 @@ describe('templatingTask', () => {
         pluginVersion: '0.0.0',
       },
       () => '^0.1.2',
+      true,
     );
 
     await expect(

--- a/packages/cli/src/lib/tasks.ts
+++ b/packages/cli/src/lib/tasks.ts
@@ -22,7 +22,6 @@ import { promisify } from 'util';
 import { basename, dirname } from 'path';
 import recursive from 'recursive-readdir';
 import { exec as execCb } from 'child_process';
-import { paths } from './paths';
 import { assertError } from '@backstage/errors';
 
 const exec = promisify(execCb);
@@ -102,11 +101,11 @@ export async function templatingTask(
   destinationDir: string,
   context: any,
   versionProvider: (name: string, versionHint?: string) => string,
+  isMonoRepo: boolean,
 ) {
   const files = await recursive(templateDir).catch(error => {
     throw new Error(`Failed to read template directory: ${error.message}`);
   });
-  const isMonoRepo = await fs.pathExists(paths.resolveTargetRoot('lerna.json'));
 
   for (const file of files) {
     const destinationFile = file.replace(templateDir, destinationDir);


### PR DESCRIPTION
This gets rid of the last couple of dependencies on Lerna in the CLI. There's still detection and reading of `lerna.json` for backwards compatibility, but it's no longer required.