### PR TITLE
gitlab oauth: consider hosted gitlab with relative path

### DIFF
--- a/.changeset/slow-mirrors-eat.md
+++ b/.changeset/slow-mirrors-eat.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-oauth callbacks to consider installations with relative URL.
+Fix GitLab provider setup so that it supports GitLab installations with a path in the URL.

--- a/.changeset/slow-mirrors-eat.md
+++ b/.changeset/slow-mirrors-eat.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-oauth callbacks to consider installations with relative_url
+oauth callbacks to consider installations with relative URL.

--- a/.changeset/slow-mirrors-eat.md
+++ b/.changeset/slow-mirrors-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+oauth callbacks to consider installations with relative_url

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -91,6 +91,9 @@ export class GitlabAuthProvider implements OAuthHandlers {
         clientSecret: options.clientSecret,
         callbackURL: options.callbackUrl,
         baseURL: options.baseUrl,
+        authorizationURL: `${options.baseUrl}/oauth/authorize`,
+        tokenURL: `${options.baseUrl}/oauth/token`,
+        profileURL: `${options.baseUrl}/api/v4/user`,
       },
       (
         accessToken: any,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix backstage gitlab oauth callbacks to consider installations with [relative_url](https://docs.gitlab.com/ee/install/relative_url.html)
Originally reported in #8358, specifically [this comment](https://github.com/backstage/backstage/issues/8358#issuecomment-1014316566)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
