### PR TITLE
[Catalog] Location url was incorrect in tests

### DIFF
--- a/.changeset/plenty-kids-fetch.md
+++ b/.changeset/plenty-kids-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Renamed argument in `validateEntity` from `location` to `locationRef`

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -68,7 +68,7 @@ export interface CatalogApi {
   ): Promise<void>;
   validateEntity(
     entity: Entity,
-    location: string,
+    locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<ValidateEntityResponse>;
 }
@@ -130,7 +130,7 @@ export class CatalogClient implements CatalogApi {
   ): Promise<void>;
   validateEntity(
     entity: Entity,
-    location: string,
+    locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<ValidateEntityResponse>;
 }

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -322,7 +322,7 @@ describe('CatalogClient', () => {
               name: '',
             },
           },
-          'http://example.com',
+          'url:http://example.com',
         ),
       ).toMatchObject({
         valid: false,
@@ -350,7 +350,7 @@ describe('CatalogClient', () => {
               name: 'good',
             },
           },
-          'http://example.com',
+          'url:http://example.com',
         ),
       ).toMatchObject({
         valid: true,
@@ -373,7 +373,7 @@ describe('CatalogClient', () => {
               name: 'good',
             },
           },
-          'http://example.com',
+          'url:http://example.com',
         ),
       ).rejects.toThrow(/Request failed with 500 Error/);
     });

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -359,7 +359,7 @@ export class CatalogClient implements CatalogApi {
    */
   async validateEntity(
     entity: Entity,
-    location: string,
+    locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<ValidateEntityResponse> {
     const response = await this.fetchApi.fetch(
@@ -370,7 +370,7 @@ export class CatalogClient implements CatalogApi {
           ...(options?.token && { Authorization: `Bearer ${options?.token}` }),
         },
         method: 'POST',
-        body: JSON.stringify({ entity, location }),
+        body: JSON.stringify({ entity, location: locationRef }),
       },
     );
 

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -405,11 +405,11 @@ export interface CatalogApi {
    * Validate entity and its location.
    *
    * @param entity - Entity to validate
-   * @param location - URL location of the entity
+   * @param locationRef - Location ref in format `url:http://example.com/file`
    */
   validateEntity(
     entity: Entity,
-    location: string,
+    locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<ValidateEntityResponse>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It was brought to my attention that my test examples were incorrect. Actual validation was always failing because location has to be in url location format with `url:` prefix.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
