### PR TITLE
hack google provider to work with AAD+AKS

### DIFF
--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -29,11 +29,16 @@ import {
 } from '@backstage/plugin-graphiql';
 import {
   AnyApiFactory,
+  azureADAuthApiRef,
   configApiRef,
   createApiFactory,
+  createApiRef,
+  discoveryApiRef,
   errorApiRef,
   githubAuthApiRef,
+  oauthRequestApiRef,
 } from '@backstage/core-plugin-api';
+import { OAuth2 } from '@backstage/core-app-api';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -64,4 +69,24 @@ export const apis: AnyApiFactory[] = [
   }),
 
   createApiFactory(costInsightsApiRef, new ExampleCostInsightsClient()),
+
+  createApiFactory({
+    api: azureADAuthApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      oauthRequestApi: oauthRequestApiRef,
+      configApi: configApiRef,
+    },
+    factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
+      OAuth2.create({
+        discoveryApi,
+        oauthRequestApi,
+        provider: {
+          id: 'oauth2',
+          title: 'Azure AD',
+          icon: () => null,
+        },
+        environment: configApi.getOptionalString('auth.environment'),
+      }),
+  }),
 ];

--- a/packages/core-plugin-api/src/apis/definitions/auth.ts
+++ b/packages/core-plugin-api/src/apis/definitions/auth.ts
@@ -328,6 +328,16 @@ export const githubAuthApiRef: ApiRef<
   id: 'core.auth.github',
 });
 
+export const azureADAuthApiRef: ApiRef<
+  OAuthApi &
+    OpenIdConnectApi &
+    ProfileInfoApi &
+    BackstageIdentityApi &
+    SessionApi
+> = createApiRef({
+  id: 'internal.auth.azuread',
+});
+
 /**
  * Provides authentication towards Okta APIs.
  *

--- a/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
@@ -29,7 +29,7 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
     const googleAuthToken: string = await this.authProvider.getAccessToken(
-      'https://www.googleapis.com/auth/cloud-platform',
+      '6dae42f8-4368-4678-94ff-3960e28e3630/user.read',
     );
     if ('auth' in requestBody) {
       requestBody.auth!.google = googleAuthToken;

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -18,6 +18,7 @@ import { kubernetesApiRef } from './api/types';
 import { kubernetesAuthProvidersApiRef } from './kubernetes-auth-provider/types';
 import { KubernetesAuthProviders } from './kubernetes-auth-provider/KubernetesAuthProviders';
 import {
+  azureADAuthApiRef,
   createApiFactory,
   createPlugin,
   createRouteRef,
@@ -49,7 +50,7 @@ export const kubernetesPlugin = createPlugin({
     createApiFactory({
       api: kubernetesAuthProvidersApiRef,
       deps: {
-        googleAuthApi: googleAuthApiRef,
+        googleAuthApi: azureADAuthApiRef,
         microsoftAuthApi: microsoftAuthApiRef,
         oktaAuthApi: oktaAuthApiRef,
         oneloginAuthApi: oneloginAuthApiRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is not intended to be merged, it's just an example of how the existing Backstage code can be hacked to permit a client-side kubernetes auth solution for AKS.

To see the solution in action, you must:
1. Create an AKS cluster with Azure AD Authentication and appropriate role bindings to allow your Azure account to view objects on that cluster
1. Create an Azure AD app registration with the ability to access the "Azure Kubernetes Service AAD Server" resource, by running something like
    ```console
    export CLIENT_ID=$(az ad app create --display-name my-backstage --web-redirect-uris http://localhost:7007/api/auth/oauth2/handler/frame --required-resource-accesses '[{"resourceAppId":"6dae42f8-4368-4678-94ff-3960e28e3630","resourceAccess":[{"id":"34a47c2f-cd0d-47b4-a93c-2c41130c671c","type":"Scope"}]}]' | jq -r .appId)
    export CLIENT_SECRET=$(az ad app credential reset --append --id $CLIENT_ID | jq -r .password)
    ```
1. Run the code on this branch with an app-config like this:
    ```yaml
    auth:
      environment: development
      session:
        secret: secret
      providers:
        oauth2:
          development:
            authorizationUrl: https://login.microsoftonline.com/<TENANT-ID>/oauth2/v2.0/authorize
            tokenUrl: https://login.microsoftonline.com/<TENANT-ID>/oauth2/v2.0/token
            clientId: ${CLIENT_ID}
            clientSecret: ${CLIENT_SECRET}
            scope: 6dae42f8-4368-4678-94ff-3960e28e3630/user.read
    kubernetes:
      clusterLocatorMethods:
        - type: config
          clusters:
            - name: aks-cluster
              url: https://<AKS apiserver address>
              authProvider: google
              skipTLSVerify: true
              skipMetricsLookup: true
    catalog:
      locations:
        - type: file
          target: ../../kubernetes.yaml
    ```
    where `kubernetes.yaml` is in the root of the repo and looks like
    ```yaml
    apiVersion: backstage.io/v1alpha1
    kind: Component
    metadata:
      name: backstage-k8s
      title: Backstage Server on k8s
      annotations:
        'backstage.io/kubernetes-label-selector': 'app=backstage'
    spec:
      type: service
      lifecycle: stable
      owner: user:guest
    ```
    (or any other appropriate service that tracks real k8s objects)
1. View the 'Kubernetes' tab for 'backstage-k8s'
1. Click the 'Azure AD' login prompt
1. Log in with azure and give your consent
1. Profit: see pods and stuff