### PR TITLE
Deep-import LightAsync to improve module-import time in tests

### DIFF
--- a/.changeset/eleven-apples-accept.md
+++ b/.changeset/eleven-apples-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Deep-import LightAsync component to improve module-import speed

--- a/packages/core-components/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core-components/src/components/CodeSnippet/CodeSnippet.tsx
@@ -18,7 +18,8 @@ import React from 'react';
 import { useTheme } from '@material-ui/core/styles';
 import { BackstageTheme } from '@backstage/theme';
 import { CopyTextButton } from '../CopyTextButton';
-import { LightAsync } from 'react-syntax-highlighter';
+import type {} from 'react-syntax-highlighter';
+import { default as LightAsync } from 'react-syntax-highlighter/dist/esm/light-async';
 import dark from 'react-syntax-highlighter/dist/esm/styles/hljs/dark';
 import docco from 'react-syntax-highlighter/dist/esm/styles/hljs/docco';
 


### PR DESCRIPTION
`LightAsync` is a `react-syntax-highlighter` that defers the computation of some fancy syntax-parsing logic.
However, `react-syntax-highlighter` exposes a `Light` variant that does this computation up-front.

In runtime, tree-shaking ensures that we only import `LightAsync`, but tree-shaking doesn't happen in tests (because it's slow).

So, deep-import to avoid incurring the syntax-parsing penalty when that functionality isn't used in the test itself.

----

This shaved about ~1.6 seconds from my test runtime.

```
backstage-jest-profiling(jest-profiling) ~/d/backstage-jest-profiling % hyperfine -r 10 "./node_modules/.bin/jest src/slow.test.tsx --config ./jest.js --maxConcurrency 1 --runInBand"                     
Benchmark 1: ./node_modules/.bin/jest src/slow.test.tsx --config ./jest.js --maxConcurrency 1 --runInBand
  Time (mean ± σ):      5.737 s ±  0.206 s    [User: 6.130 s, System: 0.600 s]
  Range (min … max):    5.492 s …  6.095 s    10 runs
 
backstage-jest-profiling(jest-profiling) ~/d/backstage-jest-profiling % hyperfine -r 10 "./node_modules/.bin/jest src/slow.test.tsx --config ./jest.js --maxConcurrency 1 --runInBand"
Benchmark 1: ./node_modules/.bin/jest src/slow.test.tsx --config ./jest.js --maxConcurrency 1 --runInBand
  Time (mean ± σ):      7.258 s ±  0.206 s    [User: 7.782 s, System: 0.677 s]
  Range (min … max):    7.003 s …  7.628 s    10 runs

```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
