### PR TITLE
add link to questions tagged 'backstage' in Stack Overflow

### DIFF
--- a/docs/overview/support.md
+++ b/docs/overview/support.md
@@ -6,6 +6,7 @@ description: Support and Community Details and Links
 
 - [Discord chatroom](https://discord.gg/MUpMjP2) - Get support or discuss the
   project.
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/backstage) - Browse or ask questions on Stack Overflow.
 - [Good First Issues](https://github.com/backstage/backstage/contribute) - Start
   here if you want to contribute.
 - [RFCs](https://github.com/backstage/backstage/labels/rfc) - Help shape the


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds an item in the bullet list on the doc page **[Support and community](https://backstage.io/docs/overview/support)** with a link to questions tagged `backstage` in the [public Stack Overflow site](https://stackoverflow.com/questions/tagged/backstage). There is activity there and some developers prefer the QnA style that SO is famous for.

