### PR TITLE
Catalog: Fixes issue where the query kind parameter is not honored

### DIFF
--- a/.changeset/nice-monkeys-punch.md
+++ b/.changeset/nice-monkeys-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed issue where the query kind parameter is not honored

--- a/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
@@ -154,10 +154,7 @@ export const EntityKindPicker = (props: EntityKindPickerProps) => {
         severity: 'error',
       });
     }
-    if (initialFilter) {
-      setSelectedKind(initialFilter);
-    }
-  }, [error, alertApi, initialFilter, setSelectedKind]);
+  }, [error, alertApi]);
 
   if (availableKinds?.length === 0 || error) return null;
 


### PR DESCRIPTION
The kind query parameter is not honored and the
user is forward to the initial catalog kind filter.

Verify by starting a dev environment and go to:
http://localhost:3000/catalog?filters%5Bkind%5D=group&filters%5Buser%5D=all

The user is always forwarded to the default kind
(component).

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
