### PR TITLE
Catalog: add support for multiple sort fields to paginated endpoint

### DIFF
--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -151,6 +151,12 @@ export const ENTITY_STATUS_CATALOG_PROCESSING_TYPE =
   'backstage.io/catalog-processing';
 
 // @public
+export type EntitySortField = {
+  field: string;
+  order: 'asc' | 'desc';
+};
+
+// @public
 export interface GetEntitiesRequest {
   after?: string;
   fields?: string[] | undefined;
@@ -212,9 +218,8 @@ export type GetPaginatedEntitiesInitialRequest =
       fields?: string[];
       limit?: number;
       filter?: EntitiesFilter;
-      sortField?: string;
+      sortFields?: EntitySortField[];
       query?: string;
-      sortFieldOrder?: 'asc' | 'desc';
     }
   | undefined;
 

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -308,11 +308,13 @@ describe('CatalogClient', () => {
         fields: ['a', 'b'],
         limit: 100,
         query: 'query',
-        sortField: 'metadata.name',
-        sortFieldOrder: 'asc',
+        sortFields: [
+          { field: 'metadata.name', order: 'asc' },
+          { field: 'metadata.uid', order: 'desc' },
+        ],
       });
       expect(mockedEndpoint.mock.calls[0][0].url.search).toBe(
-        '?limit=100&sortField=metadata.name&sortFieldOrder=asc&fields=a,b&query=query',
+        '?limit=100&sortField=metadata.name,asc&sortField=metadata.uid,desc&fields=a,b&query=query',
       );
     });
 
