### PR TITLE
Increase memory for synk action for the snyk github issue sync workflow

### DIFF
--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         node-version: [14.x]
 
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Signed-off-by: Harry Hogg <hhogg@spotify.com>

## Hey, I just made a Pull Request!

The Snyk github issue sync workflow has been [failing since Aug31](https://github.com/backstage/backstage/actions/runs/2965305756/jobs/4746083076#step:6:24) due to out of memory error.  As suggest in #14131, increasing the memory.

Closes #14131

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
