### PR TITLE
add refresh action to TemplateCard

### DIFF
--- a/.changeset/fifty-eagles-nail.md
+++ b/.changeset/fifty-eagles-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Added a refresh entity action to the `TemplateCard` to make the refreshing of the template easier.


### PR DESCRIPTION
Signed-off-by: Kiss Miklos <miklos@roadie.io>

## Hey, I just made a Pull Request!
Adds a refresh entity button to the TemplateCard to make sure you are using the latest template before you run it.
| Before | After |
|-------|------|
| <img width="393" alt="image" src="https://user-images.githubusercontent.com/24729496/196277937-428a244c-1ed0-49eb-b131-a00ebcc2734e.png">| <img width="397" alt="image" src="https://user-images.githubusercontent.com/24729496/196277613-0d2f326d-56a4-4004-81fd-862f345faf58.png">|


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
