### PR TITLE
feat(docs): hide document description if not provided

### DIFF
--- a/.changeset/silly-snails-fail.md
+++ b/.changeset/silly-snails-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Hide document description if not provided

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -81,7 +81,7 @@ export const TechDocsReaderPageHeader = (
     setSubtitle(() => {
       let { site_description } = metadata;
       if (!site_description || site_description === 'None') {
-        site_description = 'Home';
+        site_description = '';
       }
       return site_description;
     });
@@ -155,7 +155,7 @@ export const TechDocsReaderPageHeader = (
       type="Documentation"
       typeLink={docsRootLink}
       title={title || skeleton}
-      subtitle={subtitle || skeleton}
+      subtitle={subtitle === '' ? undefined : subtitle || skeleton}
     >
       <Helmet titleTemplate="%s">
         <title>{tabTitle}</title>


### PR DESCRIPTION
Signed-off-by: Ömer Faruk Doğan <8117265+omerfarukdogan@users.noreply.github.com>

## Hey, I just made a Pull Request!

In `TechDocsReaderPageHeader`, site_description information, which can be set in mkdocs.yaml file, is displayed. If site_description is not provided, a default "Home" description is displayed instead. This pull request aims to remove the default "Home" description and hide the area completely if a site_description is not provided.

Before:

![image](https://user-images.githubusercontent.com/8117265/196975497-cb33b395-3f55-4b86-9b7d-f3c74a6e999a.png)

After:

![image](https://user-images.githubusercontent.com/8117265/196975544-49a583a7-6da5-480d-b715-8ee323418441.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
