### PR TITLE
fix(jenkins-backend): use same config prop name

### DIFF
--- a/.changeset/quiet-hats-kick.md
+++ b/.changeset/quiet-hats-kick.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-jenkins-backend': patch
 ---
 
-fix incorrect jenkins backend config initialization. named config and non named config use extraRequestHeaders
+Fixed a bug where `extraRequestHeaders` configuration was ignored.

--- a/.changeset/quiet-hats-kick.md
+++ b/.changeset/quiet-hats-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+fix incorrect jenkins backend config initialization. named config and non named config use extraRequestHeaders

--- a/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
@@ -55,7 +55,7 @@ describe('JenkinsConfig', () => {
               baseUrl: 'https://jenkins.example.com',
               username: 'backstage - bot',
               apiKey: '123456789abcdef0123456789abcedf012',
-              headers: {
+              extraRequestHeaders: {
                 myHeader: 'my-value',
               },
             },
@@ -70,7 +70,7 @@ describe('JenkinsConfig', () => {
         baseUrl: 'https://jenkins.example.com',
         username: 'backstage - bot',
         apiKey: '123456789abcdef0123456789abcedf012',
-        headers: {
+        extraRequestHeaders: {
           myHeader: 'my-value',
         },
       },

--- a/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -84,7 +84,7 @@ export class JenkinsConfig {
         baseUrl: c.getString('baseUrl'),
         username: c.getString('username'),
         apiKey: c.getString('apiKey'),
-        headers: c.getOptional('headers'),
+        extraRequestHeaders: c.getOptional('extraRequestHeaders'),
         crumbIssuer: c.getOptionalBoolean('crumbIssuer'),
       })) || [];
 


### PR DESCRIPTION
Signed-off-by: TANGUY Antoine (SIB) <tanguyantoine@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

fix typo, every config should have the same format  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
