### PR TITLE
workflows: fix yarn lerna invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: test changed packages
         if: ${{ steps.yarn-lock.outcome == 'success' }}
-        run: yarn lerna -- run test --since origin/master -- --coverage --runInBand
+        run: yarn lerna run test --since origin/master -- --coverage --runInBand
         env:
           BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
@@ -208,7 +208,7 @@ jobs:
       - name: test all packages (and upload coverage)
         if: ${{ steps.yarn-lock.outcome == 'failure' }}
         run: |
-          yarn lerna -- run test -- --coverage --runInBand
+          yarn lerna run test -- --coverage --runInBand
           bash <(curl -s https://codecov.io/bash) -N $(git rev-parse FETCH_HEAD)
         env:
           BACKSTAGE_NEXT_TESTS: 1

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: test (and upload coverage)
         run: |
-          yarn lerna -- run test -- --coverage --runInBand
+          yarn lerna run test -- --coverage --runInBand
           bash <(curl -s https://codecov.io/bash)
           # Upload code coverage for some specific flags. Also see .codecov.yml
           bash <(curl -s https://codecov.io/bash) -f packages/core-app-api/coverage/* -F core-app-api
@@ -163,9 +163,9 @@ jobs:
       - name: publish
         run: |
           if [ -f ".changeset/pre.json" ]; then
-              yarn lerna -- publish from-package --yes --dist-tag next
+              yarn lerna publish from-package --yes --dist-tag next
           else
-              yarn lerna -- publish from-package --yes
+              yarn lerna publish from-package --yes
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn lint:type-deps
 
       - name: test
-        run: yarn lerna -- run test
+        run: yarn lerna run test
         env:
           BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1


### PR DESCRIPTION
Turns out the `yarn lerna --` syntax is broken with Yarn v3 and results in nothing being run.