### PR TITLE
Add support for links on Template Card

### DIFF
--- a/.changeset/odd-singers-taste.md
+++ b/.changeset/odd-singers-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Add support for link to TechDocs and other links defined in template entity specification metadata on TemplateCard

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  DEFAULT_NAMESPACE,
   Entity,
   EntityLink,
   parseEntityRef,
@@ -62,6 +63,7 @@ import {
   useApp,
   useRouteRef,
 } from '@backstage/core-plugin-api';
+import { viewTechDocRouteRef } from '@backstage/plugin-catalog/src/routes';
 
 const useStyles = makeStyles(theme => ({
   cardHeader: {
@@ -189,6 +191,19 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
   const { name, namespace } = parseEntityRef(stringifyEntityRef(template));
   const href = templateRoute({ templateName: name, namespace });
 
+  // TechDocs Links
+  const viewTechdocRoute = useRouteRef(viewTechDocRouteRef);
+  const viewTechdocAnnotation =
+    template.metadata.annotations?.['backstage.io/techdocs-ref'];
+  const viewTechdocLink =
+    !!viewTechdocAnnotation &&
+    !!viewTechdocRoute &&
+    viewTechdocRoute({
+      namespace: template.metadata?.namespace || DEFAULT_NAMESPACE,
+      kind: template.kind,
+      name: template.metadata.name,
+    });
+
   const iconResolver = (key?: string): IconComponent =>
     key ? app.getSystemIcon(key) ?? LanguageIcon : LanguageIcon;
 
@@ -257,6 +272,13 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
                 href={sourceLocation.locationTargetUrl}
               >
                 <ScmIntegrationIcon type={sourceLocation.integrationType} />
+              </IconButton>
+            </Tooltip>
+          )}
+          {viewTechdocLink && (
+            <Tooltip title="View TechDocs">
+              <IconButton className={classes.leftButton} href={viewTechdocLink}>
+                <MuiIcon icon={iconResolver('docs')} />
               </IconButton>
             </Tooltip>
           )}

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -192,13 +192,13 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
   const href = templateRoute({ templateName: name, namespace });
 
   // TechDocs Links
-  const viewTechdocRoute = useRouteRef(viewTechDocRouteRef);
-  const viewTechdocAnnotation =
+  const viewTechDocsRoute = useRouteRef(viewTechDocRouteRef);
+  const viewTechDocsAnnotation =
     template.metadata.annotations?.['backstage.io/techdocs-ref'];
-  const viewTechdocLink =
-    !!viewTechdocAnnotation &&
-    !!viewTechdocRoute &&
-    viewTechdocRoute({
+  const viewTechDocsLink =
+    !!viewTechDocsAnnotation &&
+    !!viewTechDocsRoute &&
+    viewTechDocsRoute({
       namespace: template.metadata?.namespace || DEFAULT_NAMESPACE,
       kind: template.kind,
       name: template.metadata.name,
@@ -275,9 +275,12 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
               </IconButton>
             </Tooltip>
           )}
-          {viewTechdocLink && (
+          {viewTechDocsLink && (
             <Tooltip title="View TechDocs">
-              <IconButton className={classes.leftButton} href={viewTechdocLink}>
+              <IconButton
+                className={classes.leftButton}
+                href={viewTechDocsLink}
+              >
                 <MuiIcon icon={iconResolver('docs')} />
               </IconButton>
             </Tooltip>


### PR DESCRIPTION
## Why

The current `TemplateCard`-component lacks the support for links to TechDocs and other pages defined in the metadata property defined in the template entity. As a creator of a template I want to link to my Techdocs directly form this page, rather than having to navigate deep down to the `EntityPage` to find my links.

The current design is also a bit inconstant when it comes to the spacing/padding  between label and content on the different sections of the card.

Also. the `CardActions`-component hugs the content, rather than the bottom of the card when there are multiple cars of different height.

## How

By updating the `TemplateCard`-component i've added support for:
- Better, and more constituent padding between label and text inside card 
- Fixing the `CardActions`-component to the bottom of the card.
- MUI IconButtons at the bottom of the card, in the CardActions section.
    - **Icons will appear in the following order:**
    - SCM-link (if found)
    - TechDocs link, with `docs` icon (if annotation was defined). This will deep link to the templates actual TechDocs (the same as on the `EntityPage`)
    - Other links. These will get icons from `app.getSystemIcon`, the same as on the `EntityPage`

## Screenshots

### Better scaling of cards of different sizes

| Before      | After |
| ----------- | ----------- |
| A screenshot of some cards from our (Intility) Backstage instance where we can see some incorrect scaling  | Updated component where `CardActions`-component is fixed at the bottom of the card |
| ![image](https://user-images.githubusercontent.com/24533038/189844811-890511fe-de64-48ae-8453-07c275fdd70a.png)   | ![image](https://user-images.githubusercontent.com/24533038/189844933-956fef69-2a81-4135-8ee9-018ee5d91e42.png)  |

### Links on cards

![image](https://user-images.githubusercontent.com/24533038/189844170-ecb2dc58-de2e-42e3-b12e-fecd58d788c9.png)

| Card      | Screenshot |
| ----------- | ----------- |
| Card with no SCM and no TechDocs, but many links      | ![image](https://user-images.githubusercontent.com/24533038/189842793-38327077-99b2-4929-a9b7-b1298658fd4f.png)       |
| Card with no SCM but TechDocs annotation exist and link is generated   | ![image](https://user-images.githubusercontent.com/24533038/189843179-1418f51f-a6bf-44a9-aa13-7fae19a29faa.png)        |
| Card with SCM and TechDocs annotation exist and link is generated and one link   | ![image](https://user-images.githubusercontent.com/24533038/189843748-a9cd74ef-bef5-4924-a423-6dc5161126b5.png)    |
| Card link in footer shows a tooltip on hovering. If no title is provided, the URL will be shown | ![image](https://user-images.githubusercontent.com/24533038/189856891-ba6241e1-b6b4-45ea-a1f6-f5849c21da11.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
-
