### PR TITLE
fix(GithubLocationAnalyzer): support github app auth & authenticated backends

### DIFF
--- a/.changeset/eight-pears-attack.md
+++ b/.changeset/eight-pears-attack.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+BREAKING: Support authenticated backends by including a server token for catalog requests. The constructor of `GithubLocationAnalyzer` now requires an instance of `TokenManager` to be supplied:
+
+```diff
+...
+  builder.addLocationAnalyzers(
+    new GitHubLocationAnalyzer({
+      discovery: env.discovery,
+      config: env.config,
++     tokenManager: env.tokenManager,
+    }),
+  );
+...
+```

--- a/.changeset/popular-bulldogs-lie.md
+++ b/.changeset/popular-bulldogs-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Properly derive Github credentials when making requests in `GithubLocationAnalyzer` to support Github App authentication

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -20,6 +20,7 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmLocationAnalyzer } from '@backstage/plugin-catalog-backend';
 import { TaskRunner } from '@backstage/backend-tasks';
+import { TokenManager } from '@backstage/backend-common';
 
 // @public
 export class GithubDiscoveryProcessor implements CatalogProcessor {
@@ -111,6 +112,7 @@ export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
 export type GithubLocationAnalyzerOptions = {
   config: Config;
   discovery: PluginEndpointDiscovery;
+  tokenManager: TokenManager;
 };
 
 // @public

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.test.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.test.ts
@@ -32,7 +32,10 @@ jest.mock('@octokit/rest', () => {
   return { Octokit };
 });
 
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import {
+  PluginEndpointDiscovery,
+  TokenManager,
+} from '@backstage/backend-common';
 import { GithubLocationAnalyzer } from './GithubLocationAnalyzer';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { setupServer } from 'msw/node';
@@ -45,6 +48,10 @@ describe('GithubLocationAnalyzer', () => {
   const mockDiscoveryApi: jest.Mocked<PluginEndpointDiscovery> = {
     getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7007'),
     getExternalBaseUrl: jest.fn(),
+  };
+  const mockTokenManager: jest.Mocked<TokenManager> = {
+    authenticate: jest.fn(),
+    getToken: jest.fn().mockResolvedValue('abc123'),
   };
   const config = new ConfigReader({
     integrations: {
@@ -117,6 +124,7 @@ describe('GithubLocationAnalyzer', () => {
     const analyzer = new GithubLocationAnalyzer({
       discovery: mockDiscoveryApi,
       config,
+      tokenManager: mockTokenManager,
     });
     const result = await analyzer.analyze({
       url: 'https://github.com/foo/bar',
@@ -142,6 +150,7 @@ describe('GithubLocationAnalyzer', () => {
     const analyzer = new GithubLocationAnalyzer({
       discovery: mockDiscoveryApi,
       config,
+      tokenManager: mockTokenManager,
     });
     const result = await analyzer.analyze({
       url: 'https://github.com/foo/bar',


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This fixes the way the `GithubLocationAnalyzer` was grabbing tokens for Github requests to be able to support either PAT or Github App auths. This change also adds support for authenticated backends by forwarding server tokens. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
