### PR TITLE
Add ability to hide tabs on EntityLayout based on permissions

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -153,6 +153,7 @@ import {
   TextSize,
   ReportIssue,
 } from '@backstage/plugin-techdocs-module-addons-contrib';
+import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common';
 
 const customEntityFilterKind = ['Component', 'API', 'System'];
 
@@ -485,7 +486,11 @@ const serviceEntityPage = (
       <EntityKafkaContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/todos" title="TODOs">
+    <EntityLayout.Route
+      path="/todos"
+      title="TODOs"
+      permission={catalogEntityDeletePermission}
+    >
       <EntityTodoContent />
     </EntityLayout.Route>
 
@@ -572,7 +577,11 @@ const websiteEntityPage = (
       <EntityCodeCoverageContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/todos" title="TODOs">
+    <EntityLayout.Route
+      path="/todos"
+      title="TODOs"
+      permission={catalogEntityDeletePermission}
+    >
       <EntityTodoContent />
     </EntityLayout.Route>
   </EntityLayoutWrapper>
@@ -588,7 +597,11 @@ const defaultEntityPage = (
       {techdocsContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/todos" title="TODOs">
+    <EntityLayout.Route
+      path="/todos"
+      title="TODOs"
+      permission={catalogEntityDeletePermission}
+    >
       <EntityTodoContent />
     </EntityLayout.Route>
   </EntityLayoutWrapper>

--- a/packages/test-utils/src/testUtils/apis/PermissionApi/MockPermissionApi.ts
+++ b/packages/test-utils/src/testUtils/apis/PermissionApi/MockPermissionApi.ts
@@ -41,4 +41,10 @@ export class MockPermissionApi implements PermissionApi {
   ): Promise<EvaluatePermissionResponse> {
     return { result: this.requestHandler(request) };
   }
+
+  async authorizeAll(
+    requests: EvaluatePermissionRequest[],
+  ): Promise<EvaluatePermissionResponse[]> {
+    return await Promise.all(requests.map(request => this.authorize(request)));
+  }
 }

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -40,6 +40,8 @@
     "@backstage/integration-react": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
+    "@backstage/plugin-permission-common": "workspace:^",
+    "@backstage/plugin-permission-react": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-search-react": "workspace:^",
     "@backstage/theme": "workspace:^",

--- a/plugins/permission-react/src/apis/IdentityPermissionApi.ts
+++ b/plugins/permission-react/src/apis/IdentityPermissionApi.ts
@@ -53,4 +53,11 @@ export class IdentityPermissionApi implements PermissionApi {
     );
     return response[0];
   }
+
+  async authorizeAll(requests: AuthorizePermissionRequest[]) {
+    return this.permissionClient.authorize(
+      requests,
+      await this.identityApi.getCredentials(),
+    );
+  }
 }

--- a/plugins/permission-react/src/apis/PermissionApi.ts
+++ b/plugins/permission-react/src/apis/PermissionApi.ts
@@ -30,6 +30,10 @@ export type PermissionApi = {
   authorize(
     request: EvaluatePermissionRequest,
   ): Promise<EvaluatePermissionResponse>;
+
+  authorizeAll(
+    requests: EvaluatePermissionRequest[],
+  ): Promise<EvaluatePermissionResponse[]>;
 };
 
 /**

--- a/plugins/permission-react/src/hooks/index.ts
+++ b/plugins/permission-react/src/hooks/index.ts
@@ -16,3 +16,4 @@
 
 export { usePermission } from './usePermission';
 export type { AsyncPermissionResult } from './usePermission';
+export { usePermissions } from './usePermissions';

--- a/plugins/permission-react/src/hooks/usePermissions.ts
+++ b/plugins/permission-react/src/hooks/usePermissions.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  isResourcePermission,
+  Permission,
+  ResourcePermission,
+} from '@backstage/plugin-permission-common';
+import { AsyncPermissionResult, usePermission } from './usePermission';
+
+/**
+ * React hook for authorization of multiple permissions. This wraps
+ * {@link @backstage/plugin-permission-react#usePermission} to return a Record of {
+ * [permissionName]: AsyncPermissionResult }.
+ * @public
+ */
+export function usePermissions(
+  input:
+    | {
+        permissions: Array<Exclude<Permission, ResourcePermission>>;
+        resourceRef?: never;
+      }
+    | {
+        permissions: Array<ResourcePermission>;
+        resourceRef: string | undefined;
+      },
+): Record<string, AsyncPermissionResult> {
+  const { permissions, resourceRef } = input;
+
+  const results: Record<string, AsyncPermissionResult> = {};
+  for (const permission of permissions) {
+    if (!results[permission.name]) {
+      if (isResourcePermission(permission)) {
+        results[permission.name] = usePermission({ permission, resourceRef });
+      } else {
+        results[permission.name] = usePermission({ permission });
+      }
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
Adds a `permission` prop on `EntityLayout.Route` to allow hiding EntityPage routes based on permissions. This could allow showing a tab only to the entity owners, for example. The rules around authorization of the permission are handled in the policy as usual.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
