### PR TITLE
dev-utils: fix route discovery with react-router stable

### DIFF
--- a/.changeset/metal-candles-tease.md
+++ b/.changeset/metal-candles-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/dev-utils': patch
+---
+
+Fixed routing when using React Router v6 stable.

--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -46,16 +46,23 @@ import { Box } from '@material-ui/core';
 import BookmarkIcon from '@material-ui/icons/Bookmark';
 import React, { ComponentType, ReactNode } from 'react';
 import ReactDOM from 'react-dom';
-import { Route } from 'react-router';
+import { createRoutesFromChildren, Route } from 'react-router';
 import { SidebarThemeSwitcher } from './SidebarThemeSwitcher';
 
-const GatheringRoute: (props: {
+export function isReactRouterBeta(): boolean {
+  const [obj] = createRoutesFromChildren(<Route index element={<div />} />);
+  return !obj.index;
+}
+
+const MaybeGatheringRoute: (props: {
   path: string;
   element: JSX.Element;
   children?: ReactNode;
 }) => JSX.Element = ({ element }) => element;
 
-attachComponentData(GatheringRoute, 'core.gatherMountPoints', true);
+if (isReactRouterBeta()) {
+  attachComponentData(MaybeGatheringRoute, 'core.gatherMountPoints', true);
+}
 
 /** @public */
 export type DevAppPageOptions = {
@@ -136,7 +143,7 @@ export class DevAppBuilder {
       );
     }
     this.routes.push(
-      <GatheringRoute
+      <MaybeGatheringRoute
         key={path}
         path={path}
         element={opts.element}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The element discovery that we did for dev app pages previously was a workaround for the fact that extensions couldn't be placed further into the `element` prop tree. We now allow that in the new system, so all that needs to be done to support React Router v6 stable is to remove the discovery.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
