### PR TITLE
[auth-backend]: Calculate `SameSite` cookie attribute in defaultCookieConfigurer and default to `none`

### DIFF
--- a/.changeset/kind-penguins-report.md
+++ b/.changeset/kind-penguins-report.md
@@ -1,5 +1,8 @@
 ---
-'@backstage/plugin-auth-backend': patch
+'@backstage/plugin-auth-backend': minor
 ---
 
-Allow CookieConfigurer to optionally return the SameSite cookie attribute. Return `SameSite=None` in `defaultCookieConfigurer` for secure contexts to allow cookies to be included in third-party requests.
+CookieConfigurer can optionally return the `SameSite` cookie attribute.
+CookieConfigurer now requires an additional argument `appOrigin` - the origin URL of the app - which is used to calculate the `SameSite` attribute.
+defaultCookieConfigurer returns the `SameSite` attribute which defaults to `Lax`. In cases where an auth-backend is running on a different domain than the App, `SameSite=None` is used - but only for secure contexts. This is so that cookies can be included in third-party requests.
+OAuthAdapterOptions has been modified to require additional arguments, `baseUrl`, `cookieConfigurer` and `cookieConfig`.

--- a/.changeset/kind-penguins-report.md
+++ b/.changeset/kind-penguins-report.md
@@ -5,4 +5,6 @@
 CookieConfigurer can optionally return the `SameSite` cookie attribute.
 CookieConfigurer now requires an additional argument `appOrigin` - the origin URL of the app - which is used to calculate the `SameSite` attribute.
 defaultCookieConfigurer returns the `SameSite` attribute which defaults to `Lax`. In cases where an auth-backend is running on a different domain than the App, `SameSite=None` is used - but only for secure contexts. This is so that cookies can be included in third-party requests.
-OAuthAdapterOptions has been modified to require additional arguments, `baseUrl`, `cookieConfigurer` and `cookieConfig`.
+
+OAuthAdapterOptions has been modified to require additional arguments, `baseUrl`, and `cookieConfigurer`.
+OAuthAdapter now resolves cookie configuration using its supplied CookieConfigurer for each request to make sure that the proper attributes always are set.

