### PR TITLE
Set searchTooltip to Filter

### DIFF
--- a/.changeset/big-islands-add.md
+++ b/.changeset/big-islands-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Set the `searchTooltip` to "Filter" to follow how the `searchPlaceholder` is set making this more consistent

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -516,7 +516,9 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
         }
         data={typeof data === 'function' ? data : tableData}
         style={{ width: '100%' }}
-        localization={{ toolbar: { searchPlaceholder: 'Filter' } }}
+        localization={{
+          toolbar: { searchPlaceholder: 'Filter', searchTooltip: 'Filter' },
+        }}
         {...restProps}
       />
     </div>

--- a/plugins/dynatrace/src/components/Problems/ProblemsTable/ProblemsTable.test.tsx
+++ b/plugins/dynatrace/src/components/Problems/ProblemsTable/ProblemsTable.test.tsx
@@ -31,6 +31,6 @@ describe('ProblemsTable', () => {
         <ProblemsTable problems={problems} dynatraceBaseUrl="__dynatrace__" />,
       </ApiProvider>,
     );
-    expect(await rendered.findByTitle('Search')).toBeInTheDocument();
+    expect(await rendered.findByTitle('Filter')).toBeInTheDocument();
   });
 });

--- a/plugins/dynatrace/src/components/Problems/ProblemsTable/ProblemsTable.test.tsx
+++ b/plugins/dynatrace/src/components/Problems/ProblemsTable/ProblemsTable.test.tsx
@@ -31,6 +31,10 @@ describe('ProblemsTable', () => {
         <ProblemsTable problems={problems} dynatraceBaseUrl="__dynatrace__" />,
       </ApiProvider>,
     );
-    expect(await rendered.findByTitle('Filter')).toBeInTheDocument();
+
+    // Checking for Title from mocked problems
+    expect(
+      await rendered.findByText('this IS a big problem'),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Set the `searchTooltip` to "Filter" to follow how the `searchPlaceholder` is set making this more consistent

![Screen Shot 2022-10-12 at 4 39 24 PM](https://user-images.githubusercontent.com/67169551/195453180-531a279c-d3c9-4cd8-a503-0370abc3b918.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
