### PR TITLE
Revert "Set "application/json" content type header in TechInsightsClient"

### DIFF
--- a/.changeset/poor-moons-impress.md
+++ b/.changeset/poor-moons-impress.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-tech-insights': patch
----
-
-Set content type to 'application/json' in TechInsightsClient

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -82,9 +82,6 @@ export class TechInsightsClient implements TechInsightsApi {
       {
         method: 'POST',
         body: JSON.stringify(requestBody),
-        headers: {
-          'content-type': 'application/json',
-        },
       },
     );
   }
@@ -101,9 +98,6 @@ export class TechInsightsClient implements TechInsightsApi {
     return this.api('/checks/run', {
       method: 'POST',
       body: JSON.stringify(requestBody),
-      headers: {
-        'content-type': 'application/json',
-      },
     });
   }
 


### PR DESCRIPTION
Reverts #14222, since #14135 made it redundant