### PR TITLE
add upgrade-backstage-app.sh script to contrib

### DIFF
--- a/contrib/scripts/upgrade-backstage-app/README.md
+++ b/contrib/scripts/upgrade-backstage-app/README.md
@@ -1,0 +1,30 @@
+# Upgrade Backstage App
+
+## Overview
+
+The script upgrades the version of Backstage created via the create-app plugin. It lets you resolve conflicts iteratively with your own merge [tool](https://www.git-scm.com/docs/git-mergetool).
+
+## Requirements
+
+You will need to have the following tools in your shell environment:
+
+- git
+- curl
+- jq
+
+## Usage
+
+Here's how to use the script:
+
+1. download the script
+2. copy it in the root of your app
+3. bootstrap a git repository (you may already have done so):
+
+```bash
+git init
+git add .
+git commit -m "initial commit"
+```
+
+4. run `sh upgrade-backstage-app.sh [optional-backstage-version]`
+5. resolve any conflicts iteratively

--- a/contrib/scripts/upgrade-backstage-app/upgrade-backstage-app.sh
+++ b/contrib/scripts/upgrade-backstage-app/upgrade-backstage-app.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+CURRENT_VERSION="v$(cat backstage.json | jq -r '.version')"
+TARGET_VERSION=${1:-"$(curl -s https://api.github.com/repos/backstage/backstage/releases/latest | jq -r '.tag_name')"}
+CREATE_APP_CURRENT_VERSION=$(curl -s https://raw.githubusercontent.com/backstage/backstage/$CURRENT_VERSION/packages/create-app/package.json | jq -r '.version')
+CREATE_APP_TARGET_VERSION=$(curl -s https://raw.githubusercontent.com/backstage/backstage/$TARGET_VERSION/packages/create-app/package.json | jq -r '.version')
+
+if [ "$CURRENT_VERSION" == "$TARGET_VERSION" ]; then
+    echo "Already up to date"
+else
+    echo "Attempting upgrade from Backstage $CURRENT_VERSION (create-app $CREATE_APP_CURRENT_VERSION) to $TARGET_VERSION ($CREATE_APP_TARGET_VERSION)"
+    rm -rf .upgrade && mkdir .upgrade
+    curl -s https://raw.githubusercontent.com/backstage/upgrade-helper-diff/master/diffs/$CREATE_APP_CURRENT_VERSION..$CREATE_APP_TARGET_VERSION.diff > .upgrade/upgrade.diff
+    git apply -3 .upgrade/upgrade.diff
+    git mergetool
+fi


### PR DESCRIPTION
Signed-off-by: Matteo Silvestri <matteosilv@gmail.com>

## Upgrade backstage app contrib script

The script upgrades the version of Backstage created via the create-app plugin. It lets you resolve conflicts iteratively with your own merge [tool](https://www.git-scm.com/docs/git-mergetool).

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
