### PR TITLE
Revoke Google OAuth refresh token on logout

### DIFF
--- a/.changeset/blue-lions-greet.md
+++ b/.changeset/blue-lions-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Handle errors that may occur when the user logs out

--- a/.changeset/hot-geese-vanish.md
+++ b/.changeset/hot-geese-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Google OAuth refresh tokens will now be revoked on logout by calling Google's API

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -314,13 +314,18 @@ export interface OAuthHandlers {
     response: OAuthResponse;
     refreshToken?: string;
   }>;
-  logout?(): Promise<void>;
+  logout?(req: OAuthLogoutRequest): Promise<void>;
   refresh?(req: OAuthRefreshRequest): Promise<{
     response: OAuthResponse;
     refreshToken?: string;
   }>;
   start(req: OAuthStartRequest): Promise<OAuthStartResponse>;
 }
+
+// @public (undocumented)
+export type OAuthLogoutRequest = express.Request<{}> & {
+  refreshToken: string;
+};
 
 // @public (undocumented)
 export type OAuthProviderInfo = {

--- a/plugins/auth-backend/src/lib/oauth/index.ts
+++ b/plugins/auth-backend/src/lib/oauth/index.ts
@@ -26,5 +26,6 @@ export type {
   OAuthState,
   OAuthStartRequest,
   OAuthRefreshRequest,
+  OAuthLogoutRequest,
   OAuthResult,
 } from './types';

--- a/plugins/auth-backend/src/lib/oauth/types.ts
+++ b/plugins/auth-backend/src/lib/oauth/types.ts
@@ -104,6 +104,11 @@ export type OAuthRefreshRequest = express.Request<{}> & {
   refreshToken: string;
 };
 
+/** @public */
+export type OAuthLogoutRequest = express.Request<{}> & {
+  refreshToken: string;
+};
+
 /**
  * Any OAuth provider needs to implement this interface which has provider specific
  * handlers for different methods to perform authentication, get access tokens,
@@ -136,5 +141,5 @@ export interface OAuthHandlers {
   /**
    * (Optional) Sign out of the auth provider.
    */
-  logout?(): Promise<void>;
+  logout?(req: OAuthLogoutRequest): Promise<void>;
 }

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -16,6 +16,7 @@
 
 import express from 'express';
 import passport from 'passport';
+import { OAuth2Client } from 'google-auth-library';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import {
   encodeState,
@@ -27,6 +28,7 @@ import {
   OAuthResponse,
   OAuthResult,
   OAuthStartRequest,
+  OAuthLogoutRequest,
 } from '../../lib/oauth';
 import {
   executeFetchUserProfileStrategy,
@@ -117,6 +119,11 @@ export class GoogleAuthProvider implements OAuthHandlers {
       response: await this.handleResult(result),
       refreshToken: privateInfo.refreshToken,
     };
+  }
+
+  async logout(req: OAuthLogoutRequest) {
+    const oauthClient = new OAuth2Client();
+    await oauthClient.revokeToken(req.refreshToken);
   }
 
   async refresh(req: OAuthRefreshRequest) {

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -32,6 +32,7 @@ import {
   ProfileInfoApi,
   ProfileInfo,
   useApi,
+  errorApiRef,
   IconComponent,
 } from '@backstage/core-plugin-api';
 import { ProviderSettingsAvatar } from './ProviderSettingsAvatar';
@@ -46,6 +47,7 @@ export const ProviderSettingsItem = (props: {
   const { title, description, icon: Icon, apiRef } = props;
 
   const api = useApi(apiRef);
+  const errorApi = useApi(errorApiRef);
   const [signedIn, setSignedIn] = useState(false);
   const emptyProfile: ProfileInfo = {};
   const [profile, setProfile] = useState(emptyProfile);
@@ -126,7 +128,10 @@ export const ProviderSettingsItem = (props: {
           <Button
             variant="outlined"
             color="primary"
-            onClick={() => (signedIn ? api.signOut() : api.signIn())}
+            onClick={() => {
+              const action = signedIn ? api.signOut() : api.signIn();
+              action.catch(error => errorApi.post(error));
+            }}
           >
             {signedIn ? `Sign out` : `Sign in`}
           </Button>

--- a/plugins/user-settings/src/components/AuthProviders/UserSettingsAuthProviders.test.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/UserSettingsAuthProviders.test.tsx
@@ -26,7 +26,7 @@ import { UserSettingsAuthProviders } from './UserSettingsAuthProviders';
 import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
 import { configApiRef, googleAuthApiRef } from '@backstage/core-plugin-api';
 
-const mockSignInHandler = jest.fn().mockReturnValue('');
+const mockSignInHandler = jest.fn().mockReturnValue(Promise.resolve());
 const mockGoogleAuth = {
   sessionState$: () => ({
     [Symbol.observable]: jest.fn(),

--- a/plugins/user-settings/src/components/General/UserSettingsMenu.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsMenu.tsx
@@ -18,10 +18,15 @@ import React from 'react';
 import { IconButton, ListItemIcon, Menu, MenuItem } from '@material-ui/core';
 import SignOutIcon from '@material-ui/icons/MeetingRoom';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
-import { identityApiRef, useApi } from '@backstage/core-plugin-api';
+import {
+  identityApiRef,
+  errorApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
 
 /** @public */
 export const UserSettingsMenu = () => {
+  const errorApi = useApi(errorApiRef);
   const identityApi = useApi(identityApiRef);
   const [open, setOpen] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(
@@ -48,7 +53,12 @@ export const UserSettingsMenu = () => {
         <MoreVertIcon />
       </IconButton>
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <MenuItem data-testid="sign-out" onClick={() => identityApi.signOut()}>
+        <MenuItem
+          data-testid="sign-out"
+          onClick={() =>
+            identityApi.signOut().catch(error => errorApi.post(error))
+          }
+        >
           <ListItemIcon>
             <SignOutIcon />
           </ListItemIcon>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the revocation of refresh tokens on logout to the Google OAuth provider.
The reason for this is that our internal security team evaluated the absence of token revocation as a medium-severity security issue, as it allows for terminated sessions to be revived even after the cookie is cleared from the client's browser.
In order to implement this, we have changed the public API of the `OAuthHandlers` interface in the auth-backend. However, we think that this change is unlikely to cause breakages since the method we changed wasn't used anywhere in the auth-backend (contrary to other `OAuthHandlers` methods).

~~The only thing we are still unsure is whether we should propagate exceptions in `OAuthAdapter.logout` when the token revocation fails. For now we opted to discard the exceptions and potentially log them. Let us know what you think.~~

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation _(not needed?)_
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) _(not needed)_
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
