### PR TITLE
Remove Lerna

### DIFF
--- a/.github/workflows/deploy_nightly.yml
+++ b/.github/workflows/deploy_nightly.yml
@@ -55,7 +55,7 @@ jobs:
       # not flagged as the latest release, which means that people will not get this
       # version of the package unless requested explicitly
       - name: publish nightly release
-        run: yarn changeset publish --tag nightly
+        run: yarn workspaces foreach -v --no-private npm publish --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -163,9 +163,9 @@ jobs:
       - name: publish
         run: |
           if [ -f ".changeset/pre.json" ]; then
-              yarn lerna publish from-package --yes --dist-tag next
+              yarn workspaces foreach -v --exclude=root --no-private npm publish --tag next
           else
-              yarn lerna publish from-package --yes
+              yarn workspaces foreach -v --exclude=root --no-private npm publish
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-plugin-notice": "^0.9.10",
     "fs-extra": "10.1.0",
     "husky": "^8.0.0",
-    "lerna": "~5.0.0",
     "lint-staged": "^13.0.0",
     "minimist": "^1.2.5",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "create-plugin": "echo \"use 'yarn new' instead\"",
     "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",
     "prettier:check": "prettier --check .",
-    "lerna": "lerna",
     "storybook": "yarn ./storybook run start",
     "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
     "snyk:test:package": "yarn snyk:test --include",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9062,13 +9062,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hutson/parse-repository-url@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "@hutson/parse-repository-url@npm:3.0.2"
-  checksum: 39992c5f183c5ca3d761d6ed9dfabcb79b5f3750bf1b7f3532e1dc439ca370138bbd426ee250fdaba460bc948e6761fbefd484b8f4f36885d71ded96138340d1
-  languageName: node
-  linkType: hard
-
 "@iarna/toml@npm:^2.2.5":
   version: 2.2.5
   resolution: "@iarna/toml@npm:2.2.5"
