### PR TITLE
Fix wrong import in README.md of @backstage/plugin-user-settings-backend

### DIFF
--- a/.changeset/tall-baboons-deliver.md
+++ b/.changeset/tall-baboons-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings-backend': patch
+---
+
+Fix wrong import statement in `README.md`.

--- a/plugins/user-settings-backend/README.md
+++ b/plugins/user-settings-backend/README.md
@@ -54,7 +54,7 @@ To make use of the user settings backend, replace the `WebStorage` with the
 +  discoveryApiRef,
 +  fetchApiRef,
    errorApiRef,
-+  identityApi,
++  identityApiRef,
 +  storageApiRef,
  } from '@backstage/core-plugin-api';
 +import { UserSettingsStorage } from '@backstage/plugin-user-settings';


### PR DESCRIPTION
Replace `identityApi` with `identityApiRef` when importing from `@backstage/core-plugin-api`.

Signed-off-by: Clemens Stefan Heithecker <48448358+clemensheithecker@users.noreply.github.com>

## Hey, I just made a Pull Request!

I fixed a wrong import in the README.md of `@backstage/core-plugin-api`. Instead of importing `identityApiRef` from `@backstage/core-plugin-api` it used to say `identityApi` which does not exit.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
