### PR TITLE
Defer schema validation to improve test performance

### DIFF
--- a/.changeset/bright-rules-shout.md
+++ b/.changeset/bright-rules-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Defer `ajv` compilation of schema validators to improve module-import performance

--- a/packages/catalog-model/src/kinds/util.ts
+++ b/packages/catalog-model/src/kinds/util.ts
@@ -22,9 +22,12 @@ import { KindValidator } from './types';
 // exported kind validators have the `KindValidator` signature which is
 // different. So let's postpone that change until a later time.
 export function ajvCompiledJsonSchemaValidator(schema: unknown): KindValidator {
-  const validator = entityKindSchemaValidator(schema);
+  let validator: undefined | ((data: unknown) => any);
   return {
     async check(data) {
+      if (!validator) {
+        validator = entityKindSchemaValidator(schema);
+      }
       return validator(data) === data;
     },
   };


### PR DESCRIPTION
Many modules export an `ajvCompiledJsonSchemaValidator(...)`, which incurs the `ajv` schema compilation at module-import-time. Many tests depend on these modules transitively, but don't exercise the compiled schema - so, this compilation time is wasted.

On my machine, with an example test (airbrake/src/index.test.ts) I'm seeing the following numbers (n=10):

Before: 6005.1ms
After: 5807.8ms
Benefit: 197.3ms (~3.3%)

Weirdly, the NodeJS profiler was saying that schema compilation was taking ~2000ms, but that is likely due to the inaccuracy of the sampling.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
