### PR TITLE
fix(techdocsReader): include search params when navigating urls

### DIFF
--- a/.changeset/spicy-parents-lick.md
+++ b/.changeset/spicy-parents-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Include query parameters when navigating to relative links in documents

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -175,13 +175,14 @@ export const useTechDocsReaderDom = (
             // detect if CTRL or META keys are pressed so that links can be opened in a new tab with `window.open`
             const modifierActive = event.ctrlKey || event.metaKey;
             const parsedUrl = new URL(url);
+            const fullPath = `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
 
             // hash exists when anchor is clicked on secondary sidebar
             if (parsedUrl.hash) {
               if (modifierActive) {
-                window.open(`${parsedUrl.pathname}${parsedUrl.hash}`, '_blank');
+                window.open(fullPath, '_blank');
               } else {
-                navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
+                navigate(fullPath);
                 // Scroll to hash if it's on the current page
                 transformedElement
                   ?.querySelector(`[id="${parsedUrl.hash.slice(1)}"]`)
@@ -189,9 +190,9 @@ export const useTechDocsReaderDom = (
               }
             } else {
               if (modifierActive) {
-                window.open(parsedUrl.pathname, '_blank');
+                window.open(fullPath, '_blank');
               } else {
-                navigate(parsedUrl.pathname);
+                navigate(fullPath);
               }
             }
           },


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This fixes an issue where the search params were being stripped when navigating relative URLs within docs. 

For example for the following link:
```md
[test catalog link](/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=all&filters%5Btags%5D=website)  
```
Clicking on this currently incorrectly navigates to `/catalog` since the query params are not included in the click listener and the filters are lost in the catalog view.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
