### PR TITLE
feat(catalog/github): schedule via config + use at backend module

### DIFF
--- a/.changeset/famous-ligers-repair.md
+++ b/.changeset/famous-ligers-repair.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+`GitHubEntityProvider`: Add option to configure schedule via `app-config.yaml` instead of in code.
+
+Please find how to configure the schedule at the config at
+https://backstage.io/docs/integrations/github/discovery

--- a/.changeset/old-frogs-invent.md
+++ b/.changeset/old-frogs-invent.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Use schedule from config at backend module.
+
+Also, it removes `GithubEntityProviderCatalogModuleOptions`
+in favor of config-only for the backend module setup
+like at other similar modules.

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -39,10 +39,13 @@ And then add the entity provider to your catalog builder:
 +   builder.addEntityProvider(
 +     GitHubEntityProvider.fromConfig(env.config, {
 +       logger: env.logger,
++       // optional: alternatively, use scheduler with schedule defined in app-config.yaml
 +       schedule: env.scheduler.createScheduledTaskRunner({
 +         frequency: { minutes: 30 },
 +         timeout: { minutes: 3 },
 +       }),
++       // optional: alternatively, use schedule
++       scheduler: env.scheduler,
 +     }),
 +   );
 
@@ -68,6 +71,11 @@ catalog:
         filters:
           branch: 'main' # string
           repository: '.*' # Regex
+        schedule: # optional; same options as in TaskScheduleDefinition
+          # supports cron, ISO duration, "human duration" as used in code
+          frequency: { minutes: 30 }
+          # supports ISO duration, "human duration" as used in code
+          timeout: { minutes: 3 }
       customProviderId:
         organization: 'new-org' # string
         catalogPath: '/custom/path/catalog-info.yaml' # string
@@ -111,26 +119,35 @@ This provider supports multiple organizations via unique provider IDs.
   Default: `/catalog-info.yaml`.
   Path where to look for `catalog-info.yaml` files.
   You can use wildcards - `*` or `**` - to search the path and/or the filename
-- **filters** _(optional)_:
-  - **branch** _(optional)_:
+- **`filters`** _(optional)_:
+  - **`branch`** _(optional)_:
     String used to filter results based on the branch name.
-  - **repository** _(optional)_:
+  - **`repository`** _(optional)_:
     Regular expression used to filter results based on the repository name.
-  - **topic** _(optional)_:
+  - **`topic`** _(optional)_:
     Both of the filters below may be used at the same time but the exclusion filter has the highest priority.
     In the example above, a repository with the `backstage-include` topic would still be excluded
     if it were also carrying the `experiments` topic.
-    - **include** _(optional)_:
+    - **`include`** _(optional)_:
       An array of strings used to filter in results based on their associated GitHub topics.
       If configured, only repositories with one (or more) topic(s) present in the inclusion filter will be ingested
-    - **exclude** _(optional)_:
+    - **`exclude`** _(optional)_:
       An array of strings used to filter out results based on their associated GitHub topics.
       If configured, all repositories _except_ those with one (or more) topics(s) present in the exclusion filter will be ingested.
-- **organization**:
+- **`host`** _(optional)_:
+  The hostname of your GitHub Enterprise instance. It must match a host defined in [integrations.github](locations.md).
+- **`organization`**:
   Name of your organization account/workspace.
   If you want to add multiple organizations, you need to add one provider config each.