@@ -10074,808 +10067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna/add@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/add@npm:5.0.0"
-  dependencies:
-    "@lerna/bootstrap": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/filter-options": 5.0.0
-    "@lerna/npm-conf": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    dedent: ^0.7.0
-    npm-package-arg: ^8.1.0
-    p-map: ^4.0.0
-    pacote: ^13.4.1
-    semver: ^7.3.4
-  checksum: 3ac24d8c37b6da4078d10926d3ad840868c0b60c71118ca6120e1b286d6300423164cffca7a9a2a943b56c91d7357dd8b05103bdeb70a0ccdf8e114c64ad3c32
-  languageName: node
-  linkType: hard
-
-"@lerna/bootstrap@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/bootstrap@npm:5.0.0"
-  dependencies:
-    "@lerna/command": 5.0.0
-    "@lerna/filter-options": 5.0.0
-    "@lerna/has-npm-version": 5.0.0
-    "@lerna/npm-install": 5.0.0
-    "@lerna/package-graph": 5.0.0
-    "@lerna/pulse-till-done": 5.0.0
-    "@lerna/rimraf-dir": 5.0.0
-    "@lerna/run-lifecycle": 5.0.0
-    "@lerna/run-topologically": 5.0.0
-    "@lerna/symlink-binary": 5.0.0
-    "@lerna/symlink-dependencies": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    "@npmcli/arborist": 5.2.0
-    dedent: ^0.7.0
-    get-port: ^5.1.1
-    multimatch: ^5.0.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-    p-waterfall: ^2.1.1
-    semver: ^7.3.4
-  checksum: 2e2f4e6b508667ce4d3d6588b790cf980d08413a24dda80d61ef37d7bad31b63cc949fc80987717fd6c41cd5d776ef32fa77d672ee6df570397397203842ec1c
-  languageName: node
-  linkType: hard
-
-"@lerna/changed@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/changed@npm:5.0.0"
-  dependencies:
-    "@lerna/collect-updates": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/listable": 5.0.0
-    "@lerna/output": 5.0.0
-  checksum: 8f53e5e056bba10eda23f44b0eb04b046c382660650d2005719673688465ed124011dec00ba18ae2050b49edbdbe1a587bb62b3414f9bfad15bacc3d84953a3f
-  languageName: node
-  linkType: hard
-
-"@lerna/check-working-tree@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/check-working-tree@npm:5.0.0"
-  dependencies:
-    "@lerna/collect-uncommitted": 5.0.0
-    "@lerna/describe-ref": 5.0.0
-    "@lerna/validation-error": 5.0.0
-  checksum: 8bf7b24016c875adcd9f318300f9d5acc6e51b49da519f85e9207026a867b40b7980df8bcbb88ed6c55b3b82e44f71d9553f9402d663e70418951413816de0b5
-  languageName: node
-  linkType: hard
-
-"@lerna/child-process@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/child-process@npm:5.0.0"
-  dependencies:
-    chalk: ^4.1.0
-    execa: ^5.0.0
-    strong-log-transformer: ^2.1.0
-  checksum: 6e1e6075173d776a1f816502714694be8e593e60c512c3e5c4af5fe7f300ebc6b50bd541794e61e988114ea402fb2c919f5fa095554cf885204bb165c171ecf6
-  languageName: node
-  linkType: hard
-
-"@lerna/clean@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/clean@npm:5.0.0"
-  dependencies:
-    "@lerna/command": 5.0.0
-    "@lerna/filter-options": 5.0.0
-    "@lerna/prompt": 5.0.0
-    "@lerna/pulse-till-done": 5.0.0
-    "@lerna/rimraf-dir": 5.0.0
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-    p-waterfall: ^2.1.1
-  checksum: f839ea948d52a9aa907063de974e79cb6c06acb9fb6e80e0ec227d23c956426e46cf77586985873f34e185145b8224608228ceba6aa82aed88f8e7d1f2d70f69
-  languageName: node
-  linkType: hard
-
-"@lerna/cli@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/cli@npm:5.0.0"
-  dependencies:
-    "@lerna/global-options": 5.0.0
-    dedent: ^0.7.0
-    npmlog: ^4.1.2
-    yargs: ^16.2.0
-  checksum: 9531a3a74277f1d82febc687826a3c7f84e3407504170824ca5f373da213f8a1f7ff53a9dd44f9004ce72ae8aaae488760bf7f6d22df2240e0011635fcafc541
-  languageName: node
-  linkType: hard
-
-"@lerna/collect-uncommitted@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/collect-uncommitted@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    chalk: ^4.1.0
-    npmlog: ^4.1.2
-  checksum: b77e63e033b3a9f81a16f636e73824c695e7b97347755ef1adaa961169fd36762fec5214c6db81e612642a4ec50afff6d84824d5a850484092bb2752ff280d33
-  languageName: node
-  linkType: hard
-
-"@lerna/collect-updates@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/collect-updates@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/describe-ref": 5.0.0
-    minimatch: ^3.0.4
-    npmlog: ^4.1.2
-    slash: ^3.0.0
-  checksum: a3da2e8aced69e83b7c599eb4e2ccee2216d5964fb647874b1c2956d8089d1df15cc6ba8b3a0334d2de6b6071985e2ff77655b56d0bee6021d14b22e26b4a6a7
-  languageName: node
-  linkType: hard
-
-"@lerna/command@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/command@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/package-graph": 5.0.0
-    "@lerna/project": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    "@lerna/write-log-file": 5.0.0
-    clone-deep: ^4.0.1
-    dedent: ^0.7.0
-    execa: ^5.0.0
-    is-ci: ^2.0.0
-    npmlog: ^4.1.2
-  checksum: 4fd54db1f1749013da6d8bba59fa62953f874108a74c79cd6a9bafa0516ee2cf373ca27641fd862b22a59b8904ef6c7090c7156fa408846cbc1302545a3ea4db
-  languageName: node
-  linkType: hard
-
-"@lerna/conventional-commits@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/conventional-commits@npm:5.0.0"
-  dependencies:
-    "@lerna/validation-error": 5.0.0
-    conventional-changelog-angular: ^5.0.12
-    conventional-changelog-core: ^4.2.2
-    conventional-recommended-bump: ^6.1.0
-    fs-extra: ^9.1.0
-    get-stream: ^6.0.0
-    lodash.template: ^4.5.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    pify: ^5.0.0
-    semver: ^7.3.4
-  checksum: 3b1cf3117c0f1e0dfad824de6771e8f831badc122b2fe27a6011a39d20b959c4b49448e512c6715ea10d9ff97f2b946d98c158ce6a44a971a75bae1621eb3f4d
-  languageName: node
-  linkType: hard
-
-"@lerna/create-symlink@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/create-symlink@npm:5.0.0"
-  dependencies:
-    cmd-shim: ^4.1.0
-    fs-extra: ^9.1.0
-    npmlog: ^4.1.2
-  checksum: 75985da76c3a2666f1e8a6175bf6f652e0417290416d01e6d55b05e8f67e3b07d7852cb9c9c96bc36346c27c204c8ee3546db916c0ea356a95ffece51e25e1b3
-  languageName: node
-  linkType: hard
-
-"@lerna/create@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/create@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/npm-conf": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    dedent: ^0.7.0
-    fs-extra: ^9.1.0
-    globby: ^11.0.2
-    init-package-json: ^2.0.2
-    npm-package-arg: ^8.1.0
-    p-reduce: ^2.1.0
-    pacote: ^13.4.1
-    pify: ^5.0.0
-    semver: ^7.3.4
-    slash: ^3.0.0
-    validate-npm-package-license: ^3.0.4
-    validate-npm-package-name: ^3.0.0
-    whatwg-url: ^8.4.0
-    yargs-parser: 20.2.4
-  checksum: 916ce096b71e7e859d19c0f25e4eb8a2fee2cab608f805f698f6d2c5fef2fe6359d18a7ca5019c2aa2535a31b2e0e1416514d4994f7e0124ac88e3a7fa222b36
-  languageName: node
-  linkType: hard
-
-"@lerna/describe-ref@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/describe-ref@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    npmlog: ^4.1.2
-  checksum: 784cb6ed5bc231c3de0f2b21657511ec3beb633b19826c4af3e54d313bd3040b9bfc575de8ce1960358ec95333d7b77a4b9ba19d74b61737a5a32f0c4c5d708c
-  languageName: node
-  linkType: hard
-
-"@lerna/diff@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/diff@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    npmlog: ^4.1.2
-  checksum: 1629da4e07f67beed4ef150699fdb295bbed851f8c69663883149e32c4596e781d1cee1d8a10bb6413a6c79a96aff4918bef76dffc707a7aa1b053939bc1074c
-  languageName: node
-  linkType: hard
-
-"@lerna/exec@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/exec@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/filter-options": 5.0.0
-    "@lerna/profiler": 5.0.0
-    "@lerna/run-topologically": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    p-map: ^4.0.0
-  checksum: 6dd5b13f82843eeaf21e5030380c5c15c40affe230f42bd56ea568330da89cf3e9713a7f3c65068ba98fbae74ab05d7fd60e904a5f006ff2ecdbcce195952fd1
-  languageName: node
-  linkType: hard
-
-"@lerna/filter-options@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/filter-options@npm:5.0.0"
-  dependencies:
-    "@lerna/collect-updates": 5.0.0
-    "@lerna/filter-packages": 5.0.0
-    dedent: ^0.7.0
-    npmlog: ^4.1.2
-  checksum: 0adeb55b94ec758b6d3c2ced6c3ec7315abe98333a742a72658238a96bee22bb14bebb892777ed1b13b7a305116e1eea4d02fb99793909a6284ddda572107eaa
-  languageName: node
-  linkType: hard
-
-"@lerna/filter-packages@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/filter-packages@npm:5.0.0"
-  dependencies:
-    "@lerna/validation-error": 5.0.0
-    multimatch: ^5.0.0
-    npmlog: ^4.1.2
-  checksum: 3d0117cc1cb96a194a1d9a862c70cf1f41cef823b82e9ec16fdea34405151daade6ac8f39c03082c11f5225fdb7236284c08a4e7bfda598f238fc33bd23e3b4f
-  languageName: node
-  linkType: hard
-
-"@lerna/get-npm-exec-opts@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/get-npm-exec-opts@npm:5.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 48c0673ca1a4862140a82fef95001e4f6a8f5b0f700c1df6998f75d8f21bbe241ad5ad3ee5af43b068a77b79fd14746155f7b086d31b67d96579f5eab19f26d4
-  languageName: node
-  linkType: hard
-
-"@lerna/get-packed@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/get-packed@npm:5.0.0"
-  dependencies:
-    fs-extra: ^9.1.0
-    ssri: ^8.0.1
-    tar: ^6.1.0
-  checksum: f246da047d9f2703b35309a83cd92bb1d8af0a06405024ce99c25f5b2909d687f534ba44bed3f4419abe5710f228b6b980d9dff568baa569cb6f324d3088a9e8
-  languageName: node
-  linkType: hard
-
-"@lerna/github-client@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/github-client@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@octokit/plugin-enterprise-rest": ^6.0.1
-    "@octokit/rest": ^18.1.0
-    git-url-parse: ^11.4.4
-    npmlog: ^4.1.2
-  checksum: 936ecbfd382867465bc9d269eb7ceb071a3764ba0c8cd89c014fa4edc3f769b42193cc8a490a5a93a0d86b65bcab52d57f7a6e7c8f9eecdd0076e5d7e53a3a44
-  languageName: node
-  linkType: hard
-
-"@lerna/gitlab-client@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/gitlab-client@npm:5.0.0"
-  dependencies:
-    node-fetch: ^2.6.1
-    npmlog: ^4.1.2
-    whatwg-url: ^8.4.0
-  checksum: 6d533a4b381094d7f87c276341f15789729e06aeb44e3c3bb4e57d17485113d3d741ed2d15de36cccedef0adfc0b82a52847764bcfb0a0780f97ca1a53e05cbe
-  languageName: node
-  linkType: hard
-
-"@lerna/global-options@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/global-options@npm:5.0.0"
-  checksum: b65a9e8f3e87f2d0e764cc3f6ec7ae047816395b80ff155fc0ad5ffc3df8f254df0ebc01d58ce21da970d23783a463d5e6c054148762112ceb15bd277a44933d
-  languageName: node
-  linkType: hard
-
-"@lerna/has-npm-version@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/has-npm-version@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    semver: ^7.3.4
-  checksum: 7ddcaf2b41fbc2b50e70cd0f5d259fa55d83a1cf8663b7ad7dd427ed0ec9d9008ddd342c3beed15225255192e16504ed0feef3aa7ce8c46bc1d9ad187073bd29
-  languageName: node
-  linkType: hard
-
-"@lerna/import@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/import@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/prompt": 5.0.0
-    "@lerna/pulse-till-done": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    dedent: ^0.7.0
-    fs-extra: ^9.1.0
-    p-map-series: ^2.1.0
-  checksum: 07606a434dcf3c14afb664539f4ff4d89e67ba3f140fda8a9b5e92da932918bca6e5ac710ce98e19b00b73fc2332c19260a9c50407baed4b97083b92b731568f
-  languageName: node
-  linkType: hard
-
-"@lerna/info@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/info@npm:5.0.0"
-  dependencies:
-    "@lerna/command": 5.0.0
-    "@lerna/output": 5.0.0
-    envinfo: ^7.7.4
-  checksum: a598499a1679ef27f32dbf08ab00fb02fc8f12fcf67da5129a7cce00d9fca943b0014276398ac57e27856e443d67a994ae33c343f3a41824c6a0cf629eecc631
-  languageName: node
-  linkType: hard
-
-"@lerna/init@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/init@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/command": 5.0.0
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-    write-json-file: ^4.3.0
-  checksum: e10c42cc9164f8518c2a713906d648ab37d081ad13d13c2397336b357d8412f35e628537acc668b3da55744e343697dbe606e36039b9aab648c4605ff9ad666b
-  languageName: node
-  linkType: hard
-
-"@lerna/link@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/link@npm:5.0.0"
-  dependencies:
-    "@lerna/command": 5.0.0
-    "@lerna/package-graph": 5.0.0
-    "@lerna/symlink-dependencies": 5.0.0
-    p-map: ^4.0.0
-    slash: ^3.0.0
-  checksum: 68bb4ad21dae956234b36f333fcb5ba996ecf549e5c7b46ae01b8a1005c69bdeabb4f59a6bfc1d8f4a08a715b14c7b5398233cc7e2e70218adca28ed8f6c300b
-  languageName: node
-  linkType: hard
-
-"@lerna/list@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/list@npm:5.0.0"
-  dependencies:
-    "@lerna/command": 5.0.0
-    "@lerna/filter-options": 5.0.0
-    "@lerna/listable": 5.0.0
-    "@lerna/output": 5.0.0
-  checksum: 1b7d89dc241c8e1caa3b4f182e9634a87ed8c11e85abe20c1d39e857ce19ca4f1d3d0ed283aa272f5e708d29145c20f187153728569e708c6b2116f836ca61ff
-  languageName: node
-  linkType: hard
-
-"@lerna/listable@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/listable@npm:5.0.0"
-  dependencies:
-    "@lerna/query-graph": 5.0.0
-    chalk: ^4.1.0
-    columnify: ^1.5.4
-  checksum: 86148764bddc5ad70d8a4693333d79d87cac50300a48601bc68bb05ac21f5ad7c371ee73290a2db2331e8ca1f447368c80133847494730f3ae43348660321977
-  languageName: node
-  linkType: hard
-
-"@lerna/log-packed@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/log-packed@npm:5.0.0"
-  dependencies:
-    byte-size: ^7.0.0
-    columnify: ^1.5.4
-    has-unicode: ^2.0.1
-    npmlog: ^4.1.2
-  checksum: 06f34d1d52725a4141290ea89ad433c55384876b725a0571a96d93a507333ea16750a85a2a29439d002b764b5c737aeba51b4aefaabde7a1269dcfd9d108fe72
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-conf@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/npm-conf@npm:5.0.0"
-  dependencies:
-    config-chain: ^1.1.12
-    pify: ^5.0.0
-  checksum: d5df3d249c548ca1d976c5273dbb6702d2d6d05078db34312a56a60dd6916568bbdc478b11fbe4f6109a202cc7aad15b565cee730c7d91d8c3c1631858cb1e9e
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-dist-tag@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/npm-dist-tag@npm:5.0.0"
-  dependencies:
-    "@lerna/otplease": 5.0.0
-    npm-package-arg: ^8.1.0
-    npm-registry-fetch: ^9.0.0
-    npmlog: ^4.1.2
-  checksum: 3e25f91f7076ebf28c4e01dfd558ba4ee6ea6c01d64fd02e6dc565adb9f6421b7eff4fd5c5324bf62ac10602843fbc3c74b8f7075e149616e5957fd2e5afc6ff
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-install@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/npm-install@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/get-npm-exec-opts": 5.0.0
-    fs-extra: ^9.1.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    signal-exit: ^3.0.3
-    write-pkg: ^4.0.0
-  checksum: fc23f1c2cbc3114c8dddc70676c77aee995a29279753bf5a0ce9190e03f004a787c9fd83c7d7a861b58ac63a16540c6bb40afbe045e1642a18e05b1d7276d53e
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-publish@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/npm-publish@npm:5.0.0"
-  dependencies:
-    "@lerna/otplease": 5.0.0
-    "@lerna/run-lifecycle": 5.0.0
-    fs-extra: ^9.1.0
-    libnpmpublish: ^4.0.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    pify: ^5.0.0
-    read-package-json: ^3.0.0
-  checksum: 828b74413bb8b77bc6a808feb27823827fcdbf74e4b14a2b41cb580cceba3e5f971cb3ff69deed71c5cf58cee03b345256b4444b01723ae8abd291356a3746cb
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-run-script@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/npm-run-script@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    "@lerna/get-npm-exec-opts": 5.0.0
-    npmlog: ^4.1.2
-  checksum: 17d4adf9ab021939fb6863a068a02813862c71f301b0a0bab9fa6c884ef4f53f8dceb44fcfd1c641115edd4ee928f4e02888651ec9a024278fc310d69c1e11b8
-  languageName: node
-  linkType: hard
-
-"@lerna/otplease@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/otplease@npm:5.0.0"
-  dependencies:
-    "@lerna/prompt": 5.0.0
-  checksum: 31825528376f2dfacbef0eded9569eef623f1a012cc719f5285e1c7b27553e4ea06c0e44dcf606fd24a8bda15cd249eb538b9db467794b3d07ea6f0c2b210945
-  languageName: node
-  linkType: hard
-
-"@lerna/output@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/output@npm:5.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 8571aa7cc60ddc894a695af50c09b8c9c137b3b1227e15bde45665fffca7a686bdc0749595155b1a97e90fe0f0a696bf0770601f11f1c6d62585d5ef1926ede8
-  languageName: node
-  linkType: hard
-
-"@lerna/pack-directory@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/pack-directory@npm:5.0.0"
-  dependencies:
-    "@lerna/get-packed": 5.0.0
-    "@lerna/package": 5.0.0
-    "@lerna/run-lifecycle": 5.0.0
-    "@lerna/temp-write": 5.0.0
-    npm-packlist: ^2.1.4
-    npmlog: ^4.1.2
-    tar: ^6.1.0
-  checksum: 5388b765420714a0bb03e717d868c22191d1e72a981932d32d7336874b4d550a72dac6286349f1d5bc6dfd51696cde9a61580369bab9796a20d3b3daccc19c9d
-  languageName: node
-  linkType: hard
-
-"@lerna/package-graph@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/package-graph@npm:5.0.0"
-  dependencies:
-    "@lerna/prerelease-id-from-version": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    npm-package-arg: ^8.1.0
-    npmlog: ^4.1.2
-    semver: ^7.3.4
-  checksum: b0b3115f264d00861718e5b7c061230daec37687c7c48966c0a6be0bb2f6b4238829b05190a73e54e2ea7807977c69455aa61a9050253e7af56ba765b1ec37de
-  languageName: node
-  linkType: hard
-
-"@lerna/package@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/package@npm:5.0.0"
-  dependencies:
-    load-json-file: ^6.2.0
-    npm-package-arg: ^8.1.0
-    write-pkg: ^4.0.0
-  checksum: f26f677fd43eaf4588455edbfc79353434a411ff506f62dee8d9293bfe7b1cb4e4801252002476a4ec701064891841f7dae1ee43f5fdada7733d367e727e7a62
-  languageName: node
-  linkType: hard
-
-"@lerna/prerelease-id-from-version@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/prerelease-id-from-version@npm:5.0.0"
-  dependencies:
-    semver: ^7.3.4
-  checksum: 85eba3339fb3d17f6d95e361762fa5277ce4bbc84e2e66b013253b1ba29087a2cbbfcd090dcbda65a54d6e759a342d791635fd6397b8e3b941d620390d8af533
-  languageName: node
-  linkType: hard
-
-"@lerna/profiler@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/profiler@npm:5.0.0"
-  dependencies:
-    fs-extra: ^9.1.0
-    npmlog: ^4.1.2
-    upath: ^2.0.1
-  checksum: 3f23a917e8330fddefa610a01dddb55aea6737e763e06b58b7614bcc5c74caf5fe8bdee3b344345ea847de348a8c4d914d87039600dd6772c713611fec47bdd6
-  languageName: node
-  linkType: hard
-
-"@lerna/project@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/project@npm:5.0.0"
-  dependencies:
-    "@lerna/package": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    cosmiconfig: ^7.0.0
-    dedent: ^0.7.0
-    dot-prop: ^6.0.1
-    glob-parent: ^5.1.1
-    globby: ^11.0.2
-    load-json-file: ^6.2.0
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    resolve-from: ^5.0.0
-    write-json-file: ^4.3.0
-  checksum: ee6a3c40e1bb753255bef0f74078750d6787fd26b34a4eb4505e71502484d955de79b83d3e417b52ee67ffab3acb7588555ceaa6a7675a623bc9f54b16bd6f87
-  languageName: node
-  linkType: hard
-
-"@lerna/prompt@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/prompt@npm:5.0.0"
-  dependencies:
-    inquirer: ^7.3.3
-    npmlog: ^4.1.2
-  checksum: 4cd44c1ecfb18dff50e8ddbe4db3a180eadd173be479aaa4f1ce951353846bdf20fdc48a94c1bae34b5788989e0c8b997a17c2baed9d12a5bc86f43b81c9d709
-  languageName: node
-  linkType: hard
-
-"@lerna/publish@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/publish@npm:5.0.0"
-  dependencies:
-    "@lerna/check-working-tree": 5.0.0
-    "@lerna/child-process": 5.0.0
-    "@lerna/collect-updates": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/describe-ref": 5.0.0
-    "@lerna/log-packed": 5.0.0
-    "@lerna/npm-conf": 5.0.0
-    "@lerna/npm-dist-tag": 5.0.0
-    "@lerna/npm-publish": 5.0.0
-    "@lerna/otplease": 5.0.0
-    "@lerna/output": 5.0.0
-    "@lerna/pack-directory": 5.0.0
-    "@lerna/prerelease-id-from-version": 5.0.0
-    "@lerna/prompt": 5.0.0
-    "@lerna/pulse-till-done": 5.0.0
-    "@lerna/run-lifecycle": 5.0.0
-    "@lerna/run-topologically": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    "@lerna/version": 5.0.0
-    fs-extra: ^9.1.0
-    libnpmaccess: ^4.0.1
-    npm-package-arg: ^8.1.0
-    npm-registry-fetch: ^9.0.0
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    p-pipe: ^3.1.0
-    pacote: ^13.4.1
-    semver: ^7.3.4
-  checksum: c45d6fd3968655c46c236b40f27cec21003232a8f165ca71c249affa27fc455d9d7f01ed2b40b5cd7e9125f807bbf3beb6b573e5e30dc812ffc74bd94f0657f5
-  languageName: node
-  linkType: hard
-
-"@lerna/pulse-till-done@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/pulse-till-done@npm:5.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 9c66c24c95a64b9b0dc092da948208420f2f479ea355d2d9e8e03a2ed96f621ac557da52beb7063b457c97c87580d00c2264ec1d1a154304cb26b14ea4e12a31
-  languageName: node
-  linkType: hard
-
-"@lerna/query-graph@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/query-graph@npm:5.0.0"
-  dependencies:
-    "@lerna/package-graph": 5.0.0
-  checksum: 12cec89a007b24400de880a6265c7dfd4fe06e29792c409bb2cfa376137332876f7fc5fc528db193be416a5e795a6b80bc7b5ab46ee41a183135597184c1eb3a
-  languageName: node
-  linkType: hard
-
-"@lerna/resolve-symlink@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/resolve-symlink@npm:5.0.0"
-  dependencies:
-    fs-extra: ^9.1.0
-    npmlog: ^4.1.2
-    read-cmd-shim: ^2.0.0
-  checksum: 657f64b02abb3cf24ac4db0453ec7e729fddebd338c844e84d000b642a931d9b2c473da39e37e042cfe7d7054203c448b9485aba486c215684a2c086a8bc9eb8
-  languageName: node
-  linkType: hard
-
-"@lerna/rimraf-dir@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/rimraf-dir@npm:5.0.0"
-  dependencies:
-    "@lerna/child-process": 5.0.0
-    npmlog: ^4.1.2
-    path-exists: ^4.0.0
-    rimraf: ^3.0.2
-  checksum: a7b2023e1c54465df018dfd564ebb01bd10baf5a3612076a981533419654f3af4720de0e0d4260f6fcb48edbe63a79a7b1289229faa3750ae53652226fc903f7
-  languageName: node
-  linkType: hard
-
-"@lerna/run-lifecycle@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/run-lifecycle@npm:5.0.0"
-  dependencies:
-    "@lerna/npm-conf": 5.0.0
-    "@npmcli/run-script": ^3.0.2
-    npmlog: ^4.1.2
-  checksum: 1d893f441f54c3b95fafe356ebc22e85134a4f9f1aacaf31141657107b858517f79de5eec3ad054ee0d0042abb765e6aeafdf6eeeefecb41b785318fbce953dc
-  languageName: node
-  linkType: hard
-
-"@lerna/run-topologically@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/run-topologically@npm:5.0.0"
-  dependencies:
-    "@lerna/query-graph": 5.0.0
-    p-queue: ^6.6.2
-  checksum: 0fc337f315d23bf4035f5bdd15a4a1abb687172b0556faf3b8e3b6a848975bbdd6cba960d95755783371e66864af8e6f82bc08f70e1ef173156eeb8833f773d3
-  languageName: node
-  linkType: hard
-
-"@lerna/run@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/run@npm:5.0.0"
-  dependencies:
-    "@lerna/command": 5.0.0
-    "@lerna/filter-options": 5.0.0
-    "@lerna/npm-run-script": 5.0.0
-    "@lerna/output": 5.0.0
-    "@lerna/profiler": 5.0.0
-    "@lerna/run-topologically": 5.0.0
-    "@lerna/timer": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    p-map: ^4.0.0
-  checksum: c05484f746b3df4e364b1abb99b02aebed518ccec6b6e3e4a5b080efdebfb3387a9b6f2ee432085d3352c853b4c623f9d61d26693d0d1fd92201a4c90dfe3086
-  languageName: node
-  linkType: hard
-
-"@lerna/symlink-binary@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/symlink-binary@npm:5.0.0"
-  dependencies:
-    "@lerna/create-symlink": 5.0.0
-    "@lerna/package": 5.0.0
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-  checksum: f2a702a12cda02d29070fe73d3bb357e8552e701d490d56d5251118be98acd1632f4e8b0e25a9d84a158b26ba4cdae4e3279ecf76a77ee6fbea2cd114d017058
-  languageName: node
-  linkType: hard
-
-"@lerna/symlink-dependencies@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/symlink-dependencies@npm:5.0.0"
-  dependencies:
-    "@lerna/create-symlink": 5.0.0
-    "@lerna/resolve-symlink": 5.0.0
-    "@lerna/symlink-binary": 5.0.0
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-  checksum: e76f12bbb37e85a27d3a5099679accd5b6307f900102c54bdd835c0f98c0f32adea5d01dcf262e4e0014e907615383edb2e33189e316e5d710332fbae84fd10d
-  languageName: node
-  linkType: hard
-
-"@lerna/temp-write@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/temp-write@npm:5.0.0"
-  dependencies:
-    graceful-fs: ^4.1.15
-    is-stream: ^2.0.0
-    make-dir: ^3.0.0
-    temp-dir: ^1.0.0
-    uuid: ^8.3.2
-  checksum: 298fb6c7d11ad8c372e2e3f84a1c37f806d1498431aec03794225b28b68819881260fbffc058124e23f497ab1a9260340c1c97e478bd8fe6cee14938085e9ff0
-  languageName: node
-  linkType: hard
-
-"@lerna/timer@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/timer@npm:5.0.0"
-  checksum: a410d33c9e0c7ceb77e05f94c550597e6dc416c644ce3a963c7a7837af22ad4046fea4733946bf984a25b67b125bb661f22d14e41799c30b091d415c85b71884
-  languageName: node
-  linkType: hard
-
-"@lerna/validation-error@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/validation-error@npm:5.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-  checksum: 5e0d6bc2e01b622c584ed966749943073169ff7445bc203c017204cfeb62dc9e116ef3e01b0bf0733c7259db32815bc4241e4ddf6717d5ede9a092635c2fa78a
-  languageName: node
-  linkType: hard
-
-"@lerna/version@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/version@npm:5.0.0"
-  dependencies:
-    "@lerna/check-working-tree": 5.0.0
-    "@lerna/child-process": 5.0.0
-    "@lerna/collect-updates": 5.0.0
-    "@lerna/command": 5.0.0
-    "@lerna/conventional-commits": 5.0.0
-    "@lerna/github-client": 5.0.0
-    "@lerna/gitlab-client": 5.0.0
-    "@lerna/output": 5.0.0
-    "@lerna/prerelease-id-from-version": 5.0.0
-    "@lerna/prompt": 5.0.0
-    "@lerna/run-lifecycle": 5.0.0
-    "@lerna/run-topologically": 5.0.0
-    "@lerna/temp-write": 5.0.0
-    "@lerna/validation-error": 5.0.0
-    chalk: ^4.1.0
-    dedent: ^0.7.0
-    load-json-file: ^6.2.0
-    minimatch: ^3.0.4
-    npmlog: ^4.1.2
-    p-map: ^4.0.0
-    p-pipe: ^3.1.0
-    p-reduce: ^2.1.0
-    p-waterfall: ^2.1.1
-    semver: ^7.3.4
-    slash: ^3.0.0
-    write-json-file: ^4.3.0
-  checksum: 53efe53bce922b002f1a573032c893a76062732cb40aed343cc20a72c7182a0430086231d930a3d58b08daaeb7048aadd4691b2c0a8c5c2827a2a9f73e078633
-  languageName: node
-  linkType: hard
-
-"@lerna/write-log-file@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@lerna/write-log-file@npm:5.0.0"
-  dependencies:
-    npmlog: ^4.1.2
-    write-file-atomic: ^3.0.3
-  checksum: a925093a939d71b7d80efd4b651921f56218745c468dab22bef45633708f7943eb3e69f609476e94a2a94b0e2ed909155958d1b23c8501a82224aaa9bc456178
-  languageName: node
-  linkType: hard
-
 "@lezer/common@npm:^1.0.0":
   version: 1.0.0
   resolution: "@lezer/common@npm:1.0.0"
