### PR TITLE
Catalog: add offset pagination support to paginated entities

### DIFF
--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -146,6 +146,7 @@ export interface EntitiesCatalog {
    */
   paginatedEntities(
     request?: PaginatedEntitiesRequest,
+    options?: PaginatedEntitiesOptions,
   ): Promise<PaginatedEntitiesResponse>;
 
   /**
@@ -185,6 +186,13 @@ export interface EntitiesCatalog {
 export type PaginatedEntitiesRequest =
   | PaginatedEntitiesInitialRequest
   | PaginatedEntitiesCursorRequest;
+
+/**
+ * Options for {@link EntitiesCatalog.paginatedEntities}.
+ */
+export type PaginatedEntitiesOptions = {
+  pagination: 'cursor' | 'offset';
+};
 
 /**
  * The initial request for {@link EntitiesCatalog.paginatedEntities}.
@@ -253,8 +261,10 @@ export type Cursor = {
   /**
    * The value of the cursor of the last item returned.
    * This is used for performing pagination.
+   * The value will be a string[] in case of cursor based pagination
+   * or a number in case of offset based pagination.
    */
-  sortFieldIds: string[];
+  offset: string[] | number;
 
   /**
    * A filter to apply on the full list of entities.
@@ -269,11 +279,12 @@ export type Cursor = {
    */
   query?: string;
   /**
-   * Sort field id of the first item.
-   * The catalog uses this field internally for understanding when the beginning
-   * of the list has been reached when performing cursor based pagination.
+   * Sort field ids of the first item.
+   * The catalog uses this field internally when performing cursor based pagination,
+   * to understand if the beginning of the list has been reached.
    */
-  firstFieldId: string;
+  firstItemFields: string[];
+
   /**
    * The number of items that match the provided filters
    */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR addresses the following comment:
https://github.com/backstage/backstage/pull/12246#discussion_r909551607

> We can't really assume unique values here right? Might need a secondary offset or value to filter by as well? For example always falling back to sorting by the `entity_id`

When using cursor based pagination, it isn't possible to use a second value as a fallback for entities sorting, since a the moment different value types (for example `metadata.uid`, `metadata.name`, etc...) are currently stored in the same column in the search table.
Of course refactoring the database structure and storing "well known fields" under each own column would solve the issue above, but unfortunately it will require more changes that are out of scope from these PRs.

For the reason mentioned above, this PR adds support for offset based pagination in the paginated endpoint, in order to avoid issues in case the values used for sorting the entities aren’t unique among all entities. The offset pagination method will be used by default.
I’ve kept the cursor based pagination support in the method, but I am very open to removing it completely, simplifying the code a bit and adding it back once the proper changes are made in the database structure.

An important thing to mention is that, switching to cursor based pagination in the future won’t introduce any breaking change, since the pagination logic is only handled internally in the `DefaultEntitiesCatalog`:  the clients consuming the paginated data will always receive a base64 cursor.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
