### PR TITLE
github: switch docs-like-code label to techdocs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,7 @@ search:
   - plugins/search/**/*
   - plugins/search-*/**/*
   - packages/search-*/**/*
-docs-like-code:
+techdocs:
   - plugins/techdocs/**/*
   - plugins/techdocs-*/**/*
   - packages/techdocs-*/**/*

--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: yarn install
-        uses: backstage/actions/yarn-install@v0.5.5
+        uses: backstage/actions/yarn-install@v0.5.6
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 


### PR DESCRIPTION
Updating this along with the Discord channel.

Needs backstage/actions#70 first