### PR TITLE
Fix overflow issue for mic drop 404 image

### DIFF
--- a/.changeset/three-dryers-confess.md
+++ b/.changeset/three-dryers-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix overflow bug on MicDrop image for 404 page by moving the image and making it relative rather than absolute

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -70,7 +70,6 @@ export function ErrorPage(props: IErrorPageProps) {
 
   return (
     <Grid container spacing={0} className={classes.container}>
-      <MicDrop />
       <Grid item xs={12} sm={8} md={4}>
         <Typography
           data-testid="error"
@@ -94,6 +93,7 @@ export function ErrorPage(props: IErrorPageProps) {
           think this is a bug.
         </Typography>
       </Grid>
+      <MicDrop />
     </Grid>
   );
 }

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
@@ -22,12 +22,10 @@ const useStyles = makeStyles(
   theme => ({
     micDrop: {
       maxWidth: '60%',
-      position: 'absolute',
       bottom: theme.spacing(2),
       right: theme.spacing(2),
       [theme.breakpoints.down('xs')]: {
         maxWidth: '96%',
-        position: 'relative',
         bottom: 'unset',
         right: 'unset',
         margin: `${theme.spacing(10)}px auto ${theme.spacing(4)}px`,


### PR DESCRIPTION
Signed-off-by: sblausten <sam@roadie.io>

## Hey, I just made a Pull Request!


On an embedded Tech Docs page that has a height below ~800px the Mic Drop image starts overflowing into headers and can obscure tabs in certain views. 

The image also flows over the top of the page on a normal 404 page when the height is below 550px.

### Before:
<img width="1565" alt="Screenshot 2022-09-12 at 11 27 22" src="https://user-images.githubusercontent.com/7934833/189634144-cc3e3678-9f38-4166-a1a8-210c7f054277.png">
<img width="1293" alt="Screenshot 2022-09-12 at 13 05 09" src="https://user-images.githubusercontent.com/7934833/189648964-03571965-0a33-4d8e-9f86-ac7ba5ac4d08.png">


### After:
<img width="1567" alt="Screenshot 2022-09-12 at 11 28 41" src="https://user-images.githubusercontent.com/7934833/189634237-c976dd75-e0dd-4757-beb4-e1103b6a1d6a.png">
<img width="1311" alt="Screenshot 2022-09-12 at 11 39 06" src="https://user-images.githubusercontent.com/7934833/189634210-939d08f5-fcd8-4c6d-aff0-ee97cd6cec53.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
