### PR TITLE
[TechDocs] Increase timeout for anchors to work on Chromium browsers

### DIFF
--- a/.changeset/calm-knives-serve.md
+++ b/.changeset/calm-knives-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed scroll to anchor in Chromium based browsers

--- a/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.test.ts
+++ b/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.test.ts
@@ -28,7 +28,7 @@ describe('scrollIntoAnchor', () => {
 
   it('does nothing if there is no anchor element', async () => {
     transformer(dom as unknown as Element);
-    jest.advanceTimersByTime(200);
+    jest.advanceTimersByTime(500);
     expect(dom.querySelector).not.toHaveBeenCalled();
   });
 
@@ -37,7 +37,7 @@ describe('scrollIntoAnchor', () => {
     dom.querySelector.mockReturnValue({ scrollIntoView });
     window.location.hash = '#hash';
     transformer(dom as unknown as Element);
-    jest.advanceTimersByTime(200);
+    jest.advanceTimersByTime(500);
     expect(dom.querySelector).toHaveBeenCalledWith(
       expect.stringMatching('[id="hash"]'),
     );
@@ -50,7 +50,7 @@ describe('scrollIntoAnchor', () => {
     dom.querySelector.mockReturnValue({ scrollIntoView });
     window.location.hash = '#1-hash';
     transformer(dom as unknown as Element);
-    jest.advanceTimersByTime(200);
+    jest.advanceTimersByTime(500);
     expect(dom.querySelector).toHaveBeenCalledWith(
       expect.stringMatching('[id="1-hash"]'),
     );

--- a/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.ts
+++ b/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.ts
@@ -25,7 +25,7 @@ export const scrollIntoAnchor = (): Transformer => {
         // fix invalid selector error for anchor starting with number
         dom?.querySelector(`[id="${hash}"]`)?.scrollIntoView();
       }
-    }, 200);
+    }, 500);
     return dom;
   };
 };


### PR DESCRIPTION
Signed-off-by: Laura Ceconi <laura.cec@hotmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR fixes https://github.com/backstage/backstage/issues/11003

Increasing the timeout for `scrollIntoView` to be triggered was enough to fix the behaviour in Chromium browsers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
