### PR TITLE
chore(gitlab-mr-action): remove deprecation of projectid in template …

### DIFF
--- a/.changeset/warm-glasses-lie.md
+++ b/.changeset/warm-glasses-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Remove deprecation of `projectid` in template action `publish:gitlab:merge-request`, since it makes it easier to publish to repositories instead of writing the full path to the project, but will still allow people to not use the `projectid` and use the `repoUrl` instead.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `projectid` field for the `publish:gitlab:merge-request` template was removed and the action only works properly if the correct `repoUrl` is given, so I recovered `projectid`, making sure the publish action works both when using the `projectid` and the `repoUrl`, but when using `projectid`, it will be enough for the `repoUrl` to only have the host, rather than having the `owner` and `repo` arguments as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
