### PR TITLE
Speed up docker builds using cache mounts and a few other tricks

### DIFF
--- a/.changeset/short-plants-return.md
+++ b/.changeset/short-plants-return.md
@@ -1,5 +1,4 @@
 ---
-'example-backend': patch
 '@backstage/create-app': patch
 ---
 

--- a/.changeset/short-plants-return.md
+++ b/.changeset/short-plants-return.md
@@ -1,0 +1,6 @@
+---
+'example-backend': patch
+'@backstage/create-app': patch
+---
+
+Leverage cache mounts in Dockerfile during `yarn install ...` and `apt-get ...` commands to speed up repeated builds.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -61,9 +61,10 @@ FROM node:16-bullseye-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
-    rm -rf /var/lib/apt/lists/* && \
     yarn config set python /usr/bin/python3
 
 # From here on we use the least-privileged `node` user to run the backend.
@@ -79,7 +80,8 @@ ENV NODE_ENV production
 COPY --chown=node:node yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
-RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn install --frozen-lockfile --production --network-timeout 300000
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -165,52 +165,63 @@ RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {
 # Stage 2 - Install dependencies and build packages
 FROM node:16-bullseye-slim AS build
 
-WORKDIR /app
-COPY --from=packages /app .
-
 # install sqlite3 dependencies
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
     yarn config set python /usr/bin/python3
 
-RUN yarn install --frozen-lockfile --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+USER node
+WORKDIR /app
 
-COPY . .
+COPY --from=packages --chown=node:node /app .
+
+# Stop cypress from downloading it's massive binary.
+ENV CYPRESS_INSTALL_BINARY=0
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn install --frozen-lockfile --network-timeout 600000
+
+COPY --chown=node:node . .
 
 RUN yarn tsc
 RUN yarn --cwd packages/backend build
 # If you have not yet migrated to package roles, use the following command instead:
 # RUN yarn --cwd packages/backend backstage-cli backend:bundle --build-dependencies
 
+RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
+    && tar xzf packages/backend/dist/skeleton.tar.gz -C packages/backend/dist/skeleton \
+    && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
+
 # Stage 3 - Build the actual backend image and install production dependencies
 FROM node:16-bullseye-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
-    rm -rf /var/lib/apt/lists/* && \
     yarn config set python /usr/bin/python3
 
 # From here on we use the least-privileged `node` user to run the backend.
 USER node
 WORKDIR /app
 
-# This switches many Node.js dependencies to production mode.
-ENV NODE_ENV production
-
 # Copy the install dependencies from the build stage and context
-COPY --from=build --chown=node:node /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton.tar.gz ./
-RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
+COPY --from=build --chown=node:node /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton/ ./
 
-RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn install --frozen-lockfile --production --network-timeout 600000
 
 # Copy the built packages from the build stage
-COPY --from=build --chown=node:node /app/packages/backend/dist/bundle.tar.gz .
-RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
+COPY --from=build --chown=node:node /app/packages/backend/dist/bundle/ ./
 
 # Copy any other files that we need at runtime
 COPY --chown=node:node app-config.yaml ./
+
+# This switches many Node.js dependencies to production mode.
+ENV NODE_ENV production
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]
 ```
@@ -227,6 +238,7 @@ however ignore any existing build output or dependencies on the host. For our
 new `.dockerignore`, replace the contents of your existing one with this:
 
 ```text
+dist-types
 node_modules
 packages/*/dist
 packages/*/node_modules

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -39,7 +39,7 @@ COPY --chown=node:node yarn.lock package.json packages/backend/dist/skeleton.tar
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
 # Note that this install is not immutable, which is one of the reasons we don't recommend Yarn 3 yet
-RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.yarn/berry/cache,sharing=locked \
+RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,sharing=locked,uid=1000,gid=1000 \
     yarn workspaces focus --all --production
 
 # Then copy the rest of the backend bundle, along with any other files we might want.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -13,9 +13,10 @@ FROM node:16-bullseye-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
-    rm -rf /var/lib/apt/lists/* && \
     yarn config set python /usr/bin/python3
 
 # From here on we use the least-privileged `node` user to run the backend.
@@ -38,7 +39,8 @@ COPY --chown=node:node yarn.lock package.json packages/backend/dist/skeleton.tar
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
 # Note that this install is not immutable, which is one of the reasons we don't recommend Yarn 3 yet
-RUN yarn workspaces focus --all --production && rm -rf "$(yarn cache clean)"
+RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.yarn/berry/cache,sharing=locked \
+    yarn workspaces focus --all --production
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -13,9 +13,10 @@ FROM node:16-bullseye-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev python3 build-essential && \
-    rm -rf /var/lib/apt/lists/* && \
     yarn config set python /usr/bin/python3
 
 # From here on we use the least-privileged `node` user to run the backend.
@@ -31,7 +32,8 @@ ENV NODE_ENV production
 COPY --chown=node:node yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
-RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn install --frozen-lockfile --production --network-timeout 300000
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR updates a few `Dockerfile`s around the code and documentation to improve their build speed.

The biggest change in this PR leverages docker's cache mounts (`RUN --mount=type=cache,...`). [Documentation](https://docs.docker.com/engine/reference/builder/#run---mounttypecache) for reference. 

I leverage cache mounts in two places:
- When installing `yarn` dependencies
- When installing packages with `apt-get`

The cache mount feature allows us to have a directories cached between builds or stages. 

For the host build, this saves time on downloading packages. The first time the image is built, the build will be slow as the cache will be empty and it'll need to download all packages from the internet. After that, the following builds will be able to leverage the cache and avoid downloading packages from the internet.

For the multi-stage build, we get the same benefits as the host build since the cache is preserved between builds. We also get a guaranteed speed improvement because the cache is preserved between the various stages. During the build stage, packages are installed with `yarn` and `apt-get`. This fills up the respective caches. During the final stage, the cache is already full and all the downloads are essentially skipped.

These benefits can be felt by at multiple levels:
- Developers who are working on their `Dockerfile` won't have to wait after package downloads. This will tighten their feedback loop.
- CI or CD systems that reuse the same docker instance will on average experience faster builds as the cache will be preserved between runs.
- Anyone using the multi-stage build will see an immediate speed improvement.

On top of that big change, there's a few smaller changes in this PR:
- In the multi-stage build, during the build stage, before running `yarn install` which installs all `devDependencies`, I set `CYPRESS_INSTALL_BINARY=0` which prevents cypress from installing its binary. This download can take a while and skipping it here saves a good chunk of time.
- In the multi-stage build, I moved `ENV NODE_ENV production` to the bottom of the file. This is a micro-optimization that ensures that if this values is changed, the expensive parts of the build don't have to be re-run and the docker cache can be leveraged for those layers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