--- a/.changeset/kind-penguins-report.md
+++ b/.changeset/kind-penguins-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Allow CookieConfigurer to optionally return the SameSite cookie attribute. Return `SameSite=None` in `defaultCookieConfigurer` for secure contexts to allow cookies to be included in third-party requests.

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -187,6 +187,7 @@ export type CookieConfigurer = (ctx: {
   domain: string;
   path: string;
   secure: boolean;
+  sameSite?: 'none' | 'lax' | 'strict';
 };
 
 // @public
@@ -280,11 +281,9 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
 // @public (undocumented)
 export type OAuthAdapterOptions = {
   providerId: string;
-  secure: boolean;
   persistScopes?: boolean;
-  cookieDomain: string;
-  cookiePath: string;
   appOrigin: string;
+  cookieConfig: ReturnType<CookieConfigurer>;
   isOriginAllowed: (origin: string) => boolean;
   callbackUrl: string;
 };

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -285,7 +285,6 @@ export type OAuthAdapterOptions = {
   persistScopes?: boolean;
   appOrigin: string;
   baseUrl: string;
-  cookieConfig: ReturnType<CookieConfigurer>;
   cookieConfigurer: CookieConfigurer;
   isOriginAllowed: (origin: string) => boolean;
   callbackUrl: string;

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -183,6 +183,7 @@ export type CookieConfigurer = (ctx: {
   providerId: string;
   baseUrl: string;
   callbackUrl: string;
+  appOrigin: string;
 }) => {
   domain: string;
   path: string;
@@ -283,7 +284,9 @@ export type OAuthAdapterOptions = {
   providerId: string;
   persistScopes?: boolean;
   appOrigin: string;
+  baseUrl: string;
   cookieConfig: ReturnType<CookieConfigurer>;
+  cookieConfigurer: CookieConfigurer;
   isOriginAllowed: (origin: string) => boolean;
   callbackUrl: string;
 };

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
@@ -18,6 +18,7 @@ import express from 'express';
 import { THOUSAND_DAYS_MS, TEN_MINUTES_MS, OAuthAdapter } from './OAuthAdapter';
 import { encodeState } from './helpers';
 import { OAuthHandlers, OAuthState } from './types';
+import { CookieConfigurer } from '../../providers/types';
 
 const mockResponseData = {
   providerInfo: {
@@ -57,12 +58,17 @@ describe('OAuthAdapter', () => {
     }
   }
   const providerInstance = new MyAuthProvider();
+  const cookieConfig = {
+    domain: 'example.com',
+    path: '/auth/test-provider',
+    secure: false,
+    sameSite: 'lax',
+  } as ReturnType<CookieConfigurer>;
+
   const oAuthProviderOptions = {
     providerId: 'test-provider',
-    secure: false,
     appOrigin: 'http://localhost:3000',
-    cookieDomain: 'example.com',
-    cookiePath: '/auth/test-provider',
+    cookieConfig,
     tokenIssuer: {
       issueToken: async () => 'my-id-token',
       listPublicKeys: async () => ({ keys: [] }),
@@ -136,6 +142,8 @@ describe('OAuthAdapter', () => {
       expect.objectContaining({
         path: '/auth/test-provider',
         maxAge: THOUSAND_DAYS_MS,
+        secure: false,
+        sameSite: 'lax',
       }),
     );
   });
@@ -331,6 +339,7 @@ describe('OAuthAdapter', () => {
         domain: 'authdomain.org',
         path: '/auth/test-provider/handler',
         secure: true,
+        sameSite: 'none',
       }),
     );
   });

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -24,6 +24,7 @@ import {
 import {
   AuthProviderRouteHandlers,
   AuthProviderConfig,
+  CookieConfigurer,
 } from '../../providers/types';
 import {
   AuthenticationError,
@@ -47,11 +48,9 @@ export const TEN_MINUTES_MS = 600 * 1000;
 /** @public */
 export type OAuthAdapterOptions = {
   providerId: string;
-  secure: boolean;
   persistScopes?: boolean;
-  cookieDomain: string;
-  cookiePath: string;
   appOrigin: string;
+  cookieConfig: ReturnType<CookieConfigurer>;
   isOriginAllowed: (origin: string) => boolean;
   callbackUrl: string;
 };
@@ -78,9 +77,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
     return new OAuthAdapter(handlers, {
       ...options,
       appOrigin,
-      cookieDomain: cookieConfig.domain,
-      cookiePath: cookieConfig.path,
-      secure: cookieConfig.secure,
+      cookieConfig,
       isOriginAllowed: config.isOriginAllowed,
     });
   }
@@ -93,10 +90,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
   ) {
     this.baseCookieOptions = {
       httpOnly: true,
-      sameSite: 'lax',
-      secure: this.options.secure,
-      path: this.options.cookiePath,
-      domain: this.options.cookieDomain,
+      ...this.options.cookieConfig,
     };
   }
 
@@ -265,7 +259,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
     res.cookie(`${this.options.providerId}-nonce`, nonce, {
       maxAge: TEN_MINUTES_MS,
       ...this.baseCookieOptions,
-      path: `${this.options.cookiePath}/handler`,
+      path: `${this.options.cookieConfig.path}/handler`,
     });
   };
 

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -102,7 +102,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       throw new InputError('No env provided in request query parameters');
     }
 
-    const cookieConfig = this.getCookieConfig();
+    const cookieConfig = this.getCookieConfig(origin);
 
     const nonce = crypto.randomBytes(16).toString('base64');
     // set a nonce cookie before redirecting to oauth provider

--- a/plugins/auth-backend/src/lib/oauth/helpers.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.test.ts
@@ -117,6 +117,7 @@ describe('OAuthProvider Utils', () => {
           baseUrl: '',
           providerId: 'test-provider',
           callbackUrl: 'http://domain.org/auth',
+          appOrigin: 'http://domain.org',
         }),
       ).toMatchObject({
         domain: 'domain.org',
@@ -131,6 +132,7 @@ describe('OAuthProvider Utils', () => {
           baseUrl: '',
           providerId: 'test-provider',
           callbackUrl: 'http://domain.org/auth/test-provider/handler/frame',
+          appOrigin: 'http://domain.org',
         }),
       ).toMatchObject({
         domain: 'domain.org',
@@ -145,34 +147,66 @@ describe('OAuthProvider Utils', () => {
           baseUrl: '',
           providerId: 'test-provider',
           callbackUrl: 'https://domain.org/auth',
+          appOrigin: 'http://domain.org',
         }),
       ).toMatchObject({
         secure: true,
       });
     });
 
-    it('should set sameSite to none for https', () => {
+    it('should set sameSite to lax for https on the same domain', () => {
       expect(
         defaultCookieConfigurer({
           baseUrl: '',
           providerId: 'test-provider',
           callbackUrl: 'https://domain.org/auth',
+          appOrigin: 'http://domain.org',
         }),
       ).toMatchObject({
-        sameSite: 'none',
+        sameSite: 'lax',
         secure: true,
       });
     });
-    it('should set sameSite to lax for http', () => {
+
+    it('should set sameSite to lax for http on the same domain', () => {
       expect(
         defaultCookieConfigurer({
           baseUrl: '',
           providerId: 'test-provider',
           callbackUrl: 'http://domain.org/auth',
+          appOrigin: 'http://domain.org',
         }),
       ).toMatchObject({
         sameSite: 'lax',
         secure: false,
+      });
+    });
+
+    it('should set sameSite to lax if not secure and on different domains', () => {
+      expect(
+        defaultCookieConfigurer({
+          baseUrl: '',
+          providerId: 'test-provider',
+          callbackUrl: 'http://authdomain.org/auth',
+          appOrigin: 'http://domain.org',
+        }),
+      ).toMatchObject({
+        sameSite: 'lax',
+        secure: false,
+      });
+    });
+
+    it('should set sameSite to none if secure and on different domains', () => {
+      expect(
+        defaultCookieConfigurer({
+          baseUrl: '',
+          providerId: 'test-provider',
+          callbackUrl: 'https://authdomain.org/auth',
+          appOrigin: 'http://domain.org',
+        }),
+      ).toMatchObject({
+        sameSite: 'none',
+        secure: true,
       });
     });
   });

--- a/plugins/auth-backend/src/lib/oauth/helpers.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.test.ts
@@ -150,5 +150,30 @@ describe('OAuthProvider Utils', () => {
         secure: true,
       });
     });
