### PR TITLE
[Search] Customize <SearchResultGroup/> no results state

### DIFF
--- a/.changeset/search-dull-planes-prove.md
+++ b/.changeset/search-dull-planes-prove.md
@@ -1,0 +1,30 @@
+---
+'@backstage/plugin-search-react': minor
+---
+
+The `<SearchResultGroup />` component now accepts an optional property `disableRenderingWithNoResults` to disable rendering when no results are returned.
+Possibility to provide a custom no results component if needed through the `noResultsComponent` property.
+
+Examples:
+
+_Rendering a custom no results component_
+
+```jsx
+<SearchResultGroup
+  query={query}
+  icon={<DocsIcon />}
+  title="Documentation"
+  noResultsComponent={<ListItemText primary="No results were found" />}
+/>
+```
+
+_Disable rendering when there are no results_
+
+```jsx
+<SearchResultGroup
+  query={query}
+  icon={<DocsIcon />}
+  title="Documentation"
+  disableRenderingWithNoResults
+/>
+```

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -213,7 +213,9 @@ export type SearchFilterWrapperProps = SearchFilterComponentProps & {
 export const SearchResult: (props: SearchResultProps) => JSX.Element;
 
 // @public
-export const SearchResultApi: (props: SearchResultApiProps) => JSX.Element;
+export const SearchResultApi: (
+  props: SearchResultApiProps,
+) => JSX.Element | null;
 
 // @public
 export type SearchResultApiProps = SearchResultContextProps & {
@@ -226,11 +228,11 @@ export const SearchResultComponent: (props: SearchResultProps) => JSX.Element;
 // @public
 export const SearchResultContext: (
   props: SearchResultContextProps,
-) => JSX.Element;
+) => JSX.Element | null;
 
 // @public
 export type SearchResultContextProps = {
-  children: (state: AsyncState<SearchResultSet>) => JSX.Element;
+  children: (state: AsyncState<SearchResultSet>) => JSX.Element | null;
 };
 
 // @public
@@ -269,13 +271,22 @@ export type SearchResultGroupLayoutProps<FilterOption> = ListProps & {
   link?: ReactNode;
   linkProps?: Partial<LinkProps>;
   filterOptions?: FilterOption[];
-  renderFilterOption?: (filterOption: FilterOption) => JSX.Element;
+  renderFilterOption?: (
+    value: FilterOption,
+    index: number,
+    array: FilterOption[],
+  ) => JSX.Element | null;
   filterFields?: string[];
   renderFilterField?: (key: string) => JSX.Element | null;
   resultItems?: SearchResult_2[];
-  renderResultItem?: (resultItem: SearchResult_2) => JSX.Element;
+  renderResultItem?: (
+    value: SearchResult_2,
+    index: number,
+    array: SearchResult_2[],
+  ) => JSX.Element | null;
   error?: Error;
   loading?: boolean;
+  noResultsComponent?: ReactNode;
 };
 
 // @public
@@ -284,6 +295,7 @@ export type SearchResultGroupProps<FilterOption> = Omit<
   'loading' | 'error' | 'resultItems' | 'filterFields'
 > & {
   query: Partial<SearchQuery>;
+  disableRenderingWithNoResults?: boolean;
 };
 
 // @public

--- a/plugins/search-react/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.tsx
@@ -36,7 +36,7 @@ export type SearchResultContextProps = {
   /**
    * A child function that receives an asynchronous result set and returns a react element.
    */
-  children: (state: AsyncState<SearchResultSet>) => JSX.Element;
+  children: (state: AsyncState<SearchResultSet>) => JSX.Element | null;
 };
 
 /**

--- a/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.stories.tsx
+++ b/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.stories.tsx
@@ -269,7 +269,7 @@ export const WithFilters = () => {
   );
 };
 
-export const WithNoResults = () => {
+export const WithDefaultNoResultsComponent = () => {
   const [query] = useState<Partial<SearchQuery>>({
     types: ['techdocs'],
   });
@@ -280,6 +280,40 @@ export const WithNoResults = () => {
         query={query}
         icon={<DocsIcon />}
         title="Documentation"
+      />
+    </TestApiProvider>
+  );
+};
+
+export const WithCustomNoResultsComponent = () => {
+  const [query] = useState<Partial<SearchQuery>>({
+    types: ['techdocs'],
+  });
+
+  return (
+    <TestApiProvider apis={[[searchApiRef, new MockSearchApi()]]}>
+      <SearchResultGroup
+        query={query}
+        icon={<DocsIcon />}
+        title="Documentation"
+        noResultsComponent="No results were found"
+      />
+    </TestApiProvider>
+  );
+};
+
+export const DisableRenderingWithNoResults = () => {
+  const [query] = useState<Partial<SearchQuery>>({
+    types: ['techdocs'],
+  });
+
+  return (
+    <TestApiProvider apis={[[searchApiRef, new MockSearchApi()]]}>
+      <SearchResultGroup
+        query={query}
+        icon={<DocsIcon />}
+        title="Documentation"
+        disableRenderingWithNoResults
       />
     </TestApiProvider>
   );

--- a/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.stories.tsx
+++ b/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.stories.tsx
@@ -296,24 +296,7 @@ export const WithCustomNoResultsComponent = () => {
         query={query}
         icon={<DocsIcon />}
         title="Documentation"
-        noResultsComponent="No results were found"
-      />
-    </TestApiProvider>
-  );
-};
-
-export const DisableRenderingWithNoResults = () => {
-  const [query] = useState<Partial<SearchQuery>>({
-    types: ['techdocs'],
-  });
-
-  return (
-    <TestApiProvider apis={[[searchApiRef, new MockSearchApi()]]}>
-      <SearchResultGroup
-        query={query}
-        icon={<DocsIcon />}
-        title="Documentation"
-        disableRenderingWithNoResults
+        noResultsComponent={<ListItemText primary="No results were found" />}
       />
     </TestApiProvider>
   );

--- a/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.test.tsx
+++ b/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.test.tsx
@@ -291,6 +291,46 @@ describe('SearchResultGroup', () => {
     });
   });
 
+  it('Does not render result group if no results returned and disableRenderingWithNoResults prop is provided', async () => {
+    query.mockResolvedValueOnce({ results: [] });
+    await renderWithEffects(
+      wrapInTestApp(
+        <TestApiProvider apis={[[searchApiRef, searchApiMock]]}>
+          <SearchResultGroup
+            query={{ types: ['techdocs'] }}
+            icon={<DocsIcon titleAccess="Docs icon" />}
+            title="Documentation"
+            disableRenderingWithNoResults
+          />
+        </TestApiProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Documentation')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Should render custom component when no results returned', async () => {
+    query.mockResolvedValueOnce({ results: [] });
+    await renderWithEffects(
+      wrapInTestApp(
+        <TestApiProvider apis={[[searchApiRef, searchApiMock]]}>
+          <SearchResultGroup
+            query={{ types: ['techdocs'] }}
+            icon={<DocsIcon titleAccess="Docs icon" />}
+            title="Documentation"
+            noResultsComponent="No results were found"
+          />
+        </TestApiProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No results were found')).toBeInTheDocument();
+    });
+  });
+
   it('Shows an error panel when results rendering fails', async () => {
     query.mockRejectedValueOnce(new Error());
     await renderWithEffects(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `<SearchResultGroup />` component now accepts an optional property `disableRenderingWithNoResults` to disable rendering when no results are returned. Possibility to provide a custom no results component if needed through the `noResultsComponent` property.

Examples:

_Rendering a custom no results component_

```jsx
<SearchResultGroup
  query={query}
  icon={<DocsIcon />}
  title="Documentation"
  noResultsComponent={<ListItemText primary="No results were found" />}
/>
```

_Disable rendering when there are no results_

```jsx
<SearchResultGroup
  query={query}
  icon={<DocsIcon />}
  title="Documentation"
  disableRenderingWithNoResults
/>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
