### PR TITLE
feat(EntityTagPicker): support showing option counts

### DIFF
--- a/.changeset/gorgeous-pillows-retire.md
+++ b/.changeset/gorgeous-pillows-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Support showing counts in option labels of the `EntityTagPicker`. You can enable this by adding the `showCounts` property

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -364,7 +364,14 @@ export class EntityTagFilter implements EntityFilter {
 }
 
 // @public (undocumented)
-export const EntityTagPicker: () => JSX.Element | null;
+export const EntityTagPicker: (
+  props: EntityTagPickerProps,
+) => JSX.Element | null;
+
+// @public (undocumented)
+export type EntityTagPickerProps = {
+  showCounts?: boolean;
+};
 
 // @public
 export class EntityTextFilter implements EntityFilter {

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
@@ -28,7 +28,9 @@ const tags = ['tag1', 'tag2', 'tag3', 'tag4'];
 describe('<EntityTagPicker/>', () => {
   const mockCatalogApiRef = {
     getEntityFacets: async () => ({
-      facets: { 'metadata.tags': tags.map(value => ({ value })) },
+      facets: {
+        'metadata.tags': tags.map((value, idx) => ({ value, count: idx })),
+      },
     }),
   } as unknown as CatalogApi;
 
@@ -65,6 +67,26 @@ describe('<EntityTagPicker/>', () => {
       'tag2',
       'tag3',
       'tag4',
+    ]);
+  });
+
+  it('renders tags with counts', async () => {
+    const rendered = render(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiRef]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityTagPicker showCounts />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() => expect(rendered.getByText('Tags')).toBeInTheDocument());
+
+    fireEvent.click(rendered.getByTestId('tag-picker-expand'));
+
+    expect(rendered.getAllByRole('option').map(o => o.textContent)).toEqual([
+      'tag1 (0)',
+      'tag2 (1)',
+      'tag3 (2)',
+      'tag4 (3)',
     ]);
   });
 

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -49,7 +49,12 @@ const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 /** @public */
-export const EntityTagPicker = () => {
+export type EntityTagPickerProps = {
+  showCounts?: boolean;
+};
+
+/** @public */
+export const EntityTagPicker = (props: EntityTagPickerProps) => {
   const classes = useStyles();
   const {
     updateFilters,
@@ -65,7 +70,9 @@ export const EntityTagPicker = () => {
       filter: filters.kind?.getCatalogFilters(),
     });
 
-    return facets[facet].map(({ value }) => value);
+    return Object.fromEntries(
+      facets[facet].map(({ value, count }) => [value, count]),
+    );
   }, [filters.kind]);
 
   const queryParamTags = useMemo(
@@ -91,7 +98,7 @@ export const EntityTagPicker = () => {
     });
   }, [selectedTags, updateFilters]);
 
-  if (!availableTags?.length) return null;
+  if (!Object.keys(availableTags ?? {}).length) return null;
 
   return (
     <Box pb={1} pt={1}>
@@ -99,7 +106,7 @@ export const EntityTagPicker = () => {
         Tags
         <Autocomplete
           multiple
-          options={availableTags}
+          options={Object.keys(availableTags ?? {})}
           value={selectedTags}
           onChange={(_: object, value: string[]) => setSelectedTags(value)}
           renderOption={(option, { selected }) => (
@@ -111,7 +118,11 @@ export const EntityTagPicker = () => {
                   checked={selected}
                 />
               }
-              label={option}
+              label={
+                props.showCounts
+                  ? `${option} (${availableTags?.[option]})`
+                  : option
+              }
             />
           )}
           size="small"

--- a/plugins/catalog-react/src/components/EntityTagPicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityTagPicker/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EntityTagPicker } from './EntityTagPicker';
-export type { CatalogReactEntityTagPickerClassKey } from './EntityTagPicker';
+export type {
+  CatalogReactEntityTagPickerClassKey,
+  EntityTagPickerProps,
+} from './EntityTagPicker';


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

We would like to show counts for each option in the tag picker. This change adds an optional prop to the component to enable this. 

![Screen Shot 2022-09-07 at 11 46 46 AM](https://user-images.githubusercontent.com/6998196/188926998-3c16abb8-1b79-49b5-8841-25121987f650.png)


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
