### PR TITLE
fixed loader in gcalendar when not signed in

### DIFF
--- a/.changeset/quiet-dancers-jog.md
+++ b/.changeset/quiet-dancers-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gcalendar': patch
+---
+
+Fixed loader showing when user not signed in

--- a/plugins/gcalendar/src/components/CalendarCard/CalendarCard.tsx
+++ b/plugins/gcalendar/src/components/CalendarCard/CalendarCard.tsx
@@ -50,10 +50,13 @@ export const CalendarCard = () => {
 
   useAsync(async () => signIn(true), [signIn]);
 
-  const { isLoading: isCalendarLoading, data: calendars = [] } =
-    useCalendarsQuery({
-      enabled: isSignedIn,
-    });
+  const {
+    isLoading: isCalendarLoading,
+    isFetching: isCalendarFetching,
+    data: calendars = [],
+  } = useCalendarsQuery({
+    enabled: isSignedIn,
+  });
   const primaryCalendarId = calendars.find(c => c.primary === true)?.id;
   const defaultSelectedCalendars = primaryCalendarId ? [primaryCalendarId] : [];
   const [storedCalendars, setStoredCalendars] = useStoredCalendars(
@@ -68,6 +71,11 @@ export const CalendarCard = () => {
     timeMax: date.endOf('day').toISO(),
     timeZone: date.zoneName,
   });
+
+  const showLoader =
+    (isCalendarLoading && isCalendarFetching) ||
+    isEventLoading ||
+    !isInitialized;
 
   return (
     <InfoCard
@@ -100,7 +108,9 @@ export const CalendarCard = () => {
                 calendars={calendars}
                 selectedCalendars={storedCalendars}
                 setSelectedCalendars={setStoredCalendars}
-                disabled={isCalendarLoading || !isSignedIn}
+                disabled={
+                  (isCalendarFetching && isCalendarLoading) || !isSignedIn
+                }
               />
             </>
           ) : (
@@ -114,8 +124,8 @@ export const CalendarCard = () => {
       }}
     >
       <Box>
-        {(isCalendarLoading || isEventLoading || !isInitialized) && (
-          <Box pt={2} pb={2}>
+        {showLoader && (
+          <Box py={2}>
             <Progress variant="query" />
           </Box>
         )}


### PR DESCRIPTION
Signed-off-by: Alex Rybchenko <arybchenko@box.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
There was a change in the new version of react-query and `isLoading` is now true even on disabled queries and as the result loader was shown when user is not signed in.
Here'e link to related discussion just in case https://github.com/TanStack/query/issues/3925
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
