### PR TITLE
Add `allowAutoMerge` option for `publish:github` action

### DIFF
--- a/.changeset/red-pants-rush.md
+++ b/.changeset/red-pants-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add `allowAutoMerge` option for `publish:github` action

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -193,6 +193,7 @@ export function createGithubRepoCreateAction(options: {
   allowRebaseMerge?: boolean | undefined;
   allowSquashMerge?: boolean | undefined;
   allowMergeCommit?: boolean | undefined;
+  allowAutoMerge?: boolean | undefined;
   requireCodeOwnerReviews?: boolean | undefined;
   requiredStatusCheckContexts?: string[] | undefined;
   repoVisibility?: 'internal' | 'private' | 'public' | undefined;
@@ -358,6 +359,7 @@ export function createPublishGithubAction(options: {
   allowRebaseMerge?: boolean | undefined;
   allowSquashMerge?: boolean | undefined;
   allowMergeCommit?: boolean | undefined;
+  allowAutoMerge?: boolean | undefined;
   sourcePath?: string | undefined;
   requireCodeOwnerReviews?: boolean | undefined;
   requiredStatusCheckContexts?: string[] | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
@@ -108,6 +108,7 @@ describe('github:repo:create', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
       visibility: 'private',
     });
 
@@ -127,6 +128,7 @@ describe('github:repo:create', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
       visibility: 'public',
     });
 
@@ -147,6 +149,7 @@ describe('github:repo:create', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
       visibility: 'private',
     });
   });
@@ -171,6 +174,7 @@ describe('github:repo:create', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
 
     await action.handler({
@@ -190,6 +194,7 @@ describe('github:repo:create', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
 
     await action.handler({
@@ -210,6 +215,7 @@ describe('github:repo:create', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
@@ -50,6 +50,7 @@ export function createGithubRepoCreateAction(options: {
     allowRebaseMerge?: boolean;
     allowSquashMerge?: boolean;
     allowMergeCommit?: boolean;
+    allowAutoMerge?: boolean;
     requireCodeOwnerReviews?: boolean;
     requiredStatusCheckContexts?: string[];
     repoVisibility?: 'private' | 'internal' | 'public';
@@ -89,6 +90,7 @@ export function createGithubRepoCreateAction(options: {
           allowMergeCommit: inputProps.allowMergeCommit,
           allowSquashMerge: inputProps.allowSquashMerge,
           allowRebaseMerge: inputProps.allowRebaseMerge,
+          allowAutoMerge: inputProps.allowAutoMerge,
           collaborators: inputProps.collaborators,
           token: inputProps.token,
           topics: inputProps.topics,
@@ -113,6 +115,7 @@ export function createGithubRepoCreateAction(options: {
         allowMergeCommit = true,
         allowSquashMerge = true,
         allowRebaseMerge = true,
+        allowAutoMerge = false,
         collaborators,
         topics,
         token: providedToken,
@@ -143,6 +146,7 @@ export function createGithubRepoCreateAction(options: {
         allowMergeCommit,
         allowSquashMerge,
         allowRebaseMerge,
+        allowAutoMerge,
         access,
         collaborators,
         topics,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -102,6 +102,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
   allowMergeCommit: boolean,
   allowSquashMerge: boolean,
   allowRebaseMerge: boolean,
+  allowAutoMerge: boolean,
   access: string | undefined,
   collaborators:
     | (
@@ -139,6 +140,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           allow_merge_commit: allowMergeCommit,
           allow_squash_merge: allowSquashMerge,
           allow_rebase_merge: allowRebaseMerge,
+          allow_auto_merge: allowAutoMerge,
           homepage: homepage,
         })
       : client.rest.repos.createForAuthenticatedUser({
@@ -149,6 +151,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           allow_merge_commit: allowMergeCommit,
           allow_squash_merge: allowSquashMerge,
           allow_rebase_merge: allowRebaseMerge,
+          allow_auto_merge: allowAutoMerge,
           homepage: homepage,
         });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
@@ -86,7 +86,7 @@ const allowAutoMerge = {
   title: 'Allow Auto Merges',
   type: 'boolean',
   description: `Allow individual PRs to merge automatically when all merge requirements are met. The default value is 'false'`,
-}
+};
 const collaborators = {
   title: 'Collaborators',
   description: 'Provide additional users or teams with permissions',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
@@ -82,6 +82,11 @@ const allowRebaseMerge = {
   type: 'boolean',
   description: `Allow rebase merges. The default value is 'true'`,
 };
+const allowAutoMerge = {
+  title: 'Allow Auto Merges',
+  type: 'boolean',
+  description: `Allow individual PRs to merge automatically when all merge requirements are met. The default value is 'false'`,
+}
 const collaborators = {
   title: 'Collaborators',
   description: 'Provide additional users or teams with permissions',
@@ -153,6 +158,7 @@ export { access };
 export { allowMergeCommit };
 export { allowRebaseMerge };
 export { allowSquashMerge };
+export { allowAutoMerge };
 export { collaborators };
 export { defaultBranch };
 export { deleteBranchOnMerge };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -113,6 +113,7 @@ describe('publish:github', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
       visibility: 'private',
     });
 
@@ -132,6 +133,7 @@ describe('publish:github', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
       visibility: 'public',
     });
 
@@ -152,6 +154,7 @@ describe('publish:github', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
       visibility: 'private',
     });
   });
@@ -176,6 +179,7 @@ describe('publish:github', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
 
     await action.handler({
@@ -195,6 +199,7 @@ describe('publish:github', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
 
     await action.handler({
@@ -215,6 +220,7 @@ describe('publish:github', () => {
       allow_squash_merge: true,
       allow_merge_commit: true,
       allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -57,6 +57,7 @@ export function createPublishGithubAction(options: {
     allowRebaseMerge?: boolean;
     allowSquashMerge?: boolean;
     allowMergeCommit?: boolean;
+    allowAutoMerge?: boolean;
     sourcePath?: string;
     requireCodeOwnerReviews?: boolean;
     requiredStatusCheckContexts?: string[];
@@ -104,6 +105,7 @@ export function createPublishGithubAction(options: {
           allowMergeCommit: inputProps.allowMergeCommit,
           allowSquashMerge: inputProps.allowSquashMerge,
           allowRebaseMerge: inputProps.allowRebaseMerge,
+          allowAutoMerge: inputProps.allowAutoMerge,
           sourcePath: inputProps.sourcePath,
           collaborators: inputProps.collaborators,
           token: inputProps.token,
@@ -137,6 +139,7 @@ export function createPublishGithubAction(options: {
         allowMergeCommit = true,
         allowSquashMerge = true,
         allowRebaseMerge = true,
+        allowAutoMerge = false,
         collaborators,
         topics,
         token: providedToken,
@@ -167,6 +170,7 @@ export function createPublishGithubAction(options: {
         allowMergeCommit,
         allowSquashMerge,
         allowRebaseMerge,
+        allowAutoMerge,
         access,
         collaborators,
         topics,


### PR DESCRIPTION
This option allows individual PRs to merge automatically when all merge requirements are met.
For more information, see  https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request

Signed-off-by: Willy Go <willy.go@iress.com>

## Hey, I just made a Pull Request!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
