### PR TITLE
[CICD Statistics Module Gitlab] Add the ability to pass custom defaults to createGitlabApi constructor

### DIFF
--- a/.changeset/wicked-spies-draw.md
+++ b/.changeset/wicked-spies-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cicd-statistics-module-gitlab': patch
+---
+
+add the ability to add cicd default options to createGitlabApi constructor

--- a/.changeset/wicked-spies-draw.md
+++ b/.changeset/wicked-spies-draw.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-cicd-statistics-module-gitlab': patch
 ---
 
-add the ability to add cicd default options to createGitlabApi constructor
+add the ability to add CICD default options to createGitlabApi constructor

--- a/plugins/cicd-statistics-module-gitlab/README.md
+++ b/plugins/cicd-statistics-module-gitlab/README.md
@@ -7,6 +7,7 @@ This is an extension module to the `cicd-statistics` plugin, providing a `CicdSt
 1. Install the `cicd-statistics` and `cicd-statistics-module-gitlab` plugins in the `app` package.
 
 2. Configure your ApiFactory:
+   - You can optionally pass in a second argument to `CicdStatisticsApiGitlab` of type [CicdDefaults](https://github.com/backstage/backstage/blob/2881c53cb383bf127c150f837f37fe535d8cf97b/plugins/cicd-statistics/src/apis/types.ts#L179) to alter the default CICD UI configuration
 
 ```tsx
 // packages/app/src/apis.ts

--- a/plugins/cicd-statistics-module-gitlab/api-report.md
+++ b/plugins/cicd-statistics-module-gitlab/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { CicdConfiguration } from '@backstage/plugin-cicd-statistics';
+import { CicdDefaults } from '@backstage/plugin-cicd-statistics';
 import { CicdState } from '@backstage/plugin-cicd-statistics';
 import { CicdStatisticsApi } from '@backstage/plugin-cicd-statistics';
 import { Entity } from '@backstage/catalog-model';
@@ -13,7 +14,7 @@ import { OAuthApi } from '@backstage/core-plugin-api';
 
 // @public
 export class CicdStatisticsApiGitlab implements CicdStatisticsApi {
-  constructor(gitLabAuthApi: OAuthApi);
+  constructor(gitLabAuthApi: OAuthApi, cicdDefaults?: Partial<CicdDefaults>);
   // (undocumented)
   createGitlabApi(entity: Entity, scopes: string[]): Promise<GitlabClient>;
   // (undocumented)

--- a/plugins/cicd-statistics-module-gitlab/src/api/gitlab.ts
+++ b/plugins/cicd-statistics-module-gitlab/src/api/gitlab.ts
@@ -18,6 +18,7 @@ import {
   CicdStatisticsApi,
   CicdState,
   CicdConfiguration,
+  CicdDefaults,
   Build,
   FetchBuildsOptions,
   Stage,
@@ -47,9 +48,14 @@ export type GitlabClient = {
  */
 export class CicdStatisticsApiGitlab implements CicdStatisticsApi {
   readonly #gitLabAuthApi: OAuthApi;
+  readonly #cicdDefaults: Partial<CicdDefaults>;
 
-  constructor(gitLabAuthApi: OAuthApi) {
+  constructor(
+    gitLabAuthApi: OAuthApi,
+    cicdDefaults: Partial<CicdDefaults> = {},
+  ) {
     this.#gitLabAuthApi = gitLabAuthApi;
+    this.#cicdDefaults = cicdDefaults;
   }
 
   public async createGitlabApi(
@@ -154,6 +160,7 @@ export class CicdStatisticsApiGitlab implements CicdStatisticsApi {
         'expired',
         'unknown',
       ] as const,
+      defaults: this.#cicdDefaults,
     };
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Our team wanted the ability to change the default time period that is shown when the user tries to view their pipeline statistics for Gitlab. Currently, it shows one month of pipeline stats by default which breaks on some of our repos because of the large amount of jobs they have causes a 429 to happen and the page to break. To get around this we modified the `CicdStatisticsApiGitlab` to accept an optional argument of `CicdDefaults` so we can tweek certain settings. With the new changes we are currently able to do the following in our `apis.ts` file:

```typescript
  createApiFactory({
    api: cicdStatisticsApiRef,
    deps: { gitlabAuthApi: gitlabAuthApiRef },
    factory({ gitlabAuthApi }) {
      return new CicdStatisticsApiGitlab(gitlabAuthApi, {
        timeFrom: DateTime.fromJSDate(new Date()).minus({ week: 1 }).toJSDate(),
      });
    },
  }),
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