-- **host** _(optional)_:
-  The hostname of your GitHub Enterprise instance. It must match a host defined in [integrations.github](locations.md).
+- **`schedule`** _(optional)_:
+  - **`frequency`**:
+    How often you want the task to run. The system does its best to avoid overlapping invocations.
+  - **`timeout`**:
+    The maximum amount of time that a single task invocation can take.
+  - **`initialDelay`** _(optional)_:
+    The amount of time that should pass before the first invocation happens.
+  - **`scope`** _(optional)_:
+    `'global'` or `'local'`. Sets the scope of concurrency control.
 
 ## GitHub API Rate Limits
 

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -20,7 +20,6 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmLocationAnalyzer } from '@backstage/plugin-catalog-backend';
 import { TaskRunner } from '@backstage/backend-tasks';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 
 // @public
 export class GithubDiscoveryProcessor implements CatalogProcessor {
@@ -68,13 +67,8 @@ export class GitHubEntityProvider implements EntityProvider {
 
 // @alpha
 export const githubEntityProviderCatalogModule: (
-  options?: GithubEntityProviderCatalogModuleOptions | undefined,
+  options?: undefined,
 ) => BackendFeature;
-
-// @alpha
-export type GithubEntityProviderCatalogModuleOptions = {
-  schedule?: TaskScheduleDefinition;
-};
 
 // @public (undocumented)
 export class GitHubLocationAnalyzer implements ScmLocationAnalyzer {

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -16,6 +16,7 @@ import { GitHubIntegrationConfig } from '@backstage/integration';
 import { LocationSpec } from '@backstage/plugin-catalog-backend';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmLocationAnalyzer } from '@backstage/plugin-catalog-backend';
 import { TaskRunner } from '@backstage/backend-tasks';
@@ -55,7 +56,8 @@ export class GitHubEntityProvider implements EntityProvider {
     config: Config,
     options: {
       logger: Logger;
-      schedule: TaskRunner;
+      schedule?: TaskRunner;
+      scheduler?: PluginTaskScheduler;
     },
   ): GitHubEntityProvider[];
   // (undocumented)

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
 export interface Config {
   catalog?: {
     processors?: {
@@ -103,6 +105,10 @@ export interface Config {
                 exclude?: string[];
               };
             };
+            /**
+             * (Optional) TaskScheduleDefinition for the refresh.
+             */
+            schedule?: TaskScheduleDefinitionConfig;
           }
         | Record<
             string,
@@ -156,6 +162,10 @@ export interface Config {
                   exclude?: string[];
                 };
               };
+              /**
+               * (Optional) TaskScheduleDefinition for the refresh.
+               */
+              schedule?: TaskScheduleDefinitionConfig;
             }
           >;
     };

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -56,7 +56,8 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "@types/lodash": "^4.14.151"
+    "@types/lodash": "^4.14.151",
+    "luxon": "^3.0.0"
   },
   "files": [
     "dist",

--- a/plugins/catalog-backend-module-github/src/index.ts
+++ b/plugins/catalog-backend-module-github/src/index.ts
@@ -20,14 +20,13 @@
  * @packageDocumentation
  */
 
+export { GitHubLocationAnalyzer } from './analyzers/GitHubLocationAnalyzer';
+export type { GitHubLocationAnalyzerOptions } from './analyzers/GitHubLocationAnalyzer';
+export type { GithubMultiOrgConfig } from './lib';
 export { GithubDiscoveryProcessor } from './processors/GithubDiscoveryProcessor';
 export { GithubMultiOrgReaderProcessor } from './processors/GithubMultiOrgReaderProcessor';
 export { GithubOrgReaderProcessor } from './processors/GithubOrgReaderProcessor';
 export { GitHubEntityProvider } from './providers/GitHubEntityProvider';
 export { GitHubOrgEntityProvider } from './providers/GitHubOrgEntityProvider';
 export type { GitHubOrgEntityProviderOptions } from './providers/GitHubOrgEntityProvider';
-export type { GithubMultiOrgConfig } from './lib';
-export { githubEntityProviderCatalogModule } from './module';
-export type { GithubEntityProviderCatalogModuleOptions } from './module';
-export { GitHubLocationAnalyzer } from './analyzers/GitHubLocationAnalyzer';
-export type { GitHubLocationAnalyzerOptions } from './analyzers/GitHubLocationAnalyzer';
+export { githubEntityProviderCatalogModule } from './service/GithubEntityProviderCatalogModule';

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { ConfigReader } from '@backstage/config';
+import { Duration } from 'luxon';
 import { readProviderConfigs } from './GitHubEntityProviderConfig';
 
 describe('readProviderConfigs', () => {
@@ -81,13 +82,22 @@ describe('readProviderConfigs', () => {
               organization: 'test-org1',
               host: 'ghe.internal.com',
             },
+            providerWithSchedule: {
+              organization: 'test-org1',
+              schedule: {
+                frequency: 'PT30M',
+                timeout: {
+                  minutes: 3,
+                },
+              },
+            },
           },
         },
       },
     });
     const providerConfigs = readProviderConfigs(config);
 
