### PR TITLE
Added sourcePath to 'publish:gitlab:merge-request' action.

### DIFF
--- a/.changeset/unlucky-seas-sip.md
+++ b/.changeset/unlucky-seas-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added optional `sourcePath` parameter to `publish:gitlab:merge-request` action, `targetPath` is now optional and falls back to current workspace path.

--- a/.changeset/unlucky-seas-sip.md
+++ b/.changeset/unlucky-seas-sip.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Added optional `sourcePath` parameter to `publish:gitlab:merge-request` action, `targetPath` is now optional and falls back to current workspace path.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -429,6 +429,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   title: string;
   description: string;
   branchName: string;
+  sourcePath: string;
   targetPath: string;
   token?: string | undefined;
   commitAction?: 'update' | 'create' | 'delete' | undefined;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -429,8 +429,8 @@ export const createPublishGitlabMergeRequestAction: (options: {
   title: string;
   description: string;
   branchName: string;
-  sourcePath?: string;
-  targetPath?: string;
+  sourcePath?: string | undefined;
+  targetPath?: string | undefined;
   token?: string | undefined;
   commitAction?: 'update' | 'create' | 'delete' | undefined;
   projectid?: string | undefined;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -429,7 +429,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   title: string;
   description: string;
   branchName: string;
-  sourcePath: string;
+  sourcePath?: string;
   targetPath: string;
   token?: string | undefined;
   commitAction?: 'update' | 'create' | 'delete' | undefined;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -430,7 +430,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   description: string;
   branchName: string;
   sourcePath?: string;
-  targetPath: string;
+  targetPath?: string;
   token?: string | undefined;
   commitAction?: 'update' | 'create' | 'delete' | undefined;
   projectid?: string | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -38,8 +38,8 @@ export const createPublishGitlabMergeRequestAction = (options: {
     title: string;
     description: string;
     branchName: string;
-    sourcePath: string;
-    targetPath: string;
+    sourcePath?: string;
+    targetPath?: string;
     token?: string;
     commitAction?: 'create' | 'delete' | 'update';
     /** @deprecated Use projectPath instead */

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -38,6 +38,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
     title: string;
     description: string;
     branchName: string;
+    sourcePath: string;
     targetPath: string;
     token?: string;
     commitAction?: 'create' | 'delete' | 'update';
@@ -49,7 +50,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
     id: 'publish:gitlab:merge-request',
     schema: {
       input: {
-        required: ['repoUrl', 'targetPath', 'branchName'],
+        required: ['repoUrl', 'branchName'],
         type: 'object',
         properties: {
           repoUrl: {
@@ -77,6 +78,12 @@ export const createPublishGitlabMergeRequestAction = (options: {
             type: 'string',
             title: 'Destination Branch name',
             description: 'The description of the merge request',
+          },
+          sourcePath: {
+            type: 'string',
+            title: 'Working Subdirectory',
+            description:
+              'Subdirectory of working directory to copy changes from',
           },
           targetPath: {
             type: 'string',
@@ -128,7 +135,17 @@ export const createPublishGitlabMergeRequestAction = (options: {
       },
     },
     async handler(ctx) {
-      const repoUrl = ctx.input.repoUrl;
+      const {
+        assignee,
+        branchName,
+        description,
+        repoUrl,
+        removeSourceBranch,
+        targetPath,
+        sourcePath,
+        title,
+        token: providedToken,
+      } = ctx.input;
       const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
       const projectPath = `${owner}/${repo}`;
 
@@ -140,27 +157,23 @@ export const createPublishGitlabMergeRequestAction = (options: {
 
       const integrationConfig = integrations.gitlab.byHost(host);
 
-      const destinationBranch = ctx.input.branchName;
-
       if (!integrationConfig) {
         throw new InputError(
           `No matching integration configuration for host ${host}, please check your integrations config`,
         );
       }
 
-      if (!integrationConfig.config.token && !ctx.input.token) {
+      if (!integrationConfig.config.token && !providedToken) {
         throw new InputError(`No token available for host ${host}`);
       }
 
-      const token = ctx.input.token ?? integrationConfig.config.token!;
-      const tokenType = ctx.input.token ? 'oauthToken' : 'token';
+      const token = providedToken ?? integrationConfig.config.token!;
+      const tokenType = providedToken ? 'oauthToken' : 'token';
 
       const api = new Gitlab({
         host: integrationConfig.config.baseUrl,
         [tokenType]: token,
       });
-
-      const assignee = ctx.input.assignee;
 
       let assigneeId = undefined;
 
@@ -175,17 +188,25 @@ export const createPublishGitlabMergeRequestAction = (options: {
         }
       }
 
-      const targetPath = resolveSafeChildPath(
-        ctx.workspacePath,
-        ctx.input.targetPath,
-      );
-      const fileContents = await serializeDirectoryContents(targetPath, {
+      let fileRoot: string;
+      if (sourcePath) {
+        fileRoot = resolveSafeChildPath(ctx.workspacePath, sourcePath);
+      } else if (targetPath) {
+        // for backward compatibility
+        fileRoot = resolveSafeChildPath(ctx.workspacePath, targetPath);
+      } else {
+        fileRoot = ctx.workspacePath;
+      }
+
+      const fileContents = await serializeDirectoryContents(fileRoot, {
         gitignore: true,
       });
 
       const actions: Types.CommitAction[] = fileContents.map(file => ({
         action: ctx.input.commitAction ?? 'create',
-        filePath: path.posix.join(ctx.input.targetPath, file.path),
+        filePath: targetPath
+          ? path.posix.join(targetPath, file.path)
+          : file.path,
         encoding: 'base64',
         content: file.content.toString('base64'),
         execute_filemode: file.executable,
@@ -197,7 +218,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
       try {
         await api.Branches.create(
           projectPath,
-          destinationBranch,
+          branchName,
           String(defaultBranch),
         );
       } catch (e) {
@@ -205,30 +226,23 @@ export const createPublishGitlabMergeRequestAction = (options: {
       }
 
       try {
-        await api.Commits.create(
-          projectPath,
-          destinationBranch,
-          ctx.input.title,
-          actions,
-        );
+        await api.Commits.create(projectPath, branchName, title, actions);
       } catch (e) {
         throw new InputError(
-          `Committing the changes to ${destinationBranch} failed ${e}`,
+          `Committing the changes to ${branchName} failed ${e}`,
         );
       }
 
       try {
         const mergeRequestUrl = await api.MergeRequests.create(
           projectPath,
-          destinationBranch,
+          branchName,
           String(defaultBranch),
-          ctx.input.title,
+          title,
           {
-            description: ctx.input.description,
-            removeSourceBranch: ctx.input.removeSourceBranch
-              ? ctx.input.removeSourceBranch
-              : false,
-            assigneeId: assigneeId,
+            description,
+            removeSourceBranch: removeSourceBranch ? removeSourceBranch : false,
+            assigneeId,
           },
         ).then((mergeRequest: { web_url: string }) => {
           return mergeRequest.web_url;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Made both `sourcePath` and `targetPath` optional with fallback to `workspacePath`. Because currently `targetPath` serves as both source and target, falling back to `targetPath` if `sourcePath` is not specified. 

Here is how combination of both options work now:
|`sourcePath`|`targetPath`|Outcome|
|--|--|--|
|`undefined`|`undefined`|`foo.txt` -> `foo.txt`|
|`"source"`|`undefined`|`source/foo.txt` -> `foo.txt`|
|`undefined`|`"source"`|`source/foo.txt` -> `source/foo.txt` (for backward compatibility)|
|`"source"`|`"target"`|`source/foo.txt` -> `target/foo.txt`|

Also removed `draft` option from tests, because it's not supported in gitlab (probably copied from github tests).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #13359
