### PR TITLE
feat: Add request details to k8s service locator

### DIFF
--- a/.changeset/silent-bees-repeat.md
+++ b/.changeset/silent-bees-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-backend': patch
 ---
 
 kubernetes service locator now take request context parameters

--- a/.changeset/silent-bees-repeat.md
+++ b/.changeset/silent-bees-repeat.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': minor
 ---
 
-**BREAKING**: kubernetes service locator now take request context parameters
+kubernetes service locator now take request context parameters

--- a/.changeset/silent-bees-repeat.md
+++ b/.changeset/silent-bees-repeat.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': minor
 ---
 
-BREAKING: kubernetes service locator now take request context parameters
+**BREAKING**: kubernetes service locator now take request context parameters

--- a/.changeset/silent-bees-repeat.md
+++ b/.changeset/silent-bees-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+---
+
+BREAKING: kubernetes service locator now take request context parameters

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -326,7 +326,10 @@ export type KubernetesObjectTypes =
 // @alpha
 export interface KubernetesServiceLocator {
   // (undocumented)
-  getClustersByEntity(entity: Entity): Promise<{
+  getClustersByEntity(
+    entity: Entity,
+    requestContext: ServiceLocatorRequestContext,
+  ): Promise<{
     clusters: ClusterDetails[];
   }>;
 }
@@ -402,6 +405,14 @@ export interface ServiceAccountClusterDetails extends ClusterDetails {}
 
 // @alpha (undocumented)
 export type ServiceLocatorMethod = 'multiTenant' | 'http';
+
+// @alpha (undocumented)
+export interface ServiceLocatorRequestContext {
+  // (undocumented)
+  customResources: CustomResourceMatcher[];
+  // (undocumented)
+  objectTypesToFetch: Set<ObjectToFetch>;
+}
 
 // @alpha (undocumented)
 export type SigningCreds = {

--- a/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.test.ts
+++ b/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.test.ts
@@ -16,6 +16,7 @@
 
 import '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
+import { ServiceLocatorRequestContext } from '../types/types';
 import { MultiTenantServiceLocator } from './MultiTenantServiceLocator';
 
 describe('MultiTenantConfigClusterLocator', () => {
@@ -24,7 +25,10 @@ describe('MultiTenantConfigClusterLocator', () => {
       getClusters: async () => [],
     });
 
-    const result = await sut.getClustersByEntity({} as Entity);
+    const result = await sut.getClustersByEntity(
+      {} as Entity,
+      {} as ServiceLocatorRequestContext,
+    );
 
     expect(result).toStrictEqual({ clusters: [] });
   });
@@ -43,7 +47,10 @@ describe('MultiTenantConfigClusterLocator', () => {
       },
     });
 
-    const result = await sut.getClustersByEntity({} as Entity);
+    const result = await sut.getClustersByEntity(
+      {} as Entity,
+      {} as ServiceLocatorRequestContext,
+    );
 
     expect(result).toStrictEqual({
       clusters: [
@@ -76,7 +83,10 @@ describe('MultiTenantConfigClusterLocator', () => {
       },
     });
 
-    const result = await sut.getClustersByEntity({} as Entity);
+    const result = await sut.getClustersByEntity(
+      {} as Entity,
+      {} as ServiceLocatorRequestContext,
+    );
 
     expect(result).toStrictEqual({
       clusters: [

--- a/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.ts
+++ b/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.ts
@@ -19,6 +19,7 @@ import {
   ClusterDetails,
   KubernetesClustersSupplier,
   KubernetesServiceLocator,
+  ServiceLocatorRequestContext,
 } from '../types/types';
 
 // This locator assumes that every service is located on every cluster
@@ -33,6 +34,7 @@ export class MultiTenantServiceLocator implements KubernetesServiceLocator {
   // As this implementation always returns all clusters serviceId is ignored here
   getClustersByEntity(
     _entity: Entity,
+    _requestContext: ServiceLocatorRequestContext,
   ): Promise<{ clusters: ClusterDetails[] }> {
     return this.clusterSupplier.getClusters().then(clusters => ({ clusters }));
   }

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -27,6 +27,7 @@ import {
   CustomResource,
   CustomResourcesByEntity,
   KubernetesObjectsByEntity,
+  ServiceLocatorRequestContext,
 } from '../types/types';
 import { KubernetesAuthTranslator } from '../kubernetes-auth-translator/types';
 import { KubernetesAuthTranslatorGenerator } from '../kubernetes-auth-translator/KubernetesAuthTranslatorGenerator';
@@ -231,7 +232,10 @@ export class KubernetesFanOutHandler {
       entity.metadata?.name;
 
     const clusterDetailsDecoratedForAuth: ClusterDetails[] =
-      await this.decorateClusterDetailsWithAuth(entity, auth);
+      await this.decorateClusterDetailsWithAuth(entity, auth, {
+        objectTypesToFetch: objectTypesToFetch,
+        customResources: customResources ?? [],
+      });
 
     this.logger.info(
       `entity.metadata.name=${entityName} clusterDetails=[${clusterDetailsDecoratedForAuth
@@ -274,9 +278,10 @@ export class KubernetesFanOutHandler {
   private async decorateClusterDetailsWithAuth(
     entity: Entity,
     auth: KubernetesRequestAuth,
+    requestContext: ServiceLocatorRequestContext,
   ) {
     const clusterDetails: ClusterDetails[] = await (
-      await this.serviceLocator.getClustersByEntity(entity)
+      await this.serviceLocator.getClustersByEntity(entity, requestContext)
     ).clusters;
 
     // Execute all of these async actions simultaneously/without blocking sequentially as no common object is modified by them

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -120,12 +120,20 @@ export interface KubernetesClustersSupplier {
   getClusters(): Promise<ClusterDetails[]>;
 }
 
+export interface ServiceLocatorRequestContext {
+  objectTypesToFetch: Set<ObjectToFetch>;
+  customResources: CustomResourceMatcher[];
+}
+
 /**
  * Used to locate which cluster(s) a service is running on
  * @alpha
  */
 export interface KubernetesServiceLocator {
-  getClustersByEntity(entity: Entity): Promise<{ clusters: ClusterDetails[] }>;
+  getClustersByEntity(
+    entity: Entity,
+    requestContext: ServiceLocatorRequestContext,
+  ): Promise<{ clusters: ClusterDetails[] }>;
 }
 
 /**

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -120,6 +120,9 @@ export interface KubernetesClustersSupplier {
   getClusters(): Promise<ClusterDetails[]>;
 }
 
+/**
+ * @alpha
+ */
 export interface ServiceLocatorRequestContext {
   objectTypesToFetch: Set<ObjectToFetch>;
   customResources: CustomResourceMatcher[];


### PR DESCRIPTION
BREAKING_CHANGE: Service locator now takes additional args

It's worth noting there are no public implementations of this so far (just a no-op)

Signed-off-by: Matthew Clarke <mclarke@spotify.com>

Add request context to service locator so we can filter the cluster to call based on the provided arguments. This way we can build a service locator that only calls clusters which contain the desired resource types.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
