### PR TITLE
feat(auth-backend): Allow passing keyDurationSeconds as input to createRouter function

### DIFF
--- a/.changeset/fluffy-years-breathe.md
+++ b/.changeset/fluffy-years-breathe.md
@@ -1,0 +1,18 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Allow passing `keyDurationSeconds` as input to `createRouter` function.
+
+```diff
+export interface RouterOptions {
+   logger: Logger;
+   database: PluginDatabaseManager;
+   config: Config;
+   discovery: PluginEndpointDiscovery;
+   tokenManager: TokenManager;
+   tokenFactoryAlgorithm?: string;
+   providerFactories?: ProviderFactories;
++  keyDurationSeconds?: number;
+}
+```

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -670,6 +670,8 @@ export interface RouterOptions {
   // (undocumented)
   discovery: PluginEndpointDiscovery;
   // (undocumented)
+  keyDurationSeconds?: number;
+  // (undocumented)
   logger: Logger;
   // (undocumented)
   providerFactories?: ProviderFactories;

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -48,6 +48,7 @@ export interface RouterOptions {
   tokenManager: TokenManager;
   tokenFactoryAlgorithm?: string;
   providerFactories?: ProviderFactories;
+  keyDurationSeconds?: number;
 }
 
 /** @public */
@@ -62,6 +63,7 @@ export async function createRouter(
     tokenManager,
     tokenFactoryAlgorithm,
     providerFactories,
+    keyDurationSeconds,
   } = options;
   const router = Router();
 
@@ -69,12 +71,11 @@ export async function createRouter(
   const authUrl = await discovery.getExternalBaseUrl('auth');
 
   const keyStore = await KeyStores.fromConfig(config, { logger, database });
-  const keyDurationSeconds = 3600;
 
   const tokenIssuer = new TokenFactory({
     issuer: authUrl,
     keyStore,
-    keyDurationSeconds,
+    keyDurationSeconds: keyDurationSeconds || 3600,
     logger: logger.child({ component: 'token-factory' }),
     algorithm: tokenFactoryAlgorithm,
   });


### PR DESCRIPTION
Signed-off-by: Antonio Musolino <antoniomusolino007@gmail.com>

## Hey, I just made a Pull Request!

Hi, I need to increase the tokens expiring time, what do you think about allowing the passing of keyDurationSeconds as input? 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
