### PR TITLE
Fixing incorrect path in the custom action example

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -123,7 +123,7 @@ will set the available actions that the scaffolder has access to.
 ```ts
 import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
 import { ScmIntegrations } from '@backstage/integration';
-import { createNewFileAction } from './actions/custom';
+import { createNewFileAction } from './scaffolder/actions/custom';
 
 export default async function createPlugin(
   env: PluginEnvironment,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing incorrect path in import in the custom action example.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))