@@ -11424,50 +10615,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/arborist@npm:5.2.0":
-  version: 5.2.0
-  resolution: "@npmcli/arborist@npm:5.2.0"
-  dependencies:
-    "@isaacs/string-locale-compare": ^1.1.0
-    "@npmcli/installed-package-contents": ^1.0.7
-    "@npmcli/map-workspaces": ^2.0.3
-    "@npmcli/metavuln-calculator": ^3.0.1
-    "@npmcli/move-file": ^2.0.0
-    "@npmcli/name-from-folder": ^1.0.1
-    "@npmcli/node-gyp": ^2.0.0
-    "@npmcli/package-json": ^2.0.0
-    "@npmcli/run-script": ^3.0.0
-    bin-links: ^3.0.0
-    cacache: ^16.0.6
-    common-ancestor-path: ^1.0.1
-    json-parse-even-better-errors: ^2.3.1
-    json-stringify-nice: ^1.1.4
-    mkdirp: ^1.0.4
-    mkdirp-infer-owner: ^2.0.0
-    nopt: ^5.0.0
-    npm-install-checks: ^5.0.0
-    npm-package-arg: ^9.0.0
-    npm-pick-manifest: ^7.0.0
-    npm-registry-fetch: ^13.0.0
-    npmlog: ^6.0.2
-    pacote: ^13.0.5
-    parse-conflict-json: ^2.0.1
-    proc-log: ^2.0.0
-    promise-all-reject-late: ^1.0.0
-    promise-call-limit: ^1.0.1
-    read-package-json-fast: ^2.0.2
-    readdir-scoped-modules: ^1.1.0
-    rimraf: ^3.0.2
-    semver: ^7.3.7
-    ssri: ^9.0.0
-    treeverse: ^2.0.0
-    walk-up-path: ^1.0.0
-  bin:
-    arborist: bin/index.js
-  checksum: e466133cb564619f1544b53ed48632082e90d294a2c7f31103bc685b029c4ba6cb63cea845212148f28b5328ad42fd137936e3395039028b1bd84ed542b9108c
-  languageName: node
-  linkType: hard
-
 "@npmcli/arborist@npm:^4.0.4":
   version: 4.3.1
   resolution: "@npmcli/arborist@npm:4.3.1"
@@ -11510,13 +10657,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/ci-detect@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "@npmcli/ci-detect@npm:1.3.0"
-  checksum: 3ba5e974c71596edf5327def31fd6af02f7ca4ec08bce39f9cfb44132dda748f9f5ad631d6f1b168e983c58d01555d31ff37f26c7d45731a9784fb936a5af11e
-  languageName: node
-  linkType: hard
-
 "@npmcli/fs@npm:^1.0.0":
   version: 1.0.0
   resolution: "@npmcli/fs@npm:1.0.0"
@@ -11553,23 +10693,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/git@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@npmcli/git@npm:3.0.1"
-  dependencies:
-    "@npmcli/promise-spawn": ^3.0.0
-    lru-cache: ^7.4.4
-    mkdirp: ^1.0.4
-    npm-pick-manifest: ^7.0.0
-    proc-log: ^2.0.0
-    promise-inflight: ^1.0.1
-    promise-retry: ^2.0.1
-    semver: ^7.3.5
-    which: ^2.0.2
-  checksum: 0e289d11e2d6034652993f2d05f68396d8377603a1c1f983b2d0893e7591a22bcf3896a43c7dfbcc43f03c308a110f0b9ec37e0191e48b0bd1d236e0f57a3ec6
-  languageName: node
-  linkType: hard
-
 "@npmcli/installed-package-contents@npm:^1.0.6, @npmcli/installed-package-contents@npm:^1.0.7":
   version: 1.0.7
   resolution: "@npmcli/installed-package-contents@npm:1.0.7"
@@ -11594,18 +10717,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/map-workspaces@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@npmcli/map-workspaces@npm:2.0.3"
-  dependencies:
-    "@npmcli/name-from-folder": ^1.0.1
-    glob: ^8.0.1
-    minimatch: ^5.0.1
-    read-package-json-fast: ^2.0.3
-  checksum: c9878a22168d3f2d8df9e339ed0799628db3ea8502bd623b5bbe7b0dfcac065b3310e4093df94667a4a28ef2c54c02ce6956467a8aaa2e150305f2fe1cd64f9d
-  languageName: node
-  linkType: hard
-
 "@npmcli/metavuln-calculator@npm:^2.0.0":
   version: 2.0.0
   resolution: "@npmcli/metavuln-calculator@npm:2.0.0"
@@ -11615,18 +10726,6 @@ __metadata:
     pacote: ^12.0.0
     semver: ^7.3.2
   checksum: bf88115e7c52a5fcf9d3f06d47eeb18acb6077327ee035661b6e4c26102b5e963aa3461679a50fb54427ff4526284a8fdebc743689dd7d71d8ee3814e8f341ee
-  languageName: node
-  linkType: hard
-
-"@npmcli/metavuln-calculator@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "@npmcli/metavuln-calculator@npm:3.1.0"
-  dependencies:
-    cacache: ^16.0.0
-    json-parse-even-better-errors: ^2.3.1
-    pacote: ^13.0.3
-    semver: ^7.3.5
-  checksum: 39fb474e239d3f221178f0c2f6089cd4a2fce8183343b7f52f8f9fe0b3cb0a98b386b15c9afe63a0b0dc2ae5302497d00eb2de2f4b3431953dbf05e69d613c9a
   languageName: node
   linkType: hard
 
@@ -11673,28 +10772,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/node-gyp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@npmcli/node-gyp@npm:2.0.0"
-  checksum: b6bbf0015000f9b64d31aefdc30f244b0348c57adb64017667e0304e96c38644d83da46a4581252652f5d606268df49118f9c9993b41d8020f62b7b15dd2c8d8
-  languageName: node
-  linkType: hard
-
 "@npmcli/package-json@npm:^1.0.1":
   version: 1.0.1
   resolution: "@npmcli/package-json@npm:1.0.1"
   dependencies:
     json-parse-even-better-errors: ^2.3.1
   checksum: 08b66c8ddb1d6b678975a83006d2fe5070b3013bcb68ea9d54c0142538a614596ddfd1143183fbb8f82c5cecf477d98f3c4e473ef34df3bbf3814e97e37e18d3
-  languageName: node
-  linkType: hard
-
-"@npmcli/package-json@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@npmcli/package-json@npm:2.0.0"
-  dependencies:
-    json-parse-even-better-errors: ^2.3.1
-  checksum: 7a598e42d2778654ec87438ebfafbcbafbe5a5f5e89ed2ca1db6ca3f94ef14655e304aa41f77632a2a3f5c66b6bd5960bd9370e0ceb4902ea09346720364f9e4
   languageName: node
   linkType: hard
 
@@ -11707,15 +10790,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/promise-spawn@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@npmcli/promise-spawn@npm:3.0.0"
-  dependencies:
-    infer-owner: ^1.0.4
-  checksum: 3454465a2731cea5875ba51f80873e2205e5bd878c31517286b0ede4ea931c7bf3de895382287e906d03710fff6f9e44186bd0eee068ce578901c5d3b58e7692
-  languageName: node
-  linkType: hard
-
 "@npmcli/run-script@npm:^2.0.0":
   version: 2.0.0
   resolution: "@npmcli/run-script@npm:2.0.0"
@@ -11725,18 +10799,6 @@ __metadata:
     node-gyp: ^8.2.0
     read-package-json-fast: ^2.0.1
   checksum: c016ea9411e434d84e9bb9c30814c2868eee3ff32625f3e1af4671c3abfe0768739ffb2dba5520da926ae44315fc5f507b744f0626a80bc9461f2f19760e5fa0
-  languageName: node
-  linkType: hard
-
-"@npmcli/run-script@npm:^3.0.0, @npmcli/run-script@npm:^3.0.1, @npmcli/run-script@npm:^3.0.2":
-  version: 3.0.3
-  resolution: "@npmcli/run-script@npm:3.0.3"
-  dependencies:
-    "@npmcli/node-gyp": ^2.0.0
-    "@npmcli/promise-spawn": ^3.0.0
-    node-gyp: ^8.4.1
-    read-package-json-fast: ^2.0.3
-  checksum: 3d0540a95620420d6e77c796a9e9d4fdf2600b5cf5b8d1ceabda15b1dd1d88cc5abf11e28b0494f03eee79c075a1549127bcfa550eb758b08f3948557d77b27a
   languageName: node
   linkType: hard
 
@@ -12044,13 +11106,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-enterprise-rest@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "@octokit/plugin-enterprise-rest@npm:6.0.1"
-  checksum: 1c9720002f31daf62f4f48e73557dcdd7fcde6e0f6d43256e3f2ec827b5548417297186c361fb1af497fdcc93075a7b681e6ff06e2f20e4a8a3e74cc09d1f7e3
-  languageName: node
-  linkType: hard
-
 "@octokit/plugin-paginate-rest@npm:^2.6.2":
   version: 2.7.0
   resolution: "@octokit/plugin-paginate-rest@npm:2.7.0"
@@ -12198,7 +11253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/rest@npm:^18.1.0, @octokit/rest@npm:^18.5.3":
+"@octokit/rest@npm:^18.5.3":
   version: 18.5.6
   resolution: "@octokit/rest@npm:18.5.6"
   dependencies:
@@ -15969,18 +15024,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"JSONStream@npm:^1.0.4":
-  version: 1.3.5
-  resolution: "JSONStream@npm:1.3.5"
-  dependencies:
-    jsonparse: ^1.2.0
-    through: ">=2.2.7 <3"
-  bin:
-    JSONStream: ./bin.js
-  checksum: 2605fa124260c61bad38bb65eba30d2f72216a78e94d0ab19b11b4e0327d572b8d530c0c9cc3b0764f727ad26d39e00bf7ebad57781ca6368394d73169c59e46
-  languageName: node
-  linkType: hard
-
 "a-sync-waterfall@npm:^1.0.0":
   version: 1.0.1
   resolution: "a-sync-waterfall@npm:1.0.1"
@@ -16101,13 +15144,6 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
-  languageName: node
-  linkType: hard
-
-"add-stream@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "add-stream@npm:1.0.0"
-  checksum: 3e9e8b0b8f0170406d7c3a9a39bfbdf419ccccb0fd2a396338c0fda0a339af73bf738ad414fc520741de74517acf0dd92b4a36fd3298a47fd5371eee8f2c5a06
   languageName: node
   linkType: hard
 
