### PR TITLE
Catalog graph improvement

### DIFF
--- a/.changeset/wicked-masks-explain.md
+++ b/.changeset/wicked-masks-explain.md
@@ -1,5 +1,4 @@
 ---
-'@backstage/catalog-model': patch
 '@backstage/plugin-catalog-backend': patch
 '@backstage/plugin-catalog-graph': patch
 ---

--- a/.changeset/wicked-masks-explain.md
+++ b/.changeset/wicked-masks-explain.md
@@ -4,4 +4,4 @@
 '@backstage/plugin-catalog-graph': patch
 ---
 
-Added ownedBy filter to catalog-graph
+Added owned by filter to catalog-graph

--- a/.changeset/wicked-masks-explain.md
+++ b/.changeset/wicked-masks-explain.md
@@ -1,0 +1,7 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-graph': patch
+---
+
+Added ownedBy filter to catalog-graph

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -179,9 +179,6 @@ export type EntityMeta = JsonObject & {
  * @public
  */
 export type EntityRelation = {
-  target: {
-    name: string,
-  };
   /**
    * The type of the relation.
    */

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -179,6 +179,9 @@ export type EntityMeta = JsonObject & {
  * @public
  */
 export type EntityRelation = {
+  target: {
+    name: string,
+  };
   /**
    * The type of the relation.
    */

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -379,6 +379,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
               facet.substring('metadata.labels.'.length)
             ];
           }
+          if (facet === 'owner') return lodash.get(entity.spec, facet);
           return lodash.get(entity, facet);
         })
         .flatMap(field => {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -379,7 +379,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
               facet.substring('metadata.labels.'.length)
             ];
           }
