### PR TITLE
scaffolder-backend: use 3 parallel workers by default

### DIFF
--- a/.changeset/young-falcons-sleep.md
+++ b/.changeset/young-falcons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+The number of task workers used to execute templates now default to 3, rather than 1.

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -178,7 +178,7 @@ export async function createRouter(
   const actionRegistry = new TemplateActionRegistry();
 
   const workers = [];
-  for (let i = 0; i < (taskWorkers || 1); i++) {
+  for (let i = 0; i < (taskWorkers || 3); i++) {
     const worker = await TaskWorker.create({
       taskBroker,
       actionRegistry,


### PR DESCRIPTION
Fixes #13419