### PR TITLE
Add custom actions plugin for Azure pipelines to documentation

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -156,15 +156,16 @@ export default async function createPlugin(
 Here is a list of Open Source custom actions that you can add to your Backstage
 scaffolder backend:
 
-| Name                    | Package                                                                                                                                 | Owner                                        |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| Yeoman                  | [plugin-scaffolder-backend-module-yeoman](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend-module-yeoman)             | [Backstage](https://backstage.io)            |
-| Cookiecutter            | [plugin-scaffolder-backend-module-cookiecutter](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend-module-cookiecutter) | [Backstage](https://backstage.io)            |
-| Rails                   | [plugin-scaffolder-backend-module-rails](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend-module-rails)               | [Backstage](https://backstage.io)            |
-| HTTP requests           | [scaffolder-backend-module-http-request](https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-http-request)                | [Roadie](https://roadie.io)                  |
-| Utility actions         | [scaffolder-backend-module-utils](https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-utils)                              | [Roadie](https://roadie.io)                  |
-| AWS cli actions         | [scaffolder-backend-module-aws](https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-aws)                                  | [Roadie](https://roadie.io)                  |
-| Scaffolder .NET Actions | [plugin-scaffolder-dotnet-backend](https://www.npmjs.com/package/@plusultra/plugin-scaffolder-dotnet-backend)                           | [Alef Carlos](https://github.com/alefcarlos) |
-| Scaffolder Git Actions  | [plugin-scaffolder-git-actions](https://www.npmjs.com/package/@mdude2314/backstage-plugin-scaffolder-git-actions)                       | [Drew Hill](https://github.com/arhill05)     |
+| Name                    | Package                                                                                                                                   | Owner                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Yeoman                  | [plugin-scaffolder-backend-module-yeoman](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend-module-yeoman)               | [Backstage](https://backstage.io)                            |
+| Cookiecutter            | [plugin-scaffolder-backend-module-cookiecutter](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend-module-cookiecutter)   | [Backstage](https://backstage.io)                            |
+| Rails                   | [plugin-scaffolder-backend-module-rails](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend-module-rails)                 | [Backstage](https://backstage.io)                            |
+| HTTP requests           | [scaffolder-backend-module-http-request](https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-http-request)                  | [Roadie](https://roadie.io)                                  |
+| Utility actions         | [scaffolder-backend-module-utils](https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-utils)                                | [Roadie](https://roadie.io)                                  |
+| AWS cli actions         | [scaffolder-backend-module-aws](https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-aws)                                    | [Roadie](https://roadie.io)                                  |
+| Scaffolder .NET Actions | [plugin-scaffolder-dotnet-backend](https://www.npmjs.com/package/@plusultra/plugin-scaffolder-dotnet-backend)                             | [Alef Carlos](https://github.com/alefcarlos)                 |
+| Scaffolder Git Actions  | [plugin-scaffolder-git-actions](https://www.npmjs.com/package/@mdude2314/backstage-plugin-scaffolder-git-actions)                         | [Drew Hill](https://github.com/arhill05)                     |
+| Azure Pipeline Actions  | [scaffolder-backend-module-azure-pipelines](https://www.npmjs.com/package/@parfuemerie-douglas/scaffolder-backend-module-azure-pipelines) | [Parfümerie Douglas](https://github.com/Parfuemerie-Douglas) |
 
 Have fun! 🚀


### PR DESCRIPTION
Signed-off-by: Clemens Stefan Heithecker <48448358+clemensheithecker@users.noreply.github.com>

## Hey, I just made a Pull Request!

I added an npm plugin I wrote to the list of custom action packages. It contains three custom actions for the template scaffolder to create, run, and authorize Azure pipelines.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
