### PR TITLE
feat: Allow passing additional JWT claims to `TokenIssuer`

### DIFF
--- a/.changeset/cold-bananas-hang.md
+++ b/.changeset/cold-bananas-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Allow adding misc claims to JWT

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -706,7 +706,7 @@ export type TokenParams = {
   claims: {
     sub: string;
     ent?: string[];
-  } & Record<string, string | string[]>;
+  } & Record<string, JsonValue>;
 };
 
 // @public (undocumented)

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -706,7 +706,7 @@ export type TokenParams = {
   claims: {
     sub: string;
     ent?: string[];
-  };
+  } & Record<string, string | string[]>;
 };
 
 // @public (undocumented)

--- a/plugins/auth-backend/src/identity/TokenFactory.test.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.test.ts
@@ -48,7 +48,12 @@ describe('TokenFactory', () => {
 
     await expect(factory.listPublicKeys()).resolves.toEqual({ keys: [] });
     const token = await factory.issueToken({
-      claims: { sub: entityRef, ent: [entityRef] },
+      claims: {
+        sub: entityRef,
+        ent: [entityRef],
+        'x-fancy-claim': 'my special claim',
+        aud: 'this value will be overridden',
+      },
     });
 
     const { keys } = await factory.listPublicKeys();
@@ -60,6 +65,7 @@ describe('TokenFactory', () => {
       aud: 'backstage',
       sub: entityRef,
       ent: [entityRef],
+      'x-fancy-claim': 'my special claim',
       iat: expect.any(Number),
       exp: expect.any(Number),
     });

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -77,8 +77,7 @@ export class TokenFactory implements TokenIssuer {
     const key = await this.getKey();
 
     const iss = this.issuer;
-    const sub = params.claims.sub;
-    const ent = params.claims.ent;
+    const { sub, ent, ...additionalClaims } = params.claims;
     const aud = 'backstage';
     const iat = Math.floor(Date.now() / MS_IN_S);
     const exp = iat + this.keyDurationSeconds;
@@ -98,7 +97,7 @@ export class TokenFactory implements TokenIssuer {
       throw new AuthenticationError('No algorithm was provided in the key');
     }
 
-    return new SignJWT({ iss, sub, ent, aud, iat, exp })
+    return new SignJWT({ ...additionalClaims, iss, sub, ent, aud, iat, exp })
       .setProtectedHeader({ alg: key.alg, kid: key.kid })
       .setIssuer(iss)
       .setAudience(aud)

--- a/plugins/auth-backend/src/identity/types.ts
+++ b/plugins/auth-backend/src/identity/types.ts
@@ -28,13 +28,19 @@ export interface AnyJWK extends Record<string, string> {
  * @public
  */
 export type TokenParams = {
-  /** The claims that will be embedded within the token */
+  /**
+   * The claims that will be embedded within the token. At a minimum, this should include
+   * the subject claim, `sub`. It is common to also list entity ownership relations in the
+   * `ent` list. Additional claims may also be added at the developer's discretion except
+   * for the following list, which will be overwritten by the TokenIssuer: `iss`, `aud`,
+   * `iat`, and `exp`.
+   */
   claims: {
     /** The token subject, i.e. User ID */
     sub: string;
     /** A list of entity references that the user claims ownership through */
     ent?: string[];
-  };
+  } & Record<string, string | string[]>;
 };
 
 /**

--- a/plugins/auth-backend/src/identity/types.ts
+++ b/plugins/auth-backend/src/identity/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { JsonValue } from '@backstage/types';
+
 /** Represents any form of serializable JWK */
 export interface AnyJWK extends Record<string, string> {
   use: 'sig';
@@ -33,14 +35,15 @@ export type TokenParams = {
    * the subject claim, `sub`. It is common to also list entity ownership relations in the
    * `ent` list. Additional claims may also be added at the developer's discretion except
    * for the following list, which will be overwritten by the TokenIssuer: `iss`, `aud`,
-   * `iat`, and `exp`.
+   * `iat`, and `exp`. The Backstage team also maintains the right add new claims in the future
+   * without listing the change as a "breaking change".
    */
   claims: {
     /** The token subject, i.e. User ID */
     sub: string;
     /** A list of entity references that the user claims ownership through */
     ent?: string[];
-  } & Record<string, string | string[]>;
+  } & Record<string, JsonValue>;
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: David Zemon <david@zemon.name>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

We have, for some time now, been (ab)using the `ent` claim on the Backstage JWT to store credentials for the logged in user. Specifically, credentials to external systems that have not yet been integrated with our SSO provider. For example, we want the Backstage JWT to contain the end-user's BitBucket Personal Access Token, so we put that in the JWT as `ent: ['bbPat:xxxxx']`. This is.... not the ideal solution. But, the `TokenIssuer`, its `TokenParams` object, and even the specific implementation of `TokenFactory` prevent us from doing anything better. Even if we ignore the TypeScript compiler error and add additional claims on the input parameter, those claims will be ignored by `TokenFactory.issueToken()`.

So, I've added the ability to list any additional claims that a developer wants but ensured that those claims are the lowest priority when building the token so that a developer does not accidentally shoot themselves in the foot by overwriting important Backstage claims like `iss` and `exp`.

I've also updated the pertinent unit test to ensure that the overwriting is working correctly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
