### PR TITLE
fix(microsite): core-components docs layout fixed

### DIFF
--- a/.changeset/pretty-flies-agree.md
+++ b/.changeset/pretty-flies-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed layout for core-components docs where table was broken by splitting with code sample

--- a/packages/core-components/src/components/LogViewer/LogViewer.tsx
+++ b/packages/core-components/src/components/LogViewer/LogViewer.tsx
@@ -44,6 +44,7 @@ export interface LogViewerProps {
 /**
  * A component that displays logs in a scrollable text area.
  *
+ * @remarks
  * The LogViewer has support for search and filtering, as well as displaying
  * text content with ANSI color escape codes.
  *

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -110,10 +110,10 @@ const components: Options['components'] = {
 };
 
 /**
- * MarkdownContent
- * --
- * Renders markdown with the default dialect [gfm - GitHub flavored Markdown](https://github.github.com/gfm/) to backstage theme styled HTML.
- * If you just want to render to plain [CommonMark](https://commonmark.org/), set the dialect to `'common-mark'`
+ * Renders markdown with the default dialect {@link https://github.github.com/gfm/ | gfm - GitHub flavored Markdown} to backstage theme styled HTML.
+ *
+ * @remarks
+ * If you just want to render to plain {@link https://commonmark.org/ | CommonMark}, set the dialect to `'common-mark'`
  */
 export function MarkdownContent(props: Props) {
   const {

--- a/packages/core-components/src/components/ResponseErrorPanel/ResponseErrorPanel.tsx
+++ b/packages/core-components/src/components/ResponseErrorPanel/ResponseErrorPanel.tsx
@@ -44,6 +44,7 @@ const useStyles = makeStyles(
 /**
  * Renders a warning panel as the effect of a failed server request.
  *
+ * @remarks
  * Has special treatment for ResponseError errors, to display rich
  * server-provided information about what happened.
  */

--- a/packages/core-components/src/components/TabbedLayout/TabbedLayout.tsx
+++ b/packages/core-components/src/components/TabbedLayout/TabbedLayout.tsx
@@ -71,6 +71,7 @@ export function createSubRoutesFromChildren(
  * TabbedLayout is a compound component, which allows you to define a layout for
  * pages using a sub-navigation mechanism.
  *
+ * @remarks
  * Consists of two parts: TabbedLayout and TabbedLayout.Route
  *
  * @example

--- a/packages/core-components/src/components/WarningPanel/WarningPanel.tsx
+++ b/packages/core-components/src/components/WarningPanel/WarningPanel.tsx
@@ -134,7 +134,7 @@ const capitalize = (s: string) => {
 };
 
 /**
- * WarningPanel. Show a user friendly error message to a user similar to
+ * Show a user friendly error message to a user similar to
  * ErrorPanel except that the warning panel only shows the warning message to
  * the user.
  *

--- a/packages/core-components/src/layout/ItemCard/ItemCard.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCard.tsx
@@ -40,6 +40,7 @@ type ItemCardProps = {
  * This card type has been deprecated. Instead use plain MUI Card and helpers
  * where appropriate.
  *
+ *  @example
  * ```
  *   <Card>
  *     <CardMedia>

--- a/packages/core-components/src/layout/ItemCard/ItemCardGrid.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardGrid.tsx
@@ -49,6 +49,7 @@ export type ItemCardGridProps = Partial<WithStyles<typeof styles>> & {
  * A default grid to use when arranging "item cards" - cards that let users
  * select among several options.
  *
+ * @remarks
  * The immediate children are expected to be MUI Card components.
  *
  * Styles for the grid can be overridden using the `classes` prop, e.g.:

--- a/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
@@ -64,6 +64,7 @@ export type ItemCardHeaderProps = Partial<WithStyles<typeof styles>> & {
  * A simple card header, rendering a default look for "item cards" - cards that
  * are arranged in a grid for users to select among several options.
  *
+ * @remarks
  * This component expects to be placed within a MUI `<CardMedia>`.
  *
  * Styles for the header can be overridden using the `classes` prop, e.g.:

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -510,6 +510,7 @@ const SidebarItemWithSubmenu = ({
 /**
  * Creates a `SidebarItem`
  *
+ * @remarks
  * If children contain a `SidebarSubmenu` component the `SidebarItem` will have a expandable submenu
  */
 export const SidebarItem = forwardRef<any, SidebarItemProps>((props, ref) => {
@@ -663,6 +664,8 @@ export const SidebarScrollWrapper = styled('div')(({ theme }) => {
 
 /**
  * A button which allows you to expand the sidebar when clicked.
+ *
+ * @remarks
  * Use optionally to replace sidebar's expand-on-hover feature with expand-on-click.
  *
  * If you are using this you might want to set the `disableExpandOnHover` of the `Sidebar` to `true`.

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -159,6 +159,7 @@ export const MobileSidebarContext = createContext<MobileSidebarContextType>({
 /**
  * A navigation component for mobile screens, which sticks to the bottom.
  *
+ * @remarks
  * It alternates the normal sidebar by grouping the `SidebarItems` based on provided `SidebarGroup`s
  * either rendering them as a link or an overlay menu.
  * If no `SidebarGroup`s are provided the sidebar content is wrapped in an default overlay menu.

--- a/packages/core-components/src/layout/Sidebar/SidebarGroup.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarGroup.tsx
@@ -115,6 +115,7 @@ const MobileSidebarGroup = (props: SidebarGroupProps) => {
 /**
  * Groups items of the `Sidebar` together.
  *
+ * @remarks
  * On bigger screens, this won't have any effect at the moment.
  * On small screens, it will add an action to the bottom navigation - either triggering an overlay menu or acting as a link
  *

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -111,6 +111,7 @@ export type SidebarSubmenuItemDropdownItem = {
 /**
  * Holds submenu item content.
  *
+ * @remarks
  * title: Text content of submenu item
  * subtitle: A subtitle displayed under the main title
  * to: Path to navigate to when item is clicked

--- a/packages/core-components/src/layout/Sidebar/config.ts
+++ b/packages/core-components/src/layout/Sidebar/config.ts
@@ -20,13 +20,13 @@ const drawerWidthClosed = 72;
 const iconPadding = 24;
 const userBadgePadding = 18;
 
-/** @public **/
+/** @public */
 export type SidebarOptions = {
   drawerWidthClosed?: number;
   drawerWidthOpen?: number;
 };
 
-/** @public **/
+/** @public */
 export type SubmenuOptions = {
   drawerWidthClosed?: number;
   drawerWidthOpen?: number;

--- a/packages/core-components/src/layout/SignInPage/types.ts
+++ b/packages/core-components/src/layout/SignInPage/types.ts
@@ -32,7 +32,7 @@ export type SignInProviderConfig = {
   apiRef: ApiRef<ProfileInfoApi & BackstageIdentityApi & SessionApi>;
 };
 
-/** @public **/
+/** @public */
 export type IdentityProviders = ('guest' | 'custom' | SignInProviderConfig)[];
 
 export type ProviderComponent = ComponentType<


### PR DESCRIPTION
## Fixed table layout for core-components docs

Closing #14071 issue.

- [x] Fixed broken table layout at [core-components page](https://backstage.io/docs/reference/core-components)
- [x] Fixed _Description_ column content (extra information moved from table to _Remarks_ section)
- [x] Fixed broken markdown links and minor typos

### Details

Layout was broken because of code sample from `ItemCard` component wasn't marked as an `@example` and it was rendered inside table instead of component's page. Broken layout:

<img width="959" alt="image" src="https://user-images.githubusercontent.com/33329898/195992240-d03cbca1-01cc-4389-8533-72a61e78eb97.png">

Other improvements were related to table content. On the screenshot below you can see that some items contained extra information in the second column, so it also was moved into component's page by marking extra information with `@remarks`.

<img width="1064" alt="Pasted Graphic 24" src="https://user-images.githubusercontent.com/33329898/195990571-92b416f3-64d4-4cac-9ff1-63e96f53ea3b.png">

And fixed broken markdown links from screenshot below:

<img width="725" alt="MarkdownContent - Renders markdown with the default dialect (ofm - GitHub flavored Markdown)" src="https://user-images.githubusercontent.com/33329898/195990839-0ff26c71-e9de-4406-a917-5066e9079433.png">

## Result:

Fixed layout:

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/33329898/195990650-e1bbb253-ae2e-487b-a4fa-4cc42e10b1e3.png">

Fixed links:

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/33329898/195990886-479b80e3-94b8-44a8-ac93-75060bd8e6c1.png">

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
