### PR TITLE
Scaffolder - Addition of  Dismissable Error Banner  

### DIFF
--- a/.changeset/new-taxis-vanish.md
+++ b/.changeset/new-taxis-vanish.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Addition of a Dismissable Error Banner in Scaffolder page
+Addition of a dismissible Error Banner in Scaffolder page

--- a/.changeset/new-taxis-vanish.md
+++ b/.changeset/new-taxis-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Addition of a Dismissable Error Banner in Scaffolder page

--- a/plugins/scaffolder/src/components/TaskPage/TaskErrors.tsx
+++ b/plugins/scaffolder/src/components/TaskPage/TaskErrors.tsx
@@ -14,21 +14,25 @@
  * limitations under the License.
  */
 import { Box } from '@material-ui/core';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { DismissableBanner } from '@backstage/core-components';
-import { TaskStream } from '../hooks/useEventStream';
 
-type TaskPageLinksProps = {
-  taskStream: TaskStream;
+type TaskErrorsProps = {
+  error?: Error;
 };
 
-export const TaskErrors = ({ taskStream }: TaskPageLinksProps) => {
-  return taskStream.error ? (
+export const TaskErrors = ({ error }: TaskErrorsProps) => {
+  const id = useRef('');
+
+  useEffect(() => {
+    id.current = String(Math.random());
+  }, [error]);
+  return error ? (
     <Box>
       <DismissableBanner
-        id={String(Math.random())}
+        id={id.current}
         variant="warning"
-        message={taskStream.error.message}
+        message={error.message}
       />
     </Box>
   ) : null;

--- a/plugins/scaffolder/src/components/TaskPage/TaskErrors.tsx
+++ b/plugins/scaffolder/src/components/TaskPage/TaskErrors.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Box } from '@material-ui/core';
+import React from 'react';
+import { DismissableBanner } from '@backstage/core-components';
+import { TaskStream } from '../hooks/useEventStream';
+
+type TaskPageLinksProps = {
+  taskStream: TaskStream;
+};
+
+export const TaskErrors = ({ taskStream }: TaskPageLinksProps) => {
+  return taskStream.error ? (
+    <Box>
+      <DismissableBanner
+        id={String(Math.random())}
+        variant="warning"
+        message={taskStream.error.message}
+      />
+    </Box>
+  ) : null;
+};

--- a/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
+++ b/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
@@ -357,7 +357,7 @@ export const TaskPage = ({ loadingText }: TaskPageProps) => {
                 {!currentStepId && <Progress />}
 
                 <div style={{ height: '80vh' }}>
-                  <TaskErrors taskStream={taskStream} />
+                  <TaskErrors error={taskStream.error} />
                   <LogViewer text={logAsString} />
                 </div>
               </Grid>

--- a/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
+++ b/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
@@ -54,6 +54,7 @@ import {
 } from '../../routes';
 import { ScaffolderTaskStatus, ScaffolderTaskOutput } from '../../types';
 import { useTaskEventStream } from '../hooks/useEventStream';
+import { TaskErrors } from './TaskErrors';
 import { TaskPageLinks } from './TaskPageLinks';
 
 // typings are wrong for this library, so fallback to not parsing types.
@@ -356,6 +357,7 @@ export const TaskPage = ({ loadingText }: TaskPageProps) => {
                 {!currentStepId && <Progress />}
 
                 <div style={{ height: '80vh' }}>
+                  <TaskErrors taskStream={taskStream} />
                   <LogViewer text={logAsString} />
                 </div>
               </Grid>

--- a/plugins/scaffolder/src/components/hooks/useEventStream.ts
+++ b/plugins/scaffolder/src/components/hooks/useEventStream.ts
@@ -49,6 +49,7 @@ type ReducerLogEntry = {
     status?: ScaffolderTaskStatus;
     message: string;
     output?: ScaffolderTaskOutput;
+    error?: Error;
   };
 };
 
@@ -114,6 +115,8 @@ function reducer(draft: TaskStream, action: ReducerAction) {
     case 'COMPLETED': {
       draft.completed = true;
       draft.output = action.data.body.output;
+      draft.error = action.data.body.error;
+
       return;
     }
 


### PR DESCRIPTION
Signed-off-by: mufaddal motiwala <mufaddalmm.52@gmail.com>

## Hey, I just made a Pull Request!

This PR is our first step to enhance exception handling in the Scaffolder and show it back to the user. 

Currently I have made a simple change and have managed to show the user an error pop up , whenever an error is getting logged in the completion phase using the existing `TaskStream` features.

![image](https://user-images.githubusercontent.com/42934221/188331238-21a05816-c9cc-4f1f-9b98-7ef26843dba5.png)



## Future
The future plan is to enhance exception handling by adding the Error field to  `TaskEventType` , something like this -

`export type TaskEventType = 'completion' | 'log' | 'error';`




#12760
