### PR TITLE
[microsite] fix localKubectlProxy link

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -62,7 +62,7 @@ This is an array used to determine where to retrieve cluster configuration from.
 Valid cluster locator methods are:
 
 - [`catalog`](#catalog)
-- [`localKubectlProxy`](#localKubectlProxy)
+- [`localKubectlProxy`](#localkubectlproxy)
 - [`config`](#config)
 - [`gke`](#gke)
 - [custom `KubernetesClustersSupplier`](#custom-kubernetesclusterssupplier)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I didn't file an issue for this, but when you click the `localKubectlProxy` link, it takes you to https://backstage.io/docs/features/kubernetes/configuration#localKubectlProxy, but that doesn't automatically focus the right section. However https://backstage.io/docs/features/kubernetes/configuration#localkubectlproxy does!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~ microsite only
- [x] Added or updated documentation
- [x] ~Tests for new functionality and regression tests for bug fixes~ microsite only
- [x] ~Screenshots attached (for UI changes)~ hard to show in a screenshot, might have to test out the link's behaviour yourself or take my word for it
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
