### PR TITLE
backend-test-utils: increase max connection pool size

### DIFF
--- a/.changeset/stupid-dragons-complain.md
+++ b/.changeset/stupid-dragons-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Increased test database max connection pool size to reduce the risk of resource exhaustion.

--- a/packages/backend-test-utils/src/database/TestDatabases.ts
+++ b/packages/backend-test-utils/src/database/TestDatabases.ts
@@ -28,6 +28,13 @@ import {
   TestDatabaseProperties,
 } from './types';
 
+const LARGER_POOL_CONFIG = {
+  pool: {
+    min: 0,
+    max: 50,
+  },
+};
+
 /**
  * Encapsulates the creation of ephemeral test database instances for use
  * inside unit or integration tests.
@@ -164,6 +171,9 @@ export class TestDatabases {
             new ConfigReader({
               backend: {
                 database: {
+                  knexConfig: properties.driver.includes('sqlite')
+                    ? {}
+                    : LARGER_POOL_CONFIG,
                   client: properties.driver,
                   connection: connectionString,
                 },
@@ -203,6 +213,7 @@ export class TestDatabases {
       new ConfigReader({
         backend: {
           database: {
+            knexConfig: LARGER_POOL_CONFIG,
             client: 'pg',
             connection: { host, port, user, password },
           },
@@ -228,6 +239,7 @@ export class TestDatabases {
       new ConfigReader({
         backend: {
           database: {
+            knexConfig: LARGER_POOL_CONFIG,
             client: 'mysql2',
             connection: { host, port, user, password },
           },


### PR DESCRIPTION
Checking whether this will help out with the increased database test flakiness