### PR TITLE
Bazaar plugin: The project member link will now target the user catalog

### DIFF
--- a/.changeset/large-jars-fry.md
+++ b/.changeset/large-jars-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Link to the user catalog entity of a member

--- a/.changeset/tough-seahorses-learn.md
+++ b/.changeset/tough-seahorses-learn.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-bazaar-backend': minor
 ---
 
-**BREAKING** The bazaar-backend createRouter now requires that the `identityApi` is passed to the router.
+**BREAKING** The bazaar-backend `createRouter` now requires that the `identityApi` is passed to the router.
 
 These changes are **required** to `packages/backend/src/plugins/bazaar.ts`
 

--- a/.changeset/tough-seahorses-learn.md
+++ b/.changeset/tough-seahorses-learn.md
@@ -1,0 +1,26 @@
+---
+'@backstage/plugin-bazaar-backend': minor
+---
+
+**BREAKING** The bazaar-backend createRouter now requires that the `identityApi` is passed to the router.
+
+These changes are **required** to `packages/backend/src/plugins/bazaar.ts`
+
+The user entity ref is now added to the members table and is taken from the requesting user using the `identityApi`.
+
+```diff
+import { PluginEnvironment } from '../types';
+import { createRouter } from '@backstage/plugin-bazaar-backend';
+import { Router } from 'express';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    logger: env.logger,
+    config: env.config,
+    database: env.database,
++   identity: env.identity,
+  });
+}
+```

--- a/plugins/bazaar-backend/README.md
+++ b/plugins/bazaar-backend/README.md
@@ -15,7 +15,7 @@ yarn add --cwd packages/backend @backstage/plugin-bazaar-backend
 
 You'll need to add the plugin to the router in your `backend` package. You can do this by creating a file called `packages/backend/src/plugins/bazaar.ts`
 
-```tsx
+```typescript
 import { PluginEnvironment } from '../types';
 import { createRouter } from '@backstage/plugin-bazaar-backend';
 import { Router } from 'express';
