### PR TITLE
Optimise GitHub access tokens

### DIFF
--- a/.changeset/sweet-grapes-explain.md
+++ b/.changeset/sweet-grapes-explain.md
@@ -1,0 +1,8 @@
+---
+'@backstage/integration': minor
+---
+
+Improved caching around github app tokens.
+Tokens are now cached for 50 minutes, not 10.
+Calls to get app installations are also included in this cache.
+If you have more than one github app configured, consider adding `allowedInstallationOwners` to your apps configuration to gain the most benefit from these performance changes.

--- a/.changeset/sweet-grapes-explain.md
+++ b/.changeset/sweet-grapes-explain.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/integration': minor
+'@backstage/integration': patch
 ---
 
 Improved caching around github app tokens.

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -100,7 +100,7 @@ integrations:
 If you want to limit the GitHub app installations visible to backstage you may
 optionally include the `allowedInstallationOwners` option. If you configure
 multiple apps, specifying this will bring some small performance benefits
-as backstage can more easily select which app to use for a url.
+as backstage can more easily select which app to use for a URL.
 
 ```yaml
 appId: app id

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -98,7 +98,9 @@ integrations:
 ### Limiting the GitHub App installations
 
 If you want to limit the GitHub app installations visible to backstage you may
-optionally include the `allowedInstallationOwners` option.
+optionally include the `allowedInstallationOwners` option. If you configure
+multiple apps, specifying this will bring some small performance benefits
+as backstage can more easily select which app to use for a url.
 
 ```yaml
 appId: app id

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
@@ -57,6 +57,7 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       token: 'hardcoded_token',
     });
   });
