### PR TITLE
Unwrap error message when getting projects in Jenkins plugin

### DIFF
--- a/.changeset/ninety-knives-knock.md
+++ b/.changeset/ninety-knives-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+Unwrap error message when getting projects

--- a/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -100,7 +100,7 @@ export class JenkinsApiImpl {
         // Filter only be the information we need, instead of loading all fields.
         // Limit to only show the latest build for each job and only load 50 jobs
         // at all.
-        // Whitespaces are only included for readablity here and stripped out
+        // Whitespaces are only included for readability here and stripped out
         // before sending to Jenkins
         tree: JenkinsApiImpl.jobsTreeSpec.replace(/\s/g, ''),
       });

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -27,6 +27,7 @@ import {
 } from '@backstage/plugin-permission-common';
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import { stringifyEntityRef } from '@backstage/catalog-model';
+import { stringifyError } from "@backstage/errors";
 
 /** @public */
 export interface RouterOptions {
@@ -90,11 +91,22 @@ export async function createRouter(
         },
         backstageToken: token,
       });
-      const projects = await jenkinsApi.getProjects(jenkinsInfo, branches);
 
-      response.json({
-        projects: projects,
-      });
+
+      try {
+        const projects = await jenkinsApi.getProjects(jenkinsInfo, branches);
+
+        response.json({
+          projects: projects,
+        });
+      } catch (err) {
+        // Promise.any, used in the getProjects call returns an Aggregate error message with a useless error message 'AggregateError: All promises were rejected'
+        // extract useful information ourselves
+        if (err.errors) {
+          throw new Error(`Unable to fetch projects, for ${jenkinsInfo.jobFullName}: ${stringifyError(err.errors)}`)
+        }
+        throw err
+      }
     },
   );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed in https://github.com/backstage/backstage/issues/13692#issuecomment-1248301257

If your project doesn't exist the `getProjects` method returns an error with a message of:
`AggregateError: All promises were rejected` this is not useful to understand what is going wrong.

`Promise.any` contains the original errors in err.errors.

I'm not sure if this is the best approach. Suggestions welcomed.

Initially I used a logger in the Jenkins plugin which was nice as the logs showed it as coming from the Jenkins plugin and not an unhandled error message from backstage itself, but then I wasn't sure how to return the error object cleanly to the http response without reimplementing what's done for existing unhandled errors. 

I couldn't find any examples of handled error messages, other than ones that are ignored / `continued`. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- ~[ ] Added or updated documentation~
- ~[ ] Tests for new functionality and regression tests for bug fixes~
- ~[ ] Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
