### PR TITLE
core: switch to using built-in base path in React Router v6 stable

### DIFF
--- a/.changeset/brave-eels-allow.md
+++ b/.changeset/brave-eels-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+Updated the React Router wiring to make use of the new `basename` property of the router components in React Router v6 stable. To implement this, a new optional `basename` property has been added to the `Router` app component, which can be forwarded to the concrete router implementation in order to support this new behavior. This is done by default in any app that does not have a `Router` component override.

--- a/.changeset/eleven-pets-sneeze.md
+++ b/.changeset/eleven-pets-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': minor
+---
+
+The app `Router` component now accepts an optional `basename` property.

--- a/.changeset/shaggy-colts-watch.md
+++ b/.changeset/shaggy-colts-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Disable base path workaround in `Link` component when React Router v6 stable is used.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -144,7 +144,9 @@ export type AppComponents = {
   NotFoundErrorPage: ComponentType<{}>;
   BootErrorPage: ComponentType<BootErrorPageProps>;
   Progress: ComponentType<{}>;
-  Router: ComponentType<{}>;
+  Router: ComponentType<{
+    basename?: string;
+  }>;
   ErrorBoundaryFallback: ComponentType<ErrorBoundaryFallbackProps>;
   ThemeProvider?: ComponentType<{}>;
   SignInPage?: ComponentType<SignInPageProps>;

--- a/packages/core-app-api/src/app/AppManager.compat.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.compat.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import tlr, { render } from '@testing-library/react';
+import React from 'react';
+
+describe.each(['beta', 'stable'])('react-router %s', rrVersion => {
+  beforeAll(() => {
+    jest.doMock('react', () => React);
+    // This has some side effects, so need this to be stable to avoid re-require
+    jest.doMock('@testing-library/react', () => tlr);
+    jest.doMock('react-router', () =>
+      rrVersion === 'beta'
+        ? jest.requireActual('react-router-beta')
+        : jest.requireActual('react-router-stable'),
+    );
+    jest.doMock('react-router-dom', () =>
+      rrVersion === 'beta'
+        ? jest.requireActual('react-router-dom-beta')
+        : jest.requireActual('react-router-dom-stable'),
+    );
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  function requireDeps() {
+    return {
+      ...(require('./AppManager') as typeof import('./AppManager')),
+      ...(require('../routing') as typeof import('../routing')),
+      ...(require('react-router-dom') as typeof import('react-router-dom')),
+      ...(require('@backstage/test-utils') as typeof import('@backstage/test-utils')),
+    };
+  }
+
+  describe('AppManager', () => {
+    it('supports base path', async () => {
+      const { AppManager, MemoryRouter, Navigate, Route, FlatRoutes } =
+        requireDeps();
+      const app = new AppManager({
+        apis: [],
+        defaultApis: [],
+        themes: [
+          {
+            id: 'light',
+            title: 'Light Theme',
+            variant: 'light',
+            Provider: ({ children }) => <>{children}</>,
+          },
+        ],
+        icons: {} as any,
+        plugins: [],
+        components: {
+          NotFoundErrorPage: () => null,
+          BootErrorPage: () => null,
+          Progress: () => null,
+          Router: ({ children, basename }) => (
+            <MemoryRouter
+              initialEntries={['/foo']}
+              basename={basename}
+              children={children}
+            />
+          ),
+          ErrorBoundaryFallback: () => null,
+          ThemeProvider: ({ children }) => <>{children}</>,
+        },
+        configLoader: async () => [
+          {
+            context: 'test',
+            data: { app: { baseUrl: 'http://localhost/foo' } },
+          },
+        ],
+        bindRoutes: () => {},
+      });
+
+      const AppProvider = app.getProvider();
+      const AppRouter = app.getRouter();
+
+      const rendered = render(
+        <AppProvider>
+          <AppRouter>
+            <FlatRoutes>
+              <Route path="/" element={<Navigate to="bar" />} />
+              <Route path="/bar" element={<span>bar</span>} />
+            </FlatRoutes>
+          </AppRouter>
+        </AppProvider>,
+      );
+
+      await expect(rendered.findByText('bar')).resolves.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/core-app-api/src/app/AppManager.stable.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.stable.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Navigate, Route } from 'react-router-dom';
+import { FlatRoutes } from '../routing';
+import { AppManager } from './AppManager';
+import { AppOptions } from './types';
+
+jest.mock('react-router', () => jest.requireActual('react-router-stable'));
+jest.mock('react-router-dom', () =>
+  jest.requireActual('react-router-dom-stable'),
+);
+
+const mockAppOptions: AppOptions = {
+  apis: [],
+  defaultApis: [],
+  themes: [
+    {
+      id: 'light',
+      title: 'Light Theme',
+      variant: 'light',
+      Provider: ({ children }) => <>{children}</>,
+    },
+  ],
+  icons: {} as any,
+  plugins: [],
+  components: {
+    NotFoundErrorPage: () => null,
+    BootErrorPage: () => null,
+    Progress: () => null,
+    Router: props => <MemoryRouter {...props} />,
+    ErrorBoundaryFallback: () => null,
+    ThemeProvider: ({ children }) => <>{children}</>,
+  },
+  configLoader: async () => [],
+  bindRoutes: () => {},
+};
+
+describe('AppManager', () => {
+  it('supports base path', async () => {
+    const app = new AppManager({
+      ...mockAppOptions,
+      components: {
+        ...mockAppOptions.components,
+        Router: props => <MemoryRouter {...props} initialEntries={['/foo']} />,
+      },
+      configLoader: async () => [
+        {
+          context: 'test',
+          data: { app: { baseUrl: 'http://localhost/foo' } },
+        },
+      ],
+    });
+
+    const AppProvider = app.getProvider();
+    const AppRouter = app.getRouter();
+
+    const rendered = render(
+      <AppProvider>
+        <AppRouter>
+          <FlatRoutes>
+            <Route path="/" element={<Navigate to="bar" />} />
+            <Route path="/bar" element={<span>bar</span>} />
+          </FlatRoutes>
+        </AppRouter>
+      </AppProvider>,
+    );
+
+    await expect(rendered.findByText('bar')).resolves.toBeInTheDocument();
+  });
+
+  it('supports base path with absolute navigation', async () => {
+    const app = new AppManager({
+      ...mockAppOptions,
+      components: {
+        ...mockAppOptions.components,
+        Router: props => <MemoryRouter {...props} initialEntries={['/foo']} />,
+      },
+      configLoader: async () => [
+        {
+          context: 'test',
+          data: { app: { baseUrl: 'http://localhost/foo' } },
+        },
+      ],
+    });
+
+    const AppProvider = app.getProvider();
+    const AppRouter = app.getRouter();
+
+    const rendered = render(
+      <AppProvider>
+        <AppRouter>
+          <FlatRoutes>
+            <Route path="/" element={<Navigate to="/bar" />} />
+            <Route path="/bar" element={<span>bar</span>} />
+          </FlatRoutes>
+        </AppRouter>
+      </AppProvider>,
+    );
+
+    await expect(rendered.findByText('bar')).resolves.toBeInTheDocument();
+  });
+});

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -69,7 +69,7 @@ export type AppComponents = {
   NotFoundErrorPage: ComponentType<{}>;
   BootErrorPage: ComponentType<BootErrorPageProps>;
   Progress: ComponentType<{}>;
-  Router: ComponentType<{}>;
+  Router: ComponentType<{ basename?: string }>;
   ErrorBoundaryFallback: ComponentType<ErrorBoundaryFallbackProps>;
   ThemeProvider?: ComponentType<{}>;
 

--- a/packages/core-components/src/components/Link/Link.test.tsx
+++ b/packages/core-components/src/components/Link/Link.test.tsx
@@ -107,58 +107,6 @@ describe('<Link />', () => {
     });
   });
 
-  describe('resolves a sub-path correctly', () => {
-    it('when it starts with base path', async () => {
-      const testString = 'This is test string';
-      const linkText = 'Navigate!';
-      const configApi = new ConfigReader({
-        app: { baseUrl: 'http://localhost:3000/example' },
-      });
-
-      const { getByText } = render(
-        wrapInTestApp(
-          <TestApiProvider apis={[[configApiRef, configApi]]}>
-            <Link to="/example/test">{linkText}</Link>
-            <Routes>
-              <Route path="/example/test" element={<p>{testString}</p>} />
-            </Routes>
-          </TestApiProvider>,
-        ),
-      );
-
-      expect(() => getByText(testString)).toThrow();
-      fireEvent.click(getByText(linkText));
-      await waitFor(() => {
-        expect(getByText(testString)).toBeInTheDocument();
-      });
-    });
-
-    it('when it does not start with base path', async () => {
-      const testString = 'This is test string';
-      const linkText = 'Navigate!';
-      const configApi = new ConfigReader({
-        app: { baseUrl: 'http://localhost:3000/example' },
-      });
-
-      const { getByText } = render(
-        wrapInTestApp(
-          <TestApiProvider apis={[[configApiRef, configApi]]}>
-            <Link to="/test">{linkText}</Link>
-            <Routes>
-              <Route path="/example/test" element={<p>{testString}</p>} />
-            </Routes>
-          </TestApiProvider>,
-        ),
-      );
-
-      expect(() => getByText(testString)).toThrow();
-      fireEvent.click(getByText(linkText));
-      await waitFor(() => {
-        expect(getByText(testString)).toBeInTheDocument();
-      });
-    });
-  });
-
   describe('isExternalUri', () => {
     it.each([
       [true, 'http://'],

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -26,6 +26,12 @@ import {
   LinkProps as RouterLinkProps,
 } from 'react-router-dom';
 import { trimEnd } from 'lodash';
+import { createRoutesFromChildren, Route } from 'react-router-dom';
+
+export function isReactRouterBeta(): boolean {
+  const [obj] = createRoutesFromChildren(<Route index element={<div />} />);
+  return !obj.index;
+}
 
 const useStyles = makeStyles(
   {
@@ -79,6 +85,7 @@ const useBasePath = () => {
   return trimEnd(pathname, '/');
 };
 
+/** @deprecated Remove once we no longer support React Router v6 beta */
 export const useResolvedPath = (uri: LinkProps['to']) => {
   let resolvedPath = String(uri);
 
@@ -125,7 +132,12 @@ export const Link = React.forwardRef<any, LinkProps>(
   ({ onClick, noTrack, ...props }, ref) => {
     const classes = useStyles();
     const analytics = useAnalytics();
-    const to = useResolvedPath(props.to);
+
+    // Adding the base path to URLs breaks react-router v6 stable, so we only
+    // do it for beta. The react router version won't change at runtime so it is
+    // fine to ignore the rules of hooks.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const to = isReactRouterBeta() ? useResolvedPath(props.to) : props.to;
     const linkText = getNodeText(props.children) || to;
     const external = isExternalUri(to);
     const newWindow = external && !!/^https?:/.exec(to);

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -139,7 +139,9 @@ export type AppComponents = {
   NotFoundErrorPage: ComponentType<{}>;
   BootErrorPage: ComponentType<BootErrorPageProps>;
   Progress: ComponentType<{}>;
-  Router: ComponentType<{}>;
+  Router: ComponentType<{
+    basename?: string;
+  }>;
   ErrorBoundaryFallback: ComponentType<ErrorBoundaryFallbackProps>;
   ThemeProvider?: ComponentType<{}>;
   SignInPage?: ComponentType<SignInPageProps>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #14085, and more largely switches the base path handing to use the new `basename` prop introduced in React Router v6 stable ([docs](https://reactrouter.com/en/v6.3.0/api#router)). Overall this should make our base path handling more robust, as we're relying on React Router rather than our own workarounds. Some extra context here is that the `basename` prop did not exist in the version of React Router that we were on before.

This also removes the workaround introduced in #8002, as it's no longer needed and in fact breaks the routing. There's arguably a breaking change there in that some broken links will no longer be fixed, but I think that's arguably broken behavior to begin with so feeling it's fine to ship.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
