### PR TITLE
docs: adds backstage-plugin-ldap-auth

### DIFF
--- a/microsite/data/plugins/backstage-plugin-ldap-auth.yml
+++ b/microsite/data/plugins/backstage-plugin-ldap-auth.yml
@@ -1,9 +1,9 @@
 ---
-title: Backstage Plugin LDAP Auth
+title: LDAP Auth
 author: ImmobiliareLabs
 authorUrl: https://github.com/immobiliare
 category: Authentication
-description: Backstage plugin to authenticate users to an external LDAP server
+description: Authenticate users to an external LDAP server
 documentation: https://github.com/immobiliare/backstage-plugin-ldap-auth/blob/main/README.md
 iconUrl: https://avatars.githubusercontent.com/u/10090828
 npmPackageName: '@immobiliarelabs/backstage-plugin-ldap-auth'

--- a/microsite/data/plugins/backstage-plugin-ldap-auth.yml
+++ b/microsite/data/plugins/backstage-plugin-ldap-auth.yml
@@ -1,0 +1,9 @@
+---
+title: Backstage Plugin LDAP Auth
+author: ImmobiliareLabs
+authorUrl: https://github.com/immobiliare
+category: Authentication
+description: Backstage plugin to authenticate users to an external LDAP server
+documentation: https://github.com/immobiliare/backstage-plugin-ldap-auth/blob/main/README.md
+iconUrl: https://avatars.githubusercontent.com/u/10090828
+npmPackageName: '@immobiliarelabs/backstage-plugin-ldap-auth'


### PR DESCRIPTION
Signed-off-by: Simone Corsi <simonecorsi.dev@gmail.com>

## Hey, I just made a Pull Request!

We've developed a plugin to add LDAP authentication and think it can be useful to add to the marketplace!

I have just one question, we have two packages one for the FE and one for the BE, do I have to add two different entries or should I just add one with a `npmPackageName` pointing to one of it and then the user can get the other from the documentation?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
