### PR TITLE
cli: avoid backend schema processing when loading config

### DIFF
--- a/.changeset/gold-fishes-yawn.md
+++ b/.changeset/gold-fishes-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Avoid validating the backend configuration schema when loading static configuration for building the frontend.

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -64,10 +64,8 @@ export async function serveBundle(options: ServeOptions) {
       https:
         url.protocol === 'https:'
           ? {
-              cert: options.backendConfig.getString(
-                'app.https.certificate.cert',
-              ),
-              key: options.backendConfig.getString('app.https.certificate.key'),
+              cert: options.fullConfig.getString('app.https.certificate.cert'),
+              key: options.fullConfig.getString('app.https.certificate.key'),
             }
           : false,
       host,

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -31,7 +31,7 @@ export type ServeOptions = BundlingPathsOptions & {
   checksEnabled: boolean;
   frontendConfig: Config;
   frontendAppConfigs: AppConfig[];
-  backendConfig: Config;
+  fullConfig: Config;
 };
 
 export type BuildOptions = BundlingPathsOptions & {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -96,15 +96,14 @@ export async function loadCliConfig(options: Options) {
     });
     const frontendConfig = ConfigReader.fromConfigs(frontendAppConfigs);
 
-    const backendAppConfigs = schema.process(appConfigs);
-    const backendConfig = ConfigReader.fromConfigs(backendAppConfigs);
+    const fullConfig = ConfigReader.fromConfigs(appConfigs);
 
     return {
       schema,
       appConfigs,
       frontendConfig,
       frontendAppConfigs,
-      backendConfig,
+      fullConfig,
     };
   } catch (error) {
     const maybeSchemaError = error as Error & { messages?: string[] };


### PR DESCRIPTION
Followup of #13338. Adding the backend schema check I feel is too strict. In theory it should be alright due to only the correct backend schema being involved, but in practice the CLI has a dev dependency on backend-common and scaffolder backend, both leading to unnecessary requirements on config values being present.