### PR TITLE
Add validateEntity to catalog client

### DIFF
--- a/.changeset/large-books-deny.md
+++ b/.changeset/large-books-deny.md
@@ -2,4 +2,4 @@
 '@backstage/catalog-client': minor
 ---
 
-Adding validateEntity method that calls /validate-entity endpoint
+Adding `validateEntity` method that calls `/validate-entity` endpoint.

--- a/.changeset/large-books-deny.md
+++ b/.changeset/large-books-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': minor
+---
+
+Adding validateEntity method that calls /validate-entity endpoint

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -209,8 +209,12 @@ type Location_2 = {
 export { Location_2 as Location };
 
 // @public
-export type ValidateEntityResponse = {
-  valid: boolean;
-  errors?: SerializedError[];
-};
+export type ValidateEntityResponse =
+  | {
+      valid: true;
+    }
+  | {
+      valid: false;
+      errors: SerializedError[];
+    };
 ```

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
+import { SerializedError } from '@backstage/errors';
 
 // @public
 export type AddLocationRequest = {
@@ -65,6 +66,11 @@ export interface CatalogApi {
     id: string,
     options?: CatalogRequestOptions,
   ): Promise<void>;
+  validateEntity(
+    entity: Entity,
+    location: string,
+    options?: CatalogRequestOptions,
+  ): Promise<ValidateEntityResponse>;
 }
 
 // @public
@@ -122,6 +128,11 @@ export class CatalogClient implements CatalogApi {
     id: string,
     options?: CatalogRequestOptions,
   ): Promise<void>;
+  validateEntity(
+    entity: Entity,
+    location: string,
+    options?: CatalogRequestOptions,
+  ): Promise<ValidateEntityResponse>;
 }
 
 // @public
@@ -196,4 +207,10 @@ type Location_2 = {
   target: string;
 };
 export { Location_2 as Location };
+
+// @public
+export type ValidateEntityResponse = {
+  valid: boolean;
+  errors?: SerializedError[];
+};
 ```

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -356,5 +356,26 @@ describe('CatalogClient', () => {
         valid: true,
       });
     });
+
+    it('throws unexpected error', async () => {
+      server.use(
+        rest.post(`${mockBaseUrl}/validate-entity`, (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({}));
+        }),
+      );
+
+      await expect(() =>
+        client.validateEntity(
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'good',
+            },
+          },
+          'http://example.com',
+        ),
+      ).rejects.toThrow(/Request failed with 500 Error/);
+    });
   });
 });

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -295,4 +295,67 @@ describe('CatalogClient', () => {
       await client.getLocationById('42');
     });
   });
