### PR TITLE
[TechDocs] Pin mkdocs to latest known working version in CI

### DIFF
--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn build
 
       - name: Install mkdocs & techdocs-core
-        run: python -m pip install mkdocs-techdocs-core
+        run: python -m pip install mkdocs-techdocs-core==1.1.6 mkdocs==1.3.1
 
       - name: techdocs-cli e2e test
         working-directory: packages/techdocs-cli


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There appears to be some incompatibility between [`mkdocs` 1.4.0](https://www.mkdocs.org/about/release-notes/#version-140-2022-09-27) and `mkdocs-techdocs-core` (likely related to changes in the way `edit_uri` configs are handled).  ...Until we can get to the bottom of the underlying incompatibility, let's pin `mkdocs` to a working version (and `mkdocs-techdocs-core`) to the most recent working versions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
