### PR TITLE
One more integration test

### DIFF
--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -31,6 +31,8 @@ import { startTaskPipeline } from './TaskPipeline';
 
 const CACHE_TTL = 5;
 
+export type ProgressTracker = ReturnType<typeof progressTracker>;
+
 export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
   private stopFunc?: () => void;
 
@@ -45,7 +47,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
       unprocessedEntity: Entity;
       errors: Error[];
     }) => Promise<void> | void,
-    private readonly tracker = progressTracker(),
+    private readonly tracker: ProgressTracker = progressTracker(),
   ) {}
 
   async start() {


### PR DESCRIPTION
Trying my wings with the new integration test stuff in the catalog. This is largely a tweaked copy of #13845 .

This test is a bit odd, in that it documents an existing behaviour that we want to address eventually. I thought it was still valuable to see this in place - both as documentation as well as it could change / break for _other_ reasons than the orphaning. And when we get around to improving this behaviour, the test is there to tell us that we did good.