### PR TITLE
Update of EntityPickers to support flags which control omit of defaul…

### DIFF
--- a/.changeset/selfish-turkeys-exist.md
+++ b/.changeset/selfish-turkeys-exist.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-EntityPickers now support flags to control ommit of default namespace
+EntityPickers now support flags to control when to include default namespace
+in result

--- a/.changeset/selfish-turkeys-exist.md
+++ b/.changeset/selfish-turkeys-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+EntityPickers now support flags to control ommit of default namespace

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -66,6 +66,8 @@ export interface EntityPickerUiOptions {
   allowedKinds?: string[];
   // (undocumented)
   defaultKind?: string;
+  // (undocumented)
+  defaultNamespace?: string | false;
 }
 
 // @public
@@ -163,6 +165,8 @@ export interface OwnedEntityPickerUiOptions {
   allowedKinds?: string[];
   // (undocumented)
   defaultKind?: string;
+  // (undocumented)
+  defaultNamespace?: string | false;
 }
 
 // @public
@@ -177,6 +181,8 @@ export interface OwnerPickerUiOptions {
   allowArbitraryValues?: boolean;
   // (undocumented)
   allowedKinds?: string[];
+  // (undocumented)
+  defaultNamespace?: string | false;
 }
 
 // @public

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -35,6 +35,7 @@ export interface EntityPickerUiOptions {
   allowedKinds?: string[];
   defaultKind?: string;
   allowArbitraryValues?: boolean;
+  defaultNamespace?: string | false;
 }
 
 /**
@@ -57,6 +58,7 @@ export const EntityPicker = (
   } = props;
   const allowedKinds = uiSchema['ui:options']?.allowedKinds;
   const defaultKind = uiSchema['ui:options']?.defaultKind;
+  const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
 
   const catalogApi = useApi(catalogApiRef);
 
@@ -67,7 +69,7 @@ export const EntityPicker = (
   );
 
   const entityRefs = entities?.items.map(e =>
-    humanizeEntityRef(e, { defaultKind }),
+    humanizeEntityRef(e, { defaultKind, defaultNamespace }),
   );
 
   const onSelect = useCallback(

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -38,6 +38,7 @@ export interface OwnedEntityPickerUiOptions {
   allowedKinds?: string[];
   defaultKind?: string;
   allowArbitraryValues?: boolean;
+  defaultNamespace?: string | false;
 }
 
 /**
@@ -61,12 +62,13 @@ export const OwnedEntityPicker = (
 
   const allowedKinds = uiSchema['ui:options']?.allowedKinds;
   const defaultKind = uiSchema['ui:options']?.defaultKind;
+  const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
   const allowArbitraryValues =
     uiSchema['ui:options']?.allowArbitraryValues ?? true;
   const { ownedEntities, loading } = useOwnedEntities(allowedKinds);
 
   const entityRefs = ownedEntities?.items
-    .map(e => humanizeEntityRef(e, { defaultKind }))
+    .map(e => humanizeEntityRef(e, { defaultKind, defaultNamespace }))
     .filter(n => n);
 
   const onSelect = (_: any, value: string | null) => {

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -26,6 +26,7 @@ import { FieldExtensionComponentProps } from '../../../extensions';
 export interface OwnerPickerUiOptions {
   allowedKinds?: string[];
   allowArbitraryValues?: boolean;
+  defaultNamespace?: string | false;
 }
 
 /**
@@ -53,6 +54,7 @@ export const OwnerPicker = (
       defaultKind: 'Group',
       allowArbitraryValues:
         uiSchema['ui:options']?.allowArbitraryValues ?? true,
+      defaultNamespace: uiSchema['ui:options']?.defaultNamespace ?? '',
     },
   };
 

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -44,6 +44,8 @@ export const OwnerPicker = (
     ...restProps
   } = props;
 
+  const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
+
   const ownerUiSchema = {
     ...uiSchema,
     'ui:options': {
@@ -54,7 +56,7 @@ export const OwnerPicker = (
       defaultKind: 'Group',
       allowArbitraryValues:
         uiSchema['ui:options']?.allowArbitraryValues ?? true,
-      defaultNamespace: uiSchema['ui:options']?.defaultNamespace ?? '',
+      ...(defaultNamespace !== undefined ? { defaultNamespace } : {}),
     },
   };
 


### PR DESCRIPTION
…t namespace in result.

Signed-off-by: Tomáš Tunkl <tomas.tunkl@avast.com>

## Hey, I just made a Pull Request!

Based on #12990 I have updated the EntityPickers so that they support control of default namespace omitting.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
