### PR TITLE
Added back support for when no branch is provided for the Bitbucket Server UrlReader

### DIFF
--- a/.changeset/chilled-apes-change.md
+++ b/.changeset/chilled-apes-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added back support for when no branch is provided for the Bitbucket Server `UrlReader`

--- a/packages/backend-common/src/reading/BitbucketServerUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketServerUrlReader.test.ts
@@ -102,6 +102,25 @@ describe('BitbucketServerUrlReader', () => {
               }),
             ),
         ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
+          (_, res, ctx) =>
+            res(
+              ctx.status(200),
+              ctx.json({
+                id: 'refs/heads/master',
+                displayId: 'master',
+                type: 'BRANCH',
+                latestCommit: '3bdd5457286abdf920db4b77bf2fef79a06190c2',
+                latestChangeset: '3bdd5457286abdf920db4b77bf2fef79a06190c2',
+                isDefault: true,
+              }),
+            ),
+        ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
+          (_, res, ctx) => res(ctx.status(404)),
+        ),
       );
     });
 
@@ -118,6 +137,14 @@ describe('BitbucketServerUrlReader', () => {
       const indexMarkdownFile = await files[0].content();
 
       expect(indexMarkdownFile.toString()).toBe('# Test\n');
+    });
+
+    it('uses default branch when no branch is provided', async () => {
+      const response = await reader.readTree(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/src',
+      );
+
+      expect(response.etag).toBe('3bdd5457286a');
     });
   });
 

--- a/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
@@ -188,11 +188,13 @@ export class BitbucketServerUrlReader implements UrlReader {
   private async getLastCommitShortHash(url: string): Promise<string> {
     const { name: repoName, owner: project, ref: branch } = parseGitUrl(url);
 
-    const branchListUrl = `${
-      this.integration.config.apiBaseUrl
-    }/projects/${project}/repos/${repoName}/branches?filterText=${encodeURIComponent(
-      branch,
-    )}`;
+    // If a branch is provided use that otherwise fall back to the default branch
+    const branchParameter = branch
+      ? `?filterText=${encodeURIComponent(branch)}`
+      : '/default';
+
+    // https://docs.atlassian.com/bitbucket-server/rest/7.9.0/bitbucket-rest.html#idp211 (branches docs)
+    const branchListUrl = `${this.integration.config.apiBaseUrl}/projects/${project}/repos/${repoName}/branches${branchParameter}`;
 
     const branchListResponse = await fetch(
       branchListUrl,
@@ -216,8 +218,15 @@ export class BitbucketServerUrlReader implements UrlReader {
       return exactBranchMatch.latestCommit.substring(0, 12);
     }
 
+    // Handle when no branch is provided using the default as the fallback
+    if (!branch && branchMatches) {
+      return branchMatches.latestCommit.substring(0, 12);
+    }
+
     throw new Error(
-      `Failed to find branch "${branch}" in property "displayId" of response to ${branchListUrl}`,
+      `Failed to find Last Commit using ${
+        branch ? `branch "${branch}"` : 'default branch'
+      } in response from ${branchListUrl}`,
     );
   }
 }


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Added back support for when no branch is provided for the Bitbucket Server `UrlReader`. This is a regression created by #13990 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
