### PR TITLE
renovate: bump svgr dependencies together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,5 +15,10 @@
       groupName: 'API Extractor / Rush Stack monorepo packages',
       rangeStrategy: 'replace',
     },
+    {
+      matchSourceUrlPrefixes: ['https://github.com/gregberge/svgr'],
+      groupName: 'SVGR monorepo packages',
+      rangeStrategy: 'replace',
+    },
   ],
 }


### PR DESCRIPTION
Bump all of the SVGR packages together since it's a monorepo with the same version across packages.