### PR TITLE
Use urlreader in openApiPlaceholderResolver

### DIFF
--- a/.changeset/forty-jokes-lie.md
+++ b/.changeset/forty-jokes-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-openapi': patch
+---
+
+Added support to use the `UrlReaders` when `$ref` pointing to a URL.

--- a/plugins/catalog-backend-module-openapi/src/lib/bundle.test.ts
+++ b/plugins/catalog-backend-module-openapi/src/lib/bundle.test.ts
@@ -90,4 +90,31 @@ describe('bundleOpenApiSpecification', () => {
 
     expect(result).toEqual(expectedResult.trimStart());
   });
+  it('should use the urlreaders to fetch $refs', async () => {
+    const spec = `
+    openapi: "3.0.0"
+    info:
+      version: 1.0.0
+      title: Swagger Petstore
+      license:
+        name: MIT
+    servers:
+      - url: http://petstore.swagger.io/v1
+    paths:
+      /pets:
+        get:
+          $ref: "https://foo.com/paths/pets/list.yaml"
+    `;
+
+    read.mockResolvedValue(list);
+
+    const result = await bundleOpenApiSpecification(
+      spec,
+      'https://github.com/owner/repo/blob/main/catalog-info.yaml',
+      read,
+      resolveUrl,
+    );
+
+    expect(result).toEqual(expectedResult.trimStart());
+  });
 });

--- a/plugins/catalog-backend-module-openapi/src/lib/bundle.ts
+++ b/plugins/catalog-backend-module-openapi/src/lib/bundle.ts
@@ -47,11 +47,21 @@ export async function bundleOpenApiSpecification(
       return await read(url);
     },
   };
+  const httpUrlReaderResolver: SwaggerParser.ResolverOptions = {
+    canRead: ref => {
+      const protocol = getProtocol(ref.url);
+      return protocol === 'http' || protocol === 'https';
+    },
+    read: async ref => {
+      const url = resolveUrl(ref.url, baseUrl);
+      return await read(url);
+    },
+  };
 
   const options: SwaggerParser.Options = {
     resolve: {
       file: fileUrlReaderResolver,
-      http: true,
+      http: httpUrlReaderResolver,
     },
   };
   const specObject = parse(specification);


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Configured the resolver to use the UrlReader when a $ref pointing to a URL. This should enable cases where the $ref points to a common github repository(if you have github configured) where you store your common openapi specs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
