### PR TITLE
fix: [#13560] Pull commit hash for branch names by branch query

### DIFF
--- a/.changeset/great-numbers-reply.md
+++ b/.changeset/great-numbers-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix BitBucket server integration

--- a/packages/backend-common/src/reading/BitbucketServerUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketServerUrlReader.test.ts
@@ -83,11 +83,23 @@ describe('BitbucketServerUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/commits/*',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches',
           (_, res, ctx) =>
             res(
               ctx.status(200),
-              ctx.json({ id: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st' }),
+              ctx.json({
+                size: 2,
+                values: [
+                  {
+                    displayId: 'some-branch-that-should-be-ignored',
+                    latestCommit: 'bogus hash',
+                  },
+                  {
+                    displayId: 'some-branch',
+                    latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+                  },
+                ],
+              }),
             ),
         ),
       );
@@ -130,12 +142,22 @@ describe('BitbucketServerUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/commits/*',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches',
           (_, res, ctx) =>
             res(
               ctx.status(200),
               ctx.json({
-                values: [{ id: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st' }],
+                size: 2,
+                values: [
+                  {
+                    displayId: 'some-branch-that-should-be-ignored',
+                    latestCommit: 'bogus hash',
+                  },
+                  {
+                    displayId: 'some-branch',
+                    latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+                  },
+                ],
               }),
             ),
         ),
@@ -179,11 +201,23 @@ describe('BitbucketServerUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/commits/*',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches',
           (_, res, ctx) =>
             res(
               ctx.status(200),
-              ctx.json({ id: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st' }),
+              ctx.json({
+                size: 2,
+                values: [
+                  {
+                    displayId: 'master-of-none',
+                    latestCommit: 'bogus hash',
+                  },
+                  {
+                    displayId: 'master',
+                    latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+                  },
+                ],
+              }),
             ),
         ),
       );

--- a/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
@@ -188,38 +188,36 @@ export class BitbucketServerUrlReader implements UrlReader {
   private async getLastCommitShortHash(url: string): Promise<string> {
     const { name: repoName, owner: project, ref: branch } = parseGitUrl(url);
 
-    // Bitbucket Server https://docs.atlassian.com/bitbucket-server/rest/7.9.0/bitbucket-rest.html#idp224
-    const commitApiUrl = `${this.integration.config.apiBaseUrl}/projects/${project}/repos/${repoName}/commits/${branch}`;
+    const branchListUrl = `${
+      this.integration.config.apiBaseUrl
+    }/projects/${project}/repos/${repoName}/branches?filterText=${encodeURIComponent(
+      branch,
+    )}`;
 
-    const commitResponse = await fetch(
-      commitApiUrl,
+    const branchListResponse = await fetch(
+      branchListUrl,
       getBitbucketServerRequestOptions(this.integration.config),
     );
-    if (!commitResponse.ok) {
-      const message = `Failed to retrieve commits from ${commitApiUrl}, ${commitResponse.status} ${commitResponse.statusText}`;
-      if (commitResponse.status === 404) {
+    if (!branchListResponse.ok) {
+      const message = `Failed to retrieve branch list from ${branchListUrl}, ${branchListResponse.status} ${branchListResponse.statusText}`;
+      if (branchListResponse.status === 404) {
         throw new NotFoundError(message);
       }
       throw new Error(message);
     }
 
-    const commits = await commitResponse.json();
+    const branchMatches = await branchListResponse.json();
 
-    // Handles case when a branch is provided in the URL
-    if (commits && commits.id) {
-      return commits.id.substring(0, 12);
+    if (branchMatches && branchMatches.size > 0) {
+      const exactBranchMatch = branchMatches.values.filter(
+        (branchDetails: { displayId: string }) =>
+          branchDetails.displayId === branch,
+      )[0];
+      return exactBranchMatch.latestCommit.substring(0, 12);
     }
 
-    // Handles case when no branch is provided in the URL
-    if (
-      commits &&
-      commits.values &&
-      commits.values.length > 0 &&
-      commits.values[0].id
-    ) {
-      return commits.values[0].id.substring(0, 12);
-    }
-
-    throw new Error(`Failed to read response from ${commitApiUrl}`);
+    throw new Error(
+      `Failed to find branch "${branch}" in property "displayId" of response to ${branchListUrl}`,
+    );
   }
 }


### PR DESCRIPTION
Using the commits API was unstable and broke for branches with a '/'. Using the branches API works for any branch and is documented in the Atlassian API docs:
https://docs.atlassian.com/bitbucket-server/rest/7.9.0/bitbucket-rest.html#idp209

Signed-off-by: David Zemon <david@zemon.name>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

See #13560. This fixes the issue where BitBucket server integration fails on branches that have a `/` in them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #13560 