### PR TITLE
Bazaar plugin: Fix routing

### DIFF
--- a/.changeset/gorgeous-boats-prove.md
+++ b/.changeset/gorgeous-boats-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Fixed broken routing by removing the wrapping `Router` from the `RoutedTabs` children.

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -41,8 +41,7 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0",
-    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
+    "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.19.0-next.1",

--- a/plugins/bazaar/src/components/HomePage/HomePage.tsx
+++ b/plugins/bazaar/src/components/HomePage/HomePage.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { Header, RoutedTabs } from '@backstage/core-components';
-import { Route } from 'react-router-dom';
 import { SortView } from '../SortView';
 import { About } from '../About';
 
@@ -25,12 +24,12 @@ export const HomePage = () => {
     {
       path: '/',
       title: 'Home',
-      children: <Route path="/" element={<SortView />} />,
+      children: <SortView />,
     },
     {
       path: '/about',
       title: 'About',
-      children: <Route path="/about" element={<About />} />,
+      children: <About />,
     },
   ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4168,7 +4168,6 @@ __metadata:
     react-use: ^17.2.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
-    react-router-dom: 6.0.0-beta.0 || ^6.3.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
During the recent 'react-router-dom' upgrades the Bazaar routing broke. This patch removes the 'Route' from the 'RoutedTabs' children.

Opening the Bazaar plugin would result in the following error:

`A <Route> is only ever to be used as the child of <Routes> element, never rendered directly. Please wrap your <Route> in a <Routes>.`

Signed-off-by: Niklas Aronsson <niklasar@axis.com>

## Hey, I just made a Pull Request!

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
