### PR TITLE
Feature/pass select attr to msgraph user import

### DIFF
--- a/.changeset/cuddly-clocks-dance.md
+++ b/.changeset/cuddly-clocks-dance.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-msgraph': minor
+'@backstage/plugin-catalog-backend-module-msgraph': patch
 ---
 
 Added $select attribute to user query

--- a/.changeset/cuddly-clocks-dance.md
+++ b/.changeset/cuddly-clocks-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': minor
+---
+
+Added $select attribute to user query

--- a/plugins/catalog-backend-module-msgraph/README.md
+++ b/plugins/catalog-backend-module-msgraph/README.md
@@ -54,6 +54,8 @@ catalog:
           # and for the syntax https://docs.microsoft.com/en-us/graph/query-parameters#filter-parameter
           # This and userGroupMemberFilter are mutually exclusive, only one can be specified
           filter: accountEnabled eq true and userType eq 'member'
+          # See  https://docs.microsoft.com/en-us/graph/api/resources/schemaextension?view=graph-rest-1.0
+          select: ['id', 'displayName', 'description']
         # Optional configuration block
         userGroupMember:
           # Optional filter for users, use group membership to get users.

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -193,6 +193,7 @@ export type MicrosoftGraphProviderConfig = {
   clientId?: string;
   clientSecret?: string;
   userFilter?: string;
+  userSelect?: string[];
   userExpand?: string;
   userGroupMemberFilter?: string;
   userGroupMemberSearch?: string;

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -232,6 +232,7 @@ export function readMicrosoftGraphOrg(
   options: {
     userExpand?: string;
     userFilter?: string;
+    userSelect?: string[];
     userGroupMemberSearch?: string;
     userGroupMemberFilter?: string;
     groupExpand?: string;

--- a/plugins/catalog-backend-module-msgraph/config.d.ts
+++ b/plugins/catalog-backend-module-msgraph/config.d.ts
@@ -75,6 +75,12 @@ export interface Config {
            */
           groupFilter?: string;
           /**
+           * The fields to be fetched on query.
+           *
+           * E.g. ["id", "displayName", "description"]
+           */
+          userSelect?: string[];
+          /**
            * The search criteria to apply to extract users by groups memberships.
            *
            * E.g. "\"displayName:-team\"" would only match groups which contain '-team'

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -63,6 +63,12 @@ export type MicrosoftGraphProviderConfig = {
    */
   userFilter?: string;
   /**
+   * The fields to be fetched on query.
+   *
+   * E.g. ["id", "displayName", "description"]
+   */
+  userSelect?: string[];
+  /**
    * The "expand" argument to apply to users.
    *
    * E.g. "manager".
@@ -144,6 +150,7 @@ export function readMicrosoftGraphConfig(
 
     const userExpand = providerConfig.getOptionalString('userExpand');
     const userFilter = providerConfig.getOptionalString('userFilter');
+    const userSelect = providerConfig.getOptionalStringArray('userSelect');
     const userGroupMemberFilter = providerConfig.getOptionalString(
       'userGroupMemberFilter',
     );
@@ -196,6 +203,7 @@ export function readMicrosoftGraphConfig(
       clientSecret,
       userExpand,
       userFilter,
+      userSelect,
       userGroupMemberFilter,
       userGroupMemberSearch,
       groupExpand,

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
@@ -1128,9 +1128,6 @@ describe('read microsoft graph', () => {
 
       client.getGroups.mockImplementation(getExampleGroups);
       client.getGroupMembers.mockImplementation(getExampleGroupMembers);
-      client.getGroupPhotoWithSizeLimit.mockResolvedValue(
-        'data:image/jpeg;base64,...',
-      );
 
       await readMicrosoftGraphOrg(client, 'tenantid', {
         logger: getVoidLogger(),

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
@@ -1002,6 +1002,12 @@ describe('read microsoft graph', () => {
       };
     }
 
+    async function* getExampleUsersEmail() {
+      yield {
+        mail: 'user.name@example.com',
+      };
+    }
+
     async function getExampleUserProfile(userId: string) {
       return {
         id: userId,
@@ -1104,6 +1110,37 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq false',
+        },
+        undefined,
+      );
+    });
+
+    it('should read users with userSelect', async () => {
+      client.getOrganization.mockResolvedValue({
+        id: 'tenantid',
+        displayName: 'Organization Name',
+      });
+
+      client.getUsers.mockImplementation(getExampleUsersEmail);
+      client.getUserPhotoWithSizeLimit.mockResolvedValue(
+        'data:image/jpeg;base64,...',
+      );
+
+      client.getGroups.mockImplementation(getExampleGroups);
+      client.getGroupMembers.mockImplementation(getExampleGroupMembers);
+      client.getGroupPhotoWithSizeLimit.mockResolvedValue(
+        'data:image/jpeg;base64,...',
+      );
+
+      await readMicrosoftGraphOrg(client, 'tenantid', {
+        logger: getVoidLogger(),
+        userSelect: ['mail'],
+      });
+
+      expect(client.getUsers).toHaveBeenCalledTimes(1);
+      expect(client.getUsers).toHaveBeenCalledWith(
+        {
+          select: ['mail'],
         },
         undefined,
       );

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -89,6 +89,7 @@ export async function readMicrosoftGraphUsers(
     queryMode?: 'basic' | 'advanced';
     userFilter?: string;
     userExpand?: string;
+    userSelect?: string[];
     transformer?: UserTransformer;
     logger: Logger;
   },
@@ -105,6 +106,7 @@ export async function readMicrosoftGraphUsers(
     {
       filter: options.userFilter,
       expand: options.userExpand,
+      select: options.userSelect || [],
     },
     options.queryMode,
   )) {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -106,7 +106,7 @@ export async function readMicrosoftGraphUsers(
     {
       filter: options.userFilter,
       expand: options.userExpand,
-      select: options.userSelect || [],
+      select: options.userSelect,
     },
     options.queryMode,
   )) {
@@ -147,6 +147,7 @@ export async function readMicrosoftGraphUsersInGroups(
   options: {
     queryMode?: 'basic' | 'advanced';
     userExpand?: string;
+    userSelect?: string[];
     userGroupMemberSearch?: string;
     userGroupMemberFilter?: string;
     groupExpand?: string;
@@ -536,6 +537,7 @@ export async function readMicrosoftGraphOrg(
   options: {
     userExpand?: string;
     userFilter?: string;
+    userSelect?: string[];
     userGroupMemberSearch?: string;
     userGroupMemberFilter?: string;
     groupExpand?: string;
@@ -567,6 +569,7 @@ export async function readMicrosoftGraphOrg(
     const { users: usersWithFilter } = await readMicrosoftGraphUsers(client, {
       queryMode: options.queryMode,
       userFilter: options.userFilter,
+      userSelect: options.userSelect,
       userExpand: options.userExpand,
       transformer: options.userTransformer,
       logger: options.logger,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Microsoft Graph Import supports importing users and groups. Groups import supports passing a `$select` parameter to the query, while the Users import does not.

This pull request adds a `$select` parameter to the User import query. Underlying methods already support it, so the implementation only includes passing the string array attribute to the `getUsers` method. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
