### PR TITLE
make plugin config roots optional

### DIFF
--- a/.changeset/moody-buttons-run.md
+++ b/.changeset/moody-buttons-run.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-apache-airflow': patch
+'@backstage/plugin-azure-devops-backend': patch
+'@backstage/plugin-cost-insights': patch
+'@backstage/plugin-gocd': patch
+'@backstage/plugin-sentry': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Make the root config key optional

--- a/plugins/apache-airflow/config.d.ts
+++ b/plugins/apache-airflow/config.d.ts
@@ -16,7 +16,7 @@
 
 export interface Config {
   /** Configurations for the Apache Airflow plugin */
-  apacheAirflow: {
+  apacheAirflow?: {
     /**
      * The base url of the Apache Airflow installation.
      * @visibility frontend

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -16,7 +16,7 @@
 
 export interface Config {
   /** Configuration options for the azure-devops-backend plugin */
-  azureDevOps: {
+  azureDevOps?: {
     /**
      * The hostname of the given Azure instance
      */

--- a/plugins/cost-insights/config.d.ts
+++ b/plugins/cost-insights/config.d.ts
@@ -15,7 +15,7 @@
  */
 
 export interface Config {
-  costInsights: {
+  costInsights?: {
     /**
      * @visibility frontend
      */

--- a/plugins/gocd/config.d.ts
+++ b/plugins/gocd/config.d.ts
@@ -15,7 +15,7 @@
  */
 export interface Config {
   /** Configurations for the GoCD plugin */
-  gocd: {
+  gocd?: {
     /**
      * The base url of the GoCD installation.
      * @visibility frontend

--- a/plugins/sentry/config.d.ts
+++ b/plugins/sentry/config.d.ts
@@ -16,7 +16,7 @@
 
 export interface Config {
   /** Configuration options for the sentry plugin */
-  sentry: {
+  sentry?: {
     /**
      * The 'organization' attribute
      * @visibility frontend

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -19,7 +19,7 @@ export interface Config {
    * Configuration options for the techdocs-backend plugin
    * @see http://backstage.io/docs/features/techdocs/configuration
    */
-  techdocs: {
+  techdocs?: {
     /**
      * Documentation building process depends on the builder attr
      * @visibility frontend

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -19,7 +19,7 @@ export interface Config {
    * Configuration options for the techdocs plugin
    * @see http://backstage.io/docs/features/techdocs/configuration
    */
-  techdocs: {
+  techdocs?: {
     /**
      * Documentation building process depends on the builder attr
      * @visibility frontend


### PR DESCRIPTION
Noted that `yarn backstage-cli config:schema` had a lot of junk in it.

After this change, it only lists `app` and `backend`.