### PR TITLE
fixing techdocs-cli Docker client creation

### DIFF
--- a/.changeset/grumpy-pans-knock.md
+++ b/.changeset/grumpy-pans-knock.md
@@ -1,0 +1,14 @@
+---
+'@techdocs/cli': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+fixing techdocs-cli Docker client creation
+
+Docker client does not need to be created when --no-docker
+option is provided.
+
+If you had DOCKER_CERT_PATH environment variable defined
+the Docker client was looking for certificates
+and breaking techdocs-cli generate command even with --no-docker
+option.

--- a/packages/techdocs-cli/e2e-tests/techdocs-cli.test.ts
+++ b/packages/techdocs-cli/e2e-tests/techdocs-cli.test.ts
@@ -89,6 +89,23 @@ describe('end-to-end', () => {
     expect(proc.exit).toEqual(0);
   });
 
+  it('can generate with DOCKER_* TLS variables and --no-docker option', async () => {
+    const env = {
+      DOCKER_HOST: 'tcp://localhost:2376',
+      DOCKER_TLS_CERTDIR: '/certs',
+      DOCKER_TLS_VERIFY: '1',
+      DOCKER_CERT_PATH: '/certs/client',
+      ...process.env,
+    };
+    const proc = await executeCommand(entryPoint, ['generate', '--no-docker'], {
+      cwd,
+      timeout,
+      env,
+    });
+    expect(proc.stdout).toContain('Successfully generated docs');
+    expect(proc.exit).toEqual(0);
+  });
+
   it('can serve in mkdocs', async () => {
     const proc = await executeCommand(
       entryPoint,

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -22,7 +22,10 @@ import {
   TechdocsGenerator,
   ParsedLocationAnnotation,
 } from '@backstage/plugin-techdocs-node';
-import { DockerContainerRunner } from '@backstage/backend-common';
+import {
+  ContainerRunner,
+  DockerContainerRunner,
+} from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import {
   convertTechDocsRefToLocationAnnotation,
@@ -66,8 +69,12 @@ export default async function generate(opts: OptionValues) {
   });
 
   // Docker client (conditionally) used by the generators, based on techdocs.generators config.
-  const dockerClient = new Docker();
-  const containerRunner = new DockerContainerRunner({ dockerClient });
+  let containerRunner: ContainerRunner | undefined;
+
+  if (opts.docker) {
+    const dockerClient = new Docker();
+    containerRunner = new DockerContainerRunner({ dockerClient });
+  }
 
   let parsedLocationAnnotation = {} as ParsedLocationAnnotation;
   if (opts.techdocsRef) {

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -55,7 +55,7 @@ export class TechdocsGenerator implements GeneratorBase {
    */
   public static readonly defaultDockerImage = 'spotify/techdocs:v1.1.0';
   private readonly logger: Logger;
-  private readonly containerRunner: ContainerRunner;
+  private readonly containerRunner?: ContainerRunner;
   private readonly options: GeneratorConfig;
   private readonly scmIntegrations: ScmIntegrationRegistry;
 
@@ -77,7 +77,7 @@ export class TechdocsGenerator implements GeneratorBase {
 
   constructor(options: {
     logger: Logger;
-    containerRunner: ContainerRunner;
+    containerRunner?: ContainerRunner;
     config: Config;
     scmIntegrations: ScmIntegrationRegistry;
   }) {
@@ -143,7 +143,7 @@ export class TechdocsGenerator implements GeneratorBase {
           );
           break;
         case 'docker':
-          await this.containerRunner.runContainer({
+          await this.containerRunner!.runContainer({
             imageName:
               this.options.dockerImage ?? TechdocsGenerator.defaultDockerImage,
             args: ['build', '-d', '/output'],

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -28,7 +28,7 @@ export type GeneratorRunInType = 'docker' | 'local';
  * @public
  */
 export type GeneratorOptions = {
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
   logger: Logger;
 };
 


### PR DESCRIPTION
Docker client does not need to be created when --no-docker option is provided.

If you had DOCKER_CERT_PATH environment variable defined the Docker client was looking for certificates
and breaking techdocs-cli generate command even with --no-docker option.

Signed-off-by: Matteo Silvestri <matteosilv@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