@@ -27,6 +27,7 @@ export default async function createPlugin(
     logger: env.logger,
     config: env.config,
     database: env.database,
+    identity: env.identity,
   });
 }
 ```

--- a/plugins/bazaar-backend/api-report.md
+++ b/plugins/bazaar-backend/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { Config } from '@backstage/config';
 import express from 'express';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 
@@ -17,6 +18,8 @@ export interface RouterOptions {
   config: Config;
   // (undocumented)
   database: PluginDatabaseManager;
+  // (undocumented)
+  identity: IdentityApi;
   // (undocumented)
   logger: Logger;
 }

--- a/plugins/bazaar-backend/migrations/20220817150443_add_member_entity_ref.js
+++ b/plugins/bazaar-backend/migrations/20220817150443_add_member_entity_ref.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('members', table => {
+    table.string('user_ref').nullable();
+  });
+};
+
+exports.down = async function down(knex) {
+  return knex.schema.table('members', table => {
+    table.dropColumn('user_ref');
+  });
+};

--- a/plugins/bazaar-backend/package.json
+++ b/plugins/bazaar-backend/package.json
@@ -25,6 +25,7 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/plugin-auth-node": "workspace:^",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
@@ -75,6 +75,13 @@ describe('DatabaseHandler', () => {
         responsible: bazaarProject.responsible,
       });
 
+      // Add a member to the project
+      await knex('members').insert({
+        item_id: 1,
+        user_ref: 'user:default/thehulk',
+        user_id: 'Bruce Banner',
+      });
+
       const res = await dbHandler.getMetadataByRef('ref1');
 
       expect(res).toHaveLength(1);
@@ -85,6 +92,9 @@ describe('DatabaseHandler', () => {
       expect(res[0].end_date).toEqual(null);
       expect(res[0].size).toEqual('small');
       expect(res[0].responsible).toEqual('r');
+      expect(
+        res[0].members_count === '1' || res[0].members_count === 1,
+      ).toBeTruthy();
     },
     60_000,
   );

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.ts
@@ -67,11 +67,17 @@ export class DatabaseHandler {
     return await this.client.select('*').from('members').where({ item_id: id });
   }
 
-  async addMember(id: number, userId: string, picture?: string) {
+  async addMember(
+    id: number,
+    userId: string,
+    userRef?: string,
+    picture?: string,
+  ) {
     await this.client
       .insert({
         item_id: id,
         user_id: userId,
+        user_ref: userRef,
         picture: picture,
       })
       .into('members');

--- a/plugins/bazaar-backend/src/service/router.ts
+++ b/plugins/bazaar-backend/src/service/router.ts
@@ -19,6 +19,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { Config } from '@backstage/config';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 import { DatabaseHandler } from './DatabaseHandler';
 
 /** @public */
@@ -26,13 +27,14 @@ export interface RouterOptions {
   logger: Logger;
   database: PluginDatabaseManager;
   config: Config;
+  identity: IdentityApi;
 }
 
 /** @public */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, database } = options;
+  const { logger, database, identity } = options;
 
   const dbHandler = await DatabaseHandler.create({ database });
 
@@ -53,7 +55,14 @@ export async function createRouter(
 
   router.put('/projects/:id/member/:userId', async (request, response) => {
     const { id, userId } = request.params;
-    await dbHandler.addMember(parseInt(id, 10), userId, request.body?.picture);
+    const user = await identity.getIdentity({ request: request });
+
+    await dbHandler.addMember(
+      parseInt(id, 10),
+      userId,
+      user?.identity.userEntityRef,
+      request.body?.picture,
+    );
 
     response.json({ status: 'ok' });
   });

--- a/plugins/bazaar-backend/src/service/standaloneServer.ts
+++ b/plugins/bazaar-backend/src/service/standaloneServer.ts
@@ -19,6 +19,7 @@ import {
   loadBackendConfig,
   useHotMemoize,
 } from '@backstage/backend-common';
+import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';
@@ -54,6 +55,7 @@ export async function startStandaloneServer(
     logger,
     database: { getClient: async () => db },
     config: config,
+    identity: {} as DefaultIdentityClient,
   });
 
   let service = createServiceBuilder(module)

--- a/plugins/bazaar-backend/src/service/standaloneServer.ts
+++ b/plugins/bazaar-backend/src/service/standaloneServer.ts
@@ -19,7 +19,7 @@ import {
   loadBackendConfig,
   useHotMemoize,
 } from '@backstage/backend-common';
-import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';
@@ -55,7 +55,7 @@ export async function startStandaloneServer(
     logger,
     database: { getClient: async () => db },
     config: config,
-    identity: {} as DefaultIdentityClient,
+    identity: {} as IdentityApi,
   });
 
   let service = createServiceBuilder(module)

--- a/plugins/bazaar/src/components/CardContentFields/CardContentFields.tsx
+++ b/plugins/bazaar/src/components/CardContentFields/CardContentFields.tsx
@@ -23,8 +23,11 @@ import {
   Typography,
   GridSize,
 } from '@material-ui/core';
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Avatar, Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
 import { AboutField } from '@backstage/plugin-catalog';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { StatusTag } from '../StatusTag';
 import { Member, BazaarProject } from '../../types';
 
@@ -49,6 +52,7 @@ export const CardContentFields = ({
   membersSize,
 }: Props) => {
   const classes = useStyles();
+  const catalogEntityRoute = useRouteRef(entityRouteRef);
 
   return (
     <div>
@@ -111,8 +115,14 @@ export const CardContentFields = ({
                         />
                         <Link
                           className={classes.break}
-                          to={`http://github.com/${member.userId}`}
                           target="_blank"
+                          to={
+                            member.userRef
+                              ? `${catalogEntityRoute(
+                                  parseEntityRef(member.userRef),
+                                )}`
+                              : `http://github.com/${member.userId}`
+                          }
                         >
                           {member?.userId}
                         </Link>

--- a/plugins/bazaar/src/types.ts
+++ b/plugins/bazaar/src/types.ts
@@ -19,6 +19,7 @@ export type Member = {
   userId: string;
   joinDate?: string;
   picture?: string;
+  userRef?: string;
 };
 
 export type Status = 'ongoing' | 'proposed';

--- a/plugins/bazaar/src/util/parseMethods.ts
+++ b/plugins/bazaar/src/util/parseMethods.ts
@@ -37,6 +37,7 @@ export const parseMember = (member: any): Member => {
   return {
     itemId: member.item_id,
     userId: member.user_id,
+    userRef: member.user_ref,
     joinDate: member.join_date,
     picture: member.picture,
   } as Member;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,6 +4349,7 @@ __metadata:
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/plugin-auth-node": "workspace:^"
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The url for a project member is currently hard coded as "httpx://github.com/${backstage_display_name}", this PR changes the url to instead target the backstage catalog page of the user. 
Changes:

Backend: Added a migration to add a field ("user_ref") to the member table. This will contain the user entity ref.
Backend: When a user is requested to be added as a member the user ref is looked up using the "IdentityApi".
Front end: If the 'userRef' field is set on a member, the url will link to the catalog page of the user.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Closes #13190