@@ -16514,7 +15550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^1.0.3 || ^2.0.0, aproba@npm:^2.0.0":
+"aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
   checksum: 5615cadcfb45289eea63f8afd064ab656006361020e1735112e346593856f87435e02d8dcc7ff0d11928bc7d425f27bc7c2a84f6c0b35ab0ff659c814c138a24
@@ -16689,13 +15725,6 @@ __metadata:
   version: 2.1.2
   resolution: "array-flatten@npm:2.1.2"
   checksum: e8988aac1fbfcdaae343d08c9a06a6fddd2c6141721eeeea45c3cf523bf4431d29a46602929455ed548c7a3e0769928cdc630405427297e7081bd118fdec9262
-  languageName: node
-  linkType: hard
-
-"array-ify@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "array-ify@npm:1.0.0"
-  checksum: c0502015b319c93dd4484f18036bcc4b654eb76a4aa1f04afbcef11ac918859bb1f5d71ba1f0f1141770db9eef1a4f40f1761753650873068010bbf7bcdae4a4
   languageName: node
   linkType: hard
 
@@ -17978,15 +17007,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builtins@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "builtins@npm:5.0.1"
-  dependencies:
-    semver: ^7.0.0
-  checksum: 66d204657fe36522822a95b288943ad11b58f5eaede235b11d8c4edaa28ce4800087d44a2681524c340494aadb120a0068011acabe99d30e8f11a7d826d83515
-  languageName: node
-  linkType: hard
-
 "busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
@@ -18000,13 +17020,6 @@ __metadata:
   version: 5.0.0
   resolution: "byline@npm:5.0.0"
   checksum: 737ca83e8eda2976728dae62e68bc733aea095fab08db4c6f12d3cee3cf45b6f97dce45d1f6b6ff9c2c947736d10074985b4425b31ce04afa1985a4ef3d334a7
-  languageName: node
-  linkType: hard
-
-"byte-size@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "byte-size@npm:7.0.0"
-  checksum: 6cdd45fb64ac3f80d5cbbc01df7974a4613b3e64bd792b6b8211c8669ca3d1f7efd9379ba24cebfc371ce3e890817dcdaf0bd7ed99571fe2de4b946e6c31a138
   languageName: node
   linkType: hard
 
@@ -18050,7 +17063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^16.0.0, cacache@npm:^16.0.6, cacache@npm:^16.1.0":
+"cacache@npm:^16.1.0":
   version: 16.1.1
   resolution: "cacache@npm:16.1.1"
   dependencies:
@@ -18486,13 +17499,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ci-info@npm:2.0.0"
-  checksum: 3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
-  languageName: node
-  linkType: hard
-
 "ci-info@npm:^3.1.0, ci-info@npm:^3.2.0":
   version: 3.3.2
   resolution: "ci-info@npm:3.3.2"
@@ -18739,7 +17745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cmd-shim@npm:^4.0.1, cmd-shim@npm:^4.1.0":
+"cmd-shim@npm:^4.0.1":
   version: 4.1.0
   resolution: "cmd-shim@npm:4.1.0"
   dependencies:
@@ -18891,7 +17897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.2, color-support@npm:^1.1.3":
+"color-support@npm:^1.1.2":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
   bin:
@@ -18969,16 +17975,6 @@ __metadata:
     color: 3.0.x
     text-hex: 1.0.x
   checksum: a959ec1669176aa72185067b7d04dae1cef2698456e1a452a035ce8adcac95673fbb1547e3240903355bcbaa67e031cca0b8b4f7d42c256b3dd94dcead8e1405
-  languageName: node
-  linkType: hard
-
-"columnify@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "columnify@npm:1.5.4"
-  dependencies:
-    strip-ansi: ^3.0.0
-    wcwidth: ^1.0.0
-  checksum: f0693937412ec41d387f8ae89ff8cd5811a07ad636f753f0276ba8394fd76c0f610621ebeb379d6adcb30d98696919546dbbf93a28bd4e546efc7e30d905edc2
   languageName: node
   linkType: hard
 
@@ -19093,16 +18089,6 @@ __metadata:
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
   checksum: 59715f2fc456a73f68826285718503340b9f0dd89bfffc42749906c5cf3d4277ef11ef1cca0350d0e79204f00f1f6d83851ececc9095dc88512a697ac0b9bdcb
-  languageName: node
-  linkType: hard
-
-"compare-func@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "compare-func@npm:2.0.0"
-  dependencies:
-    array-ify: ^1.0.0
-    dot-prop: ^5.1.0
-  checksum: fb71d70632baa1e93283cf9d80f30ac97f003aabee026e0b4426c9716678079ef5fea7519b84d012cbed938c476493866a38a79760564a9e21ae9433e40e6f0d
   languageName: node
   linkType: hard
 
@@ -19276,16 +18262,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"config-chain@npm:^1.1.12":
-  version: 1.1.12
-  resolution: "config-chain@npm:1.1.12"
-  dependencies:
-    ini: ^1.3.4
-    proto-list: ~1.2.1
-  checksum: a16332f87212b4015afcdfc95fe42b40b162e7f10b4f4370ab3239979b6e69a41b4e6fb34d7891aa028a557f2340da236f810df433b18dfa5c408b2eb8489bf7
-  languageName: node
-  linkType: hard
-
 "connect-history-api-fallback@npm:^2.0.0":
   version: 2.0.0
   resolution: "connect-history-api-fallback@npm:2.0.0"
@@ -19361,109 +18337,6 @@ __metadata:
   version: 1.0.4
   resolution: "content-type@npm:1.0.4"
   checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-angular@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "conventional-changelog-angular@npm:5.0.12"
-  dependencies:
-    compare-func: ^2.0.0
-    q: ^1.5.1
-  checksum: 552db8762d210a5172b1ad8cd95312e2e2a0483ba43f8d30b075a56ccf05231fdca1d4d5843028d43bec6bc7f903f480005efc5386587321a15a1fc4d2b73016
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-core@npm:^4.2.2":
-  version: 4.2.4
-  resolution: "conventional-changelog-core@npm:4.2.4"
-  dependencies:
-    add-stream: ^1.0.0
-    conventional-changelog-writer: ^5.0.0
-    conventional-commits-parser: ^3.2.0
-    dateformat: ^3.0.0
-    get-pkg-repo: ^4.0.0
-    git-raw-commits: ^2.0.8
-    git-remote-origin-url: ^2.0.0
-    git-semver-tags: ^4.1.1
-    lodash: ^4.17.15
-    normalize-package-data: ^3.0.0
-    q: ^1.5.1
-    read-pkg: ^3.0.0
-    read-pkg-up: ^3.0.0
-    through2: ^4.0.0
-  checksum: 56d5194040495ea316e53fd64cb3614462c318f0fe54b1bf25aba6fba9b3d51cb9fdf7ac5b766f17e5529a3f90e317257394e00b0a9a5ce42caf3a59f82afb3a
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-preset-loader@npm:^2.3.4":
-  version: 2.3.4
-  resolution: "conventional-changelog-preset-loader@npm:2.3.4"
-  checksum: 23a889b7fcf6fe7653e61f32a048877b2f954dcc1e0daa2848c5422eb908e6f24c78372f8d0d2130b5ed941c02e7010c599dccf44b8552602c6c8db9cb227453
-  languageName: node
-  linkType: hard
-
-"conventional-changelog-writer@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "conventional-changelog-writer@npm:5.0.1"
-  dependencies:
-    conventional-commits-filter: ^2.0.7
-    dateformat: ^3.0.0
-    handlebars: ^4.7.7
-    json-stringify-safe: ^5.0.1
-    lodash: ^4.17.15
-    meow: ^8.0.0
-    semver: ^6.0.0
-    split: ^1.0.0
-    through2: ^4.0.0
-  bin:
-    conventional-changelog-writer: cli.js
-  checksum: 5c0129db44577f14b1f8de225b62a392a9927ba7fe3422cb21ad71a771b8472bd03badb7c87cb47419913abc3f2ce3759b69f59550cdc6f7a7b0459015b3b44c
-  languageName: node
-  linkType: hard
-
-"conventional-commits-filter@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "conventional-commits-filter@npm:2.0.7"
-  dependencies:
-    lodash.ismatch: ^4.4.0
-    modify-values: ^1.0.0
-  checksum: feb567f680a6da1baaa1ef3cff393b3c56a5828f77ab9df5e70626475425d109a6fee0289b4979223c62bbd63bf9c98ef532baa6fcb1b66ee8b5f49077f5d46c
-  languageName: node
-  linkType: hard
-
-"conventional-commits-parser@npm:^3.2.0":
-  version: 3.2.1
-  resolution: "conventional-commits-parser@npm:3.2.1"
-  dependencies:
-    JSONStream: ^1.0.4
-    is-text-path: ^1.0.1
-    lodash: ^4.17.15
-    meow: ^8.0.0
-    split2: ^3.0.0
-    through2: ^4.0.0
-    trim-off-newlines: ^1.0.0
-  bin:
-    conventional-commits-parser: cli.js
-  checksum: 01b83c625ac3d8f9dca0510a5e21385c9bb410b80bcb60dcfdef20e1fa7fe7fad5a280aa5e1dff8ac32ea0aea5966fa973696557d38f831f8630d4fcf31756d5
-  languageName: node
-  linkType: hard
-
-"conventional-recommended-bump@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "conventional-recommended-bump@npm:6.1.0"
-  dependencies:
-    concat-stream: ^2.0.0
-    conventional-changelog-preset-loader: ^2.3.4
-    conventional-commits-filter: ^2.0.7
-    conventional-commits-parser: ^3.2.0
-    git-raw-commits: ^2.0.8
-    git-semver-tags: ^4.1.1
-    meow: ^8.0.0
-    q: ^1.5.1
-  bin:
-    conventional-recommended-bump: cli.js
-  checksum: da1d7a5f3b9f7706bede685cdcb3db67997fdaa43c310fd5bf340955c84a4b85dbb9427031522ee06dad290b730a54be987b08629d79c73720dbad3a2531146b
   languageName: node
   linkType: hard
 
@@ -20482,13 +19355,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dargs@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "dargs@npm:7.0.0"
-  checksum: b8f1e3cba59c42e1f13a114ad4848c3fc1cf7470f633ee9e9f1043762429bc97d91ae31b826fb135eefde203a3fdb20deb0c0a0222ac29d937b8046085d668d1
-  languageName: node
-  linkType: hard
-
 "dashdash@npm:^1.12.0":
   version: 1.14.1
   resolution: "dashdash@npm:1.14.1"
@@ -20548,7 +19414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dateformat@npm:^3.0.0, dateformat@npm:^3.0.3":
+"dateformat@npm:^3.0.3":
   version: 3.0.3
   resolution: "dateformat@npm:3.0.3"
   checksum: ca4911148abb09887bd9bdcd632c399b06f3ecad709a18eb594d289a1031982f441e08e281db77ffebcb2cbcbfa1ac578a7cbfbf8743f41009aa5adc1846ed34
@@ -20916,13 +19782,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-indent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "detect-indent@npm:5.0.0"
-  checksum: 61763211daa498e00eec073aba95d544ae5baed19286a0a655697fa4fffc9f4539c8376e2c7df8fa11d6f8eaa16c1e6a689f403ac41ee78a060278cdadefe2ff
-  languageName: node
-  linkType: hard
-
 "detect-indent@npm:^6.0.0":
   version: 6.1.0
   resolution: "detect-indent@npm:6.1.0"
@@ -21261,24 +20120,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^5.1.0":
-  version: 5.3.0
-  resolution: "dot-prop@npm:5.3.0"
-  dependencies:
-    is-obj: ^2.0.0
-  checksum: d5775790093c234ef4bfd5fbe40884ff7e6c87573e5339432870616331189f7f5d86575c5b5af2dcf0f61172990f4f734d07844b1f23482fff09e3c4bead05ea
-  languageName: node
-  linkType: hard
-
-"dot-prop@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "dot-prop@npm:6.0.1"
-  dependencies:
-    is-obj: ^2.0.0
-  checksum: 0f47600a4b93e1dc37261da4e6909652c008832a5d3684b5bf9a9a0d3f4c67ea949a86dceed9b72f5733ed8e8e6383cc5958df3bbd0799ee317fd181f2ece700
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:^16.0.0":
   version: 16.0.0
   resolution: "dotenv@npm:16.0.0"
@@ -21300,17 +20141,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexer@npm:^0.1.1, duplexer@npm:~0.1.1":
-  version: 0.1.1
-  resolution: "duplexer@npm:0.1.1"
-  checksum: fc7937c4a43808493cd63dfa59f4deb6cf02beea783cb17f39677b53ccacb9fba48f87731b8944048dd6dfa8f456d0725f86f3fd587ab780532d9a8e2914e8b7
-  languageName: node
-  linkType: hard
-
 "duplexer@npm:^0.1.2":
   version: 0.1.2
   resolution: "duplexer@npm:0.1.2"
   checksum: 62ba61a830c56801db28ff6305c7d289b6dc9f859054e8c982abd8ee0b0a14d2e9a8e7d086ffee12e868d43e2bbe8a964be55ddbd8c8957714c87373c7a4f9b0
+  languageName: node
+  linkType: hard
+
+"duplexer@npm:~0.1.1":
+  version: 0.1.1
+  resolution: "duplexer@npm:0.1.1"
+  checksum: fc7937c4a43808493cd63dfa59f4deb6cf02beea783cb17f39677b53ccacb9fba48f87731b8944048dd6dfa8f456d0725f86f3fd587ab780532d9a8e2914e8b7
   languageName: node
   linkType: hard
 
@@ -21625,15 +20466,6 @@ __metadata:
   version: 2.2.0
   resolution: "env-paths@npm:2.2.0"
   checksum: ba2aea38301aafd69086be1f8cb453b92946e4840cb0de9d1c88a67e6f43a6174dcddb60b218ec36db8720b12de46b0d93c2f97ad9bbec6a267b479ab37debb6
-  languageName: node
-  linkType: hard
-
-"envinfo@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "envinfo@npm:7.7.4"
-  bin:
-    envinfo: dist/cli.js
-  checksum: 73fb993dd9845c61ce52118fcbe4de4d3644d8163130e7bf266f223f32e75e2d33a2c59db83fa0f01f147f122c76567f5f613457a151eb8c6835013538506704
   languageName: node
   linkType: hard
 
@@ -23397,7 +22229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^2.0.0, find-up@npm:^2.1.0":
+"find-up@npm:^2.1.0":
   version: 2.1.0
   resolution: "find-up@npm:2.1.0"
   dependencies:
