### PR TITLE
Tech Insights - Fix endpoint bug

### DIFF
--- a/.changeset/twelve-melons-notice.md
+++ b/.changeset/twelve-melons-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+---
+
+Modify router endpoint to handle singular and collections of request params similarly.

--- a/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/plugins/tech-insights-backend/src/service/router.test.ts
@@ -87,59 +87,94 @@ describe('Tech Insights router tests', () => {
 
     app = express().use(router);
   });
-
-  it('should be able to retrieve latest schemas', async () => {
-    await request(app).get('/fact-schemas').expect(200);
-    expect(latestSchemasMock).toHaveBeenCalled();
+  describe('/fact-schemas', () => {
+    it('should be able to retrieve latest schemas', async () => {
+      await request(app).get('/fact-schemas').expect(200);
+      expect(latestSchemasMock).toHaveBeenCalled();
+    });
   });
 
-  it('should not contain check endpoints when checker not present', async () => {
-    await request(app).get('/checks').expect(404);
-    await request(app).post('/checks/a/a/a').expect(404);
+  describe('/checks', () => {
+    it('should not contain check endpoints when checker not present', async () => {
+      await request(app).get('/checks').expect(404);
+      await request(app).post('/checks/a/a/a').expect(404);
+    });
   });
 
-  it('should be able to parse id request params for fact retrieval', async () => {
-    await request(app)
-      .get('/facts/latest')
-      .query({
-        entity: 'a:a/a',
-        ids: ['firstId', 'secondId'],
-      })
-      .expect(200);
-    expect(latestFactsByIdsMock).toHaveBeenCalledWith(
-      ['firstId', 'secondId'],
-      'a:a/a',
-    );
+  describe('/facts/latest', () => {
+    it('should be able to parse id request params for fact retrieval', async () => {
+      await request(app)
+        .get('/facts/latest')
+        .query({
+          entity: 'a:a/a',
+          ids: ['firstId', 'secondId'],
+        })
+        .expect(200);
+      expect(latestFactsByIdsMock).toHaveBeenCalledWith(
+        ['firstId', 'secondId'],
+        'a:a/a',
+      );
+    });
+    it('should handle singular ids in query params correctly', async () => {
+      await request(app)
+        .get('/facts/latest')
+        .query({
+          entity: 'a:a/a',
+          ids: ['secondId'],
+        })
+        .expect(200);
+      expect(latestFactsByIdsMock).toHaveBeenCalledWith(['secondId'], 'a:a/a');
+    });
   });
 
-  it('should be able to parse datetime request params for fact retrieval', async () => {
-    await request(app)
-      .get('/facts/range')
-      .query({
-        entity: 'a:a/a',
-        ids: ['firstId', 'secondId'],
-        startDatetime: '2021-12-12T12:12:12',
-        endDatetime: '2022-11-11T11:11:11',
-      })
-      .expect(200);
-    expect(factsBetweenTimestampsByIdsMock).toHaveBeenCalledWith(
-      ['firstId', 'secondId'],
-      'a:a/a',
-      DateTime.fromISO('2021-12-12T12:12:12.000+00:00'),
-      DateTime.fromISO('2022-11-11T11:11:11.000+00:00'),
-    );
-  });
+  describe('/facts/range', () => {
+    it('should be able to parse datetime request params for fact retrieval', async () => {
+      await request(app)
+        .get('/facts/range')
+        .query({
+          entity: 'a:a/a',
+          ids: ['firstId', 'secondId'],
+          startDatetime: '2021-12-12T12:12:12',
+          endDatetime: '2022-11-11T11:11:11',
+        })
+        .expect(200);
+      expect(factsBetweenTimestampsByIdsMock).toHaveBeenCalledWith(
+        ['firstId', 'secondId'],
+        'a:a/a',
+        DateTime.fromISO('2021-12-12T12:12:12.000+00:00'),
+        DateTime.fromISO('2022-11-11T11:11:11.000+00:00'),
+      );
+    });
 
-  it('should respond gracefully on parsing errors', async () => {
-    await request(app)
-      .get('/facts/range')
-      .query({
-        entity: 'a:a/a',
-        ids: ['firstId', 'secondId'],
-        startDatetime: '2021-12-1222T12:12:12',
-        endDatetime: '2022-1122-11T11:11:11',
-      })
-      .expect(422);
-    expect(latestFactsByIdsMock).toHaveBeenCalledTimes(0);
+    it('should respond gracefully on parsing errors', async () => {
+      await request(app)
+        .get('/facts/range')
+        .query({
+          entity: 'a:a/a',
+          ids: ['firstId', 'secondId'],
+          startDatetime: '2021-12-1222T12:12:12',
+          endDatetime: '2022-1122-11T11:11:11',
+        })
+        .expect(422);
+      expect(latestFactsByIdsMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should handle singular ids in query params correctly', async () => {
+      await request(app)
+        .get('/facts/range')
+        .query({
+          entity: 'a:a/a',
+          ids: ['firstId'],
+          startDatetime: '2021-12-12T12:12:12',
+          endDatetime: '2022-11-11T11:11:11',
+        })
+        .expect(200);
+      expect(factsBetweenTimestampsByIdsMock).toHaveBeenCalledWith(
+        ['firstId'],
+        'a:a/a',
+        DateTime.fromISO('2021-12-12T12:12:12.000+00:00'),
+        DateTime.fromISO('2022-11-11T11:11:11.000+00:00'),
+      );
+    });
   });
 });

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -132,7 +132,15 @@ export async function createRouter<
   router.get('/facts/latest', async (req, res) => {
     const { entity } = req.query;
     const { namespace, kind, name } = parseEntityRef(entity as string);
-    const ids = req.query.ids as string[];
+
+    if (!req.query.ids) {
+      return res
+        .status(422)
+        .send({ error: 'Failed to parse ids from request' });
+    }
+    const ids = Array.isArray(req.query.ids)
+      ? (req.query.ids as string[])
+      : ([req.query.ids] as string[]);
     return res.send(
       await techInsightsStore.getLatestFactsByIds(
         ids,
@@ -148,7 +156,14 @@ export async function createRouter<
     const { entity } = req.query;
     const { namespace, kind, name } = parseEntityRef(entity as string);
 
-    const ids = req.query.ids as string[];
+    if (!req.query.ids) {
+      return res
+        .status(422)
+        .send({ error: 'Failed to parse ids from request' });
+    }
+    const ids = Array.isArray(req.query.ids)
+      ? (req.query.ids as string[])
+      : ([req.query.ids] as string[]);
     const startDatetime = DateTime.fromISO(req.query.startDatetime as string);
     const endDatetime = DateTime.fromISO(req.query.endDatetime as string);
     if (!startDatetime.isValid || !endDatetime.isValid) {


### PR DESCRIPTION
Modify router endpoint to handle singular and collections of request params similarly.

Express automatically wraps multiple query params with same identifier into an array, like we want it to. Unfortunately if only a single item is passed in, the received value is unfortunately just a raw string. This add the necessary logic to handle both cases.

Signed-off-by: Jussi Hallila <jussi@hallila.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
