### PR TITLE
Fix Entities.spec Type Definitions

### DIFF
--- a/.changeset/small-dingos-argue.md
+++ b/.changeset/small-dingos-argue.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-scaffolder-common': patch
+---
+
+ts type def: allow unknown fields on entity.spec

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface ApiEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'API';
-  spec: {
+  spec: Entity['spec'] & {
     type: string;
     lifecycle: string;
     owner: string;

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface ComponentEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Component';
-  spec: {
+  spec: Entity['spec'] & {
     type: string;
     lifecycle: string;
     owner: string;

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface DomainEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Domain';
-  spec: {
+  spec: Entity["spec"] & {
     owner: string;
   };
 }

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface DomainEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Domain';
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     owner: string;
   };
 }

--- a/packages/catalog-model/src/kinds/GroupEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/GroupEntityV1alpha1.ts
@@ -26,7 +26,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface GroupEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Group';
-  spec: {
+  spec: Entity["spec"] & {
     type: string;
     profile?: {
       displayName?: string;

--- a/packages/catalog-model/src/kinds/GroupEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/GroupEntityV1alpha1.ts
@@ -26,7 +26,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface GroupEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Group';
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     type: string;
     profile?: {
       displayName?: string;

--- a/packages/catalog-model/src/kinds/LocationEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/LocationEntityV1alpha1.ts
@@ -26,7 +26,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface LocationEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Location';
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     type?: string;
     target?: string;
     targets?: string[];

--- a/packages/catalog-model/src/kinds/LocationEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/LocationEntityV1alpha1.ts
@@ -26,7 +26,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface LocationEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Location';
-  spec: {
+  spec: Entity["spec"] & {
     type?: string;
     target?: string;
     targets?: string[];

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface ResourceEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Resource';
-  spec: {
+  spec: Entity["spec"] & {
     type: string;
     owner: string;
     dependsOn?: string[];

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface ResourceEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Resource';
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     type: string;
     owner: string;
     dependsOn?: string[];

--- a/packages/catalog-model/src/kinds/SystemEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/SystemEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface SystemEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'System';
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     owner: string;
     domain?: string;
   };

--- a/packages/catalog-model/src/kinds/SystemEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/SystemEntityV1alpha1.ts
@@ -30,7 +30,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface SystemEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'System';
-  spec: {
+  spec: Entity["spec"] & {
     owner: string;
     domain?: string;
   };

--- a/packages/catalog-model/src/kinds/UserEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/UserEntityV1alpha1.ts
@@ -26,7 +26,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface UserEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'User';
-  spec: {
+  spec: Entity["spec"] & {
     profile?: {
       displayName?: string;
       email?: string;

--- a/packages/catalog-model/src/kinds/UserEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/UserEntityV1alpha1.ts
@@ -26,7 +26,7 @@ import { ajvCompiledJsonSchemaValidator } from './util';
 export interface UserEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'User';
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     profile?: {
       displayName?: string;
       email?: string;

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
@@ -40,7 +40,7 @@ export interface TemplateEntityV1beta3 extends Entity {
   /**
    * The specification of the Template Entity
    */
-  spec: Entity["spec"] & {
+  spec: Entity['spec'] & {
     /**
      * The type that the Template will create. For example service, website or library.
      */

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
@@ -40,7 +40,7 @@ export interface TemplateEntityV1beta3 extends Entity {
   /**
    * The specification of the Template Entity
    */
-  spec: {
+  spec: Entity["spec"] & {
     /**
      * The type that the Template will create. For example service, website or library.
      */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Referring to [the docs](https://backstage.io/docs/features/software-catalog/extending-the-model#adding-new-fields-to-the-spec-object-of-an-existing-kind):
> A kind's schema validation typically doesn't forbid "unknown" fields in an entity spec

Which however the current entities TS type definitions limit the usage of "unknown" fields.
As an example in `DomainEntityV1alpha1`:
```
// error TS2339: Property 'unkownField' does not exist on type '{ owner: string; }'.
const example = domain.spec.unkownField;
```

The changes let `spec` to extend `Entity['spec']`, which results in having the flexibility having unknown fields:
```
const example = domain.spec.unkownField; // no error, type: JsonValue | undefined
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