@@ -23910,22 +22742,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gauge@npm:^4.0.3":
-  version: 4.0.4
-  resolution: "gauge@npm:4.0.4"
-  dependencies:
-    aproba: ^1.0.3 || ^2.0.0
-    color-support: ^1.1.3
-    console-control-strings: ^1.1.0
-    has-unicode: ^2.0.1
-    signal-exit: ^3.0.7
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-    wide-align: ^1.1.5
-  checksum: 788b6bfe52f1dd8e263cda800c26ac0ca2ff6de0b6eee2fe0d9e3abf15e149b651bd27bf5226be10e6e3edb5c4e5d5985a5a1a98137e7a892f75eff76467ad2d
-  languageName: node
-  linkType: hard
-
 "gauge@npm:~2.7.3":
   version: 2.7.4
   resolution: "gauge@npm:2.7.4"
@@ -24054,20 +22870,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-pkg-repo@npm:^4.0.0":
-  version: 4.2.1
-  resolution: "get-pkg-repo@npm:4.2.1"
-  dependencies:
-    "@hutson/parse-repository-url": ^3.0.0
-    hosted-git-info: ^4.0.0
-    through2: ^2.0.0
-    yargs: ^16.2.0
-  bin:
-    get-pkg-repo: src/cli.js
-  checksum: 5abf169137665e45b09a857b33ad2fdcf2f4a09f0ecbd0ebdd789a7ce78c39186a21f58621127eb724d2d4a3a7ee8e6bd4ac7715efda01ad5200665afc218e0d
-  languageName: node
-  linkType: hard
-
 "get-port@npm:^5.1.1":
   version: 5.1.1
   resolution: "get-port@npm:5.1.1"
@@ -24140,53 +22942,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-raw-commits@npm:^2.0.8":
-  version: 2.0.10
-  resolution: "git-raw-commits@npm:2.0.10"
-  dependencies:
-    dargs: ^7.0.0
-    lodash: ^4.17.15
-    meow: ^8.0.0
-    split2: ^3.0.0
-    through2: ^4.0.0
-  bin:
-    git-raw-commits: cli.js
-  checksum: 66e2d7b4cdeff946ac639e1bba37f5dcbd9f5c9245348b31e027e4529f6b6733d23f75768d285d5f29c1f08d3485705a4932300a81a45b77b660fe3ce6089c29
-  languageName: node
-  linkType: hard
-
-"git-remote-origin-url@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "git-remote-origin-url@npm:2.0.0"
-  dependencies:
-    gitconfiglocal: ^1.0.0
-    pify: ^2.3.0
-  checksum: 85263a09c044b5f4fe2acc45cbb3c5331ab2bd4484bb53dfe7f3dd593a4bf90a9786a2e00b9884524331f50b3da18e8c924f01c2944087fc7f342282c4437b73
-  languageName: node
-  linkType: hard
-
-"git-semver-tags@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "git-semver-tags@npm:4.1.1"
-  dependencies:
-    meow: ^8.0.0
-    semver: ^6.0.0
-  bin:
-    git-semver-tags: cli.js
-  checksum: e16d02a515c0f88289a28b5bf59bf42c0dc053765922d3b617ae4b50546bd4f74a25bf3ad53b91cb6c1159319a2e92533b160c573b856c2629125c8b26b3b0e3
-  languageName: node
-  linkType: hard
-
-"git-up@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "git-up@npm:4.0.1"
-  dependencies:
-    is-ssh: ^1.3.0
-    parse-url: ^5.0.0
-  checksum: fbbd8f8f5a57dbd6830592f051564498d322acbbccec5b85b7eff41aade8e175dbd702ae9f6caa80d5ce3cb5435b03711c9d706f26e07923eba6d940fc7dcebf
-  languageName: node
-  linkType: hard
-
 "git-up@npm:^7.0.0":
   version: 7.0.0
   resolution: "git-up@npm:7.0.0"
@@ -24194,15 +22949,6 @@ __metadata:
     is-ssh: ^1.4.0
     parse-url: ^8.1.0
   checksum: 2faadbab51e94d2ffb220e426e950087cc02c15d664e673bd5d1f734cfa8196fed8b19493f7bf28fe216d087d10e22a7fd9b63687e0ba7d24f0ddcfb0a266d6e
-  languageName: node
-  linkType: hard
-
-"git-url-parse@npm:^11.4.4":
-  version: 11.6.0
-  resolution: "git-url-parse@npm:11.6.0"
-  dependencies:
-    git-up: ^4.0.0
-  checksum: 18a7d0bbac76c55fe8a501d4bd4c6b5f5528883a4dadcfce1152b4902e3e5831df8e97f36ea3f564de633e9ab44d9ab09bb2f319e41af1b6e4f627af139d35d5
   languageName: node
   linkType: hard
 
@@ -24215,15 +22961,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gitconfiglocal@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gitconfiglocal@npm:1.0.0"
-  dependencies:
-    ini: ^1.3.2
-  checksum: e6d2764c15bbab6d1d1000d1181bb907f6b3796bb04f63614dba571b18369e0ecb1beaf27ce8da5b24307ef607e3a5f262a67cb9575510b9446aac697d421beb
-  languageName: node
-  linkType: hard
-
 "github-from-package@npm:0.0.0":
   version: 0.0.0
   resolution: "github-from-package@npm:0.0.0"
@@ -24231,7 +22968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -24389,7 +23126,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.0, globby@npm:^11.0.1, globby@npm:^11.0.2, globby@npm:^11.0.3, globby@npm:^11.0.4, globby@npm:^11.1.0":
+"globby@npm:^11.0.0, globby@npm:^11.0.1, globby@npm:^11.0.3, globby@npm:^11.0.4, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -24537,7 +23274,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: 68ea4e07ff2c041ada184f9278b830375f8e0b75154e3f080af6b70f66172fabb4108d19b3863a96b53fc068a310b9b6493d86d1291acc5f3861eb4b79d26ad6
@@ -24800,7 +23537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.3, handlebars@npm:^4.7.7":
+"handlebars@npm:^4.7.3":
   version: 4.7.7
   resolution: "handlebars@npm:4.7.7"
   dependencies:
@@ -25129,30 +23866,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:^3.0.6":
-  version: 3.0.8
-  resolution: "hosted-git-info@npm:3.0.8"
-  dependencies:
-    lru-cache: ^6.0.0
-  checksum: 5af7a69581acb84206a7b8e009f4680c36396814e92c8a83973dfb3b87e44e44d1f7b8eaf3e4a953686482770ecb78406a4ce4666bfdfe447762434127871d8d
-  languageName: node
-  linkType: hard
-
-"hosted-git-info@npm:^4.0.0, hosted-git-info@npm:^4.0.1":
+"hosted-git-info@npm:^4.0.1":
   version: 4.1.0
   resolution: "hosted-git-info@npm:4.1.0"
   dependencies:
     lru-cache: ^6.0.0
   checksum: c3f87b3c2f7eb8c2748c8f49c0c2517c9a95f35d26f4bf54b2a8cba05d2e668f3753548b6ea366b18ec8dadb4e12066e19fa382a01496b0ffa0497eb23cbe461
-  languageName: node
-  linkType: hard
-
-"hosted-git-info@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "hosted-git-info@npm:5.0.0"
-  dependencies:
-    lru-cache: ^7.5.1
-  checksum: 515e69463d123635f70d70656c5ec648951ffc1987f92a87cb4a038e1794bfed833cf87569b358b137ebbc75d992c073ed0408d420c9e5b717c2b4f0a291490c
   languageName: node
   linkType: hard
 
@@ -25534,15 +24253,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore-walk@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "ignore-walk@npm:3.0.3"
-  dependencies:
-    minimatch: ^3.0.4
-  checksum: 34bc6f0497276a9bfad7ba1ae301c7d16bc6424890755a21d90536eaa1f4b7acd598686a01033e64345483b2fef41dad8f93794af73c8b13a7cf21a3cae34a4e
-  languageName: node
-  linkType: hard
-
 "ignore-walk@npm:^4.0.1":
   version: 4.0.1
   resolution: "ignore-walk@npm:4.0.1"
@@ -25748,26 +24458,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.2, ini@npm:^1.3.4, ini@npm:^1.3.5, ini@npm:~1.3.0":
+"ini@npm:^1.3.5, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
-  languageName: node
-  linkType: hard
-
-"init-package-json@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "init-package-json@npm:2.0.2"
-  dependencies:
-    glob: ^7.1.1
-    npm-package-arg: ^8.1.0
-    promzard: ^0.3.0
-    read: ~1.0.1
-    read-package-json: ^3.0.0
-    semver: ^7.3.2
-    validate-npm-package-license: ^3.0.4
-    validate-npm-package-name: ^3.0.0
-  checksum: d8bfd3bd0de46411768011d441c6c96299e639279d7720184f51796533d0088a04a1010ad675718ec899bf6991e84a5e2de6b1ffa3c9357cea919b87c9fb4f73
   languageName: node
   linkType: hard
 
@@ -25806,27 +24500,6 @@ __metadata:
     strip-ansi: ^6.0.0
     through: ^2.3.6
   checksum: 69a2cf32f51af0e94dd66c597fdca42b890ff521b537dbfe1fd532c19a751d54893b7896523691ec30357f6212a80a2417fec7bf34411f369bbf151bdbc95ae9
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:^7.3.3":
-  version: 7.3.3
-  resolution: "inquirer@npm:7.3.3"
-  dependencies:
-    ansi-escapes: ^4.2.1
-    chalk: ^4.1.0
-    cli-cursor: ^3.1.0
-    cli-width: ^3.0.0
-    external-editor: ^3.0.3
-    figures: ^3.0.0
-    lodash: ^4.17.19
-    mute-stream: 0.0.8
-    run-async: ^2.4.0
-    rxjs: ^6.6.0
-    string-width: ^4.1.0
-    strip-ansi: ^6.0.0
-    through: ^2.3.6
-  checksum: 4d387fc1eb6126acbd58cbdb9ad99d2887d181df86ab0c2b9abdf734e751093e2d5882c2b6dc7144d9ab16b7ab30a78a1d7f01fb6a2850a44aeb175d1e3f8778
   languageName: node
   linkType: hard
 
@@ -26094,17 +24767,6 @@ __metadata:
   version: 1.2.4
   resolution: "is-callable@npm:1.2.4"
   checksum: 1a28d57dc435797dae04b173b65d6d1e77d4f16276e9eff973f994eadcfdc30a017e6a597f092752a083c1103cceb56c91e3dadc6692fedb9898dfaba701575f
-  languageName: node
-  linkType: hard
-
-"is-ci@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-ci@npm:2.0.0"
-  dependencies:
-    ci-info: ^2.0.0
-  bin:
-    is-ci: bin.js
-  checksum: 77b869057510f3efa439bbb36e9be429d53b3f51abd4776eeea79ab3b221337fe1753d1e50058a9e2c650d38246108beffb15ccfd443929d77748d8c0cc90144
   languageName: node
   linkType: hard
 
@@ -26404,13 +25066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-obj@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-obj@npm:2.0.0"
-  checksum: c9916ac8f4621962a42f5e80e7ffdb1d79a3fab7456ceaeea394cd9e0858d04f985a9ace45be44433bf605673c8be8810540fe4cc7f4266fc7526ced95af5a08
-  languageName: node
-  linkType: hard
-
 "is-object@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-object@npm:1.0.1"
@@ -26432,17 +25087,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^1.0.0, is-plain-obj@npm:^1.1.0":
+"is-plain-obj@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-plain-obj@npm:1.1.0"
   checksum: 0ee04807797aad50859652a7467481816cbb57e5cc97d813a7dcd8915da8195dc68c436010bf39d195226cde6a2d352f4b815f16f26b7bf486a5754290629931
-  languageName: node
-  linkType: hard
-
-"is-plain-obj@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-plain-obj@npm:2.1.0"
-  checksum: cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
   languageName: node
   linkType: hard
 
@@ -26571,15 +25219,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-ssh@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "is-ssh@npm:1.3.1"
-  dependencies:
-    protocols: ^1.1.0
-  checksum: 769a6ce56477881b66cc3f9ef7924785d32bd904d7fff39bef8eac08251fc5cc9e02fd4b3d99f0b357312b550c2122d9202a887f5630c67cf890263f2c7f1acc
-  languageName: node
-  linkType: hard
-
 "is-ssh@npm:^1.4.0":
   version: 1.4.0
   resolution: "is-ssh@npm:1.4.0"
@@ -26637,15 +25276,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-text-path@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "is-text-path@npm:1.0.1"
-  dependencies:
-    text-extensions: ^1.0.0
-  checksum: fb5d78752c22b3f73a7c9540768f765ffcfa38c9e421e2b9af869565307fa1ae5e3d3a2ba016a43549742856846566d327da406e94a5846ec838a288b1704fd2
-  languageName: node
-  linkType: hard
-
 "is-typed-array@npm:^1.1.3":
   version: 1.1.5
   resolution: "is-typed-array@npm:1.1.5"
@@ -26659,7 +25289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typedarray@npm:^1.0.0, is-typedarray@npm:~1.0.0":
+"is-typedarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
@@ -28078,7 +26708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonparse@npm:^1.2.0, jsonparse@npm:^1.3.1":
+"jsonparse@npm:^1.3.1":
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 6514a7be4674ebf407afca0eda3ba284b69b07f9958a8d3113ef1005f7ec610860c312be067e450c569aab8b89635e332cee3696789c750692bb60daba627f4d
@@ -28574,34 +27204,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lerna@npm:~5.0.0":
-  version: 5.0.0
-  resolution: "lerna@npm:5.0.0"
-  dependencies:
-    "@lerna/add": 5.0.0
-    "@lerna/bootstrap": 5.0.0
-    "@lerna/changed": 5.0.0
-    "@lerna/clean": 5.0.0
-    "@lerna/cli": 5.0.0
-    "@lerna/create": 5.0.0
-    "@lerna/diff": 5.0.0
-    "@lerna/exec": 5.0.0
-    "@lerna/import": 5.0.0
-    "@lerna/info": 5.0.0
-    "@lerna/init": 5.0.0
-    "@lerna/link": 5.0.0
-    "@lerna/list": 5.0.0
-    "@lerna/publish": 5.0.0
-    "@lerna/run": 5.0.0
-    "@lerna/version": 5.0.0
-    import-local: ^3.0.2
-    npmlog: ^4.1.2
-  bin:
-    lerna: cli.js
-  checksum: 27383b3dba162041dbd9de8ca3cd134fe6c6fe57082fee3f12fbf795dfc0e9e513eca9a1cc0aacbea29ef19c6009c3ba64d620ef3e67143e001fbcd4eebeebf5
-  languageName: node
-  linkType: hard
-
 "leven@npm:2.1.0":
   version: 2.1.0
   resolution: "leven@npm:2.1.0"
