### PR TITLE
fix(techdocs): Fix scrolling for anchors on the current page

### DIFF
--- a/.changeset/tender-pumpkins-burn.md
+++ b/.changeset/tender-pumpkins-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed a bug where scrolling for anchors where the id starts with number didn't work for the current page.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -184,7 +184,7 @@ export const useTechDocsReaderDom = (
                 navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
                 // Scroll to hash if it's on the current page
                 transformedElement
-                  ?.querySelector(`#${parsedUrl.hash.slice(1)}`)
+                  ?.querySelector(`[id="${parsedUrl.hash.slice(1)}"]`)
                   ?.scrollIntoView();
               }
             } else {


### PR DESCRIPTION
Signed-off-by: drankou <aliaksandr.drankou@productboard.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fixes the issue where clicking on the anchor(which id starts with number) on the current page resulted in an invalid `querySelector`:
![image](https://user-images.githubusercontent.com/25752851/188411702-f9f6a527-c9c4-4155-8093-40193563338d.png)

Related to https://github.com/backstage/backstage/pull/10311

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