+
+  describe('validateEntity', () => {
+    it('returns valid false when validation fails', async () => {
+      server.use(
+        rest.post(`${mockBaseUrl}/validate-entity`, (req, res, ctx) => {
+          return res(
+            ctx.status(400),
+            ctx.json({
+              errors: [
+                {
+                  message: 'Missing name',
+                },
+              ],
+            }),
+          );
+        }),
+      );
+
+      expect(
+        await client.validateEntity(
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: '',
+            },
+          },
+          'http://example.com',
+        ),
+      ).toMatchObject({
+        valid: false,
+        errors: [
+          {
+            message: 'Missing name',
+          },
+        ],
+      });
+    });
+
+    it('returns valid true when validation fails', async () => {
+      server.use(
+        rest.post(`${mockBaseUrl}/validate-entity`, (req, res, ctx) => {
+          return res(ctx.status(200), ctx.text(''));
+        }),
+      );
+
+      expect(
+        await client.validateEntity(
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'good',
+            },
+          },
+          'http://example.com',
+        ),
+      ).toMatchObject({
+        valid: true,
+        errors: undefined,
+      });
+    });
+  });
 });

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -354,7 +354,6 @@ describe('CatalogClient', () => {
         ),
       ).toMatchObject({
         valid: true,
-        errors: undefined,
       });
     });
   });

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -299,7 +299,7 @@ describe('CatalogClient', () => {
   describe('validateEntity', () => {
     it('returns valid false when validation fails', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/validate-entity`, (req, res, ctx) => {
+        rest.post(`${mockBaseUrl}/validate-entity`, (_req, res, ctx) => {
           return res(
             ctx.status(400),
             ctx.json({
@@ -336,7 +336,7 @@ describe('CatalogClient', () => {
 
     it('returns valid true when validation fails', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/validate-entity`, (req, res, ctx) => {
+        rest.post(`${mockBaseUrl}/validate-entity`, (_req, res, ctx) => {
           return res(ctx.status(200), ctx.text(''));
         }),
       );

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -21,7 +21,7 @@ import {
   stringifyEntityRef,
   stringifyLocationRef,
 } from '@backstage/catalog-model';
-import { ResponseError, SerializedError } from '@backstage/errors';
+import { ResponseError } from '@backstage/errors';
 import crossFetch from 'cross-fetch';
 import {
   CATALOG_FILTER_EXISTS,
@@ -377,11 +377,14 @@ export class CatalogClient implements CatalogApi {
     if (response.ok) {
       return {
         valid: true,
-        errors: undefined,
       };
     }
 
-    const { errors } = (await response.json()) as { errors: SerializedError[] };
+    if (response.status !== 400) {
+      throw await ResponseError.fromResponse(response);
+    }
+
+    const { errors = [] } = await response.json();
 
     return {
       valid: false,

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -21,7 +21,7 @@ import {
   stringifyEntityRef,
   stringifyLocationRef,
 } from '@backstage/catalog-model';
-import { ResponseError } from '@backstage/errors';
+import { ResponseError, SerializedError } from '@backstage/errors';
 import crossFetch from 'cross-fetch';
 import {
   CATALOG_FILTER_EXISTS,
@@ -36,6 +36,7 @@ import {
   Location,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  ValidateEntityResponse,
 } from './types/api';
 import { DiscoveryApi } from './types/discovery';
 import { FetchApi } from './types/fetch';
@@ -351,6 +352,41 @@ export class CatalogClient implements CatalogApi {
       `/entities/by-uid/${encodeURIComponent(uid)}`,
       options,
     );
+  }
+
+  /**
+   * {@inheritdoc CatalogApi.validateEntity}
+   */
+  async validateEntity(
+    entity: Entity,
+    location: string,
+    options?: CatalogRequestOptions,
+  ): Promise<ValidateEntityResponse> {
+    const response = await this.fetchApi.fetch(
+      `${await this.discoveryApi.getBaseUrl('catalog')}/validate-entity`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(options?.token && { Authorization: `Bearer ${options?.token}` }),
+        },
+        method: 'POST',
+        body: JSON.stringify({ entity, location }),
+      },
+    );
+
+    if (response.ok) {
+      return {
+        valid: true,
+        errors: undefined,
+      };
+    }
+
+    const { errors } = (await response.json()) as { errors: SerializedError[] };
+
+    return {
+      valid: false,
+      errors,
+    };
   }
 
   //

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -15,6 +15,7 @@
  */
 
 import { CompoundEntityRef, Entity } from '@backstage/catalog-model';
+import { SerializedError } from '@backstage/errors';
 
 /**
  * This symbol can be used in place of a value when passed to filters in e.g.
@@ -270,6 +271,16 @@ export type AddLocationResponse = {
 };
 
 /**
+ * The response type for {@link CatalogClient.validateEntity}
+ *
+ * @public
+ */
+export type ValidateEntityResponse = {
+  valid: boolean;
+  errors?: SerializedError[];
+};
+
+/**
  * A client for interacting with the Backstage software catalog through its API.
  *
  * @public
@@ -390,4 +401,16 @@ export interface CatalogApi {
     id: string,
     options?: CatalogRequestOptions,
   ): Promise<void>;
+
+  /**
+   * Validate entity and its location.
+   *
+   * @param entity - Entity to validate
+   * @param location - URL location of the entity
+   */
+  validateEntity(
+    entity: Entity,
+    location: string,
+    options?: CatalogRequestOptions,
+  ): Promise<ValidateEntityResponse>;
 }

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -275,10 +275,9 @@ export type AddLocationResponse = {
  *
  * @public
  */
-export type ValidateEntityResponse = {
-  valid: boolean;
-  errors?: SerializedError[];
-};
+export type ValidateEntityResponse =
+  | { valid: true }
+  | { valid: false; errors: SerializedError[] };
 
 /**
  * A client for interacting with the Backstage software catalog through its API.

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -27,5 +27,6 @@ export type {
   Location,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  ValidateEntityResponse,
 } from './api';
 export { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from './status';

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -35,6 +35,7 @@ describe('CatalogIdentityClient', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
   const tokenManager: jest.Mocked<TokenManager> = {
     getToken: jest.fn(),

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -68,6 +68,7 @@ describe('createRouter', () => {
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
       getEntityFacets: jest.fn(),
+      validateEntity: jest.fn(),
     };
 
     config = new ConfigReader({

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -59,6 +59,7 @@ describe('<CatalogGraphCard/>', () => {
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
       getEntityFacets: jest.fn(),
+      validateEntity: jest.fn(),
     };
     apis = TestApiRegistry.from([catalogApiRef, catalog]);
 

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
@@ -92,6 +92,7 @@ describe('<CatalogGraphPage/>', () => {
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
       getEntityFacets: jest.fn(),
+      validateEntity: jest.fn(),
     };
 
     wrapper = (

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
@@ -119,6 +119,7 @@ describe('<EntityRelationsGraph/>', () => {
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
       getEntityFacets: jest.fn(),
+      validateEntity: jest.fn(),
     };
 
     Wrapper = ({ children }) => (

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityStore.test.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityStore.test.ts
@@ -38,6 +38,7 @@ describe('useEntityStore', () => {
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
       getEntityFacets: jest.fn(),
+      validateEntity: jest.fn(),
     };
 
     useApi.mockReturnValue(catalogApi);

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -100,6 +100,7 @@ describe('CatalogImportClient', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
 
   let catalogImportClient: CatalogImportClient;

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -46,6 +46,7 @@ describe('<StepPrepareCreatePullRequest />', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
 
   const errorApi: jest.Mocked<typeof errorApiRef.T> = {

--- a/plugins/explore/src/components/DefaultExplorePage/DefaultExplorePage.test.tsx
+++ b/plugins/explore/src/components/DefaultExplorePage/DefaultExplorePage.test.tsx
@@ -32,6 +32,7 @@ describe('<DefaultExplorePage />', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -33,6 +33,7 @@ describe('<DomainExplorerContent />', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
@@ -33,6 +33,7 @@ describe('<GroupsExplorerContent />', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
+++ b/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
@@ -37,6 +37,7 @@ describe('<FossaPage />', () => {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
   const fossaApi: jest.Mocked<FossaApi> = {
     getFindingSummary: jest.fn(),

--- a/plugins/todo-backend/src/service/TodoReaderService.test.ts
+++ b/plugins/todo-backend/src/service/TodoReaderService.test.ts
@@ -53,6 +53,7 @@ function mockCatalogClient(entity?: Entity): jest.Mocked<CatalogApi> {
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),
+    validateEntity: jest.fn(),
   };
   if (entity) {
     mock.getEntityByRef.mockReturnValue(entity);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`/validate-entity` endpoint has been available on the Catalog REST API for a while. It was never added to the catalog client; as a result, it's not well known that it is available. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
