### PR TITLE
[K8s plugin] Handle the error when fetching pod metrics

### DIFF
--- a/.changeset/wet-cameras-call.md
+++ b/.changeset/wet-cameras-call.md
@@ -1,8 +1,10 @@
 ---
 '@backstage/plugin-kubernetes-backend': minor
-'@backstage/plugin-kubernetes-common': minor
+'@backstage/plugin-kubernetes-common': patch
 ---
 
 The Kubernetes errors when fetching pod metrics are now captured and returned to the frontend.
 
-Include the `PodStatusFetchResponse` into the `FetchResponse` union type. Now the method `fetchPodMetricsByNamespaces` accepts a set of namespaces and returns a `FetchResponseWrapper`, just like other public fetch methods in the fetcher.
+- **BREAKING** The method `fetchPodMetricsByNamespace` in the interface `KubernetesFetcher` is changed to `fetchPodMetricsByNamespaces`. It now accepts a set of namespace strings and returns `Promise<FetchResponseWrapper>`.
+- Add the `PodStatusFetchResponse` to the `FetchResponse` union type.
+- Add `NOT_FOUND` to the `KubernetesErrorTypes` union type, the HTTP error with status code 404 will be mapped to this error.

--- a/.changeset/wet-cameras-call.md
+++ b/.changeset/wet-cameras-call.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-common': minor
+---
+
+The Kubernetes errors when fetching pod metrics are now captured and returned to the frontend.
+
+Include the `PodStatusFetchResponse` into the `FetchResponse` union type. Now the method `fetchPodMetricsByNamespaces` accepts a set of namespaces and returns a `FetchResponseWrapper`, just like other public fetch methods in the fetcher.

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -22,7 +22,6 @@ import { Logger } from 'winston';
 import { Metrics } from '@kubernetes/client-node';
 import type { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
-import { PodStatus } from '@kubernetes/client-node/dist/top';
 import { TokenCredential } from '@azure/identity';
 
 // @alpha (undocumented)
@@ -267,10 +266,10 @@ export interface KubernetesFetcher {
     params: ObjectFetchParams,
   ): Promise<FetchResponseWrapper>;
   // (undocumented)
-  fetchPodMetricsByNamespace(
+  fetchPodMetricsByNamespaces(
     clusterDetails: ClusterDetails,
-    namespace: string,
-  ): Promise<PodStatus[]>;
+    namespaces: Set<string>,
+  ): Promise<FetchResponseWrapper>;
 }
 
 // @alpha (undocumented)

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -30,7 +30,6 @@ import {
 } from '../types/types';
 import { KubernetesBuilder } from './KubernetesBuilder';
 import { KubernetesFanOutHandler } from './KubernetesFanOutHandler';
