### PR TITLE
Fix '.set()' quest mode in user settings 

### DIFF
--- a/.changeset/clever-ties-burn.md
+++ b/.changeset/clever-ties-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Prevent `.set()` to execute a request to the StorageClient if the user is `guest`

--- a/plugins/user-settings/src/apis/StorageApi/UserSettingsStorage.ts
+++ b/plugins/user-settings/src/apis/StorageApi/UserSettingsStorage.ts
@@ -118,6 +118,7 @@ export class UserSettingsStorage implements StorageApi {
     if (!(await this.isSignedIn())) {
       await this.fallback.set(key, data);
       this.notifyChanges({ key, presence: 'present', value: data });
+      return;
     }
 
     const fetchUrl = await this.getFetchUrl(key);


### PR DESCRIPTION
Signed-off-by: ivgo <ivgo@spreadgroup.com>

## Hey, I just made a Pull Request!
While trying to test the newly created `user-settings` plugin, I found out the frontend was making a request to the storage even in guest mode. After checking the code, I found out a `return` was missing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
