### PR TITLE
[Search] Be less restrictive with unknown keys on query endpoint

### DIFF
--- a/.changeset/mean-spiders-design.md
+++ b/.changeset/mean-spiders-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': minor
+---
+
+Be less restrictive with unknown keys on query endpoint

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -18,9 +18,7 @@ import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { IndexBuilder } from '@backstage/plugin-search-backend-node';
-import {
-  SearchEngine,
-} from '@backstage/plugin-search-common';
+import { SearchEngine } from '@backstage/plugin-search-common';
 import express from 'express';
 import request from 'supertest';
 

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -18,7 +18,9 @@ import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { IndexBuilder } from '@backstage/plugin-search-backend-node';
-import { SearchEngine } from '@backstage/plugin-search-common';
+import {
+  SearchEngine,
+} from '@backstage/plugin-search-common';
 import express from 'express';
 import request from 'supertest';
 
@@ -146,6 +148,25 @@ describe('createRouter', () => {
           },
         ],
       });
+    });
+
+    it('is less restrictive with unknown keys on query endpoint', async () => {
+      const queryString =
+        'term=test&%5BdocType%5D%5B0%5D=Service&filters%5BdocType%5D%5B0%5D=filter1&unknownKey1%5B2%5D=unknownValue1&unknownKey1%5B3%5D=unknownValue2&unknownKey2=unknownValue1&pageCursor';
+      const response = await request(app).get(`/query?${queryString}`);
+      const firstArg: Object = {
+        docType: ['Service'],
+        filters: { docType: ['filter1'] },
+        pageCursor: '',
+        term: 'test',
+        unknownKey1: ['unknownValue1', 'unknownValue2'],
+        unknownKey2: 'unknownValue1',
+      };
+      const secondArg = {
+        token: undefined,
+      };
+      expect(response.status).toEqual(200);
+      expect(mockSearchEngine.query).toHaveBeenCalledWith(firstArg, secondArg);
     });
 
     describe('search result filtering', () => {

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -133,7 +133,7 @@ export async function createRouter(
       req: express.Request,
       res: express.Response<SearchResultSet | ErrorResponseBody>,
     ) => {
-      const parseResult = requestSchema.safeParse(req.query);
+      const parseResult = requestSchema.passthrough().safeParse(req.query);
 
       if (!parseResult.success) {
         throw new InputError(`Invalid query string: ${parseResult.error}`);


### PR DESCRIPTION
---
'@backstage/plugin-search-backend': minor
---

[Search] Be less restrictive with unknown keys on query endpoint by adding .passthrough() method to parse the requestSchema

```diff
-      const parseResult = requestSchema.safeParse(req.query);
+      const parseResult = requestSchema.passthrough().safeParse(req.query);
```
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))