### PR TITLE
feat: enhance catalog-plugin table with label column

### DIFF
--- a/.changeset/fifty-berries-learn.md
+++ b/.changeset/fifty-berries-learn.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog': minor
 ---
 
 Added new column `Label` to `CatalogTable.columns`, this new column allows you make use of labels from metadata.

--- a/.changeset/fifty-berries-learn.md
+++ b/.changeset/fifty-berries-learn.md
@@ -2,13 +2,10 @@
 '@backstage/plugin-catalog': patch
 ---
 
----
+Added new column `Label` to `CatalogTable.columns`, this new column allows you make use of labels from metadata.
+For example: category and visibility are type of labels associated with API entity illustrated below.
 
-This change would allow consumers of plugin catalog to make use of labels just like tags from metadata.
-
-The intent of change is to show customised columns based on selected label with which entity is associated.
-For example: In example below category and visibility are type of labels associated with API entity.
-YAML for API entity
+YAML code snippet for API entity
 
 ```yaml
 apiVersion: backstage.io/v1alpha1

--- a/.changeset/fifty-berries-learn.md
+++ b/.changeset/fifty-berries-learn.md
@@ -1,0 +1,40 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+---
+
+This change would allow consumers of plugin catalog to make use of labels just like tags from metadata.
+
+The intent of change is to show customised columns based on selected label with which entity is associated.
+For example: In example below category and visibility are type of labels associated with API entity.
+YAML for API entity
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: sample-api
+  description: API for sample
+  links:
+    - url: http://localhost:8080/swagger-ui.html
+      title: Swagger UI
+  tags:
+    - http
+  labels:
+    category: legacy
+    visibility: protected
+```
+
+Consumers can customise columns to include label column and show in api-docs list
+
+```typescript
+const columns = [
+  CatalogTable.columns.createNameColumn({ defaultKind: 'API' }),
+  CatalogTable.columns.createLabelColumn('category', { title: 'Category' }),
+  CatalogTable.columns.createLabelColumn('visibility', {
+    title: 'Visibility',
+    defaultValue: 'public',
+  }),
+];
+```

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -148,6 +148,15 @@ export const CatalogTable: {
           }
         | undefined,
     ): TableColumn<CatalogTableRow>;
+    createLabelColumn(
+      key: string,
+      options?:
+        | {
+            title?: string | undefined;
+            defaultValue?: string | undefined;
+          }
+        | undefined,
+    ): TableColumn<CatalogTableRow>;
   }>;
 };
 

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -331,4 +331,42 @@ describe('CatalogTable component', () => {
 
     expect(getByText('Should be rendered')).toBeInTheDocument();
   });
+
+  it('should render the label column with customised title and value as specified', async () => {
+    const columns = [
+      CatalogTable.columns.createNameColumn({ defaultKind: 'API' }),
+      CatalogTable.columns.createLabelColumn('category', { title: 'Category' }),
+    ];
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'API',
+      metadata: {
+        name: 'APIWithLabel',
+        labels: { category: 'generic' },
+      },
+    };
+    const expectedColumns = ['Name', 'Category', 'Actions'];
+
+    const { getAllByRole, getByText } = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ entities: [entity] }}>
+          <CatalogTable columns={columns} />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const columnHeader = getAllByRole('button').filter(
+      c => c.tagName === 'SPAN',
+    );
+    const columnHeaderLabels = columnHeader.map(c => c.textContent);
+    expect(columnHeaderLabels).toEqual(expectedColumns);
+
+    const labelCellValue = getByText('generic');
+    expect(labelCellValue).toBeInTheDocument();
+  });
 });

--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -25,6 +25,31 @@ import { OverflowTooltip, TableColumn } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { JsonArray } from '@backstage/types';
 
