### PR TITLE
consistently show parent and child relations in group profile card

### DIFF
--- a/.changeset/breezy-pots-worry.md
+++ b/.changeset/breezy-pots-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+consistently show parent and child relations in group profile card

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -144,9 +144,10 @@ export const GroupProfileCard = (props: { variant?: InfoCardVariants }) => {
                     <EmailIcon />
                   </Tooltip>
                 </ListItemIcon>
-                <ListItemText>
-                  <Link to={emailHref}>{profile.email}</Link>
-                </ListItemText>
+                <ListItemText
+                  primary={<Link to={emailHref}>{profile.email}</Link>}
+                  secondary="Email"
+                />
               </ListItem>
             )}
             <ListItem>
@@ -155,16 +156,19 @@ export const GroupProfileCard = (props: { variant?: InfoCardVariants }) => {
                   <AccountTreeIcon />
                 </Tooltip>
               </ListItemIcon>
-              <ListItemText>
-                {parentRelations.length ? (
-                  <EntityRefLinks
-                    entityRefs={parentRelations}
-                    defaultKind="Group"
-                  />
-                ) : (
-                  '-'
-                )}
-              </ListItemText>
+              <ListItemText
+                primary={
+                  parentRelations.length ? (
+                    <EntityRefLinks
+                      entityRefs={parentRelations}
+                      defaultKind="Group"
+                    />
+                  ) : (
+                    'N/A'
+                  )
+                }
+                secondary="Parent Group"
+              />
             </ListItem>
             <ListItem>
               <ListItemIcon>
@@ -172,16 +176,19 @@ export const GroupProfileCard = (props: { variant?: InfoCardVariants }) => {
                   <GroupIcon />
                 </Tooltip>
               </ListItemIcon>
-              <ListItemText>
-                {childRelations.length ? (
-                  <EntityRefLinks
-                    entityRefs={childRelations}
-                    defaultKind="Group"
-                  />
-                ) : (
-                  '-'
-                )}
-              </ListItemText>
+              <ListItemText
+                primary={
+                  childRelations.length ? (
+                    <EntityRefLinks
+                      entityRefs={childRelations}
+                      defaultKind="Group"
+                    />
+                  ) : (
+                    'N/A'
+                  )
+                }
+                secondary="Child Groups"
+              />
             </ListItem>
           </List>
         </Grid>

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -149,38 +149,40 @@ export const GroupProfileCard = (props: { variant?: InfoCardVariants }) => {
                 </ListItemText>
               </ListItem>
             )}
-
-            {parentRelations.length ? (
-              <ListItem>
-                <ListItemIcon>
-                  <Tooltip title="Parent Group">
-                    <AccountTreeIcon />
-                  </Tooltip>
-                </ListItemIcon>
-                <ListItemText>
+            <ListItem>
+              <ListItemIcon>
+                <Tooltip title="Parent Group">
+                  <AccountTreeIcon />
+                </Tooltip>
+              </ListItemIcon>
+              <ListItemText>
+                {parentRelations.length ? (
                   <EntityRefLinks
                     entityRefs={parentRelations}
                     defaultKind="Group"
                   />
-                </ListItemText>
-              </ListItem>
-            ) : null}
-
-            {childRelations.length ? (
-              <ListItem>
-                <ListItemIcon>
-                  <Tooltip title="Child Groups">
-                    <GroupIcon />
-                  </Tooltip>
-                </ListItemIcon>
-                <ListItemText>
+                ) : (
+                  '-'
+                )}
+              </ListItemText>
+            </ListItem>
+            <ListItem>
+              <ListItemIcon>
+                <Tooltip title="Child Groups">
+                  <GroupIcon />
+                </Tooltip>
+              </ListItemIcon>
+              <ListItemText>
+                {childRelations.length ? (
                   <EntityRefLinks
                     entityRefs={childRelations}
                     defaultKind="Group"
                   />
-                </ListItemText>
-              </ListItem>
-            ) : null}
+                ) : (
+                  '-'
+                )}
+              </ListItemText>
+            </ListItem>
           </List>
         </Grid>
       </Grid>


### PR DESCRIPTION
Signed-off-by: Prasetya Aria Wibawa <prasetya.wibawa@grabtaxi.com>

## Hey, I just made a Pull Request!

Hi Backstage team, this is just small UI changes.
So initially `GroupProfileCard` was using some conditional to render the list item of parent relations and child relations.
Me and my team found this could become a problem and actually confusing, the behavior seems like a circular dependency but it is in fact showing both parent and child relationship which is hard to tell in the UI.

So with this pull request, I suggest that we should show both list items from parent relations and child relations consistently and fill the blank value with '-' instead.

Screenshots before : 
- **acme-corp before (no parent relation)**
<img width="769" alt="acme-corp-before" src="https://user-images.githubusercontent.com/7909323/191252614-026d80dd-a59e-44ae-94a3-bdb1b701a429.png">

- **team-a before (no children relations)**
<img width="769" alt="team-a-before" src="https://user-images.githubusercontent.com/7909323/191252775-08f8b7bf-cd5a-4f3f-8b53-b77c35c42a54.png">

Screenshot after : 
- **acme-corp aft
<img width="756" alt="acme_corp_new" src="https://user-images.githubusercontent.com/7909323/191675330-7df141d5-9769-4566-80be-9e0482df22b4.png">
er (no parent relation)**


- **team-a after (no children relations)**
<img width="760" alt="team-a-new" src="https://user-images.githubusercontent.com/7909323/191675358-5953d776-1948-4697-8f65-8cfb73c0c07f.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
