### PR TITLE
Added missing daemonsets to RBAC permissions

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -413,6 +413,7 @@ rules:
       - ingresses
       - statefulsets
       - limitranges
+      - daemonsets
     verbs:
       - get
       - list


### PR DESCRIPTION
Signed-off-by: ivgo <ivgo@spreadgroup.com>

## Hey, I just made a Pull Request!

I have just noticed that the `daemonsets` are now also included in the custom resources fetched by the Kubernetes plugin. However, this parameter is missing in the documentation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
