### PR TITLE
docs: fix incorrect import in frontend permission integration docs

### DIFF
--- a/docs/permissions/frontend-integration.md
+++ b/docs/permissions/frontend-integration.md
@@ -17,7 +17,7 @@ If your Backstage permission policy may return a `DENY` for users requesting the
 
 ...
 
-+ import { PermissionedRoute } from '@backstage/plugin-permission-react';
++ import { RequirePermission } from '@backstage/plugin-permission-react';
 + import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
 
 ...


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Thanks to `@jguarini` on Discord for [flagging](https://discord.com/channels/687207715902193673/935836080563966042/1022576442422329374) this issue with the docs - the wrong thing was being imported.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
