### PR TITLE
Cleanup the momentjs dependency in plugin-github-pull-requests-board

### DIFF
--- a/.changeset/curvy-islands-marry.md
+++ b/.changeset/curvy-islands-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-pull-requests-board': patch
+---
+
+Replace the momentjs dependency with luxon.

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -44,7 +44,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^19.0.3",
-    "moment": "^2.29.1",
+    "luxon": "^3.0.0",
     "react-use": "^17.2.4"
   },
   "devDependencies": {

--- a/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import {
   Reviews,
   PullRequests,
@@ -58,7 +58,7 @@ export const filterSameUser = (users: Author[]): Author[] => {
 };
 
 export const getElapsedTime = (start: string): string => {
-  return moment(start).fromNow();
+  return DateTime.fromISO(start).toRelative() ?? start;
 };
 
 export const formatPRsByReviewDecision = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5674,7 +5674,7 @@ __metadata:
     "@types/node": ^16.11.26
     "@types/react": ^16.13.1 || ^17.0.0
     cross-fetch: ^3.1.5
-    moment: ^2.29.1
+    luxon: ^3.0.0
     msw: ^0.47.0
     react-use: ^17.2.4
   peerDependencies:


### PR DESCRIPTION
As per [ADR010: Use the Luxon Date Library](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr010-luxon-date-library.md), we should replace momentjs with luxon.

Signed-off-by: Mengnan Gong <namco1992@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