-          if (facet === 'owner') return lodash.get(entity.spec, facet);
+          if (facet === entity.kind) return entity.metadata.name;
           return lodash.get(entity, facet);
         })
         .flatMap(field => {

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -24,6 +24,7 @@ export const CatalogGraphPage: (props: {
     | {
         selectedRelations?: string[] | undefined;
         selectedKinds?: string[] | undefined;
+        selectedOwnedby?: string[] | undefined;
         rootEntityRefs?: string[] | undefined;
         maxDepth?: number | undefined;
         unidirectional?: boolean | undefined;
@@ -108,6 +109,7 @@ export const EntityRelationsGraph: (props: {
   unidirectional?: boolean | undefined;
   mergeRelations?: boolean | undefined;
   kinds?: string[] | undefined;
+  ownedby?: string[] | undefined;
   relations?: string[] | undefined;
   direction?: Direction | undefined;
   onNodeClick?:

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -24,7 +24,7 @@ export const CatalogGraphPage: (props: {
     | {
         selectedRelations?: string[] | undefined;
         selectedKinds?: string[] | undefined;
-        selectedOwnedby?: string[] | undefined;
+        selectedOwnedBy?: string[] | undefined;
         rootEntityRefs?: string[] | undefined;
         maxDepth?: number | undefined;
         unidirectional?: boolean | undefined;
@@ -109,7 +109,7 @@ export const EntityRelationsGraph: (props: {
   unidirectional?: boolean | undefined;
   mergeRelations?: boolean | undefined;
   kinds?: string[] | undefined;
-  ownedby?: string[] | undefined;
+  ownedBy?: string[] | undefined;
   relations?: string[] | undefined;
   direction?: Direction | undefined;
   onNodeClick?:

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -105,7 +105,7 @@ export const CatalogGraphPage = (props: {
   initialState?: {
     selectedRelations?: string[];
     selectedKinds?: string[];
-    selectedOwnedby?: string[];
+    selectedOwnedBy?: string[];
     rootEntityRefs?: string[];
     maxDepth?: number;
     unidirectional?: boolean;
@@ -126,8 +126,8 @@ export const CatalogGraphPage = (props: {
     setSelectedKinds,
     selectedRelations,
     setSelectedRelations,
-    selectedOwnedby,
-    setSelectedOwnedby,
+    selectedOwnedBy,
+    setSelectedOwnedBy,
     unidirectional,
     setUnidirectional,
     mergeRelations,
@@ -205,8 +205,8 @@ export const CatalogGraphPage = (props: {
                 relationPairs={relationPairs}
               />
               <SelectedOwnbyFilter
-                value={selectedOwnedby}
-                onChange={setSelectedOwnedby}
+                value={selectedOwnedBy}
+                onChange={setSelectedOwnedBy}
               />
               <DirectionFilter value={direction} onChange={setDirection} />
               <SwitchFilter
@@ -246,9 +246,9 @@ export const CatalogGraphPage = (props: {
                     ? selectedRelations
                     : undefined
                 }
-                ownedby={
-                  selectedOwnedby && selectedOwnedby.length > 0
-                    ? selectedOwnedby
+                ownedBy={
+                  selectedOwnedBy && selectedOwnedBy.length > 0
+                    ? selectedOwnedBy
                     : undefined
                 }
                 mergeRelations={mergeRelations}

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -143,7 +143,6 @@ export const CatalogGraphPage = (props: {
   const onNodeClick = useCallback(
     (node: EntityNode, event: MouseEvent<unknown>) => {
       const nodeEntityName = parseEntityRef(node.id);
-      console.log(nodeEntityName, '---------nodee name');
 
       if (event.shiftKey) {
         const path = catalogEntityRoute({

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -44,6 +44,7 @@ import { DirectionFilter } from './DirectionFilter';
 import { MaxDepthFilter } from './MaxDepthFilter';
 import { SelectedKindsFilter } from './SelectedKindsFilter';
 import { SelectedRelationsFilter } from './SelectedRelationsFilter';
+import { SelectedOwnbyFilter } from './SelectedOwnbyFilter';
 import { SwitchFilter } from './SwitchFilter';
 import { useCatalogGraphPage } from './useCatalogGraphPage';
 
@@ -104,6 +105,7 @@ export const CatalogGraphPage = (props: {
   initialState?: {
     selectedRelations?: string[];
     selectedKinds?: string[];
+    selectedOwnedby?: string[];
     rootEntityRefs?: string[];
     maxDepth?: number;
     unidirectional?: boolean;
@@ -124,6 +126,8 @@ export const CatalogGraphPage = (props: {
     setSelectedKinds,
     selectedRelations,
     setSelectedRelations,
+    selectedOwnedby,
+    setSelectedOwnedby,
     unidirectional,
     setUnidirectional,
     mergeRelations,
@@ -139,6 +143,7 @@ export const CatalogGraphPage = (props: {
   const onNodeClick = useCallback(
     (node: EntityNode, event: MouseEvent<unknown>) => {
       const nodeEntityName = parseEntityRef(node.id);
+      console.log(nodeEntityName, '---------nodee name');
 
       if (event.shiftKey) {
         const path = catalogEntityRoute({
@@ -200,6 +205,10 @@ export const CatalogGraphPage = (props: {
                 onChange={setSelectedRelations}
                 relationPairs={relationPairs}
               />
+              <SelectedOwnbyFilter
+                value={selectedOwnedby}
+                onChange={setSelectedOwnedby}
+              />
               <DirectionFilter value={direction} onChange={setDirection} />
               <SwitchFilter
                 value={unidirectional}
@@ -236,6 +245,11 @@ export const CatalogGraphPage = (props: {
                 relations={
                   selectedRelations && selectedRelations.length > 0
                     ? selectedRelations
+                    : undefined
+                }
+                ownedby={
+                  selectedOwnedby && selectedOwnedby.length > 0
+                    ? selectedOwnedby
                     : undefined
                 }
                 mergeRelations={mergeRelations}

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -44,7 +44,7 @@ import { DirectionFilter } from './DirectionFilter';
 import { MaxDepthFilter } from './MaxDepthFilter';
 import { SelectedKindsFilter } from './SelectedKindsFilter';
 import { SelectedRelationsFilter } from './SelectedRelationsFilter';
-import { SelectedOwnbyFilter } from './SelectedOwnbyFilter';
+import { SelectedOwnByFilter } from './SelectedOwnbyFilter';
 import { SwitchFilter } from './SwitchFilter';
 import { useCatalogGraphPage } from './useCatalogGraphPage';
 
@@ -204,7 +204,7 @@ export const CatalogGraphPage = (props: {
                 onChange={setSelectedRelations}
                 relationPairs={relationPairs}
               />
-              <SelectedOwnbyFilter
+              <SelectedOwnByFilter
                 value={selectedOwnedBy}
                 onChange={setSelectedOwnedBy}
               />

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
@@ -47,10 +47,9 @@ export const SelectedOwnByFilter = ({ value, onChange }: Props) => {
   const catalogApi = useApi(catalogApiRef);
 
   const { error, value: ownedby } = useAsync(async () => {
-    return await catalogApi.getEntityFacets({ facets: ["Group", "User"] }).then(
+    return await catalogApi.getEntityFacets({ facets: ['Group', 'User'] }).then(
       response =>
-        response.facets["Group"]
-          .concat(response.facets["User"])
+        response.facets.Group.concat(response.facets.User)
           ?.map(f => f.value)
           .sort() || [],
     );

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
@@ -1,0 +1,110 @@
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  makeStyles,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Autocomplete } from '@material-ui/lab';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+
+const useStyles = makeStyles({
+  formControl: {
+    maxWidth: 300,
+  },
+});
+
+export type Props = {
+  value: string[] | undefined;
+  onChange: (value: string[] | undefined) => void;
+};
+
+export const SelectedOwnbyFilter = ({ value, onChange }: Props) => {
+  const classes = useStyles();
+  const alertApi = useApi(alertApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const { error, value: ownedby } = useAsync(async () => {
+    return await catalogApi
+      .getEntityFacets({ facets: ['owner'] })
+      .then(response => response.facets.owner?.map(f => f.value).sort() || []);
+  });
+
+  useEffect(() => {
+    if (error) {
+      alertApi.post({
+        message: `Failed to load entity kinds`,
+        severity: 'error',
+      });
+    }
+  }, [error, alertApi]);
+
+  const normalizedOwnedby = useMemo(
+    () =>
+      ownedby
+        ? ownedby.map(owner => owner.toLocaleLowerCase('en-US'))
+        : ownedby,
+    [ownedby],
+  );
+
+  const handleChange = useCallback(
+    (_: unknown, v: string[]) => {
+      onChange(
+        normalizedOwnedby && normalizedOwnedby.every(r => v.includes(r))
+          ? undefined
+          : v,
+      );
+    },
+    [normalizedOwnedby, onChange],
+  );
+
+  const handleEmpty = useCallback(() => {
+    onChange(value?.length ? value : undefined);
+  }, [value, onChange]);
+
+  if (!ownedby?.length || !normalizedOwnedby?.length || error) {
+    return <></>;
+  }
+
+  return (
+    <Box pb={1} pt={1}>
+      <Typography variant="button">Ownedby</Typography>
+      <Autocomplete
+        className={classes.formControl}
+        multiple
+        limitTags={4}
+        disableCloseOnSelect
+        aria-label="Ownedby"
+        options={normalizedOwnedby}
+        value={value ?? normalizedOwnedby}
+        getOptionLabel={owner =>
+          ownedby[normalizedOwnedby.indexOf(owner)] ?? owner
+        }
+        onChange={handleChange}
+        onBlur={handleEmpty}
+        renderOption={(option, { selected }) => (
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                checkedIcon={<CheckBoxIcon fontSize="small" />}
+                checked={selected}
+              />
+            }
+            label={ownedby[normalizedOwnedby.indexOf(option)] ?? option}
+          />
+        )}
+        size="small"
+        popupIcon={<ExpandMoreIcon data-testid="selected-ownedby-expand" />}
+        renderInput={params => <TextField {...params} variant="outlined" />}
+      />
+    </Box>
+  );
+};

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
@@ -41,16 +41,16 @@ export type Props = {
   onChange: (value: string[] | undefined) => void;
 };
 
-export const SelectedOwnbyFilter = ({ value, onChange }: Props) => {
+export const SelectedOwnByFilter = ({ value, onChange }: Props) => {
   const classes = useStyles();
   const alertApi = useApi(alertApiRef);
   const catalogApi = useApi(catalogApiRef);
 
   const { error, value: ownedby } = useAsync(async () => {
-    return await catalogApi.getEntityFacets({ facets: ['Group', 'User'] }).then(
+    return await catalogApi.getEntityFacets({ facets: ["Group", "User"] }).then(
       response =>
-        response.facets['Group']
-          .concat(response.facets['User'])
+        response.facets["Group"]
+          .concat(response.facets["User"])
           ?.map(f => f.value)
           .sort() || [],
     );

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
@@ -47,9 +47,13 @@ export const SelectedOwnbyFilter = ({ value, onChange }: Props) => {
   const catalogApi = useApi(catalogApiRef);
 
   const { error, value: ownedby } = useAsync(async () => {
-    return await catalogApi
-      .getEntityFacets({ facets: ['owner'] })
-      .then(response => response.facets.owner?.map(f => f.value).sort() || []);
+    return await catalogApi.getEntityFacets({ facets: ['Group', 'User'] }).then(
+      response =>
+        response.facets['Group']
+          .concat(response.facets['User'])
+          ?.map(f => f.value)
+          .sort() || [],
+    );
   });
 
   useEffect(() => {
@@ -85,7 +89,7 @@ export const SelectedOwnbyFilter = ({ value, onChange }: Props) => {
   }, [value, onChange]);
 
   if (!ownedby?.length || !normalizedOwnedby?.length || error) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnbyFilter.tsx
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import {

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/useCatalogGraphPage.ts
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/useCatalogGraphPage.ts
@@ -38,8 +38,8 @@ export type CatalogGraphPageValue = {
   setMaxDepth: Dispatch<React.SetStateAction<number>>;
   selectedRelations: string[] | undefined;
   setSelectedRelations: Dispatch<React.SetStateAction<string[] | undefined>>;
-  selectedOwnedby: string[] | undefined;
-  setSelectedOwnedby: Dispatch<React.SetStateAction<string[] | undefined>>;
+  selectedOwnedBy: string[] | undefined;
+  setSelectedOwnedBy: Dispatch<React.SetStateAction<string[] | undefined>>;
   selectedKinds: string[] | undefined;
   setSelectedKinds: Dispatch<React.SetStateAction<string[] | undefined>>;
   unidirectional: boolean;
@@ -58,7 +58,7 @@ export function useCatalogGraphPage({
   initialState?: {
     selectedRelations?: string[] | undefined;
     selectedKinds?: string[] | undefined;
-    selectedOwnedby?: string[] | undefined;
+    selectedOwnedBy?: string[] | undefined;
     rootEntityRefs?: string[];
     maxDepth?: number;
     unidirectional?: boolean;
@@ -74,7 +74,7 @@ export function useCatalogGraphPage({
         {}) as {
         selectedRelations?: string[] | string;
         selectedKinds?: string[] | string;
-        selectedOwnedby?: string[] | undefined;
+        selectedOwnedBy?: string[] | undefined;
         rootEntityRefs?: string[] | string;
         maxDepth?: string[] | string;
         unidirectional?: string[] | string;
@@ -111,11 +111,11 @@ export function useCatalogGraphPage({
       : initialState?.selectedKinds
     )?.map(k => k.toLocaleLowerCase('en-US')),
   );
-  const [selectedOwnedby, setSelectedOwnedby] = useState<string[] | undefined>(
+  const [selectedOwnedBy, setSelectedOwnedBy] = useState<string[] | undefined>(
     () =>
-      (Array.isArray(query.selectedOwnedby)
-        ? query.selectedOwnedby
-        : initialState?.selectedOwnedby
+      (Array.isArray(query.selectedOwnedBy)
+        ? query.selectedOwnedBy
+        : initialState?.selectedOwnedBy
       )?.map(k => k.toLocaleLowerCase('en-US')),
   );
   const [unidirectional, setUnidirectional] = useState<boolean>(() =>
@@ -167,8 +167,8 @@ export function useCatalogGraphPage({
       setSelectedRelations(query.selectedRelations);
     }
 
-    if (Array.isArray(query.selectedOwnedby)) {
-      setSelectedOwnedby(query.selectedOwnedby);
+    if (Array.isArray(query.selectedOwnedBy)) {
+      setSelectedOwnedBy(query.selectedOwnedBy);
     }
 
     if (typeof query.unidirectional === 'string') {
@@ -194,7 +194,7 @@ export function useCatalogGraphPage({
     setMaxDepth,
     setSelectedKinds,
     setSelectedRelations,
-    setSelectedOwnedby,
+    setSelectedOwnedBy,
     setUnidirectional,
     setMergeRelations,
     setDirection,
@@ -214,7 +214,7 @@ export function useCatalogGraphPage({
         maxDepth: isFinite(maxDepth) ? maxDepth : '∞',
         selectedKinds,
         selectedRelations,
-        selectedOwnedby,
+        selectedOwnedBy,
         unidirectional,
         mergeRelations,
         direction,
@@ -244,7 +244,7 @@ export function useCatalogGraphPage({
     maxDepth,
     selectedKinds,
     selectedRelations,
-    selectedOwnedby,
+    selectedOwnedBy,
     unidirectional,
     mergeRelations,
     direction,
@@ -259,8 +259,8 @@ export function useCatalogGraphPage({
     setMaxDepth,
     selectedRelations,
     setSelectedRelations,
-    selectedOwnedby,
-    setSelectedOwnedby,
+    selectedOwnedBy,
+    setSelectedOwnedBy,
     selectedKinds,
     setSelectedKinds,
     unidirectional,

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/useCatalogGraphPage.ts
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/useCatalogGraphPage.ts
@@ -38,6 +38,8 @@ export type CatalogGraphPageValue = {
   setMaxDepth: Dispatch<React.SetStateAction<number>>;
   selectedRelations: string[] | undefined;
   setSelectedRelations: Dispatch<React.SetStateAction<string[] | undefined>>;
+  selectedOwnedby: string[] | undefined;
+  setSelectedOwnedby: Dispatch<React.SetStateAction<string[] | undefined>>;
   selectedKinds: string[] | undefined;
   setSelectedKinds: Dispatch<React.SetStateAction<string[] | undefined>>;
   unidirectional: boolean;
@@ -56,6 +58,7 @@ export function useCatalogGraphPage({
   initialState?: {
     selectedRelations?: string[] | undefined;
     selectedKinds?: string[] | undefined;
+    selectedOwnedby?: string[] | undefined;
     rootEntityRefs?: string[];
     maxDepth?: number;
     unidirectional?: boolean;
@@ -71,6 +74,7 @@ export function useCatalogGraphPage({
         {}) as {
         selectedRelations?: string[] | string;
         selectedKinds?: string[] | string;
+        selectedOwnedby?: string[] | undefined;
         rootEntityRefs?: string[] | string;
         maxDepth?: string[] | string;
         unidirectional?: string[] | string;
@@ -106,6 +110,13 @@ export function useCatalogGraphPage({
       ? query.selectedKinds
       : initialState?.selectedKinds
     )?.map(k => k.toLocaleLowerCase('en-US')),
+  );
+  const [selectedOwnedby, setSelectedOwnedby] = useState<string[] | undefined>(
+    () =>
+      (Array.isArray(query.selectedOwnedby)
+        ? query.selectedOwnedby
+        : initialState?.selectedOwnedby
+      )?.map(k => k.toLocaleLowerCase('en-US')),
   );
   const [unidirectional, setUnidirectional] = useState<boolean>(() =>
     typeof query.unidirectional === 'string'
@@ -156,6 +167,10 @@ export function useCatalogGraphPage({
       setSelectedRelations(query.selectedRelations);
     }
 
+    if (Array.isArray(query.selectedOwnedby)) {
+      setSelectedOwnedby(query.selectedOwnedby);
+    }
+
     if (typeof query.unidirectional === 'string') {
       setUnidirectional(query.unidirectional === 'true');
     }
@@ -179,6 +194,7 @@ export function useCatalogGraphPage({
     setMaxDepth,
     setSelectedKinds,
     setSelectedRelations,
+    setSelectedOwnedby,
     setUnidirectional,
     setMergeRelations,
     setDirection,
@@ -198,6 +214,7 @@ export function useCatalogGraphPage({
         maxDepth: isFinite(maxDepth) ? maxDepth : '∞',
         selectedKinds,
         selectedRelations,
+        selectedOwnedby,
         unidirectional,
         mergeRelations,
         direction,
@@ -227,6 +244,7 @@ export function useCatalogGraphPage({
     maxDepth,
     selectedKinds,
     selectedRelations,
+    selectedOwnedby,
     unidirectional,
     mergeRelations,
     direction,
@@ -241,6 +259,8 @@ export function useCatalogGraphPage({
     setMaxDepth,
     selectedRelations,
     setSelectedRelations,
+    selectedOwnedby,
+    setSelectedOwnedby,
     selectedKinds,
     setSelectedKinds,
     unidirectional,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -74,6 +74,7 @@ export const EntityRelationsGraph = (props: {
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
+  ownedby?: string[];
   relations?: string[];
   direction?: Direction;
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
@@ -89,6 +90,7 @@ export const EntityRelationsGraph = (props: {
     unidirectional = true,
     mergeRelations = true,
     kinds,
+    ownedby,
     relations,
     direction = Direction.LEFT_RIGHT,
     onNodeClick,
@@ -116,6 +118,7 @@ export const EntityRelationsGraph = (props: {
     unidirectional,
     mergeRelations,
     kinds,
+    ownedby,
     relations,
     onNodeClick,
     relationPairs,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -74,7 +74,7 @@ export const EntityRelationsGraph = (props: {
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
-  ownedby?: string[];
+  ownedBy?: string[];
   relations?: string[];
   direction?: Direction;
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
@@ -90,7 +90,7 @@ export const EntityRelationsGraph = (props: {
     unidirectional = true,
     mergeRelations = true,
     kinds,
-    ownedby,
+    ownedBy,
     relations,
     direction = Direction.LEFT_RIGHT,
     onNodeClick,
@@ -118,7 +118,7 @@ export const EntityRelationsGraph = (props: {
     unidirectional,
     mergeRelations,
     kinds,
-    ownedby,
+    ownedBy,
     relations,
     onNodeClick,
     relationPairs,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
@@ -24,13 +24,19 @@ import { useEntityStore } from './useEntityStore';
  */
 export function useEntityRelationGraph({
   rootEntityRefs,
-  filter: { maxDepth = Number.POSITIVE_INFINITY, relations, kinds } = {},
+  filter: {
+    maxDepth = Number.POSITIVE_INFINITY,
+    relations,
+    kinds,
+    ownedby,
+  } = {},
 }: {
   rootEntityRefs: string[];
   filter?: {
     maxDepth?: number;
     relations?: string[];
     kinds?: string[];
+    ownedby?: string[];
   };
 }): {
   entities?: { [ref: string]: Entity };
@@ -68,7 +74,11 @@ export function useEntityRelationGraph({
                   rel.targetRef.startsWith(
                     `${kind.toLocaleLowerCase('en-US')}:`,
                   ),
-                ))
+                )) &&
+              (!ownedby ||
+                (rel.type == 'ownedBy' && ownedby.includes(rel.target.name)) ||
+                (rel.type == 'ownerOf' &&
+                  ownedby.includes(entity.metadata.name)))
             ) {
               if (!processedEntityRefs.has(rel.targetRef)) {
                 nextDepthRefQueue.push(rel.targetRef);
@@ -83,7 +93,15 @@ export function useEntityRelationGraph({
     }
 
     requestEntities([...expectedEntities]);
-  }, [entities, rootEntityRefs, maxDepth, relations, kinds, requestEntities]);
+  }, [
+    entities,
+    rootEntityRefs,
+    maxDepth,
+    relations,
+    kinds,
+    ownedby,
+    requestEntities,
+  ]);
 
   return {
     entities,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
@@ -76,8 +76,9 @@ export function useEntityRelationGraph({
                   ),
                 )) &&
               (!ownedby ||
-                (rel.type == 'ownedBy' && ownedby.includes(rel.target.name)) ||
-                (rel.type == 'ownerOf' &&
+                (rel.type === 'ownedBy' &&
+                  ownedby.includes(rel.targetRef.split('/').slice(-1)[0])) ||
+                (rel.type === 'ownerOf' &&
                   ownedby.includes(entity.metadata.name)))
             ) {
               if (!processedEntityRefs.has(rel.targetRef)) {

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
@@ -28,7 +28,7 @@ export function useEntityRelationGraph({
     maxDepth = Number.POSITIVE_INFINITY,
     relations,
     kinds,
-    ownedby,
+    ownedBy,
   } = {},
 }: {
   rootEntityRefs: string[];
@@ -36,7 +36,7 @@ export function useEntityRelationGraph({
     maxDepth?: number;
     relations?: string[];
     kinds?: string[];
-    ownedby?: string[];
+    ownedBy?: string[];
   };
 }): {
   entities?: { [ref: string]: Entity };
@@ -75,11 +75,11 @@ export function useEntityRelationGraph({
                     `${kind.toLocaleLowerCase('en-US')}:`,
                   ),
                 )) &&
-              (!ownedby ||
+              (!ownedBy ||
                 (rel.type === 'ownedBy' &&
-                  ownedby.includes(rel.targetRef.split('/').slice(-1)[0])) ||
+                  ownedBy.includes(rel.targetRef.split('/').slice(-1)[0])) ||
                 (rel.type === 'ownerOf' &&
-                  ownedby.includes(entity.metadata.name)))
+                  ownedBy.includes(entity.metadata.name)))
             ) {
               if (!processedEntityRefs.has(rel.targetRef)) {
                 nextDepthRefQueue.push(rel.targetRef);
@@ -100,7 +100,7 @@ export function useEntityRelationGraph({
     maxDepth,
     relations,
     kinds,
-    ownedby,
+    ownedBy,
     requestEntities,
   ]);
 

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
@@ -29,6 +29,7 @@ export function useEntityRelationNodesAndEdges({
   unidirectional = true,
   mergeRelations = true,
   kinds,
+  ownedby,
   relations,
   onNodeClick,
   relationPairs = ALL_RELATION_PAIRS,
@@ -38,6 +39,7 @@ export function useEntityRelationNodesAndEdges({
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
+  ownedby?: string[];
   relations?: string[];
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
   relationPairs?: RelationPairs;
@@ -57,6 +59,7 @@ export function useEntityRelationNodesAndEdges({
       maxDepth,
       kinds,
       relations,
+      ownedby,
     },
   });
 

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
@@ -29,7 +29,7 @@ export function useEntityRelationNodesAndEdges({
   unidirectional = true,
   mergeRelations = true,
   kinds,
-  ownedby,
+  ownedBy,
   relations,
   onNodeClick,
   relationPairs = ALL_RELATION_PAIRS,
@@ -39,7 +39,7 @@ export function useEntityRelationNodesAndEdges({
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
-  ownedby?: string[];
+  ownedBy?: string[];
   relations?: string[];
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
   relationPairs?: RelationPairs;
@@ -59,7 +59,7 @@ export function useEntityRelationNodesAndEdges({
       maxDepth,
       kinds,
       relations,
-      ownedby,
+      ownedBy,
     },
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding filters for the Owner (owned by) so that we can see a subset of the catalog graph

- Added **ownedby** filter box just like **kinds** and **relations** 
- By default, it has all the group(owners) options 
- We can filter out entities owned by a particular group 


https://user-images.githubusercontent.com/35890623/195792493-86dd3a70-8020-4dcd-a6c7-35c51adb89ce.mov



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
