### PR TITLE
[Documentation] Fix the example in the switching to postgres tutorial

### DIFF
--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -72,6 +72,12 @@ backend:
 +      port: ${POSTGRES_PORT}
 +      user: ${POSTGRES_USER}
 +      password: ${POSTGRES_PASSWORD}
++      # https://node-postgres.com/features/ssl
++      # you can set the sslmode configuration option via the `PGSSLMODE` environment variable
++      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
++      # ssl:
++      #   ca: # if you have a CA file and want to verify it you can uncomment this section
++      #     $file: <file-path>/ca/server.crt
 +    # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
 +    knexConfig:
 +      pool:
@@ -79,12 +85,6 @@ backend:
 +        max: 12
 +        acquireTimeoutMillis: 60000
 +        idleTimeoutMillis: 60000
-+      # https://node-postgres.com/features/ssl
-+      # you can set the sslmode configuration option via the `PGSSLMODE` environment variable
-+      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
-+      # ssl:
-+      #   ca: # if you have a CA file and want to verify it you can uncomment this section
-+      #     $file: <file-path>/ca/server.crt
 ```
 
 ### Using a single database


### PR DESCRIPTION
The `ssl` config is part of the `connection` config. It's misplaced under the `knexConfig.pool`, which might lead to confusion. This PR fixes it.

Signed-off-by: Mengnan Gong <namco1992@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
