### PR TITLE
cli: skip testinging of repo test --since matches nothing

### DIFF
--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -101,6 +101,12 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
         pkg => pkg.allLocalDependents.keys(),
       ),
     );
+
+    if (packageNames.length === 0) {
+      console.log(`No packages changed since ${opts.since}`);
+      return;
+    }
+
     args.push('--selectProjects', ...packageNames);
   }
 


### PR DESCRIPTION
Fixes the case where no packages were changed, since that would result in an error from Jest.

Skipping changset since this is just a fix for #13574, which isn't released yet.