@@ -28640,31 +27242,6 @@ __metadata:
   version: 1.3.0
   resolution: "li@npm:1.3.0"
   checksum: 44056b8278771cc11c93a9622860554e34181a7c3789b6bf57b2f9a5ccb02fadc169d211c3f360615a790f3bd54bfc5618c5615ffce3a8e68e515b5bea4bede4
-  languageName: node
-  linkType: hard
-
-"libnpmaccess@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "libnpmaccess@npm:4.0.1"
-  dependencies:
-    aproba: ^2.0.0
-    minipass: ^3.1.1
-    npm-package-arg: ^8.0.0
-    npm-registry-fetch: ^9.0.0
-  checksum: ca89f579311b2d348236107566f9c9a9e84678428fc267c3ed284ab99b4179ae560864fee36b676726c906e9dd83725d2e91b334d0c4cb7b2d3a52827fa75dd9
-  languageName: node
-  linkType: hard
-
-"libnpmpublish@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "libnpmpublish@npm:4.0.0"
-  dependencies:
-    normalize-package-data: ^3.0.0
-    npm-package-arg: ^8.1.0
-    npm-registry-fetch: ^9.0.0
-    semver: ^7.1.3
-    ssri: ^8.0.0
-  checksum: 382cb15b19053b7097cdd6fe36e1c760cbb4906e5a3fac02f8909e4f2792e66f4652a655cd74c6744ad412a000a769d40fee23a58e8c38299535c0d76a1ff3a9
   languageName: node
   linkType: hard
 
@@ -28804,18 +27381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"load-json-file@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "load-json-file@npm:6.2.0"
-  dependencies:
-    graceful-fs: ^4.1.15
-    parse-json: ^5.0.0
-    strip-bom: ^4.0.0
-    type-fest: ^0.6.0
-  checksum: 4429e430ebb99375fc7cd936348e4f7ba729486080ced4272091c1e386a7f5f738ea3337d8ffd4b01c2f5bc3ddde92f2c780045b66838fe98bdb79f901884643
-  languageName: node
-  linkType: hard
-
 "load-yaml-file@npm:^0.2.0":
   version: 0.2.0
   resolution: "load-yaml-file@npm:0.2.0"
@@ -28906,13 +27471,6 @@ __metadata:
   version: 4.17.21
   resolution: "lodash-es@npm:4.17.21"
   checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
-  languageName: node
-  linkType: hard
-
-"lodash._reinterpolate@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "lodash._reinterpolate@npm:3.0.0"
-  checksum: 06d2d5f33169604fa5e9f27b6067ed9fb85d51a84202a656901e5ffb63b426781a601508466f039c720af111b0c685d12f1a5c14ff8df5d5f27e491e562784b2
   languageName: node
   linkType: hard
 
@@ -29042,13 +27600,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.ismatch@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.ismatch@npm:4.4.0"
-  checksum: a393917578842705c7fc1a30fb80613d1ac42d20b67eb26a2a6004d6d61ee90b419f9eb320508ddcd608e328d91eeaa2651411727eaa9a12534ed6ccb02fc705
-  languageName: node
-  linkType: hard
-
 "lodash.isnil@npm:^4.0.0":
   version: 4.0.0
   resolution: "lodash.isnil@npm:4.0.0"
@@ -29130,25 +27681,6 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.startcase@npm:4.4.0"
   checksum: c03a4a784aca653845fe09d0ef67c902b6e49288dc45f542a4ab345a9c406a6dc194c774423fa313ee7b06283950301c1221dd2a1d8ecb2dac8dfbb9ed5606b5
-  languageName: node
-  linkType: hard
-
-"lodash.template@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "lodash.template@npm:4.5.0"
-  dependencies:
-    lodash._reinterpolate: ^3.0.0
-    lodash.templatesettings: ^4.0.0
-  checksum: ca64e5f07b6646c9d3dbc0fe3aaa995cb227c4918abd1cef7a9024cd9c924f2fa389a0ec4296aa6634667e029bc81d4bbdb8efbfde11df76d66085e6c529b450
-  languageName: node
-  linkType: hard
-
-"lodash.templatesettings@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "lodash.templatesettings@npm:4.2.0"
-  dependencies:
-    lodash._reinterpolate: ^3.0.0
-  checksum: 863e025478b092997e11a04e9d9e735875eeff1ffcd6c61742aa8272e3c2cddc89ce795eb9726c4e74cef5991f722897ff37df7738a125895f23fc7d12a7bb59
   languageName: node
   linkType: hard
 
@@ -29317,7 +27849,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.10.1, lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.10.1, lru-cache@npm:^7.7.1":
   version: 7.10.1
   resolution: "lru-cache@npm:7.10.1"
   checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
@@ -29457,53 +27989,6 @@ __metadata:
     socks-proxy-agent: ^7.0.0
     ssri: ^9.0.0
   checksum: 2332eb9a8ec96f1ffeeea56ccefabcb4193693597b132cd110734d50f2928842e22b84cfa1508e921b8385cdfd06dda9ad68645fed62b50fff629a580f5fb72c
-  languageName: node
-  linkType: hard
-
-"make-fetch-happen@npm:^10.0.6":
-  version: 10.1.7
-  resolution: "make-fetch-happen@npm:10.1.7"
-  dependencies:
-    agentkeepalive: ^4.2.1
-    cacache: ^16.1.0
-    http-cache-semantics: ^4.1.0
-    http-proxy-agent: ^5.0.0
-    https-proxy-agent: ^5.0.0
-    is-lambda: ^1.0.1
-    lru-cache: ^7.7.1
-    minipass: ^3.1.6
-    minipass-collect: ^1.0.2
-    minipass-fetch: ^2.0.3
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.4
-    negotiator: ^0.6.3
-    promise-retry: ^2.0.1
-    socks-proxy-agent: ^7.0.0
-    ssri: ^9.0.0
-  checksum: 2b7301256e18a2f825c1c3cad14e11492428531ecdea04d846dc12c2d69658d65832746ce965e67c7f98b0d0506115674cf43676c3322709278620bfc886cf4a
-  languageName: node
-  linkType: hard
-
-"make-fetch-happen@npm:^8.0.9":
-  version: 8.0.14
-  resolution: "make-fetch-happen@npm:8.0.14"
-  dependencies:
-    agentkeepalive: ^4.1.3
-    cacache: ^15.0.5
-    http-cache-semantics: ^4.1.0
-    http-proxy-agent: ^4.0.1
-    https-proxy-agent: ^5.0.0
-    is-lambda: ^1.0.1
-    lru-cache: ^6.0.0
-    minipass: ^3.1.3
-    minipass-collect: ^1.0.2
-    minipass-fetch: ^1.3.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.4
-    promise-retry: ^2.0.1
-    socks-proxy-agent: ^5.0.0
-    ssri: ^8.0.0
-  checksum: 326fefde1aec1f1314e548be74baaaa322208718d1b51c9688a326f73dea70f57767b4f5423230e39408cfe7c6dcf7adcf86ca4798c919c3ea78f54532910434
   languageName: node
   linkType: hard
 
@@ -29917,25 +28402,6 @@ __metadata:
     type-fest: ^0.13.1
     yargs-parser: ^18.1.3
   checksum: 77b569781145ad030be77130623d9f74d6eef0af5e0a349419d3df39bcf6d88cc25be046a7757062162a88160fb5d8604e540b5177b371d2bbc2aaf73ec01479
-  languageName: node
-  linkType: hard
-
-"meow@npm:^8.0.0":
-  version: 8.1.2
-  resolution: "meow@npm:8.1.2"
-  dependencies:
-    "@types/minimist": ^1.2.0
-    camelcase-keys: ^6.2.2
-    decamelize-keys: ^1.1.0
-    hard-rejection: ^2.1.0
-    minimist-options: 4.1.0
-    normalize-package-data: ^3.0.0
-    read-pkg-up: ^7.0.1
-    redent: ^3.0.0
-    trim-newlines: ^3.0.0
-    type-fest: ^0.18.0
-    yargs-parser: ^20.2.3
-  checksum: bc23bf1b4423ef6a821dff9734406bce4b91ea257e7f10a8b7f896f45b59649f07adc0926e2917eacd8cf1df9e4cd89c77623cf63dfd0f8bf54de07a32ee5a85
   languageName: node
   linkType: hard
 
@@ -30535,7 +29001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist-options@npm:4.1.0, minimist-options@npm:^4.0.2":
+"minimist-options@npm:^4.0.2":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
   dependencies:
@@ -30571,7 +29037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^1.3.0, minipass-fetch@npm:^1.3.2, minipass-fetch@npm:^1.4.1":
+"minipass-fetch@npm:^1.3.2, minipass-fetch@npm:^1.4.1":
   version: 1.4.1
   resolution: "minipass-fetch@npm:1.4.1"
   dependencies:
@@ -30751,13 +29217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"modify-values@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "modify-values@npm:1.0.1"
-  checksum: 8296610c608bc97b03c2cf889c6cdf4517e32fa2d836440096374c2209f6b7b3e256c209493a0b32584b9cb32d528e99d0dd19dcd9a14d2d915a312d391cc7e9
-  languageName: node
-  linkType: hard
-
 "moment@npm:^2.27.0, moment@npm:^2.29.1":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
@@ -30902,7 +29361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:0.0.8, mute-stream@npm:~0.0.4":
+"mute-stream@npm:0.0.8":
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: ff48d251fc3f827e5b1206cda0ffdaec885e56057ee86a3155e1951bc940fd5f33531774b1cc8414d7668c10a8907f863f6561875ee6e8768931a62121a531a1
@@ -31145,7 +29604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^8.2.0, node-gyp@npm:^8.4.1":
+"node-gyp@npm:^8.2.0":
   version: 8.4.1
   resolution: "node-gyp@npm:8.4.1"
   dependencies:
@@ -31298,30 +29757,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "normalize-package-data@npm:3.0.0"
-  dependencies:
-    hosted-git-info: ^3.0.6
-    resolve: ^1.17.0
-    semver: ^7.3.2
-    validate-npm-package-license: ^3.0.1
-  checksum: 665ad6e3d0463f56ee8acc1f8f71c5f62535e4c689ed389521c36e8fd34273306f978c934154de3a43f5b128ed7010872ce3381948f8d4a63d70f50ed01ac2e0
-  languageName: node
-  linkType: hard
-
-"normalize-package-data@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "normalize-package-data@npm:4.0.0"
-  dependencies:
-    hosted-git-info: ^5.0.0
-    is-core-module: ^2.8.1
-    semver: ^7.3.5
-    validate-npm-package-license: ^3.0.4
-  checksum: b0f47de4295a0f8499bd478e84b9f9592a29f65227c2b4446ae80f7dff6e7a5ec6ef25ea8f06f3dcb9b7b7d945c2daa274385925b3d85e77e34eaffa0b42e316
-  languageName: node
-  linkType: hard
-
 "normalize-path@npm:^2.1.1":
   version: 2.1.1
   resolution: "normalize-path@npm:2.1.1"
@@ -31335,13 +29770,6 @@ __metadata:
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
-  languageName: node
-  linkType: hard
-
-"normalize-url@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "normalize-url@npm:3.3.0"
-  checksum: f6aa4a1a94c3b799812f3e7fc987fb4599d869bfa8e9a160b6f2c5a2b4e62ada998d64dca30d9e20769d8bd95d3da1da3d4841dba2cc3c4d85364e1eb46219a2
   languageName: node
   linkType: hard
 
@@ -31379,15 +29807,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-install-checks@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "npm-install-checks@npm:5.0.0"
-  dependencies:
-    semver: ^7.1.1
-  checksum: 0e7d1aae52b1fe9d3a0fd4a008850c7047931722dd49ee908afd13fd0297ac5ddb10964d9c59afcdaaa2ca04b51d75af2788f668c729ae71fec0e4cdac590ffc
-  languageName: node
-  linkType: hard
-
 "npm-normalize-package-bin@npm:^1.0.0, npm-normalize-package-bin@npm:^1.0.1":
   version: 1.0.1
   resolution: "npm-normalize-package-bin@npm:1.0.1"
@@ -31402,7 +29821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-package-arg@npm:^8.0.0, npm-package-arg@npm:^8.0.1, npm-package-arg@npm:^8.1.0, npm-package-arg@npm:^8.1.2, npm-package-arg@npm:^8.1.5":
+"npm-package-arg@npm:^8.0.1, npm-package-arg@npm:^8.1.2, npm-package-arg@npm:^8.1.5":
   version: 8.1.5
   resolution: "npm-package-arg@npm:8.1.5"
   dependencies:
@@ -31410,31 +29829,6 @@ __metadata:
     semver: ^7.3.4
     validate-npm-package-name: ^3.0.0
   checksum: ae76afbcebb4ea8d0b849b8b18ed1b0491030fb04a0af5d75f1b8390cc50bec186ced9fbe60f47d939eab630c7c0db0919d879ac56a87d3782267dfe8eec60d3
-  languageName: node
-  linkType: hard
-
-"npm-package-arg@npm:^9.0.0, npm-package-arg@npm:^9.0.1":
-  version: 9.0.2
-  resolution: "npm-package-arg@npm:9.0.2"
-  dependencies:
-    hosted-git-info: ^5.0.0
-    semver: ^7.3.5
-    validate-npm-package-name: ^4.0.0
-  checksum: 07828f330f611214a0aa1e87f402b30b3dc90388671470ad8dc1551f28b0cb886f1f75fa7c37e894a9598640a555c05643642994ecacb9a6c68f655e571968f7
-  languageName: node
-  linkType: hard
-
-"npm-packlist@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "npm-packlist@npm:2.1.4"
-  dependencies:
-    glob: ^7.1.6
-    ignore-walk: ^3.0.3
-    npm-bundled: ^1.1.1
-    npm-normalize-package-bin: ^1.0.1
-  bin:
-    npm-packlist: bin/index.js
-  checksum: 916eb67d81c52124b01e20a72168e83fed6fbc168fb6ecd659f5581f515818b9668dab9c1a6b19c7fd6dbe583ad2ed7ceb06924aa884336696f1b08f0f637b22
   languageName: node
   linkType: hard
 
@@ -31452,7 +29846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-packlist@npm:^5.0.0, npm-packlist@npm:^5.1.0":
+"npm-packlist@npm:^5.0.0":
   version: 5.1.3
   resolution: "npm-packlist@npm:5.1.3"
   dependencies:
