### PR TITLE
backend-common: Deprecate `read` in favour of `readUrl` in UrlReader

### DIFF
--- a/.changeset/calm-bottles-happen.md
+++ b/.changeset/calm-bottles-happen.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': minor
+---
+
+**BREAKING CHANGE**: The `UrlReader` interface has been updated to require that `readUrl` is implemented. `readUrl` has previously been optional to implement but a warning has been logged when calling its predecessor `read`.
+The `read` method is now deprecated and will be removed in a future release.

--- a/.changeset/few-books-remember.md
+++ b/.changeset/few-books-remember.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-techdocs-node': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Replace usage of deprecataed `UrlReader.read` with `UrlReader.readUrl`.

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -27,8 +27,6 @@ import {
   UrlReaderPredicateTuple,
 } from './types';
 
-const MIN_WARNING_INTERVAL_MS = 1000 * 60 * 15;
-
 function notAllowedMessage(url: string) {
   return (
     `Reading from '${url}' is not allowed. ` +
@@ -43,7 +41,6 @@ function notAllowedMessage(url: string) {
  */
 export class UrlReaderPredicateMux implements UrlReader {
   private readonly readers: UrlReaderPredicateTuple[] = [];
-  private readonly readerWarnings: Map<UrlReader, number> = new Map();
 
   constructor(private readonly logger: Logger) {}
 
@@ -71,23 +68,7 @@ export class UrlReaderPredicateMux implements UrlReader {
 
     for (const { predicate, reader } of this.readers) {
       if (predicate(parsed)) {
-        if (reader.readUrl) {
-          return reader.readUrl(url, options);
-        }
-        const now = Date.now();
-        const lastWarned = this.readerWarnings.get(reader) ?? 0;
-        if (now > lastWarned + MIN_WARNING_INTERVAL_MS) {
-          this.readerWarnings.set(reader, now);
-          this.logger.warn(
-            `No implementation of readUrl found for ${reader}, this method will be required in the ` +
-              `future and will replace the 'read' method. See the changelog for more details here: ` +
-              'https://github.com/backstage/backstage/blob/master/packages/backend-common/CHANGELOG.md#085',
-          );
-        }
-        const buffer = await reader.read(url);
-        return {
-          buffer: async () => buffer,
-        };
+        return reader.readUrl(url, options);
       }
     }
 

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -27,6 +27,7 @@ import { AbortSignal } from 'node-abort-controller';
 export type UrlReader = {
   /**
    * Reads a single file and return its content.
+   * @deprecated use readUrl instead.
    */
   read(url: string): Promise<Buffer>;
 
@@ -38,10 +39,9 @@ export type UrlReader = {
    * This is a replacement for the read method that supports options and
    * complex responses.
    *
-   * Use this whenever it is available, as the read method will be
-   * deprecated and eventually removed in a future release.
+   * Use this as the read method will be removed in a future release.
    */
-  readUrl?(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
 
   /**
    * Reads a full or partial file tree.

--- a/plugins/catalog-backend-module-openapi/src/OpenApiRefProcessor.test.ts
+++ b/plugins/catalog-backend-module-openapi/src/OpenApiRefProcessor.test.ts
@@ -48,6 +48,7 @@ describe('OpenApiRefProcessor', () => {
       const config = new ConfigReader({});
       const reader = {
         read: jest.fn(),
+        readUrl: jest.fn(),
         readTree: jest.fn(),
         search: jest.fn(),
       };

--- a/plugins/catalog-backend/src/modules/codeowners/CodeOwnersProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/codeowners/CodeOwnersProcessor.test.ts
@@ -33,34 +33,24 @@ describe('CodeOwnersProcessor', () => {
     target: `https://github.com/backstage/backstage/blob/master/${basePath}catalog-info.yaml`,
   });
 
-  const mockReadResult = ({
-    error = undefined,
-    data = undefined,
-  }: {
-    error?: string;
-    data?: string;
-  } = {}) => {
-    if (error) {
-      throw Error(error);
-    }
-    return data;
-  };
-
   describe('preProcessEntity', () => {
     const setupTest = ({ kind = 'Component', spec = {} } = {}) => {
       const entity = { kind, spec };
-      const read = jest
-        .fn()
-        .mockResolvedValue(mockReadResult({ data: mockCodeOwnersText() }));
-
       const config = new ConfigReader({});
-      const reader = { read, readTree: jest.fn(), search: jest.fn() };
+      const reader = {
+        read: jest.fn(),
+        readTree: jest.fn(),
+        search: jest.fn(),
+        readUrl: jest.fn().mockResolvedValue({
+          buffer: jest.fn().mockResolvedValue(mockCodeOwnersText()),
+        }),
+      };
       const processor = CodeOwnersProcessor.fromConfig(config, {
         logger: getVoidLogger(),
         reader,
       });
 
-      return { entity, processor, read };
+      return { entity, processor };
     };
 
     it('should not modify existing owner', async () => {

--- a/plugins/catalog-backend/src/modules/codeowners/lib/read.ts
+++ b/plugins/catalog-backend/src/modules/codeowners/lib/read.ts
@@ -28,14 +28,9 @@ export async function readCodeOwners(
 ): Promise<string | undefined> {
   const readOwnerLocation = async (path: string): Promise<string> => {
     const url = `${sourceUrl}${path}`;
-
-    if (reader.readUrl) {
-      const data = await reader.readUrl(url);
-      const buffer = await data.buffer();
-      return buffer.toString();
-    }
-    const data = await reader.read(url);
-    return data.toString();
+    const data = await reader.readUrl(url);
+    const buffer = await data.buffer();
+    return buffer.toString();
   };
 
   const candidates = codeownersPaths.map(readOwnerLocation);

--- a/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
@@ -120,12 +120,9 @@ export class PlaceholderProcessor implements CatalogProcessor {
       }
 
       const read = async (url: string): Promise<Buffer> => {
-        if (this.options.reader.readUrl) {
-          const response = await this.options.reader.readUrl(url);
-          const buffer = await response.buffer();
-          return buffer;
-        }
-        return this.options.reader.read(url);
+        const response = await this.options.reader.readUrl(url);
+        const buffer = await response.buffer();
+        return buffer;
       };
 
       const resolveUrl = (url: string, base: string): string =>

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
@@ -195,6 +195,7 @@ describe('UrlReaderProcessor', () => {
 
     const reader: jest.Mocked<UrlReader> = {
       read: jest.fn(),
+      readUrl: jest.fn(),
       readTree: jest.fn(),
       search: jest.fn().mockImplementation(async () => []),
     };

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
@@ -135,16 +135,10 @@ export class UrlReaderProcessor implements CatalogProcessor {
       return { response: await Promise.all(output), etag: response.etag };
     }
 
-    // Otherwise do a plain read, prioritizing readUrl if available
-    if (this.options.reader.readUrl) {
-      const data = await this.options.reader.readUrl(location, { etag });
-      return {
-        response: [{ url: location, data: await data.buffer() }],
-        etag: data.etag,
-      };
-    }
-
-    const data = await this.options.reader.read(location);
-    return { response: [{ url: location, data }] };
+    const data = await this.options.reader.readUrl(location, { etag });
+    return {
+      response: [{ url: location, data: await data.buffer() }],
+      etag: data.etag,
+    };
   }
 }

--- a/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
@@ -74,6 +74,7 @@ describe('fetch:cookiecutter', () => {
   };
 
   const mockReader: UrlReader = {
+    readUrl: jest.fn(),
     read: jest.fn(),
     readTree: jest.fn(),
     search: jest.fn(),

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
@@ -75,6 +75,7 @@ describe('fetch:rails', () => {
 
   const mockReader: UrlReader = {
     read: jest.fn(),
+    readUrl: jest.fn(),
     readTree: jest.fn(),
     search: jest.fn(),
   };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
@@ -40,6 +40,7 @@ describe('fetchContent helper', () => {
   const readTree = jest.fn();
   const reader: UrlReader = {
     read: jest.fn(),
+    readUrl: jest.fn(),
     readTree,
     search: jest.fn(),
   };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.test.ts
@@ -33,6 +33,7 @@ describe('fetch:plain', () => {
     }),
   );
   const reader: UrlReader = {
+    readUrl: jest.fn(),
     read: jest.fn(),
     readTree: jest.fn(),
     search: jest.fn(),

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -54,6 +54,7 @@ export async function startStandaloneServer(
   const discovery = SingleHostDiscovery.fromConfig(config);
   const mockUrlReader: jest.Mocked<UrlReader> = {
     read: jest.fn(),
+    readUrl: jest.fn(),
     readTree: jest.fn(),
     search: jest.fn(),
   };

--- a/plugins/techdocs-node/src/helpers.test.ts
+++ b/plugins/techdocs-node/src/helpers.test.ts
@@ -16,6 +16,8 @@
 
 import {
   ReadTreeResponse,
+  ReadUrlOptions,
+  ReadUrlResponse,
   SearchResponse,
   UrlReader,
 } from '@backstage/backend-common';
@@ -290,6 +292,13 @@ describe('getDocFilesFromRepository', () => {
     class MockUrlReader implements UrlReader {
       async read() {
         return Buffer.from('mock');
+      }
+
+      async readUrl(
+        _url: string,
+        _options?: ReadUrlOptions | undefined,
+      ): Promise<ReadUrlResponse> {
+        throw new Error('Method not implemented.');
       }
 
       async readTree(): Promise<ReadTreeResponse> {

--- a/plugins/techdocs-node/src/stages/prepare/dir.test.ts
+++ b/plugins/techdocs-node/src/stages/prepare/dir.test.ts
@@ -46,6 +46,7 @@ const createMockEntity = (annotations: {}) => {
 const mockConfig = new ConfigReader({});
 const mockUrlReader: jest.Mocked<UrlReader> = {
   read: jest.fn(),
+  readUrl: jest.fn(),
   readTree: jest.fn(),
   search: jest.fn(),
 };

--- a/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.test.ts
+++ b/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.test.ts
@@ -30,6 +30,7 @@ function mockReader(): jest.Mocked<UrlReader> {
     read: jest.fn(),
     readTree: jest.fn(),
     search: jest.fn(),
+    readUrl: jest.fn(),
   } as jest.Mocked<UrlReader>;
 }
 


### PR DESCRIPTION
**BREAKING CHANGE**: The `UrlReader` interface has been updated to require that `readUrl` is implemented. `readUrl` has previously been optional to implement but a warning has been logged when calling its predecessor `read`.
The `read` method is now deprecated and will be removed in a future release.