### PR TITLE
Replace outdated url of Cookiecuter.dockerfile

### DIFF
--- a/contrib/docker/cookiecutter-with-jinja2-extensions/README.md
+++ b/contrib/docker/cookiecutter-with-jinja2-extensions/README.md
@@ -12,7 +12,7 @@ Using Cookiecutter extensions is a two-step process:
 This step depends on how the scaffolder is setup to use Cookiecutter:
 
 - Using a local Cookiecutter, or
-- Using a Cookiecutter Docker image, e.g. [spotify/backstage-cookiecutter](https://github.com/backstage/backstage/blob/37e35b91/plugins/scaffolder-backend/scripts/Cookiecutter.dockerfile).
+- Using a Cookiecutter Docker image, e.g. [spotify/backstage-cookiecutter](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/scripts/Cookiecutter.dockerfile).
 
 Say we want to install [`jinja2_custom_filters_extension`](https://pypi.org/project/jinja2-custom-filters-extension/) to use the `upper_case_first_letter` filter in a Cookiecutter template.
 


### PR DESCRIPTION
- Clicked the URL & it was outdated due to this change: https://github.com/backstage/backstage/commit/ad9d74ff240c934ce46a474ae3f440d5f5fa493b 
- No update or verification of the actual documenation content

