### PR TITLE
Sort entries in skeleton.tar.gz

### DIFF
--- a/.changeset/clever-rocks-train.md
+++ b/.changeset/clever-rocks-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Sort entries in skeleton.tar.gz for better docker layer caching

--- a/packages/cli/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli/src/lib/packager/createDistWorkspace.ts
@@ -22,7 +22,7 @@ import {
   relative as relativePath,
 } from 'path';
 import { tmpdir } from 'os';
-import tar, { CreateOptions } from 'tar';
+import tar, { CreateOptions, FileOptions } from 'tar';
 import partition from 'lodash/partition';
 import { paths } from '../paths';
 import { run } from '../run';
@@ -214,10 +214,12 @@ export async function createDistWorkspace(
   }
 
   if (options.skeleton) {
-    const skeletonFiles = targets.map(target => {
-      const dir = relativePath(paths.targetRoot, target.dir);
-      return joinPath(dir, 'package.json');
-    });
+    const skeletonFiles = targets
+      .map(target => {
+        const dir = relativePath(paths.targetRoot, target.dir);
+        return joinPath(dir, 'package.json');
+      })
+      .sort();
 
     await tar.create(
       {
@@ -226,7 +228,7 @@ export async function createDistWorkspace(
         portable: true,
         noMtime: true,
         gzip: options.skeleton.endsWith('.gz'),
-      } as CreateOptions & { noMtime: boolean },
+      } as CreateOptions & FileOptions & { noMtime: boolean },
       skeletonFiles,
     );
   }


### PR DESCRIPTION
Signed-off-by: Tomasz Szuba <tszuba@box.com>

## Hey, I just made a Pull Request!

This makes skeleton.tar.gz deterministic and makes [--cache-from](https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources) working on CI.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
