### PR TITLE
doc: fix incorrect example in elasticsearch search engine

### DIFF
--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -101,7 +101,7 @@ Similarly to Lunr above, ElasticSearch can be set up like this:
 
 ```typescript
 // app/backend/src/plugins/search.ts
-const searchEngine = await ElasticSearchSearchEngine.initialize({
+const searchEngine = await ElasticSearchSearchEngine.fromConfig({
   logger: env.logger,
   config: env.config,
 });


### PR DESCRIPTION
Signed-off-by: Mehmet Mallı <mehmet.malli@trendyol.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I fixed the incorrect example in Backstage documentation site for using Elasticsearch as search engine.

Fixes https://github.com/backstage/backstage/issues/13983
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->


- [X] Added or updated documentation
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