-    expect(providerConfigs).toHaveLength(6);
+    expect(providerConfigs).toHaveLength(7);
     expect(providerConfigs[0]).toEqual({
       id: 'providerOrganizationOnly',
       organization: 'test-org1',
@@ -101,6 +111,7 @@ describe('readProviderConfigs', () => {
           exclude: undefined,
         },
       },
+      schedule: undefined,
     });
     expect(providerConfigs[1]).toEqual({
       id: 'providerCustomCatalogPath',
@@ -115,6 +126,7 @@ describe('readProviderConfigs', () => {
           exclude: undefined,
         },
       },
+      schedule: undefined,
     });
     expect(providerConfigs[2]).toEqual({
       id: 'providerWithRepositoryFilter',
@@ -129,6 +141,7 @@ describe('readProviderConfigs', () => {
           exclude: undefined,
         },
       },
+      schedule: undefined,
     });
     expect(providerConfigs[3]).toEqual({
       id: 'providerWithBranchFilter',
@@ -143,6 +156,7 @@ describe('readProviderConfigs', () => {
           exclude: undefined,
         },
       },
+      schedule: undefined,
     });
     expect(providerConfigs[4]).toEqual({
       id: 'providerWithTopicFilter',
@@ -157,6 +171,7 @@ describe('readProviderConfigs', () => {
           exclude: ['backstage-exclude'],
         },
       },
+      schedule: undefined,
     });
     expect(providerConfigs[5]).toEqual({
       id: 'providerWithHost',
@@ -169,6 +184,27 @@ describe('readProviderConfigs', () => {
         topic: {
           include: undefined,
           exclude: undefined,
+        },
+      },
+      schedule: undefined,
+    });
+    expect(providerConfigs[6]).toEqual({
+      id: 'providerWithSchedule',
+      organization: 'test-org1',
+      catalogPath: '/catalog-info.yaml',
+      host: 'github.com',
+      filters: {
+        repository: undefined,
+        branch: undefined,
+        topic: {
+          include: undefined,
+          exclude: undefined,
+        },
+      },
+      schedule: {
+        frequency: Duration.fromISO('PT30M'),
+        timeout: {
+          minutes: 3,
         },
       },
     });

--- a/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GitHubEntityProviderConfig.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import {
+  readTaskScheduleDefinitionFromConfig,
+  TaskScheduleDefinition,
+} from '@backstage/backend-tasks';
 import { Config } from '@backstage/config';
 
 const DEFAULT_CATALOG_PATH = '/catalog-info.yaml';
@@ -29,6 +33,7 @@ export type GitHubEntityProviderConfig = {
     branch?: string;
     topic?: GithubTopicFilters;
   };
+  schedule?: TaskScheduleDefinition;
 };
 
 export type GithubTopicFilters = {
@@ -73,6 +78,10 @@ function readProviderConfig(
     'filters.topic.exclude',
   );
 
+  const schedule = config.has('schedule')
+    ? readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'))
+    : undefined;
+
   return {
     id,
     catalogPath,
@@ -88,8 +97,10 @@ function readProviderConfig(
         exclude: topicFilterExclude,
       },
     },
+    schedule,
   };
 }
