### PR TITLE
Remove the duplicated scheduleFn initialization in GitHubEntityProvider

### DIFF
--- a/.changeset/yellow-tips-exist.md
+++ b/.changeset/yellow-tips-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Remove the duplicated `scheduleFn` initialization in `GitHubEntityProvider`.

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProvider.ts
@@ -98,7 +98,6 @@ export class GitHubEntityProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(schedule);
     this.githubCredentialsProvider =
       SingleInstanceGithubCredentialsProvider.create(integration.config);
-    this.scheduleFn = this.createScheduleFn(schedule);
   }
 
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getProviderName} */


### PR DESCRIPTION
Signed-off-by: Mengnan Gong <namco1992@gmail.com>

## Hey, I just made a Pull Request!

I just came cross that the `scheduleFn` is initialized twice in `GitHubEntityProvider`, so open this PR to fix it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
