### PR TITLE
feat: add refresh to EntityProviderConnection

### DIFF
--- a/.changeset/flat-crabs-love.md
+++ b/.changeset/flat-crabs-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-node': minor
+---
+
+Added refresh function to the `EntityProviderConnection` to be able to schedule refreshes from entity providers.

--- a/.changeset/rude-weeks-retire.md
+++ b/.changeset/rude-weeks-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Added refresh function to the EntityProviderConnection to be able to schedule refreshes from entity providers.

--- a/.changeset/rude-weeks-retire.md
+++ b/.changeset/rude-weeks-retire.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Added refresh function to the EntityProviderConnection to be able to schedule refreshes from entity providers.
+Added the `refresh` function to the Connection of the entity providers.

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts
@@ -100,6 +100,7 @@ describe('AwsS3EntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const provider = AwsS3EntityProvider.fromConfig(config, {

--- a/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.test.ts
@@ -71,6 +71,7 @@ describe('AzureDevOpsEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const provider = AzureDevOpsEntityProvider.fromConfig(config, {

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/BitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/BitbucketCloudEntityProvider.test.ts
@@ -127,6 +127,7 @@ describe('BitbucketCloudEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = BitbucketCloudEntityProvider.fromConfig(config, {
       logger,

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.test.ts
@@ -221,6 +221,7 @@ describe('BitbucketServerEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = BitbucketServerEntityProvider.fromConfig(config, {
       logger,
@@ -296,6 +297,7 @@ describe('BitbucketServerEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = BitbucketServerEntityProvider.fromConfig(config, {
       logger,

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
@@ -83,6 +83,7 @@ describe('GerritEntityProvider', () => {
 
   const entityProviderConnection: EntityProviderConnection = {
     applyMutation: jest.fn(),
+    refresh: jest.fn(),
   };
 
   it('discovers projects from the api.', async () => {

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.test.ts
@@ -146,6 +146,7 @@ describe('GitHubEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const provider = GitHubEntityProvider.fromConfig(config, {
@@ -233,6 +234,7 @@ describe('GitHubEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const provider = GitHubEntityProvider.fromConfig(config, {
@@ -306,6 +308,7 @@ describe('GitHubEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const provider = GitHubEntityProvider.fromConfig(config, {
@@ -404,6 +407,7 @@ it('apply full update on scheduled execution with topic exclusion taking priorit
   const schedule = new PersistingTaskRunner();
   const entityProviderConnection: EntityProviderConnection = {
     applyMutation: jest.fn(),
+    refresh: jest.fn(),
   };
 
   const provider = GitHubEntityProvider.fromConfig(config, {

--- a/plugins/catalog-backend-module-github/src/providers/GitHubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubOrgEntityProvider.test.ts
@@ -83,6 +83,7 @@ describe('GitHubOrgEntityProvider', () => {
 
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
+        refresh: jest.fn(),
       };
 
       const logger = getVoidLogger();

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -155,6 +155,7 @@ describe('GitlabDiscoveryEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
       logger,
@@ -253,6 +254,7 @@ describe('GitlabDiscoveryEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
       logger,

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.test.ts
@@ -95,6 +95,7 @@ describe('MicrosoftGraphOrgEntityProvider', () => {
     };
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = MicrosoftGraphOrgEntityProvider.fromConfig(
       new ConfigReader(config),

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -158,6 +158,14 @@ export interface ProcessingDatabase {
   refresh(txOpaque: Transaction, options: RefreshOptions): Promise<void>;
 
   /**
+   * Schedules a refresh for every entity that has a matching set of refresh key stored for it.
+   */
+  refreshByRefreshKeys(
+    txOpaque: Transaction,
+    options: RefreshByKeyOptions,
+  ): Promise<void>;
+
+  /**
    * Lists all ancestors of a given entityRef.
    *
    * The returned list is ordered from the most immediate ancestor to the most distant one.

--- a/plugins/catalog-backend/src/modules/core/DefaultLocationStore.test.ts
+++ b/plugins/catalog-backend/src/modules/core/DefaultLocationStore.test.ts
@@ -26,7 +26,7 @@ describe('DefaultLocationStore', () => {
   async function createLocationStore(databaseId: TestDatabaseId) {
     const knex = await databases.init(databaseId);
     await applyDatabaseMigrations(knex);
-    const connection = { applyMutation: jest.fn() };
+    const connection = { applyMutation: jest.fn(), refresh: jest.fn() };
     const store = new DefaultLocationStore(knex);
     await store.connect(connection);
     return { store, connection };

--- a/plugins/catalog-backend/src/processing/connectEntityProviders.ts
+++ b/plugins/catalog-backend/src/processing/connectEntityProviders.ts
@@ -22,6 +22,7 @@ import { ProcessingDatabase } from '../database/types';
 import {
   EntityProvider,
   EntityProviderConnection,
+  EntityProviderRefreshOptions,
   EntityProviderMutation,
 } from '@backstage/plugin-catalog-node';
 
@@ -61,12 +62,12 @@ class Connection implements EntityProviderConnection {
     }
   }
 
-  async refresh(keys: string[]): Promise<void> {
+  async refresh(options: EntityProviderRefreshOptions): Promise<void> {
     const db = this.config.processingDatabase;
 
     await db.transaction(async (tx: any) => {
       return db.refreshByRefreshKeys(tx, {
-        keys,
+        keys: options.keys,
       });
     });
   }

--- a/plugins/catalog-backend/src/processing/connectEntityProviders.ts
+++ b/plugins/catalog-backend/src/processing/connectEntityProviders.ts
@@ -61,6 +61,16 @@ class Connection implements EntityProviderConnection {
     }
   }
 
+  async refresh(keys: string[]): Promise<void> {
+    const db = this.config.processingDatabase;
+
+    await db.transaction(async (tx: any) => {
+      return db.refreshByRefreshKeys(tx, {
+        keys,
+      });
+    });
+  }
+
   private check(entities: Entity[]) {
     for (const entity of entities) {
       try {

--- a/plugins/catalog-node/api-report.md
+++ b/plugins/catalog-node/api-report.md
@@ -126,7 +126,7 @@ export interface EntityProvider {
 // @public
 export interface EntityProviderConnection {
   applyMutation(mutation: EntityProviderMutation): Promise<void>;
-  refresh(keys: string[]): Promise<void>;
+  refresh(options: EntityProviderRefreshOptions): Promise<void>;
 }
 
 // @public
@@ -140,6 +140,11 @@ export type EntityProviderMutation =
       added: DeferredEntity[];
       removed: DeferredEntity[];
     };
+
+// @public (undocumented)
+export type EntityProviderRefreshOptions = {
+  keys: string[];
+};
 
 // @public
 export type EntityRelationSpec = {

--- a/plugins/catalog-node/api-report.md
+++ b/plugins/catalog-node/api-report.md
@@ -126,6 +126,7 @@ export interface EntityProvider {
 // @public
 export interface EntityProviderConnection {
   applyMutation(mutation: EntityProviderMutation): Promise<void>;
+  refresh(keys: string[]): Promise<void>;
 }
 
 // @public

--- a/plugins/catalog-node/src/api/index.ts
+++ b/plugins/catalog-node/src/api/index.ts
@@ -32,4 +32,5 @@ export type {
   EntityProvider,
   EntityProviderConnection,
   EntityProviderMutation,
+  EntityProviderRefreshOptions,
 } from './provider';

--- a/plugins/catalog-node/src/api/provider.ts
+++ b/plugins/catalog-node/src/api/provider.ts
@@ -36,6 +36,7 @@ export interface EntityProviderConnection {
    * Applies either a full or delta update to the catalog engine.
    */
   applyMutation(mutation: EntityProviderMutation): Promise<void>;
+  refresh(keys: string[]): Promise<void>;
 }
 
 /**

--- a/plugins/catalog-node/src/api/provider.ts
+++ b/plugins/catalog-node/src/api/provider.ts
@@ -27,6 +27,13 @@ export type EntityProviderMutation =
   | { type: 'delta'; added: DeferredEntity[]; removed: DeferredEntity[] };
 
 /**
+ * @public
+ */
+export type EntityProviderRefreshOptions = {
+  keys: string[];
+};
+
+/**
  * The EntityProviderConnection is the connection between the catalog and the entity provider.
  * The EntityProvider use this connection to add and remove entities from the catalog.
  * @public
@@ -40,7 +47,7 @@ export interface EntityProviderConnection {
   /**
    * Schedules a refresh on all of the entities that has a matching refresh key associated with the provided keys.
    */
-  refresh(keys: string[]): Promise<void>;
+  refresh(options: EntityProviderRefreshOptions): Promise<void>;
 }
 
 /**

--- a/plugins/catalog-node/src/api/provider.ts
+++ b/plugins/catalog-node/src/api/provider.ts
@@ -36,6 +36,10 @@ export interface EntityProviderConnection {
    * Applies either a full or delta update to the catalog engine.
    */
   applyMutation(mutation: EntityProviderMutation): Promise<void>;
+
+  /**
+   * Schedules a refresh on all of the entities that has a matching refresh key associated with the provided keys.
+   */
   refresh(keys: string[]): Promise<void>;
 }
 


### PR DESCRIPTION
Signed-off-by: Kiss Miklos <miklos@roadie.io>

## Hey, I just made a Pull Request!
This is a followup of the https://github.com/backstage/backstage/pull/12156 
It adds a refresh function to the entity provider connection, to make sure the entity providers can schedule refreshes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
