### PR TITLE
chore: add new reviewer to codeowners (8294)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@ yarn.lock                                           @backstage/reviewers @backst
 /plugins/code-coverage                              @backstage/reviewers @alde @nissayeva
 /plugins/code-coverage-backend                      @backstage/reviewers @alde @nissayeva
 /plugins/cost-insights                              @backstage/reviewers @backstage/silver-lining
+/plugins/cost-insights-*                            @backstage/reviewers @backstage/silver-lining
 /plugins/explore                                    @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/explore-react                              @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/fossa                                      @backstage/reviewers @backstage/sda-se-reviewers
@@ -44,13 +45,15 @@ yarn.lock                                           @backstage/reviewers @backst
 /plugins/ilert                                      @backstage/reviewers @yacut
 /plugins/jenkins                                    @backstage/reviewers @timja
 /plugins/jenkins-backend                            @backstage/reviewers @timja
-/plugins/kafka                                      @backstage/reviewers @nirga
-/plugins/kafka-backend                              @backstage/reviewers @nirga
+/plugins/kafka                                      @backstage/reviewers @nirga @andrewthauer
+/plugins/kafka-backend                              @backstage/reviewers @nirga @andrewthauer
 /plugins/kubernetes                                 @backstage/reviewers @backstage/warpspeed
 /plugins/kubernetes-*                               @backstage/reviewers @backstage/warpspeed
 /plugins/newrelic-dashboard                         @backstage/reviewers @mufaddal7
 /plugins/playlist                                   @backstage/reviewers @kuangp
 /plugins/playlist-*                                 @backstage/reviewers @kuangp
+/plugins/rollbar                                    @backstage/reviewers @andrewthauer
+/plugins/rollbar-backend                            @backstage/reviewers @andrewthauer
 /plugins/scaffolder-backend-module-rails            @backstage/reviewers @angeliski
 /plugins/scaffolder-backend-module-yeoman           @backstage/reviewers @pawelmitka
 /plugins/search                                     @backstage/reviewers @backstage/techdocs-core


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a very late follow up to issue #8294 which requested reviewers on certain plugins. Also added an entry for `cost-insights-*` since there is now a `cost-insights-common` package.  @jhaals asked me back in Dec about this, and I'm just getting around to it now :(

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
