### PR TITLE
fix(docs): import SignInProviderConfig - not used

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -165,7 +165,7 @@ Open `packages/app/src/App.tsx` and below the last `import` line, add:
 
 ```typescript
 import { githubAuthApiRef } from '@backstage/core-plugin-api';
-import { SignInProviderConfig, SignInPage } from '@backstage/core-components';
+import { SignInPage } from '@backstage/core-components';
 ```
 
 Search for `const app = createApp({` in this file, and below `apis,` add:


### PR DESCRIPTION
Signed-off-by: Leena <19555355+sploschee@users.noreply.github.com>

## superfluous import of `SignInProviderConfig`

`SignInProviderConfig` appears to be a superfluous import - flagged as imported but never used.
<img width="819" alt="image" src="https://user-images.githubusercontent.com/19555355/191339677-f54b8f05-fb3a-492f-a98a-151ecf555461.png">

was 
```
import { githubAuthApiRef } from '@backstage/core-plugin-api';
import { SignInProviderConfig, SignInPage } from '@backstage/core-components';
```

now 
```
import { githubAuthApiRef } from '@backstage/core-plugin-api';
import { SignInPage } from '@backstage/core-components';
```

Verified that authentication functions without `SignInProviderConfig`
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
