### PR TITLE
build: add __tests__ and __mocks__ dirs to relevant parts of eslint-factory

### DIFF
--- a/.changeset/great-crews-own.md
+++ b/.changeset/great-crews-own.md
@@ -1,0 +1,14 @@
+---
+'@backstage/cli': minor
+---
+
+Treat files in `__tests__` and `__mocks__` directories as test files for linting
+purposes.
+
+Updates the parts of the eslint configuration generator that specify which files
+should be treated as test code to include any files under directories named
+`__tests__` or `__mocks__`, to match the default file locations used in Jest.
+
+cf.
+https://jestjs.io/docs/configuration/#testmatch-arraystring
+https://jestjs.io/docs/manual-mocks#mocking-user-modules

--- a/.changeset/great-crews-own.md
+++ b/.changeset/great-crews-own.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/cli': minor
+'@backstage/cli': patch
 ---
 
 Treat files in `__testUtils__` and `__mocks__` directories as test files for linting

--- a/.changeset/great-crews-own.md
+++ b/.changeset/great-crews-own.md
@@ -2,13 +2,15 @@
 '@backstage/cli': minor
 ---
 
-Treat files in `__tests__` and `__mocks__` directories as test files for linting
+Treat files in `__testUtils__` and `__mocks__` directories as test files for linting
 purposes.
 
 Updates the parts of the eslint configuration generator that specify which files
-should be treated as test code to include any files under directories named
-`__tests__` or `__mocks__`, to match the default file locations used in Jest.
+should be treated as test code to include any files under two additional
+directories:
 
-cf.
-https://jestjs.io/docs/configuration/#testmatch-arraystring
-https://jestjs.io/docs/manual-mocks#mocking-user-modules
+- `__mocks__`: this is the directory used by Jest[0] for mock code.
+- `__testUtils__`: a suggested location for utility code executed only when
+  running tests.
+
+[0]: https://jestjs.io/docs/manual-mocks#mocking-user-modules

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -96,7 +96,7 @@ function createConfig(dir, extraConfig = {}) {
                 `!${joinPath(dir, 'src/**')}`,
                 joinPath(dir, 'src/**/*.test.*'),
                 joinPath(dir, 'src/**/*.stories.*'),
-                joinPath(dir, 'src/**/__tests__/**'),
+                joinPath(dir, 'src/**/__testUtils__/**'),
                 joinPath(dir, 'src/**/__mocks__/**'),
                 joinPath(dir, 'src/setupTests.*'),
               ]
@@ -104,7 +104,7 @@ function createConfig(dir, extraConfig = {}) {
                 // Legacy config for packages that don't provide a dir
                 '**/*.test.*',
                 '**/*.stories.*',
-                '**/__tests__/**',
+                '**/__testUtils__/**',
                 '**/__mocks__/**',
                 '**/src/setupTests.*',
                 '**/dev/**',
@@ -141,7 +141,7 @@ function createConfig(dir, extraConfig = {}) {
             // Prevent imports of stories or tests
             '*.stories*',
             '*.test*',
-            '**/__tests__/**',
+            '**/__testUtils__/**',
             '**/__mocks__/**',
           ],
         },
@@ -168,7 +168,7 @@ function createConfig(dir, extraConfig = {}) {
         files: [
           '**/*.test.*',
           '**/*.stories.*',
-          '**/__tests__/**',
+          '**/__testUtils__/**',
           '**/__mocks__/**',
           'src/setupTests.*',
           '!src/**',

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -96,12 +96,16 @@ function createConfig(dir, extraConfig = {}) {
                 `!${joinPath(dir, 'src/**')}`,
                 joinPath(dir, 'src/**/*.test.*'),
                 joinPath(dir, 'src/**/*.stories.*'),
+                joinPath(dir, 'src/**/__tests__/**'),
+                joinPath(dir, 'src/**/__mocks__/**'),
                 joinPath(dir, 'src/setupTests.*'),
               ]
             : [
                 // Legacy config for packages that don't provide a dir
                 '**/*.test.*',
                 '**/*.stories.*',
+                '**/__tests__/**',
+                '**/__mocks__/**',
                 '**/src/setupTests.*',
                 '**/dev/**',
               ],
@@ -137,6 +141,8 @@ function createConfig(dir, extraConfig = {}) {
             // Prevent imports of stories or tests
             '*.stories*',
             '*.test*',
+            '**/__tests__/**',
+            '**/__mocks__/**',
           ],
         },
       ],
@@ -159,7 +165,14 @@ function createConfig(dir, extraConfig = {}) {
         },
       },
       {
-        files: ['**/*.test.*', '**/*.stories.*', 'src/setupTests.*', '!src/**'],
+        files: [
+          '**/*.test.*',
+          '**/*.stories.*',
+          '**/__tests__/**',
+          '**/__mocks__/**',
+          'src/setupTests.*',
+          '!src/**',
+        ],
         rules: {
           ...testRules,
           'no-restricted-syntax': [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Alternative to #13612 as discussed [here](https://github.com/backstage/backstage/pull/13612/files#r984520091) - rather than making the test patterns overridable, we can instead add some more common patterns to the default set.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
