### PR TITLE
fix(scaffolder): properly set isDryRun flag in dry-run mode

### DIFF
--- a/.changeset/spicy-lizards-pay.md
+++ b/.changeset/spicy-lizards-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Properly set `ctx.isDryRun` when running actions in dry run mode. Also always log action inputs for debugging purposes when running in dry run mode.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -236,25 +236,53 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
           const action = this.options.actionRegistry.get(step.action);
           const { taskLogger, streamLogger } = createStepLogger({ task, step });
 
-          if (task.isDryRun && !action.supportsDryRun) {
-            task.emitLog(
-              `Skipping because ${action.id} does not support dry-run`,
-              {
-                stepId: step.id,
-                status: 'skipped',
-              },
+          if (task.isDryRun) {
+            const redactedSecrets = Object.fromEntries(
+              Object.entries(task.secrets ?? {}).map(secret => [
+                secret[0],
+                '[REDACTED]',
+              ]),
             );
-            const outputSchema = action.schema?.output;
-            if (outputSchema) {
-              context.steps[step.id] = {
-                output: generateExampleOutput(outputSchema) as {
-                  [name in string]: JsonValue;
+            const debugInput =
+              (step.input &&
+                this.render(
+                  step.input,
+                  {
+                    ...context,
+                    secrets: redactedSecrets,
+                  },
+                  renderTemplate,
+                )) ??
+              {};
+            taskLogger.info(
+              `Running ${
+                action.id
+              } in dry-run mode with inputs (secrets redacted): ${JSON.stringify(
+                debugInput,
+                undefined,
+                2,
+              )}`,
+            );
+            if (!action.supportsDryRun) {
+              task.emitLog(
+                `Skipping because ${action.id} does not support dry-run`,
+                {
+                  stepId: step.id,
+                  status: 'skipped',
                 },
-              };
-            } else {
-              context.steps[step.id] = { output: {} };
+              );
+              const outputSchema = action.schema?.output;
+              if (outputSchema) {
+                context.steps[step.id] = {
+                  output: generateExampleOutput(outputSchema) as {
+                    [name in string]: JsonValue;
+                  },
+                };
+              } else {
+                context.steps[step.id] = { output: {} };
+              }
+              continue;
             }
-            continue;
           }
 
           // Secrets are only passed when templating the input to actions for security reasons
@@ -301,6 +329,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
             },
             templateInfo: task.spec.templateInfo,
             user: task.spec.user,
+            isDryRun: task.isDryRun,
           });
 
           // Remove all temporary directories that were created when executing the action


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

The `ctx.isDryRun` flag wasn't being set when running in dry run mode. This fixes that and also logs action inputs in dry run mode to make it easier to debug. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
