### PR TITLE
add accidentally missing cluster locator config

### DIFF
--- a/.changeset/rude-tables-shout.md
+++ b/.changeset/rude-tables-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Added missing cluster locator configuration schema entries, for the catalog and local proxy types

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -33,18 +33,6 @@ export interface Config {
     clusterLocatorMethods: Array<
       | {
           /** @visibility frontend */
-          type: 'gke';
-          /** @visibility frontend */
-          projectId: string;
-          /** @visibility frontend */
-          region?: string;
-          /** @visibility frontend */
-          skipTLSVerify?: boolean;
-          /** @visibility frontend */
-          skipMetricsLookup?: boolean;
-        }
-      | {
-          /** @visibility frontend */
           type: 'config';
           clusters: Array<{
             /** @visibility frontend */
@@ -67,6 +55,26 @@ export interface Config {
             /** @visibility frontend */
             skipMetricsLookup?: boolean;
           }>;
+        }
+      | {
+          /** @visibility frontend */
+          type: 'catalog';
+        }
+      | {
+          /** @visibility frontend */
+          type: 'localKubectlProxy';
+        }
+      | {
+          /** @visibility frontend */
+          type: 'gke';
+          /** @visibility frontend */
+          projectId: string;
+          /** @visibility frontend */
+          region?: string;
+          /** @visibility frontend */
+          skipTLSVerify?: boolean;
+          /** @visibility frontend */
+          skipMetricsLookup?: boolean;
         }
     >;
     customResources?: Array<{

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -23,7 +23,7 @@
     "backstage",
     "kubernetes"
   ],
-  "configSchema": "schema.d.ts",
+  "configSchema": "config.d.ts",
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
@@ -69,6 +69,6 @@
   },
   "files": [
     "dist",
-    "schema.d.ts"
+    "config.d.ts"
   ]
 }


### PR DESCRIPTION
Also renamed the file to `config.d.ts` to follow the standard.

The diff is a bit bigger than needed because I rearranged the entries a bit (getting the per-provider ones at the bottom) but those are unchanged