### PR TITLE
Permissions - Add a required parameter schema

### DIFF
--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-permission-backend': minor
+'@backstage/plugin-permission-node': minor
+'@backstage/plugin-playlist-backend': minor
+---
+
+Permission rules now require a schema (ZodSchema) that details the parameters a rule expects. This is to validate the parameters given to a rule and to provide more details of a rule via the metadata endpoint

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -1,8 +1,31 @@
 ---
 '@backstage/plugin-catalog-backend': minor
 '@backstage/plugin-permission-backend': minor
+'@backstage/plugin-permission-common': minor
 '@backstage/plugin-permission-node': minor
 '@backstage/plugin-playlist-backend': minor
 ---
 
-Permission rules now require a schema (ZodSchema) that details the parameters a rule expects. This is to validate the parameters given to a rule and to provide more details of a rule via the metadata endpoint
+**BREAKING**: When defining permission rules, they must now also include a ZodSchema that details the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.
+
+To help with this, we have also made a change to the API of permission rules. Before, the permission rules `toQuery` and `apply` signature expected parameters to be seprate arguments, like so...
+
+```ts
+createPermissionRule({
+  apply: (resource, foo, bar) => true,
+  toQuery: (foo, bar) => {},
+});
+```
+
+The API has now changed to expect the parameters as a single object
+
+```ts
+createPermissionRule({
+  schema: z.object({
+    foo: z.string().describe('Foo value to match'),
+    bar: z.string().describe('Bar value to match'),
+  }),
+  apply: (resource, { foo, bar }) => true,
+  toQuery: ({ foo, bar }) => {},
+});
+```

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -6,7 +6,7 @@
 '@backstage/plugin-playlist-backend': minor
 ---
 
-**BREAKING**: When defining permission rules, they must now also include a ZodSchema that details the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.
+**BREAKING**: When defining permission rules, it's now necessary to provide a ZodSchema that specifies the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.
 
 To help with this, we have also made a change to the API of permission rules. Before, the permission rules `toQuery` and `apply` signature expected parameters to be seprate arguments, like so...
 

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -29,3 +29,5 @@ createPermissionRule({
   toQuery: ({ foo, bar }) => {},
 });
 ```
+
+One final change made is to limit the possible values for a parameter to primitives and arrays of primitives.

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -20,7 +20,7 @@ The API has now changed to expect the parameters as a single object
 
 ```ts
 createPermissionRule({
-  schema: z.object({
+  paramSchema: z.object({
     foo: z.string().describe('Foo value to match'),
     bar: z.string().describe('Bar value to match'),
   }),

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -8,7 +8,7 @@
 
 **BREAKING**: When defining permission rules, it's now necessary to provide a ZodSchema that specifies the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.
 
-To help with this, we have also made a change to the API of permission rules. Before, the permission rules `toQuery` and `apply` signature expected parameters to be seprate arguments, like so...
+To help with this, we have also made a change to the API of permission rules. Before, the permission rules `toQuery` and `apply` signature expected parameters to be separate arguments, like so...
 
 ```ts
 createPermissionRule({

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -3,7 +3,7 @@
 '@backstage/plugin-permission-node': minor
 ---
 
-**BREAKING**: When defining permission rules, it's now necessary to provide a ZodSchema that specifies the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.
+**BREAKING**: When defining permission rules, it's now necessary to provide a [ZodSchema](https://github.com/colinhacks/zod) that specifies the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.
 
 To help with this, we have also made a change to the API of permission rules. Before, the permission rules `toQuery` and `apply` signature expected parameters to be separate arguments, like so...
 

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -1,8 +1,6 @@
 ---
-'@backstage/plugin-catalog-backend': minor
 '@backstage/plugin-permission-common': minor
 '@backstage/plugin-permission-node': minor
-'@backstage/plugin-playlist-backend': minor
 ---
 
 **BREAKING**: When defining permission rules, it's now necessary to provide a ZodSchema that specifies the parameters the rule expects. This has been added to help better describe the parameters in the response of the metadata endpoint and to validate the parameters before a rule is executed.

--- a/.changeset/kind-bees-suffer.md
+++ b/.changeset/kind-bees-suffer.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-catalog-backend': minor
-'@backstage/plugin-permission-backend': minor
 '@backstage/plugin-permission-common': minor
 '@backstage/plugin-permission-node': minor
 '@backstage/plugin-playlist-backend': minor

--- a/.changeset/quick-meals-talk.md
+++ b/.changeset/quick-meals-talk.md
@@ -10,7 +10,7 @@ For example, the `playlistConditions.isOwner` API has changed from:
 playlistConditions.isOwner(['user:default/me', 'group:default/owner']);
 ```
 
-to the new API
+to:
 
 ```ts
 playlistConditions.isOwner({

--- a/.changeset/quick-meals-talk.md
+++ b/.changeset/quick-meals-talk.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-playlist-backend': minor
 ---
 
-**BREAKING** Due to the changes made in the Permission framework. The playlist backends permission rules have change to reflect this.
+**BREAKING** The exported permission rules have changed to reflect the breaking changes made to the PermissionRule type.
 
 As an example the `playlistConditions.isOwner` API has changed from
 

--- a/.changeset/quick-meals-talk.md
+++ b/.changeset/quick-meals-talk.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-playlist-backend': minor
+---
+
+**BREAKING** Due to the changes made in the Permission framework. The playlist backends permission rules have change to reflect this.
+
+As an example the `playlistConditions.isOwner` API has changed from
+
+```ts
+playlistConditions.isOwner(['user:default/me', 'group:default/owner']);
+```
+
+to the new API
+
+```ts
+playlistConditions.isOwner({
+  owners: ['user:default/me', 'group:default/owner'],
+});
+```

--- a/.changeset/quick-meals-talk.md
+++ b/.changeset/quick-meals-talk.md
@@ -4,7 +4,7 @@
 
 **BREAKING** The exported permission rules have changed to reflect the breaking changes made to the PermissionRule type.
 
-As an example the `playlistConditions.isOwner` API has changed from
+For example, the `playlistConditions.isOwner` API has changed from:
 
 ```ts
 playlistConditions.isOwner(['user:default/me', 'group:default/owner']);

--- a/.changeset/seven-panthers-chew.md
+++ b/.changeset/seven-panthers-chew.md
@@ -2,32 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-**BREAKING** Due to the changes made in the Permission framework. The catalogs permission rules and the API of `createCatalogPermissionRule` have been changed to reflect the change from individual function parameters to a single object parameter and the addition of the `paramsSchema`.
-
-As an example for the `hasLabel` rule. The API before the change was
-
-```ts
-hasLabel.apply(entity, 'backstage.io/testLabel');
-hasLabel.toQuery('backstage.io/testLabel');
-```
-
-and the API after the change now is
-
-```ts
-hasLabel.apply(entity, {
-  label: 'backstage.io/testLabel',
-});
-
-hasLabel.toQuery({
-  label: 'backstage.io/testLabel',
-});
-```
-
-This applies to all of the permission rules exported by the catalog backend.
-
-- `hasAnnotation`
-- `hasLabel`
-- `hasMetadata`
-- `hasSpec`
-- `isEntityKind`
-- `isEntityOwner`
+**BREAKING** The exported permission rules and the API of `createCatalogConditionalDecision` have changed to reflect the breaking changes made to the PermissionRule type.

--- a/.changeset/seven-panthers-chew.md
+++ b/.changeset/seven-panthers-chew.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-**BREAKING** The exported permission rules and the API of `createCatalogConditionalDecision` have changed to reflect the breaking changes made to the PermissionRule type.
+The exported permission rules and the API of `createCatalogConditionalDecision` have changed to reflect the breaking changes made to the `PermissionRule` type. Note that all involved types are exported from `@backstage/plugin-catalog-backend/alpha`

--- a/.changeset/seven-panthers-chew.md
+++ b/.changeset/seven-panthers-chew.md
@@ -1,0 +1,33 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+**BREAKING** Due to the changes made in the Permission framework. The catalogs permission rules and the API of `createCatalogPermissionRule` have been changed to reflect the change from individual function parameters to a single object parameter and the addition of the `paramsSchema`.
+
+As an example for the `hasLabel` rule. The API before the change was
+
+```ts
+hasLabel.apply(entity, 'backstage.io/testLabel');
+hasLabel.toQuery('backstage.io/testLabel');
+```
+
+and the API after the change now is
+
+```ts
+hasLabel.apply(entity, {
+  label: 'backstage.io/testLabel',
+});
+
+hasLabel.toQuery({
+  label: 'backstage.io/testLabel',
+});
+```
+
+This applies to all of the permission rules exported by the catalog backend.
+
+- `hasAnnotation`
+- `hasLabel`
+- `hasMetadata`
+- `hasSpec`
+- `isEntityKind`
+- `isEntityOwner`

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -179,8 +179,8 @@ export const catalogConditions: Conditions<{
     EntitiesSearchFilter,
     'catalog-entity',
     {
+      value?: string | undefined;
       annotation: string;
-      value: string | undefined;
     }
   >;
   hasLabel: PermissionRule<
@@ -196,8 +196,8 @@ export const catalogConditions: Conditions<{
     EntitiesSearchFilter,
     'catalog-entity',
     {
+      value?: string | undefined;
       key: string;
-      value: string | undefined;
     }
   >;
   hasSpec: PermissionRule<
@@ -205,8 +205,8 @@ export const catalogConditions: Conditions<{
     EntitiesSearchFilter,
     'catalog-entity',
     {
+      value?: string | undefined;
       key: string;
-      value: string | undefined;
     }
   >;
   isEntityKind: PermissionRule<
@@ -468,8 +468,8 @@ export const permissionRules: {
     EntitiesSearchFilter,
     'catalog-entity',
     {
+      value?: string | undefined;
       annotation: string;
-      value: string | undefined;
     }
   >;
   hasLabel: PermissionRule<
@@ -485,8 +485,8 @@ export const permissionRules: {
     EntitiesSearchFilter,
     'catalog-entity',
     {
+      value?: string | undefined;
       key: string;
-      value: string | undefined;
     }
   >;
   hasSpec: PermissionRule<
@@ -494,8 +494,8 @@ export const permissionRules: {
     EntitiesSearchFilter,
     'catalog-entity',
     {
+      value?: string | undefined;
       key: string;
-      value: string | undefined;
     }
   >;
   isEntityKind: PermissionRule<

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -303,7 +303,7 @@ export const createCatalogConditionalDecision: (
 
 // @alpha
 export const createCatalogPermissionRule: <
-  TParams extends PermissionRuleParams = PermissionRuleParams,
+  TParams extends PermissionRuleParams = undefined,
 >(
   rule: PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>,
 ) => PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -40,6 +40,7 @@ import { PermissionCondition } from '@backstage/plugin-permission-common';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { processingResult } from '@backstage/plugin-catalog-node';
@@ -177,37 +178,52 @@ export const catalogConditions: Conditions<{
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [annotation: string, value?: string | undefined]
+    {
+      annotation: string;
+      value: string | undefined;
+    }
   >;
   hasLabel: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [label: string]
+    {
+      label: string;
+    }
   >;
   hasMetadata: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [key: string, value?: string | undefined]
+    {
+      key: string;
+      value: string | undefined;
+    }
   >;
   hasSpec: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [key: string, value?: string | undefined]
+    {
+      key: string;
+      value: string | undefined;
+    }
   >;
   isEntityKind: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [kinds: string[]]
+    {
+      kinds: string[];
+    }
   >;
   isEntityOwner: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [claims: string[]]
+    {
+      claims: string[];
+    }
   >;
 }>;
 
@@ -221,8 +237,9 @@ export type CatalogEnvironment = {
 };
 
 // @alpha
-export type CatalogPermissionRule<TParams extends unknown[] = unknown[]> =
-  PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
+export type CatalogPermissionRule<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 // @alpha
 export const catalogPlugin: (options?: undefined) => BackendFeature;
@@ -280,12 +297,14 @@ export class CodeOwnersProcessor implements CatalogProcessor {
 export const createCatalogConditionalDecision: (
   permission: ResourcePermission<'catalog-entity'>,
   conditions: PermissionCriteria<
-    PermissionCondition<'catalog-entity', unknown[]>
+    PermissionCondition<'catalog-entity', PermissionRuleParams>
   >,
 ) => ConditionalPolicyDecision;
 
 // @alpha
-export const createCatalogPermissionRule: <TParams extends unknown[]>(
+export const createCatalogPermissionRule: <
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+>(
   rule: PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>,
 ) => PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
@@ -448,37 +467,52 @@ export const permissionRules: {
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [annotation: string, value?: string | undefined]
+    {
+      annotation: string;
+      value: string | undefined;
+    }
   >;
   hasLabel: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [label: string]
+    {
+      label: string;
+    }
   >;
   hasMetadata: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [key: string, value?: string | undefined]
+    {
+      key: string;
+      value: string | undefined;
+    }
   >;
   hasSpec: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [key: string, value?: string | undefined]
+    {
+      key: string;
+      value: string | undefined;
+    }
   >;
   isEntityKind: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [kinds: string[]]
+    {
+      kinds: string[];
+    }
   >;
   isEntityOwner: PermissionRule<
     Entity,
     EntitiesSearchFilter,
     'catalog-entity',
-    [claims: string[]]
+    {
+      claims: string[];
+    }
   >;
 };
 

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.test.ts
@@ -41,7 +41,9 @@ describe('createPropertyRule', () => {
                 name: 'test-component',
               },
             },
-            'org.name',
+            {
+              key: 'org.name',
+            },
           ),
         ).toBe(false);
       });
@@ -57,7 +59,9 @@ describe('createPropertyRule', () => {
                 tags: [],
               },
             },
-            'tags',
+            {
+              key: 'tags',
+            },
           ),
         ).toBe(false);
       });
@@ -75,7 +79,9 @@ describe('createPropertyRule', () => {
                 },
               },
             },
-            'org.name',
+            {
+              key: 'org.name',
+            },
           ),
         ).toBe(true);
       });
@@ -91,7 +97,9 @@ describe('createPropertyRule', () => {
                 tags: ['java'],
               },
             },
-            'tags',
+            {
+              key: 'tags',
+            },
           ),
         ).toBe(true);
       });
@@ -108,8 +116,10 @@ describe('createPropertyRule', () => {
                 name: 'test-component',
               },
             },
-            'org.name',
-            'test-org',
+            {
+              key: 'org.name',
+              value: 'test-org',
+            },
           ),
         ).toBe(false);
       });
@@ -127,8 +137,10 @@ describe('createPropertyRule', () => {
                 },
               },
             },
-            'org.name',
-            'test-org',
+            {
+              key: 'org.name',
+              value: 'test-org',
+            },
           ),
         ).toBe(false);
       });
@@ -144,8 +156,10 @@ describe('createPropertyRule', () => {
                 tags: ['java'],
               },
             },
-            'tags',
-            'python',
+            {
+              key: 'tags',
+              value: 'python',
+            },
           ),
         ).toBe(false);
       });
@@ -163,8 +177,10 @@ describe('createPropertyRule', () => {
                 },
               },
             },
-            'org.name',
-            'test-org',
+            {
+              key: 'org.name',
+              value: 'test-org',
+            },
           ),
         ).toBe(true);
       });
@@ -180,8 +196,10 @@ describe('createPropertyRule', () => {
                 tags: ['java', 'java11'],
               },
             },
-            'tags',
-            'java',
+            {
+              key: 'tags',
+              value: 'java',
+            },
           ),
         ).toBe(true);
       });
