### PR TITLE
Add support for copy entity url in entity page context menu

### DIFF
--- a/.changeset/warm-days-watch.md
+++ b/.changeset/warm-days-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Added support for copy entity URL in entity page context menu

--- a/.changeset/young-spies-wait.md
+++ b/.changeset/young-spies-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': major
+---
+
+Added support for copy entity url in entity page context menu

--- a/.changeset/young-spies-wait.md
+++ b/.changeset/young-spies-wait.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog': major
----
-
-Added support for copy entity url in entity page context menu

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -89,7 +89,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
   const [state, setState] = useState({
     open: false,
     vertical: 'top',
-    horizontal:'right'
+    horizontal: 'right',
   });
 
   const { open, vertical, horizontal } = state;
@@ -99,7 +99,9 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
   };
 
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(window.location.toString()).then(()=> setState({...state, open:true}));
+    navigator.clipboard
+      .writeText(window.location.toString())
+      .then(() => setState({ ...state, open: true }));
   };
 
   const extraItems = UNSTABLE_extraContextMenuItems && [

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -26,12 +26,14 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 import BugReportIcon from '@material-ui/icons/BugReport';
 import MoreVert from '@material-ui/icons/MoreVert';
+import FileCopyTwoToneIcon from '@material-ui/icons/FileCopyTwoTone';
 import React, { useState } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useEntityPermission } from '@backstage/plugin-catalog-react';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common';
 import { BackstageTheme } from '@backstage/theme';
 import { UnregisterEntity, UnregisterEntityOptions } from './UnregisterEntity';
+import Snackbar from '@material-ui/core/Snackbar';
 
 /** @public */
 export type EntityContextMenuClassKey = 'button';
@@ -82,6 +84,22 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
 
   const onClose = () => {
     setAnchorEl(undefined);
+  };
+
+  const [state, setState] = useState({
+    open: false,
+    vertical: 'top',
+    horizontal:'right'
+  });
+
+  const { open, vertical, horizontal } = state;
+
+  const handleClose = () => {
+    setState({ ...state, open: false });
+  };
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(window.location.toString()).then(()=> setState({...state, open:true}));
   };
 
   const extraItems = UNSTABLE_extraContextMenuItems && [
@@ -144,6 +162,24 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
             </ListItemIcon>
             <ListItemText primary="Inspect entity" />
           </MenuItem>
+          <MenuItem
+            onClick={() => {
+              copyToClipboard();
+            }}
+          >
+            <ListItemIcon>
+              <FileCopyTwoToneIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Copy entity url" />
+          </MenuItem>
+          <Snackbar
+            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            autoHideDuration={1000}
+            open={open}
+            onClose={handleClose}
+            message="copied!"
+            key={vertical + horizontal}
+          />
         </MenuList>
       </Popover>
     </>

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -27,13 +27,13 @@ import { makeStyles } from '@material-ui/core/styles';
 import BugReportIcon from '@material-ui/icons/BugReport';
 import MoreVert from '@material-ui/icons/MoreVert';
 import FileCopyTwoToneIcon from '@material-ui/icons/FileCopyTwoTone';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useEntityPermission } from '@backstage/plugin-catalog-react';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common';
 import { BackstageTheme } from '@backstage/theme';
 import { UnregisterEntity, UnregisterEntityOptions } from './UnregisterEntity';
-import Snackbar from '@material-ui/core/Snackbar';
+import { useApi, alertApiRef } from '@backstage/core-plugin-api';
 
 /** @public */
 export type EntityContextMenuClassKey = 'button';
@@ -86,23 +86,13 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
     setAnchorEl(undefined);
   };
 
-  const [state, setState] = useState({
-    open: false,
-    vertical: 'top',
-    horizontal: 'right',
-  });
+  const alertApi = useApi(alertApiRef);
 
-  const { open, vertical, horizontal } = state;
-
-  const handleClose = () => {
-    setState({ ...state, open: false });
-  };
-
-  const copyToClipboard = () => {
+  const copyToClipboard = useCallback(() => {
     navigator.clipboard
       .writeText(window.location.toString())
-      .then(() => setState({ ...state, open: true }));
-  };
+      .then(() => alertApi.post({ message: 'Copied!', severity: 'info' }));
+  }, []);
 
   const extraItems = UNSTABLE_extraContextMenuItems && [
     ...UNSTABLE_extraContextMenuItems.map(item => (
@@ -174,14 +164,6 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
             </ListItemIcon>
             <ListItemText primary="Copy entity url" />
           </MenuItem>
-          <Snackbar
-            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-            autoHideDuration={1000}
-            open={open}
-            onClose={handleClose}
-            message="copied!"
-            key={vertical + horizontal}
-          />
         </MenuList>
       </Popover>
     </>

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -92,7 +92,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
     navigator.clipboard
       .writeText(window.location.toString())
       .then(() => alertApi.post({ message: 'Copied!', severity: 'info' }));
-  }, []);
+  }, [alertApi]);
 
   const extraItems = UNSTABLE_extraContextMenuItems && [
     ...UNSTABLE_extraContextMenuItems.map(item => (
@@ -156,13 +156,14 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
           </MenuItem>
           <MenuItem
             onClick={() => {
+              onClose();
               copyToClipboard();
             }}
           >
             <ListItemIcon>
               <FileCopyTwoToneIcon fontSize="small" />
             </ListItemIcon>
-            <ListItemText primary="Copy entity url" />
+            <ListItemText primary="Copy entity URL" />
           </MenuItem>
         </MenuList>
       </Popover>


### PR DESCRIPTION



## Hey, I just made a Pull Request!

Added capability to copy the entity URL in the entity page context menu.

https://user-images.githubusercontent.com/35890623/190348230-60a01085-90f9-4b85-8c28-2fc4fdc92e59.mov

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
