### PR TITLE
techdocs: fix addons not rendering on subpages with react router v6

### DIFF
--- a/.changeset/moody-berries-sneeze.md
+++ b/.changeset/moody-berries-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed a bug where addons wouldn't render on sub pages when using React Route v6 stable.

--- a/plugins/techdocs/src/Router.tsx
+++ b/plugins/techdocs/src/Router.tsx
@@ -68,7 +68,7 @@ export const EmbeddedDocsRouter = (props: PropsWithChildren<{}>) => {
       element: <EntityPageDocs entity={entity} />,
       children: [
         {
-          path: '/*',
+          path: '*',
           element: children,
         },
       ],


### PR DESCRIPTION
🧹 

Verified towards both React Router v6 stable and `beta.0`.