@@ -31478,18 +29872,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-pick-manifest@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "npm-pick-manifest@npm:7.0.1"
-  dependencies:
-    npm-install-checks: ^5.0.0
-    npm-normalize-package-bin: ^1.0.1
-    npm-package-arg: ^9.0.0
-    semver: ^7.3.5
-  checksum: 9a4a8e64d2214783b2b74a361845000f5d91bb40c7858e2a30af2ac7876d9296efc37f8cacf60335e96a45effee2035b033d9bdefb4889757cc60d85959accbb
-  languageName: node
-  linkType: hard
-
 "npm-registry-fetch@npm:^12.0.0, npm-registry-fetch@npm:^12.0.1":
   version: 12.0.2
   resolution: "npm-registry-fetch@npm:12.0.2"
@@ -31501,37 +29883,6 @@ __metadata:
     minizlib: ^2.1.2
     npm-package-arg: ^8.1.5
   checksum: 88ef49b6fad104165f183ec804a65471a23cead40fa035ac57f2cbe084feffe9c10bed8c4234af3fa549d947108450d5359b41ae5dec9a1ffca4d8fa7c7f78b8
-  languageName: node
-  linkType: hard
-
-"npm-registry-fetch@npm:^13.0.0, npm-registry-fetch@npm:^13.0.1":
-  version: 13.1.1
-  resolution: "npm-registry-fetch@npm:13.1.1"
-  dependencies:
-    make-fetch-happen: ^10.0.6
-    minipass: ^3.1.6
-    minipass-fetch: ^2.0.3
-    minipass-json-stream: ^1.0.1
-    minizlib: ^2.1.2
-    npm-package-arg: ^9.0.1
-    proc-log: ^2.0.0
-  checksum: e085faf5cdc1cfe9b8f825065a0823531b2a28799d84614b3971e344dde087f9089c0f0220360771a81f110c5444978c6f7309084ff7d7d396252b068148bb44
-  languageName: node
-  linkType: hard
-
-"npm-registry-fetch@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "npm-registry-fetch@npm:9.0.0"
-  dependencies:
-    "@npmcli/ci-detect": ^1.0.0
-    lru-cache: ^6.0.0
-    make-fetch-happen: ^8.0.9
-    minipass: ^3.1.3
-    minipass-fetch: ^1.3.0
-    minipass-json-stream: ^1.0.1
-    minizlib: ^2.0.0
-    npm-package-arg: ^8.0.0
-  checksum: b5376b72efc503e46a84cda967b79c08b093f040bfa819b59db32dfa9b057c810401a740dbf739a94a2ebbd0f6a3888bc0918db6506553ab97afb555260a5a22
   languageName: node
   linkType: hard
 
@@ -31586,18 +29937,6 @@ __metadata:
     gauge: ^4.0.0
     set-blocking: ^2.0.0
   checksum: f1a4078a73ebc89896a832bbf869f491c32ecb12e0434b9a7499878ce8f29f22e72befe3c53cd8cdc9dbf4b4057297e783ab0b6746a8b067734de6205af4d538
-  languageName: node
-  linkType: hard
-
-"npmlog@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "npmlog@npm:6.0.2"
-  dependencies:
-    are-we-there-yet: ^3.0.0
-    console-control-strings: ^1.1.0
-    gauge: ^4.0.3
-    set-blocking: ^2.0.0
-  checksum: ae238cd264a1c3f22091cdd9e2b106f684297d3c184f1146984ecbe18aaa86343953f26b9520dedd1b1372bc0316905b736c1932d778dbeb1fcf5a1001390e2a
   languageName: node
   linkType: hard
 
@@ -32141,13 +30480,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map-series@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-map-series@npm:2.1.0"
-  checksum: 69d4efbb6951c0dd62591d5a18c3af0af78496eae8b55791e049da239d70011aa3af727dece3fc9943e0bb3fd4fa64d24177cfbecc46efaf193179f0feeac486
-  languageName: node
-  linkType: hard
-
 "p-map@npm:^2.0.0":
   version: 2.1.0
   resolution: "p-map@npm:2.1.0"
@@ -32164,13 +30496,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-pipe@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "p-pipe@npm:3.1.0"
-  checksum: ee9a2609685f742c6ceb3122281ec4453bbbcc80179b13e66fd139dcf19b1c327cf6c2fdfc815b548d6667e7eaefe5396323f6d49c4f7933e4cef47939e3d65c
-  languageName: node
-  linkType: hard
-
 "p-queue@npm:^6.6.2":
   version: 6.6.2
   resolution: "p-queue@npm:6.6.2"
@@ -32178,13 +30503,6 @@ __metadata:
     eventemitter3: ^4.0.4
     p-timeout: ^3.2.0
   checksum: 832642fcc4ab6477b43e6d7c30209ab10952969ed211c6d6f2931be8a4f9935e3578c72e8cce053dc34f2eb6941a408a2c516a54904e989851a1a209cf19761c
-  languageName: node
-  linkType: hard
-
-"p-reduce@npm:^2.0.0, p-reduce@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-reduce@npm:2.1.0"
-  checksum: 99b26d36066a921982f25c575e78355824da0787c486e3dd9fc867460e8bf17d5fb3ce98d006b41bdc81ffc0aa99edf5faee53d11fe282a20291fb721b0cb1c7
   languageName: node
   linkType: hard
 
@@ -32231,15 +30549,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-waterfall@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "p-waterfall@npm:2.1.1"
-  dependencies:
-    p-reduce: ^2.0.0
-  checksum: 8588bb8b004ee37e559c7e940a480c1742c42725d477b0776ff30b894920a3e48bddf8f60aa0ae82773e500a8fc99d75e947c450e0c2ce187aff72cc1b248f6d
-  languageName: node
-  linkType: hard
-
 "packet-reader@npm:1.0.0":
   version: 1.0.0
   resolution: "packet-reader@npm:1.0.0"
@@ -32273,37 +30582,6 @@ __metadata:
   bin:
     pacote: lib/bin.js
   checksum: 730e2b344619daff078b1f7c085c2da3b1417f1667204384cba981409098af2375b130a6470f75ea22f09b83c00fe227143b68e50d0dd7ff972e28a697b9c1d5
-  languageName: node
-  linkType: hard
-
-"pacote@npm:^13.0.3, pacote@npm:^13.0.5, pacote@npm:^13.4.1":
-  version: 13.6.0
-  resolution: "pacote@npm:13.6.0"
-  dependencies:
-    "@npmcli/git": ^3.0.0
-    "@npmcli/installed-package-contents": ^1.0.7
-    "@npmcli/promise-spawn": ^3.0.0
-    "@npmcli/run-script": ^3.0.1
-    cacache: ^16.0.0
-    chownr: ^2.0.0
-    fs-minipass: ^2.1.0
-    infer-owner: ^1.0.4
-    minipass: ^3.1.6
-    mkdirp: ^1.0.4
-    npm-package-arg: ^9.0.0
-    npm-packlist: ^5.1.0
-    npm-pick-manifest: ^7.0.0
-    npm-registry-fetch: ^13.0.1
-    proc-log: ^2.0.0
-    promise-retry: ^2.0.1
-    read-package-json: ^5.0.0
-    read-package-json-fast: ^2.0.3
-    rimraf: ^3.0.2
-    ssri: ^9.0.0
-    tar: ^6.1.11
-  bin:
-    pacote: lib/bin.js
-  checksum: 9e68300fbe35d4f004444f949b88ce3f5a92c44b92b63e57514962b228ef78bb1a92208f8f2a5fc8066e639c76a442e1cf6fad2a1d29efa63f07aece3cccc6f7
   languageName: node
   linkType: hard
 
@@ -32473,34 +30751,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-path@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "parse-path@npm:4.0.1"
-  dependencies:
-    is-ssh: ^1.3.0
-    protocols: ^1.4.0
-  checksum: dbe025d5827359fee9162932757bf7eb964220a6636ec6d233f9acc981a646aa605d5b49df585792a56e9fdd238d8d5daf2d532d1cd45642f15a47817e4352f6
-  languageName: node
-  linkType: hard
-
 "parse-path@npm:^7.0.0":
   version: 7.0.0
   resolution: "parse-path@npm:7.0.0"
   dependencies:
     protocols: ^2.0.0
   checksum: 244b46523a58181d251dda9b888efde35d8afb957436598d948852f416d8c76ddb4f2010f9fc94218b4be3e5c0f716aa0d2026194a781e3b8981924142009302
-  languageName: node
-  linkType: hard
-
-"parse-url@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "parse-url@npm:5.0.1"
-  dependencies:
-    is-ssh: ^1.3.0
-    normalize-url: ^3.3.0
-    parse-path: ^4.0.0
-    protocols: ^1.4.0
-  checksum: 05c8e88f8c918b11a4feeedfa693a547987eb11266e852746d362bfb92662bd79fa5a422dd41ed297d73e2cfe659dad8c594d97f4ca9e523bec1af289a9a4366
   languageName: node
   linkType: hard
 
@@ -33830,13 +32086,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "proc-log@npm:2.0.1"
-  checksum: f6f23564ff759097db37443e6e2765af84979a703d2c52c1b9df506ee9f87caa101ba49d8fdc115c1a313ec78e37e8134704e9069e6a870f3499d98bb24c436f
-  languageName: node
-  linkType: hard
-
 "process-nextick-args@npm:^2.0.0, process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
@@ -33931,15 +32180,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promzard@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "promzard@npm:0.3.0"
-  dependencies:
-    read: 1
-  checksum: 443a3b39ac916099988ee0161ab4e22edd1fa27e3d39a38d60e48c11ca6df3f5a90bfe44d95af06ed8659c4050b789ffe64c3f9f8e49a4bea1ea19105c98445a
-  languageName: node
-  linkType: hard
-
 "prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.7, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
@@ -33980,13 +32220,6 @@ __metadata:
   version: 6.0.1
   resolution: "property-information@npm:6.0.1"
   checksum: 9a147208ae3bb98629012d384cd8184f5021d60aee9f67d0459605e0c94e2f24db9e263d2b67c333e79981cd7349172a524638681d6e167ddf1c7f06cb2ff2c6
-  languageName: node
-  linkType: hard
-
-"proto-list@npm:~1.2.1":
-  version: 1.2.4
-  resolution: "proto-list@npm:1.2.4"
-  checksum: 4d4826e1713cbfa0f15124ab0ae494c91b597a3c458670c9714c36e8baddf5a6aad22842776f2f5b137f259c8533e741771445eb8df82e861eea37a6eaba03f7
   languageName: node
   linkType: hard
 
@@ -34107,13 +32340,6 @@ __metadata:
     pbjs: bin/pbjs
     pbts: bin/pbts
   checksum: 4a6ce1964167e4c45c53fd8a312d7646415c777dd31b4ba346719947b88e61654912326101f927da387d6b6473ab52a7ea4f54d6f15d63b31130ce28e2e15070
-  languageName: node
-  linkType: hard
-
-"protocols@npm:^1.1.0, protocols@npm:^1.4.0":
-  version: 1.4.7
-  resolution: "protocols@npm:1.4.7"
-  checksum: e4be48f9304303bdbca6159cbbf04edc91ff34921e6e3e3e75ea29eb02e64b38191b73f3404d14f551af87b53572a321b59a402b31a3a2005d62b668b35a8b53
   languageName: node
   linkType: hard
 
@@ -34257,13 +32483,6 @@ __metadata:
   version: 1.1.3
   resolution: "pvutils@npm:1.1.3"
   checksum: 2ee26a9e5176c348977d6ec00d8ee80bff62f51743b1c5fe8abeeb4c5d29d9959cdfe0ce146707a9e6801bce88190fed3002d720b072dc87d031c692820b44c9
-  languageName: node
-  linkType: hard
-
-"q@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "q@npm:1.5.1"
-  checksum: 147baa93c805bc1200ed698bdf9c72e9e42c05f96d007e33a558b5fdfd63e5ea130e99313f28efc1783e90e6bdb4e48b67a36fcc026b7b09202437ae88a1fb12
   languageName: node
   linkType: hard
 
@@ -35071,37 +33290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-package-json-fast@npm:^2.0.1, read-package-json-fast@npm:^2.0.2, read-package-json-fast@npm:^2.0.3":
+"read-package-json-fast@npm:^2.0.1, read-package-json-fast@npm:^2.0.2":
   version: 2.0.3
   resolution: "read-package-json-fast@npm:2.0.3"
   dependencies:
     json-parse-even-better-errors: ^2.3.0
     npm-normalize-package-bin: ^1.0.1
   checksum: fca37b3b2160b9dda7c5588b767f6a2b8ce68d03a044000e568208e20bea0cf6dd2de17b90740ce8da8b42ea79c0b3859649dadf29510bbe77224ea65326a903
-  languageName: node
-  linkType: hard
-
-"read-package-json@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-package-json@npm:3.0.0"
-  dependencies:
-    glob: ^7.1.1
-    json-parse-even-better-errors: ^2.3.0
-    normalize-package-data: ^3.0.0
-    npm-normalize-package-bin: ^1.0.0
-  checksum: f17d10f7c3bd641c0462184cdeacfe22f9494911d4ab3232dd987accc75b6c26387c4573811486e733d1b403780de8c9b2187a51f8d56ff7165f79c199ddce71
-  languageName: node
-  linkType: hard
-
-"read-package-json@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "read-package-json@npm:5.0.1"
-  dependencies:
-    glob: ^8.0.1
-    json-parse-even-better-errors: ^2.3.1
-    normalize-package-data: ^4.0.0
-    npm-normalize-package-bin: ^1.0.1
-  checksum: e8c2ad72df1f17e71268feabdb9bb0153ed2c7d38a05b759c5c49cf368a754bdd3c0e8a279fbc8d707802ff91d2cf144a995e6ebd5534de2848d52ab2c14034d
   languageName: node
   linkType: hard
 
@@ -35112,16 +33307,6 @@ __metadata:
     find-up: ^1.0.0
     read-pkg: ^1.0.0
   checksum: d18399a0f46e2da32beb2f041edd0cda49d2f2cc30195a05c759ef3ed9b5e6e19ba1ad1bae2362bdec8c6a9f2c3d18f4d5e8c369e808b03d498d5781cb9122c7
-  languageName: node
-  linkType: hard
-
-"read-pkg-up@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg-up@npm:3.0.0"
-  dependencies:
-    find-up: ^2.0.0
-    read-pkg: ^3.0.0
-  checksum: 16175573f2914ab9788897bcbe2a62b5728d0075e62285b3680cebe97059e2911e0134a062cf6e51ebe3e3775312bc788ac2039ed6af38ec68d2c10c6f2b30fb
   languageName: node
   linkType: hard
 
@@ -35144,17 +33329,6 @@ __metadata:
     normalize-package-data: ^2.3.2
     path-type: ^1.0.0
   checksum: a0f5d5e32227ec8e6a028dd5c5134eab229768dcb7a5d9a41a284ed28ad4b9284fecc47383dc1593b5694f4de603a7ffaee84b738956b9b77e0999567485a366
