### PR TITLE
update yarn workspace in setup command

### DIFF
--- a/docs/permissions/plugin-authors/01-setup.md
+++ b/docs/permissions/plugin-authors/01-setup.md
@@ -37,8 +37,8 @@ The source code is available here:
 2.  Add these packages as dependencies for your Backstage app:
 
     ```
-    $ yarn workspace backend add @internal/plugin-todo-list-backend@^1.0.0 @internal/plugin-todo-list-common@^1.0.0
-    $ yarn workspace app add @internal/plugin-todo-list@^1.0.0
+    $ yarn workspace example-backend add @internal/plugin-todo-list-backend@^1.0.0 @internal/plugin-todo-list-common@^1.0.0
+    $ yarn workspace example-app add @internal/plugin-todo-list@^1.0.0
     ```
 
 3.  Include the backend and frontend plugin in your application:


### PR DESCRIPTION
Signed-off-by: Gabriel Croitoru <gabriel.croitoru.cristian@gmail.com>

While running the setup from https://backstage.io/docs/permissions/plugin-authors/01-setup, the commands for yarn workspace were failing with wrong workspace.
Fixed the command to use the correct workspace.

```
$ yarn workspace app add @internal/plugin-todo-list@^1.0.0
Usage Error: Workspace 'app' not found. Did you mean any of the following:

```




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
