### PR TITLE
chore(gitlab-mr-action): remove deprecation of projectid for template…

### DIFF
--- a/.changeset/grumpy-clouds-drum.md
+++ b/.changeset/grumpy-clouds-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+- The GitLab Project ID for the `publish:gitlab:merge-request` action is now passed through the query parameter `project` in the `repoUrl`. It still allows people to not use the `projectid` and use the `repoUrl` with the `owner` and `repo` query parameters instead. This makes it easier to publish to repositories instead of writing the full path to the project.


### PR DESCRIPTION
* `projectid` is now passed through the query parameter `project` in the `repoUrl`. It still allows people to not use the `projectid` and use the `repoUrl` with the `owner` and `repo` query parameters instead. This makes it easier to publish to repositories instead of writing the full path to the project.
* Changed the `parseUrl` function so it uses a `switch-case` statement which makes the function more readable than having several `if-else` statements.
* Created an auxiliary function called `checkRequiredParams`. The function checks if the required parameters (given as arguments) are present in the URL.
* The function `parseUrl` uses `checkRequiredParams` to verify that all the required query parameters are present in the repo's URL. This replaces the `if-else` mess with a `switch` statement for better readability.

Signed-off-by: Borja González <borja.gonzalez@sinch.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