@@ -190,7 +208,11 @@ describe('createPropertyRule', () => {
 
   describe('toQuery', () => {
     it('returns an appropriate catalog-backend filter', () => {
-      expect(toQuery('backstage.io/test-component')).toEqual({
+      expect(
+        toQuery({
+          key: 'backstage.io/test-component',
+        }),
+      ).toEqual({
         key: 'metadata.backstage.io/test-component',
       });
     });

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -18,12 +18,17 @@ import { get } from 'lodash';
 import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
 import { createCatalogPermissionRule } from './util';
+import { z } from 'zod';
 
 export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
   createCatalogPermissionRule({
     name: `HAS_${propertyType.toUpperCase()}`,
     description: `Allow entities which have the specified ${propertyType} subfield.`,
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+    schema: z.tuple([
+      z.string().describe('Property name'),
+      z.string().optional().describe('Property value'),
+    ]),
     apply: (resource: Entity, key: string, value?: string) => {
       const foundValue = get(resource[propertyType], key);
 

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -20,7 +20,10 @@ import { createCatalogPermissionRule } from './util';
 import { z } from 'zod';
 
 export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
-  createCatalogPermissionRule({
+  createCatalogPermissionRule<{
+    key: string;
+    value?: string;
+  }>({
     name: `HAS_${propertyType.toUpperCase()}`,
     description: `Allow entities which have the specified ${propertyType} subfield.`,
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -28,11 +28,13 @@ export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
     description: `Allow entities which have the specified ${propertyType} subfield.`,
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
     schema: z.object({
-      key: z.string().describe(`The key of the ${propertyType} to match on`),
+      key: z
+        .string()
+        .describe(`Property within the entities ${propertyType} to match on`),
       value: z
         .string()
         .optional()
-        .describe(`Optional value of the ${propertyType} to match on`),
+        .describe(`Value of the given property to match on`),
     }),
     apply: (resource, { key, value }) => {
       const foundValue = get(resource[propertyType], key);

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -24,7 +24,7 @@ export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
     name: `HAS_${propertyType.toUpperCase()}`,
     description: `Allow entities which have the specified ${propertyType} subfield.`,
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-    schema: z.object({
+    paramsSchema: z.object({
       key: z
         .string()
         .describe(`Property within the entities ${propertyType} to match on`),

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -20,10 +20,7 @@ import { createCatalogPermissionRule } from './util';
 import { z } from 'zod';
 
 export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
-  createCatalogPermissionRule<{
-    key: string;
-    value?: string;
-  }>({
+  createCatalogPermissionRule({
     name: `HAS_${propertyType.toUpperCase()}`,
     description: `Allow entities which have the specified ${propertyType} subfield.`,
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
@@ -31,7 +31,9 @@ describe('hasAnnotation permission rule', () => {
               },
             },
           },
-          'backstage.io/test-annotation',
+          {
+            annotation: 'backstage.io/test-annotation',
+          },
         ),
       ).toEqual(false);
     });
@@ -46,7 +48,9 @@ describe('hasAnnotation permission rule', () => {
               name: 'test-component',
             },
           },
-          'backstage.io/test-annotation',
+          {
+            annotation: 'backstage.io/test-annotation',
+          },
         ),
       ).toEqual(false);
       expect(
@@ -58,8 +62,10 @@ describe('hasAnnotation permission rule', () => {
               name: 'test-component',
             },
           },
-          'backstage.io/test-annotation',
-          'some value',
+          {
+            annotation: 'backstage.io/test-annotation',
+            value: 'some value',
+          },
         ),
       ).toEqual(false);
     });
@@ -78,7 +84,9 @@ describe('hasAnnotation permission rule', () => {
               },
             },
           },
-          'backstage.io/test-annotation',
+          {
+            annotation: 'backstage.io/test-annotation',
+          },
         ),
       ).toEqual(true);
     });
@@ -97,8 +105,10 @@ describe('hasAnnotation permission rule', () => {
               },
             },
           },
-          'backstage.io/test-annotation',
-          'baz',
+          {
+            annotation: 'backstage.io/test-annotation',
+            value: 'baz',
+          },
         ),
       ).toEqual(false);
     });
@@ -117,8 +127,10 @@ describe('hasAnnotation permission rule', () => {
               },
             },
           },
-          'backstage.io/test-annotation',
-          'bar',
+          {
+            annotation: 'backstage.io/test-annotation',
+            value: 'bar',
+          },
         ),
       ).toEqual(true);
     });
