### PR TITLE
Define a simple yet risky Jest resolver

### DIFF
--- a/.changeset/smooth-mayflies-behave.md
+++ b/.changeset/smooth-mayflies-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add simple (but risky) Jest resolver implementation to slightly bump test speed

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -25,6 +25,10 @@ const envOptions = {
   enableSourceMaps: Boolean(process.env.ENABLE_SOURCE_MAPS),
 };
 
+if (envOptions.nextTests) {
+  require('./jestSimpleResolver');
+}
+
 const transformIgnorePattern = [
   '@material-ui',
   'ajv',
@@ -194,6 +198,9 @@ async function getProjectConfig(targetPath, displayName) {
     // A bit more opinionated
     testMatch: ['**/*.test.{js,jsx,ts,tsx,mjs,cjs}'],
 
+    resolver: envOptions.nextTests
+      ? require.resolve('./jestSimpleResolver')
+      : undefined,
     runtime: envOptions.nextTests
       ? require.resolve('./jestCachingModuleLoader')
       : undefined,

--- a/packages/cli/config/jestSimpleResolver.js
+++ b/packages/cli/config/jestSimpleResolver.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { sync } = require('resolve');
+const { default: JestResolver } = require('jest-resolve');
+const { default: JestRuntime } = require('jest-runtime');
+
+// This implementation has some risky assumptions, such as:
+// * This is never called with any options that impact runtime
+// * This is never called with virtualMocks
+// * There's no FS shenanigans (symlinks, etc) that could cause
+//   the generated id to be inaccurate.
+class SimpleJestResolver extends JestResolver {
+  getModuleID(virtualMocks, from, moduleName, _options = undefined) {
+    return `${from}:${moduleName}`;
+  }
+}
+
+// Copied from Jest's "createResolver" code, so that we could still fill
+// the Resolver constructor accurately.
+const getModuleNameMapper = config => {
+  if (
+    Array.isArray(config.moduleNameMapper) &&
+    config.moduleNameMapper.length
+  ) {
+    return config.moduleNameMapper.map(([regex, moduleName]) => ({
+      moduleName,
+      regex: new RegExp(regex),
+    }));
+  }
+  return null;
+};
+
+// Hook into Jest (in a risky way!) so that our resolver is used for generating
+// module IDs.
+JestRuntime.createResolver = (config, moduleMap) => {
+  return new SimpleJestResolver(moduleMap, {
+    defaultPlatform: config.haste.defaultPlatform,
+    extensions: config.moduleFileExtensions.map(extension => `.${extension}`),
+    hasCoreModules: true,
+    moduleDirectories: config.moduleDirectories,
+    moduleNameMapper: getModuleNameMapper(config),
+    modulePaths: config.modulePaths,
+    platforms: config.haste.platforms,
+    resolver: config.resolver,
+    rootDir: config.rootDir,
+  });
+};
+
+module.exports = function moduleResolver(p, options) {
+  return sync(p, options);
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -161,7 +161,9 @@
     "type-fest": "^2.0.0"
   },
   "peerDependencies": {
-    "@microsoft/api-extractor": "^7.21.2"
+    "@microsoft/api-extractor": "^7.21.2",
+    "jest-resolve": "*",
+    "resolve": "1.*"
   },
   "peerDependenciesMeta": {
     "@microsoft/api-extractor": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,6 +3379,8 @@ __metadata:
     zod: ^3.11.6
   peerDependencies:
     "@microsoft/api-extractor": ^7.21.2
+    jest-resolve: "*"
+    resolve: 1.*
   peerDependenciesMeta:
     "@microsoft/api-extractor":
       optional: true


### PR DESCRIPTION
It needs to be injected into Jest twice (`resolver` config option *and* `createResolver()`) because we want to cover two cases:
1. Determining where a module is, and
2. Defining a module's ID.

Using the public Jest API, only the first is possible. So, injection is necessary.

This is able to make things faster in two ways:
1. In `getModuleID`, we no longer try to resolve symlinks and do any FS work. Instead, we try to generate a unique ID as simply as possible.
2. In `moduleResolver()`, we avoid some extra FS path-resolving work that Jest does, and instead just call `resolve.sync()`.

This is ~11% faster on my machine (704ms to 622ms) when re-running a watched test, but I'm not sure how stable it will be on CI. Let's find out!

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
