### PR TITLE
no longer transpile tsx files in backend packages

### DIFF
--- a/.changeset/swift-phones-cheat.md
+++ b/.changeset/swift-phones-cheat.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/cli': minor
+'@backstage/cli': patch
 ---
 
 Removed `tsx` and `jsx` as supported extensions in backend packages. For most

--- a/.changeset/swift-phones-cheat.md
+++ b/.changeset/swift-phones-cheat.md
@@ -1,0 +1,12 @@
+---
+'@backstage/cli': minor
+---
+
+Removed `tsx` and `jsx` as supported extensions in backend packages. For most
+repos, this will not have any effect. But if you inadvertently had added some
+`tsx`/`jsx` files to your backend package, you may now start to see `code: 'MODULE_NOT_FOUND'` errors when launching the backend locally. The reason for
+this is that the offending files get ignored during transpilation. Hence, the
+importing file can no longer find anything to import.
+
+The fix is to rename any `.tsx` files in your backend packages to `.ts` instead,
+or `.jsx` to `.js`.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -267,7 +267,7 @@ export async function createBackendConfig(
       paths.targetRunFile ? paths.targetRunFile : paths.targetEntry,
     ],
     resolve: {
-      extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json'],
+      extensions: ['.ts', '.mjs', '.js', '.json'],
       mainFields: ['main'],
       modules: [paths.rootNodeModules, ...moduleDirs],
       plugins: [


### PR DESCRIPTION
Due to reports on Discord of seeing errors like the following after the `swc` + `fast refresh` upgrade:

```
[1] /.../packages/backend/dist/main.js:1533
[1] /******/                      throw e;
[1]                               ^
[1]
[1] ReferenceError: $RefreshReg$ is not defined
```
