### PR TITLE
chore(catalog/github): use consistent naming of `[gG]ithub` in code

### DIFF
--- a/.changeset/fuzzy-dolls-shake.md
+++ b/.changeset/fuzzy-dolls-shake.md
@@ -9,10 +9,10 @@ Add the following to your `CatalogBuilder` to have the repo URL ingestion workin
 
 ```ts
 // catalog.ts
-import { GitHubLocationAnalyzer } from '@backstage/plugin-catalog-backend-module-github';
+import { GithubLocationAnalyzer } from '@backstage/plugin-catalog-backend-module-github';
 ...
   builder.addLocationAnalyzers(
-    new GitHubLocationAnalyzer({
+    new GithubLocationAnalyzer({
       discovery: env.discovery,
       config: env.config,
     }),

--- a/.changeset/moody-carrots-shout.md
+++ b/.changeset/moody-carrots-shout.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-Added `GitHubLocationAnalyzer`. This can be used to add to the `CatalogBuilder`. When added this will be used by `RepoLocationAnalyzer` to figure out if the given URL that you are trying to import from the /catalog-import page already contains catalog-info.yaml files.
+Added `GithubLocationAnalyzer`. This can be used to add to the `CatalogBuilder`. When added this will be used by `RepoLocationAnalyzer` to figure out if the given URL that you are trying to import from the /catalog-import page already contains catalog-info.yaml files.

--- a/.changeset/tame-ads-complain.md
+++ b/.changeset/tame-ads-complain.md
@@ -1,0 +1,18 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Replaces in-code uses of `GitHub` by `Github` and deprecates old versions.
+
+Deprecates
+
+- `GitHubEntityProvider` replaced by `GithubEntityProvider`
+- `GitHubLocationAnalyzer` replaced by `GithubLocationAnalyzer`
+- `GitHubLocationAnalyzerOptions` replaced by `GithubLocationAnalyzerOptions`
+- `GitHubOrgEntityProvider` replaced by `GithubOrgEntityProvider`
+- `GitHubOrgEntityProviderOptions` replaced by `GithubOrgEntityProviderOptions`
+
+Renames
+
+- `GitHubLocationAnalyzer` to `GithubLocationAnalyzer`
+- `GitHubLocationAnalyzerOptions` to `GithubLocationAnalyzerOptions`

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -30,14 +30,14 @@ And then add the entity provider to your catalog builder:
 
 ```diff
   // In packages/backend/src/plugins/catalog.ts
