### PR TITLE
fix(PermissionClient): fix rules schema to handle optional params

### DIFF
--- a/.changeset/real-swans-repair.md
+++ b/.changeset/real-swans-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-common': patch
+---
+
+Properly handle rules that have no parameters in `PermissionClient`

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -41,7 +41,7 @@ const permissionCriteriaSchema: z.ZodSchema<
     .object({
       rule: z.string(),
       resourceType: z.string(),
-      params: z.record(z.any()),
+      params: z.record(z.any()).optional(),
     })
     .or(z.object({ anyOf: z.array(permissionCriteriaSchema).nonempty() }))
     .or(z.object({ allOf: z.array(permissionCriteriaSchema).nonempty() }))


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Fixes #14228 

This fixes the schema validation to handle scenarios where a rule has no params such as:
https://github.com/backstage/backstage/blob/8db366cc4ceb0fe6e10de81b8ba2277a350a3729/plugins/playlist-backend/src/permissions/rules.ts#L46-L52 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