+/**
+ * Renders label if exists in entities or default
+ * @param labels - Key value pairs of labels specified in entity metadata
+ * @param key - specified label key to be extracted from all labels
+ * @param defaultValue - shows default in case label key does not exist
+ * @returns Chip style component when label value exists undefined otherwise.
+ */
+const renderLabel = (
+  labels: Record<string, string> | undefined,
+  key: string,
+  defaultValue?: string,
+) => {
+  const specifiedLabelValue = (labels && labels[key]) || defaultValue;
+  return (
+    specifiedLabelValue && (
+      <Chip
+        key={specifiedLabelValue}
+        label={specifiedLabelValue}
+        size="small"
+        variant="outlined"
+      />
+    )
+  );
+};
+
 // The columnFactories symbol is not directly exported, but through the
 // CatalogTable.columns field.
 /** @public */
@@ -160,6 +185,22 @@ export const columnFactories = Object.freeze({
       field: 'entity.metadata.title',
       hidden: options?.hidden,
       searchable: true,
+    };
+  },
+  createLabelColumn(
+    key: string,
+    options?: { title?: string; defaultValue?: string },
+  ): TableColumn<CatalogTableRow> {
+    return {
+      title: options?.title || 'Label',
+      field: 'entity.metadata.labels',
+      cellStyle: {
+        padding: '0px 16px 0px 20px',
+      },
+      render: ({ entity }: { entity: Entity }) => (
+        <>{renderLabel(entity.metadata?.labels, key, options?.defaultValue)}</>
+      ),
+      width: 'auto',
     };
   },
 });

--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -25,31 +25,6 @@ import { OverflowTooltip, TableColumn } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { JsonArray } from '@backstage/types';
 
-/**
- * Renders label if exists in entities or default
- * @param labels - Key value pairs of labels specified in entity metadata
- * @param key - specified label key to be extracted from all labels
- * @param defaultValue - shows default in case label key does not exist
- * @returns Chip style component when label value exists undefined otherwise.
- */
-const renderLabel = (
-  labels: Record<string, string> | undefined,
-  key: string,
-  defaultValue?: string,
-) => {
-  const specifiedLabelValue = (labels && labels[key]) || defaultValue;
-  return (
-    specifiedLabelValue && (
-      <Chip
-        key={specifiedLabelValue}
-        label={specifiedLabelValue}
-        size="small"
-        variant="outlined"
-      />
-    )
-  );
-};
-
 // The columnFactories symbol is not directly exported, but through the
 // CatalogTable.columns field.
 /** @public */
@@ -197,9 +172,24 @@ export const columnFactories = Object.freeze({
       cellStyle: {
         padding: '0px 16px 0px 20px',
       },
-      render: ({ entity }: { entity: Entity }) => (
-        <>{renderLabel(entity.metadata?.labels, key, options?.defaultValue)}</>
-      ),
+      render: ({ entity }: { entity: Entity }) => {
+        const labels: Record<string, string> | undefined =
+          entity.metadata?.labels;
+        const specifiedLabelValue =
+          (labels && labels[key]) || options?.defaultValue;
+        return (
+          <>
+            {specifiedLabelValue && (
+              <Chip
+                key={specifiedLabelValue}
+                label={specifiedLabelValue}
+                size="small"
+                variant="outlined"
+              />
+            )}
+          </>
+        );
+      },
       width: 'auto',
     };
   },


### PR DESCRIPTION
## Enhancement in catalog plugin table with label column

This change would allow consumers of plugin catalog to make use of labels just like tags from metadata.

The intent of change is to show customised columns based on selected label with which entity is associated.
In case label is not present in entity consumer can choose to show customised default value 
which is sensibly defaulted to blank thus showing no label in the column. Please checkout detailed examples are shown in changeset.

Here's example screenshot of api-docs with customised label columns.

<img width="1085" alt="Screenshot 2022-09-28 at 6 10 11 PM" src="https://user-images.githubusercontent.com/11464872/193045259-933cdc7e-eab4-47f6-bb42-aef7cd1433d4.png">


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
