### PR TITLE
workflows: add auth and access config to publishing

### DIFF
--- a/.github/workflows/deploy_nightly.yml
+++ b/.github/workflows/deploy_nightly.yml
@@ -55,7 +55,9 @@ jobs:
       # not flagged as the latest release, which means that people will not get this
       # version of the package unless requested explicitly
       - name: publish nightly release
-        run: yarn workspaces foreach -v --no-private npm publish --tag nightly
+        run: |
+          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+          yarn workspaces foreach -v --no-private npm publish --access public --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -162,10 +162,11 @@ jobs:
       # Publishes current version of packages that are not already present in the registry
       - name: publish
         run: |
+          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
           if [ -f ".changeset/pre.json" ]; then
-              yarn workspaces foreach -v --exclude=root --no-private npm publish --tag next
+              yarn workspaces foreach -v --no-private npm publish --access public --tag next
           else
-              yarn workspaces foreach -v --exclude=root --no-private npm publish
+              yarn workspaces foreach -v --no-private npm publish --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Nightly failed because of missing auth.

As far as I can tell from Yarn docs we also need to provide the access config even though it's in the `package.json`s too. Not entirely sure about that but want to be on the safe side.