### PR TITLE
[Catalog] [Scaffolder] Analytics entity-awareness

### DIFF
--- a/.changeset/analyze-software-creation.md
+++ b/.changeset/analyze-software-creation.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Basic analytics instrumentation is now in place:
+
+- As users make their way through template steps, a `click` event is fired, including the step number.
+- After a user clicks "Create" a `create` event is fired, including the name of the software that was just created. The template used at creation is set on the `entityRef` context key.

--- a/.changeset/analyze-software-exploration.md
+++ b/.changeset/analyze-software-exploration.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Both `EntityProvider` and `AsyncEntityProvider` contexts now wrap all children with an `AnalyticsContext` containing the corresponding `entityRef`; this opens up the possibility for all events underneath these contexts to be associated with and aggregated by the corresponding entity.

--- a/docs/plugins/analytics.md
+++ b/docs/plugins/analytics.md
@@ -301,11 +301,11 @@ it's important to keep each of these levels of detail disaggregated.
   automatically as part of the `extension` in which the `filter` event was
   captured).
 
-- On the flip side, when adding `attributes` to an event, look at existing
-  events and see if the data you are capturing matches the intention, type, or
-  even the content of _their_ `attributes`. For instance, it may be common for
-  events that involve the Catalog to add details like entity `name`, `kind`,
-  and/or `namespace` as `attributes`. Using the same keys in your event will
+- On the flip side, when adding `attributes` to or `context` around an event,
+  look at existing events and see if the data you are capturing matches the
+  intention, type, or even the content of _their_ `attributes` or `context`.
+  For instance, it's common for events that involve the Catalog to include an
+  `entityRef` contextual key. Using the same keys and values in your event will
   ensure that events instrumented across plugins can easily be aggregated.
 
 ### Unit Testing Event Capture

--- a/docs/plugins/analytics.md
+++ b/docs/plugins/analytics.md
@@ -52,12 +52,13 @@ learn how to contribute the integration yourself!
 The following table summarizes events that, depending on the plugins you have
 installed, may be captured.
 
-| Action     | Subject                                             | Other Notes                                                       |
-| ---------- | --------------------------------------------------- | ----------------------------------------------------------------- |
-| `navigate` | The URL of the page that was navigated to           |                                                                   |
-| `click`    | The text of the link that was clicked on            | The `to` attribute represents the URL clicked to                  |
-| `search`   | The search term entered in any search bar component | The `searchTypes` attribute holds `types` constraining the search |
-| `discover` | The title of the search result that was clicked on  | The `value` is the result rank. A `to` attribute is also provided |
+| Action     | Subject                                                                                                                                                            | Other Notes                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `navigate` | The URL of the page that was navigated to                                                                                                                          |                                                                                                     |
+| `click`    | The text of the link that was clicked on                                                                                                                           | The `to` attribute represents the URL clicked to                                                    |
+| `create`   | The `name` of the software being created; if no `name` property is requested by the given Software Template, then the string `new {templateName}` is used instead. | The context holds an `entityRef`, set to the template's ref (e.g. `template:default/template-name`) |
+| `search`   | The search term entered in any search bar component                                                                                                                | The context holds `searchTypes`, representing `types` constraining the search                       |
+| `discover` | The title of the search result that was clicked on                                                                                                                 | The `value` is the result rank. A `to` attribute is also provided                                   |
 
 If there is an event you'd like to see captured, please [open an
 issue][add-event] describing the event you want to see and the questions it

--- a/plugins/badges/src/components/EntityBadgesDialog.test.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.test.tsx
@@ -38,7 +38,10 @@ describe('EntityBadgesDialog', () => {
         },
       ]),
     };