@@ -329,8 +331,7 @@ describe('CatalogClient', () => {
         fields: ['a', 'b'],
         limit: 100,
         query: 'query',
-        sortField: 'metadata.name',
-        sortFieldOrder: 'asc',
+        sortFields: [{ field: 'metadata.name', order: 'asc' }],
         cursor: 'cursor',
       });
       expect(mockedEndpoint.mock.calls[0][0].url.search).toBe(

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -162,24 +162,16 @@ export class CatalogClient implements CatalogApi {
     const params: string[] = [];
 
     if (isPaginatedEntitiesInitialRequest(request)) {
-      const {
-        fields = [],
-        filter,
-        limit,
-        sortField,
-        sortFieldOrder,
-        query,
-      } = request ?? {};
+      const { fields = [], filter, limit, sortFields, query } = request ?? {};
       params.push(...this.getParams(filter));
 
       if (limit !== undefined) {
         params.push(`limit=${limit}`);
       }
-      if (sortField !== undefined) {
-        params.push(`sortField=${sortField}`);
-      }
-      if (sortFieldOrder !== undefined) {
-        params.push(`sortFieldOrder=${sortFieldOrder}`);
+      if (sortFields !== undefined) {
+        sortFields.forEach(({ field, order }) =>
+          params.push(`sortField=${field},${order}`),
+        );
       }
       if (fields.length) {
         params.push(`fields=${fields.map(encodeURIComponent).join(',')}`);

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -262,6 +262,11 @@ export type EntitiesFilter =
   | undefined;
 
 /**
+ * Used for sorting the entities.
+ */
+export type EntitySortField = { field: string; order: 'asc' | 'desc' };
+
+/**
  * The response type for {@link CatalogClient.addLocation}.
  *
  * @public
@@ -297,9 +302,8 @@ export type GetPaginatedEntitiesInitialRequest =
       fields?: string[];
       limit?: number;
       filter?: EntitiesFilter;
-      sortField?: string;
+      sortFields?: EntitySortField[];
       query?: string;
-      sortFieldOrder?: 'asc' | 'desc';
     }
   | undefined;
 

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -263,6 +263,8 @@ export type EntitiesFilter =
 
 /**
  * Used for sorting the entities.
+ *
+ * @public
  */
 export type EntitySortField = { field: string; order: 'asc' | 'desc' };
 

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -21,6 +21,7 @@ export type {
   CatalogApi,
   CatalogRequestOptions,
   EntitiesFilter,
+  EntitySortField,
   GetEntitiesRequest,
   GetEntitiesResponse,
   GetEntityAncestorsRequest,

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -39,6 +39,14 @@ export type EntityPagination = {
 };
 
 /**
+ * A sorting rule for entities.
+ */
+export type EntitySortField = {
+  field: string;
+  order?: 'asc' | 'desc' | undefined;
+};
+
+/**
  * Matches rows in the search table.
  * @public
  */
@@ -190,9 +198,8 @@ export interface PaginatedEntitiesInitialRequest {
   fields?: (entity: Entity) => Entity;
   limit?: number;
   filter?: EntityFilter;
-  sortField?: string;
+  sortFields?: EntitySortField[];
   query?: string;
-  sortFieldOrder?: 'asc' | 'desc' | undefined;
 }
 
 /**
@@ -239,20 +246,19 @@ export interface PaginatedEntitiesResponse {
  */
 export type Cursor = {
   /**
-   * the id of the field used for sorting the data.
-   * For example, metadata.name
+   * An array of fields used for sorting the data.
+   * For example, [ { field: 'metadata.name', order: 'asc' } ]
    */
-  sortField: string;
+  sortFields: EntitySortField[];
   /**
-   * The value of the last item returned
-   * by the request. This is used for performing
-   * cursor based pagination.
+   * The value of the cursor of the last item returned.
+   * This is used for performing pagination.
    */
-  sortFieldId: string;
+  sortFieldIds: string[];
+
   /**
-   * In which order the data should be paginated.
+   * A filter to apply on the full list of entities.
    */
-  sortFieldOrder: 'asc' | 'desc';
   filter?: EntityFilter;
   /**
    * true if the cursor is a previous cursor.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -582,7 +582,7 @@ describe('DefaultEntitiesCatalog', () => {
         const request1: PaginatedEntitiesInitialRequest = {
           filter,
           limit,
-          sortField: 'metadata.name',
+          sortFields: [{ field: 'metadata.name' }],
         };
         const response1 = await catalog.paginatedEntities(request1);
         expect(response1.entities).toEqual([entityFrom('A'), entityFrom('B')]);
@@ -734,8 +734,7 @@ describe('DefaultEntitiesCatalog', () => {
         const request1: PaginatedEntitiesInitialRequest = {
           filter,
           limit,
-          sortField: 'metadata.name',
-          sortFieldOrder: 'desc',
+          sortFields: [{ field: 'metadata.name', order: 'desc' }],
         };
         const response1 = await catalog.paginatedEntities(request1);
         expect(response1.entities).toEqual([entityFrom('G'), entityFrom('F')]);
@@ -885,7 +884,8 @@ describe('DefaultEntitiesCatalog', () => {
         const request: PaginatedEntitiesInitialRequest = {
           filter,
           limit: 100,
-          sortField: 'metadata.name',
+
+          sortFields: [{ field: 'metadata.name' }],
           query: 'cAt ',
         };
         const response = await catalog.paginatedEntities(request);

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -161,7 +161,7 @@ describe('createRouter readonly disabled', () => {
         totalItems: 0,
       });
       const response = await request(app).get(
-        '/v2beta1/entities?filter=a=1,a=2,b=3&filter=c=4',
+        '/v2beta1/entities?filter=a=1,a=2,b=3&filter=c=4&sortField=metadata.name,asc&sortField=metadata.uid,desc',
       );
 
       expect(response.status).toEqual(200);
@@ -178,6 +178,10 @@ describe('createRouter readonly disabled', () => {
             { allOf: [{ key: 'c', values: ['4'] }] },
           ],
         },
+        sortFields: [
+          { field: 'metadata.name', order: 'asc' },
+          { field: 'metadata.uid', order: 'desc' },
+        ],
       });
     });
 

--- a/plugins/catalog-backend/src/service/request/parseEntitySortFieldParams.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntitySortFieldParams.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseEntitySortFieldParams } from './parseEntitySortFieldParams';
+
+describe('parseEntitySortFieldParams', () => {
+  it('supports no sort fields', () => {
+    const result = parseEntitySortFieldParams({});
+    expect(result).toEqual(undefined);
+  });
+
+  it('supports single sortField', () => {
+    const result = parseEntitySortFieldParams({
+      sortField: ['metadata.name,desc'],
+    })!;
+    expect(result).toEqual([{ field: 'metadata.name', order: 'desc' }]);
+  });
+
+  it('supports single sortField without order', () => {
+    const result = parseEntitySortFieldParams({
+      sortField: ['metadata.name'],
+    })!;
+    expect(result).toEqual([{ field: 'metadata.name' }]);
+  });
+
+  it('supports multiple sort fields', () => {
+    const result = parseEntitySortFieldParams({
+      sortField: ['metadata.name,desc', 'metadata.uid,asc'],
+    });
+
+    expect(result).toEqual([
+      { field: 'metadata.name', order: 'desc' },
+      { field: 'metadata.uid', order: 'asc' },
+    ]);
+  });
+
+  it('throws if sortField order is not valid', () => {
+    expect(() =>
+      parseEntitySortFieldParams({
+        sortField: ['metadata.name,desc', 'metadata.uid,invalid'],
+      }),
+    ).toThrow(/Invalid sort field order/);
+  });
+});

--- a/plugins/catalog-backend/src/service/request/parseEntitySortFieldParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntitySortFieldParams.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import { EntitySortField } from '../../catalog/types';
+import { parseStringsParam } from './common';
+
+export function parseEntitySortFieldParams(
+  params: Record<string, unknown>,
+): EntitySortField[] | undefined {
+  const sortFieldStrings = parseStringsParam(params.sortField, 'sortField');
+  if (!sortFieldStrings) {
+    return undefined;
+  }
+
+  return sortFieldStrings.map(sortFieldString => {
+    const [field, order] = sortFieldString.split(',');
+
+    if (order !== undefined && !isOrder(order)) {
+      throw new InputError('Invalid sort field order, must be asc or desc');
+    }
+    return { field, order };
+  });
+}
+
+export function isOrder(order: string): order is 'asc' | 'desc' {
+  return ['asc', 'desc'].includes(order);
+}

--- a/plugins/catalog-backend/src/service/request/parsePaginatedEntitiesParams.test.ts
+++ b/plugins/catalog-backend/src/service/request/parsePaginatedEntitiesParams.test.ts
@@ -28,8 +28,7 @@ describe('parsePaginatedEntitiesParams', () => {
         fields: ['kind'],
         limit: '3',
         filter: ['a=1', 'b=2'],
-        sortField: 'sortField',
-        sortFieldOrder: 'desc',
+        sortField: ['metadata.name,desc'],
         query: 'query',
       };
       const parsedObj = parsePaginatedEntitiesParams(
@@ -37,8 +36,9 @@ describe('parsePaginatedEntitiesParams', () => {
       ) as PaginatedEntitiesInitialRequest;
       expect(parsedObj.limit).toBe(3);
       expect(parsedObj.fields).toBeDefined();
-      expect(parsedObj.sortField).toBe('sortField');
-      expect(parsedObj.sortFieldOrder).toBe('desc');
+      expect(parsedObj.sortFields).toEqual([
+        { field: 'metadata.name', order: 'desc' },
+      ]);
       expect(parsedObj.filter).toBeDefined();
       expect(parsedObj.query).toBe('query');
       expect(parsedObj).not.toHaveProperty('authorizationToken');
@@ -50,8 +50,7 @@ describe('parsePaginatedEntitiesParams', () => {
       ) as PaginatedEntitiesInitialRequest;
       expect(parsedObj.limit).toBeUndefined();
       expect(parsedObj.fields).toBeUndefined();
-      expect(parsedObj.sortField).toBeUndefined();
-      expect(parsedObj.sortFieldOrder).toBeUndefined();
+      expect(parsedObj.sortFields).toBeUndefined();
       expect(parsedObj.filter).toBeUndefined();
       expect(parsedObj.query).toBeUndefined();
       expect(parsedObj).not.toHaveProperty('authorizationToken');
@@ -63,8 +62,7 @@ describe('parsePaginatedEntitiesParams', () => {
         limit: 'asd',
       },
       { filter: 3 },
-      { sortField: [] },
-      { sortFieldOrder: 'something' },
+      { sortField: ['metadata.uid,diagonal'] },
       { fields: [4] },
       { query: [] },
     ])('should throw if some parameter is not valid %p', params => {

--- a/plugins/catalog-backend/src/service/request/parsePaginatedEntitiesParams.ts
+++ b/plugins/catalog-backend/src/service/request/parsePaginatedEntitiesParams.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { InputError } from '@backstage/errors';
 import {
   PaginatedEntitiesCursorRequest,
   PaginatedEntitiesInitialRequest,
@@ -22,6 +21,7 @@ import {
 } from '../../catalog/types';
 import { parseIntegerParam, parseStringParam } from './common';
 import { parseEntityFilterParams } from './parseEntityFilterParams';
+import { parseEntitySortFieldParams } from './parseEntitySortFieldParams';
 import { parseEntityTransformParams } from './parseEntityTransformParams';
 
 export function parsePaginatedEntitiesParams(
@@ -42,33 +42,16 @@ export function parsePaginatedEntitiesParams(
 
   const filter = parseEntityFilterParams(params);
   const query = parseStringParam(params.query, 'query');
-  const sortField = parseStringParam(params.sortField, 'sortField');
-  const sortFieldOrder = parseSortFieldOrder(
-    params.sortFieldOrder,
-    'sortFieldOrder',
-  );
+  const sortFields = parseEntitySortFieldParams(params);
 
   const response: Omit<PaginatedEntitiesInitialRequest, 'authorizationToken'> =
     {
       fields,
       filter,
       limit,
-      sortField,
-      sortFieldOrder,
+      sortFields,
       query,
     };
 
   return response;
-}
-
-function parseSortFieldOrder(sortFieldOrder: unknown, ctx: string) {
-  const isSortFieldOrder =
-    sortFieldOrder === undefined ||
-    sortFieldOrder === 'asc' ||
-    sortFieldOrder === 'desc';
-
-  if (isSortFieldOrder) {
-    return sortFieldOrder;
-  }
-  throw new InputError(`Invalid ${ctx}, not asc or desc`);
 }


### PR DESCRIPTION
In order to avoid breaking changes to the apis in the future, this PR adds support for multiple sortFields in the new paginated endpoint,
addressing https://github.com/backstage/backstage/pull/12246#discussion_r909521977

The current implementation of the catalog still supports a single sort field.
