### PR TITLE
[Tech Insights] Add a delay to the fact retrievers to prevent cold-start errors

### DIFF
--- a/.changeset/tame-ads-appear.md
+++ b/.changeset/tame-ads-appear.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-tech-insights-backend': minor
+'@backstage/plugin-tech-insights-backend': patch
 ---
 
 Add a default delay to the fact retrievers to prevent cold-start errors

--- a/.changeset/tame-ads-appear.md
+++ b/.changeset/tame-ads-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend': minor
+---
+
+Add a default delay to the fact retrievers to prevent cold-start errors

--- a/.changeset/tame-ads-appear.md
+++ b/.changeset/tame-ads-appear.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-tech-insights-backend': patch
+'@backstage/plugin-tech-insights-node': patch
 ---
 
 Add a default delay to the fact retrievers to prevent cold-start errors

--- a/plugins/tech-insights-backend/api-report.md
+++ b/plugins/tech-insights-backend/api-report.md
@@ -60,6 +60,7 @@ export type FactRetrieverRegistrationOptions = {
   factRetriever: FactRetriever;
   lifecycle?: FactLifecycle;
   timeout?: Duration | HumanDuration;
+  initialDelay?: Duration | HumanDuration;
 };
 
 // @public (undocumented)

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -76,6 +76,7 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
     private readonly scheduler: PluginTaskScheduler,
     private readonly defaultCadence?: string,
     private readonly defaultTimeout?: Duration,
+    private readonly defaultInitialDelay?: Duration,
   ) {}
 
   static async create(options: {
@@ -85,6 +86,7 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
     scheduler: PluginTaskScheduler;
     defaultCadence?: string;
     defaultTimeout?: Duration;
+    defaultInitialDelay?: Duration;
   }) {
     const {
       repository,
@@ -93,6 +95,7 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
       scheduler,
       defaultCadence,
       defaultTimeout,
+      defaultInitialDelay,
     } = options;
 
     const retrievers = await factRetrieverRegistry.listRetrievers();
@@ -106,6 +109,7 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
       scheduler,
       defaultCadence,
       defaultTimeout,
+      defaultInitialDelay,
     );
   }
 
@@ -115,11 +119,13 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
 
     await Promise.all(
       registrations.map(async registration => {
-        const { factRetriever, cadence, lifecycle, timeout } = registration;
+        const { factRetriever, cadence, lifecycle, timeout, initialDelay } = registration;
         const cronExpression =
           cadence || this.defaultCadence || randomDailyCron();
         const timeLimit =
           timeout || this.defaultTimeout || Duration.fromObject({ minutes: 5 });
+        const initialDelaySetting =
+          initialDelay || this.defaultInitialDelay || Duration.fromObject({ seconds: 5 });
         try {
           await this.scheduler.scheduleTask({
             id: factRetriever.id,
@@ -128,7 +134,7 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
             timeout: timeLimit,
             // We add a delay in order to prevent errors due to the
             // fact that the backend is not yet online in a cold-start scenario
-            initialDelay: Duration.fromObject({ seconds: 5 }),
+            initialDelay: initialDelaySetting,
           });
           newRegs.push(factRetriever.id);
         } catch (e) {

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -126,6 +126,9 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
             frequency: { cron: cronExpression },
             fn: this.createFactRetrieverHandler(factRetriever, lifecycle),
             timeout: timeLimit,
+            // We add a delay in order to prevent errors due to the
+            // fact that the backend is not yet online in a cold-start scenario
+            initialDelay: Duration.fromObject({ seconds: 5 }),
           });
           newRegs.push(factRetriever.id);
         } catch (e) {

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -119,13 +119,16 @@ export class DefaultFactRetrieverEngine implements FactRetrieverEngine {
 
     await Promise.all(
       registrations.map(async registration => {
-        const { factRetriever, cadence, lifecycle, timeout, initialDelay } = registration;
+        const { factRetriever, cadence, lifecycle, timeout, initialDelay } =
+          registration;
         const cronExpression =
           cadence || this.defaultCadence || randomDailyCron();
         const timeLimit =
           timeout || this.defaultTimeout || Duration.fromObject({ minutes: 5 });
         const initialDelaySetting =
-          initialDelay || this.defaultInitialDelay || Duration.fromObject({ seconds: 5 });
+          initialDelay ||
+          this.defaultInitialDelay ||
+          Duration.fromObject({ seconds: 5 });
         try {
           await this.scheduler.scheduleTask({
             id: factRetriever.id,

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -35,6 +35,7 @@ export type FactRetrieverRegistrationOptions = {
   factRetriever: FactRetriever;
   lifecycle?: FactLifecycle;
   timeout?: Duration | HumanDuration;
+  initialDelay?: Duration | HumanDuration;
 };
 
 /**
@@ -45,6 +46,7 @@ export type FactRetrieverRegistrationOptions = {
  * @param factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
  * @param lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
  * @param timeout - Optional duration to determine how long the fact retriever should be allowed to run, defaults to 5 minutes
+ * @param initialDelay - Optional initial delay to determine how long the fact retriever should wait before the initial run, defaults to 5 seconds
  *
  *
  * @remarks
@@ -68,11 +70,12 @@ export type FactRetrieverRegistrationOptions = {
 export function createFactRetrieverRegistration(
   options: FactRetrieverRegistrationOptions,
 ): FactRetrieverRegistration {
-  const { cadence, factRetriever, lifecycle, timeout } = options;
+  const { cadence, factRetriever, lifecycle, timeout, initialDelay } = options;
   return {
     cadence,
     factRetriever,
     lifecycle,
     timeout,
+    initialDelay,
   };
 }

--- a/plugins/tech-insights-node/api-report.md
+++ b/plugins/tech-insights-node/api-report.md
@@ -75,6 +75,7 @@ export type FactRetrieverRegistration = {
   cadence?: string;
   timeout?: Duration | HumanDuration;
   lifecycle?: FactLifecycle;
+  initialDelay?: Duration | HumanDuration;
 };
 
 // @public

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -279,4 +279,11 @@ export type FactRetrieverRegistration = {
    * If defined this value will be used to determine expired items which will deleted when this fact retriever is run
    */
   lifecycle?: FactLifecycle;
+
+  /**
+   * A duration to determine the initial delay for the fact retriever. Useful for cold start scenarios when e.g. the
+   * catalog backend is not yet available. Defaults to 5 seconds.
+   *
+   */
+   initialDelay?: Duration | HumanDuration;
 };

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -285,5 +285,5 @@ export type FactRetrieverRegistration = {
    * catalog backend is not yet available. Defaults to 5 seconds.
    *
    */
-   initialDelay?: Duration | HumanDuration;
+  initialDelay?: Duration | HumanDuration;
 };


### PR DESCRIPTION
Signed-off-by: Leon <leonvanginneken@gmail.com>

## Hey, I just made a Pull Request!

When developing facts I keep seeing the following error:

```
2022-10-06T09:48:59.400Z tech-insights error Failed to retrieve facts for retriever some-fact-retriever request to http://localhost:7000/api/catalog/entities?filter=kind=Group failed, reason: connect ECONNREFUSED 127.0.0.1:7000 type=system errno=ECONNREFUSED code=ECONNREFUSED stack=FetchError: request to http://localhost:7000/api/catalog/entities?filter=kind=Group failed, reason: connect ECONNREFUSED 127.0.0.1:7000
```

This is fixed by adding a delay to all fact retrievers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
