### PR TITLE
Handle Bitbucket optional config

### DIFF
--- a/.changeset/clever-chefs-flow.md
+++ b/.changeset/clever-chefs-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Handles undefined optional config values without crashing on startup

--- a/packages/catalog-model/src/kinds/GroupEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/GroupEntityV1alpha1.test.ts
@@ -95,8 +95,33 @@ describe('GroupV1alpha1Validator', () => {
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
+  it('profile accepts multiple words in displayName', async () => {
+    (entity as any).spec.profile.displayName = 'Testing test test';
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('profile accepts dashes and underscores in displayName', async () => {
+    (entity as any).spec.profile.displayName = 'test-test test_test';
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('profile accepts numbers in displayName', async () => {
+    (entity as any).spec.profile.displayName = 'test1 23';
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
   it('profile rejects wrong displayName', async () => {
     (entity as any).spec.profile.displayName = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/displayName/);
+  });
+
+  it('profile rejects special characters in displayName', async () => {
+    (entity as any).spec.profile.displayName = 'M & M';
+    await expect(validator.check(entity)).rejects.toThrow(/displayName/);
+  });
+
+  it('profile rejects punctuation in displayName', async () => {
+    (entity as any).spec.profile.displayName = 'Test.';
     await expect(validator.check(entity)).rejects.toThrow(/displayName/);
   });
 

--- a/packages/catalog-model/src/schema/kinds/Group.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Group.v1alpha1.schema.json
@@ -54,6 +54,7 @@
                   "type": "string",
                   "description": "A simple display name to present to users.",
                   "examples": ["Infrastructure"],
+                  "pattern": "^[A-Za-z0-9-_\\s]{2,}$",
                   "minLength": 1
                 },
                 "email": {

--- a/packages/integration/src/bitbucketCloud/config.ts
+++ b/packages/integration/src/bitbucketCloud/config.ts
@@ -61,8 +61,8 @@ export function readBitbucketCloudIntegrationConfig(
   const apiBaseUrl = BITBUCKET_CLOUD_API_BASE_URL;
   // If config is provided, we assume authenticated access is desired
   // (as the anonymous one is provided by default).
-  const username = config.getString('username');
-  const appPassword = config.getString('appPassword');
+  const username = config.getOptionalString('username');
+  const appPassword = config.getOptionalString('appPassword');
 
   return {
     host,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We were accessing optional config values with getString which was crashing the backend when these values were not present. In this case, the Bitbucket appPassword should be injected in via an environment variable normally and shouldn't be required to start the app. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
