### PR TITLE
Document `host` attribute for github catalog provider

### DIFF
--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -96,6 +96,10 @@ catalog:
           topic:
             include: ['backstage-include'] # optional array of strings
             exclude: ['experiments'] # optional array of strings
+      enterpriseProviderId:
+        host: ghe.example.net
+        organization: 'backstage' # string
+        catalogPath: '/catalog-info.yaml' # string
 ```
 
 This provider supports multiple organizations via unique provider IDs.
@@ -125,6 +129,8 @@ This provider supports multiple organizations via unique provider IDs.
 - **organization**:
   Name of your organization account/workspace.
   If you want to add multiple organizations, you need to add one provider config each.
+- **host** _(optional)_:
+  The hostname of your GitHub Enterprise instance. It must match a host defined in [integrations.github](locations.md).
 
 ## GitHub API Rate Limits
 


### PR DESCRIPTION
This was added in https://github.com/backstage/backstage/pull/13400 but isn't documented yet.

#### :heavy_check_mark: Checklist

- [ ] **N/A** A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] **N/A** Tests for new functionality and regression tests for bug fixes
- [ ] **N/A** Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
