### PR TITLE
Update docker guide for clarity

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -16,7 +16,8 @@ are stateless, so for a production deployment you will want to set up and
 connect to an external PostgreSQL instance where the backend plugins can store
 their state, rather than using SQLite.
 
-By default, in an app created with `@backstage/create-app`, the frontend is
+It is in this section assumed that an [app](https://backstage.io/docs/getting-started/create-an-app)
+has already been created with`@backstage/create-app`, in which the frontend is
 bundled and served from the backend. This is done using the
 `@backstage/plugin-app-backend` plugin, which also injects the frontend
 configuration into the app. This means that you only need to build and deploy a

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -16,8 +16,8 @@ are stateless, so for a production deployment you will want to set up and
 connect to an external PostgreSQL instance where the backend plugins can store
 their state, rather than using SQLite.
 
-It is in this section assumed that an [app](https://backstage.io/docs/getting-started/create-an-app)
-has already been created with`@backstage/create-app`, in which the frontend is
+This section assumes that an [app](https://backstage.io/docs/getting-started/create-an-app)
+has already been created with `@backstage/create-app`, in which the frontend is
 bundled and served from the backend. This is done using the
 `@backstage/plugin-app-backend` plugin, which also injects the frontend
 configuration into the app. This means that you only need to build and deploy a


### PR DESCRIPTION
As happened to a colleague of mine and might happen to others, one might see a "docker" section and skip straight to that since it looks on the surface to be a quick way to check out backstage yourself. In this case that resulted in trying to make all these builds from the main backstage/backstage repo, before even understanding the concept of a Backstage App, which obviously did not work out.

Signed-off-by: Tomás Mota <tomasrebelomota@gmail.com>