-    const mockEntity = { metadata: { name: 'mock' } } as Entity;
+    const mockEntity = {
+      metadata: { name: 'mock' },
+      kind: 'MockKind',
+    } as Entity;
 
     const rendered = await renderWithEffects(
       <TestApiProvider

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { AnalyticsContext } from '@backstage/core-plugin-api';
 import {
   createVersionedContext,
   createVersionedValueMap,
@@ -66,7 +67,13 @@ export const AsyncEntityProvider = ({
   // consumers might be doing things like `useContext(EntityContext)`
   return (
     <NewEntityContext.Provider value={createVersionedValueMap({ 1: value })}>
-      {children}
+      <AnalyticsContext
+        attributes={{
+          ...(entity ? { entityRef: stringifyEntityRef(entity) } : undefined),
+        }}
+      >
+        {children}
+      </AnalyticsContext>
     </NewEntityContext.Provider>
   );
 };

--- a/plugins/catalog/src/components/EntityLinksCard/EntityLinksCard.test.tsx
+++ b/plugins/catalog/src/components/EntityLinksCard/EntityLinksCard.test.tsx
@@ -24,8 +24,10 @@ describe('EntityLinksCard', () => {
   const createEntity = (links: EntityLink[] = []): Entity =>
     ({
       metadata: {
+        name: 'mock',
         links,
       },
+      kind: 'MockKind',
     } as Entity);
 
   const createLink = ({

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.test.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.test.tsx
@@ -46,7 +46,9 @@ describe('EntitySwitch', () => {
 
     const rendered = render(
       <Wrapper>
-        <EntityProvider entity={{ kind: 'component' } as Entity}>
+        <EntityProvider
+          entity={{ metadata: { name: 'mock' }, kind: 'component' } as Entity}
+        >
           {content}
         </EntityProvider>
       </Wrapper>,
@@ -58,7 +60,9 @@ describe('EntitySwitch', () => {
 
     rendered.rerender(
       <Wrapper>
-        <EntityProvider entity={{ kind: 'template' } as Entity}>
+        <EntityProvider
+          entity={{ metadata: { name: 'mock' }, kind: 'template' } as Entity}
+        >
           {content}
         </EntityProvider>
       </Wrapper>,
@@ -70,7 +74,9 @@ describe('EntitySwitch', () => {
 
     rendered.rerender(
       <Wrapper>
-        <EntityProvider entity={{ kind: 'derp' } as Entity}>
+        <EntityProvider
+          entity={{ metadata: { name: 'mock' }, kind: 'derp' } as Entity}
+        >
           {content}
         </EntityProvider>
       </Wrapper>,
@@ -94,7 +100,7 @@ describe('EntitySwitch', () => {
   });
 
   it('should switch child when filters switch', () => {
-    const entity = { kind: 'component' } as Entity;
+    const entity = { metadata: { name: 'mock' }, kind: 'component' } as Entity;
 
     const rendered = render(
       <Wrapper>
@@ -126,7 +132,7 @@ describe('EntitySwitch', () => {
   });
 
   it('should switch with async condition that is true', async () => {
-    const entity = { kind: 'component' } as Entity;
+    const entity = { metadata: { name: 'mock' }, kind: 'component' } as Entity;
 
     const shouldRender = () => Promise.resolve(true);
     const rendered = render(
@@ -145,7 +151,7 @@ describe('EntitySwitch', () => {
   });
 
   it('should switch with sync condition that is false', async () => {
-    const entity = { kind: 'component' } as Entity;
+    const entity = { metadata: { name: 'mock' }, kind: 'component' } as Entity;
 
     const shouldRender = () => Promise.resolve(false);
     const rendered = render(
@@ -164,7 +170,7 @@ describe('EntitySwitch', () => {
   });
 
   it('should switch with sync condition that throws', async () => {
-    const entity = { kind: 'component' } as Entity;
+    const entity = { metadata: { name: 'mock' }, kind: 'component' } as Entity;
 
     const shouldRender = () => Promise.reject();
     const rendered = render(

--- a/plugins/gocd/src/components/GoCdBuildsComponent/GoCdBuildsComponent.test.tsx
+++ b/plugins/gocd/src/components/GoCdBuildsComponent/GoCdBuildsComponent.test.tsx
@@ -36,7 +36,9 @@ describe('GoCdArtifactsComponent', () => {
       baseUrl: 'gocd.baseurl.com',
     },
   });
-  const entityValue = { entity: { metadata: {} } as Entity };
+  const entityValue = {
+    entity: { metadata: { name: 'mock' }, kind: 'MockKind' } as Entity,
+  };
 
   const renderComponent = () =>
     renderWithEffects(

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -32,6 +32,7 @@ import { createValidator } from './createValidator';
 
 import { Content, Header, InfoCard, Page } from '@backstage/core-components';
 import {
+  AnalyticsContext,
   errorApiRef,
   useApi,
   useApiHolder,
@@ -129,41 +130,43 @@ export const TemplatePage = ({
   );
 
   return (
-    <Page themeId="home">
-      <Header
-        pageTitleOverride="Create a New Component"
-        title="Create a New Component"
-        subtitle="Create new software components using standard templates"
-      />
-      <Content>
-        {loading && <LinearProgress data-testid="loading-progress" />}
-        {schema && (
-          <InfoCard
-            title={schema.title}
-            noPadding
-            titleTypographyProps={{ component: 'h2' }}
-          >
-            <MultistepJsonForm
-              formData={formState}
-              fields={customFieldComponents}
-              onChange={handleChange}
-              onReset={handleFormReset}
-              onFinish={handleCreate}
-              layouts={layouts}
-              steps={schema.steps.map(step => {
-                return {
-                  ...step,
-                  validate: createValidator(
-                    step.schema,
-                    customFieldValidators,
-                    { apiHolder },
-                  ),
-                };
-              })}
-            />
-          </InfoCard>
-        )}
-      </Content>
-    </Page>
+    <AnalyticsContext attributes={{ entityRef: templateRef }}>
+      <Page themeId="home">
+        <Header
+          pageTitleOverride="Create a New Component"
+          title="Create a New Component"
+          subtitle="Create new software components using standard templates"
+        />
+        <Content>
+          {loading && <LinearProgress data-testid="loading-progress" />}
+          {schema && (
+            <InfoCard
+              title={schema.title}
+              noPadding
+              titleTypographyProps={{ component: 'h2' }}
+            >
+              <MultistepJsonForm
+                formData={formState}
+                fields={customFieldComponents}
+                onChange={handleChange}
+                onReset={handleFormReset}
+                onFinish={handleCreate}
+                layouts={layouts}
+                steps={schema.steps.map(step => {
+                  return {
+                    ...step,
+                    validate: createValidator(
+                      step.schema,
+                      customFieldValidators,
+                      { apiHolder },
+                    ),
+                  };
+                })}
+              />
+            </InfoCard>
+          )}
+        </Content>
+      </Page>
+    </AnalyticsContext>
   );
 };

--- a/plugins/todo/src/components/TodoList/TodoList.test.tsx
+++ b/plugins/todo/src/components/TodoList/TodoList.test.tsx
@@ -38,7 +38,10 @@ describe('TodoList', () => {
         offset: 0,
       }),
     };
-    const mockEntity = { metadata: { name: 'mock' } } as Entity;
+    const mockEntity = {
+      metadata: { name: 'mock' },
+      kind: 'MockKind',
+    } as Entity;
 
     const rendered = await renderWithEffects(
       <TestApiProvider apis={[[todoApiRef, mockApi]]}>


### PR DESCRIPTION
## What / Why

- Introduces a by-convention `entityRef` analytics context key (set on the `(Async)EntityProvider`) to allow events on catalog (and other) pages to be aggregated by entity.
- Adds a `create` event in the scaffolder whose subject is the name of the software created (falling backed to `new {templateName}` if for some reason the template doesn't ask for `name`). The template entity ref is set on the `entityRef` context.
- Also adds click handling on the Scaffolder stepper's "Next Step" buttons as a way to measure scaffolder form abandonment.

### Show me the data

The "create" event looks something like this:

<img width="901" alt="Screenshot 2022-10-13 at 16 46 33" src="https://user-images.githubusercontent.com/3496491/195629787-734dfe06-0d5a-40ee-a517-6ee53fb63cd2.png">

The step events look like this:

<img width="901" alt="Screenshot 2022-10-13 at 16 48 19" src="https://user-images.githubusercontent.com/3496491/195630101-ccf9a253-6944-480b-b2f6-c1f8475ad647.png">

And events underneath the analytics context resemble this:

<img width="847" alt="Screenshot 2022-10-13 at 16 50 03" src="https://user-images.githubusercontent.com/3496491/195630606-03658f04-07fb-42aa-a7f6-c7767417f69b.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