-import { PodStatus } from '@kubernetes/client-node';
 import { CatalogApi } from '@backstage/catalog-client';
 
 describe('KubernetesBuilder', () => {
@@ -222,11 +221,11 @@ describe('KubernetesBuilder', () => {
       };
 
       const fetcher: KubernetesFetcher = {
-        fetchPodMetricsByNamespace(
+        fetchPodMetricsByNamespaces(
           _clusterDetails: ClusterDetails,
-          _namespace: string,
-        ): Promise<PodStatus[]> {
-          return Promise.resolve([]);
+          _namespaces: Set<string>,
+        ): Promise<FetchResponseWrapper> {
+          return Promise.resolve({ errors: [], responses: [] });
         },
         fetchObjectsForService(
           _params: ObjectFetchParams,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -40,6 +40,7 @@ import {
   PodFetchResponse,
   KubernetesRequestAuth,
   CustomResourceMatcher,
+  PodStatusFetchResponse,
 } from '@backstage/plugin-kubernetes-common';
 import {
   ContainerStatus,
@@ -162,19 +163,22 @@ const toClientSafeContainer = (
 };
 
 const toClientSafePodMetrics = (
-  podMetrics: PodStatus[][],
+  podMetrics: PodStatusFetchResponse[],
 ): ClientPodStatus[] => {
-  return podMetrics.flat().map((pd: PodStatus): ClientPodStatus => {
-    return {
-      pod: pd.Pod,
-      memory: toClientSafeResource(pd.Memory),
-      cpu: toClientSafeResource(pd.CPU),
-      containers: pd.Containers.map(toClientSafeContainer),
-    };
-  });
+  return podMetrics
+    .map(r => r.resources)
+    .flat()
+    .map((pd: PodStatus): ClientPodStatus => {
+      return {
+        pod: pd.Pod,
+        memory: toClientSafeResource(pd.Memory),
+        cpu: toClientSafeResource(pd.CPU),
+        containers: pd.Containers.map(toClientSafeContainer),
+      };
+    });
 };
 
-type responseWithMetrics = [FetchResponseWrapper, PodStatus[][]];
+type responseWithMetrics = [FetchResponseWrapper, PodStatusFetchResponse[]];
 
 export class KubernetesFanOutHandler {
   private readonly logger: Logger;
@@ -345,11 +349,17 @@ export class KubernetesFanOutHandler {
         .filter(isString),
     );
 
-    const podMetrics = Array.from(namespaces).map(ns =>
-      this.fetcher.fetchPodMetricsByNamespace(clusterDetails, ns),
+    if (namespaces.size === 0) {
+      return [result, []];
+    }
+
+    const podMetrics = await this.fetcher.fetchPodMetricsByNamespaces(
+      clusterDetails,
+      namespaces,
     );
 
-    return Promise.all([result, Promise.all(podMetrics)]);
+    result.errors.concat(podMetrics.errors);
+    return [result, podMetrics.responses as PodStatusFetchResponse[]];
   }
 
   private getAuthTranslator(provider: string): KubernetesAuthTranslator {

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -358,7 +358,7 @@ export class KubernetesFanOutHandler {
       namespaces,
     );
 
-    result.errors.concat(podMetrics.errors);
+    result.errors.push(...podMetrics.errors);
     return [result, podMetrics.responses as PodStatusFetchResponse[]];
   }
 

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -17,6 +17,12 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 import { ObjectToFetch } from '../types/types';
+import { topPods } from '@kubernetes/client-node';
+
+jest.mock('@kubernetes/client-node', () => ({
+  ...jest.requireActual('@kubernetes/client-node'),
+  topPods: jest.fn(),
+}));
 
 const OBJECTS_TO_FETCH = new Set<ObjectToFetch>([
   {
@@ -33,63 +39,52 @@ const OBJECTS_TO_FETCH = new Set<ObjectToFetch>([
   },
 ]);
 
+const POD_METRICS_FIXTURE = {
+  containers: [],
+  cpu: {
+    currentUsage: 100,
+    limitTotal: 102,
+    requestTotal: 101,
+  },
+  memory: {
+    currentUsage: '1000',
+    limitTotal: '1002',
+    requestTotal: '1001',
+  },
+  pod: {},
+};
+
 describe('KubernetesFetcher', () => {
-  let clientMock: any;
-  let kubernetesClientProvider: any;
-  let sut: KubernetesClientBasedFetcher;
+  describe('fetchObjectsForService', () => {
+    let clientMock: any;
+    let kubernetesClientProvider: any;
+    let sut: KubernetesClientBasedFetcher;
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-    clientMock = {
-      listClusterCustomObject: jest.fn(),
-      listNamespacedCustomObject: jest.fn(),
-      addInterceptor: jest.fn(),
-    };
+    beforeEach(() => {
+      jest.resetAllMocks();
+      clientMock = {
+        listClusterCustomObject: jest.fn(),
+        listNamespacedCustomObject: jest.fn(),
+        addInterceptor: jest.fn(),
+      };
 
-    kubernetesClientProvider = {
-      getCustomObjectsClient: jest.fn(() => clientMock),
-    };
+      kubernetesClientProvider = {
+        getCustomObjectsClient: jest.fn(() => clientMock),
+      };
 
-    sut = new KubernetesClientBasedFetcher({
-      kubernetesClientProvider,
-      logger: getVoidLogger(),
-    });
-  });
-
-  const testErrorResponse = async (errorResponse: any, expectedResult: any) => {
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
-          {
-            metadata: {
-              name: 'pod-name',
-            },
-          },
-        ],
-      },
+      sut = new KubernetesClientBasedFetcher({
+        kubernetesClientProvider,
+        logger: getVoidLogger(),
+      });
     });
 
-    clientMock.listClusterCustomObject.mockRejectedValue(errorResponse);
-
-    const result = await sut.fetchObjectsForService({
-      serviceId: 'some-service',
-      clusterDetails: {
-        name: 'cluster1',
-        url: 'http://localhost:9999',
-        serviceAccountToken: 'token',
-        authProvider: 'serviceAccount',
-      },
-      objectTypesToFetch: OBJECTS_TO_FETCH,
-      labelSelector: '',
-      customResources: [],
-    });
-
-    expect(result).toStrictEqual({
-      errors: [expectedResult],
-      responses: [
-        {
-          type: 'pods',
-          resources: [
+    const testErrorResponse = async (
+      errorResponse: any,
+      expectedResult: any,
+    ) => {
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
             {
               metadata: {
                 name: 'pod-name',
@@ -97,82 +92,72 @@ describe('KubernetesFetcher', () => {
             },
           ],
         },
-      ],
-    });
+      });
 
-    expect(clientMock.listClusterCustomObject.mock.calls.length).toBe(2);
+      clientMock.listClusterCustomObject.mockRejectedValue(errorResponse);
 
-    expect(clientMock.listClusterCustomObject.mock.calls[0]).toEqual([
-      '',
-      'v1',
-      'pods',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
+      const result = await sut.fetchObjectsForService({
+        serviceId: 'some-service',
+        clusterDetails: {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
+        },
+        objectTypesToFetch: OBJECTS_TO_FETCH,
+        labelSelector: '',
+        customResources: [],
+      });
 
-    expect(clientMock.listClusterCustomObject.mock.calls[1]).toEqual([
-      '',
-      'v1',
-      'services',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
-
-    expect(
-      kubernetesClientProvider.getCustomObjectsClient.mock.calls.length,
-    ).toBe(2);
-  };
-
-  it('should return pods, services', async () => {
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
+      expect(result).toStrictEqual({
+        errors: [expectedResult],
+        responses: [
           {
-            metadata: {
-              name: 'pod-name',
-            },
+            type: 'pods',
+            resources: [
+              {
+                metadata: {
+                  name: 'pod-name',
+                },
+              },
+            ],
           },
         ],
-      },
-    });
+      });
 
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
-          {
-            metadata: {
-              name: 'service-name',
-            },
-          },
-        ],
-      },
-    });
+      expect(clientMock.listClusterCustomObject.mock.calls.length).toBe(2);
 
-    const result = await sut.fetchObjectsForService({
-      serviceId: 'some-service',
-      clusterDetails: {
-        name: 'cluster1',
-        url: 'http://localhost:9999',
-        serviceAccountToken: 'token',
-        authProvider: 'serviceAccount',
-      },
-      objectTypesToFetch: OBJECTS_TO_FETCH,
-      labelSelector: '',
-      customResources: [],
-    });
+      expect(clientMock.listClusterCustomObject.mock.calls[0]).toEqual([
+        '',
+        'v1',
+        'pods',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
 
-    expect(result).toStrictEqual({
-      errors: [],
-      responses: [
-        {
-          type: 'pods',
-          resources: [
+      expect(clientMock.listClusterCustomObject.mock.calls[1]).toEqual([
+        '',
+        'v1',
+        'services',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
+
+      expect(
+        kubernetesClientProvider.getCustomObjectsClient.mock.calls.length,
+      ).toBe(2);
+    };
+
+    it('should return pods, services', async () => {
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
             {
               metadata: {
                 name: 'pod-name',
@@ -180,9 +165,11 @@ describe('KubernetesFetcher', () => {
             },
           ],
         },
-        {
-          type: 'services',
-          resources: [
+      });
+
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
             {
               metadata: {
                 name: 'service-name',
@@ -190,100 +177,79 @@ describe('KubernetesFetcher', () => {
             },
           ],
         },
-      ],
-    });
+      });
 
-    expect(clientMock.listClusterCustomObject.mock.calls.length).toBe(2);
-
-    expect(clientMock.listClusterCustomObject.mock.calls[0]).toEqual([
-      '',
-      'v1',
-      'pods',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
-
-    expect(clientMock.listClusterCustomObject.mock.calls[1]).toEqual([
-      '',
-      'v1',
-      'services',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
-
-    expect(
-      kubernetesClientProvider.getCustomObjectsClient.mock.calls.length,
-    ).toBe(2);
-  });
-  it('should return pods, services and customobjects', async () => {
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
-          {
-            metadata: {
-              name: 'pod-name',
-            },
-          },
-        ],
-      },
-    });
-
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
-          {
-            metadata: {
-              name: 'service-name',
-            },
-          },
-        ],
-      },
-    });
-
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
-          {
-            metadata: {
-              name: 'something-else',
-            },
-          },
-        ],
-      },
-    });
-
-    const result = await sut.fetchObjectsForService({
-      serviceId: 'some-service',
-      clusterDetails: {
-        name: 'cluster1',
-        url: 'http://localhost:9999',
-        serviceAccountToken: 'token',
-        authProvider: 'serviceAccount',
-      },
-      objectTypesToFetch: OBJECTS_TO_FETCH,
-      labelSelector: '',
-      customResources: [
-        {
-          objectType: 'customresources',
-          group: 'some-group',
-          apiVersion: 'v2',
-          plural: 'things',
+      const result = await sut.fetchObjectsForService({
+        serviceId: 'some-service',
+        clusterDetails: {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
         },
-      ],
-    });
+        objectTypesToFetch: OBJECTS_TO_FETCH,
+        labelSelector: '',
+        customResources: [],
+      });
 
-    expect(result).toStrictEqual({
-      errors: [],
-      responses: [
-        {
-          type: 'pods',
-          resources: [
+      expect(result).toStrictEqual({
+        errors: [],
+        responses: [
+          {
+            type: 'pods',
+            resources: [
+              {
+                metadata: {
+                  name: 'pod-name',
+                },
+              },
+            ],
+          },
+          {
+            type: 'services',
+            resources: [
+              {
+                metadata: {
+                  name: 'service-name',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(clientMock.listClusterCustomObject.mock.calls.length).toBe(2);
+
+      expect(clientMock.listClusterCustomObject.mock.calls[0]).toEqual([
+        '',
+        'v1',
+        'pods',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
+
+      expect(clientMock.listClusterCustomObject.mock.calls[1]).toEqual([
+        '',
+        'v1',
+        'services',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
+
+      expect(
+        kubernetesClientProvider.getCustomObjectsClient.mock.calls.length,
+      ).toBe(2);
+    });
+    it('should return pods, services and customobjects', async () => {
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
             {
               metadata: {
                 name: 'pod-name',
@@ -291,9 +257,11 @@ describe('KubernetesFetcher', () => {
             },
           ],
         },
-        {
-          type: 'services',
-          resources: [
+      });
+
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
             {
               metadata: {
                 name: 'service-name',
@@ -301,9 +269,11 @@ describe('KubernetesFetcher', () => {
             },
           ],
         },
-        {
-          type: 'customresources',
-          resources: [
+      });
+
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
             {
               metadata: {
                 name: 'something-else',
@@ -311,216 +281,358 @@ describe('KubernetesFetcher', () => {
             },
           ],
         },
-      ],
+      });
+
+      const result = await sut.fetchObjectsForService({
+        serviceId: 'some-service',
+        clusterDetails: {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
+        },
+        objectTypesToFetch: OBJECTS_TO_FETCH,
+        labelSelector: '',
+        customResources: [
+          {
+            objectType: 'customresources',
+            group: 'some-group',
+            apiVersion: 'v2',
+            plural: 'things',
+          },
+        ],
+      });
+
+      expect(result).toStrictEqual({
+        errors: [],
+        responses: [
+          {
+            type: 'pods',
+            resources: [
+              {
+                metadata: {
+                  name: 'pod-name',
+                },
+              },
+            ],
+          },
+          {
+            type: 'services',
+            resources: [
+              {
+                metadata: {
+                  name: 'service-name',
+                },
+              },
+            ],
+          },
+          {
+            type: 'customresources',
+            resources: [
+              {
+                metadata: {
+                  name: 'something-else',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(clientMock.listClusterCustomObject.mock.calls.length).toBe(3);
+
+      expect(clientMock.listClusterCustomObject.mock.calls[0]).toEqual([
+        '',
+        'v1',
+        'pods',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
+
+      expect(clientMock.listClusterCustomObject.mock.calls[1]).toEqual([
+        '',
+        'v1',
+        'services',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
+
+      expect(clientMock.listClusterCustomObject.mock.calls[2]).toEqual([
+        'some-group',
+        'v2',
+        'things',
+        '',
+        false,
+        '',
+        '',
+        'backstage.io/kubernetes-id=some-service',
+      ]);
+
+      expect(
+        kubernetesClientProvider.getCustomObjectsClient.mock.calls.length,
+      ).toBe(3);
     });
-
-    expect(clientMock.listClusterCustomObject.mock.calls.length).toBe(3);
-
-    expect(clientMock.listClusterCustomObject.mock.calls[0]).toEqual([
-      '',
-      'v1',
-      'pods',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
-
-    expect(clientMock.listClusterCustomObject.mock.calls[1]).toEqual([
-      '',
-      'v1',
-      'services',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
-
-    expect(clientMock.listClusterCustomObject.mock.calls[2]).toEqual([
-      'some-group',
-      'v2',
-      'things',
-      '',
-      false,
-      '',
-      '',
-      'backstage.io/kubernetes-id=some-service',
-    ]);
-
-    expect(
-      kubernetesClientProvider.getCustomObjectsClient.mock.calls.length,
-    ).toBe(3);
-  });
-  // they're in testErrorResponse
-  // eslint-disable-next-line jest/expect-expect
-  it('should return pods, bad request error', async () => {
-    await testErrorResponse(
-      {
-        response: {
+    // they're in testErrorResponse
+    // eslint-disable-next-line jest/expect-expect
+    it('should return pods, bad request error', async () => {
+      await testErrorResponse(
+        {
+          response: {
+            statusCode: 400,
+            request: {
+              uri: {
+                pathname: '/some/path',
+              },
+            },
+          },
+        },
+        {
+          errorType: 'BAD_REQUEST',
+          resourcePath: '/some/path',
           statusCode: 400,
-          request: {
-            uri: {
-              pathname: '/some/path',
+        },
+      );
+    });
+    // they're in testErrorResponse
+    // eslint-disable-next-line jest/expect-expect
+    it('should return pods, unauthorized error', async () => {
+      await testErrorResponse(
+        {
+          response: {
+            statusCode: 401,
+            request: {
+              uri: {
+                pathname: '/some/path',
+              },
             },
           },
         },
-      },
-      {
-        errorType: 'BAD_REQUEST',
-        resourcePath: '/some/path',
-        statusCode: 400,
-      },
-    );
-  });
-  // they're in testErrorResponse
-  // eslint-disable-next-line jest/expect-expect
-  it('should return pods, unauthorized error', async () => {
-    await testErrorResponse(
-      {
-        response: {
+        {
+          errorType: 'UNAUTHORIZED_ERROR',
+          resourcePath: '/some/path',
           statusCode: 401,
-          request: {
-            uri: {
-              pathname: '/some/path',
+        },
+      );
+    });
+    // they're in testErrorResponse
+    // eslint-disable-next-line jest/expect-expect
+    it('should return pods, system error', async () => {
+      await testErrorResponse(
+        {
+          response: {
+            statusCode: 500,
+            request: {
+              uri: {
+                pathname: '/some/path',
+              },
             },
           },
         },
-      },
-      {
-        errorType: 'UNAUTHORIZED_ERROR',
-        resourcePath: '/some/path',
-        statusCode: 401,
-      },
-    );
-  });
-  // they're in testErrorResponse
-  // eslint-disable-next-line jest/expect-expect
-  it('should return pods, system error', async () => {
-    await testErrorResponse(
-      {
-        response: {
+        {
+          errorType: 'SYSTEM_ERROR',
+          resourcePath: '/some/path',
           statusCode: 500,
-          request: {
-            uri: {
-              pathname: '/some/path',
+        },
+      );
+    });
+    // they're in testErrorResponse
+    // eslint-disable-next-line jest/expect-expect
+    it('should return pods, unknown error', async () => {
+      await testErrorResponse(
+        {
+          response: {
+            statusCode: 900,
+            request: {
+              uri: {
+                pathname: '/some/path',
+              },
             },
           },
         },
-      },
-      {
-        errorType: 'SYSTEM_ERROR',
-        resourcePath: '/some/path',
-        statusCode: 500,
-      },
-    );
-  });
-  // they're in testErrorResponse
-  // eslint-disable-next-line jest/expect-expect
-  it('should return pods, unknown error', async () => {
-    await testErrorResponse(
-      {
-        response: {
+        {
+          errorType: 'UNKNOWN_ERROR',
+          resourcePath: '/some/path',
           statusCode: 900,
-          request: {
-            uri: {
-              pathname: '/some/path',
-            },
-          },
         },
-      },
-      {
-        errorType: 'UNKNOWN_ERROR',
-        resourcePath: '/some/path',
-        statusCode: 900,
-      },
-    );
+      );
+    });
+    it('should always add a labelSelector query', async () => {
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
+            {
+              metadata: {
+                name: 'pod-name',
+              },
+            },
+          ],
+        },
+      });
+
+      clientMock.listClusterCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
+            {
+              metadata: {
+                name: 'service-name',
+              },
+            },
+          ],
+        },
+      });
+
+      await sut.fetchObjectsForService({
+        serviceId: 'some-service',
+        clusterDetails: {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
+        },
+        objectTypesToFetch: OBJECTS_TO_FETCH,
+        labelSelector: '',
+        customResources: [],
+      });
+
+      const mockCall = clientMock.listClusterCustomObject.mock.calls[0];
+      const actualSelector = mockCall[mockCall.length - 1];
+      const expectedSelector = 'backstage.io/kubernetes-id=some-service';
+      expect(actualSelector).toBe(expectedSelector);
+    });
+    it('should use namespace if provided', async () => {
+      clientMock.listNamespacedCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
+            {
+              metadata: {
+                name: 'pod-name',
+              },
+            },
+          ],
+        },
+      });
+
+      clientMock.listNamespacedCustomObject.mockResolvedValueOnce({
+        body: {
+          items: [
+            {
+              metadata: {
+                name: 'service-name',
+              },
+            },
+          ],
+        },
+      });
+
+      await sut.fetchObjectsForService({
+        serviceId: 'some-service',
+        clusterDetails: {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
+        },
+        objectTypesToFetch: OBJECTS_TO_FETCH,
+        labelSelector: '',
+        namespace: 'some-namespace',
+        customResources: [],
+      });
+
+      const mockCall = clientMock.listNamespacedCustomObject.mock.calls[0];
+      const namespace = mockCall[2];
+      expect(namespace).toBe('some-namespace');
+    });
   });
-  it('should always add a labelSelector query', async () => {
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
+
+  describe('fetchPodMetricsByNamespaces', () => {
+    let kubernetesClientProvider: any;
+    let sut: KubernetesClientBasedFetcher;
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      kubernetesClientProvider = {
+        getMetricsClient: jest.fn(),
+        getCoreClientByClusterDetails: jest.fn(),
+      };
+
+      sut = new KubernetesClientBasedFetcher({
+        kubernetesClientProvider,
+        logger: getVoidLogger(),
+      });
+    });
+
+    it('should return pod metrics', async () => {
+      (topPods as jest.Mock).mockResolvedValue(POD_METRICS_FIXTURE);
+
+      const result = await sut.fetchPodMetricsByNamespaces(
+        {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
+        },
+        new Set(['ns-a', 'ns-b']),
+      );
+      expect(result).toStrictEqual({
+        errors: [],
+        responses: [
           {
-            metadata: {
-              name: 'pod-name',
-            },
+            type: 'podstatus',
+            resources: POD_METRICS_FIXTURE,
+          },
+          {
+            type: 'podstatus',
+            resources: POD_METRICS_FIXTURE,
           },
         ],
-      },
+      });
     });
-
-    clientMock.listClusterCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
-          {
-            metadata: {
-              name: 'service-name',
+    it('should return pod metrics and error', async () => {
+      const topPodsMock = topPods as jest.Mock;
+      topPodsMock
+        .mockResolvedValueOnce(POD_METRICS_FIXTURE)
+        .mockRejectedValueOnce({
+          response: {
+            statusCode: 404,
+            request: {
+              uri: {
+                pathname: '/some/path',
+              },
             },
           },
-        ],
-      },
-    });
+        });
 
-    await sut.fetchObjectsForService({
-      serviceId: 'some-service',
-      clusterDetails: {
-        name: 'cluster1',
-        url: 'http://localhost:9999',
-        serviceAccountToken: 'token',
-        authProvider: 'serviceAccount',
-      },
-      objectTypesToFetch: OBJECTS_TO_FETCH,
-      labelSelector: '',
-      customResources: [],
-    });
-
-    const mockCall = clientMock.listClusterCustomObject.mock.calls[0];
-    const actualSelector = mockCall[mockCall.length - 1];
-    const expectedSelector = 'backstage.io/kubernetes-id=some-service';
-    expect(actualSelector).toBe(expectedSelector);
-  });
-  it('should use namespace if provided', async () => {
-    clientMock.listNamespacedCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
+      const result = await sut.fetchPodMetricsByNamespaces(
+        {
+          name: 'cluster1',
+          url: 'http://localhost:9999',
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
+        },
+        new Set(['ns-a', 'ns-b']),
+      );
+      expect(result).toStrictEqual({
+        errors: [
           {
-            metadata: {
-              name: 'pod-name',
-            },
+            errorType: 'NOT_FOUND',
+            resourcePath: '/some/path',
+            statusCode: 404,
           },
         ],
-      },
-    });
-
-    clientMock.listNamespacedCustomObject.mockResolvedValueOnce({
-      body: {
-        items: [
+        responses: [
           {
-            metadata: {
-              name: 'service-name',
-            },
+            type: 'podstatus',
+            resources: POD_METRICS_FIXTURE,
           },
         ],
-      },
+      });
     });
-
-    await sut.fetchObjectsForService({
-      serviceId: 'some-service',
-      clusterDetails: {
-        name: 'cluster1',
-        url: 'http://localhost:9999',
-        serviceAccountToken: 'token',
-        authProvider: 'serviceAccount',
-      },
-      objectTypesToFetch: OBJECTS_TO_FETCH,
-      labelSelector: '',
-      namespace: 'some-namespace',
-      customResources: [],
-    });
-
-    const mockCall = clientMock.listNamespacedCustomObject.mock.calls[0];
-    const namespace = mockCall[2];
-    expect(namespace).toBe('some-namespace');
   });
 });

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CoreV1Api, topPods } from '@kubernetes/client-node';
+import { topPods } from '@kubernetes/client-node';
 import lodash, { Dictionary } from 'lodash';
 import { Logger } from 'winston';
 import {
@@ -32,10 +32,6 @@ import {
   PodStatusFetchResponse,
 } from '@backstage/plugin-kubernetes-common';
 import { KubernetesClientProvider } from './KubernetesClientProvider';
-
-export interface Clients {
-  core: CoreV1Api;
-}
 
 export interface KubernetesClientBasedFetcherOptions {
   kubernetesClientProvider: KubernetesClientProvider;
@@ -66,6 +62,8 @@ const statusCodeToErrorType = (statusCode: number): KubernetesErrorTypes => {
       return 'BAD_REQUEST';
     case 401:
       return 'UNAUTHORIZED_ERROR';
+    case 404:
+      return 'NOT_FOUND';
     case 500:
       return 'SYSTEM_ERROR';
     default:

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -25,7 +25,6 @@ import type {
   KubernetesRequestBody,
   ObjectsByEntityResponse,
 } from '@backstage/plugin-kubernetes-common';
-import { PodStatus } from '@kubernetes/client-node/dist/top';
 
 /**
  *
@@ -53,10 +52,10 @@ export interface KubernetesFetcher {
   fetchObjectsForService(
     params: ObjectFetchParams,
   ): Promise<FetchResponseWrapper>;
-  fetchPodMetricsByNamespace(
+  fetchPodMetricsByNamespaces(
     clusterDetails: ClusterDetails,
-    namespace: string,
-  ): Promise<PodStatus[]>;
+    namespaces: Set<string>,
+  ): Promise<FetchResponseWrapper>;
 }
 
 /**

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { Entity } from '@backstage/catalog-model';
 import type { JsonObject } from '@backstage/types';
+import { PodStatus } from '@kubernetes/client-node';
 import { V1ConfigMap } from '@kubernetes/client-node';
 import { V1CronJob } from '@kubernetes/client-node';
 import { V1DaemonSet } from '@kubernetes/client-node';
@@ -147,7 +148,8 @@ export type FetchResponse =
   | IngressesFetchResponse
   | CustomResourceFetchResponse
   | StatefulSetsFetchResponse
-  | DaemonSetsFetchResponse;
+  | DaemonSetsFetchResponse
+  | PodStatusFetchResponse;
 
 // @public (undocumented)
 export interface HorizontalPodAutoscalersFetchResponse {
@@ -228,6 +230,14 @@ export interface PodFetchResponse {
   resources: Array<V1Pod>;
   // (undocumented)
   type: 'pods';
+}
+
+// @public (undocumented)
+export interface PodStatusFetchResponse {
+  // (undocumented)
+  resources: Array<PodStatus>;
+  // (undocumented)
+  type: 'podstatus';
 }
 
 // @public (undocumented)

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -179,6 +179,7 @@ export interface JobsFetchResponse {
 export type KubernetesErrorTypes =
   | 'BAD_REQUEST'
   | 'UNAUTHORIZED_ERROR'
+  | 'NOT_FOUND'
   | 'SYSTEM_ERROR'
   | 'UNKNOWN_ERROR';
 

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -16,6 +16,7 @@
 
 import type { JsonObject } from '@backstage/types';
 import {
+  PodStatus,
   V1ConfigMap,
   V1CronJob,
   V1DaemonSet,
@@ -134,7 +135,8 @@ export type FetchResponse =
   | IngressesFetchResponse
   | CustomResourceFetchResponse
   | StatefulSetsFetchResponse
-  | DaemonSetsFetchResponse;
+  | DaemonSetsFetchResponse
+  | PodStatusFetchResponse;
 
 /** @public */
 export interface PodFetchResponse {
@@ -212,6 +214,12 @@ export interface StatefulSetsFetchResponse {
 export interface DaemonSetsFetchResponse {
   type: 'daemonsets';
   resources: Array<V1DaemonSet>;
+}
+
+/** @public */
+export interface PodStatusFetchResponse {
+  type: 'podstatus';
+  resources: Array<PodStatus>;
 }
 
 /** @public */

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -233,6 +233,7 @@ export interface KubernetesFetchError {
 export type KubernetesErrorTypes =
   | 'BAD_REQUEST'
   | 'UNAUTHORIZED_ERROR'
+  | 'NOT_FOUND'
   | 'SYSTEM_ERROR'
   | 'UNKNOWN_ERROR';
 


### PR DESCRIPTION
Related to https://github.com/backstage/backstage/issues/13794.

The Kubernetes errors when fetching pod metrics are now captured and returned to the frontend.

Include the `PodStatus` into the `FetchResponse` union type. Now the method `fetchPodMetricsByNamespaces` accepts a set of namespaces and returns a `FetchResponseWrapper`, which is consistent with other public fetch methods.

Signed-off-by: Mengnan Gong <namco1992@gmail.com>

## Hey, I just made a Pull Request!

Currently, the whole endpoint for getting resources fails when it fails to fetch pod metrics, with just an error message "HTTP request failed" which doesn't help much.

Since the `fetchObjectsForService` in the fetcher already has a proper error handling mechanism, I think it's good to unify the fetch methods to have a consistent error handling and return type.

The appearance of the error is similar to https://github.com/backstage/backstage/issues/13794, but it's a different cause and the change in this PR is relatively isolated from what might be changed in #13794, so I decided to open a new PR. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
