### PR TITLE
fix(docs): dead link to Active LTS Releases in Getting Started docs

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -25,7 +25,7 @@ guide to do a repository-based installation.
   [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)
 - An account with elevated rights to install the dependencies
 - `curl` or `wget` installed
-- Node.js [Active LTS Release](https://nodejs.org/en/about/releases/) installed using one of these
+- Node.js [Active LTS Release](https://nodejs.org/en/blog/release/) installed using one of these
   methods:
   - Using `nvm` (recommended)
     - [Installing nvm](https://github.com/nvm-sh/nvm#install--update-script)


### PR DESCRIPTION
Signed-off-by: Leena <19555355+sploschee@users.noreply.github.com>

### Dead link in Getting Started docs
The link to **Active LTS Releases** in the [Getting Started](https://backstage.io/docs/getting-started/) docs was dead.  

was `https://nodejs.org/en/about/releases/`
now `https://nodejs.org/en/blog/release/`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
