### PR TITLE
Propagate identityApi to FactRetrieverContext

### DIFF
--- a/.changeset/lovely-bears-join.md
+++ b/.changeset/lovely-bears-join.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-tech-insights-backend': minor
+'@backstage/plugin-tech-insights-node': minor
+---
+
+Propagate IdentityApi to the FactRetrieverContext so that FactRetrievers could invoke other plugins

--- a/packages/backend/src/plugins/techInsights.ts
+++ b/packages/backend/src/plugins/techInsights.ts
@@ -38,6 +38,7 @@ export default async function createPlugin(
     database: env.database,
     scheduler: env.scheduler,
     discovery: env.discovery,
+    identity: env.identity,
     tokenManager: env.tokenManager,
     factRetrievers: [
       createFactRetrieverRegistration({

--- a/plugins/tech-insights-backend/api-report.md
+++ b/plugins/tech-insights-backend/api-report.md
@@ -14,6 +14,7 @@ import { FactRetriever } from '@backstage/plugin-tech-insights-node';
 import { FactRetrieverRegistration } from '@backstage/plugin-tech-insights-node';
 import { FactSchema } from '@backstage/plugin-tech-insights-node';
 import { HumanDuration } from '@backstage/backend-tasks';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -119,6 +120,8 @@ export interface TechInsightsOptions<
   factCheckerFactory?: FactCheckerFactory<CheckType, CheckResultType>;
   factRetrieverRegistry?: FactRetrieverRegistry;
   factRetrievers?: FactRetrieverRegistration[];
+  // (undocumented)
+  identity: IdentityApi;
   // (undocumented)
   logger: Logger;
   // (undocumented)

--- a/plugins/tech-insights-backend/package.json
+++ b/plugins/tech-insights-backend/package.json
@@ -39,6 +39,7 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
+    "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-tech-insights-common": "workspace:^",
     "@backstage/plugin-tech-insights-node": "workspace:^",
     "@types/express": "^4.17.6",

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
@@ -20,7 +20,7 @@ import {
   TechInsightFact,
   TechInsightsStore,
 } from '@backstage/plugin-tech-insights-node';
-import {FactRetrieverRegistry} from './FactRetrieverRegistry';
+import { FactRetrieverRegistry } from './FactRetrieverRegistry';
 import {
   DefaultFactRetrieverEngine,
   FactRetrieverEngine,
@@ -30,12 +30,12 @@ import {
   getVoidLogger,
   ServerTokenManager,
 } from '@backstage/backend-common';
-import {ConfigReader} from '@backstage/config';
-import {TestDatabaseId, TestDatabases} from '@backstage/backend-test-utils';
-import {TaskScheduler} from '@backstage/backend-tasks';
+import { ConfigReader } from '@backstage/config';
+import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
+import { TaskScheduler } from '@backstage/backend-tasks';
 import {
   BackstageIdentityResponse,
-  IdentityApiGetIdentityRequest
+  IdentityApiGetIdentityRequest,
 } from '@backstage/plugin-auth-node';
 
 jest.useFakeTimers();
@@ -45,7 +45,7 @@ const testFactRetriever: FactRetriever = {
   version: '0.0.1',
   title: 'Test 1',
   description: 'testing',
-  entityFilter: [{kind: 'component'}],
+  entityFilter: [{ kind: 'component' }],
   schema: {
     testnumberfact: {
       type: 'integer',
@@ -77,9 +77,9 @@ describe('FactRetrieverEngine', () => {
   jest.setTimeout(15000);
 
   type FactInsertionAssertionCallback = ({
-                                           facts,
-                                           id,
-                                         }: {
+    facts,
+    id,
+  }: {
     id: string;
     facts: TechInsightFact[];
   }) => void;
@@ -111,10 +111,10 @@ describe('FactRetrieverEngine', () => {
         return [retriever];
       },
       listRegistrations(): FactRetrieverRegistration[] {
-        return [{factRetriever: retriever, cadence: cron}];
+        return [{ factRetriever: retriever, cadence: cron }];
       },
       get: (_: string): FactRetrieverRegistration => {
-        return {factRetriever: retriever, cadence: cron};
+        return { factRetriever: retriever, cadence: cron };
       },
     } as unknown as FactRetrieverRegistry;
   }
@@ -154,8 +154,11 @@ describe('FactRetrieverEngine', () => {
           getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
         },
         identity: {
-          getIdentity: (_: IdentityApiGetIdentityRequest) => Promise.resolve({ identity: mockUser } as BackstageIdentityResponse)
-        }
+          getIdentity: (_: IdentityApiGetIdentityRequest) =>
+            Promise.resolve({
+              identity: mockUser,
+            } as BackstageIdentityResponse),
+        },
       },
       factRetrieverRegistry: createMockFactRetrieverRegistry(
         cadence,
@@ -172,7 +175,7 @@ describe('FactRetrieverEngine', () => {
       const schemaAssertionCallback = jest.fn((def: FactSchemaDefinition) => {
         expect(def.id).toEqual('test_factretriever');
         expect(def.version).toEqual('0.0.1');
-        expect(def.entityFilter).toEqual([{kind: 'component'}]);
+        expect(def.entityFilter).toEqual([{ kind: 'component' }]);
         expect(def.schema).toEqual({
           testnumberfact: {
             type: 'integer',
@@ -183,8 +186,7 @@ describe('FactRetrieverEngine', () => {
 
       engine = await createEngine(
         databaseId,
-        () => {
-        },
+        () => {},
         schemaAssertionCallback,
       );
       expect(schemaAssertionCallback).toHaveBeenCalled();
@@ -196,9 +198,9 @@ describe('FactRetrieverEngine', () => {
     'Should insert facts when scheduled step is run with %s',
     async databaseId => {
       function insertCallback({
-                                facts,
-                                id,
-                              }: {
+        facts,
+        id,
+      }: {
         id: string;
         facts: TechInsightFact[];
       }) {
@@ -220,10 +222,9 @@ describe('FactRetrieverEngine', () => {
       engine = await createEngine(
         databaseId,
         insertCallback,
-        () => {
-        },
+        () => {},
         undefined,
-        {...testFactRetriever, handler},
+        { ...testFactRetriever, handler },
       );
       await engine.schedule();
       const job = await engine.getJobRegistration(testFactRetriever.id);

--- a/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityMetadataFactRetriever.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityMetadataFactRetriever.test.ts
@@ -23,6 +23,7 @@ import {
 import { ConfigReader } from '@backstage/config';
 import { GetEntitiesResponse } from '@backstage/catalog-client';
 import { entityMetadataFactRetriever } from './entityMetadataFactRetriever';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 const getEntitiesMock = jest.fn();
 jest.mock('@backstage/catalog-client', () => {
@@ -36,6 +37,10 @@ const discovery: jest.Mocked<PluginEndpointDiscovery> = {
   getBaseUrl: jest.fn(),
   getExternalBaseUrl: jest.fn(),
 };
+
+const identityApi: jest.Mocked<IdentityApi> = {
+  getIdentity: jest.fn(),
+} as unknown as jest.Mocked<IdentityApi>;
 
 const defaultEntityListResponse: GetEntitiesResponse = {
   items: [
@@ -103,6 +108,7 @@ const defaultEntityListResponse: GetEntitiesResponse = {
 
 const handlerContext = {
   discovery,
+  identity: identityApi,
   logger: getVoidLogger(),
   config: ConfigReader.fromConfigs([]),
   tokenManager: ServerTokenManager.noop(),

--- a/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityOwnershipFactRetriever.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityOwnershipFactRetriever.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { GetEntitiesResponse } from '@backstage/catalog-client';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 const getEntitiesMock = jest.fn();
 jest.mock('@backstage/catalog-client', () => {
@@ -36,6 +37,10 @@ const discovery: jest.Mocked<PluginEndpointDiscovery> = {
   getBaseUrl: jest.fn(),
   getExternalBaseUrl: jest.fn(),
 };
+
+const identityApi: jest.Mocked<IdentityApi> = {
+  getIdentity: jest.fn(),
+} as unknown as jest.Mocked<IdentityApi>;
 
 const defaultEntityListResponse: GetEntitiesResponse = {
   items: [
@@ -103,6 +108,7 @@ const defaultEntityListResponse: GetEntitiesResponse = {
 
 const handlerContext = {
   discovery,
+  identity: identityApi,
   logger: getVoidLogger(),
   config: ConfigReader.fromConfigs([]),
   tokenManager: ServerTokenManager.noop(),

--- a/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { GetEntitiesResponse } from '@backstage/catalog-client';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 const getEntitiesMock = jest.fn();
 jest.mock('@backstage/catalog-client', () => {
@@ -35,6 +36,9 @@ jest.mock('@backstage/catalog-client', () => {
 const discovery: jest.Mocked<PluginEndpointDiscovery> = {
   getBaseUrl: jest.fn(),
   getExternalBaseUrl: jest.fn(),
+};
+const identity: jest.Mocked<IdentityApi> = {
+  getIdentity: jest.fn()
 };
 
 const defaultEntityListResponse: GetEntitiesResponse = {
@@ -103,6 +107,7 @@ const defaultEntityListResponse: GetEntitiesResponse = {
 
 const handlerContext = {
   discovery,
+  identity,
   logger: getVoidLogger(),
   config: ConfigReader.fromConfigs([]),
   tokenManager: ServerTokenManager.noop(),

--- a/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
@@ -38,7 +38,7 @@ const discovery: jest.Mocked<PluginEndpointDiscovery> = {
   getExternalBaseUrl: jest.fn(),
 };
 const identity: jest.Mocked<IdentityApi> = {
-  getIdentity: jest.fn()
+  getIdentity: jest.fn(),
 };
 
 const defaultEntityListResponse: GetEntitiesResponse = {

--- a/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/plugins/tech-insights-backend/src/service/router.test.ts
@@ -29,6 +29,7 @@ import { TechInsightsStore } from '@backstage/plugin-tech-insights-node';
 import { DateTime } from 'luxon';
 import { Knex } from 'knex';
 import { TaskScheduler } from '@backstage/backend-tasks';
+import {IdentityApi} from '@backstage/plugin-auth-node';
 
 describe('Tech Insights router tests', () => {
   let app: express.Express;
@@ -44,6 +45,17 @@ describe('Tech Insights router tests', () => {
       getLatestSchemas: latestSchemasMock,
     } as unknown as TechInsightsStore,
   };
+
+  const mockUser = {
+    type: 'user',
+    ownershipEntityRefs: ['user:default/me', 'group:default/owner'],
+    userEntityRef: 'user:default/me',
+  };
+  const mockIdentityClient = {
+    getIdentity: jest
+      .fn()
+      .mockImplementation(async () => ({ identity: mockUser })),
+  } as unknown as IdentityApi;
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -75,6 +87,7 @@ describe('Tech Insights router tests', () => {
         getBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
         getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
       },
+      identity:mockIdentityClient,
       tokenManager: ServerTokenManager.noop(),
     });
 

--- a/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/plugins/tech-insights-backend/src/service/router.test.ts
@@ -29,7 +29,7 @@ import { TechInsightsStore } from '@backstage/plugin-tech-insights-node';
 import { DateTime } from 'luxon';
 import { Knex } from 'knex';
 import { TaskScheduler } from '@backstage/backend-tasks';
-import {IdentityApi} from '@backstage/plugin-auth-node';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 describe('Tech Insights router tests', () => {
   let app: express.Express;
@@ -87,7 +87,7 @@ describe('Tech Insights router tests', () => {
         getBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
         getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
       },
-      identity:mockIdentityClient,
+      identity: mockIdentityClient,
       tokenManager: ServerTokenManager.noop(),
     });
 

--- a/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.test.ts
+++ b/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.test.ts
@@ -24,7 +24,7 @@ import { ConfigReader } from '@backstage/config';
 import { TaskScheduler } from '@backstage/backend-tasks';
 import { DefaultFactRetrieverRegistry } from './fact/FactRetrieverRegistry';
 import { Knex } from 'knex';
-import { IdentityApi } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 jest.mock('./fact/FactRetrieverRegistry');
 jest.mock('./fact/FactRetrieverEngine', () => ({

--- a/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
+++ b/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
@@ -41,6 +41,7 @@ import {
 } from './persistence/persistenceContext';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
+import { IdentityApi } from '@backstage/core-plugin-api';
 
 /**
  * @public
@@ -77,6 +78,7 @@ export interface TechInsightsOptions<
   logger: Logger;
   config: Config;
   discovery: PluginEndpointDiscovery;
+  identity: IdentityApi;
   database: PluginDatabaseManager;
   scheduler: PluginTaskScheduler;
   tokenManager: TokenManager;
@@ -119,6 +121,7 @@ export const buildTechInsightsContext = async <
     factCheckerFactory,
     config,
     discovery,
+    identity,
     database,
     logger,
     scheduler,
@@ -150,6 +153,7 @@ export const buildTechInsightsContext = async <
     factRetrieverContext: {
       config,
       discovery,
+      identity,
       logger,
       tokenManager,
     },

--- a/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
+++ b/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
@@ -41,7 +41,7 @@ import {
 } from './persistence/persistenceContext';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
-import { IdentityApi } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 /**
  * @public

--- a/plugins/tech-insights-node/api-report.md
+++ b/plugins/tech-insights-node/api-report.md
@@ -9,6 +9,7 @@ import { DateTime } from 'luxon';
 import { Duration } from 'luxon';
 import { DurationLike } from 'luxon';
 import { HumanDuration } from '@backstage/backend-tasks';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -62,6 +63,7 @@ export interface FactRetriever {
 export type FactRetrieverContext = {
   config: Config;
   discovery: PluginEndpointDiscovery;
+  identity: IdentityApi;
   logger: Logger;
   tokenManager: TokenManager;
   entityFilter?:

--- a/plugins/tech-insights-node/package.json
+++ b/plugins/tech-insights-node/package.json
@@ -35,6 +35,7 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-tech-insights-common": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/luxon": "^3.0.0",

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -22,6 +22,7 @@ import {
 } from '@backstage/backend-common';
 import { Logger } from 'winston';
 import { HumanDuration } from '@backstage/backend-tasks';
+import { IdentityApi } from '@backstage/core-plugin-api';
 
 /**
  * A container for facts. The shape of the fact records needs to correspond to the FactSchema with same `ref` value.
@@ -147,6 +148,7 @@ export type FactSchema = {
 export type FactRetrieverContext = {
   config: Config;
   discovery: PluginEndpointDiscovery;
+  identityApi: IdentityApi,
   logger: Logger;
   tokenManager: TokenManager;
   entityFilter?:

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -148,7 +148,7 @@ export type FactSchema = {
 export type FactRetrieverContext = {
   config: Config;
   discovery: PluginEndpointDiscovery;
-  identity: IdentityApi,
+  identity: IdentityApi;
   logger: Logger;
   tokenManager: TokenManager;
   entityFilter?:

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -22,7 +22,7 @@ import {
 } from '@backstage/backend-common';
 import { Logger } from 'winston';
 import { HumanDuration } from '@backstage/backend-tasks';
-import { IdentityApi } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/plugin-auth-node';
 
 /**
  * A container for facts. The shape of the fact records needs to correspond to the FactSchema with same `ref` value.
@@ -148,7 +148,7 @@ export type FactSchema = {
 export type FactRetrieverContext = {
   config: Config;
   discovery: PluginEndpointDiscovery;
-  identityApi: IdentityApi,
+  identity: IdentityApi,
   logger: Logger;
   tokenManager: TokenManager;
   entityFilter?:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6869,6 +6869,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
+    "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-tech-insights-common": "workspace:^"
     "@backstage/plugin-tech-insights-node": "workspace:^"
     "@types/express": ^4.17.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -6909,6 +6909,7 @@ __metadata:
     "@backstage/backend-tasks": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-tech-insights-common": "workspace:^"
     "@backstage/types": "workspace:^"
     "@types/luxon": ^3.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

We'd like to invoke other Clients in FactRetrievers so that we can store facts that are fed by other integrations.
This in the end effect would allow us to expose data from other plugins in the score cards.
In order to achieve this we'd need to inject IdentityApi into the `FactRetrieverContext`
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
