### PR TITLE
release-manifests: add fallback that fetches from GitHub raw

### DIFF
--- a/.changeset/dry-phones-type.md
+++ b/.changeset/dry-phones-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/release-manifests': patch
+---
+
+Added a fallback that fetches manifests from `https://raw.githubusercontent.com` if `https://versions.backstage.io` is unavailable.

--- a/packages/release-manifests/src/manifest.ts
+++ b/packages/release-manifests/src/manifest.ts
@@ -73,7 +73,25 @@ export async function withFallback<T>(
       return res;
     });
 
-  return Promise.any([promise1, promise2]).catch(() => promise1);
+  // TODO(Rugvip): Replace with this once we no longer support Node 14
+  // return Promise.any([promise1, promise2]).catch(() => promise1);
+  return new Promise((resolve, reject) => {
+    let rejection: Error | undefined = undefined;
+    promise1.then(resolve, e => {
+      if (rejection) {
+        reject(e);
+      } else {
+        rejection = e;
+      }
+    });
+    promise2.then(resolve, e => {
+      if (rejection) {
+        reject(rejection);
+      } else {
+        rejection = e;
+      }
+    });
+  });
 }
 
 /**

--- a/packages/release-manifests/src/manifest.ts
+++ b/packages/release-manifests/src/manifest.ts
@@ -73,25 +73,7 @@ export async function withFallback<T>(
       return res;
     });
 
-  // TODO(Rugvip): Replace with this once we no longer support Node 14
-  // return Promise.any([promise1, promise2]).catch(() => promise1);
-  return new Promise((resolve, reject) => {
-    let rejection: Error | undefined = undefined;
-    promise1.then(resolve, e => {
-      if (rejection) {
-        reject(e);
-      } else {
-        rejection = e;
-      }
-    });
-    promise2.then(resolve, e => {
-      if (rejection) {
-        reject(rejection);
-      } else {
-        rejection = e;
-      }
-    });
-  });
+  return Promise.any([promise1, promise2]).catch(() => promise1);
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Potentially fixes #13892. The idea is that the GitHub raw endpoint is more likely to be available in a restrictive environment compared to `versions.backstage.io`. We could also switch it out for the GitHub API, but I figured that endpoint is about as likely to be available, and more complicated to use.

If this works well then it replaces #13605 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
