### PR TITLE
CachingJestRuntime should not do extra work if not watching

### DIFF
--- a/.changeset/curly-rats-itch.md
+++ b/.changeset/curly-rats-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Tweak the Jest Caching loader to only operate when in `watch` mode

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -25,6 +25,11 @@ const envOptions = {
   enableSourceMaps: Boolean(process.env.ENABLE_SOURCE_MAPS),
 };
 
+if (envOptions.nextTests) {
+  // Needed so that, at import-time, it can hook into Jest's internals.
+  require('./jestCachingModuleLoader');
+}
+
 const transformIgnorePattern = [
   '@material-ui',
   'ajv',


### PR DESCRIPTION
The benefits of `CachingJestRuntime` only apply if in `watch` mode. If not, then we're doing FS calls but not getting benefit from them.

This is a small optimization that will hopefully make CI happier with our caching runtime, if/when it's used.

Signed-off-by: Mitchell Hentges <mhentges@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