+
 /**
  * Compiles a RegExp while enforcing the pattern to contain
  * the start-of-line and end-of-line anchors.

--- a/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import {
+  configServiceRef,
+  loggerServiceRef,
+  schedulerServiceRef,
+} from '@backstage/backend-plugin-api';
+import {
+  PluginTaskScheduler,
+  TaskScheduleDefinition,
+} from '@backstage/backend-tasks';
+import { startTestBackend } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { Duration } from 'luxon';
+import { githubEntityProviderCatalogModule } from './GithubEntityProviderCatalogModule';
+import { GitHubEntityProvider } from '../providers/GitHubEntityProvider';
+
+describe('githubEntityProviderCatalogModule', () => {
+  it('should register provider at the catalog extension point', async () => {
+    let addedProviders: Array<GitHubEntityProvider> | undefined;
+    let usedSchedule: TaskScheduleDefinition | undefined;
+
+    const extensionPoint = {
+      addEntityProvider: (providers: any) => {
+        addedProviders = providers;
+      },
+    };
+    const runner = jest.fn();
+    const scheduler = {
+      createScheduledTaskRunner: (schedule: TaskScheduleDefinition) => {
+        usedSchedule = schedule;
+        return runner;
+      },
+    } as unknown as PluginTaskScheduler;
+
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          github: {
+            organization: 'module-test',
+            schedule: {
+              frequency: 'P1M',
+              timeout: 'PT3M',
+            },
+          },
+        },
+      },
+    });
+
+    await startTestBackend({
+      extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
+      services: [
+        [configServiceRef, config],
+        [loggerServiceRef, getVoidLogger()],
+        [schedulerServiceRef, scheduler],
+      ],
+      features: [githubEntityProviderCatalogModule()],
+    });
+
+    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
+    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(addedProviders?.length).toEqual(1);
+    expect(addedProviders?.pop()?.getProviderName()).toEqual(
+      'github-provider:default',
+    );
+    expect(runner).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.ts
@@ -21,18 +21,8 @@ import {
   loggerServiceRef,
   schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
-import { GitHubEntityProvider } from './providers/GitHubEntityProvider';
-
-/**
- * Options for {@link githubEntityProviderCatalogModule}.
- *
- * @alpha
- */
-export type GithubEntityProviderCatalogModuleOptions = {
-  schedule?: TaskScheduleDefinition;
-};
+import { GitHubEntityProvider } from '../providers/GitHubEntityProvider';
 
 /**
  * Registers the GitHubEntityProvider with the catalog processing extension point.
@@ -42,25 +32,19 @@ export type GithubEntityProviderCatalogModuleOptions = {
 export const githubEntityProviderCatalogModule = createBackendModule({
   pluginId: 'catalog',
   moduleId: 'githubEntityProvider',
-  register(env, options?: GithubEntityProviderCatalogModuleOptions) {
+  register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
         catalog: catalogProcessingExtensionPoint,
+        config: configServiceRef,
         logger: loggerServiceRef,
         scheduler: schedulerServiceRef,
       },
-      async init({ config, catalog, logger, scheduler }) {
-        const scheduleDef = options?.schedule ?? {
-          frequency: { seconds: 600 },
-          timeout: { seconds: 900 },
-          initialDelay: { seconds: 3 },
-        };
-
+      async init({ catalog, config, logger, scheduler }) {
         catalog.addEntityProvider(
           GitHubEntityProvider.fromConfig(config, {
             logger: loggerToWinstonLogger(logger),
-            schedule: scheduler.createScheduledTaskRunner(scheduleDef),
+            scheduler,
           }),
         );
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,6 +4590,7 @@ __metadata:
     "@types/lodash": ^4.14.151
     git-url-parse: ^13.0.0
     lodash: ^4.17.21
+    luxon: ^3.0.0
     msw: ^0.47.0
     node-fetch: ^2.6.7
     uuid: ^8.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

- Add option to configure schedule via app-config.yaml
- Use schedule from config at backend module (and drop `GithubEntityProviderCatalogModuleOptions`)
- Adds tests for the backend module

Relates-to: PR #13859
Relates-to: PR #14034

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
