### PR TITLE
Reset error on success path

### DIFF
--- a/.changeset/rare-tips-glow.md
+++ b/.changeset/rare-tips-glow.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+[Bugfix][bugfix]: reset error state on success
+
+[bugfix]: https://github.com/backstage/backstage/pull/13539

--- a/.changeset/rare-tips-glow.md
+++ b/.changeset/rare-tips-glow.md
@@ -2,6 +2,4 @@
 '@backstage/plugin-kubernetes': patch
 ---
 
-[Bugfix][bugfix]: reset error state on success
-
-[bugfix]: https://github.com/backstage/backstage/pull/13539
+Reset error state on success

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -337,9 +337,9 @@ export const KubernetesDrawer: <T extends KubernetesDrawerable>({
 // @public (undocumented)
 export interface KubernetesObjects {
   // (undocumented)
-  error: string | undefined;
+  error?: string;
   // (undocumented)
-  kubernetesObjects: ObjectsByEntityResponse | undefined;
+  kubernetesObjects?: ObjectsByEntityResponse;
 }
 
 // Warning: (ae-missing-release-tag) "kubernetesPlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.test.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.test.ts
@@ -125,6 +125,8 @@ describe('useKubernetesObjects', () => {
     );
 
     await waitForNextUpdate();
+    expect(result.current.error).toBeUndefined();
+
     await waitForNextUpdate();
 
     expect(result.current.error).toBeUndefined();
@@ -198,5 +200,139 @@ describe('useKubernetesObjects', () => {
       entity,
     });
     expect(mockGetObjectsByEntity).toHaveBeenCalledTimes(0);
+  });
+
+  describe('when retrying', () => {
+    it('should reset error after getClusters has failed and then succeeded', async () => {
+      (useApi as any).mockReturnValue({
+        getClusters: mockGetClusters
+          .mockRejectedValueOnce({ message: 'some-error' })
+          .mockResolvedValue(getClustersResponse),
+        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth.mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBe('some-error')
+      expect(result.current.kubernetesObjects).toBeUndefined()
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.kubernetesObjects).not.toBeUndefined()
+    })
+
+    it('should reset error after decorateRequestBodyForAuth has failed and then succeeded', async () => {
+      (useApi as any).mockReturnValue({
+        getClusters: mockGetClusters.mockResolvedValue(getClustersResponse),
+        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
+          .mockRejectedValueOnce({ message: 'decoration failed' })
+          .mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBe('decoration failed')
+      expect(result.current.kubernetesObjects).toBeUndefined()
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.kubernetesObjects).not.toBeUndefined()
+    })
+
+    it('should reset error after getObjectsByEntity has failed and then succeeded', async () => {
+      (useApi as any).mockReturnValue({
+        getClusters: mockGetClusters.mockResolvedValue(getClustersResponse),
+        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
+          .mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity.mockRejectedValueOnce({ message: 'failed to fetch' }).mockResolvedValue(mockResponse)
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBe('failed to fetch')
+      expect(result.current.kubernetesObjects).toBeUndefined()
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.kubernetesObjects).not.toBeUndefined()
+    })
+
+    it('should reset data after getClusters succeeded then failed', async () => {
+      (useApi as any).mockReturnValue({
+        getClusters: mockGetClusters
+          .mockResolvedValueOnce(getClustersResponse)
+          .mockRejectedValue({ message: "fetch clusters failed" }),
+        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
+          .mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+      })
+      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.kubernetesObjects).not.toBeUndefined()
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBe('fetch clusters failed')
+      expect(result.current.kubernetesObjects).toBeUndefined()
+    })
+
+    it('should reset data after decorateBodyForAuth succeeded then failed', async () => {
+      (useApi as any).mockReturnValue({
+        getClusters: mockGetClusters.mockResolvedValue(getClustersResponse),
+        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
+          // this call happens twice per successful hook render
+          .mockResolvedValueOnce(entityWithAuthToken)
+          .mockResolvedValueOnce(entityWithAuthToken)
+          .mockRejectedValue({ message: 'decorate failed' }),
+        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.kubernetesObjects).not.toBeUndefined()
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBe('decorate failed')
+      expect(result.current.kubernetesObjects).toBeUndefined()
+    });
+
+    it('should reset data after getObjectsByEntity succeeded then failed', async () => {
+      (useApi as any).mockReturnValue({
+        getClusters: mockGetClusters.mockResolvedValue(getClustersResponse),
+        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
+          .mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValueOnce(mockResponse).mockRejectedValue({ message: 'failed to fetch' })
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.kubernetesObjects).not.toBeUndefined()
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toBe('failed to fetch')
+      expect(result.current.kubernetesObjects).toBeUndefined()
+    })
   });
 });

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.test.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.test.ts
@@ -208,22 +208,26 @@ describe('useKubernetesObjects', () => {
         getClusters: mockGetClusters
           .mockRejectedValueOnce({ message: 'some-error' })
           .mockResolvedValue(getClustersResponse),
-        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth.mockResolvedValue(entityWithAuthToken),
-        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+        decorateRequestBodyForAuth:
+          mockDecorateRequestBodyForAuth.mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity:
+          mockGetObjectsByEntity.mockResolvedValue(mockResponse),
       });
 
-      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useKubernetesObjects(entity, 100),
+      );
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBe('some-error')
-      expect(result.current.kubernetesObjects).toBeUndefined()
+      expect(result.current.error).toBe('some-error');
+      expect(result.current.kubernetesObjects).toBeUndefined();
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBeUndefined()
-      expect(result.current.kubernetesObjects).not.toBeUndefined()
-    })
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.kubernetesObjects).not.toBeUndefined();
+    });
 
     it('should reset error after decorateRequestBodyForAuth has failed and then succeeded', async () => {
       (useApi as any).mockReturnValue({
@@ -231,64 +235,74 @@ describe('useKubernetesObjects', () => {
         decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
           .mockRejectedValueOnce({ message: 'decoration failed' })
           .mockResolvedValue(entityWithAuthToken),
-        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+        getObjectsByEntity:
+          mockGetObjectsByEntity.mockResolvedValue(mockResponse),
       });
 
-      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useKubernetesObjects(entity, 100),
+      );
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBe('decoration failed')
-      expect(result.current.kubernetesObjects).toBeUndefined()
+      expect(result.current.error).toBe('decoration failed');
+      expect(result.current.kubernetesObjects).toBeUndefined();
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBeUndefined()
-      expect(result.current.kubernetesObjects).not.toBeUndefined()
-    })
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.kubernetesObjects).not.toBeUndefined();
+    });
 
     it('should reset error after getObjectsByEntity has failed and then succeeded', async () => {
       (useApi as any).mockReturnValue({
         getClusters: mockGetClusters.mockResolvedValue(getClustersResponse),
-        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
-          .mockResolvedValue(entityWithAuthToken),
-        getObjectsByEntity: mockGetObjectsByEntity.mockRejectedValueOnce({ message: 'failed to fetch' }).mockResolvedValue(mockResponse)
+        decorateRequestBodyForAuth:
+          mockDecorateRequestBodyForAuth.mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity
+          .mockRejectedValueOnce({ message: 'failed to fetch' })
+          .mockResolvedValue(mockResponse),
       });
 
-      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useKubernetesObjects(entity, 100),
+      );
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBe('failed to fetch')
-      expect(result.current.kubernetesObjects).toBeUndefined()
+      expect(result.current.error).toBe('failed to fetch');
+      expect(result.current.kubernetesObjects).toBeUndefined();
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBeUndefined()
-      expect(result.current.kubernetesObjects).not.toBeUndefined()
-    })
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.kubernetesObjects).not.toBeUndefined();
+    });
 
     it('should reset data after getClusters succeeded then failed', async () => {
       (useApi as any).mockReturnValue({
         getClusters: mockGetClusters
           .mockResolvedValueOnce(getClustersResponse)
-          .mockRejectedValue({ message: "fetch clusters failed" }),
-        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
-          .mockResolvedValue(entityWithAuthToken),
-        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
-      })
-      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+          .mockRejectedValue({ message: 'fetch clusters failed' }),
+        decorateRequestBodyForAuth:
+          mockDecorateRequestBodyForAuth.mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity:
+          mockGetObjectsByEntity.mockResolvedValue(mockResponse),
+      });
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useKubernetesObjects(entity, 100),
+      );
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBeUndefined()
-      expect(result.current.kubernetesObjects).not.toBeUndefined()
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.kubernetesObjects).not.toBeUndefined();
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBe('fetch clusters failed')
-      expect(result.current.kubernetesObjects).toBeUndefined()
-    })
+      expect(result.current.error).toBe('fetch clusters failed');
+      expect(result.current.kubernetesObjects).toBeUndefined();
+    });
 
     it('should reset data after decorateBodyForAuth succeeded then failed', async () => {
       (useApi as any).mockReturnValue({
@@ -298,41 +312,48 @@ describe('useKubernetesObjects', () => {
           .mockResolvedValueOnce(entityWithAuthToken)
           .mockResolvedValueOnce(entityWithAuthToken)
           .mockRejectedValue({ message: 'decorate failed' }),
-        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValue(mockResponse)
+        getObjectsByEntity:
+          mockGetObjectsByEntity.mockResolvedValue(mockResponse),
       });
 
-      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useKubernetesObjects(entity, 100),
+      );
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBeUndefined()
-      expect(result.current.kubernetesObjects).not.toBeUndefined()
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.kubernetesObjects).not.toBeUndefined();
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBe('decorate failed')
-      expect(result.current.kubernetesObjects).toBeUndefined()
+      expect(result.current.error).toBe('decorate failed');
+      expect(result.current.kubernetesObjects).toBeUndefined();
     });
 
     it('should reset data after getObjectsByEntity succeeded then failed', async () => {
       (useApi as any).mockReturnValue({
         getClusters: mockGetClusters.mockResolvedValue(getClustersResponse),
-        decorateRequestBodyForAuth: mockDecorateRequestBodyForAuth
-          .mockResolvedValue(entityWithAuthToken),
-        getObjectsByEntity: mockGetObjectsByEntity.mockResolvedValueOnce(mockResponse).mockRejectedValue({ message: 'failed to fetch' })
+        decorateRequestBodyForAuth:
+          mockDecorateRequestBodyForAuth.mockResolvedValue(entityWithAuthToken),
+        getObjectsByEntity: mockGetObjectsByEntity
+          .mockResolvedValueOnce(mockResponse)
+          .mockRejectedValue({ message: 'failed to fetch' }),
       });
 
-      const { result, waitForNextUpdate } = renderHook(() => useKubernetesObjects(entity, 100))
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useKubernetesObjects(entity, 100),
+      );
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBeUndefined()
-      expect(result.current.kubernetesObjects).not.toBeUndefined()
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.kubernetesObjects).not.toBeUndefined();
 
       await waitForNextUpdate();
 
