### PR TITLE
cli: upfront resolution of swc-loader

### DIFF
--- a/.changeset/smooth-tables-pull.md
+++ b/.changeset/smooth-tables-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switch to upfront resolution of `swc-loader` in Webpack config.

--- a/packages/cli/src/lib/bundler/transforms.ts
+++ b/packages/cli/src/lib/bundler/transforms.ts
@@ -55,7 +55,7 @@ export const transforms = (options: TransformOptions): Transforms => {
       exclude: /node_modules/,
       use: [
         {
-          loader: 'swc-loader',
+          loader: require.resolve('swc-loader'),
           options: {
             jsc: {
               target: 'es2019',
@@ -81,7 +81,7 @@ export const transforms = (options: TransformOptions): Transforms => {
       exclude: /node_modules/,
       use: [
         {
-          loader: 'swc-loader',
+          loader: require.resolve('swc-loader'),
           options: {
             jsc: {
               target: 'es2019',
@@ -112,7 +112,7 @@ export const transforms = (options: TransformOptions): Transforms => {
       test: [/\.icon\.svg$/],
       use: [
         {
-          loader: 'swc-loader',
+          loader: require.resolve('swc-loader'),
           options: {
             jsc: {
               target: 'es2019',


### PR DESCRIPTION
🧹, otherwise it may end up being resolved from the wrong context