### PR TITLE
enable extra css links for techdocs

### DIFF
--- a/.changeset/shy-walls-burn.md
+++ b/.changeset/shy-walls-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+enable extra css links for techdocs

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -422,6 +422,18 @@ techdocs:
 This way, all iframes where the host of src attribute is in the
 `sanitizer.allowedIframeHosts` list will be displayed.
 
+To add additional css links you can add `techdocs.sanitizer.saveLinks` configuration of your `app-config.yaml`
+
+E.g.
+
+```yaml
+techdocs:
+  sanitizer:
+    saveLinks:
+      - stylesheets
+      - stylesheets/extra.css
+```
+
 ## How to add Mermaid support in TechDocs
 
 To add `Mermaid` support in Techdocs, you can use [`kroki`](https://kroki.io)

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -42,6 +42,14 @@ export interface Config {
        * @visibility frontend
        */
       allowedIframeHosts?: string[];
+      /**
+       * Allows extra save links
+       * Example:
+       *  saveLinks: ["stylesheets/extra.css"]
+       *  this will allow all links which match the given path in the href attribute
+       * @visibility frontend
+       */
+      saveLinks?: string[];
     };
   };
 }

--- a/plugins/techdocs/src/reader/transformers/html/hooks/links.ts
+++ b/plugins/techdocs/src/reader/transformers/html/hooks/links.ts
@@ -27,25 +27,32 @@ const isLink = (node: Element) => node.nodeName === 'LINK';
 
 /**
  * Checks whether a link is safe or not.
+ * @param saveLinks - list of allowed links.
  * @param node - is an link element.
  * @returns true when link is mkdocs css, google fonts or gstatic fonts.
  */
-const isSafe = (node: Element) => {
+const isSafe = (saveLinks: string[] | undefined, node: Element) => {
   const href = node?.getAttribute('href') || '';
   const isMkdocsCss = href.match(MKDOCS_CSS);
   const isGoogleFonts = href.match(GOOGLE_FONTS);
   const isGstaticFonts = href.match(GSTATIC_FONTS);
+  if (saveLinks) {
+    if (saveLinks.filter(i => href.match(i)).length > 0) {
+      return true;
+    }
+  }
   return isMkdocsCss || isGoogleFonts || isGstaticFonts;
 };
 
 /**
  * Function that removes unsafe link nodes.
+ * @param saveLinks - list of allowed links.
  * @param node - can be any element.
- * @param hosts - list of allowed hosts.
  */
-export const removeUnsafeLinks = (node: Element) => {
-  if (isLink(node) && !isSafe(node)) {
-    node.remove();
-  }
-  return node;
-};
+export const removeUnsafeLinks =
+  (saveLinks: string[] | undefined) => (node: Element) => {
+    if (isLink(node) && !isSafe(saveLinks, node)) {
+      node.remove();
+    }
+    return node;
+  };

--- a/plugins/techdocs/src/reader/transformers/html/transformer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.test.tsx
@@ -27,6 +27,7 @@ const configApiMock: ConfigApi = new ConfigReader({
   techdocs: {
     sanitizer: {
       allowedIframeHosts: ['docs.google.com'],
+      saveLinks: ['stylesheets'],
     },
   },
 });
@@ -59,6 +60,32 @@ describe('Transformers > Html', () => {
     expect(links[0].href).toMatch('assets/stylesheets/main.50e68009.min.css');
     expect(links[1].href).toMatch('https://fonts.googleapis.com');
     expect(links[2].href).toMatch('https://fonts.gstatic.com');
+  });
+
+  it('should return a function that keeps some links', async () => {
+    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+
+    const dirtyDom = document.createElement('html');
+    dirtyDom.innerHTML = `
+      <head>
+        <link src="http://unsafe-host.com"/>
+        <link rel="stylesheet" href="assets/stylesheets/main.50e68009.min.css">
+        <link rel="stylesheet" href="stylesheets/extra.css">
+        <link rel="stylesheet" href="invalid/extra.css">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&display=fallback">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+      </head>
+    `;
+    const clearDom = await result.current(dirtyDom); // calling html transformer
+
+    const links = Array.from(
+      clearDom.querySelectorAll<HTMLLinkElement>('head > link'),
+    );
+    expect(links).toHaveLength(4);
+    expect(links[0].href).toMatch('assets/stylesheets/main.50e68009.min.css');
+    expect(links[1].href).toMatch('stylesheets/extra.css');
+    expect(links[2].href).toMatch('https://fonts.googleapis.com');
+    expect(links[3].href).toMatch('https://fonts.gstatic.com');
   });
 
   it('should return a function that removes unsafe iframes from a given dom element', async () => {

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -42,8 +42,9 @@ export const useSanitizerTransformer = (): Transformer => {
   return useCallback(
     async (dom: Element) => {
       const hosts = config?.getOptionalStringArray('allowedIframeHosts');
+      const saveLinks = config?.getOptionalStringArray('saveLinks');
 
-      DOMPurify.addHook('beforeSanitizeElements', removeUnsafeLinks);
+      DOMPurify.addHook('beforeSanitizeElements', removeUnsafeLinks(saveLinks));
       const tags = ['link'];
 
       if (hosts) {


### PR DESCRIPTION
Signed-off-by: Rico Pahlisch <rico.pahlisch@grayc.de>

## Hey, I just made a Pull Request!

Add an option to enable extra links inside the mkdocs html.
Relates to #12302

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