@@ -126,7 +138,11 @@ describe('hasAnnotation permission rule', () => {
 
   describe('toQuery', () => {
     it('returns an appropriate catalog-backend filter', () => {
-      expect(hasAnnotation.toQuery('backstage.io/test-annotation')).toEqual({
+      expect(
+        hasAnnotation.toQuery({
+          annotation: 'backstage.io/test-annotation',
+        }),
+      ).toEqual({
         key: 'metadata.annotations.backstage.io/test-annotation',
       });
     });
@@ -134,7 +150,10 @@ describe('hasAnnotation permission rule', () => {
 
   it('returns an appropriate catalog-backend filter with values', () => {
     expect(
-      hasAnnotation.toQuery('backstage.io/test-annotation', 'foo'),
+      hasAnnotation.toQuery({
+        annotation: 'backstage.io/test-annotation',
+        value: 'foo',
+      }),
     ).toEqual({
       key: 'metadata.annotations.backstage.io/test-annotation',
       values: ['foo'],

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -16,6 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import { z } from 'zod';
 import { createCatalogPermissionRule } from './util';
 
 /**
@@ -31,6 +32,10 @@ export const hasAnnotation = createCatalogPermissionRule({
   description:
     'Allow entities which are annotated with the specified annotation',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  schema: z.tuple([
+    z.string().describe('Annotation name'),
+    z.string().optional().describe('Annotation value'),
+  ]),
   apply: (resource: Entity, annotation: string, value?: string) =>
     !!resource.metadata.annotations?.hasOwnProperty(annotation) &&
     (value === undefined

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -26,7 +26,10 @@ import { createCatalogPermissionRule } from './util';
  *
  * @alpha
  */
-export const hasAnnotation = createCatalogPermissionRule({
+export const hasAnnotation = createCatalogPermissionRule<{
+  annotation: string;
+  value?: string;
+}>({
   name: 'HAS_ANNOTATION',
   description:
     'Allow entities which are annotated with the specified annotation',

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
 import { z } from 'zod';
 import { createCatalogPermissionRule } from './util';
@@ -32,16 +31,19 @@ export const hasAnnotation = createCatalogPermissionRule({
   description:
     'Allow entities which are annotated with the specified annotation',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.tuple([
-    z.string().describe('Annotation name'),
-    z.string().optional().describe('Annotation value'),
-  ]),
-  apply: (resource: Entity, annotation: string, value?: string) =>
+  schema: z.object({
+    annotation: z.string().describe('The name of the annotation to match on'),
+    value: z
+      .string()
+      .optional()
+      .describe('Optional value of the annotation to match on'),
+  }),
+  apply: (resource, { annotation, value }) =>
     !!resource.metadata.annotations?.hasOwnProperty(annotation) &&
     (value === undefined
       ? true
       : resource.metadata.annotations?.[annotation] === value),
-  toQuery: (annotation: string, value?: string) =>
+  toQuery: ({ annotation, value }) =>
     value === undefined
       ? {
           key: `metadata.annotations.${annotation}`,

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -26,10 +26,7 @@ import { createCatalogPermissionRule } from './util';
  *
  * @alpha
  */
-export const hasAnnotation = createCatalogPermissionRule<{
-  annotation: string;
-  value?: string;
-}>({
+export const hasAnnotation = createCatalogPermissionRule({
   name: 'HAS_ANNOTATION',
   description:
     'Allow entities which are annotated with the specified annotation',

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -31,7 +31,7 @@ export const hasAnnotation = createCatalogPermissionRule({
   description:
     'Allow entities which are annotated with the specified annotation',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.object({
+  paramsSchema: z.object({
     annotation: z.string().describe('Name of the annotation to match on'),
     value: z
       .string()

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -35,11 +35,11 @@ export const hasAnnotation = createCatalogPermissionRule<{
     'Allow entities which are annotated with the specified annotation',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
   schema: z.object({
-    annotation: z.string().describe('The name of the annotation to match on'),
+    annotation: z.string().describe('Name of the annotation to match on'),
     value: z
       .string()
       .optional()
-      .describe('Optional value of the annotation to match on'),
+      .describe('Value of the annotation to match on'),
   }),
   apply: (resource, { annotation, value }) =>
     !!resource.metadata.annotations?.hasOwnProperty(annotation) &&

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
@@ -31,7 +31,9 @@ describe('hasLabel permission rule', () => {
               },
             },
           },
-          'backstage.io/testlabel',
+          {
+            label: 'backstage.io/testlabel',
+          },
         ),
       ).toEqual(false);
     });
@@ -46,7 +48,9 @@ describe('hasLabel permission rule', () => {
               name: 'test-component',
             },
           },
-          'backstage.io/testlabel',
+          {
+            label: 'backstage.io/testlabel',
+          },
         ),
       ).toEqual(false);
     });
@@ -65,7 +69,7 @@ describe('hasLabel permission rule', () => {
               },
             },
           },
-          'backstage.io/testlabel',
+          { label: 'backstage.io/testlabel' },
         ),
       ).toEqual(true);
     });
@@ -73,7 +77,11 @@ describe('hasLabel permission rule', () => {
 
   describe('toQuery', () => {
     it('returns an appropriate catalog-backend filter', () => {
-      expect(hasLabel.toQuery('backstage.io/testlabel')).toEqual({
+      expect(
+        hasLabel.toQuery({
+          label: 'backstage.io/testlabel',
+        }),
+      ).toEqual({
         key: 'metadata.labels.backstage.io/testlabel',
       });
     });

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -16,6 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import { z } from 'zod';
 import { createCatalogPermissionRule } from './util';
 
 /**
@@ -27,6 +28,7 @@ export const hasLabel = createCatalogPermissionRule({
   name: 'HAS_LABEL',
   description: 'Allow entities which have the specified label metadata.',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  schema: z.tuple([z.string().describe('Label name')]),
   apply: (resource: Entity, label: string) =>
     !!resource.metadata.labels?.hasOwnProperty(label),
   toQuery: (label: string) => ({

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
 import { z } from 'zod';
 import { createCatalogPermissionRule } from './util';
@@ -28,10 +27,12 @@ export const hasLabel = createCatalogPermissionRule({
   name: 'HAS_LABEL',
   description: 'Allow entities which have the specified label metadata.',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.tuple([z.string().describe('Label name')]),
-  apply: (resource: Entity, label: string) =>
+  schema: z.object({
+    label: z.string().describe('Name of the label'),
+  }),
+  apply: (resource, { label }) =>
     !!resource.metadata.labels?.hasOwnProperty(label),
-  toQuery: (label: string) => ({
+  toQuery: ({ label }) => ({
     key: `metadata.labels.${label}`,
   }),
 });

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -27,7 +27,7 @@ export const hasLabel = createCatalogPermissionRule({
   name: 'HAS_LABEL',
   description: 'Allow entities which have the specified label metadata.',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.object({
+  paramsSchema: z.object({
     label: z.string().describe('Name of the label to match one'),
   }),
   apply: (resource, { label }) =>

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -28,7 +28,7 @@ export const hasLabel = createCatalogPermissionRule({
   description: 'Allow entities which have the specified label metadata.',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
   schema: z.object({
-    label: z.string().describe('Name of the label'),
+    label: z.string().describe('Name of the label to match one'),
   }),
   apply: (resource, { label }) =>
     !!resource.metadata.labels?.hasOwnProperty(label),

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.test.ts
@@ -27,7 +27,11 @@ describe('isEntityKind', () => {
           name: 'some-component',
         },
       };
-      expect(isEntityKind.apply(component, ['b'])).toBe(true);
+      expect(
+        isEntityKind.apply(component, {
+          kinds: ['b'],
+        }),
+      ).toBe(true);
     });
 
     it('returns false when entity is not the correct kind', () => {
@@ -38,13 +42,21 @@ describe('isEntityKind', () => {
           name: 'some-component',
         },
       };
-      expect(isEntityKind.apply(component, ['c'])).toBe(false);
+      expect(
+        isEntityKind.apply(component, {
+          kinds: ['c'],
+        }),
+      ).toBe(false);
     });
   });
 
   describe('toQuery', () => {
     it('returns an appropriate catalog-backend filter', () => {
-      expect(isEntityKind.toQuery(['b'])).toEqual({
+      expect(
+        isEntityKind.toQuery({
+          kinds: ['b'],
+        }),
+      ).toEqual({
         key: 'kind',
         values: ['b'],
       });

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
@@ -15,6 +15,7 @@
  */
 import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import { z } from 'zod';
 import { EntitiesSearchFilter } from '../../catalog/types';
 import { createCatalogPermissionRule } from './util';
 
@@ -27,6 +28,7 @@ export const isEntityKind = createCatalogPermissionRule({
   name: 'IS_ENTITY_KIND',
   description: 'Allow entities with the specified kind',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  schema: z.tuple([z.array(z.string().describe('List of entity kinds'))]),
   apply(resource: Entity, kinds: string[]) {
     const resourceKind = resource.kind.toLocaleLowerCase('en-US');
     return kinds.some(kind => kind.toLocaleLowerCase('en-US') === resourceKind);

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
 import { z } from 'zod';
 import { EntitiesSearchFilter } from '../../catalog/types';
@@ -28,12 +27,14 @@ export const isEntityKind = createCatalogPermissionRule({
   name: 'IS_ENTITY_KIND',
   description: 'Allow entities with the specified kind',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.tuple([z.array(z.string().describe('List of entity kinds'))]),
-  apply(resource: Entity, kinds: string[]) {
+  schema: z.object({
+    kinds: z.array(z.string()),
+  }),
+  apply(resource, { kinds }) {
     const resourceKind = resource.kind.toLocaleLowerCase('en-US');
     return kinds.some(kind => kind.toLocaleLowerCase('en-US') === resourceKind);
   },
-  toQuery(kinds: string[]): EntitiesSearchFilter {
+  toQuery({ kinds }): EntitiesSearchFilter {
     return {
       key: 'kind',
       values: kinds.map(kind => kind.toLocaleLowerCase('en-US')),

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
@@ -28,7 +28,9 @@ export const isEntityKind = createCatalogPermissionRule({
   description: 'Allow entities with the specified kind',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
   schema: z.object({
-    kinds: z.array(z.string()),
+    kinds: z
+      .array(z.string())
+      .describe('List of kinds to match at least one of'),
   }),
   apply(resource, { kinds }) {
     const resourceKind = resource.kind.toLocaleLowerCase('en-US');

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
@@ -27,7 +27,7 @@ export const isEntityKind = createCatalogPermissionRule({
   name: 'IS_ENTITY_KIND',
   description: 'Allow entities with the specified kind',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.object({
+  paramsSchema: z.object({
     kinds: z
       .array(z.string())
       .describe('List of kinds to match at least one of'),

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.test.ts
@@ -33,9 +33,11 @@ describe('isEntityOwner', () => {
           },
         ],
       };
-      expect(isEntityOwner.apply(component, ['user:default/spiderman'])).toBe(
-        true,
-      );
+      expect(
+        isEntityOwner.apply(component, {
+          claims: ['user:default/spiderman'],
+        }),
+      ).toBe(true);
     });
 
     it('returns false when entity is not owned by the given user', () => {
@@ -52,9 +54,11 @@ describe('isEntityOwner', () => {
           },
         ],
       };
-      expect(isEntityOwner.apply(component, ['user:default/spiderman'])).toBe(
-        false,
-      );
+      expect(
+        isEntityOwner.apply(component, {
+          claims: ['user:default/spiderman'],
+        }),
+      ).toBe(false);
     });
 
     it('returns false when entity does not have an owner', () => {
@@ -65,15 +69,21 @@ describe('isEntityOwner', () => {
           name: 'some-component',
         },
       };
-      expect(isEntityOwner.apply(component, ['user:default/spiderman'])).toBe(
-        false,
-      );
+      expect(
+        isEntityOwner.apply(component, {
+          claims: ['user:default/spiderman'],
+        }),
+      ).toBe(false);
     });
   });
 
   describe('toQuery', () => {
     it('returns an appropriate catalog-backend filter', () => {
-      expect(isEntityOwner.toQuery(['user:default/spiderman'])).toEqual({
+      expect(
+        isEntityOwner.toQuery({
+          claims: ['user:default/spiderman'],
+        }),
+      ).toEqual({
         key: 'relations.ownedBy',
         values: ['user:default/spiderman'],
       });

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
@@ -16,6 +16,7 @@
 
 import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import { z } from 'zod';
 import { createCatalogPermissionRule } from './util';
 
 /**
@@ -28,6 +29,7 @@ export const isEntityOwner = createCatalogPermissionRule({
   name: 'IS_ENTITY_OWNER',
   description: 'Allow entities owned by the current user',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  schema: z.tuple([z.array(z.string().describe('List of owners'))]),
   apply: (resource: Entity, claims: string[]) => {
     if (!resource.relations) {
       return false;

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
 import { z } from 'zod';
 import { createCatalogPermissionRule } from './util';
@@ -29,8 +29,10 @@ export const isEntityOwner = createCatalogPermissionRule({
   name: 'IS_ENTITY_OWNER',
   description: 'Allow entities owned by the current user',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.tuple([z.array(z.string().describe('List of owners'))]),
-  apply: (resource: Entity, claims: string[]) => {
+  schema: z.object({
+    claims: z.array(z.string()),
+  }),
+  apply: (resource, { claims }) => {
     if (!resource.relations) {
       return false;
     }
@@ -39,7 +41,7 @@ export const isEntityOwner = createCatalogPermissionRule({
       .filter(relation => relation.type === RELATION_OWNED_BY)
       .some(relation => claims.includes(relation.targetRef));
   },
-  toQuery: (claims: string[]) => ({
+  toQuery: ({ claims }) => ({
     key: 'relations.ownedBy',
     values: claims,
   }),

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
@@ -30,7 +30,11 @@ export const isEntityOwner = createCatalogPermissionRule({
   description: 'Allow entities owned by the current user',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
   schema: z.object({
-    claims: z.array(z.string()),
+    claims: z
+      .array(z.string())
+      .describe(
+        `List of claims to match at least one on within ${RELATION_OWNED_BY}`,
+      ),
   }),
   apply: (resource, { claims }) => {
     if (!resource.relations) {

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
@@ -29,7 +29,7 @@ export const isEntityOwner = createCatalogPermissionRule({
   name: 'IS_ENTITY_OWNER',
   description: 'Allow entities owned by the current user',
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-  schema: z.object({
+  paramsSchema: z.object({
     claims: z
       .array(z.string())
       .describe(

--- a/plugins/catalog-backend/src/permissions/rules/util.ts
+++ b/plugins/catalog-backend/src/permissions/rules/util.ts
@@ -29,8 +29,9 @@ import { EntitiesSearchFilter } from '../../catalog/types';
  *
  * @alpha
  */
-export type CatalogPermissionRule<TParams extends unknown[] = unknown[]> =
-  PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
+export type CatalogPermissionRule<
+  TParams extends Record<string, unknown> = Record<string, unknown>,
+> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 /**
  * Helper function for creating correctly-typed

--- a/plugins/catalog-backend/src/permissions/rules/util.ts
+++ b/plugins/catalog-backend/src/permissions/rules/util.ts
@@ -16,6 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import {
   makeCreatePermissionRule,
   PermissionRule,
@@ -30,7 +31,7 @@ import { EntitiesSearchFilter } from '../../catalog/types';
  * @alpha
  */
 export type CatalogPermissionRule<
-  TParams extends Record<string, unknown> = Record<string, unknown>,
+  TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 /**

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -65,7 +65,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       fakePermissionApi.authorizeConditional.mockResolvedValue([
         {
           result: AuthorizeResult.CONDITIONAL,
-          conditions: { rule: 'IS_ENTITY_KIND', params: [['b']] },
+          conditions: { rule: 'IS_ENTITY_KIND', params: { kinds: ['b'] } },
         },
       ]);
       const catalog = createCatalog(isEntityKind);
@@ -117,7 +117,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       fakePermissionApi.authorizeConditional.mockResolvedValue([
         {
           result: AuthorizeResult.CONDITIONAL,
-          conditions: { rule: 'IS_ENTITY_KIND', params: [['b']] },
+          conditions: { rule: 'IS_ENTITY_KIND', params: { kinds: ['b'] } },
         },
       ]);
       fakeCatalog.entities.mockResolvedValue({ entities: [] });
@@ -136,7 +136,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       fakePermissionApi.authorizeConditional.mockResolvedValue([
         {
           result: AuthorizeResult.CONDITIONAL,
-          conditions: { rule: 'IS_ENTITY_KIND', params: [['b']] },
+          conditions: { rule: 'IS_ENTITY_KIND', params: { kinds: ['b'] } },
         },
       ]);
       fakeCatalog.entities.mockResolvedValue({
@@ -272,7 +272,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       fakePermissionApi.authorizeConditional.mockResolvedValue([
         {
           result: AuthorizeResult.CONDITIONAL,
-          conditions: { rule: 'IS_ENTITY_KIND', params: [['b']] },
+          conditions: { rule: 'IS_ENTITY_KIND', params: { kinds: ['b'] } },
         },
       ]);
       const catalog = createCatalog(isEntityKind);

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -36,6 +36,7 @@ import {
 } from '@backstage/plugin-permission-node';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
 import { CatalogProcessingOrchestrator } from '../processing/types';
+import { z } from 'zod';
 
 describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
@@ -695,6 +696,7 @@ describe('NextRouter permissioning', () => {
     name: 'FAKE_RULE',
     description: 'fake rule',
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+    schema: z.tuple([]),
     apply: () => true,
     toQuery: () => ({ key: '', values: [] }),
   });

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -696,7 +696,9 @@ describe('NextRouter permissioning', () => {
     name: 'FAKE_RULE',
     description: 'fake rule',
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-    schema: z.tuple([]),
+    schema: z.object({
+      foo: z.string(),
+    }),
     apply: () => true,
     toQuery: () => ({ key: '', values: [] }),
   });
@@ -760,7 +762,9 @@ describe('NextRouter permissioning', () => {
           conditions: {
             rule: 'FAKE_RULE',
             resourceType: 'catalog-entity',
-            params: ['user:default/spiderman'],
+            params: {
+              foo: 'user:default/spiderman',
+            },
           },
         },
       ],

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -696,7 +696,7 @@ describe('NextRouter permissioning', () => {
     name: 'FAKE_RULE',
     description: 'fake rule',
     resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
-    schema: z.object({
+    paramsSchema: z.object({
       foo: z.string(),
     }),
     apply: () => true,

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
@@ -30,6 +30,7 @@ import {
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
 import { PermissionIntegrationClient } from './PermissionIntegrationClient';
+import { z } from 'zod';
 
 describe('PermissionIntegrationClient', () => {
   describe('applyConditions', () => {
@@ -279,6 +280,7 @@ describe('PermissionIntegrationClient', () => {
               name: 'RULE_1',
               description: 'Test rule 1',
               resourceType: 'test-resource',
+              schema: z.tuple([z.enum(['yes', 'no'])]),
               apply: (_resource: any, input: 'yes' | 'no') => input === 'yes',
               toQuery: () => {
                 throw new Error('Not implemented');
@@ -288,6 +290,7 @@ describe('PermissionIntegrationClient', () => {
               name: 'RULE_2',
               description: 'Test rule 2',
               resourceType: 'test-resource',
+              schema: z.tuple([z.enum(['yes', 'no'])]),
               apply: (_resource: any, input: 'yes' | 'no') => input === 'yes',
               toQuery: () => {
                 throw new Error('Not implemented');

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
@@ -39,8 +39,12 @@ describe('PermissionIntegrationClient', () => {
     const mockConditions: PermissionCriteria<PermissionCondition> = {
       not: {
         allOf: [
-          { rule: 'RULE_1', resourceType: 'test-resource', params: [] },
-          { rule: 'RULE_2', resourceType: 'test-resource', params: ['abc'] },
+          { rule: 'RULE_1', resourceType: 'test-resource', params: {} },
+          {
+            rule: 'RULE_2',
+            resourceType: 'test-resource',
+            params: { foo: 'abc' },
+          },
         ],
       },
     };
@@ -280,8 +284,10 @@ describe('PermissionIntegrationClient', () => {
               name: 'RULE_1',
               description: 'Test rule 1',
               resourceType: 'test-resource',
-              schema: z.tuple([z.enum(['yes', 'no'])]),
-              apply: (_resource: any, input: 'yes' | 'no') => input === 'yes',
+              schema: z.object({
+                input: z.enum(['yes', 'no']),
+              }),
+              apply: (_resource, { input }) => input === 'yes',
               toQuery: () => {
                 throw new Error('Not implemented');
               },
@@ -290,8 +296,11 @@ describe('PermissionIntegrationClient', () => {
               name: 'RULE_2',
               description: 'Test rule 2',
               resourceType: 'test-resource',
-              schema: z.tuple([z.enum(['yes', 'no'])]),
-              apply: (_resource: any, input: 'yes' | 'no') => input === 'yes',
+
+              schema: z.object({
+                input: z.enum(['yes', 'no']),
+              }),
+              apply: (_resource, { input }) => input === 'yes',
               toQuery: () => {
                 throw new Error('Not implemented');
               },
@@ -347,7 +356,9 @@ describe('PermissionIntegrationClient', () => {
             conditions: {
               rule: 'RULE_1',
               resourceType: 'test-resource',
-              params: ['no'],
+              params: {
+                input: 'no',
+              },
             },
           },
         ]),
@@ -368,13 +379,17 @@ describe('PermissionIntegrationClient', () => {
                     {
                       rule: 'RULE_1',
                       resourceType: 'test-resource',
-                      params: ['yes'],
+                      params: {
+                        input: 'yes',
+                      },
                     },
                     {
                       not: {
                         rule: 'RULE_2',
                         resourceType: 'test-resource',
-                        params: ['no'],
+                        params: {
+                          input: 'no',
+                        },
                       },
                     },
                   ],
@@ -385,12 +400,16 @@ describe('PermissionIntegrationClient', () => {
                       {
                         rule: 'RULE_1',
                         resourceType: 'test-resource',
-                        params: ['no'],
+                        params: {
+                          input: 'no',
+                        },
                       },
                       {
                         rule: 'RULE_2',
                         resourceType: 'test-resource',
-                        params: ['yes'],
+                        params: {
+                          input: 'yes',
+                        },
                       },
                     ],
                   },

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
@@ -284,7 +284,7 @@ describe('PermissionIntegrationClient', () => {
               name: 'RULE_1',
               description: 'Test rule 1',
               resourceType: 'test-resource',
-              schema: z.object({
+              paramsSchema: z.object({
                 input: z.enum(['yes', 'no']),
               }),
               apply: (_resource, { input }) => input === 'yes',
@@ -297,7 +297,7 @@ describe('PermissionIntegrationClient', () => {
               description: 'Test rule 2',
               resourceType: 'test-resource',
 
-              schema: z.object({
+              paramsSchema: z.object({
                 input: z.enum(['yes', 'no']),
               }),
               apply: (_resource, { input }) => input === 'yes',

--- a/plugins/permission-common/api-report.md
+++ b/plugins/permission-common/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { Config } from '@backstage/config';
+import { JsonPrimitive } from '@backstage/types';
 
 // @public
 export type AllOfCriteria<TQuery> = {
@@ -172,7 +173,7 @@ export class PermissionClient implements PermissionEvaluator {
 // @public
 export type PermissionCondition<
   TResourceType extends string = string,
-  TParams extends unknown[] = unknown[],
+  TParams extends PermissionRuleParams = PermissionRuleParams,
 > = {
   resourceType: TResourceType;
   rule: string;
@@ -202,6 +203,12 @@ export interface PermissionEvaluator {
 export type PermissionMessageBatch<T> = {
   items: IdentifiedPermissionMessage<T>[];
 };
+
+// @public
+export type PermissionRuleParam = undefined | JsonPrimitive | JsonPrimitive[];
+
+// @public
+export type PermissionRuleParams = Record<string, PermissionRuleParam>;
 
 // @public
 export type PolicyDecision =

--- a/plugins/permission-common/api-report.md
+++ b/plugins/permission-common/api-report.md
@@ -177,7 +177,7 @@ export type PermissionCondition<
 > = {
   resourceType: TResourceType;
   rule: string;
-  params: TParams;
+  params?: TParams;
 };
 
 // @public
@@ -208,7 +208,9 @@ export type PermissionMessageBatch<T> = {
 export type PermissionRuleParam = undefined | JsonPrimitive | JsonPrimitive[];
 
 // @public
-export type PermissionRuleParams = Record<string, PermissionRuleParam>;
+export type PermissionRuleParams =
+  | undefined
+  | Record<string, PermissionRuleParam>;
 
 // @public
 export type PolicyDecision =

--- a/plugins/permission-common/package.json
+++ b/plugins/permission-common/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
+    "@backstage/types": "workspace:^",
     "cross-fetch": "^3.1.5",
     "uuid": "^8.0.0",
     "zod": "^3.11.6"

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -227,7 +227,7 @@ describe('PermissionClient', () => {
             conditions: {
               resourceType: 'test-resource',
               rule: 'FOO',
-              params: ['bar'],
+              params: { foo: 'bar' },
             },
           }),
         );
@@ -275,7 +275,7 @@ describe('PermissionClient', () => {
           conditions: {
             rule: 'FOO',
             resourceType: 'test-resource',
-            params: ['bar'],
+            params: { foo: 'bar' },
           },
         }),
       );

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -41,7 +41,7 @@ const permissionCriteriaSchema: z.ZodSchema<
     .object({
       rule: z.string(),
       resourceType: z.string(),
-      params: z.array(z.unknown()),
+      params: z.record(z.unknown()),
     })
     .or(z.object({ anyOf: z.array(permissionCriteriaSchema).nonempty() }))
     .or(z.object({ allOf: z.array(permissionCriteriaSchema).nonempty() }))

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -41,7 +41,7 @@ const permissionCriteriaSchema: z.ZodSchema<
     .object({
       rule: z.string(),
       resourceType: z.string(),
-      params: z.record(z.unknown()),
+      params: z.record(z.any()),
     })
     .or(z.object({ anyOf: z.array(permissionCriteriaSchema).nonempty() }))
     .or(z.object({ allOf: z.array(permissionCriteriaSchema).nonempty() }))

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -101,7 +101,7 @@ export type PolicyDecision =
  */
 export type PermissionCondition<
   TResourceType extends string = string,
-  TParams extends unknown[] = unknown[],
+  TParams extends Record<string, unknown> = Record<string, unknown>,
 > = {
   resourceType: TResourceType;
   rule: string;

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -151,11 +151,15 @@ export type PermissionCriteria<TQuery> =
 
 /**
  * A parameter to a permission rule.
+ *
+ * @public
  */
 export type PermissionRuleParam = undefined | JsonPrimitive | JsonPrimitive[];
 
 /**
  * Types that can be used as parameters to permission rules.
+ *
+ * @public
  */
 export type PermissionRuleParams = Record<string, PermissionRuleParam>;
 

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -106,7 +106,7 @@ export type PermissionCondition<
 > = {
   resourceType: TResourceType;
   rule: string;
-  params: TParams;
+  params?: TParams;
 };
 
 /**
@@ -161,7 +161,9 @@ export type PermissionRuleParam = undefined | JsonPrimitive | JsonPrimitive[];
  *
  * @public
  */
-export type PermissionRuleParams = Record<string, PermissionRuleParam>;
+export type PermissionRuleParams =
+  | undefined
+  | Record<string, PermissionRuleParam>;
 
 /**
  * An individual request sent to the permission backend.

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { JsonPrimitive } from '@backstage/types';
 import { ResourcePermission } from '.';
 import { Permission } from './permission';
 
@@ -101,7 +102,7 @@ export type PolicyDecision =
  */
 export type PermissionCondition<
   TResourceType extends string = string,
-  TParams extends Record<string, unknown> = Record<string, unknown>,
+  TParams extends PermissionRuleParams = PermissionRuleParams,
 > = {
   resourceType: TResourceType;
   rule: string;
@@ -147,6 +148,16 @@ export type PermissionCriteria<TQuery> =
   | AnyOfCriteria<TQuery>
   | NotCriteria<TQuery>
   | TQuery;
+
+/**
+ * A parameter to a permission rule.
+ */
+export type PermissionRuleParam = undefined | JsonPrimitive | JsonPrimitive[];
+
+/**
+ * Types that can be used as parameters to permission rules.
+ */
+export type PermissionRuleParams = Record<string, PermissionRuleParam>;
 
 /**
  * An individual request sent to the permission backend.

--- a/plugins/permission-common/src/types/index.ts
+++ b/plugins/permission-common/src/types/index.ts
@@ -33,6 +33,8 @@ export type {
   PolicyDecision,
   PermissionCondition,
   PermissionCriteria,
+  PermissionRuleParam,
+  PermissionRuleParams,
   AllOfCriteria,
   AnyOfCriteria,
   NotCriteria,

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -24,6 +24,7 @@ import { PolicyDecision } from '@backstage/plugin-permission-common';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { TokenManager } from '@backstage/backend-common';
+import { z } from 'zod';
 
 // @public
 export type ApplyConditionsRequest = {
@@ -170,6 +171,7 @@ export type PermissionRule<
   name: string;
   description: string;
   resourceType: TResourceType;
+  schema: z.ZodSchema<TParams>;
   apply(resource: TResource, ...params: TParams): boolean;
   toQuery(...params: TParams): PermissionCriteria<TQuery>;
 };

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -55,7 +55,9 @@ export type Condition<TRule> = TRule extends PermissionRule<
   infer TResourceType,
   infer TParams
 >
-  ? (params: TParams) => PermissionCondition<TResourceType, TParams>
+  ? undefined extends TParams
+    ? () => PermissionCondition<TResourceType, TParams>
+    : (params: TParams) => PermissionCondition<TResourceType, TParams>
   : never;
 
 // @public
@@ -98,7 +100,7 @@ export const createConditionFactory: <
   TParams extends PermissionRuleParams = PermissionRuleParams,
 >(
   rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
-) => (params: TParams) => PermissionCondition<TResourceType, TParams>;
+) => (args_0: TParams) => PermissionCondition<TResourceType, TParams>;
 
 // @public
 export const createConditionTransformer: <
@@ -129,7 +131,7 @@ export const createPermissionRule: <
   TResource,
   TQuery,
   TResourceType extends string,
-  TParams extends PermissionRuleParams = PermissionRuleParams,
+  TParams extends PermissionRuleParams = undefined,
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
@@ -154,7 +156,7 @@ export const makeCreatePermissionRule: <
   TResource,
   TQuery,
   TResourceType extends string,
->() => <TParams extends PermissionRuleParams = PermissionRuleParams>(
+>() => <TParams extends PermissionRuleParams = undefined>(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
 
@@ -177,7 +179,7 @@ export type PermissionRule<
   name: string;
   description: string;
   resourceType: TResourceType;
-  paramsSchema: PermissionRuleSchema<TParams>;
+  paramsSchema?: PermissionRuleSchema<TParams>;
   apply(
     resource: TResource,
     params: NoInfer<z.input<PermissionRuleSchema<TParams>>>,

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -100,7 +100,7 @@ export const createConditionFactory: <
   TParams extends PermissionRuleParams = PermissionRuleParams,
 >(
   rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
-) => (args_0: TParams) => PermissionCondition<TResourceType, TParams>;
+) => (params: TParams) => PermissionCondition<TResourceType, TParams>;
 
 // @public
 export const createConditionTransformer: <

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -179,22 +179,10 @@ export type PermissionRule<
   name: string;
   description: string;
   resourceType: TResourceType;
-  paramsSchema?: PermissionRuleSchema<TParams>;
-  apply(
-    resource: TResource,
-    params: NoInfer<z.input<PermissionRuleSchema<TParams>>>,
-  ): boolean;
-  toQuery(
-    params: NoInfer<z.input<PermissionRuleSchema<TParams>>>,
-  ): PermissionCriteria<TQuery>;
+  paramsSchema?: z.ZodSchema<TParams>;
+  apply(resource: TResource, params: NoInfer<TParams>): boolean;
+  toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
 };
-
-// @public
-export type PermissionRuleSchema<TParams> = z.ZodObject<{
-  [P in keyof TParams]-?: TParams[P] extends undefined
-    ? z.ZodOptionalType<z.ZodType<TParams[P]>>
-    : z.ZodType<TParams[P]>;
-}>;
 
 // @public
 export type PolicyQuery = {

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -177,7 +177,7 @@ export type PermissionRule<
   name: string;
   description: string;
   resourceType: TResourceType;
-  schema: PermissionRuleSchema<TParams>;
+  paramsSchema: PermissionRuleSchema<TParams>;
   apply(
     resource: TResource,
     params: NoInfer<z.input<PermissionRuleSchema<TParams>>>,

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -41,7 +41,8 @@
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "zod": "^3.11.6"
+    "zod": "^3.11.6",
+    "zod-to-json-schema": "^3.18.1"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/permission-node/src/integration/createConditionExports.test.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.test.ts
@@ -18,6 +18,7 @@ import {
   AuthorizeResult,
   createPermission,
 } from '@backstage/plugin-permission-common';
+import { z } from 'zod';
 import { createConditionExports } from './createConditionExports';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -30,6 +31,7 @@ const testIntegration = () =>
         name: 'testRule1',
         description: 'Test rule 1',
         resourceType: 'test-resource',
+        schema: z.tuple([z.string(), z.number()]),
         apply: jest.fn(
           (_resource: any, _firstParam: string, _secondParam: number) => true,
         ),
@@ -42,6 +44,7 @@ const testIntegration = () =>
         name: 'testRule2',
         description: 'Test rule 2',
         resourceType: 'test-resource',
+        schema: z.tuple([z.object({})]),
         apply: jest.fn((_resource: any, _firstParam: object) => false),
         toQuery: jest.fn((firstParam: object) => ({
           query: 'testRule2',

--- a/plugins/permission-node/src/integration/createConditionExports.test.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.test.ts
@@ -31,25 +31,28 @@ const testIntegration = () =>
         name: 'testRule1',
         description: 'Test rule 1',
         resourceType: 'test-resource',
-        schema: z.tuple([z.string(), z.number()]),
-        apply: jest.fn(
-          (_resource: any, _firstParam: string, _secondParam: number) => true,
-        ),
-        toQuery: jest.fn((firstParam: string, secondParam: number) => ({
+        schema: z.object({
+          foo: z.string(),
+          bar: z.number(),
+        }),
+        apply: (_resource: any, _params) => true,
+        toQuery: params => ({
           query: 'testRule1',
-          params: [firstParam, secondParam],
-        })),
+          params,
+        }),
       }),
       testRule2: createPermissionRule({
         name: 'testRule2',
         description: 'Test rule 2',
         resourceType: 'test-resource',
-        schema: z.tuple([z.object({})]),
-        apply: jest.fn((_resource: any, _firstParam: object) => false),
-        toQuery: jest.fn((firstParam: object) => ({
+        schema: z.object({
+          foo: z.object({}),
+        }),
+        apply: (_resource: any) => false,
+        toQuery: params => ({
           query: 'testRule2',
-          params: [firstParam],
-        })),
+          params,
+        }),
       }),
     },
   });
@@ -59,16 +62,26 @@ describe('createConditionExports', () => {
     it('creates condition factories for the supplied rules', () => {
       const { conditions } = testIntegration();
 
-      expect(conditions.testRule1('a', 1)).toEqual({
+      expect(
+        conditions.testRule1({
+          foo: 'a',
+          bar: 1,
+        }),
+      ).toEqual({
         rule: 'testRule1',
         resourceType: 'test-resource',
-        params: ['a', 1],
+        params: {
+          foo: 'a',
+          bar: 1,
+        },
       });
 
-      expect(conditions.testRule2({ baz: 'quux' })).toEqual({
+      expect(conditions.testRule2({ foo: { baz: 'quux' } })).toEqual({
         rule: 'testRule2',
         resourceType: 'test-resource',
-        params: [{ baz: 'quux' }],
+        params: {
+          foo: { baz: 'quux' },
+        },
       });
     });
   });
@@ -88,7 +101,10 @@ describe('createConditionExports', () => {
             {
               rule: 'testRule1',
               resourceType: 'test-resource',
-              params: ['a', 1],
+              params: {
+                foo: 'a',
+                bar: 1,
+              },
             },
           ],
         }),
@@ -101,7 +117,10 @@ describe('createConditionExports', () => {
             {
               rule: 'testRule1',
               resourceType: 'test-resource',
-              params: ['a', 1],
+              params: {
+                foo: 'a',
+                bar: 1,
+              },
             },
           ],
         },

--- a/plugins/permission-node/src/integration/createConditionExports.test.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.test.ts
@@ -31,7 +31,7 @@ const testIntegration = () =>
         name: 'testRule1',
         description: 'Test rule 1',
         resourceType: 'test-resource',
-        schema: z.object({
+        paramsSchema: z.object({
           foo: z.string(),
           bar: z.number(),
         }),
@@ -45,7 +45,7 @@ const testIntegration = () =>
         name: 'testRule2',
         description: 'Test rule 2',
         resourceType: 'test-resource',
-        schema: z.object({
+        paramsSchema: z.object({
           foo: z.string(),
         }),
         apply: (_resource: any) => false,

--- a/plugins/permission-node/src/integration/createConditionExports.test.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.test.ts
@@ -46,7 +46,7 @@ const testIntegration = () =>
         description: 'Test rule 2',
         resourceType: 'test-resource',
         schema: z.object({
-          foo: z.object({}),
+          foo: z.string(),
         }),
         apply: (_resource: any) => false,
         toQuery: params => ({
@@ -76,11 +76,11 @@ describe('createConditionExports', () => {
         },
       });
 
-      expect(conditions.testRule2({ foo: { baz: 'quux' } })).toEqual({
+      expect(conditions.testRule2({ foo: 'baz' })).toEqual({
         rule: 'testRule2',
         resourceType: 'test-resource',
         params: {
-          foo: { baz: 'quux' },
+          foo: 'baz',
         },
       });
     });

--- a/plugins/permission-node/src/integration/createConditionExports.test.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.test.ts
@@ -46,7 +46,7 @@ const testIntegration = () =>
         description: 'Test rule 2',
         resourceType: 'test-resource',
         paramsSchema: z.object({
-          foo: z.string(),
+          foo: z.string().optional(),
         }),
         apply: (_resource: any) => false,
         toQuery: params => ({
@@ -76,12 +76,10 @@ describe('createConditionExports', () => {
         },
       });
 
-      expect(conditions.testRule2({ foo: 'baz' })).toEqual({
+      expect(conditions.testRule2({})).toEqual({
         rule: 'testRule2',
         resourceType: 'test-resource',
-        params: {
-          foo: 'baz',
-        },
+        params: {},
       });
     });
   });

--- a/plugins/permission-node/src/integration/createConditionExports.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.ts
@@ -36,7 +36,7 @@ export type Condition<TRule> = TRule extends PermissionRule<
   infer TResourceType,
   infer TParams
 >
-  ? (...params: TParams) => PermissionCondition<TResourceType, TParams>
+  ? (params: TParams) => PermissionCondition<TResourceType, TParams>
   : never;
 
 /**

--- a/plugins/permission-node/src/integration/createConditionExports.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.ts
@@ -36,7 +36,9 @@ export type Condition<TRule> = TRule extends PermissionRule<
   infer TResourceType,
   infer TParams
 >
-  ? (params: TParams) => PermissionCondition<TResourceType, TParams>
+  ? undefined extends TParams
+    ? () => PermissionCondition<TResourceType, TParams>
+    : (params: TParams) => PermissionCondition<TResourceType, TParams>
   : never;
 
 /**

--- a/plugins/permission-node/src/integration/createConditionFactory.test.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { z } from 'zod';
 import { createConditionFactory } from './createConditionFactory';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -22,6 +23,7 @@ describe('createConditionFactory', () => {
     name: 'test-rule',
     description: 'test-description',
     resourceType: 'test-resource',
+    schema: z.tuple([]),
     apply: jest.fn(),
     toQuery: jest.fn(),
   });

--- a/plugins/permission-node/src/integration/createConditionFactory.test.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.test.ts
@@ -23,9 +23,11 @@ describe('createConditionFactory', () => {
     name: 'test-rule',
     description: 'test-description',
     resourceType: 'test-resource',
-    schema: z.tuple([]),
-    apply: jest.fn(),
-    toQuery: jest.fn(),
+    schema: z.object({
+      foo: z.string(),
+    }),
+    apply: (_resource, _params) => true,
+    toQuery: _params => ({}),
   });
 
   it('returns a function', () => {
@@ -35,10 +37,16 @@ describe('createConditionFactory', () => {
   describe('return value', () => {
     it('constructs a condition with the rule name and supplied params', () => {
       const conditionFactory = createConditionFactory(testRule);
-      expect(conditionFactory('a', 'b', 1, 2)).toEqual({
+      expect(
+        conditionFactory({
+          foo: 'bar',
+        }),
+      ).toEqual({
         rule: 'test-rule',
         resourceType: 'test-resource',
-        params: ['a', 'b', 1, 2],
+        params: {
+          foo: 'bar',
+        },
       });
     });
   });

--- a/plugins/permission-node/src/integration/createConditionFactory.test.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.test.ts
@@ -23,7 +23,7 @@ describe('createConditionFactory', () => {
     name: 'test-rule',
     description: 'test-description',
     resourceType: 'test-resource',
-    schema: z.object({
+    paramsSchema: z.object({
       foo: z.string(),
     }),
     apply: (_resource, _params) => true,

--- a/plugins/permission-node/src/integration/createConditionFactory.test.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.test.ts
@@ -37,6 +37,7 @@ describe('createConditionFactory', () => {
   describe('return value', () => {
     it('constructs a condition with the rule name and supplied params', () => {
       const conditionFactory = createConditionFactory(testRule);
+
       expect(
         conditionFactory({
           foo: 'bar',

--- a/plugins/permission-node/src/integration/createConditionFactory.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.ts
@@ -34,10 +34,10 @@ import { PermissionRule } from '../types';
  * @public
  */
 export const createConditionFactory =
-  <TResourceType extends string, TParams extends any[]>(
+  <TResourceType extends string, TParams extends Record<string, unknown>>(
     rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
   ) =>
-  (...params: TParams): PermissionCondition<TResourceType, TParams> => ({
+  (params: TParams): PermissionCondition<TResourceType, TParams> => ({
     rule: rule.name,
     resourceType: rule.resourceType,
     params,

--- a/plugins/permission-node/src/integration/createConditionFactory.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { PermissionCondition } from '@backstage/plugin-permission-common';
+import {
+  PermissionCondition,
+  PermissionRuleParams,
+} from '@backstage/plugin-permission-common';
 import { PermissionRule } from '../types';
 
 /**
@@ -34,7 +37,10 @@ import { PermissionRule } from '../types';
  * @public
  */
 export const createConditionFactory =
-  <TResourceType extends string, TParams extends Record<string, unknown>>(
+  <
+    TResourceType extends string,
+    TParams extends PermissionRuleParams = PermissionRuleParams,
+  >(
     rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
   ) =>
   (params: TParams): PermissionCondition<TResourceType, TParams> => ({

--- a/plugins/permission-node/src/integration/createConditionFactory.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.ts
@@ -36,15 +36,17 @@ import { PermissionRule } from '../types';
  *
  * @public
  */
-export const createConditionFactory =
-  <
-    TResourceType extends string,
-    TParams extends PermissionRuleParams = PermissionRuleParams,
-  >(
-    rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
-  ) =>
-  (params: TParams): PermissionCondition<TResourceType, TParams> => ({
-    rule: rule.name,
-    resourceType: rule.resourceType,
-    params,
-  });
+export const createConditionFactory = <
+  TResourceType extends string,
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+>(
+  rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
+) => {
+  return (...args: [TParams]): PermissionCondition<TResourceType, TParams> => {
+    return {
+      rule: rule.name,
+      resourceType: rule.resourceType,
+      params: args[0],
+    };
+  };
+};

--- a/plugins/permission-node/src/integration/createConditionFactory.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.ts
@@ -42,11 +42,11 @@ export const createConditionFactory = <
 >(
   rule: PermissionRule<unknown, unknown, TResourceType, TParams>,
 ) => {
-  return (...args: [TParams]): PermissionCondition<TResourceType, TParams> => {
+  return (params: TParams): PermissionCondition<TResourceType, TParams> => {
     return {
       rule: rule.name,
       resourceType: rule.resourceType,
-      params: args[0],
+      params,
     };
   };
 };

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -27,7 +27,7 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-1',
     description: 'Test rule 1',
     resourceType: 'test-resource',
-    schema: z.tuple([]),
+    schema: z.tuple([z.string(), z.number()]),
     apply: jest.fn(),
     toQuery: jest.fn(
       (firstParam: string, secondParam: number) =>
@@ -38,7 +38,7 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-2',
     description: 'Test rule 2',
     resourceType: 'test-resource',
-    schema: z.tuple([]),
+    schema: z.tuple([z.object({})]),
     apply: jest.fn(),
     toQuery: jest.fn(
       (firstParam: object) => `test-rule-2:${JSON.stringify(firstParam)}`,

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -18,6 +18,7 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
+import { z } from 'zod';
 import { createConditionTransformer } from './createConditionTransformer';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -26,6 +27,7 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-1',
     description: 'Test rule 1',
     resourceType: 'test-resource',
+    schema: z.tuple([]),
     apply: jest.fn(),
     toQuery: jest.fn(
       (firstParam: string, secondParam: number) =>
@@ -36,6 +38,7 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-2',
     description: 'Test rule 2',
     resourceType: 'test-resource',
+    schema: z.tuple([]),
     apply: jest.fn(),
     toQuery: jest.fn(
       (firstParam: object) => `test-rule-2:${JSON.stringify(firstParam)}`,

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -27,22 +27,22 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-1',
     description: 'Test rule 1',
     resourceType: 'test-resource',
-    schema: z.tuple([z.string(), z.number()]),
+    schema: z.object({
+      foo: z.string(),
+      bar: z.number(),
+    }),
     apply: jest.fn(),
-    toQuery: jest.fn(
-      (firstParam: string, secondParam: number) =>
-        `test-rule-1:${firstParam}/${secondParam}`,
-    ),
+    toQuery: jest.fn(({ foo, bar }) => `test-rule-1:${foo}/${bar}`),
   }),
   createPermissionRule({
     name: 'test-rule-2',
     description: 'Test rule 2',
     resourceType: 'test-resource',
-    schema: z.tuple([z.object({})]),
+    schema: z.object({
+      foo: z.object({}),
+    }),
     apply: jest.fn(),
-    toQuery: jest.fn(
-      (firstParam: object) => `test-rule-2:${JSON.stringify(firstParam)}`,
-    ),
+    toQuery: jest.fn(({ foo }) => `test-rule-2:${JSON.stringify(foo)}`),
   }),
 ]);
 
@@ -55,7 +55,10 @@ describe('createConditionTransformer', () => {
       conditions: {
         rule: 'test-rule-1',
         resourceType: 'test-resource',
-        params: ['abc', 123],
+        params: {
+          foo: 'abc',
+          bar: 123,
+        },
       },
       expectedResult: 'test-rule-1:abc/123',
     },
@@ -63,7 +66,9 @@ describe('createConditionTransformer', () => {
       conditions: {
         rule: 'test-rule-2',
         resourceType: 'test-resource',
-        params: [{ foo: 0 }],
+        params: {
+          foo: { foo: 0 },
+        },
       },
       expectedResult: 'test-rule-2:{"foo":0}',
     },
@@ -73,9 +78,18 @@ describe('createConditionTransformer', () => {
           {
             rule: 'test-rule-1',
             resourceType: 'test-resource',
-            params: ['a', 1],
+            params: {
+              foo: 'a',
+              bar: 1,
+            },
           },
-          { rule: 'test-rule-2', resourceType: 'test-resource', params: [{}] },
+          {
+            rule: 'test-rule-2',
+            resourceType: 'test-resource',
+            params: {
+              foo: {},
+            },
+          },
         ],
       },
       expectedResult: {
@@ -88,9 +102,18 @@ describe('createConditionTransformer', () => {
           {
             rule: 'test-rule-1',
             resourceType: 'test-resource',
-            params: ['a', 1],
+            params: {
+              foo: 'a',
+              bar: 1,
+            },
           },
-          { rule: 'test-rule-2', resourceType: 'test-resource', params: [{}] },
+          {
+            rule: 'test-rule-2',
+            resourceType: 'test-resource',
+            params: {
+              foo: {},
+            },
+          },
         ],
       },
       expectedResult: {
@@ -102,7 +125,9 @@ describe('createConditionTransformer', () => {
         not: {
           rule: 'test-rule-2',
           resourceType: 'test-resource',
-          params: [{}],
+          params: {
+            foo: {},
+          },
         },
       },
       expectedResult: {
@@ -117,12 +142,17 @@ describe('createConditionTransformer', () => {
               {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
               {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
-                params: [{}],
+                params: {
+                  foo: {},
+                },
               },
             ],
           },
@@ -132,12 +162,19 @@ describe('createConditionTransformer', () => {
                 {
                   rule: 'test-rule-1',
                   resourceType: 'test-resource',
-                  params: ['b', 2],
+                  params: {
+                    foo: 'b',
+                    bar: 2,
+                  },
                 },
                 {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
-                  params: [{ c: 3 }],
+                  params: {
+                    foo: {
+                      c: 3,
+                    },
+                  },
                 },
               ],
             },
@@ -165,12 +202,19 @@ describe('createConditionTransformer', () => {
               {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
               {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
-                params: [{ b: 2 }],
+                params: {
+                  foo: {
+                    b: 2,
+                  },
+                },
               },
             ],
           },
@@ -180,13 +224,20 @@ describe('createConditionTransformer', () => {
                 {
                   rule: 'test-rule-1',
                   resourceType: 'test-resource',
-                  params: ['c', 3],
+                  params: {
+                    foo: 'c',
+                    bar: 3,
+                  },
                 },
                 {
                   not: {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
-                    params: [{ d: 4 }],
+                    params: {
+                      foo: {
+                        d: 4,
+                      },
+                    },
                   },
                 },
               ],

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -39,10 +39,10 @@ const transformConditions = createConditionTransformer([
     description: 'Test rule 2',
     resourceType: 'test-resource',
     schema: z.object({
-      foo: z.object({}),
+      foo: z.string(),
     }),
     apply: jest.fn(),
-    toQuery: jest.fn(({ foo }) => `test-rule-2:${JSON.stringify(foo)}`),
+    toQuery: jest.fn(({ foo }) => `test-rule-2:${foo}`),
   }),
 ]);
 
@@ -67,10 +67,10 @@ describe('createConditionTransformer', () => {
         rule: 'test-rule-2',
         resourceType: 'test-resource',
         params: {
-          foo: { foo: 0 },
+          foo: '0',
         },
       },
-      expectedResult: 'test-rule-2:{"foo":0}',
+      expectedResult: 'test-rule-2:0',
     },
     {
       conditions: {
@@ -87,13 +87,13 @@ describe('createConditionTransformer', () => {
             rule: 'test-rule-2',
             resourceType: 'test-resource',
             params: {
-              foo: {},
+              foo: 'b',
             },
           },
         ],
       },
       expectedResult: {
-        anyOf: ['test-rule-1:a/1', 'test-rule-2:{}'],
+        anyOf: ['test-rule-1:a/1', 'test-rule-2:b'],
       },
     },
     {
@@ -111,13 +111,13 @@ describe('createConditionTransformer', () => {
             rule: 'test-rule-2',
             resourceType: 'test-resource',
             params: {
-              foo: {},
+              foo: 'b',
             },
           },
         ],
       },
       expectedResult: {
-        allOf: ['test-rule-1:a/1', 'test-rule-2:{}'],
+        allOf: ['test-rule-1:a/1', 'test-rule-2:b'],
       },
     },
     {
@@ -126,12 +126,12 @@ describe('createConditionTransformer', () => {
           rule: 'test-rule-2',
           resourceType: 'test-resource',
           params: {
-            foo: {},
+            foo: 'a',
           },
         },
       },
       expectedResult: {
-        not: 'test-rule-2:{}',
+        not: 'test-rule-2:a',
       },
     },
     {
@@ -151,7 +151,7 @@ describe('createConditionTransformer', () => {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
                 params: {
-                  foo: {},
+                  foo: 'b',
                 },
               },
             ],
@@ -171,9 +171,7 @@ describe('createConditionTransformer', () => {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
                   params: {
-                    foo: {
-                      c: 3,
-                    },
+                    foo: 'c',
                   },
                 },
               ],
@@ -184,11 +182,11 @@ describe('createConditionTransformer', () => {
       expectedResult: {
         allOf: [
           {
-            anyOf: ['test-rule-1:a/1', 'test-rule-2:{}'],
+            anyOf: ['test-rule-1:a/1', 'test-rule-2:b'],
           },
           {
             not: {
-              allOf: ['test-rule-1:b/2', 'test-rule-2:{"c":3}'],
+              allOf: ['test-rule-1:b/2', 'test-rule-2:c'],
             },
           },
         ],
@@ -211,9 +209,7 @@ describe('createConditionTransformer', () => {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
                 params: {
-                  foo: {
-                    b: 2,
-                  },
+                  foo: 'b',
                 },
               },
             ],
@@ -234,9 +230,7 @@ describe('createConditionTransformer', () => {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
                     params: {
-                      foo: {
-                        d: 4,
-                      },
+                      foo: 'd',
                     },
                   },
                 },
@@ -248,11 +242,11 @@ describe('createConditionTransformer', () => {
       expectedResult: {
         allOf: [
           {
-            anyOf: ['test-rule-1:a/1', 'test-rule-2:{"b":2}'],
+            anyOf: ['test-rule-1:a/1', 'test-rule-2:b'],
           },
           {
             not: {
-              allOf: ['test-rule-1:c/3', { not: 'test-rule-2:{"d":4}' }],
+              allOf: ['test-rule-1:c/3', { not: 'test-rule-2:d' }],
             },
           },
         ],

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -27,7 +27,7 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-1',
     description: 'Test rule 1',
     resourceType: 'test-resource',
-    schema: z.object({
+    paramsSchema: z.object({
       foo: z.string(),
       bar: z.number(),
     }),
@@ -38,7 +38,7 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-2',
     description: 'Test rule 2',
     resourceType: 'test-resource',
-    schema: z.object({
+    paramsSchema: z.object({
       foo: z.string(),
     }),
     apply: jest.fn(),

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { InputError } from '@backstage/errors';
 import {
   AllOfCriteria,
   AnyOfCriteria,
@@ -45,7 +46,14 @@ const mapConditions = <TQuery>(
     };
   }
 
-  return getRule(criteria.rule).toQuery(...criteria.params);
+  const rule = getRule(criteria.rule);
+  const result = rule.schema.safeParse(criteria.params);
+
+  if (rule.schema && !result.success) {
+    throw new InputError(`Parameters to rule are invalid`, result.error);
+  }
+
+  return rule.toQuery(...criteria.params);
 };
 
 /**

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -53,7 +53,7 @@ const mapConditions = <TQuery>(
     throw new InputError(`Parameters to rule are invalid`, result.error);
   }
 
-  return rule.toQuery(...criteria.params);
+  return rule.toQuery(criteria.params);
 };
 
 /**

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -47,9 +47,9 @@ const mapConditions = <TQuery>(
   }
 
   const rule = getRule(criteria.rule);
-  const result = rule.schema.safeParse(criteria.params);
+  const result = rule.paramsSchema.safeParse(criteria.params);
 
-  if (rule.schema && !result.success) {
+  if (rule.paramsSchema && !result.success) {
     throw new InputError(`Parameters to rule are invalid`, result.error);
   }
 

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -47,13 +47,13 @@ const mapConditions = <TQuery>(
   }
 
   const rule = getRule(criteria.rule);
-  const result = rule.paramsSchema.safeParse(criteria.params);
+  const result = rule.paramsSchema?.safeParse(criteria.params);
 
-  if (rule.paramsSchema && !result.success) {
+  if (result && !result.success) {
     throw new InputError(`Parameters to rule are invalid`, result.error);
   }
 
-  return rule.toQuery(criteria.params);
+  return rule.toQuery(criteria.params ?? {});
 };
 
 /**

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@backstage/plugin-permission-common';
 import express, { Express, Router } from 'express';
 import request, { Response } from 'supertest';
+import { z } from 'zod';
 import { createPermissionIntegrationRouter } from './createPermissionIntegrationRouter';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -39,6 +40,7 @@ const testRule1 = createPermissionRule({
   name: 'test-rule-1',
   description: 'Test rule 1',
   resourceType: 'test-resource',
+  schema: z.tuple([z.string(), z.number()]),
   apply: (_resource: any, _firstParam: string, _secondParam: number) => true,
   toQuery: (_firstParam: string, _secondParam: number) => ({}),
 });
@@ -47,6 +49,7 @@ const testRule2 = createPermissionRule({
   name: 'test-rule-2',
   description: 'Test rule 2',
   resourceType: 'test-resource',
+  schema: z.tuple([z.object({})]),
   apply: (_resource: any, _firstParam: object) => false,
   toQuery: (_firstParam: object) => ({}),
 });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -40,7 +40,10 @@ const testRule1 = createPermissionRule({
   name: 'test-rule-1',
   description: 'Test rule 1',
   resourceType: 'test-resource',
-  schema: z.tuple([z.string(), z.number()]),
+  schema: z.tuple([
+    z.string().describe('firstParam'),
+    z.number().describe('secondParam'),
+  ]),
   apply: (_resource: any, _firstParam: string, _secondParam: number) => true,
   toQuery: (_firstParam: string, _secondParam: number) => ({}),
 });
@@ -49,7 +52,7 @@ const testRule2 = createPermissionRule({
   name: 'test-rule-2',
   description: 'Test rule 2',
   resourceType: 'test-resource',
-  schema: z.tuple([z.object({})]),
+  schema: z.tuple([z.object({}).describe('firstParam')]),
   apply: (_resource: any, _firstParam: object) => false,
   toQuery: (_firstParam: object) => ({}),
 });
@@ -250,7 +253,7 @@ describe('createPermissionIntegrationRouter', () => {
                 conditions: {
                   rule: 'test-rule-1',
                   resourceType: 'test-resource',
-                  params: [],
+                  params: ['a', 1],
                 },
               },
               {
@@ -260,7 +263,7 @@ describe('createPermissionIntegrationRouter', () => {
                 conditions: {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
-                  params: [],
+                  params: [{}],
                 },
               },
               {
@@ -271,7 +274,7 @@ describe('createPermissionIntegrationRouter', () => {
                   not: {
                     rule: 'test-rule-1',
                     resourceType: 'test-resource',
-                    params: [],
+                    params: ['a', 1],
                   },
                 },
               },
@@ -283,7 +286,7 @@ describe('createPermissionIntegrationRouter', () => {
                   not: {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
-                    params: [],
+                    params: [{}],
                   },
                 },
               },
@@ -296,12 +299,12 @@ describe('createPermissionIntegrationRouter', () => {
                     {
                       rule: 'test-rule-1',
                       resourceType: 'test-resource',
-                      params: [],
+                      params: ['a', 1],
                     },
                     {
                       rule: 'test-rule-2',
                       resourceType: 'test-resource',
-                      params: [],
+                      params: [{}],
                     },
                   ],
                 },
@@ -430,7 +433,7 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: [],
+                params: ['a', 1],
               },
             },
             {
@@ -440,7 +443,7 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: [],
+                params: ['a', 1],
               },
             },
             {
@@ -450,7 +453,7 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: [],
+                params: ['a', 1],
               },
             },
           ],

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -530,12 +530,42 @@ describe('createPermissionIntegrationRouter', () => {
             name: testRule1.name,
             description: testRule1.description,
             resourceType: testRule1.resourceType,
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              items: [
+                {
+                  description: 'firstParam',
+                  type: 'string',
+                },
+                {
+                  description: 'secondParam',
+                  type: 'number',
+                },
+              ],
+              maxItems: 2,
+              minItems: 2,
+              type: 'array',
+            },
             parameters: { count: 2 },
           },
           {
             name: testRule2.name,
             description: testRule2.description,
             resourceType: testRule2.resourceType,
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              items: [
+                {
+                  additionalProperties: false,
+                  description: 'firstParam',
+                  properties: {},
+                  type: 'object',
+                },
+              ],
+              maxItems: 1,
+              minItems: 1,
+              type: 'array',
+            },
             parameters: { count: 1 },
           },
         ],

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -40,21 +40,23 @@ const testRule1 = createPermissionRule({
   name: 'test-rule-1',
   description: 'Test rule 1',
   resourceType: 'test-resource',
-  schema: z.tuple([
-    z.string().describe('firstParam'),
-    z.number().describe('secondParam'),
-  ]),
-  apply: (_resource: any, _firstParam: string, _secondParam: number) => true,
-  toQuery: (_firstParam: string, _secondParam: number) => ({}),
+  schema: z.object({
+    foo: z.string(),
+    bar: z.number().describe('bar'),
+  }),
+  apply: (_resource: any, _params) => true,
+  toQuery: _params => ({}),
 });
 
 const testRule2 = createPermissionRule({
   name: 'test-rule-2',
   description: 'Test rule 2',
   resourceType: 'test-resource',
-  schema: z.tuple([z.object({}).describe('firstParam')]),
-  apply: (_resource: any, _firstParam: object) => false,
-  toQuery: (_firstParam: object) => ({}),
+  schema: z.object({
+    foo: z.object({}).describe('foo'),
+  }),
+  apply: (_resource: any, _foo) => false,
+  toQuery: _foo => ({}),
 });
 
 describe('createPermissionIntegrationRouter', () => {
@@ -85,23 +87,35 @@ describe('createPermissionIntegrationRouter', () => {
       {
         rule: 'test-rule-1',
         resourceType: 'test-resource',
-        params: ['abc', 123],
+        params: {
+          foo: 'abc',
+          bar: 123,
+        },
       },
       {
         anyOf: [
           {
             rule: 'test-rule-1',
             resourceType: 'test-resource',
-            params: ['a', 1],
+            params: {
+              foo: 'a',
+              bar: 1,
+            },
           },
-          { rule: 'test-rule-2', resourceType: 'test-resource', params: [{}] },
+          {
+            rule: 'test-rule-2',
+            resourceType: 'test-resource',
+            params: { foo: {} },
+          },
         ],
       },
       {
         not: {
           rule: 'test-rule-2',
           resourceType: 'test-resource',
-          params: [{}],
+          params: {
+            foo: {},
+          },
         },
       },
       {
@@ -111,12 +125,17 @@ describe('createPermissionIntegrationRouter', () => {
               {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
               {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
-                params: [{}],
+                params: {
+                  foo: {},
+                },
               },
             ],
           },
@@ -126,12 +145,17 @@ describe('createPermissionIntegrationRouter', () => {
                 {
                   rule: 'test-rule-1',
                   resourceType: 'test-resource',
-                  params: ['b', 2],
+                  params: {
+                    foo: 'b',
+                    bar: 2,
+                  },
                 },
                 {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
-                  params: [{ c: 3 }],
+                  params: {
+                    foo: { c: 3 },
+                  },
                 },
               ],
             },
@@ -167,16 +191,25 @@ describe('createPermissionIntegrationRouter', () => {
       {
         rule: 'test-rule-2',
         resourceType: 'test-resource',
-        params: [{ foo: 0 }],
+        params: {
+          foo: { foo: 0 },
+        },
       },
       {
         allOf: [
           {
             rule: 'test-rule-1',
             resourceType: 'test-resource',
-            params: ['a', 1],
+            params: {
+              foo: 'a',
+              bar: 1,
+            },
           },
-          { rule: 'test-rule-2', resourceType: 'test-resource', params: [{}] },
+          {
+            rule: 'test-rule-2',
+            resourceType: 'test-resource',
+            params: { foo: {} },
+          },
         ],
       },
       {
@@ -186,12 +219,17 @@ describe('createPermissionIntegrationRouter', () => {
               {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
               {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
-                params: [{ b: 2 }],
+                params: {
+                  foo: { b: 2 },
+                },
               },
             ],
           },
@@ -201,13 +239,18 @@ describe('createPermissionIntegrationRouter', () => {
                 {
                   rule: 'test-rule-1',
                   resourceType: 'test-resource',
-                  params: ['c', 3],
+                  params: {
+                    foo: 'c',
+                    bar: 3,
+                  },
                 },
                 {
                   not: {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
-                    params: [{ d: 4 }],
+                    params: {
+                      foo: { d: 4 },
+                    },
                   },
                 },
               ],
@@ -253,7 +296,10 @@ describe('createPermissionIntegrationRouter', () => {
                 conditions: {
                   rule: 'test-rule-1',
                   resourceType: 'test-resource',
-                  params: ['a', 1],
+                  params: {
+                    foo: 'a',
+                    bar: 1,
+                  },
                 },
               },
               {
@@ -263,7 +309,9 @@ describe('createPermissionIntegrationRouter', () => {
                 conditions: {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
-                  params: [{}],
+                  params: {
+                    foo: {},
+                  },
                 },
               },
               {
@@ -274,7 +322,10 @@ describe('createPermissionIntegrationRouter', () => {
                   not: {
                     rule: 'test-rule-1',
                     resourceType: 'test-resource',
-                    params: ['a', 1],
+                    params: {
+                      foo: 'a',
+                      bar: 1,
+                    },
                   },
                 },
               },
@@ -286,7 +337,9 @@ describe('createPermissionIntegrationRouter', () => {
                   not: {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
-                    params: [{}],
+                    params: {
+                      foo: {},
+                    },
                   },
                 },
               },
@@ -299,12 +352,17 @@ describe('createPermissionIntegrationRouter', () => {
                     {
                       rule: 'test-rule-1',
                       resourceType: 'test-resource',
-                      params: ['a', 1],
+                      params: {
+                        foo: 'a',
+                        bar: 1,
+                      },
                     },
                     {
                       rule: 'test-rule-2',
                       resourceType: 'test-resource',
-                      params: [{}],
+                      params: {
+                        foo: {},
+                      },
                     },
                   ],
                 },
@@ -348,7 +406,9 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-incorrect-resource-1',
-                params: [{}],
+                params: {
+                  foo: {},
+                },
               },
             },
             {
@@ -358,7 +418,9 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: [{}],
+                params: {
+                  foo: {},
+                },
               },
             },
             {
@@ -368,7 +430,9 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-incorrect-resource-2',
-                params: [{}],
+                params: {
+                  foo: {},
+                },
               },
             },
           ],
@@ -396,7 +460,7 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: [],
+                params: {},
               },
             },
           ],
@@ -433,7 +497,10 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
             },
             {
@@ -443,7 +510,10 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
             },
             {
@@ -453,7 +523,10 @@ describe('createPermissionIntegrationRouter', () => {
               conditions: {
                 rule: 'test-rule-1',
                 resourceType: 'test-resource',
-                params: ['a', 1],
+                params: {
+                  foo: 'a',
+                  bar: 1,
+                },
               },
             },
           ],
@@ -532,21 +605,20 @@ describe('createPermissionIntegrationRouter', () => {
             resourceType: testRule1.resourceType,
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
-              items: [
-                {
-                  description: 'firstParam',
+              additionalProperties: false,
+              properties: {
+                foo: {
                   type: 'string',
                 },
-                {
-                  description: 'secondParam',
+                bar: {
+                  description: 'bar',
                   type: 'number',
                 },
-              ],
-              maxItems: 2,
-              minItems: 2,
-              type: 'array',
+              },
+              required: ['foo', 'bar'],
+              type: 'object',
             },
-            parameters: { count: 2 },
+            parameters: { count: 1 },
           },
           {
             name: testRule2.name,
@@ -554,17 +626,17 @@ describe('createPermissionIntegrationRouter', () => {
             resourceType: testRule2.resourceType,
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
-              items: [
-                {
+              additionalProperties: false,
+              properties: {
+                foo: {
                   additionalProperties: false,
-                  description: 'firstParam',
+                  description: 'foo',
                   properties: {},
                   type: 'object',
                 },
-              ],
-              maxItems: 1,
-              minItems: 1,
-              type: 'array',
+              },
+              required: ['foo'],
+              type: 'object',
             },
             parameters: { count: 1 },
           },

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -52,11 +52,8 @@ const testRule2 = createPermissionRule({
   name: 'test-rule-2',
   description: 'Test rule 2',
   resourceType: 'test-resource',
-  paramsSchema: z.object({
-    foo: z.string().describe('foo'),
-  }),
-  apply: (_resource: any, _foo) => false,
-  toQuery: _foo => ({}),
+  apply: (_resource: any) => false,
+  toQuery: () => ({}),
 });
 
 describe('createPermissionIntegrationRouter', () => {
@@ -105,7 +102,6 @@ describe('createPermissionIntegrationRouter', () => {
           {
             rule: 'test-rule-2',
             resourceType: 'test-resource',
-            params: { foo: 'b' },
           },
         ],
       },
@@ -113,9 +109,6 @@ describe('createPermissionIntegrationRouter', () => {
         not: {
           rule: 'test-rule-2',
           resourceType: 'test-resource',
-          params: {
-            foo: 'c',
-          },
         },
       },
       {
@@ -133,9 +126,6 @@ describe('createPermissionIntegrationRouter', () => {
               {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
-                params: {
-                  foo: 'b',
-                },
               },
             ],
           },
@@ -153,9 +143,6 @@ describe('createPermissionIntegrationRouter', () => {
                 {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
-                  params: {
-                    foo: 'c',
-                  },
                 },
               ],
             },
@@ -191,9 +178,6 @@ describe('createPermissionIntegrationRouter', () => {
       {
         rule: 'test-rule-2',
         resourceType: 'test-resource',
-        params: {
-          foo: 'a',
-        },
       },
       {
         allOf: [
@@ -208,7 +192,6 @@ describe('createPermissionIntegrationRouter', () => {
           {
             rule: 'test-rule-2',
             resourceType: 'test-resource',
-            params: { foo: 'b' },
           },
         ],
       },
@@ -227,9 +210,6 @@ describe('createPermissionIntegrationRouter', () => {
               {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
-                params: {
-                  foo: 'b',
-                },
               },
             ],
           },
@@ -248,9 +228,6 @@ describe('createPermissionIntegrationRouter', () => {
                   not: {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
-                    params: {
-                      foo: 'd',
-                    },
                   },
                 },
               ],
@@ -309,9 +286,6 @@ describe('createPermissionIntegrationRouter', () => {
                 conditions: {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
-                  params: {
-                    foo: 'b',
-                  },
                 },
               },
               {
@@ -337,9 +311,6 @@ describe('createPermissionIntegrationRouter', () => {
                   not: {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
-                    params: {
-                      foo: 'c',
-                    },
                   },
                 },
               },
@@ -360,9 +331,6 @@ describe('createPermissionIntegrationRouter', () => {
                     {
                       rule: 'test-rule-2',
                       resourceType: 'test-resource',
-                      params: {
-                        foo: 'd',
-                      },
                     },
                   ],
                 },
@@ -626,13 +594,7 @@ describe('createPermissionIntegrationRouter', () => {
             paramsSchema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               additionalProperties: false,
-              properties: {
-                foo: {
-                  description: 'foo',
-                  type: 'string',
-                },
-              },
-              required: ['foo'],
+              properties: {},
               type: 'object',
             },
           },

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -40,7 +40,7 @@ const testRule1 = createPermissionRule({
   name: 'test-rule-1',
   description: 'Test rule 1',
   resourceType: 'test-resource',
-  schema: z.object({
+  paramsSchema: z.object({
     foo: z.string(),
     bar: z.number().describe('bar'),
   }),
@@ -52,7 +52,7 @@ const testRule2 = createPermissionRule({
   name: 'test-rule-2',
   description: 'Test rule 2',
   resourceType: 'test-resource',
-  schema: z.object({
+  paramsSchema: z.object({
     foo: z.string().describe('foo'),
   }),
   apply: (_resource: any, _foo) => false,
@@ -603,7 +603,7 @@ describe('createPermissionIntegrationRouter', () => {
             name: testRule1.name,
             description: testRule1.description,
             resourceType: testRule1.resourceType,
-            schema: {
+            paramsSchema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               additionalProperties: false,
               properties: {
@@ -623,7 +623,7 @@ describe('createPermissionIntegrationRouter', () => {
             name: testRule2.name,
             description: testRule2.description,
             resourceType: testRule2.resourceType,
-            schema: {
+            paramsSchema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               additionalProperties: false,
               properties: {

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -53,7 +53,7 @@ const testRule2 = createPermissionRule({
   description: 'Test rule 2',
   resourceType: 'test-resource',
   schema: z.object({
-    foo: z.object({}).describe('foo'),
+    foo: z.string().describe('foo'),
   }),
   apply: (_resource: any, _foo) => false,
   toQuery: _foo => ({}),
@@ -105,7 +105,7 @@ describe('createPermissionIntegrationRouter', () => {
           {
             rule: 'test-rule-2',
             resourceType: 'test-resource',
-            params: { foo: {} },
+            params: { foo: 'b' },
           },
         ],
       },
@@ -114,7 +114,7 @@ describe('createPermissionIntegrationRouter', () => {
           rule: 'test-rule-2',
           resourceType: 'test-resource',
           params: {
-            foo: {},
+            foo: 'c',
           },
         },
       },
@@ -134,7 +134,7 @@ describe('createPermissionIntegrationRouter', () => {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
                 params: {
-                  foo: {},
+                  foo: 'b',
                 },
               },
             ],
@@ -154,7 +154,7 @@ describe('createPermissionIntegrationRouter', () => {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
                   params: {
-                    foo: { c: 3 },
+                    foo: 'c',
                   },
                 },
               ],
@@ -192,7 +192,7 @@ describe('createPermissionIntegrationRouter', () => {
         rule: 'test-rule-2',
         resourceType: 'test-resource',
         params: {
-          foo: { foo: 0 },
+          foo: 'a',
         },
       },
       {
@@ -208,7 +208,7 @@ describe('createPermissionIntegrationRouter', () => {
           {
             rule: 'test-rule-2',
             resourceType: 'test-resource',
-            params: { foo: {} },
+            params: { foo: 'b' },
           },
         ],
       },
@@ -228,7 +228,7 @@ describe('createPermissionIntegrationRouter', () => {
                 rule: 'test-rule-2',
                 resourceType: 'test-resource',
                 params: {
-                  foo: { b: 2 },
+                  foo: 'b',
                 },
               },
             ],
@@ -249,7 +249,7 @@ describe('createPermissionIntegrationRouter', () => {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
                     params: {
-                      foo: { d: 4 },
+                      foo: 'd',
                     },
                   },
                 },
@@ -310,7 +310,7 @@ describe('createPermissionIntegrationRouter', () => {
                   rule: 'test-rule-2',
                   resourceType: 'test-resource',
                   params: {
-                    foo: {},
+                    foo: 'b',
                   },
                 },
               },
@@ -338,7 +338,7 @@ describe('createPermissionIntegrationRouter', () => {
                     rule: 'test-rule-2',
                     resourceType: 'test-resource',
                     params: {
-                      foo: {},
+                      foo: 'c',
                     },
                   },
                 },
@@ -361,7 +361,7 @@ describe('createPermissionIntegrationRouter', () => {
                       rule: 'test-rule-2',
                       resourceType: 'test-resource',
                       params: {
-                        foo: {},
+                        foo: 'd',
                       },
                     },
                   ],
@@ -628,10 +628,8 @@ describe('createPermissionIntegrationRouter', () => {
               additionalProperties: false,
               properties: {
                 foo: {
-                  additionalProperties: false,
                   description: 'foo',
-                  properties: {},
-                  type: 'object',
+                  type: 'string',
                 },
               },
               required: ['foo'],

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -618,7 +618,6 @@ describe('createPermissionIntegrationRouter', () => {
               required: ['foo', 'bar'],
               type: 'object',
             },
-            parameters: { count: 1 },
           },
           {
             name: testRule2.name,
@@ -638,7 +637,6 @@ describe('createPermissionIntegrationRouter', () => {
               required: ['foo'],
               type: 'object',
             },
-            parameters: { count: 1 },
           },
         ],
       });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -124,7 +124,14 @@ const applyConditions = <TResourceType extends string, TResource>(
     return !applyConditions(criteria.not, resource, getRule);
   }
 
-  return getRule(criteria.rule).apply(resource, ...criteria.params);
+  const rule = getRule(criteria.rule);
+  const result = rule.schema.safeParse(criteria.params);
+
+  if (rule.schema && !result.success) {
+    throw new InputError(`Parameters to rule are invalid`, result.error);
+  }
+
+  return rule.apply(resource, ...criteria.params);
 };
 
 /**

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -46,7 +46,7 @@ const permissionCriteriaSchema: z.ZodSchema<
     z.object({
       rule: z.string(),
       resourceType: z.string(),
-      params: z.array(z.unknown()),
+      params: z.record(z.unknown()),
     }),
   ]),
 );
@@ -132,7 +132,7 @@ const applyConditions = <TResourceType extends string, TResource>(
     throw new InputError(`Parameters to rule are invalid`, result.error);
   }
 
-  return rule.apply(resource, ...criteria.params);
+  return rule.apply(resource, criteria.params);
 };
 
 /**

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -17,6 +17,7 @@
 import express, { Response } from 'express';
 import Router from 'express-promise-router';
 import { z } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
 import { InputError } from '@backstage/errors';
 import { errorHandler } from '@backstage/backend-common';
 import {
@@ -201,6 +202,7 @@ export const createPermissionIntegrationRouter = <
       name: rule.name,
       description: rule.description,
       resourceType: rule.resourceType,
+      schema: zodToJsonSchema(rule.schema),
       parameters: {
         count: rule.toQuery.length,
       },

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -28,8 +28,9 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import { NoInfer, PermissionRule } from '../types';
+import { PermissionRule } from '../types';
 import {
+  NoInfer,
   createGetRule,
   isAndCriteria,
   isNotCriteria,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -47,7 +47,7 @@ const permissionCriteriaSchema: z.ZodSchema<
     z.object({
       rule: z.string(),
       resourceType: z.string(),
-      params: z.record(z.any()),
+      params: z.record(z.any()).optional(),
     }),
   ]),
 );
@@ -127,13 +127,13 @@ const applyConditions = <TResourceType extends string, TResource>(
   }
 
   const rule = getRule(criteria.rule);
-  const result = rule.paramsSchema.safeParse(criteria.params);
+  const result = rule.paramsSchema?.safeParse(criteria.params);
 
-  if (rule.paramsSchema && !result.success) {
+  if (result && !result.success) {
     throw new InputError(`Parameters to rule are invalid`, result.error);
   }
 
-  return rule.apply(resource, criteria.params);
+  return rule.apply(resource, criteria.params ?? {});
 };
 
 /**
@@ -195,7 +195,7 @@ export const createPermissionIntegrationRouter = <
       name: rule.name,
       description: rule.description,
       resourceType: rule.resourceType,
-      paramsSchema: zodToJsonSchema(rule.paramsSchema),
+      paramsSchema: zodToJsonSchema(rule.paramsSchema ?? z.object({})),
     }));
 
     return res.json({ permissions, rules: serializableRules });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -28,7 +28,7 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import { PermissionRule } from '../types';
+import { NoInfer, PermissionRule } from '../types';
 import {
   createGetRule,
   isAndCriteria,
@@ -134,14 +134,6 @@ const applyConditions = <TResourceType extends string, TResource>(
 
   return rule.apply(resource, criteria.params);
 };
-
-/**
- * Prevent use of type parameter from contributing to type inference.
- *
- * https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-980401795
- * @ignore
- */
-type NoInfer<T> = T extends infer S ? S : never;
 
 /**
  * Create an express Router which provides an authorization route to allow

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -127,9 +127,9 @@ const applyConditions = <TResourceType extends string, TResource>(
   }
 
   const rule = getRule(criteria.rule);
-  const result = rule.schema.safeParse(criteria.params);
+  const result = rule.paramsSchema.safeParse(criteria.params);
 
-  if (rule.schema && !result.success) {
+  if (rule.paramsSchema && !result.success) {
     throw new InputError(`Parameters to rule are invalid`, result.error);
   }
 
@@ -195,7 +195,7 @@ export const createPermissionIntegrationRouter = <
       name: rule.name,
       description: rule.description,
       resourceType: rule.resourceType,
-      schema: zodToJsonSchema(rule.schema),
+      paramsSchema: zodToJsonSchema(rule.paramsSchema),
     }));
 
     return res.json({ permissions, rules: serializableRules });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -195,9 +195,6 @@ export const createPermissionIntegrationRouter = <
       description: rule.description,
       resourceType: rule.resourceType,
       schema: zodToJsonSchema(rule.schema),
-      parameters: {
-        count: rule.toQuery.length,
-      },
     }));
 
     return res.json({ permissions, rules: serializableRules });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -46,7 +46,7 @@ const permissionCriteriaSchema: z.ZodSchema<
     z.object({
       rule: z.string(),
       resourceType: z.string(),
-      params: z.record(z.unknown()),
+      params: z.record(z.any()),
     }),
   ]),
 );

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -25,7 +25,7 @@ export const createPermissionRule = <
   TResource,
   TQuery,
   TResourceType extends string,
-  TParams extends unknown[],
+  TParams extends Record<string, unknown>,
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => rule;
@@ -40,7 +40,7 @@ export const createPermissionRule = <
  */
 export const makeCreatePermissionRule =
   <TResource, TQuery, TResourceType extends string>() =>
-  <TParams extends unknown[]>(
+  <TParams extends Record<string, unknown>>(
     rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
   ) =>
     createPermissionRule(rule);

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -26,7 +26,7 @@ export const createPermissionRule = <
   TResource,
   TQuery,
   TResourceType extends string,
-  TParams extends PermissionRuleParams = PermissionRuleParams,
+  TParams extends PermissionRuleParams = undefined,
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => rule;
@@ -41,7 +41,7 @@ export const createPermissionRule = <
  */
 export const makeCreatePermissionRule =
   <TResource, TQuery, TResourceType extends string>() =>
-  <TParams extends PermissionRuleParams = PermissionRuleParams>(
+  <TParams extends PermissionRuleParams = undefined>(
     rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
   ) =>
     createPermissionRule(rule);

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '../types';
 
 /**
@@ -25,7 +26,7 @@ export const createPermissionRule = <
   TResource,
   TQuery,
   TResourceType extends string,
-  TParams extends Record<string, unknown>,
+  TParams extends PermissionRuleParams = PermissionRuleParams,
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => rule;
@@ -40,7 +41,7 @@ export const createPermissionRule = <
  */
 export const makeCreatePermissionRule =
   <TResource, TQuery, TResourceType extends string>() =>
-  <TParams extends Record<string, unknown>>(
+  <TParams extends PermissionRuleParams = PermissionRuleParams>(
     rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
   ) =>
     createPermissionRule(rule);

--- a/plugins/permission-node/src/integration/util.test.ts
+++ b/plugins/permission-node/src/integration/util.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { z } from 'zod';
 import { createPermissionRule } from './createPermissionRule';
 import {
   createGetRule,
@@ -30,6 +31,7 @@ describe('permission integration utils', () => {
       name: 'test-rule-1',
       description: 'Test rule 1',
       resourceType: 'test-resource',
+      schema: z.tuple([]),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });
@@ -38,6 +40,7 @@ describe('permission integration utils', () => {
       name: 'test-rule-2',
       description: 'Test rule 2',
       resourceType: 'test-resource',
+      schema: z.tuple([]),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });

--- a/plugins/permission-node/src/integration/util.test.ts
+++ b/plugins/permission-node/src/integration/util.test.ts
@@ -31,7 +31,7 @@ describe('permission integration utils', () => {
       name: 'test-rule-1',
       description: 'Test rule 1',
       resourceType: 'test-resource',
-      schema: z.tuple([]),
+      schema: z.object({}),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });
@@ -40,7 +40,7 @@ describe('permission integration utils', () => {
       name: 'test-rule-2',
       description: 'Test rule 2',
       resourceType: 'test-resource',
-      schema: z.tuple([]),
+      schema: z.object({}),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });

--- a/plugins/permission-node/src/integration/util.test.ts
+++ b/plugins/permission-node/src/integration/util.test.ts
@@ -31,7 +31,7 @@ describe('permission integration utils', () => {
       name: 'test-rule-1',
       description: 'Test rule 1',
       resourceType: 'test-resource',
-      schema: z.object({}),
+      paramsSchema: z.object({}),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });
@@ -40,7 +40,7 @@ describe('permission integration utils', () => {
       name: 'test-rule-2',
       description: 'Test rule 2',
       resourceType: 'test-resource',
-      schema: z.object({}),
+      paramsSchema: z.object({}),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });

--- a/plugins/permission-node/src/integration/util.test.ts
+++ b/plugins/permission-node/src/integration/util.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { z } from 'zod';
 import { createPermissionRule } from './createPermissionRule';
 import {
   createGetRule,
@@ -31,7 +30,6 @@ describe('permission integration utils', () => {
       name: 'test-rule-1',
       description: 'Test rule 1',
       resourceType: 'test-resource',
-      paramsSchema: z.object({}),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });
@@ -40,7 +38,6 @@ describe('permission integration utils', () => {
       name: 'test-rule-2',
       description: 'Test rule 2',
       resourceType: 'test-resource',
-      paramsSchema: z.object({}),
       apply: jest.fn(),
       toQuery: jest.fn(),
     });

--- a/plugins/permission-node/src/integration/util.ts
+++ b/plugins/permission-node/src/integration/util.ts
@@ -23,6 +23,14 @@ import {
 import { PermissionRule } from '../types';
 
 /**
+ * Prevent use of type parameter from contributing to type inference.
+ *
+ * https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-980401795
+ * @ignore
+ */
+export type NoInfer<T> = T extends infer S ? S : never;
+
+/**
  * Utility function used to parse a PermissionCriteria
  * @param criteria - a PermissionCriteria
  * @alpha

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { PermissionCriteria } from '@backstage/plugin-permission-common';
+import { z } from 'zod';
 
 /**
  * A conditional rule that can be provided in an
@@ -41,6 +42,11 @@ export type PermissionRule<
   name: string;
   description: string;
   resourceType: TResourceType;
+
+  /**
+   * A ZodSchema that documents the parameters that this rule accepts.
+   */
+  schema: z.ZodSchema<TParams>;
 
   /**
    * Apply this rule to a resource already loaded from a backing data source. The params are

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -37,7 +37,7 @@ export type PermissionRule<
   TResource,
   TQuery,
   TResourceType extends string,
-  TParams extends unknown[] = unknown[],
+  TParams extends Record<string, unknown> = Record<string, unknown>,
 > = {
   name: string;
   description: string;
@@ -46,19 +46,23 @@ export type PermissionRule<
   /**
    * A ZodSchema that documents the parameters that this rule accepts.
    */
-  schema: z.ZodSchema<TParams>;
+  schema: z.ZodObject<{
+    [P in keyof TParams]-?: TParams[P] extends undefined
+      ? z.ZodOptionalType<z.ZodType<TParams[P]>>
+      : z.ZodType<TParams[P], any, any>;
+  }>;
 
   /**
    * Apply this rule to a resource already loaded from a backing data source. The params are
    * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
    * params.
    */
-  apply(resource: TResource, ...params: TParams): boolean;
+  apply(resource: TResource, params: TParams): boolean;
 
   /**
    * Translate this rule to criteria suitable for use in querying a backing data store. The criteria
    * can be used for loading a collection of resources efficiently with conditional criteria already
    * applied.
    */
-  toQuery(...params: TParams): PermissionCriteria<TQuery>;
+  toQuery(params: TParams): PermissionCriteria<TQuery>;
 };

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -46,6 +46,15 @@ export type PermissionRule<
   TQuery,
   TResourceType extends string,
   TParams extends Record<string, unknown> = Record<string, unknown>,
+  TSchema extends z.ZodType = z.ZodObject<{
+    // Parameters can be optional, however we we want to make sure that the
+    // parameters are always present in the schema, even if they are undefined.
+    // We remove the optional flag from the schema, and then add it back in
+    // with an optional zod type.
+    [P in keyof TParams]-?: TParams[P] extends undefined
+      ? z.ZodOptionalType<z.ZodType<TParams[P]>>
+      : z.ZodType<TParams[P]>;
+  }>,
 > = {
   name: string;
   description: string;
@@ -54,27 +63,19 @@ export type PermissionRule<
   /**
    * A ZodSchema that documents the parameters that this rule accepts.
    */
-  schema: z.ZodObject<{
-    // Parameters can be optional, however we we want to make sure that the
-    // parameters are always present in the schema, even if they are undefined.
-    // We remove the optional flag from the schema, and then add it back in
-    // with an optional zod type.
-    [P in keyof TParams]-?: TParams[P] extends undefined
-      ? z.ZodOptionalType<z.ZodType<TParams[P]>>
-      : z.ZodType<TParams[P]>;
-  }>;
+  schema: TSchema;
 
   /**
    * Apply this rule to a resource already loaded from a backing data source. The params are
    * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
    * params.
    */
-  apply(resource: TResource, params: NoInfer<TParams>): boolean;
+  apply(resource: TResource, params: NoInfer<z.input<TSchema>>): boolean;
 
   /**
    * Translate this rule to criteria suitable for use in querying a backing data store. The criteria
    * can be used for loading a collection of resources efficiently with conditional criteria already
    * applied.
    */
-  toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
+  toQuery(params: NoInfer<z.input<TSchema>>): PermissionCriteria<TQuery>;
 };

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -64,9 +64,9 @@ export type PermissionRule<
   resourceType: TResourceType;
 
   /**
-   * A ZodSchema that documents the parameters that this rule accepts.
+   * A ZodSchema that reflects the structure of the parameters that are passed to
    */
-  paramsSchema: PermissionRuleSchema<TParams>;
+  paramsSchema?: PermissionRuleSchema<TParams>;
 
   /**
    * Apply this rule to a resource already loaded from a backing data source. The params are

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -55,6 +55,10 @@ export type PermissionRule<
    * A ZodSchema that documents the parameters that this rule accepts.
    */
   schema: z.ZodObject<{
+    // Parameters can be optional, however we we want to make sure that the
+    // parameters are always present in the schema, even if they are undefined.
+    // We remove the optional flag from the schema, and then add it back in
+    // with an optional zod type.
     [P in keyof TParams]-?: TParams[P] extends undefined
       ? z.ZodOptionalType<z.ZodType<TParams[P]>>
       : z.ZodType<TParams[P], any, any>;

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -22,22 +22,6 @@ import { z } from 'zod';
 import { NoInfer } from './integration/util';
 
 /**
- * A ZodSchema that reflects the structure of the parameters that are passed to
- * into a {@link PermissionRule}.
- *
- * @public
- */
-export type PermissionRuleSchema<TParams> = z.ZodObject<{
-  // Parameters can be optional, however we we want to make sure that the
-  // parameters are always present in the schema, even if they are undefined.
-  // We remove the optional flag from the schema, and then add it back in
-  // with an optional zod type.
-  [P in keyof TParams]-?: TParams[P] extends undefined
-    ? z.ZodOptionalType<z.ZodType<TParams[P]>>
-    : z.ZodType<TParams[P]>;
-}>;
-
-/**
  * A conditional rule that can be provided in an
  * {@link @backstage/permission-common#AuthorizeDecision} response to an authorization request.
  *
@@ -66,24 +50,19 @@ export type PermissionRule<
   /**
    * A ZodSchema that reflects the structure of the parameters that are passed to
    */
-  paramsSchema?: PermissionRuleSchema<TParams>;
+  paramsSchema?: z.ZodSchema<TParams>;
 
   /**
    * Apply this rule to a resource already loaded from a backing data source. The params are
    * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
    * params.
    */
-  apply(
-    resource: TResource,
-    params: NoInfer<z.input<PermissionRuleSchema<TParams>>>,
-  ): boolean;
+  apply(resource: TResource, params: NoInfer<TParams>): boolean;
 
   /**
    * Translate this rule to criteria suitable for use in querying a backing data store. The criteria
    * can be used for loading a collection of resources efficiently with conditional criteria already
    * applied.
    */
-  toQuery(
-    params: NoInfer<z.input<PermissionRuleSchema<TParams>>>,
-  ): PermissionCriteria<TQuery>;
+  toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
 };

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { PermissionCriteria } from '@backstage/plugin-permission-common';
+import type {
+  PermissionCriteria,
+  PermissionRuleParams,
+} from '@backstage/plugin-permission-common';
 import { z } from 'zod';
 
 /**
@@ -45,7 +48,7 @@ export type PermissionRule<
   TResource,
   TQuery,
   TResourceType extends string,
-  TParams extends Record<string, unknown> = Record<string, unknown>,
+  TParams extends PermissionRuleParams = PermissionRuleParams,
   TSchema extends z.ZodType = z.ZodObject<{
     // Parameters can be optional, however we we want to make sure that the
     // parameters are always present in the schema, even if they are undefined.

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -18,6 +18,14 @@ import type { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { z } from 'zod';
 
 /**
+ * Prevent use of type parameter from contributing to type inference.
+ *
+ * https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-980401795
+ * @ignore
+ */
+export type NoInfer<T> = T extends infer S ? S : never;
+
+/**
  * A conditional rule that can be provided in an
  * {@link @backstage/permission-common#AuthorizeDecision} response to an authorization request.
  *
@@ -57,12 +65,12 @@ export type PermissionRule<
    * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
    * params.
    */
-  apply(resource: TResource, params: TParams): boolean;
+  apply(resource: TResource, params: NoInfer<TParams>): boolean;
 
   /**
    * Translate this rule to criteria suitable for use in querying a backing data store. The criteria
    * can be used for loading a collection of resources efficiently with conditional criteria already
    * applied.
    */
-  toQuery(params: TParams): PermissionCriteria<TQuery>;
+  toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
 };

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -66,7 +66,7 @@ export type PermissionRule<
   /**
    * A ZodSchema that documents the parameters that this rule accepts.
    */
-  schema: PermissionRuleSchema<TParams>;
+  paramsSchema: PermissionRuleSchema<TParams>;
 
   /**
    * Apply this rule to a resource already loaded from a backing data source. The params are

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -61,7 +61,7 @@ export type PermissionRule<
     // with an optional zod type.
     [P in keyof TParams]-?: TParams[P] extends undefined
       ? z.ZodOptionalType<z.ZodType<TParams[P]>>
-      : z.ZodType<TParams[P], any, any>;
+      : z.ZodType<TParams[P]>;
   }>;
 
   /**

--- a/plugins/playlist-backend/api-report.md
+++ b/plugins/playlist-backend/api-report.md
@@ -15,6 +15,7 @@ import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionPolicy } from '@backstage/plugin-permission-node';
 import { PermissionRule } from '@backstage/plugin-permission-node';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaylistMetadata } from '@backstage/plugin-playlist-common';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -26,7 +27,7 @@ import { ResourcePermission } from '@backstage/plugin-permission-common';
 export const createPlaylistConditionalDecision: (
   permission: ResourcePermission<'playlist-list'>,
   conditions: PermissionCriteria<
-    PermissionCondition<'playlist-list', unknown[]>
+    PermissionCondition<'playlist-list', PermissionRuleParams>
   >,
 ) => ConditionalPolicyDecision;
 
@@ -70,13 +71,15 @@ export const playlistConditions: Conditions<{
     PlaylistMetadata,
     ListPlaylistsFilter,
     'playlist-list',
-    [userOwnershipRefs: string[]]
+    {
+      owners: string[];
+    }
   >;
   isPublic: PermissionRule<
     PlaylistMetadata,
     ListPlaylistsFilter,
     'playlist-list',
-    []
+    PermissionRuleParams
   >;
 }>;
 

--- a/plugins/playlist-backend/api-report.md
+++ b/plugins/playlist-backend/api-report.md
@@ -79,7 +79,7 @@ export const playlistConditions: Conditions<{
     PlaylistMetadata,
     ListPlaylistsFilter,
     'playlist-list',
-    PermissionRuleParams
+    undefined
   >;
 }>;
 

--- a/plugins/playlist-backend/package.json
+++ b/plugins/playlist-backend/package.json
@@ -39,7 +39,8 @@
     "node-fetch": "^2.6.7",
     "uuid": "^8.2.0",
     "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "yn": "^4.0.0",
+    "zod": "^3.11.6"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.test.ts
+++ b/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.test.ts
@@ -67,11 +67,10 @@ describe('DefaultPlaylistPermissionPolicy', () => {
       resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
       conditions: {
         anyOf: [
-          playlistConditions.isOwner([
-            'user:default/me',
-            'group:default/owner',
-          ]),
-          playlistConditions.isPublic(),
+          playlistConditions.isOwner({
+            owners: ['user:default/me', 'group:default/owner'],
+          }),
+          playlistConditions.isPublic({}),
         ],
       },
     });
@@ -89,11 +88,10 @@ describe('DefaultPlaylistPermissionPolicy', () => {
       resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
       conditions: {
         anyOf: [
-          playlistConditions.isOwner([
-            'user:default/me',
-            'group:default/owner',
-          ]),
-          playlistConditions.isPublic(),
+          playlistConditions.isOwner({
+            owners: ['user:default/me', 'group:default/owner'],
+          }),
+          playlistConditions.isPublic({}),
         ],
       },
     });
@@ -109,10 +107,9 @@ describe('DefaultPlaylistPermissionPolicy', () => {
       result: AuthorizeResult.CONDITIONAL,
       pluginId: 'playlist',
       resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-      conditions: playlistConditions.isOwner([
-        'user:default/me',
-        'group:default/owner',
-      ]),
+      conditions: playlistConditions.isOwner({
+        owners: ['user:default/me', 'group:default/owner'],
+      }),
     });
   });
 
@@ -126,10 +123,9 @@ describe('DefaultPlaylistPermissionPolicy', () => {
       result: AuthorizeResult.CONDITIONAL,
       pluginId: 'playlist',
       resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-      conditions: playlistConditions.isOwner([
-        'user:default/me',
-        'group:default/owner',
-      ]),
+      conditions: playlistConditions.isOwner({
+        owners: ['user:default/me', 'group:default/owner'],
+      }),
     });
   });
 });

--- a/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.test.ts
+++ b/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.test.ts
@@ -70,7 +70,7 @@ describe('DefaultPlaylistPermissionPolicy', () => {
           playlistConditions.isOwner({
             owners: ['user:default/me', 'group:default/owner'],
           }),
-          playlistConditions.isPublic({}),
+          playlistConditions.isPublic(),
         ],
       },
     });
@@ -91,7 +91,7 @@ describe('DefaultPlaylistPermissionPolicy', () => {
           playlistConditions.isOwner({
             owners: ['user:default/me', 'group:default/owner'],
           }),
-          playlistConditions.isPublic({}),
+          playlistConditions.isPublic(),
         ],
       },
     });

--- a/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.ts
+++ b/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.ts
@@ -68,8 +68,10 @@ export class DefaultPlaylistPermissionPolicy implements PermissionPolicy {
     ) {
       return createPlaylistConditionalDecision(request.permission, {
         anyOf: [
-          playlistConditions.isOwner(user?.identity.ownershipEntityRefs ?? []),
-          playlistConditions.isPublic(),
+          playlistConditions.isOwner({
+            owners: user?.identity.ownershipEntityRefs ?? [],
+          }),
+          playlistConditions.isPublic({}),
         ],
       });
     }
@@ -81,7 +83,9 @@ export class DefaultPlaylistPermissionPolicy implements PermissionPolicy {
     ) {
       return createPlaylistConditionalDecision(
         request.permission,
-        playlistConditions.isOwner(user?.identity.ownershipEntityRefs ?? []),
+        playlistConditions.isOwner({
+          owners: user?.identity.ownershipEntityRefs ?? [],
+        }),
       );
     }
 

--- a/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.ts
+++ b/plugins/playlist-backend/src/permissions/DefaultPlaylistPermissionPolicy.ts
@@ -71,7 +71,7 @@ export class DefaultPlaylistPermissionPolicy implements PermissionPolicy {
           playlistConditions.isOwner({
             owners: user?.identity.ownershipEntityRefs ?? [],
           }),
-          playlistConditions.isPublic({}),
+          playlistConditions.isPublic(),
         ],
       });
     }

--- a/plugins/playlist-backend/src/permissions/rules.ts
+++ b/plugins/playlist-backend/src/permissions/rules.ts
@@ -19,6 +19,7 @@ import {
   PLAYLIST_LIST_RESOURCE_TYPE,
   PlaylistMetadata,
 } from '@backstage/plugin-playlist-common';
+import { z } from 'zod';
 
 import { ListPlaylistsFilter } from '../service';
 
@@ -32,6 +33,7 @@ const isOwner = createPlaylistPermissionRule({
   name: 'IS_OWNER',
   description: 'Should allow only if the playlist belongs to the user',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
+  schema: z.tuple([z.array(z.string().describe('List of owners'))]),
   apply: (list: PlaylistMetadata, userOwnershipRefs: string[]) =>
     userOwnershipRefs.includes(list.owner),
   toQuery: (userOwnershipRefs: string[]) => ({
@@ -44,6 +46,7 @@ const isPublic = createPlaylistPermissionRule({
   name: 'IS_PUBLIC',
   description: 'Should allow only if the playlist is public',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
+  schema: z.tuple([]),
   apply: (list: PlaylistMetadata) => list.public,
   toQuery: () => ({ key: 'public', values: [true] }),
 });

--- a/plugins/playlist-backend/src/permissions/rules.ts
+++ b/plugins/playlist-backend/src/permissions/rules.ts
@@ -29,16 +29,19 @@ const createPlaylistPermissionRule = makeCreatePermissionRule<
   typeof PLAYLIST_LIST_RESOURCE_TYPE
 >();
 
-const isOwner = createPlaylistPermissionRule({
+const isOwner = createPlaylistPermissionRule<{
+  owners: string[];
+}>({
   name: 'IS_OWNER',
   description: 'Should allow only if the playlist belongs to the user',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-  schema: z.tuple([z.array(z.string().describe('List of owners'))]),
-  apply: (list: PlaylistMetadata, userOwnershipRefs: string[]) =>
-    userOwnershipRefs.includes(list.owner),
-  toQuery: (userOwnershipRefs: string[]) => ({
+  schema: z.object({
+    owners: z.array(z.string().describe('List of owner entity refs')),
+  }),
+  apply: (list: PlaylistMetadata, { owners }) => owners.includes(list.owner),
+  toQuery: ({ owners }) => ({
     key: 'owner',
-    values: userOwnershipRefs,
+    values: owners,
   }),
 });
 
@@ -46,7 +49,7 @@ const isPublic = createPlaylistPermissionRule({
   name: 'IS_PUBLIC',
   description: 'Should allow only if the playlist is public',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-  schema: z.tuple([]),
+  schema: z.object({}),
   apply: (list: PlaylistMetadata) => list.public,
   toQuery: () => ({ key: 'public', values: [true] }),
 });

--- a/plugins/playlist-backend/src/permissions/rules.ts
+++ b/plugins/playlist-backend/src/permissions/rules.ts
@@ -33,7 +33,7 @@ const isOwner = createPlaylistPermissionRule({
   name: 'IS_OWNER',
   description: 'Should allow only if the playlist belongs to the user',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-  schema: z.object({
+  paramsSchema: z.object({
     owners: z.array(z.string()).describe('List of owner entity refs'),
   }),
   apply: (list: PlaylistMetadata, { owners }) => owners.includes(list.owner),
@@ -47,7 +47,7 @@ const isPublic = createPlaylistPermissionRule({
   name: 'IS_PUBLIC',
   description: 'Should allow only if the playlist is public',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-  schema: z.object({}),
+  paramsSchema: z.object({}),
   apply: (list: PlaylistMetadata) => list.public,
   toQuery: () => ({ key: 'public', values: [true] }),
 });

--- a/plugins/playlist-backend/src/permissions/rules.ts
+++ b/plugins/playlist-backend/src/permissions/rules.ts
@@ -29,9 +29,7 @@ const createPlaylistPermissionRule = makeCreatePermissionRule<
   typeof PLAYLIST_LIST_RESOURCE_TYPE
 >();
 
-const isOwner = createPlaylistPermissionRule<{
-  owners: string[];
-}>({
+const isOwner = createPlaylistPermissionRule({
   name: 'IS_OWNER',
   description: 'Should allow only if the playlist belongs to the user',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,

--- a/plugins/playlist-backend/src/permissions/rules.ts
+++ b/plugins/playlist-backend/src/permissions/rules.ts
@@ -36,7 +36,7 @@ const isOwner = createPlaylistPermissionRule<{
   description: 'Should allow only if the playlist belongs to the user',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
   schema: z.object({
-    owners: z.array(z.string().describe('List of owner entity refs')),
+    owners: z.array(z.string()).describe('List of owner entity refs'),
   }),
   apply: (list: PlaylistMetadata, { owners }) => owners.includes(list.owner),
   toQuery: ({ owners }) => ({

--- a/plugins/playlist-backend/src/permissions/rules.ts
+++ b/plugins/playlist-backend/src/permissions/rules.ts
@@ -47,7 +47,6 @@ const isPublic = createPlaylistPermissionRule({
   name: 'IS_PUBLIC',
   description: 'Should allow only if the playlist is public',
   resourceType: PLAYLIST_LIST_RESOURCE_TYPE,
-  paramsSchema: z.object({}),
   apply: (list: PlaylistMetadata) => list.public,
   toQuery: () => ({ key: 'public', values: [true] }),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,6 +6359,7 @@ __metadata:
     msw: ^0.47.0
     supertest: ^6.1.3
     zod: ^3.11.6
+    zod-to-json-schema: ^3.18.1
   languageName: unknown
   linkType: soft
 
@@ -40074,6 +40075,15 @@ __metadata:
     compress-commons: ^4.1.0
     readable-stream: ^3.6.0
   checksum: 4a73da856738b0634700b52f4ab3fe0bf0a532bea6820ad962d0bda0163d2d5525df4859f89a7238e204a378384e12551985049790c1894c3ac191866e85887f
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.18.1":
+  version: 3.18.1
+  resolution: "zod-to-json-schema@npm:3.18.1"
+  peerDependencies:
+    zod: ^3.18.0
+  checksum: e55d0de83b50fbd1caa7541d037858815964477b52a9e6495496e447107386cf16e2c08b007fcfbffd7fbe069ca2c19018425a53eaee36aff5dda942d3db71f4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,6 +6427,7 @@ __metadata:
     uuid: ^8.2.0
     winston: ^3.2.1
     yn: ^4.0.0
+    zod: ^3.11.6
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6334,6 +6334,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
+    "@backstage/types": "workspace:^"
     cross-fetch: ^3.1.5
     msw: ^0.47.0
     uuid: ^8.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a required schema to permission rules that details the parameter a rule is expecting. This change is to:

- provide a way for the permission framework to validate the parameters provided to a rule before executing it 
- detail the expected parameters in the output of the .well-know metadata output. 
- change the permission rule API to expect a single parameter object rather than individual parameters. 
-  restrict parameters to json primitives and arrays of primitives

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
