### PR TITLE
docs: fix toQuery method in custom rules permissions docs

### DIFF
--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -30,7 +30,7 @@ export const isInSystemRule = createCatalogPermissionRule({
   },
   toQuery: (systemRef: string) => ({
     key: 'relations.partOf',
-    value: systemRef,
+    values: [systemRef],
   }),
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

These docs were previously specifying the expected return type of `toQuery` incorrectly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