+
+    it('should set sameSite to none for https', () => {
+      expect(
+        defaultCookieConfigurer({
+          baseUrl: '',
+          providerId: 'test-provider',
+          callbackUrl: 'https://domain.org/auth',
+        }),
+      ).toMatchObject({
+        sameSite: 'none',
+        secure: true,
+      });
+    });
+    it('should set sameSite to lax for http', () => {
+      expect(
+        defaultCookieConfigurer({
+          baseUrl: '',
+          providerId: 'test-provider',
+          callbackUrl: 'http://domain.org/auth',
+        }),
+      ).toMatchObject({
+        sameSite: 'lax',
+        secure: false,
+      });
+    });
   });
 });

--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -68,6 +68,7 @@ export const defaultCookieConfigurer: CookieConfigurer = ({
 }) => {
   const { hostname: domain, pathname, protocol } = new URL(callbackUrl);
   const secure = protocol === 'https:';
+  const sameSite = secure ? 'none' : 'lax';
 
   // If the provider supports callbackUrls, the pathname will
   // contain the complete path to the frame handler so we need
@@ -76,5 +77,5 @@ export const defaultCookieConfigurer: CookieConfigurer = ({
     ? pathname.slice(0, -'/handler/frame'.length)
     : `${pathname}/${providerId}`;
 
-  return { domain, path, secure };
+  return { domain, path, secure, sameSite };
 };

--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -65,10 +65,19 @@ export const verifyNonce = (req: express.Request, providerId: string) => {
 export const defaultCookieConfigurer: CookieConfigurer = ({
   callbackUrl,
   providerId,
+  appOrigin,
 }) => {
   const { hostname: domain, pathname, protocol } = new URL(callbackUrl);
   const secure = protocol === 'https:';
-  const sameSite = secure ? 'none' : 'lax';
+
+  // For situations where the auth-backend is running on a
+  // different domain than the app, we set the SameSite attribute
+  // to 'none' to allow third-party access to the cookie, but
+  // only if it's in a secure context (https).
+  let sameSite: ReturnType<CookieConfigurer>['sameSite'] = 'lax';
+  if (new URL(appOrigin).hostname !== domain && secure) {
+    sameSite = 'none';
+  }
 
   // If the provider supports callbackUrls, the pathname will
   // contain the complete path to the frame handler so we need

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -100,7 +100,12 @@ export type CookieConfigurer = (ctx: {
   baseUrl: string;
   /** The configured callback URL of the auth provider */
   callbackUrl: string;
-}) => { domain: string; path: string; secure: boolean };
+}) => {
+  domain: string;
+  path: string;
+  secure: boolean;
+  sameSite?: 'none' | 'lax' | 'strict';
+};
 
 /** @public */
 export type AuthProviderConfig = {

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -100,6 +100,8 @@ export type CookieConfigurer = (ctx: {
   baseUrl: string;
   /** The configured callback URL of the auth provider */
   callbackUrl: string;
+  /** The origin URL of the app */
+  appOrigin: string;
 }) => {
   domain: string;
   path: string;


### PR DESCRIPTION
Signed-off-by: Marcus Eide <eide@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Currently the `SameSite` cookie attribute is set to `Lax` which allows a cookie to be included if a user is navigating to the origin site (i.e., when following a link). It does not however allow other third-party cookie requests. 

For me this is a problem when running the app locally on `localhost` for development, but using a deployed auth-backend on an actual domain. I can sign in but there's no session persistence as the `refresh-cookie` is set to `Lax` which prevents `localhost` from including it in subsequent calls to the `/refresh` endpoint. 
For those spinning up a local auth-backend this is not an issue as the `Domain` attribute of the cookie and the origin of the app are both `localhost`.

I'll imagine that if my app were running on `app.example.com` and the auth-backend on `auth.other-example.net` this would be an issue as well.

There's a lot of things to consider here and I'm no expert, so looking for any concerns or suggestions people might have.

This PR is doing two things:

1. Makes the `SameSite` attribute an optional part of the `CookieConfigurer` return value so that it can be overridden if needed. 
2. `defaultCookieConfigurer` defaults to `none` for all cookies that are in a secure context (using `https`).

A few notes:
- Modern browsers treat a missing `SameSite` attribute the same as if it were set to `lax`.
- Cookies with `SameSite=None` must specify the `Secure` attribute as well.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
