### PR TITLE
Changed IdentityClient to DefaultIdentityClient in Permissions Docs

### DIFF
--- a/docs/permissions/getting-started.md
+++ b/docs/permissions/getting-started.md
@@ -53,7 +53,6 @@ $ yarn workspace backend add @backstage/plugin-permission-backend
 2. Add the following to a new file, `packages/backend/src/plugins/permission.ts`. This adds the permission-backend router, and configures it with a policy which allows everything.
 
 ```typescript
-import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 import { createRouter } from '@backstage/plugin-permission-backend';
 import {
   AuthorizeResult,
@@ -77,10 +76,7 @@ export default async function createPlugin(
     logger: env.logger,
     discovery: env.discovery,
     policy: new TestPermissionPolicy(),
-    identity: DefaultIdentityClient.create({
-      discovery: env.discovery,
-      issuer: await env.discovery.getExternalBaseUrl('auth'),
-    }),
+    identity: env.identity,
   });
 }
 ```
@@ -122,7 +118,6 @@ permission:
 2. Update the PermissionPolicy in `packages/backend/src/plugins/permission.ts` to disable a permission that’s easy for us to test. This policy rejects any attempt to delete a catalog entity:
 
 ```diff
-  import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
   import { createRouter } from '@backstage/plugin-permission-backend';
   import {
     AuthorizeResult,

--- a/docs/permissions/getting-started.md
+++ b/docs/permissions/getting-started.md
@@ -53,7 +53,7 @@ $ yarn workspace backend add @backstage/plugin-permission-backend
 2. Add the following to a new file, `packages/backend/src/plugins/permission.ts`. This adds the permission-backend router, and configures it with a policy which allows everything.
 
 ```typescript
-import { IdentityClient } from '@backstage/plugin-auth-node';
+import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 import { createRouter } from '@backstage/plugin-permission-backend';
 import {
   AuthorizeResult,
@@ -77,7 +77,10 @@ export default async function createPlugin(
     logger: env.logger,
     discovery: env.discovery,
     policy: new TestPermissionPolicy(),
-    identity: env.identity,
+    identity: DefaultIdentityClient.create({
+      discovery: env.discovery,
+      issuer: await env.discovery.getExternalBaseUrl('auth'),
+    }),
   });
 }
 ```
@@ -119,7 +122,7 @@ permission:
 2. Update the PermissionPolicy in `packages/backend/src/plugins/permission.ts` to disable a permission that’s easy for us to test. This policy rejects any attempt to delete a catalog entity:
 
 ```diff
-  import { IdentityClient } from '@backstage/plugin-auth-node';
+  import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
   import { createRouter } from '@backstage/plugin-permission-backend';
   import {
     AuthorizeResult,

--- a/docs/permissions/writing-a-policy.md
+++ b/docs/permissions/writing-a-policy.md
@@ -37,7 +37,6 @@ As we confirmed in the previous section, we know that this now prevents us from 
 Let's change the policy to the following:
 
 ```diff
-- import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 + import {
 +   BackstageIdentityResponse,
 +   DefaultIdentityClient

--- a/docs/permissions/writing-a-policy.md
+++ b/docs/permissions/writing-a-policy.md
@@ -37,10 +37,10 @@ As we confirmed in the previous section, we know that this now prevents us from 
 Let's change the policy to the following:
 
 ```diff
-- import { IdentityClient } from '@backstage/plugin-auth-node';
+- import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 + import {
 +   BackstageIdentityResponse,
-+   IdentityClient
++   DefaultIdentityClient
 + } from '@backstage/plugin-auth-node';
   import {
   AuthorizeResult,


### PR DESCRIPTION

Signed-off-by: Peter Macdonald <macdonald.peter90@gmail.com>

## Hey, I just made a Pull Request!

I changed the `IdentityApi` to `DefaultIdentityClient` as I believe in the docs (after following it) it doesn't seem to work if you use `IdentityApi` and I only got it to work using `DefaultIdentityClient`

If I am mistaken, then I apologize and we can close this :+1: 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
