### PR TITLE
[GitlabDiscoveryEntityProvider] - entityFilename wildcard support

### DIFF
--- a/.changeset/heavy-pumpkins-speak.md
+++ b/.changeset/heavy-pumpkins-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': minor
+---
+
+Added support to wildcard locations in GitlabDiscoveryEntityProvider. If it passed in provider entityFilename with wildcard sign, file existence check is not needed more

--- a/.changeset/heavy-pumpkins-speak.md
+++ b/.changeset/heavy-pumpkins-speak.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-Added support to wildcard locations in GitlabDiscoveryEntityProvider. If it passed in provider entityFilename with wildcard sign, file existence check is not needed more
+Support to wildcard locations in GitlabDiscoveryEntityProvider. If it passed in provider entityFilename with wildcard sign, file existence check is not needed more

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -155,6 +155,7 @@ describe('GitlabDiscoveryEntityProvider', () => {
     const schedule = new PersistingTaskRunner();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
     const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
       logger,

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -161,6 +161,13 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
         continue;
       }
 
+      const isRelativePath = this.config.catalogFile?.match(/[*?]/);
+
+      if (isRelativePath) {
+        res.matches.push(project);
+        continue;
+      }
+
       const project_branch = project.default_branch ?? this.config.branch;
 
       const projectHasFile: boolean = await client.hasFile(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Now it's mandatory to pass existing file to provider config, it would be nice if we can pass pattern with wildcard to match entities with UrlLoader for a more efficient discovery process. ([according this advice](https://github.com/backstage/backstage/issues/8232#issuecomment-980128488))

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
