### PR TITLE
workflows: allow republish

### DIFF
--- a/.github/workflows/deploy_nightly.yml
+++ b/.github/workflows/deploy_nightly.yml
@@ -57,7 +57,7 @@ jobs:
       - name: publish nightly release
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tag nightly
+          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -164,9 +164,9 @@ jobs:
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
           if [ -f ".changeset/pre.json" ]; then
-              yarn workspaces foreach -v --no-private npm publish --access public --tag next
+              yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag next
           else
-              yarn workspaces foreach -v --no-private npm publish --access public
+              yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Nightly releases seem to almost work, except this lil bit.

Worth noting that the docs for `--tolerate-republish` are

> Warn and exit when republishing an already existing version of a package

Digging into it a bit verifies that it's indeed exiting with a success code, https://github.com/yarnpkg/berry/blob/8ff27df294a3bf056d26675f12d85aeb553d8402/packages/plugin-npm-cli/sources/commands/npm/publish.ts#L82-L85