### PR TITLE
Fix permissions API to return 401 instead of 500 on throw

### DIFF
--- a/.changeset/early-hornets-pay.md
+++ b/.changeset/early-hornets-pay.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-node': minor
+'@backstage/plugin-auth-node': patch
 ---
 
 Ensure `getIdentity` throws an `AuthenticationError` instead of a `NotAllowed` error when authentication fails

--- a/.changeset/early-hornets-pay.md
+++ b/.changeset/early-hornets-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': minor
+---
+
+Ensure `getIdentity` throws an `AuthenticationError` instead of a `NotAllowed` error when authentication fails

--- a/plugins/auth-node/src/DefaultIdentityClient.ts
+++ b/plugins/auth-node/src/DefaultIdentityClient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
-import { AuthenticationError, NotAllowedError } from '@backstage/errors';
+import { AuthenticationError } from '@backstage/errors';
 import {
   createRemoteJWKSet,
   decodeJwt,
@@ -86,7 +86,7 @@ export class DefaultIdentityClient implements IdentityApi {
         getBearerTokenFromAuthorizationHeader(request.headers.authorization),
       );
     } catch (e) {
-      throw new NotAllowedError(e.message);
+      throw new AuthenticationError(e.message);
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix permissions API return 401 instead of 500 when IdentityApi.getIdentity throws an error

Context here: https://discord.com/channels/687207715902193673/935836080563966042/1027826427745275935

My suspicion for why this is currently implemented the way it is is because `permissions` assumes there's already an authentication middleware filtering out requests with invalid `Authorization` headers. Nevertheless, I think it's better to explicitly handle the case rather than hold hidden assumptions that don't always hold true; hence this MR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