-+ import { GitHubEntityProvider } from '@backstage/plugin-catalog-backend-module-github';
++ import { GithubEntityProvider } from '@backstage/plugin-catalog-backend-module-github';
 
   export default async function createPlugin(
     env: PluginEnvironment,
   ): Promise<Router> {
     const builder = await CatalogBuilder.create(env);
 +   builder.addEntityProvider(
-+     GitHubEntityProvider.fromConfig(env.config, {
++     GithubEntityProvider.fromConfig(env.config, {
 +       logger: env.logger,
 +       // optional: alternatively, use scheduler with schedule defined in app-config.yaml
 +       schedule: env.scheduler.createScheduledTaskRunner({

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -46,7 +46,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class GitHubEntityProvider implements EntityProvider {
   // (undocumented)
   connect(connection: EntityProviderConnection): Promise<void>;
@@ -65,14 +65,33 @@ export class GitHubEntityProvider implements EntityProvider {
   refresh(logger: Logger): Promise<void>;
 }
 
+// @public
+export class GithubEntityProvider implements EntityProvider {
+  // (undocumented)
+  connect(connection: EntityProviderConnection): Promise<void>;
+  // (undocumented)
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: Logger;
+      schedule?: TaskRunner;
+      scheduler?: PluginTaskScheduler;
+    },
+  ): GithubEntityProvider[];
+  // (undocumented)
+  getProviderName(): string;
+  // (undocumented)
+  refresh(logger: Logger): Promise<void>;
+}
+
 // @alpha
 export const githubEntityProviderCatalogModule: (
   options?: undefined,
 ) => BackendFeature;
 
 // @public (undocumented)
-export class GitHubLocationAnalyzer implements ScmLocationAnalyzer {
-  constructor(options: GitHubLocationAnalyzerOptions);
+export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
+  constructor(options: GithubLocationAnalyzerOptions);
   // (undocumented)
   analyze({ url, catalogFilename }: AnalyzeOptions): Promise<{
     existing: {
@@ -89,7 +108,7 @@ export class GitHubLocationAnalyzer implements ScmLocationAnalyzer {
 }
 
 // @public (undocumented)
-export type GitHubLocationAnalyzerOptions = {
+export type GithubLocationAnalyzerOptions = {
   config: Config;
   discovery: PluginEndpointDiscovery;
 };
@@ -127,8 +146,17 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
+// @public @deprecated (undocumented)
+export class GitHubOrgEntityProvider extends GithubOrgEntityProvider {
+  // (undocumented)
+  static fromConfig(
+    config: Config,
+    options: GitHubOrgEntityProviderOptions,
+  ): GitHubOrgEntityProvider;
+}
+
 // @public
-export class GitHubOrgEntityProvider implements EntityProvider {
+export class GithubOrgEntityProvider implements EntityProvider {
   constructor(options: {
     id: string;
     orgUrl: string;
@@ -141,15 +169,18 @@ export class GitHubOrgEntityProvider implements EntityProvider {
   // (undocumented)
   static fromConfig(
     config: Config,
-    options: GitHubOrgEntityProviderOptions,
-  ): GitHubOrgEntityProvider;
+    options: GithubOrgEntityProviderOptions,
+  ): GithubOrgEntityProvider;
   // (undocumented)
   getProviderName(): string;
   read(options?: { logger?: Logger }): Promise<void>;
 }
 
+// @public @deprecated (undocumented)
+export type GitHubOrgEntityProviderOptions = GithubOrgEntityProviderOptions;
+
 // @public
-export interface GitHubOrgEntityProviderOptions {
+export interface GithubOrgEntityProviderOptions {
   githubCredentialsProvider?: GithubCredentialsProvider;
   id: string;
   logger: Logger;

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -50,7 +50,7 @@ export interface Config {
 
     providers?: {
       /**
-       * GitHubEntityProvider configuration
+       * GithubEntityProvider configuration
        *
        * Uses "default" as default id for the single config variant.
        */

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.test.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.test.ts
@@ -33,7 +33,7 @@ jest.mock('@octokit/rest', () => {
 });
 
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
-import { GitHubLocationAnalyzer } from './GitHubLocationAnalyzer';
+import { GithubLocationAnalyzer } from './GithubLocationAnalyzer';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
@@ -41,7 +41,7 @@ import { ConfigReader } from '@backstage/config';
 
 const server = setupServer();
 
-describe('GitHubLocationAnalyzer', () => {
+describe('GithubLocationAnalyzer', () => {
   const mockDiscoveryApi: jest.Mocked<PluginEndpointDiscovery> = {
     getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7007'),
     getExternalBaseUrl: jest.fn(),
@@ -114,7 +114,7 @@ describe('GitHubLocationAnalyzer', () => {
       return Promise.reject();
     });
 
-    const analyzer = new GitHubLocationAnalyzer({
+    const analyzer = new GithubLocationAnalyzer({
       discovery: mockDiscoveryApi,
       config,
     });
@@ -139,7 +139,7 @@ describe('GitHubLocationAnalyzer', () => {
       return Promise.reject();
     });
 
-    const analyzer = new GitHubLocationAnalyzer({
+    const analyzer = new GithubLocationAnalyzer({
       discovery: mockDiscoveryApi,
       config,
     });

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
@@ -27,24 +27,27 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
 
 /** @public */
-export type GitHubLocationAnalyzerOptions = {
+export type GithubLocationAnalyzerOptions = {
   config: Config;
   discovery: PluginEndpointDiscovery;
 };
+
 /** @public */
-export class GitHubLocationAnalyzer implements ScmLocationAnalyzer {
+export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
   private readonly catalogClient: CatalogApi;
   private readonly config: Config;
 
-  constructor(options: GitHubLocationAnalyzerOptions) {
+  constructor(options: GithubLocationAnalyzerOptions) {
     this.config = options.config;
     this.catalogClient = new CatalogClient({ discoveryApi: options.discovery });
   }
+
   supports(url: string) {
     const integrations = ScmIntegrations.fromConfig(this.config);
     const integration = integrations.byUrl(url);
     return integration?.type === 'github';
   }
+
   async analyze({ url, catalogFilename }: AnalyzeOptions) {
     const { owner, name: repo } = parseGitUrl(url);
 

--- a/plugins/catalog-backend-module-github/src/deprecated.ts
+++ b/plugins/catalog-backend-module-github/src/deprecated.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PluginTaskScheduler, TaskRunner } from '@backstage/backend-tasks';
+import { Config } from '@backstage/config';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-backend';
+import { Logger } from 'winston';
+import { GithubEntityProvider } from './providers/GithubEntityProvider';
+import {
+  GithubOrgEntityProvider,
+  GithubOrgEntityProviderOptions,
+} from './providers/GithubOrgEntityProvider';
+
+/**
+ * @public
+ * @deprecated Use {@link GithubOrgEntityProvider} instead.
+ */
+export class GitHubOrgEntityProvider extends GithubOrgEntityProvider {
+  static fromConfig(config: Config, options: GitHubOrgEntityProviderOptions) {
+    options.logger.warn(
+      '[Deprecated] Use GithubOrgEntityProvider instead of GitHubOrgEntityProvider.',
+    );
+    return GithubOrgEntityProvider.fromConfig(
+      config,
+      options as GithubOrgEntityProviderOptions,
+    ) as GitHubOrgEntityProvider;
+  }
+}
+
+/**
+ * @public
+ * @deprecated Use {@link GithubOrgEntityProviderOptions} instead.
+ */
+export type GitHubOrgEntityProviderOptions = GithubOrgEntityProviderOptions;
+
+/**
+ * @public
+ * @deprecated Use {@link GithubEntityProvider} instead.
+ */
+export class GitHubEntityProvider implements EntityProvider {
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: Logger;
+      schedule?: TaskRunner;
+      scheduler?: PluginTaskScheduler;
+    },
+  ): GitHubEntityProvider[] {
+    options.logger.warn(
+      '[Deprecated] Please use GithubEntityProvider instead of GitHubEntityProvider.',
+    );
+    return GithubEntityProvider.fromConfig(config, options).map(
+      delegate => new GitHubEntityProvider(delegate),
+    );
+  }
+
+  private constructor(private readonly delegate: GithubEntityProvider) {}
+
+  connect(connection: EntityProviderConnection): Promise<void> {
+    return this.delegate.connect(connection);
+  }
+
+  getProviderName(): string {
+    return this.delegate.getProviderName();
+  }
+
+  refresh(logger: Logger): Promise<void> {
+    return this.delegate.refresh(logger);
+  }
+}

--- a/plugins/catalog-backend-module-github/src/index.ts
+++ b/plugins/catalog-backend-module-github/src/index.ts
@@ -20,13 +20,15 @@
  * @packageDocumentation
  */
 
-export { GitHubLocationAnalyzer } from './analyzers/GitHubLocationAnalyzer';
-export type { GitHubLocationAnalyzerOptions } from './analyzers/GitHubLocationAnalyzer';
+export { GithubLocationAnalyzer } from './analyzers/GithubLocationAnalyzer';
+export type { GithubLocationAnalyzerOptions } from './analyzers/GithubLocationAnalyzer';
 export type { GithubMultiOrgConfig } from './lib';
 export { GithubDiscoveryProcessor } from './processors/GithubDiscoveryProcessor';
 export { GithubMultiOrgReaderProcessor } from './processors/GithubMultiOrgReaderProcessor';
 export { GithubOrgReaderProcessor } from './processors/GithubOrgReaderProcessor';
-export { GitHubEntityProvider } from './providers/GitHubEntityProvider';
-export { GitHubOrgEntityProvider } from './providers/GitHubOrgEntityProvider';
-export type { GitHubOrgEntityProviderOptions } from './providers/GitHubOrgEntityProvider';
+export { GithubEntityProvider } from './providers/GithubEntityProvider';
+export { GithubOrgEntityProvider } from './providers/GithubOrgEntityProvider';
+export type { GithubOrgEntityProviderOptions } from './providers/GithubOrgEntityProvider';
 export { githubEntityProviderCatalogModule } from './service/GithubEntityProviderCatalogModule';
+
+export * from './deprecated';

--- a/plugins/catalog-backend-module-github/src/lib/index.ts
+++ b/plugins/catalog-backend-module-github/src/lib/index.ts
@@ -22,4 +22,4 @@ export {
   getOrganizationUsers,
 } from './github';
 export { assignGroupsToUsers, buildOrgHierarchy } from './org';
-export { parseGitHubOrgUrl } from './util';
+export { parseGithubOrgUrl } from './util';

--- a/plugins/catalog-backend-module-github/src/lib/util.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/util.test.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { GithubTopicFilters } from '../providers/GitHubEntityProviderConfig';
-import { parseGitHubOrgUrl, satisfiesTopicFilter } from './util';
+import { GithubTopicFilters } from '../providers/GithubEntityProviderConfig';
+import { parseGithubOrgUrl, satisfiesTopicFilter } from './util';
 
-describe('parseGitHubOrgUrl', () => {
+describe('parseGithubOrgUrl', () => {
   it('only supports clean org urls, and decodes them', () => {
-    expect(() => parseGitHubOrgUrl('https://github.com')).toThrow();
-    expect(() => parseGitHubOrgUrl('https://github.com/org/foo')).toThrow();
+    expect(() => parseGithubOrgUrl('https://github.com')).toThrow();
+    expect(() => parseGithubOrgUrl('https://github.com/org/foo')).toThrow();
     expect(() =>
-      parseGitHubOrgUrl('https://github.com/org/foo/teams'),
+      parseGithubOrgUrl('https://github.com/org/foo/teams'),
     ).toThrow();
-    expect(parseGitHubOrgUrl('https://github.com/foo%32')).toEqual({
+    expect(parseGithubOrgUrl('https://github.com/foo%32')).toEqual({
       org: 'foo2',
     });
   });

--- a/plugins/catalog-backend-module-github/src/lib/util.ts
+++ b/plugins/catalog-backend-module-github/src/lib/util.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { GithubTopicFilters } from '../providers/GitHubEntityProviderConfig';
+import { GithubTopicFilters } from '../providers/GithubEntityProviderConfig';
 
-export function parseGitHubOrgUrl(urlString: string): { org: string } {
+export function parseGithubOrgUrl(urlString: string): { org: string } {
   const path = new URL(urlString).pathname.substr(1).split('/');
 
   // /backstage

--- a/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.ts
@@ -35,7 +35,7 @@ import {
   buildOrgHierarchy,
   getOrganizationTeams,
   getOrganizationUsers,
-  parseGitHubOrgUrl,
+  parseGithubOrgUrl,
 } from '../lib';
 
 type GraphQL = typeof graphql;
@@ -45,7 +45,7 @@ type GraphQL = typeof graphql;
  *
  * @remarks
  *
- * Consider using {@link GitHubOrgEntityProvider} instead.
+ * Consider using {@link GithubOrgEntityProvider} instead.
  *
  * @public
  */
@@ -94,7 +94,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     }
 
     const { client, tokenType } = await this.createClient(location.target);
-    const { org } = parseGitHubOrgUrl(location.target);
+    const { org } = parseGithubOrgUrl(location.target);
 
     // Read out all of the raw data
     const startTimestamp = Date.now();

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@backstage/backend-tasks';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
-import { GitHubEntityProvider } from './GitHubEntityProvider';
+import { GithubEntityProvider } from './GithubEntityProvider';
 import * as helpers from '../lib/github';
 
 jest.mock('../lib/github', () => {
@@ -45,13 +45,13 @@ class PersistingTaskRunner implements TaskRunner {
 
 const logger = getVoidLogger();
 
-describe('GitHubEntityProvider', () => {
+describe('GithubEntityProvider', () => {
   afterEach(() => jest.resetAllMocks());
 
   it('no provider config', () => {
     const schedule = new PersistingTaskRunner();
     const config = new ConfigReader({});
-    const providers = GitHubEntityProvider.fromConfig(config, {
+    const providers = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     });
@@ -70,7 +70,7 @@ describe('GitHubEntityProvider', () => {
         },
       },
     });
-    const providers = GitHubEntityProvider.fromConfig(config, {
+    const providers = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     });
@@ -93,7 +93,7 @@ describe('GitHubEntityProvider', () => {
     });
 
     expect(() =>
-      GitHubEntityProvider.fromConfig(config, {
+      GithubEntityProvider.fromConfig(config, {
         logger,
         schedule,
       }),
@@ -116,7 +116,7 @@ describe('GitHubEntityProvider', () => {
         },
       },
     });
-    const providers = GitHubEntityProvider.fromConfig(config, {
+    const providers = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     });
@@ -153,7 +153,7 @@ describe('GitHubEntityProvider', () => {
       refresh: jest.fn(),
     };
 
-    const provider = GitHubEntityProvider.fromConfig(config, {
+    const provider = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     })[0];
@@ -241,7 +241,7 @@ describe('GitHubEntityProvider', () => {
       refresh: jest.fn(),
     };
 
-    const provider = GitHubEntityProvider.fromConfig(config, {
+    const provider = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     })[0];
@@ -315,7 +315,7 @@ describe('GitHubEntityProvider', () => {
       refresh: jest.fn(),
     };
 
-    const provider = GitHubEntityProvider.fromConfig(config, {
+    const provider = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     })[0];
@@ -413,7 +413,7 @@ describe('GitHubEntityProvider', () => {
       refresh: jest.fn(),
     };
 
-    const provider = GitHubEntityProvider.fromConfig(config, {
+    const provider = GithubEntityProvider.fromConfig(config, {
       logger,
       schedule,
     })[0];
@@ -526,7 +526,7 @@ describe('GitHubEntityProvider', () => {
     });
 
     expect(() =>
-      GitHubEntityProvider.fromConfig(config, {
+      GithubEntityProvider.fromConfig(config, {
         logger,
       }),
     ).toThrow('Either schedule or scheduler must be provided');
@@ -547,7 +547,7 @@ describe('GitHubEntityProvider', () => {
     });
 
     expect(() =>
-      GitHubEntityProvider.fromConfig(config, {
+      GithubEntityProvider.fromConfig(config, {
         logger,
         scheduler,
       }),
@@ -574,7 +574,7 @@ describe('GitHubEntityProvider', () => {
         },
       },
     });
-    const providers = GitHubEntityProvider.fromConfig(config, {
+    const providers = GithubEntityProvider.fromConfig(config, {
       logger,
       scheduler,
     });

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -35,8 +35,8 @@ import * as uuid from 'uuid';
 import { Logger } from 'winston';
 import {
   readProviderConfigs,
-  GitHubEntityProviderConfig,
-} from './GitHubEntityProviderConfig';
+  GithubEntityProviderConfig,
+} from './GithubEntityProviderConfig';
 import { getOrganizationRepositories, Repository } from '../lib/github';
 import { satisfiesTopicFilter } from '../lib/util';
 
@@ -48,8 +48,8 @@ import { satisfiesTopicFilter } from '../lib/util';
  *
  * @public
  */
-export class GitHubEntityProvider implements EntityProvider {
-  private readonly config: GitHubEntityProviderConfig;
+export class GithubEntityProvider implements EntityProvider {
+  private readonly config: GithubEntityProviderConfig;
   private readonly logger: Logger;
   private readonly integration: GitHubIntegrationConfig;
   private readonly scheduleFn: () => Promise<void>;
@@ -63,7 +63,7 @@ export class GitHubEntityProvider implements EntityProvider {
       schedule?: TaskRunner;
       scheduler?: PluginTaskScheduler;
     },
-  ): GitHubEntityProvider[] {
+  ): GithubEntityProvider[] {
     if (!options.schedule && !options.scheduler) {
       throw new Error('Either schedule or scheduler must be provided.');
     }
@@ -90,7 +90,7 @@ export class GitHubEntityProvider implements EntityProvider {
         options.schedule ??
         options.scheduler!.createScheduledTaskRunner(providerConfig.schedule!);
 
-      return new GitHubEntityProvider(
+      return new GithubEntityProvider(
         providerConfig,
         integration,
         options.logger,
@@ -100,7 +100,7 @@ export class GitHubEntityProvider implements EntityProvider {
   }
 
   private constructor(
-    config: GitHubEntityProviderConfig,
+    config: GithubEntityProviderConfig,
     integration: GitHubIntegration,
     logger: Logger,
     taskRunner: TaskRunner,
@@ -133,7 +133,7 @@ export class GitHubEntityProvider implements EntityProvider {
         id: taskId,
         fn: async () => {
           const logger = this.logger.child({
-            class: GitHubEntityProvider.prototype.constructor.name,
+            class: GithubEntityProvider.prototype.constructor.name,
             taskId,
             taskInstanceId: uuid.v4(),
           });
@@ -156,7 +156,7 @@ export class GitHubEntityProvider implements EntityProvider {
     const matchingTargets = this.matchesFilters(targets);
     const entities = matchingTargets
       .map(repository => this.createLocationUrl(repository))
-      .map(GitHubEntityProvider.toLocationSpec)
+      .map(GithubEntityProvider.toLocationSpec)
       .map(location => {
         return {
           locationKey: this.getProviderName(),

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
@@ -16,7 +16,7 @@
 
 import { ConfigReader } from '@backstage/config';
 import { Duration } from 'luxon';
-import { readProviderConfigs } from './GitHubEntityProviderConfig';
+import { readProviderConfigs } from './GithubEntityProviderConfig';
 
 describe('readProviderConfigs', () => {
   afterEach(() => jest.resetAllMocks());

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
@@ -23,7 +23,7 @@ import { Config } from '@backstage/config';
 const DEFAULT_CATALOG_PATH = '/catalog-info.yaml';
 const DEFAULT_PROVIDER_ID = 'default';
 
-export type GitHubEntityProviderConfig = {
+export type GithubEntityProviderConfig = {
   id: string;
   catalogPath: string;
   organization: string;
@@ -43,7 +43,7 @@ export type GithubTopicFilters = {
 
 export function readProviderConfigs(
   config: Config,
-): GitHubEntityProviderConfig[] {
+): GithubEntityProviderConfig[] {
   const providersConfig = config.getOptionalConfig('catalog.providers.github');
   if (!providersConfig) {
     return [];
@@ -64,7 +64,7 @@ export function readProviderConfigs(
 function readProviderConfig(
   id: string,
   config: Config,
-): GitHubEntityProviderConfig {
+): GithubEntityProviderConfig {
   const organization = config.getString('organization');
   const catalogPath =
     config.getOptionalString('catalogPath') ?? DEFAULT_CATALOG_PATH;

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -23,13 +23,13 @@ import {
 import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
 import { graphql } from '@octokit/graphql';
 import {
-  GitHubOrgEntityProvider,
+  GithubOrgEntityProvider,
   withLocations,
-} from './GitHubOrgEntityProvider';
+} from './GithubOrgEntityProvider';
 
 jest.mock('@octokit/graphql');
 
-describe('GitHubOrgEntityProvider', () => {
+describe('GithubOrgEntityProvider', () => {
   describe('read', () => {
     afterEach(() => jest.resetAllMocks());
 
@@ -100,7 +100,7 @@ describe('GitHubOrgEntityProvider', () => {
         getCredentials: mockGetCredentials,
       };
 
-      const entityProvider = new GitHubOrgEntityProvider({
+      const entityProvider = new GithubOrgEntityProvider({
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -41,15 +41,15 @@ import {
   buildOrgHierarchy,
   getOrganizationTeams,
   getOrganizationUsers,
-  parseGitHubOrgUrl,
+  parseGithubOrgUrl,
 } from '../lib';
 
 /**
- * Options for {@link GitHubOrgEntityProvider}.
+ * Options for {@link GithubOrgEntityProvider}.
  *
  * @public
  */
-export interface GitHubOrgEntityProviderOptions {
+export interface GithubOrgEntityProviderOptions {
   /**
    * A unique, stable identifier for this provider.
    *
@@ -96,12 +96,12 @@ export interface GitHubOrgEntityProviderOptions {
  *
  * @public
  */
-export class GitHubOrgEntityProvider implements EntityProvider {
+export class GithubOrgEntityProvider implements EntityProvider {
   private readonly credentialsProvider: GithubCredentialsProvider;
   private connection?: EntityProviderConnection;
   private scheduleFn?: () => Promise<void>;
 
-  static fromConfig(config: Config, options: GitHubOrgEntityProviderOptions) {
+  static fromConfig(config: Config, options: GithubOrgEntityProviderOptions) {
     const integrations = ScmIntegrations.fromConfig(config);
     const gitHubConfig = integrations.github.byUrl(options.orgUrl)?.config;
 
@@ -115,7 +115,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
       target: options.orgUrl,
     });
 
-    const provider = new GitHubOrgEntityProvider({
+    const provider = new GithubOrgEntityProvider({
       id: options.id,
       orgUrl: options.orgUrl,
       logger,
@@ -146,7 +146,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
 
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.getProviderName} */
   getProviderName() {
-    return `GitHubOrgEntityProvider:${this.options.id}`;
+    return `GithubOrgEntityProvider:${this.options.id}`;
   }
 
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */
@@ -176,7 +176,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
       headers,
     });
 
-    const { org } = parseGitHubOrgUrl(this.options.orgUrl);
+    const { org } = parseGithubOrgUrl(this.options.orgUrl);
     const { users } = await getOrganizationUsers(client, org, tokenType);
     const { groups, groupMemberUsers } = await getOrganizationTeams(
       client,
@@ -202,7 +202,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
     markCommitComplete();
   }
 
-  private schedule(schedule: GitHubOrgEntityProviderOptions['schedule']) {
+  private schedule(schedule: GithubOrgEntityProviderOptions['schedule']) {
     if (!schedule || schedule === 'manual') {
       return;
     }
@@ -213,7 +213,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
         id,
         fn: async () => {
           const logger = this.options.logger.child({
-            class: GitHubOrgEntityProvider.prototype.constructor.name,
+            class: GithubOrgEntityProvider.prototype.constructor.name,
             taskId: id,
             taskInstanceId: uuid.v4(),
           });

--- a/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.test.ts
@@ -29,11 +29,11 @@ import { ConfigReader } from '@backstage/config';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { Duration } from 'luxon';
 import { githubEntityProviderCatalogModule } from './GithubEntityProviderCatalogModule';
-import { GitHubEntityProvider } from '../providers/GitHubEntityProvider';
+import { GithubEntityProvider } from '../providers/GithubEntityProvider';
 
 describe('githubEntityProviderCatalogModule', () => {
   it('should register provider at the catalog extension point', async () => {
-    let addedProviders: Array<GitHubEntityProvider> | undefined;
+    let addedProviders: Array<GithubEntityProvider> | undefined;
     let usedSchedule: TaskScheduleDefinition | undefined;
 
     const extensionPoint = {

--- a/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.ts
@@ -22,10 +22,10 @@ import {
   schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
-import { GitHubEntityProvider } from '../providers/GitHubEntityProvider';
+import { GithubEntityProvider } from '../providers/GithubEntityProvider';
 
 /**
- * Registers the GitHubEntityProvider with the catalog processing extension point.
+ * Registers the {@link GithubEntityProvider} with the catalog processing extension point.
  *
  * @alpha
  */
@@ -42,7 +42,7 @@ export const githubEntityProviderCatalogModule = createBackendModule({
       },
       async init({ catalog, config, logger, scheduler }) {
         catalog.addEntityProvider(
-          GitHubEntityProvider.fromConfig(config, {
+          GithubEntityProvider.fromConfig(config, {
             logger: loggerToWinstonLogger(logger),
             scheduler,
           }),


### PR DESCRIPTION
Replaces in-code uses of `GitHub` by `Github` and deprecates old versions.

Deprecates

- `GitHubEntityProvider` replaced by `GithubEntityProvider`
- `GitHubLocationAnalyzer` replaced by `GithubLocationAnalyzer`
- `GitHubLocationAnalyzerOptions` replaced by `GithubLocationAnalyzerOptions`
- `GitHubOrgEntityProvider` replaced by `GithubOrgEntityProvider`
- `GitHubOrgEntityProviderOptions` replaced by `GithubOrgEntityProviderOptions`

Relates to the discussion at PR #14039.

Relates-to: PR #14039
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
