### PR TITLE
cli: allow overriding test file patterns in eslint-factory

### DIFF
--- a/.changeset/great-crews-own.md
+++ b/.changeset/great-crews-own.md
@@ -1,0 +1,15 @@
+---
+'@backstage/cli': patch
+---
+
+Add support for supplying `testFilePatterns` when generating eslint config.
+
+Any additional patterns supplied in `testFilePatterns` will be used when applying test-specific linting configuration. Note that the test running configuration in Backstage is opinionated about which files contain _tests_ - with that in mind, this option is mostly useful for supplying patterns which match test support files (utils, mocks, etc).
+
+To supply the new option, pass it in the options object passed as the second parameter to `eslint-factory`:
+
+```javascript
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  testFilePatterns: ['src/**/__tests__/**'],
+});
+```

--- a/.changeset/great-crews-own.md
+++ b/.changeset/great-crews-own.md
@@ -2,14 +2,18 @@
 '@backstage/cli': patch
 ---
 
-Add support for supplying `testFilePatterns` when generating eslint config.
+Add support for overriding the `testFilePatterns` used when generating eslint config.
 
-Any additional patterns supplied in `testFilePatterns` will be used when applying test-specific linting configuration. Note that the test running configuration in Backstage is opinionated about which files contain _tests_ - with that in mind, this option is mostly useful for supplying patterns which match test support files (utils, mocks, etc).
+If `testFilePatterns` is supplied, the patterns will be used instead of the defaults when applying test-specific linting configuration. Note that the test running configuration in Backstage is opinionated about which files contain _tests_ - with that in mind, this option is mostly useful for supplying patterns which match test support files (utils, mocks, etc).
 
 To supply the new option, pass it in the options object passed as the second parameter to `eslint-factory`:
 
 ```javascript
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
-  testFilePatterns: ['src/**/__tests__/**'],
+  testFilePatterns: [
+    'src/**/__tests__/**'
+    'src/setupTests.*',
+    '!src/**',
+  ],
 });
 ```

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -22,6 +22,7 @@ const { join: joinPath } = require('path');
  * parameter also accepts the following keys:
  *
  * - `tsRules`: Additional ESLint rules to apply to TypeScript
+ * - `testFilePatterns`: Additional patterns to which to apply test overrides
  * - `testRules`: Additional ESLint rules to apply to tests
  * - `restrictedImports`: Additional paths to add to no-restricted-imports
  * - `restrictedSrcImports`: Additional paths to add to no-restricted-imports in src files
@@ -37,6 +38,7 @@ function createConfig(dir, extraConfig = {}) {
     env,
     parserOptions,
     ignorePatterns,
+    testFilePatterns,
     overrides,
 
     rules,
@@ -97,6 +99,9 @@ function createConfig(dir, extraConfig = {}) {
                 joinPath(dir, 'src/**/*.test.*'),
                 joinPath(dir, 'src/**/*.stories.*'),
                 joinPath(dir, 'src/setupTests.*'),
+                ...(testFilePatterns || []).map(pattern =>
+                  joinPath(dir, pattern),
+                ),
               ]
             : [
                 // Legacy config for packages that don't provide a dir
@@ -159,7 +164,13 @@ function createConfig(dir, extraConfig = {}) {
         },
       },
       {
-        files: ['**/*.test.*', '**/*.stories.*', 'src/setupTests.*', '!src/**'],
+        files: [
+          '**/*.test.*',
+          '**/*.stories.*',
+          'src/setupTests.*',
+          '!src/**',
+          ...(testFilePatterns || []),
+        ],
         rules: {
           ...testRules,
           'no-restricted-syntax': [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This addition makes life a little easier for folks using different test file patterns (e.g. putting tests or test support files in `__tests__` directories), by allowing them to ~~supply additional~~ _specify_ test file patterns when calling eslint-factory:

```javascript
module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
  testFilePatterns: [
    'src/**/__tests__/**'
    'src/setupTests.*',
    '!src/**',
  ],
});
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
