### PR TITLE
fixed scroll on tech-docs page

### DIFF
--- a/.changeset/nine-bananas-leave.md
+++ b/.changeset/nine-bananas-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed the page where it was creating 2 scrolls in techdocs when the content was long

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -16,25 +16,9 @@
 
 import React from 'react';
 import { BackstageTheme } from '@backstage/theme';
-import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
-import { useSidebarPinState } from '../Sidebar/SidebarPinStateContext';
+import { ThemeProvider } from '@material-ui/core/styles';
 
 export type PageClassKey = 'root';
-
-const useStyles = makeStyles<BackstageTheme, { isMobile?: boolean }>(
-  () => ({
-    root: ({ isMobile }) => ({
-      display: 'grid',
-      gridTemplateAreas:
-        "'pageHeader pageHeader pageHeader' 'pageSubheader pageSubheader pageSubheader' 'pageNav pageContent pageSidebar'",
-      gridTemplateRows: 'max-content auto 1fr',
-      gridTemplateColumns: 'auto 1fr auto',
-      height: isMobile ? '100%' : '100vh',
-      overflowY: 'auto',
-    }),
-  }),
-  { name: 'BackstagePage' },
-);
 
 type Props = {
   themeId: string;
@@ -43,8 +27,6 @@ type Props = {
 
 export function Page(props: Props) {
   const { themeId, children } = props;
-  const { isMobile } = useSidebarPinState();
-  const classes = useStyles({ isMobile });
   return (
     <ThemeProvider
       theme={(baseTheme: BackstageTheme) => ({
@@ -52,7 +34,7 @@ export function Page(props: Props) {
         page: baseTheme.getPageTheme({ themeId }),
       })}
     >
-      <main className={classes.root}>{children}</main>
+      {children}
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
Signed-off-by: Alisson Fabiano <afabiano@eshopworld.com>

## Hey, I just made a Pull Request!

Fixed the page where it was creating 2 scrolls in tech-docs when the content was long

_I looked for an open issue for this and found this scenario, where I also tried, and it worked as expected_
[Issue 13717](https://github.com/backstage/backstage/issues/13717)

### How was it before
![before](https://user-images.githubusercontent.com/56898864/195880816-6ab26664-7497-4e7a-9622-1e46a359804e.PNG)

### How is it now
![after](https://user-images.githubusercontent.com/56898864/195880840-2dc17398-a1f8-4f1e-94c9-6f211c03f94e.PNG)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
