### PR TITLE
Revert "Re-order dockerfile in example backend slightly"

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -19,8 +19,10 @@ RUN apt-get update && \
     yarn config set python /usr/bin/python3
 
 # From here on we use the least-privileged `node` user to run the backend.
-USER node
 WORKDIR /app
+RUN chown node:node /app
+USER node
+
 
 # This switches many Node.js dependencies to production mode.
 ENV NODE_ENV production


### PR DESCRIPTION
Reverts backstage/backstage#13747

This worked locally on MacOS but does not work on linux e.g. GitHub actions, see

https://github.com/hmcts/backstage/actions/runs/3088858979/jobs/4995823429

from commit:
https://github.com/hmcts/backstage/pull/73/commits/f909b9a6c476efe0ac3fea930e616d0cb3c2ca1a

in PR https://github.com/hmcts/backstage/pull/73




