### PR TITLE
fix(cost-insights): tearing in cost overview breakdown chart

### DIFF
--- a/.changeset/wise-ligers-scream.md
+++ b/.changeset/wise-ligers-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fixed bug in `CostOverviewBreakdownChart` component where some datasets caused the cost overview breakdown chart to tear.

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewBreakdownChart.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewBreakdownChart.tsx
@@ -113,8 +113,8 @@ export const CostOverviewBreakdownChart = ({
     {} as Record<string, Record<string, number>>,
   );
 
-  const chartData: Record<string, number>[] = Object.keys(breakdownsByDate).map(
-    date => {
+  const chartData: Record<string, number>[] = Object.keys(breakdownsByDate)
+    .map(date => {
       const costsForDate = Object.keys(breakdownsByDate[date]).reduce(
         (dateCosts, breakdown) => {
           // Group costs for items that belong to 'Other' in the chart.
@@ -131,8 +131,8 @@ export const CostOverviewBreakdownChart = ({
         ...costsForDate,
         date: Date.parse(date),
       };
-    },
-  );
+    })
+    .sort((a, b) => a.date - b.date);
 
   const sortedBreakdowns = costBreakdown.sort(
     (a, b) => aggregationSum(a.aggregation) - aggregationSum(b.aggregation),


### PR DESCRIPTION
Signed-off-by: Gabriel Testault <gabriel.testault@goto.com>

## Hey, I just made a Pull Request!

fixes #13771
  
Sort data by XAxis (date) before passing it to the recharts framework. Fixes tearing of breakdown chart for big datasets. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Example
#### Before

![image](https://user-images.githubusercontent.com/22593117/191462901-be2e1d41-0c9f-4934-9e0b-5da67962b96a.png)

#### After

![image](https://user-images.githubusercontent.com/22593117/191463030-bd48dfe0-2af1-47bd-875c-18f81be98c0f.png)