-      expect(result.current.error).toBe('failed to fetch')
-      expect(result.current.kubernetesObjects).toBeUndefined()
-    })
+      expect(result.current.error).toBe('failed to fetch');
+      expect(result.current.kubernetesObjects).toBeUndefined();
+    });
   });
 });

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
@@ -38,7 +38,7 @@ export const useKubernetesObjects = (
   const kubernetesAuthProvidersApi = useApi(kubernetesAuthProvidersApiRef);
   const [result, setResult] = useState<KubernetesObjects>({
     kubernetesObjects: undefined,
-    error: undefined
+    error: undefined,
   });
 
   const getObjects = async () => {
@@ -55,7 +55,8 @@ export const useKubernetesObjects = (
       ...new Set(
         clusters.map(
           c =>
-            `${c.authProvider}${c.oidcTokenProvider ? `.${c.oidcTokenProvider}` : ''
+            `${c.authProvider}${
+              c.oidcTokenProvider ? `.${c.oidcTokenProvider}` : ''
             }`,
         ),
       ),
@@ -81,9 +82,9 @@ export const useKubernetesObjects = (
 
     try {
       const objects = await kubernetesApi.getObjectsByEntity(requestBody);
-      setResult({ kubernetesObjects: objects })
+      setResult({ kubernetesObjects: objects });
     } catch (e) {
-      setResult({ error: e.message })
+      setResult({ error: e.message });
       return;
     }
   };

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
@@ -47,6 +47,7 @@ export const useKubernetesObjects = (
 
     try {
       clusters = await kubernetesApi.getClusters();
+      setError(null);
     } catch (e) {
       setError(e.message);
       return;
@@ -75,6 +76,7 @@ export const useKubernetesObjects = (
             authProviderStr,
             requestBody,
           );
+        setError(null);
       } catch (e) {
         setError(e.message);
         return;
@@ -83,6 +85,7 @@ export const useKubernetesObjects = (
 
     try {
       setKubernetesObjects(await kubernetesApi.getObjectsByEntity(requestBody));
+      setError(null);
     } catch (e) {
       setError(e.message);
       return;

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
@@ -26,8 +26,8 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 
 export interface KubernetesObjects {
-  kubernetesObjects: ObjectsByEntityResponse | undefined;
-  error: string | undefined;
+  kubernetesObjects?: ObjectsByEntityResponse;
+  error?: string;
 }
 
 export const useKubernetesObjects = (
@@ -36,20 +36,18 @@ export const useKubernetesObjects = (
 ): KubernetesObjects => {
   const kubernetesApi = useApi(kubernetesApiRef);
   const kubernetesAuthProvidersApi = useApi(kubernetesAuthProvidersApiRef);
-  const [kubernetesObjects, setKubernetesObjects] = useState<
-    ObjectsByEntityResponse | undefined
-  >(undefined);
-
-  const [error, setError] = useState<string | undefined>(undefined);
+  const [result, setResult] = useState<KubernetesObjects>({
+    kubernetesObjects: undefined,
+    error: undefined
+  });
 
   const getObjects = async () => {
     let clusters = [];
 
     try {
       clusters = await kubernetesApi.getClusters();
-      setError(null);
     } catch (e) {
-      setError(e.message);
+      setResult({ error: e.message });
       return;
     }
 
@@ -76,18 +74,17 @@ export const useKubernetesObjects = (
             authProviderStr,
             requestBody,
           );
-        setError(null);
       } catch (e) {
-        setError(e.message);
+        setResult({ error: e.message });
         return;
       }
     }
 
     try {
-      setKubernetesObjects(await kubernetesApi.getObjectsByEntity(requestBody));
-      setError(null);
+      const objects = await kubernetesApi.getObjectsByEntity(requestBody);
+      setResult({ kubernetesObjects: objects })
     } catch (e) {
-      setError(e.message);
+      setResult({ error: e.message })
       return;
     }
   };
@@ -102,8 +99,5 @@ export const useKubernetesObjects = (
     getObjects();
   }, intervalMs);
 
-  return {
-    kubernetesObjects,
-    error,
-  };
+  return result;
 };

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
@@ -55,8 +55,7 @@ export const useKubernetesObjects = (
       ...new Set(
         clusters.map(
           c =>
-            `${c.authProvider}${
-              c.oidcTokenProvider ? `.${c.oidcTokenProvider}` : ''
+            `${c.authProvider}${c.oidcTokenProvider ? `.${c.oidcTokenProvider}` : ''
             }`,
         ),
       ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

If a re-render - or simply the intervalMs parameter - causes a retry that
turns a previously failed operation into a successful one, the error was
previously not reset, resulting in the somewhat odd combination of an
error message and a full, successful, response data object.

This change ensures that the error state is reset every time an operation
succeeds, so the UI state remains consistent.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
