### PR TITLE
[TechDocs] Pass catalog client to techdocs router

### DIFF
--- a/.changeset/techdocs-olive-worms-yell.md
+++ b/.changeset/techdocs-olive-worms-yell.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-backend': minor
 ---
 
-Add optional catalogClient argument to createRouter parameters
+Add optional `catalogClient` argument to `createRoute` parameters

--- a/.changeset/techdocs-olive-worms-yell.md
+++ b/.changeset/techdocs-olive-worms-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+Add optional catalogClient argument to createRouter parameters

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 
 import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DocumentCollatorFactory } from '@backstage/plugin-search-common';
 import { Entity } from '@backstage/catalog-model';
@@ -79,6 +80,7 @@ export type OutOfTheBoxDeploymentOptions = {
   cache: PluginCacheManager;
   docsBuildStrategy?: DocsBuildStrategy;
   buildLogTransport?: winston.transport;
+  catalogClient?: CatalogClient;
 };
 
 // @public
@@ -90,6 +92,7 @@ export type RecommendedDeploymentOptions = {
   cache: PluginCacheManager;
   docsBuildStrategy?: DocsBuildStrategy;
   buildLogTransport?: winston.transport;
+  catalogClient?: CatalogClient;
 };
 
 // @public

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -58,6 +58,7 @@ export type OutOfTheBoxDeploymentOptions = {
   cache: PluginCacheManager;
   docsBuildStrategy?: DocsBuildStrategy;
   buildLogTransport?: winston.transport;
+  catalogClient?: CatalogClient;
 };
 
 /**
@@ -74,6 +75,7 @@ export type RecommendedDeploymentOptions = {
   cache: PluginCacheManager;
   docsBuildStrategy?: DocsBuildStrategy;
   buildLogTransport?: winston.transport;
+  catalogClient?: CatalogClient;
 };
 
 /**
@@ -107,7 +109,7 @@ export async function createRouter(
 ): Promise<express.Router> {
   const router = Router();
   const { publisher, config, logger, discovery } = options;
-  const catalogClient = new CatalogClient({ discoveryApi: discovery });
+  const catalogClient = options.catalogClient ?? new CatalogClient({ discoveryApi: discovery });
   const docsBuildStrategy =
     options.docsBuildStrategy ?? DefaultDocsBuildStrategy.fromConfig(config);
   const buildLogTransport =

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -109,7 +109,8 @@ export async function createRouter(
 ): Promise<express.Router> {
   const router = Router();
   const { publisher, config, logger, discovery } = options;
-  const catalogClient = options.catalogClient ?? new CatalogClient({ discoveryApi: discovery });
+  const catalogClient =
+    options.catalogClient ?? new CatalogClient({ discoveryApi: discovery });
   const docsBuildStrategy =
     options.docsBuildStrategy ?? DefaultDocsBuildStrategy.fromConfig(config);
   const buildLogTransport =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow passing a catalog client when creating the techdocs router.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
