### PR TITLE
Fix "new" ribbon showing on all plugins in marketplace

### DIFF
--- a/docs/plugins/add-to-marketplace.md
+++ b/docs/plugins/add-to-marketplace.md
@@ -23,4 +23,5 @@ iconUrl: # Used as the src attribute for your logo.
 # You can provide an external url or add your logo under static/img and provide a path
 # relative to static/ e.g. img/my-logo.png
 npmPackageName: # Your npm package name E.g. '@backstage/plugin-<etc>' quotes are required
+addedDate: # The date plugin added to marketplace E.g. '2022-10-01' quotes are required
 ```

--- a/microsite/data/plugins/adr.yaml
+++ b/microsite/data/plugins/adr.yaml
@@ -7,3 +7,4 @@ description: Browse your project's ADRs.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/adr
 iconUrl: img/adr-logo.png
 npmPackageName: '@backstage/plugin-adr'
+addedDate: '2022-04-13'

--- a/microsite/data/plugins/airbrake.yaml
+++ b/microsite/data/plugins/airbrake.yaml
@@ -7,3 +7,4 @@ description: Access Airbrake error monitoring and other integrations from within
 documentation: https://github.com/backstage/backstage/blob/master/plugins/airbrake
 iconUrl: https://wp-assets.airbrake.io/wp-content/uploads/2020/10/05222904/Square-white-A-on-Orange.png
 npmPackageName: '@backstage/plugin-airbrake'
+addedDate: '2022-01-10'

--- a/microsite/data/plugins/allure.yaml
+++ b/microsite/data/plugins/allure.yaml
@@ -7,3 +7,4 @@ description: View Allure reports for your components in Backstage.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/allure
 iconUrl: https://avatars.githubusercontent.com/u/5879127
 npmPackageName: '@backstage/plugin-allure'
+addedDate: '2021-09-02'

--- a/microsite/data/plugins/api-docs.yaml
+++ b/microsite/data/plugins/api-docs.yaml
@@ -7,3 +7,4 @@ description: Components to discover and display API entities as an extension to 
 documentation: https://github.com/backstage/backstage/blob/master/plugins/api-docs/README.md
 iconUrl: https://raw.githubusercontent.com/vscode-icons/vscode-icons/master/icons/file_type_swagger.svg
 npmPackageName: '@backstage/plugin-api-docs'
+addedDate: '2020-11-19'

--- a/microsite/data/plugins/apollo-explorer.yaml
+++ b/microsite/data/plugins/apollo-explorer.yaml
@@ -7,3 +7,4 @@ description: Integrates Apollo Explorer graphs as a tool to browse GraphQL API e
 documentation: https://github.com/backstage/backstage/blob/master/plugins/apollo-explorer/README.md
 iconUrl: img/apollo-explorer.png
 npmPackageName: '@backstage/plugin-apollo-explorer'
+addedDate: '2022-07-20'

--- a/microsite/data/plugins/argo-cd.yaml
+++ b/microsite/data/plugins/argo-cd.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@roadiehq/backstage-plugin-argo-cd'
 tags:
   - cd
   - ci
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/aws-cloudformation.yaml
+++ b/microsite/data/plugins/aws-cloudformation.yaml
@@ -7,3 +7,4 @@ description: Load Backstage entities from AWS CloudFormation stacks
 documentation: https://github.com/purple-technology/backstage-aws-cloudformation-plugin#readme
 iconUrl: https://raw.githubusercontent.com/purple-technology/backstage-aws-cloudformation-plugin/master/docs/cloudformation-logo.png
 npmPackageName: 'backstage-aws-cloudformation-plugin'
+addedDate: '2021-08-30'

--- a/microsite/data/plugins/aws-lambda.yaml
+++ b/microsite/data/plugins/aws-lambda.yaml
@@ -7,3 +7,4 @@ description: View AWS Lambda functions for your components in Backstage.
 documentation: https://roadie.io/backstage/plugins/aws-lambda/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=aws-lambda
 iconUrl: https://roadie.io/images/logos/lambda.png
 npmPackageName: '@roadiehq/backstage-plugin-aws-lambda'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/aws-proton.yaml
+++ b/microsite/data/plugins/aws-proton.yaml
@@ -7,3 +7,4 @@ description: Create and view AWS Proton services for your components in Backstag
 documentation: https://github.com/awslabs/aws-proton-plugins-for-backstage#readme
 iconUrl: https://github.com/awslabs/aws-proton-plugins-for-backstage/blob/main/docs/images/proton-logo.png?raw=true
 npmPackageName: '@aws/aws-proton-plugin-for-backstage'
+addedDate: '2022-06-21'

--- a/microsite/data/plugins/azure-pipelines.yaml
+++ b/microsite/data/plugins/azure-pipelines.yaml
@@ -7,3 +7,4 @@ description: Easily view your Azure Pipelines within the Software Catalog
 documentation: https://github.com/backstage/backstage/blob/master/plugins/azure-devops/README.md
 iconUrl: img/azure-pipelines.svg
 npmPackageName: '@backstage/plugin-azure-devops'
+addedDate: '2021-12-22'

--- a/microsite/data/plugins/azure-resources.yaml
+++ b/microsite/data/plugins/azure-resources.yaml
@@ -6,3 +6,4 @@ category: Infrastructure
 description: A plugin showing Azure resource groups and security recommendations in relation to an entity in the catalog.
 documentation: https://github.com/vippsas/backstage-azure-resource-frontend
 npmPackageName: '@vippsno/plugin-azure-resources'
+addedDate: '2022-09-05'

--- a/microsite/data/plugins/azure-sites.yaml
+++ b/microsite/data/plugins/azure-sites.yaml
@@ -6,3 +6,4 @@ category: Infrastructure
 description: Azure Sites (Apps & Functions) support for a given entity. View the current status of the site, quickly jump to site's Overview page, or Log Stream page.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/azure-sites
 npmPackageName: '@backstage/plugin-azure-sites'
+addedDate: '2022-10-18'

--- a/microsite/data/plugins/backstage-analytics-module-ga.yaml
+++ b/microsite/data/plugins/backstage-analytics-module-ga.yaml
@@ -7,3 +7,4 @@ description: Track usage of your Backstage instance using Google Analytics.
 documentation: https://github.com/backstage/backstage/blob/master/plugins/analytics-module-ga/README.md
 iconUrl: img/ga-icon.png
 npmPackageName: '@backstage/plugin-analytics-module-ga'
+addedDate: '2021-10-07'

--- a/microsite/data/plugins/backstage-kubernetes.yaml
+++ b/microsite/data/plugins/backstage-kubernetes.yaml
@@ -8,3 +8,4 @@ documentation: https://backstage.io/docs/features/kubernetes/overview
 iconUrl: img/backstage-k8s.svg
 npmPackageName: '@backstage/plugin-kubernetes'
 order: 4
+addedDate: '2021-03-29'

--- a/microsite/data/plugins/backstage-search-platform.yaml
+++ b/microsite/data/plugins/backstage-search-platform.yaml
@@ -8,3 +8,4 @@ documentation: https://backstage.io/docs/features/software-catalog/software-cata
 iconUrl: img/backstage-search-platform.svg
 npmPackageName: '@backstage/plugin-search'
 order: 5
+addedDate: '2022-09-07'

--- a/microsite/data/plugins/backstage-software-catalog.yaml
+++ b/microsite/data/plugins/backstage-software-catalog.yaml
@@ -8,3 +8,4 @@ documentation: https://backstage.io/docs/features/software-catalog/software-cata
 iconUrl: img/backstage-software-catalog.svg
 npmPackageName: '@backstage/plugin-catalog'
 order: 1
+addedDate: '2021-06-17'

--- a/microsite/data/plugins/backstage-software-templates.yaml
+++ b/microsite/data/plugins/backstage-software-templates.yaml
@@ -8,3 +8,4 @@ documentation: https://backstage.io/docs/features/software-templates/software-te
 iconUrl: img/backstage-software-templates.svg
 npmPackageName: '@backstage/plugin-scaffolder'
 order: 2
+addedDate: '2021-03-29'

--- a/microsite/data/plugins/backstage-techdocs.yaml
+++ b/microsite/data/plugins/backstage-techdocs.yaml
@@ -8,3 +8,4 @@ documentation: https://backstage.io/docs/features/techdocs/techdocs-overview
 iconUrl: img/backstage-techdocs.svg
 npmPackageName: '@backstage/plugin-techdocs'
 order: 3
+addedDate: '2021-03-29'

--- a/microsite/data/plugins/badges.yaml
+++ b/microsite/data/plugins/badges.yaml
@@ -7,3 +7,4 @@ description: The badges plugin offers a set of badges that can be used outside o
 documentation: https://github.com/backstage/backstage/blob/master/plugins/badges/README.md
 iconUrl: img/badges.svg
 npmPackageName: '@backstage/plugin-badges'
+addedDate: '2021-09-29'

--- a/microsite/data/plugins/bazaar.yaml
+++ b/microsite/data/plugins/bazaar.yaml
@@ -6,3 +6,4 @@ description: A marketplace where engineers can propose projects suitable for inn
 documentation: https://github.com/backstage/backstage/blob/master/plugins/bazaar/README.md
 iconUrl: img/bazaar.svg
 npmPackageName: '@backstage/plugin-bazaar'
+addedDate: '2022-01-11'

--- a/microsite/data/plugins/bitrise.yaml
+++ b/microsite/data/plugins/bitrise.yaml
@@ -7,3 +7,4 @@ description: View Bitrise builds and download the build artifacts within Backsta
 documentation: https://github.com/backstage/backstage/blob/master/plugins/bitrise/README.md
 iconUrl: https://avatars.githubusercontent.com/u/7174390?s=400&v=4
 npmPackageName: '@backstage/plugin-bitrise'
+addedDate: '2021-03-01'

--- a/microsite/data/plugins/bugsnag.yaml
+++ b/microsite/data/plugins/bugsnag.yaml
@@ -7,3 +7,4 @@ description: View and monitor Bugsnag errors.
 documentation: https://roadie.io/backstage/plugins/bugsnag/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=bugsnag
 iconUrl: https://roadie.io/images/logos/bugsnag.png
 npmPackageName: '@roadiehq/backstage-plugin-bugsnag'
+addedDate: '2021-09-24'

--- a/microsite/data/plugins/buildkite.yaml
+++ b/microsite/data/plugins/buildkite.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@roadiehq/backstage-plugin-buildkite'
 tags:
   - ci
   - cd
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/catalog-graph.yaml
+++ b/microsite/data/plugins/catalog-graph.yaml
@@ -7,3 +7,4 @@ description: Extend the Backstage Software Catalog with a graph that shows all e
 documentation: https://github.com/backstage/backstage/blob/master/plugins/catalog-graph/README.md
 iconUrl: img/catalog-graph.svg
 npmPackageName: '@backstage/plugin-catalog-graph'
+addedDate: '2021-09-15'

--- a/microsite/data/plugins/circleci.yaml
+++ b/microsite/data/plugins/circleci.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@backstage/plugin-circleci'
 tags:
   - ci
   - cd
+addedDate: '2021-04-28'

--- a/microsite/data/plugins/cloud-build.yaml
+++ b/microsite/data/plugins/cloud-build.yaml
@@ -11,3 +11,4 @@ tags:
   - ci
   - cd
   - test
+addedDate: '2021-01-20'

--- a/microsite/data/plugins/cloud-carbon-footprint.yaml
+++ b/microsite/data/plugins/cloud-carbon-footprint.yaml
@@ -13,3 +13,4 @@ tags:
   - climate
   - carbon-emissions
   - carbon-footprint
+addedDate: '2022-05-03'

--- a/microsite/data/plugins/cloudify.yaml
+++ b/microsite/data/plugins/cloudify.yaml
@@ -7,3 +7,4 @@ description: Cloudify provides a remote execution and environment management bac
 documentation: https://github.com/cloudify-cosmo/backstage-cloudify-plugin#readme
 iconUrl: https://avatars.githubusercontent.com/u/6260555?s=200&v=4
 npmPackageName: 'plugin-cloudify'
+addedDate: '2022-05-31'

--- a/microsite/data/plugins/codescene.yaml
+++ b/microsite/data/plugins/codescene.yaml
@@ -7,3 +7,4 @@ description: CodeScene is a multi-purpose tool bridging code, business and peopl
 documentation: https://github.com/backstage/backstage/tree/master/plugins/codescene
 iconUrl: img/codescene_logo.svg
 npmPackageName: '@backstage/plugin-codescene'
+addedDate: '2022-04-12'

--- a/microsite/data/plugins/cortex.yaml
+++ b/microsite/data/plugins/cortex.yaml
@@ -11,3 +11,4 @@ tags:
   - web
   - monitoring
   - sre
+addedDate: '2021-06-03'

--- a/microsite/data/plugins/cost-insights.yaml
+++ b/microsite/data/plugins/cost-insights.yaml
@@ -9,3 +9,4 @@ iconUrl: img/cost-insights.png
 npmPackageName: '@backstage/plugin-cost-insights'
 tags:
   - web
+addedDate: '2021-04-28'

--- a/microsite/data/plugins/datadog.yaml
+++ b/microsite/data/plugins/datadog.yaml
@@ -7,3 +7,4 @@ description: Embed Datadog graphs and dashboards in Backstage.
 documentation: https://roadie.io/backstage/plugins/datadog/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=datadog
 iconUrl: https://roadie.io/images/logos/datadog-white-background.png
 npmPackageName: '@roadiehq/backstage-plugin-datadog'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/dora-metrics.yaml
+++ b/microsite/data/plugins/dora-metrics.yaml
@@ -7,3 +7,4 @@ description: Embed dashboards (like DORA metrics) in your team or service pages 
 documentation: https://github.com/OkayHQ/backstage-plugin
 iconUrl: img/okay.png
 npmPackageName: '@okayhq/backstage-plugin'
+addedDate: '2022-06-16'

--- a/microsite/data/plugins/dynatrace.yaml
+++ b/microsite/data/plugins/dynatrace.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@backstage/plugin-dynatrace'
 tags:
   - dynatrace
   - monitoring
+addedDate: '2022-06-23'

--- a/microsite/data/plugins/firebase-functions.yaml
+++ b/microsite/data/plugins/firebase-functions.yaml
@@ -7,3 +7,4 @@ description: View Firebase Functions details for your service in Backstage.
 documentation: https://roadie.io/backstage/plugins/firebase-functions/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=firebase-functions
 iconUrl: https://roadie.io/images/logos/firebase.png
 npmPackageName: '@roadiehq/backstage-plugin-firebase-functions'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/firehydrant.yaml
+++ b/microsite/data/plugins/firehydrant.yaml
@@ -7,3 +7,4 @@ description: View service incidents information from FireHydrant, such as active
 documentation: https://github.com/backstage/backstage/blob/master/plugins/firehydrant/README.md
 iconUrl: https://raw.githubusercontent.com/backstage/backstage/master/plugins/firehydrant/doc/firehydrant_logo.png
 npmPackageName: '@backstage/plugin-firehydrant'
+addedDate: '2021-08-18'

--- a/microsite/data/plugins/fossa.yaml
+++ b/microsite/data/plugins/fossa.yaml
@@ -7,3 +7,4 @@ description: View FOSSA license compliance of your components in Backstage.
 documentation: https://github.com/backstage/backstage/blob/master/plugins/fossa/README.md
 iconUrl: https://avatars0.githubusercontent.com/u/9543448?s=400&v=4
 npmPackageName: '@backstage/plugin-fossa'
+addedDate: '2020-12-10'

--- a/microsite/data/plugins/gcp-projects.yaml
+++ b/microsite/data/plugins/gcp-projects.yaml
@@ -11,3 +11,4 @@ tags:
   - cloud
   - project
   - resources
+addedDate: '2021-01-20'

--- a/microsite/data/plugins/git-release-manager.yaml
+++ b/microsite/data/plugins/git-release-manager.yaml
@@ -7,3 +7,4 @@ description: Manage releases without having to juggle git commands.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/git-release-manager
 iconUrl: img/git-release-manager-logo.svg
 npmPackageName: '@backstage/plugin-git-release-manager'
+addedDate: '2021-10-04'

--- a/microsite/data/plugins/github-actions.yaml
+++ b/microsite/data/plugins/github-actions.yaml
@@ -11,3 +11,4 @@ tags:
   - ci
   - cd
   - github
+addedDate: '2021-01-20'

--- a/microsite/data/plugins/github-insights.yaml
+++ b/microsite/data/plugins/github-insights.yaml
@@ -7,3 +7,4 @@ description: View GitHub Insights for your components in Backstage.
 documentation: https://roadie.io/backstage/plugins/github-insights/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=github-insights
 iconUrl: https://roadie.io/images/logos/insights.png
 npmPackageName: '@roadiehq/backstage-plugin-github-insights'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/github-pull-requests-board.yaml
+++ b/microsite/data/plugins/github-pull-requests-board.yaml
@@ -7,3 +7,4 @@ description: View all open GitHub pull requests owned by your team in Backstage.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/github-pull-requests-board
 iconUrl: img/github-pull-requests-board-logo.svg
 npmPackageName: '@backstage/plugin-github-pull-requests-board'
+addedDate: '2022-05-10'

--- a/microsite/data/plugins/github-pull-requests.yaml
+++ b/microsite/data/plugins/github-pull-requests.yaml
@@ -7,3 +7,4 @@ description: View GitHub pull requests for your service in Backstage.
 documentation: https://roadie.io/backstage/plugins/github-pull-requests/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=github-pull-requests
 iconUrl: https://roadie.io/images/logos/github.png
 npmPackageName: '@roadiehq/backstage-plugin-github-pull-requests'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/gitlab.yaml
+++ b/microsite/data/plugins/gitlab.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@loblaw/backstage-plugin-gitlab'
 tags:
   - ci
   - cd
+addedDate: '2021-08-17'

--- a/microsite/data/plugins/gitops-cluster.yaml
+++ b/microsite/data/plugins/gitops-cluster.yaml
@@ -12,3 +12,4 @@ tags:
   - gitops
   - github
   - eks
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/gocd.yaml
+++ b/microsite/data/plugins/gocd.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@backstage/plugin-gocd'
 tags:
   - ci
   - cd
+addedDate: '2022-01-15'

--- a/microsite/data/plugins/grafana.yaml
+++ b/microsite/data/plugins/grafana.yaml
@@ -11,3 +11,4 @@ tags:
   - dashboards
   - monitoring
   - alerting
+addedDate: '2021-10-11'

--- a/microsite/data/plugins/graphiql.yaml
+++ b/microsite/data/plugins/graphiql.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@backstage/plugin-graphiql'
 tags:
   - graphql
   - graphiql
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/grpc-playground.yaml
+++ b/microsite/data/plugins/grpc-playground.yaml
@@ -7,3 +7,4 @@ description: Easily view and test your gRPC API with a GUI Client, inspired from
 documentation: https://github.com/zalopay-oss/backstage-grpc-playground
 iconUrl: https://raw.githubusercontent.com/zalopay-oss/backstage-grpc-playground/main/images/gprc-logo.png
 npmPackageName: 'backstage-grpc-playground'
+addedDate: '2022-06-08'

--- a/microsite/data/plugins/harbor.yaml
+++ b/microsite/data/plugins/harbor.yaml
@@ -11,3 +11,4 @@ tags:
   - goharbor
   - harbor
   - docker
+addedDate: '2022-06-23'

--- a/microsite/data/plugins/home.yaml
+++ b/microsite/data/plugins/home.yaml
@@ -7,3 +7,4 @@ description: This plugin provides a composable home page, and ability to create 
 documentation: https://github.com/backstage/backstage/blob/master/plugins/home/README.md
 iconUrl: img/home.png
 npmPackageName: '@backstage/plugin-home'
+addedDate: '2021-08-31'

--- a/microsite/data/plugins/humanitec.yaml
+++ b/microsite/data/plugins/humanitec.yaml
@@ -9,3 +9,4 @@ description: |
 documentation: https://github.com/thefrontside/backstage/tree/main/plugins/humanitec
 iconUrl: img/humanitec-logo.png
 npmPackageName: '@frontside/backstage-plugin-humanitec'
+addedDate: '2022-06-22'

--- a/microsite/data/plugins/ilert.yaml
+++ b/microsite/data/plugins/ilert.yaml
@@ -13,3 +13,4 @@ tags:
   - alerting
   - uptime
   - on-call
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/jenkins.yaml
+++ b/microsite/data/plugins/jenkins.yaml
@@ -10,3 +10,4 @@ npmPackageName: '@backstage/plugin-jenkins'
 tags:
   - ci
   - cd
+addedDate: '2021-01-20'

--- a/microsite/data/plugins/jira.yaml
+++ b/microsite/data/plugins/jira.yaml
@@ -7,3 +7,4 @@ description: View Jira summary for your projects in Backstage.
 documentation: https://roadie.io/backstage/plugins/jira/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=jira
 iconUrl: https://roadie.io/images/logos/jira.png
 npmPackageName: '@roadiehq/backstage-plugin-jira'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/kafka.yaml
+++ b/microsite/data/plugins/kafka.yaml
@@ -9,3 +9,4 @@ iconUrl: https://kafka.apache.org/images/apache-kafka.png
 npmPackageName: '@backstage/plugin-kafka'
 tags:
   - monitoring
+addedDate: '2021-01-21'

--- a/microsite/data/plugins/kpt-config-as-data.yaml
+++ b/microsite/data/plugins/kpt-config-as-data.yaml
@@ -7,3 +7,4 @@ description: Configuration GUI over GitOps using kpt, with WYSIWYG editing, revi
 documentation: https://github.com/GoogleContainerTools/kpt-backstage-plugins/tree/main/plugins/cad
 iconUrl: https://github.com/GoogleContainerTools/kpt/blob/main/logo/KptLogoSmall.png?raw=true
 npmPackageName: '@kpt/backstage-plugin-cad'
+addedDate: '2022-05-13'

--- a/microsite/data/plugins/lighthouse.yaml
+++ b/microsite/data/plugins/lighthouse.yaml
@@ -12,3 +12,4 @@ tags:
   - seo
   - accessibility
   - performance
+addedDate: '2021-01-20'

--- a/microsite/data/plugins/new-relic.yaml
+++ b/microsite/data/plugins/new-relic.yaml
@@ -12,3 +12,4 @@ tags:
   - monitoring
   - errors
   - alerting
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/newrelic-dashboard.yaml
+++ b/microsite/data/plugins/newrelic-dashboard.yaml
@@ -13,3 +13,4 @@ tags:
   - errors
   - alerting
   - dashboards
+addedDate: '2021-12-23'

--- a/microsite/data/plugins/okta-entity-providers.yaml
+++ b/microsite/data/plugins/okta-entity-providers.yaml
@@ -7,3 +7,4 @@ description: Load users and groups from Okta into the Backstage catalog.
 documentation: https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backend/catalog-backend-module-okta
 iconUrl: https://roadie.io/images/logos/okta.png
 npmPackageName: '@roadiehq/catalog-backend-module-okta'
+addedDate: '2022-07-26'

--- a/microsite/data/plugins/opsgenie.yaml
+++ b/microsite/data/plugins/opsgenie.yaml
@@ -11,3 +11,4 @@ tags:
   - monitoring
   - errors
   - alerting
+addedDate: '2022-03-13'

--- a/microsite/data/plugins/pager-duty.yaml
+++ b/microsite/data/plugins/pager-duty.yaml
@@ -11,3 +11,4 @@ tags:
   - monitoring
   - errors
   - alerting
+addedDate: '2020-12-22'

--- a/microsite/data/plugins/periskop.yaml
+++ b/microsite/data/plugins/periskop.yaml
@@ -7,3 +7,4 @@ description: Periskop is a pull-based, language agnostic exception aggregator fo
 documentation: https://github.com/backstage/backstage/tree/master/plugins/periskop
 iconUrl: https://raw.githubusercontent.com/periskop-dev/periskop/master/docs/assets/periskop-logo.png
 npmPackageName: '@backstage/plugin-periskop'
+addedDate: '2022-02-25'

--- a/microsite/data/plugins/playlist.yaml
+++ b/microsite/data/plugins/playlist.yaml
@@ -7,3 +7,4 @@ description: Create, share, and follow custom collections of entities available 
 documentation: https://github.com/backstage/backstage/tree/master/plugins/playlist
 iconUrl: img/playlist-logo.png
 npmPackageName: '@backstage/plugin-playlist'
+addedDate: '2022-07-02'

--- a/microsite/data/plugins/prometheus.yaml
+++ b/microsite/data/plugins/prometheus.yaml
@@ -11,3 +11,4 @@ tags:
   - monitoring
   - graphs
   - alerting
+addedDate: '2021-10-06'

--- a/microsite/data/plugins/rollbar.yaml
+++ b/microsite/data/plugins/rollbar.yaml
@@ -7,3 +7,4 @@ description: View Rollbar errors for your services in Backstage.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/rollbar
 iconUrl: https://rollbar.com/assets/media/rollbar-mark-color.png
 npmPackageName: '@backstage/plugin-rollbar'
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/rootly.yaml
+++ b/microsite/data/plugins/rootly.yaml
@@ -7,3 +7,4 @@ description: Import your Backstage entities into Rootly services and view incide
 documentation: https://github.com/rootlyhq/backstage-plugin/blob/master/README.md
 iconUrl: https://raw.githubusercontent.com/rootlyhq/backstage-plugin/master/docs/logo.png
 npmPackageName: '@rootly/backstage-plugin'
+addedDate: '2022-06-16'

--- a/microsite/data/plugins/scaffolder-backend-dotnet.yaml
+++ b/microsite/data/plugins/scaffolder-backend-dotnet.yaml
@@ -7,3 +7,4 @@ description: Here you can find all .NET related actions to improve your scaffold
 documentation: https://github.com/alefcarlos/plusultra-dotnet-backstage-plugins/blob/main/plugins/scaffolder-dotnet-backend/README.md
 iconUrl: img/scaffolder-backend-dotnet-icon.png
 npmPackageName: '@plusultra/plugin-scaffolder-dotnet-backend'
+addedDate: '2022-01-24'

--- a/microsite/data/plugins/scaffolder-backend-git.yaml
+++ b/microsite/data/plugins/scaffolder-backend-git.yaml
@@ -7,3 +7,4 @@ description: Easily run git CLI commands from your scaffolder actions
 documentation: https://github.com/arhill05/backstage-plugin-scaffolder-git-actions#readme
 iconUrl: https://git-scm.com/images/logos/downloads/Git-Logo-2Color.png
 npmPackageName: '@mdude2314/backstage-plugin-scaffolder-git-actions'
+addedDate: '2022-05-13'

--- a/microsite/data/plugins/scaffolder-backend-module-rails.yaml
+++ b/microsite/data/plugins/scaffolder-backend-module-rails.yaml
@@ -7,3 +7,4 @@ description: Here you can find all Rails related features to improve your scaffo
 documentation: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend-module-rails/README.md
 iconUrl: img/rails-icon.png
 npmPackageName: '@backstage/plugin-scaffolder-backend-module-rails'
+addedDate: '2021-06-24'

--- a/microsite/data/plugins/scaffolder-backend-roadie-aws.yaml
+++ b/microsite/data/plugins/scaffolder-backend-roadie-aws.yaml
@@ -7,3 +7,4 @@ description: Here you can find some AWS cli actions
 documentation: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
 iconUrl: https://upload.wikimedia.org/wikipedia/commons/9/93/Amazon_Web_Services_Logo.svg
 npmPackageName: '@roadiehq/scaffolder-backend-module-aws'
+addedDate: '2022-03-07'

--- a/microsite/data/plugins/scaffolder-backend-roadie-http-request.yaml
+++ b/microsite/data/plugins/scaffolder-backend-roadie-http-request.yaml
@@ -7,3 +7,4 @@ description: An action to fire an arbitrary HTTP request
 documentation: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
 iconUrl: img/scaffolder-http-request-logo.svg
 npmPackageName: '@roadiehq/scaffolder-backend-module-http-request'
+addedDate: '2022-03-03'

--- a/microsite/data/plugins/scaffolder-backend-roadie-utils.yaml
+++ b/microsite/data/plugins/scaffolder-backend-roadie-utils.yaml
@@ -7,3 +7,4 @@ description: A collection of utility actions including sleep, zip and file manip
 documentation: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
 iconUrl: img/scaffolder-utils-logo.png
 npmPackageName: '@roadiehq/scaffolder-backend-module-utils'
+addedDate: '2022-03-03'

--- a/microsite/data/plugins/score-card.yaml
+++ b/microsite/data/plugins/score-card.yaml
@@ -7,3 +7,4 @@ description: Visualization of maturity (and improving it) of services/systems th
 documentation: https://github.com/Oriflame/backstage-plugins/tree/main/plugins/score-card
 iconUrl: img/score-card-plugin-logo.png
 npmPackageName: '@oriflame/backstage-plugin-score-card'
+addedDate: '2022-10-06'

--- a/microsite/data/plugins/security-insights.yaml
+++ b/microsite/data/plugins/security-insights.yaml
@@ -7,3 +7,4 @@ description: View Security Insights for your components in Backstage.
 documentation: https://roadie.io/backstage/plugins/security-insights/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=security-insights
 iconUrl: https://roadie.io/images/logos/github.png
 npmPackageName: '@roadiehq/backstage-plugin-security-insights'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/sentry.yaml
+++ b/microsite/data/plugins/sentry.yaml
@@ -7,3 +7,4 @@ description: View Sentry issues in Backstage.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/sentry
 iconUrl: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 npmPackageName: '@backstage/plugin-sentry'
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/shortcuts.yaml
+++ b/microsite/data/plugins/shortcuts.yaml
@@ -7,3 +7,4 @@ description: The shortcuts plugin allows a user to have easy access to pages wit
 documentation: https://github.com/backstage/backstage/blob/master/plugins/shortcuts/README.md
 iconUrl: img/shortcuts.svg
 npmPackageName: '@backstage/plugin-shortcuts'
+addedDate: '2021-10-06'

--- a/microsite/data/plugins/snyk-security.yaml
+++ b/microsite/data/plugins/snyk-security.yaml
@@ -7,3 +7,4 @@ description: View Snyk scanned vulnerabilities and license compliance of your co
 documentation: https://github.com/snyk-tech-services/backstage-plugin-snyk/blob/main/README.md
 iconUrl: https://storage.googleapis.com/snyk-technical-services.appspot.com/snyk-logo-vertical-black.png
 npmPackageName: 'backstage-plugin-snyk'
+addedDate: '2021-01-22'

--- a/microsite/data/plugins/sonarqube.yaml
+++ b/microsite/data/plugins/sonarqube.yaml
@@ -7,3 +7,4 @@ description: Components to display code quality metrics from SonarCloud and Sona
 documentation: https://github.com/backstage/backstage/blob/master/plugins/sonarqube/README.md
 iconUrl: img/sonarqube-icon.svg
 npmPackageName: '@backstage/plugin-sonarqube'
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/splunk-on-call.yaml
+++ b/microsite/data/plugins/splunk-on-call.yaml
@@ -12,3 +12,4 @@ tags:
   - errors
   - alerting
   - splunk
+addedDate: '2021-11-17'

--- a/microsite/data/plugins/stack-overflow.yaml
+++ b/microsite/data/plugins/stack-overflow.yaml
@@ -7,3 +7,4 @@ description: Provides Stack Overflow specific functionality that can be used in 
 documentation: https://github.com/backstage/backstage/blob/master/plugins/stack-overflow
 iconUrl: img/stack-overflow-logo.svg
 npmPackageName: '@backstage/plugin-stack-overflow'
+addedDate: '2022-06-14'

--- a/microsite/data/plugins/tech-insights.yaml
+++ b/microsite/data/plugins/tech-insights.yaml
@@ -12,3 +12,4 @@ tags:
   - reporting
   - tech health
   - migrations
+addedDate: '2022-03-31'

--- a/microsite/data/plugins/tech-radar.yaml
+++ b/microsite/data/plugins/tech-radar.yaml
@@ -7,3 +7,4 @@ description: Visualize the your company's official guidelines of different areas
 documentation: https://github.com/backstage/backstage/tree/master/plugins/tech-radar
 iconUrl: https://www.materialui.co/materialIcons/action/track_changes_white_192x192.png
 npmPackageName: '@backstage/plugin-tech-radar'
+addedDate: '2020-11-03'

--- a/microsite/data/plugins/tekton-pipelines.yaml
+++ b/microsite/data/plugins/tekton-pipelines.yaml
@@ -7,3 +7,4 @@ description: View the status of the Tekton PipelineRun resources.
 documentation: https://github.com/jquad-group/backstage-jquad#readme
 iconUrl: https://raw.githubusercontent.com/jquad-group/backstage-jquad/main/img/tekton-horizontal-color.png
 npmPackageName: '@jquad-group/plugin-tekton-pipelines'
+addedDate: '2022-08-08'

--- a/microsite/data/plugins/todo.yaml
+++ b/microsite/data/plugins/todo.yaml
@@ -7,3 +7,4 @@ description: Browse TODO comments in your project's source code.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/todo
 iconUrl: https://backstage.io/img/todo-logo.png
 npmPackageName: '@backstage/plugin-todo'
+addedDate: '2021-03-16'

--- a/microsite/data/plugins/travis-ci.yaml
+++ b/microsite/data/plugins/travis-ci.yaml
@@ -7,3 +7,4 @@ description: View Travis CI builds for your service in Backstage.
 documentation: https://roadie.io/backstage/plugins/travis-ci/?utm_source=backstage.io&utm_medium=marketplace&utm_campaign=travis-ci
 iconUrl: https://roadie.io/images/logos/travis.png
 npmPackageName: '@roadiehq/backstage-plugin-travis-ci'
+addedDate: '2021-04-20'

--- a/microsite/data/plugins/vault.yaml
+++ b/microsite/data/plugins/vault.yaml
@@ -9,3 +9,4 @@ iconUrl: img/vault.png
 npmPackageName: '@backstage/plugin-vault'
 tags:
   - vault
+addedDate: '2022-06-03'

--- a/microsite/data/plugins/xcmetrics.yaml
+++ b/microsite/data/plugins/xcmetrics.yaml
@@ -7,3 +7,4 @@ description: Discover valuable insights hiding inside Xcode’s build logs.
 documentation: https://xcmetrics.io/
 iconUrl: img/xcmetrics-icon.png
 npmPackageName: '@backstage/plugin-xcmetrics'
+addedDate: '2021-08-06'

--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -16,24 +16,7 @@ const {
 const pluginsDirectory = require('path').join(process.cwd(), 'data/plugins');
 const pluginMetadata = fs
   .readdirSync(pluginsDirectory)
-  .map(file => {
-    const fileContent = fs.readFileSync(`./data/plugins/${file}`, 'utf8');
-    let metadata = yaml.load(fileContent);
-
-    const gitIsoDate = require('child_process')
-      .execFileSync('git', [
-        'log',
-        '-1',
-        '--format="%ai"',
-        '--reverse',
-        `./data/plugins/${file}`,
-      ])
-      .toString();
-
-    metadata.date = new Date(gitIsoDate);
-
-    return metadata;
-  })
+  .map(file => yaml.load(fs.readFileSync(`./data/plugins/${file}`, 'utf8')))
   .sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()));
 const truncate = text =>
   text.length > 170 ? text.substr(0, 170) + '...' : text;
@@ -119,11 +102,12 @@ const Plugins = () => (
               authorUrl,
               documentation,
               category,
-              date,
+              addedDate,
             }) => (
               <div className="PluginCard">
-                {Math.trunc((Date.now() - date) / (1000 * 60 * 60 * 24)) <
-                  newForDays && (
+                {Math.trunc(
+                  (Date.now() - new Date(addedDate)) / (1000 * 60 * 60 * 24),
+                ) < newForDays && (
                   <div className="ribbon ribbon-top-right">
                     <span>NEW</span>
                   </div>


### PR DESCRIPTION
The original commit 913145399e added a ribbon to show which plugins were recently added to the marketplace but on the live site all plugins were showing as 'new'. The problem is due to relying on the git author date which is incorrect when using shallow depth clones in the build process.

![image](https://user-images.githubusercontent.com/606038/196963279-215b49a1-d632-4f85-abb8-48eeda7f0586.png)

Fixed by adding new key to plugin marketplace metadata to be parsed.

Fixes: https://github.com/backstage/backstage/issues/13015

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