-  languageName: node
-  linkType: hard
-
-"read-pkg@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "read-pkg@npm:3.0.0"
-  dependencies:
-    load-json-file: ^4.0.0
-    normalize-package-data: ^2.3.2
-    path-type: ^3.0.0
-  checksum: 398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
   languageName: node
   linkType: hard
 
@@ -35182,15 +33356,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read@npm:1, read@npm:~1.0.1":
-  version: 1.0.7
-  resolution: "read@npm:1.0.7"
-  dependencies:
-    mute-stream: ~0.0.4
-  checksum: 2777c254e5732cac96f5d0a1c0f6b836c89ae23d8febd405b206f6f24d5de1873420f1a0795e0e3721066650d19adf802c7882c4027143ee0acf942a4f34f97b
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
@@ -35202,7 +33367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.0.6, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.0.6, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -36301,7 +34466,6 @@ __metadata:
     eslint-plugin-notice: ^0.9.10
     fs-extra: 10.1.0
     husky: ^8.0.0
-    lerna: ~5.0.0
     lint-staged: ^13.0.0
     minimist: ^1.2.5
     prettier: ^2.2.1
@@ -36353,7 +34517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.6.0, rxjs@npm:^6.6.3":
+"rxjs@npm:^6.6.3":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:
@@ -36613,7 +34777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:~7.3.0":
+"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:~7.3.0":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -37170,17 +35334,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "socks-proxy-agent@npm:5.0.0"
-  dependencies:
-    agent-base: 6
-    debug: 4
-    socks: ^2.3.3
-  checksum: 1dd30d1cc346c33b3180a5bbe75ed93979ca3a916f453a6802f64642f07d30af7e93a640a607c920f10d4b1dfe1d0eec485f64c2a93c951a8d9a50090e6a7776
-  languageName: node
-  linkType: hard
-
 "socks-proxy-agent@npm:^6.0.0, socks-proxy-agent@npm:^6.1.1":
   version: 6.1.1
   resolution: "socks-proxy-agent@npm:6.1.1"
@@ -37203,7 +35356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.3.3, socks@npm:^2.6.1, socks@npm:^2.6.2":
+"socks@npm:^2.6.1, socks@npm:^2.6.2":
   version: 2.6.2
   resolution: "socks@npm:2.6.2"
   dependencies:
@@ -37220,24 +35373,6 @@ __metadata:
     atomic-sleep: ^1.0.0
     flatstr: ^1.0.12
   checksum: b08e20dfa8d888ba32393141f96d195ab6fdecf341a736f25d9c1127cf0de8eaa4e03cde38c23cfa06c50a20ba4b5cb1b107dfc1251283b7c7a153c50f646628
-  languageName: node
-  linkType: hard
-
-"sort-keys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "sort-keys@npm:2.0.0"
-  dependencies:
-    is-plain-obj: ^1.0.0
-  checksum: f0fd827fa9f8f866e98588d2a38c35209afbf1e9a05bb0e4ceeeb8bbf31d923c8902b0a7e0f561590ddb65e58eba6a74f74b991c85360bcc52e83a3f0d1cffd7
-  languageName: node
-  linkType: hard
-
-"sort-keys@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "sort-keys@npm:4.2.0"
-  dependencies:
-    is-plain-obj: ^2.0.0
-  checksum: 1535ffd5a789259fc55107d5c3cec09b3e47803a9407fcaae37e1b9e0b813762c47dfee35b6e71e20ca7a69798d0a4791b2058a07f6cab5ef17b2dae83cedbda
   languageName: node
   linkType: hard
 
@@ -38016,19 +36151,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strong-log-transformer@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "strong-log-transformer@npm:2.1.0"
-  dependencies:
-    duplexer: ^0.1.1
-    minimist: ^1.2.0
-    through: ^2.3.4
-  bin:
-    sl-log-transformer: bin/sl-log-transformer.js
-  checksum: abf9a4ac143118f26c3a0771b204b02f5cf4fa80384ae158f25e02bfbff761038accc44a7f65869ccd5a5995a7f2c16b1466b83149644ba6cecd3072a8927297
-  languageName: node
-  linkType: hard
-
 "strtok3@npm:^6.2.4":
   version: 6.2.4
   resolution: "strtok3@npm:6.2.4"
@@ -38509,13 +36631,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"temp-dir@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "temp-dir@npm:1.0.0"
-  checksum: cb2b58ddfb12efa83e939091386ad73b425c9a8487ea0095fe4653192a40d49184a771a1beba99045fbd011e389fd563122d79f54f82be86a55620667e08a6b2
-  languageName: node
-  linkType: hard
-
 "temp@npm:^0.8.4":
   version: 0.8.4
   resolution: "temp@npm:0.8.4"
@@ -38616,13 +36731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"text-extensions@npm:^1.0.0":
-  version: 1.9.0
-  resolution: "text-extensions@npm:1.9.0"
-  checksum: 56a9962c1b62d39b2bcb369b7558ca85c1b55e554b38dfd725edcc0a1babe5815782a60c17ff6b839093b163dfebb92b804208aaaea616ec7571c8059ae0cf44
-  languageName: node
-  linkType: hard
-
 "text-hex@npm:1.0.x":
   version: 1.0.0
   resolution: "text-hex@npm:1.0.0"
@@ -38676,16 +36784,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through2@npm:^2.0.0":
-  version: 2.0.5
-  resolution: "through2@npm:2.0.5"
-  dependencies:
-    readable-stream: ~2.3.6
-    xtend: ~4.0.1
-  checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
-  languageName: node
-  linkType: hard
-
 "through2@npm:^4.0.0":
   version: 4.0.2
   resolution: "through2@npm:4.0.2"
@@ -38695,7 +36793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1":
+"through@npm:2, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
@@ -38989,24 +37087,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"treeverse@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "treeverse@npm:2.0.0"
-  checksum: 3c6b2b890975a4d42c86b9a0f1eb932b4450db3fa874be5c301c4f5e306fd76330c6a490cf334b0937b3a44b049787ba5d98c88bc7b140f34fdb3ab1f83e5269
-  languageName: node
-  linkType: hard
-
 "trim-newlines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
-  languageName: node
-  linkType: hard
-
-"trim-off-newlines@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "trim-off-newlines@npm:1.0.3"
-  checksum: faf042bb7dd4cb097ab6d358cd51012a9ff5e06f7f2c6570da2ef6f01da9da3ff22ab01080866815e3927ffbf367d57c6aab4c275c67662676b60c563142a558
   languageName: node
   linkType: hard
 
@@ -39239,13 +37323,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.18.0":
-  version: 0.18.1
-  resolution: "type-fest@npm:0.18.1"
-  checksum: e96dcee18abe50ec82dab6cbc4751b3a82046da54c52e3b2d035b3c519732c0b3dd7a2fa9df24efd1a38d953d8d4813c50985f215f1957ee5e4f26b0fe0da395
-  languageName: node
-  linkType: hard
-
 "type-fest@npm:^0.20.2":
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
@@ -39257,13 +37334,6 @@ __metadata:
   version: 0.21.3
   resolution: "type-fest@npm:0.21.3"
   checksum: e6b32a3b3877f04339bae01c193b273c62ba7bfc9e325b8703c4ee1b32dc8fe4ef5dfa54bf78265e069f7667d058e360ae0f37be5af9f153b22382cd55a9afe0
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "type-fest@npm:0.4.1"
-  checksum: 25f882d9cc2f24af7a0a529157f96dead157894c456bfbad16d48f990c43b470dfb79848e8d9c03fe1be72a7d169e44f6f3135b54628393c66a6189c5dc077f7
   languageName: node
   linkType: hard
 
@@ -39313,15 +37383,6 @@ __metadata:
     tunnel: 0.0.6
     underscore: ^1.12.1
   checksum: 238e2139724310fed39756ae734fbc811e803abaa7598720ad6cc5ab7f160d415d8107551422b186f6b2e08c5761c0e7b66ca47d60b2ccd952bb5e20d3b92f3c
-  languageName: node
-  linkType: hard
-
-"typedarray-to-buffer@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "typedarray-to-buffer@npm:3.1.5"
-  dependencies:
-    is-typedarray: ^1.0.0
-  checksum: 99c11aaa8f45189fcfba6b8a4825fd684a321caa9bd7a76a27cf0c7732c174d198b99f449c52c3818107430b5f41c0ccbbfb75cb2ee3ca4a9451710986d61a60
   languageName: node
   linkType: hard
 
@@ -39777,13 +37838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"upath@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "upath@npm:2.0.1"
-  checksum: 2db04f24a03ef72204c7b969d6991abec9e2cb06fb4c13a1fd1c59bc33b46526b16c3325e55930a11ff86a77a8cbbcda8f6399bf914087028c5beae21ecdb33c
-  languageName: node
-  linkType: hard
-
 "update-browserslist-db@npm:^1.0.4":
   version: 1.0.5
   resolution: "update-browserslist-db@npm:1.0.5"
@@ -40077,7 +38131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.4":
+"validate-npm-package-license@npm:^3.0.1":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
@@ -40093,15 +38147,6 @@ __metadata:
   dependencies:
     builtins: ^1.0.3
   checksum: ce4c68207abfb22c05eedb09ff97adbcedc80304a235a0844f5344f1fd5086aa80e4dbec5684d6094e26e35065277b765c1caef68bcea66b9056761eddb22967
-  languageName: node
-  linkType: hard
-
-"validate-npm-package-name@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "validate-npm-package-name@npm:4.0.0"
-  dependencies:
-    builtins: ^5.0.0
-  checksum: a32fd537bad17fcb59cfd58ae95a414d443866020d448ec3b22e8d40550cb585026582a57efbe1f132b882eea4da8ac38ee35f7be0dd72988a3cb55d305a20c1
   languageName: node
   linkType: hard
 
@@ -40352,7 +38397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wcwidth@npm:>=1.0.1, wcwidth@npm:^1.0.0, wcwidth@npm:^1.0.1":
+"wcwidth@npm:>=1.0.1, wcwidth@npm:^1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
   dependencies:
@@ -40626,7 +38671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^8.0.0, whatwg-url@npm:^8.4.0, whatwg-url@npm:^8.5.0":
+"whatwg-url@npm:^8.0.0, whatwg-url@npm:^8.5.0":
   version: 8.7.0
   resolution: "whatwg-url@npm:8.7.0"
   dependencies:
@@ -40711,7 +38756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.0, wide-align@npm:^1.1.2, wide-align@npm:^1.1.5":
+"wide-align@npm:^1.1.0, wide-align@npm:^1.1.2":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:
@@ -40812,7 +38857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^2.3.0, write-file-atomic@npm:^2.4.2":
+"write-file-atomic@npm:^2.3.0":
   version: 2.4.3
   resolution: "write-file-atomic@npm:2.4.3"
   dependencies:
@@ -40820,18 +38865,6 @@ __metadata:
     imurmurhash: ^0.1.4
     signal-exit: ^3.0.2
   checksum: 2db81f92ae974fd87ab4a5e7932feacaca626679a7c98fcc73ad8fcea5a1950eab32fa831f79e9391ac99b562ca091ad49be37a79045bd65f595efbb8f4596ae
-  languageName: node
-  linkType: hard
-
-"write-file-atomic@npm:^3.0.0, write-file-atomic@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "write-file-atomic@npm:3.0.3"
-  dependencies:
-    imurmurhash: ^0.1.4
-    is-typedarray: ^1.0.0
-    signal-exit: ^3.0.2
-    typedarray-to-buffer: ^3.1.5
-  checksum: c55b24617cc61c3a4379f425fc62a386cc51916a9b9d993f39734d005a09d5a4bb748bc251f1304e7abd71d0a26d339996c275955f527a131b1dcded67878280
   languageName: node
   linkType: hard
 
@@ -40852,45 +38885,6 @@ __metadata:
     imurmurhash: ^0.1.4
     signal-exit: ^3.0.7
   checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
-  languageName: node
-  linkType: hard
-
-"write-json-file@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "write-json-file@npm:3.2.0"
-  dependencies:
-    detect-indent: ^5.0.0
-    graceful-fs: ^4.1.15
-    make-dir: ^2.1.0
-    pify: ^4.0.1
-    sort-keys: ^2.0.0
-    write-file-atomic: ^2.4.2
-  checksum: 2b97ce2027d53c28a33e4a8e7b0d565faf785988b3776f9e0c68d36477c1fb12639fd0d70877d92a861820707966c62ea9c5f7a36a165d615fd47ca8e24c8371
-  languageName: node
-  linkType: hard
-
-"write-json-file@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "write-json-file@npm:4.3.0"
-  dependencies:
-    detect-indent: ^6.0.0
-    graceful-fs: ^4.1.15
-    is-plain-obj: ^2.0.0
-    make-dir: ^3.0.0
-    sort-keys: ^4.0.0
-    write-file-atomic: ^3.0.0
-  checksum: 33908c591923dc273e6574e7c0e2df157acfcf498e3a87c5615ced006a465c4058877df6abce6fc1acd2844fa3cf4518ace4a34d5d82ab28bcf896317ba1db6f
-  languageName: node
-  linkType: hard
-
-"write-pkg@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "write-pkg@npm:4.0.0"
-  dependencies:
-    sort-keys: ^2.0.0
-    type-fest: ^0.4.1
-    write-json-file: ^3.2.0
-  checksum: 7864d44370f42a6761f6898d07ee2818c7a2faad45116580cf779f3adaf94e4bea5557612533a6c421c32323253ecb63b50615094960a637aeaef5df0fd2d6cd
   languageName: node
   linkType: hard
 
@@ -41127,7 +39121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
@@ -41194,13 +39188,6 @@ __metadata:
   version: 2.1.1
   resolution: "yaml@npm:2.1.1"
   checksum: f48bb209918aa57cfaf78ef6448d1a1f8187f45c746f933268b7023dc59e5456004611879126c9bb5ea55b0a2b1c2b392dfde436931ece0c703a3d754562bb96
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:20.2.4, yargs-parser@npm:^20.2.3":
-  version: 20.2.4
-  resolution: "yargs-parser@npm:20.2.4"
-  checksum: d251998a374b2743a20271c2fd752b9fbef24eb881d53a3b99a7caa5e8227fcafd9abf1f345ac5de46435821be25ec12189a11030c12ee6481fef6863ed8b924
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
🧹 🎉 ✨ 

Depends on #13520, #13519, #13574

Want to verify the publishing flow somehow before merging this too.

I'm not updating `create-app` since that still ships Yarn v1, so we don't have the new `workspaces foreach` command. Once the removal of the dependencies on Lerna in the CLI have been release I figure we'll add instructions to the Yarn v3 migration guide for how to remove Lerna.
