### PR TITLE
[Search] Tag indexing logs with documentType

### DIFF
--- a/.changeset/search-konstiga-fika-reglar.md
+++ b/.changeset/search-konstiga-fika-reglar.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-adr-backend': patch
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+'@backstage/plugin-search-backend-node': patch
+'@backstage/plugin-stack-overflow-backend': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+In order to improve the debuggability of the search indexing process, messages logged during indexing are now tagged with a `documentType` whose value corresponds to the `type` being indexed.

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -68,6 +68,7 @@ dataflow
 dayjs
 debounce
 Debounce
+debuggability
 declaratively
 deduplicated
 deps

--- a/plugins/adr-backend/src/search/DefaultAdrCollatorFactory.ts
+++ b/plugins/adr-backend/src/search/DefaultAdrCollatorFactory.ts
@@ -113,7 +113,7 @@ export class DefaultAdrCollatorFactory implements DocumentCollatorFactory {
     this.catalogClient =
       options.catalogClient ??
       new CatalogClient({ discoveryApi: options.discovery });
-    this.logger = options.logger;
+    this.logger = options.logger.child({ documentType: this.type });
     this.parser = options.parser ?? createMadrParser();
     this.reader = options.reader;
     this.scmIntegrations = ScmIntegrations.fromConfig(options.config);

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
@@ -63,7 +63,7 @@ export class ElasticSearchSearchEngineIndexer extends BatchSearchEngineIndexer {
 
   constructor(options: ElasticSearchSearchEngineIndexerOptions) {
     super({ batchSize: options.batchSize });
-    this.logger = options.logger;
+    this.logger = options.logger.child({ documentType: options.type });
     this.startTimestamp = process.hrtime();
     this.type = options.type;
     this.indexPrefix = options.indexPrefix;

--- a/plugins/search-backend-node/src/collators/NewlineDelimitedJsonCollatorFactory.ts
+++ b/plugins/search-backend-node/src/collators/NewlineDelimitedJsonCollatorFactory.ts
@@ -93,7 +93,7 @@ export class NewlineDelimitedJsonCollatorFactory
       options.type,
       options.searchPattern,
       options.reader,
-      options.logger,
+      options.logger.child({ documentType: options.type }),
       options.visibilityPermission,
     );
   }

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -76,7 +76,7 @@ export class StackOverflowQuestionsCollatorFactory
     this.apiKey = options.apiKey;
     this.maxPage = options.maxPage;
     this.requestParams = options.requestParams;
-    this.logger = options.logger;
+    this.logger = options.logger.child({ documentType: this.type });
   }
 
   static fromConfig(

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollatorFactory.ts
@@ -90,7 +90,7 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
     this.discovery = options.discovery;
     this.locationTemplate =
       options.locationTemplate || '/docs/:namespace/:kind/:name/:path';
-    this.logger = options.logger;
+    this.logger = options.logger.child({ documentType: this.type });
     this.catalogClient =
       options.catalogClient ||
       new CatalogClient({ discoveryApi: options.discovery });


### PR DESCRIPTION
## What / Why

We're toying with the idea of allowing internal teams to own specific indices in our search instance.  In order to make them successful, we need to make it easy for them to filter logs down to just the stuff they care about.

The proposal is to tag any log messages related to the indexing of documents with their corresponding `documentType`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
