### PR TITLE
kubernetes-backend: ignore taffydb vulnerability

### DIFF
--- a/plugins/kubernetes-backend/.snyk
+++ b/plugins/kubernetes-backend/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-TAFFYDB-2992450:
+    - '*':
+        reason: Development dependency only
+        expires: 2023-03-07T20:23:00.000Z
+        created: 2022-09-07T20:23:00.000Z
+patch: {}


### PR DESCRIPTION
See #13412

It's a transitive deb via the protobuf + jsdoc CLI, which is a little bit strange too