### PR TITLE
feat: allow auth0 provider to specify connection/connection_scope config

### DIFF
--- a/.changeset/pretty-buttons-develop.md
+++ b/.changeset/pretty-buttons-develop.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-auth-backend': patch
 ---
 
 Auth0 provider now supports optional `connection` and `connectionScope` parameters to configure social identity providers.

--- a/.changeset/pretty-buttons-develop.md
+++ b/.changeset/pretty-buttons-develop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Auth0 provider now supports optional `connection` and `connectionScope` parameters to configure social identity providers.

--- a/docs/auth/auth0/provider.md
+++ b/docs/auth/auth0/provider.md
@@ -35,6 +35,8 @@ auth:
         clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
         domain: ${AUTH_AUTH0_DOMAIN_ID}
         audience: ${AUTH_AUTH0_AUDIENCE}
+        connection: ${AUTH_AUTH0_CONNECTION}
+        connectionScope: ${AUTH_AUTH0_CONNECTION_SCOPE}
 ```
 
 The Auth0 provider is a structure with three configuration keys:
@@ -43,6 +45,12 @@ The Auth0 provider is a structure with three configuration keys:
 - `clientSecret`: The Application client secret, found on the Auth0 Application
   page
 - `domain`: The Application domain, found on the Auth0 Application page
+
+## Optional Configuration
+
+- `audience`: The intended recipients of the token
+- `connection`: Social identity provider name
+- `connectionScope`: Additional scopes in the interactive token request. It should always be used in combination with the `connection` parameter
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/auth0/provider.md
+++ b/docs/auth/auth0/provider.md
@@ -49,7 +49,7 @@ The Auth0 provider is a structure with three configuration keys:
 ## Optional Configuration
 
 - `audience`: The intended recipients of the token
-- `connection`: Social identity provider name
+- `connection`: Social identity provider name. To check the available social connections, please visit [Auth0 Social Connections](https://marketplace.auth0.com/features/social-connections).
 - `connectionScope`: Additional scopes in the interactive token request. It should always be used in combination with the `connection` parameter
 
 ## Adding the provider to the Backstage frontend

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -134,7 +134,9 @@ export class Auth0AuthProvider implements OAuthHandlers {
       state: encodeState(req.state),
       ...(this.audience ? { audience: this.audience } : {}),
       ...(this.connection ? { connection: this.connection } : {}),
-      ...(this.connectionScope ? { connection_scope: this.connectionScope } : {}),
+      ...(this.connectionScope
+        ? { connection_scope: this.connectionScope }
+        : {}),
     });
   }
 
@@ -145,7 +147,9 @@ export class Auth0AuthProvider implements OAuthHandlers {
     >(req, this._strategy, {
       ...(this.audience ? { audience: this.audience } : {}),
       ...(this.connection ? { connection: this.connection } : {}),
-      ...(this.connectionScope ? { connection_scope: this.connectionScope } : {}),
+      ...(this.connectionScope
+        ? { connection_scope: this.connectionScope }
+        : {}),
     });
 
     return {

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -55,6 +55,8 @@ export type Auth0AuthProviderOptions = OAuthProviderOptions & {
   authHandler: AuthHandler<OAuthResult>;
   resolverContext: AuthResolverContext;
   audience?: string;
+  connection?: string;
+  connectionScope?: string;
 };
 
 export class Auth0AuthProvider implements OAuthHandlers {
@@ -63,6 +65,8 @@ export class Auth0AuthProvider implements OAuthHandlers {
   private readonly authHandler: AuthHandler<OAuthResult>;
   private readonly resolverContext: AuthResolverContext;
   private readonly audience?: string;
+  private readonly connection?: string;
+  private readonly connectionScope?: string;
 
   /**
    * Due to passport-auth0 forcing options.state = true,
@@ -86,6 +90,8 @@ export class Auth0AuthProvider implements OAuthHandlers {
     this.authHandler = options.authHandler;
     this.resolverContext = options.resolverContext;
     this.audience = options.audience;
+    this.connection = options.connection;
+    this.connectionScope = options.connectionScope;
     this._strategy = new Auth0Strategy(
       {
         clientID: options.clientId,
@@ -127,6 +133,8 @@ export class Auth0AuthProvider implements OAuthHandlers {
       scope: req.scope,
       state: encodeState(req.state),
       ...(this.audience ? { audience: this.audience } : {}),
+      ...(this.connection ? { connection: this.connection } : {}),
+      ...(this.connectionScope ? { connection_scope: this.connectionScope } : {}),
     });
   }
 
@@ -136,6 +144,8 @@ export class Auth0AuthProvider implements OAuthHandlers {
       PrivateInfo
     >(req, this._strategy, {
       ...(this.audience ? { audience: this.audience } : {}),
+      ...(this.connection ? { connection: this.connection } : {}),
+      ...(this.connectionScope ? { connection_scope: this.connectionScope } : {}),
     });
 
     return {
@@ -224,6 +234,8 @@ export const auth0 = createAuthProviderIntegration({
         const domain = envConfig.getString('domain');
         const customCallbackUrl = envConfig.getOptionalString('callbackUrl');
         const audience = envConfig.getOptionalString('audience');
+        const connection = envConfig.getOptionalString('connection');
+        const connectionScope = envConfig.getOptionalString('connectionScope');
         const callbackUrl =
           customCallbackUrl ||
           `${globalConfig.baseUrl}/${providerId}/handler/frame`;
@@ -245,6 +257,8 @@ export const auth0 = createAuthProviderIntegration({
           signInResolver,
           resolverContext,
           audience,
+          connection,
+          connectionScope,
         });
 
         return OAuthAdapter.fromConfig(globalConfig, provider, {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible. 
     That makes it easier to understand the change so we can :shipit: faster. -->

Now, Auth0 provider supports integration with social identity providers without creating friction or compromising the user experience. To check the available social connections, please visit [Auth0 Social Connections](https://marketplace.auth0.com/features/social-connections?_gl=1*6egh1p*rollup_ga*MTA1MTcyNDY1LjE2NjQ0NjA5Nzk.*rollup_ga_F1G3E656YZ*MTY2NDQ2NDEzNC4yLjEuMTY2NDQ2NDEzNy41Ny4wLjA.&_ga=2.201317486.1936071227.1664461101-105172465.1664460979).

In order to make this possible, `connection` and `connectionScope` configs were created (both optional), fully compatible with the `passport-auth` (added on [#13586](https://github.com/backstage/backstage/pull/13586)).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