+
   it('create repository specific tokens', async () => {
     octokit.apps.listInstallations.mockResolvedValue({
       headers: {
@@ -65,11 +66,6 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       data: [
         {
           id: 1,
-          repository_selection: 'selected',
-          account: null,
-        },
-        {
-          id: 2,
           repository_selection: 'selected',
           account: {
             login: 'backstage',
@@ -195,8 +191,13 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       data: {
         expires_at: DateTime.local().plus({ hours: 1 }).toString(),
         token: 'secret_token',
+        repository_selection: 'selected',
       },
     } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+    octokit.apps.listReposAccessibleToInstallation.mockReturnValue({
+      data: [{ name: 'some-repo' }],
+    } as unknown as RestEndpointMethodTypes['apps']['listReposAccessibleToInstallation']['response']);
 
     const { token, headers } = await github.getCredentials({
       url: 'https://github.com/backstage',
@@ -402,7 +403,7 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
   });
 
   it('should cache access token', async () => {
-    octokit.apps.listInstallations.mockResolvedValueOnce({
+    octokit.apps.listInstallations.mockReturnValue({
       headers: {
         etag: '123',
       },
@@ -417,19 +418,19 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       ],
     } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
 
-    octokit.apps.createInstallationAccessToken.mockResolvedValueOnce({
+    octokit.apps.createInstallationAccessToken.mockReturnValue({
       data: {
         expires_at: DateTime.local().plus({ hours: 1 }).toString(),
         token: 'secret_token',
       },
     } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
 
-    for (let i = 0; i < 2; i++) {
-      const { token, headers } = await github.getCredentials({
-        url: 'https://github.com/backstage',
-      });
-      expect(headers).toEqual({ Authorization: 'Bearer secret_token' });
-      expect(token).toEqual('secret_token');
-    }
+    await github.getCredentials({ url: 'https://github.com/backstage' });
+    await github.getCredentials({ url: 'https://github.com/backstage' });
+
+    expect(octokit.apps.listInstallations.mock.calls.length).toBe(1);
+    expect(octokit.apps.createInstallationAccessToken.mock.calls.length).toBe(
+      1,
+    );
   });
 });

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
@@ -434,7 +434,7 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
     );
   });
 
-  it('should expire access token cache 10 mins before token expires', async () => {
+  it('should expire access token cache when less than 10 mins before token expires', async () => {
     octokit.apps.listInstallations.mockReturnValue({
       headers: {
         etag: '123',
@@ -452,7 +452,9 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
 
     octokit.apps.createInstallationAccessToken.mockReturnValue({
       data: {
-        expires_at: DateTime.local().plus({ minutes: 10 }).toString(),
+        expires_at: DateTime.local()
+          .plus({ minutes: 9, seconds: 59, milliseconds: 999 })
+          .toString(),
         token: 'secret_token',
       },
     } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -93,12 +93,13 @@ class GithubAppManager {
     owner: string,
     repo?: string,
   ): Promise<{ accessToken: string | undefined }> {
-    const { installationId, suspended } = await this.getInstallationData(owner);
     if (this.allowedInstallationOwners) {
       if (!this.allowedInstallationOwners?.includes(owner)) {
         return { accessToken: undefined }; // An empty token allows anonymous access to public repos
       }
     }
+
+    const { installationId, suspended } = await this.getInstallationData(owner);
     if (suspended) {
       throw new Error(`The GitHub application for ${owner} is suspended`);
     }

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -62,7 +62,6 @@ class Cache {
     return { accessToken: ownerData.token };
   }
 
-  // consider timestamps older than 50 minutes to be expired.
   private isExpired = (date: DateTime) => DateTime.local() > date;
 
   private appliesToRepo(tokenData: InstallationTokenData, repo?: string) {

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -99,19 +99,22 @@ class GithubAppManager {
       }
     }
 
-    const { installationId, suspended } = await this.getInstallationData(owner);
-    if (suspended) {
-      throw new Error(`The GitHub application for ${owner} is suspended`);
-    }
-
     const cacheKey = repo ? `${owner}/${repo}` : owner;
 
     // Go and grab an access token for the app scoped to a repository if provided, if not use the organisation installation.
     return this.cache.getOrCreateToken(cacheKey, async () => {
+      const { installationId, suspended } = await this.getInstallationData(
+        owner,
+      );
+      if (suspended) {
+        throw new Error(`The GitHub application for ${owner} is suspended`);
+      }
+
       const result = await this.appClient.apps.createInstallationAccessToken({
         installation_id: installationId,
         headers: HEADERS,
       });
+
       if (repo && result.data.repository_selection === 'selected') {
         const installationClient = new Octokit({
           baseUrl: this.baseUrl,

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -30,29 +30,52 @@ type InstallationData = {
   suspended: boolean;
 };
 
+type InstallationTokenData = {
+  token: string;
+  expiresAt: DateTime;
+  repositories?: String[];
+};
+
 class Cache {
-  private readonly tokenCache = new Map<
-    string,
-    { token: string; expiresAt: DateTime }
-  >();
+  private readonly tokenCache = new Map<string, InstallationTokenData>();
 
   async getOrCreateToken(
-    key: string,
-    supplier: () => Promise<{ token: string; expiresAt: DateTime }>,
+    owner: string,
+    repo: string | undefined,
+    supplier: () => Promise<InstallationTokenData>,
   ): Promise<{ accessToken: string }> {
-    const item = this.tokenCache.get(key);
-    if (item && this.isNotExpired(item.expiresAt)) {
-      return { accessToken: item.token };
+    let ownerData = this.tokenCache.get(owner);
+
+    if (!ownerData || !this.isNotExpired(ownerData.expiresAt)) {
+      ownerData = await supplier();
+      this.tokenCache.set(owner, ownerData);
     }
 
-    const result = await supplier();
-    this.tokenCache.set(key, result);
-    return { accessToken: result.token };
+    if (!this.appliesToRepo(ownerData, repo)) {
+      throw new Error(
+        `The Backstage GitHub application used in the ${owner} organization does not have access to a repository with the name ${repo}`,
+      );
+    }
+
+    return { accessToken: ownerData.token };
   }
 
   // consider timestamps older than 50 minutes to be expired.
   private isNotExpired = (date: DateTime) =>
     date.diff(DateTime.local(), 'minutes').minutes > 50;
+
+  private appliesToRepo(tokenData: InstallationTokenData, repo?: string) {
+    // If no specific repo has been requested the token is applicable
+    if (repo === undefined) {
+      return true;
+    }
+    // If the token is restricted to repositories, the token only applies if the repo is in the allow list
+    if (tokenData.repositories !== undefined) {
+      return tokenData.repositories.includes(repo);
+    }
+    // Otherwise the token is applicable
+    return true;
+  }
 }
 
 /**
@@ -99,10 +122,8 @@ class GithubAppManager {
       }
     }
 
-    const cacheKey = repo ? `${owner}/${repo}` : owner;
-
     // Go and grab an access token for the app scoped to a repository if provided, if not use the organisation installation.
-    return this.cache.getOrCreateToken(cacheKey, async () => {
+    return this.cache.getOrCreateToken(owner, repo, async () => {
       const { installationId, suspended } = await this.getInstallationData(
         owner,
       );
@@ -115,7 +136,9 @@ class GithubAppManager {
         headers: HEADERS,
       });
 
-      if (repo && result.data.repository_selection === 'selected') {
+      let repositoryNames;
+
+      if (result.data.repository_selection === 'selected') {
         const installationClient = new Octokit({
           baseUrl: this.baseUrl,
           auth: result.data.token,
@@ -126,18 +149,13 @@ class GithubAppManager {
         // The return type of the paginate method is incorrect.
         const repositories: RestEndpointMethodTypes['apps']['listReposAccessibleToInstallation']['response']['data']['repositories'] =
           repos.repositories ?? repos;
-        const hasRepo = repositories.some(repository => {
-          return repository.name === repo;
-        });
-        if (!hasRepo) {
-          throw new Error(
-            `The Backstage GitHub application used in the ${owner} organization does not have access to a repository with the name ${repo}`,
-          );
-        }
+
+        repositoryNames = repositories.map(repository => repository.name);
       }
       return {
         token: result.data.token,
         expiresAt: DateTime.fromISO(result.data.expires_at),
+        repositories: repositoryNames,
       };
     });
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Partially Fixes #13481

* Avoid all calls to github if the requested org is not on the app's `allowedInstallationOwners` property.  (Previously the calls to list installations was made regardless).
* Cache one token per organisation, rather than one per org/repo combination. Nothing repo specific is being passed in to the 
* Calls to list installations are now included in the cache
* Tokens previously expired 50 mins early.  With installation tokens only lasting 1 hour, this was leading to them expiring very prematurely. 10 minutes premature token expiration was chosen to match the existing documentation on `DefaultGithubCredentialsProvider`

This caching approach isn't perfect - it works well on the happy path, but still has all the existing cache problems on the unhappy path within a credential provider.  Such paths include:

1. When referencing a public repo (i.e. falling back to no github auth). 
2. When multiple github apps are used to auth against different orgs.  In this case, all but one  this would be common when a private github app is used, as private github apps can't be installed to multiple orgs.
3. If multiple apps are used within the same org with different allow lists of allowed repos.

This caching approach isn't perfect - it works well on the happy path, but still has all the existing cache problems on the unhappy path within a credential provider.  Such paths include:

1. When referencing a public repo (i.e. falling back to no github auth). 
2. When multiple github apps are used to auth against different orgs.  In this case, all but one  this would be common when a private github app is used, as private github apps can't be installed to multiple orgs.
3. If multiple apps are used within the same org with different allow lists of allowed repos.

In both of these cases, this PR makes things no worse than before.  After this PR, scenario 2 can be mitigated by specifying `allowedInstallationOwners` on the app config.

I tried playing with doing some negative caching (i.e. each app cache scenarios in which they can't get a token), but it started getting messy so I backed it out.  (I pushed these changes to https://github.com/afscrome/backstage/commit/d21760ebe08f75fea74bafdb94160af1caa88398 for reference). Optimising for this case is going to require some more substantial refactoring.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
