### PR TITLE
ci: skip publishing upgrade-helper diff for next releases

### DIFF
--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -53,6 +53,10 @@ jobs:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           # TODO(Rugvip): Remove the create-app dispatch once we've been on the release version for a while
           script: |
+            const releaseVersion = require('./backstage/package.json').version;
+            if(releaseVersion.includes('next')) {
+              return;
+            }
             console.log('Dispatching upgrade helper sync');
             await github.rest.actions.createWorkflowDispatch({
               owner: 'backstage',
@@ -61,6 +65,6 @@ jobs:
               ref: 'master',
               inputs: {
                 version: require('./backstage/packages/create-app/package.json').version,
-                releaseVersion: require('./backstage/package.json').version
+                releaseVersion
               },
             });


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <vincenzos@spotify.com>

## Hey, I just made a Pull Request!

This PR stops `next` releases diffs from being published in https://backstage.github.io/upgrade-helper

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
