### PR TITLE
Making the GitLab repoUrl picker description clearer

### DIFF
--- a/.changeset/brave-peaches-brush.md
+++ b/.changeset/brave-peaches-brush.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Making the descrition of the GitLab repoUrl owner more clearer.
+Making the description of the GitLab repoUrl owner field more clearer by focusing it refers to the GitLab namespace.

--- a/.changeset/brave-peaches-brush.md
+++ b/.changeset/brave-peaches-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Making the descrition of the GitLab repoUrl owner more clearer.

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -66,7 +66,8 @@ export const GitlabRepoPicker = (props: {
           </>
         )}
         <FormHelperText>
-          GitLab namespace where this repository will belong to. It can be the name of organization, group, subgroup, user, or the project.
+          GitLab namespace where this repository will belong to. It can be the
+          name of organization, group, subgroup, user, or the project.
         </FormHelperText>
       </FormControl>
     </>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -66,8 +66,7 @@ export const GitlabRepoPicker = (props: {
           </>
         )}
         <FormHelperText>
-          The organization, groups, subgroups, user, project (also known as
-          namespaces in gitlab), that this repo will belong to
+          GitLab namespace where this repository will belong to. It can be the name of organization, group, subgroup, user, or the project.
         </FormHelperText>
       </FormControl>
     </>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A minor update to the description but hopeful it would make life easy for the adopters.

For us at WH, we've been requested this for a while now. The field states `Owner` so people tend to fill the team name but it should be GitLab namespace.

Calling a Spade a Spade would make it easy to fill the form correctly.

Reference: https://docs.gitlab.com/ee/user/namespace/

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
