### PR TITLE
Ignore .git store on Template uploads for editor and increase payload size to 10MB (fixes #12561)

### DIFF
--- a/.changeset/wild-weeks-live.md
+++ b/.changeset/wild-weeks-live.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Ignore .git directories in Template Editor, increase upload limit for dry-runs to 10MB.

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -148,7 +148,8 @@ export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const router = Router();
-  router.use(express.json());
+  // Be generous in upload size to support a wide rande of templates in dry-run mode.
+  router.use(express.json({ limit: '10MB' }));
 
   const {
     logger: parentLogger,

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -148,7 +148,7 @@ export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const router = Router();
-  // Be generous in upload size to support a wide rande of templates in dry-run mode.
+  // Be generous in upload size to support a wide range of templates in dry-run mode.
   router.use(express.json({ limit: '10MB' }));
 
   const {

--- a/plugins/scaffolder/src/lib/filesystem/WebFileSystemAccess.ts
+++ b/plugins/scaffolder/src/lib/filesystem/WebFileSystemAccess.ts
@@ -71,6 +71,10 @@ class WebDirectoryAccess implements TemplateDirectoryAccess {
       if (handle.kind === 'file') {
         yield new WebFileAccess([...basePath, handle.name].join('/'), handle);
       } else if (handle.kind === 'directory') {
+        // Skip git storage directory
+        if (handle.name === '.git') {
+          continue;
+        }
         yield* this.listDirectoryContents(handle, [...basePath, handle.name]);
       }
     }


### PR DESCRIPTION
Signed-off-by: Axel Hecht <axel@pike.org>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
