### PR TITLE
chore(catalog/bitbucket): Deprecate catalog-backend-module-bitbucket

### DIFF
--- a/.changeset/fresh-donuts-arrive.md
+++ b/.changeset/fresh-donuts-arrive.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket': patch
+---
+
+Deprecate `@backstage/plugin-catalog-backend-module-bitbucket`.
+
+Please migrate to `@backstage/plugin-catalog-backend-module-bitbucket-cloud`
+or `@backstage/plugin-catalog-backend-module-bitbucket-server` instead.

--- a/plugins/catalog-backend-module-bitbucket/api-report.md
+++ b/plugins/catalog-backend-module-bitbucket/api-report.md
@@ -12,7 +12,7 @@ import { LocationSpec } from '@backstage/plugin-catalog-backend';
 import { Logger } from 'winston';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class BitbucketDiscoveryProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;
@@ -37,7 +37,7 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
-// @public
+// @public @deprecated
 export type BitbucketRepositoryParser = (options: {
   integration: BitbucketIntegration;
   target: string;

--- a/plugins/catalog-backend-module-bitbucket/package.json
+++ b/plugins/catalog-backend-module-bitbucket/package.json
@@ -2,6 +2,7 @@
   "name": "@backstage/plugin-catalog-backend-module-bitbucket",
   "description": "A Backstage catalog backend module that helps integrate towards Bitbucket",
   "version": "0.2.4-next.1",
+  "deprecated": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-bitbucket/src/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/BitbucketDiscoveryProcessor.ts
@@ -41,7 +41,10 @@ import {
 const DEFAULT_BRANCH = 'master';
 const DEFAULT_CATALOG_LOCATION = '/catalog-info.yaml';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Please migrate to `@backstage/plugin-catalog-backend-module-bitbucket-cloud` or `@backstage/plugin-catalog-backend-module-bitbucket-server` instead.
+ */
 export class BitbucketDiscoveryProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrationRegistry;
   private readonly parser: BitbucketRepositoryParser;
@@ -70,6 +73,9 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
     this.integrations = options.integrations;
     this.parser = options.parser || defaultRepositoryParser;
     this.logger = options.logger;
+    this.logger.warn(
+      'Please migrate to `@backstage/plugin-catalog-backend-module-bitbucket-cloud` or `@backstage/plugin-catalog-backend-module-bitbucket-server` instead.',
+    );
   }
 
   getProcessorName(): string {

--- a/plugins/catalog-backend-module-bitbucket/src/lib/BitbucketRepositoryParser.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/lib/BitbucketRepositoryParser.ts
@@ -26,6 +26,7 @@ import { Logger } from 'winston';
  * results.
  *
  * @public
+ * @deprecated Please migrate to `@backstage/plugin-catalog-backend-module-bitbucket-cloud` or `@backstage/plugin-catalog-backend-module-bitbucket-server` instead.
  */
 export type BitbucketRepositoryParser = (options: {
   integration: BitbucketIntegration;


### PR DESCRIPTION
Deprecate `@backstage/plugin-catalog-backend-module-bitbucket`.

Please migrate to `@backstage/plugin-catalog-backend-module-bitbucket-cloud` or `@backstage/plugin-catalog-backend-module-bitbucket-server` instead.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
