### PR TITLE
add missing cli dependencies to be able to run yarn test etc

### DIFF
--- a/.changeset/cold-pumpkins-mate.md
+++ b/.changeset/cold-pumpkins-mate.md
@@ -1,0 +1,15 @@
+---
+'@backstage/cli-common': patch
+'@backstage/codemods': patch
+'@backstage/config': patch
+'@backstage/config-loader': patch
+'@backstage/create-app': patch
+'@backstage/release-manifests': patch
+'@backstage/plugin-cicd-statistics': patch
+'@backstage/plugin-scaffolder-backend-module-yeoman': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-stack-overflow-backend': patch
+'@backstage/plugin-techdocs-react': patch
+---
+
+Add missing dependency on `@backstage/cli`

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -32,6 +32,7 @@
     "start": "backstage-cli package start"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.0.0"
   },

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -39,6 +39,7 @@
     "jscodeshift-add-imports": "^1.0.10"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/jscodeshift": "^0.11.0",
     "@types/node": "^16.11.26",
     "commander": "^9.1.0",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -50,6 +50,7 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/jest": "^26.0.7",
     "@types/json-schema-merge-allof": "^0.6.0",
     "@types/mock-fs": "^4.10.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@backstage/test-utils": "^1.2.0-next.1",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.0.0"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -42,6 +42,7 @@
     "recursive-readdir": "^2.2.2"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/fs-extra": "^9.0.1",
     "@types/inquirer": "^8.1.3",
     "@types/node": "^16.11.26",

--- a/packages/e2e-test/package.json
+++ b/packages/e2e-test/package.json
@@ -27,6 +27,7 @@
   },
   "bin": "bin/e2e-test",
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@backstage/cli-common": "^0.1.9-next.0",
     "@backstage/errors": "^1.1.0-next.0",
     "@types/fs-extra": "^9.0.1",

--- a/packages/release-manifests/package.json
+++ b/packages/release-manifests/package.json
@@ -35,6 +35,7 @@
     "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@backstage/test-utils": "^1.2.0-next.1",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.0.0",

--- a/plugins/catalog-customized/package.json
+++ b/plugins/catalog-customized/package.json
@@ -38,6 +38,7 @@
     "@backstage/plugin-catalog-react": "^1.1.4-next.0"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/react": "^16.13.1 || ^17.0.0"
   },
   "peerDependencies": {

--- a/plugins/cicd-statistics/package.json
+++ b/plugins/cicd-statistics/package.json
@@ -32,6 +32,7 @@
     "start": "backstage-cli package start"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/luxon": "^3.0.0",
     "@types/react": "^16.13.1 || ^17.0.0"
   },

--- a/plugins/scaffolder-backend-module-yeoman/package.json
+++ b/plugins/scaffolder-backend-module-yeoman/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@backstage/backend-common": "^0.15.1-next.0",
+    "@backstage/cli": "^0.19.0-next.1",
     "@types/jest": "^26.0.7"
   },
   "files": [

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -48,6 +48,7 @@
     "react-router": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@backstage/core-app-api": "^1.1.0-next.1",
     "@backstage/test-utils": "^1.2.0-next.1",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/stack-overflow-backend/package.json
+++ b/plugins/stack-overflow-backend/package.json
@@ -38,6 +38,9 @@
     "qs": "^6.9.4",
     "winston": "^3.2.1"
   },
+  "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1"
+  },
   "files": [
     "dist",
     "config.d.ts"

--- a/plugins/techdocs-react/package.json
+++ b/plugins/techdocs-react/package.json
@@ -53,6 +53,7 @@
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
+    "@backstage/cli": "^0.19.0-next.1",
     "@backstage/test-utils": "^1.2.0-next.1",
     "@backstage/theme": "^0.2.16",
     "@testing-library/jest-dom": "^5.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3055,6 +3055,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/cli-common@workspace:packages/cli-common"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@types/jest": ^26.0.7
     "@types/node": ^16.0.0
   languageName: unknown
@@ -3203,6 +3204,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/codemods@workspace:packages/codemods"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/cli-common": ^0.1.9
     "@types/jscodeshift": ^0.11.0
     "@types/node": ^16.11.26
@@ -3220,6 +3222,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/config-loader@workspace:packages/config-loader"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/cli-common": ^0.1.9
     "@backstage/config": ^1.0.1
     "@backstage/errors": ^1.1.0
@@ -3249,6 +3252,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/config@workspace:packages/config"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/test-utils": ^1.2.0-next.1
     "@backstage/types": ^1.0.0
     "@types/jest": ^26.0.7
@@ -3468,6 +3472,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/create-app@workspace:packages/create-app"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/cli-common": ^0.1.9
     "@types/fs-extra": ^9.0.1
     "@types/inquirer": ^8.1.3
@@ -4806,6 +4811,7 @@ __metadata:
   resolution: "@backstage/plugin-cicd-statistics@workspace:plugins/cicd-statistics"
   dependencies:
     "@backstage/catalog-model": ^1.1.0
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/core-plugin-api": ^1.0.6-next.1
     "@backstage/plugin-catalog-react": ^1.1.4-next.1
     "@date-io/luxon": ^1.3.13
@@ -6375,6 +6381,7 @@ __metadata:
   resolution: "@backstage/plugin-scaffolder-backend-module-yeoman@workspace:plugins/scaffolder-backend-module-yeoman"
   dependencies:
     "@backstage/backend-common": ^0.15.1-next.0
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/config": ^1.0.1
     "@backstage/plugin-scaffolder-backend": ^1.6.0-next.0
     "@backstage/types": ^1.0.0
@@ -6635,6 +6642,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-search-react@workspace:plugins/search-react"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/core-app-api": ^1.1.0-next.1
     "@backstage/core-components": ^0.11.1-next.1
     "@backstage/core-plugin-api": ^1.0.6-next.1
@@ -6855,6 +6863,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-stack-overflow-backend@workspace:plugins/stack-overflow-backend"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/config": ^1.0.1
     "@backstage/plugin-search-common": ^1.0.1-next.0
     node-fetch: ^2.6.7
@@ -7208,6 +7217,7 @@ __metadata:
   resolution: "@backstage/plugin-techdocs-react@workspace:plugins/techdocs-react"
   dependencies:
     "@backstage/catalog-model": ^1.1.0
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/config": ^1.0.1
     "@backstage/core-components": ^0.11.1-next.1
     "@backstage/core-plugin-api": ^1.0.6-next.1
@@ -7458,6 +7468,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/release-manifests@workspace:packages/release-manifests"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/test-utils": ^1.2.0-next.1
     "@types/jest": ^26.0.7
     "@types/node": ^16.0.0
@@ -9159,6 +9170,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/plugin-catalog-customized@workspace:plugins/catalog-customized"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/plugin-catalog": ^1.5.1-next.0
     "@backstage/plugin-catalog-react": ^1.1.4-next.0
     "@types/react": ^16.13.1 || ^17.0.0
@@ -21315,6 +21327,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e2e-test@workspace:packages/e2e-test"
   dependencies:
+    "@backstage/cli": ^0.19.0-next.1
     "@backstage/cli-common": ^0.1.9-next.0
     "@backstage/errors": ^1.1.0-next.0
     "@types/fs-extra": ^9.0.1


### PR DESCRIPTION
See warnings about missing backstage-cli (after the yarn3 migration) https://github.com/backstage/backstage/runs/8177619519?check_suite_focus=true#step:8:8027