### PR TITLE
Set "application/json" content type header in TechInsightsClient

### DIFF
--- a/.changeset/poor-moons-impress.md
+++ b/.changeset/poor-moons-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Set content type to 'application/json' in TechInsightsClient

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -82,6 +82,9 @@ export class TechInsightsClient implements TechInsightsApi {
       {
         method: 'POST',
         body: JSON.stringify(requestBody),
+        headers: {
+          'content-type': 'application/json',
+        },
       },
     );
   }
@@ -98,6 +101,9 @@ export class TechInsightsClient implements TechInsightsApi {
     return this.api('/checks/run', {
       method: 'POST',
       body: JSON.stringify(requestBody),
+      headers: {
+        'content-type': 'application/json',
+      },
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Alex Rybchenko <arybchenko@box.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
After last upgrade we encountered 500 errors in tech insights plugin. Looks like `Request` sets 'content-type' header to `text/plain;charset=UTF-8` by default for POST method type and backend fails to process such request, so I added headers to init params.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
