### PR TITLE
Fixed bug that when sending data by Post

### DIFF
--- a/.changeset/brown-days-pretend.md
+++ b/.changeset/brown-days-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': minor
+---
+
+Fixed bug that when sending data by Post, the default context type used was `plain/text`

--- a/.changeset/brown-days-pretend.md
+++ b/.changeset/brown-days-pretend.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-insights': minor
 ---
 
-Fixed bug that when sending data by Post, the default context type used was `plain/text`
+Fixed bug when sending data by Post in `runChecks` and `runBulkChecks` functions of the `TechInsightsClient` class, the default `Content-Type` used was `plain/text`

--- a/.changeset/brown-days-pretend.md
+++ b/.changeset/brown-days-pretend.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-tech-insights': minor
+'@backstage/plugin-tech-insights': patch
 ---
 
 Fixed bug when sending data by Post in `runChecks` and `runBulkChecks` functions of the `TechInsightsClient` class, the default `Content-Type` used was `plain/text`

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -82,6 +82,9 @@ export class TechInsightsClient implements TechInsightsApi {
       {
         method: 'POST',
         body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
     );
   }
@@ -98,6 +101,9 @@ export class TechInsightsClient implements TechInsightsApi {
     return this.api('/checks/run', {
       method: 'POST',
       body: JSON.stringify(requestBody),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   }
 

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -82,9 +82,6 @@ export class TechInsightsClient implements TechInsightsApi {
       {
         method: 'POST',
         body: JSON.stringify(requestBody),
-        headers: {
-          'Content-Type': 'application/json',
-        },
       },
     );
   }
@@ -101,9 +98,6 @@ export class TechInsightsClient implements TechInsightsApi {
     return this.api('/checks/run', {
       method: 'POST',
       body: JSON.stringify(requestBody),
-      headers: {
-        'Content-Type': 'application/json',
-      },
     });
   }
 
@@ -111,13 +105,17 @@ export class TechInsightsClient implements TechInsightsApi {
     const url = await this.discoveryApi.getBaseUrl('tech-insights');
     const { token } = await this.identityApi.getCredentials();
 
-    const request = new Request(`${url}${path}`, init);
-    if (!request.headers.has('content-type')) {
-      request.headers.set('content-type', 'application/json');
+    const headers: HeadersInit = new Headers(init?.headers);
+    if (!headers.has('content-type'))
+      headers.set('content-type', 'application/json');
+    if (token && !headers.has('authorization')) {
+      headers.set('authorization', `Bearer ${token}`);
     }
-    if (token && !request.headers.has('authorization')) {
-      request.headers.set('authorization', `Bearer ${token}`);
-    }
+
+    const request = new Request(`${url}${path}`, {
+      ...init,
+      headers,
+    });
 
     return fetch(request).then(async response => {
       if (!response.ok) {


### PR DESCRIPTION
Signed-off-by: Alisson Fabiano <afabiano@eshopworld.com>

## Hey, I just made a Pull Request!

Fixed bug when sending data by Post in `runChecks` and `runBulkChecks` functions of the `TechInsightsClient` class, the default `Content-Type` used was `plain/text`

**Here we have a link for reference here this error has been included**
https://github.com/backstage/backstage/pull/13755

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
