### PR TITLE
just getting rid of vale warnings

### DIFF
--- a/.changeset/gorgeous-balloons-sit.md
+++ b/.changeset/gorgeous-balloons-sit.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-auth-backend': patch
+'@backstage/plugin-cost-insights': patch
+'@backstage/plugin-dynatrace': patch
+'@backstage/plugin-stack-overflow-backend': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Tweak README

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -1,5 +1,6 @@
 abc
 accessors
+ACLs
 addon
 addons
 ADRs
@@ -17,6 +18,7 @@ autoscaling
 Autoscaling
 autoselect
 Avro
+backend's
 backported
 backporting
 Bigtable
@@ -88,6 +90,8 @@ dockerfiles
 Dockerize
 dockerode
 Docusaurus
+DOMPurify
+don'ts
 dynatrace
 Dynatrace
 ecco
@@ -96,6 +100,8 @@ Env
 elasticsearch
 esbuild
 eslint
+ESModule
+ESModules
 etag
 Expedia
 facto
@@ -136,8 +142,10 @@ iLert
 img
 incentivised
 Indal
+indexable
 inlined
 inlinehilite
+integrator's
 interop
 JaCoCo
 JavaScript
@@ -168,6 +176,7 @@ lunr
 Luxon
 magiclink
 mailto
+maintainer's
 maintainership
 makefile
 md
@@ -222,6 +231,7 @@ orgs
 pagerduty
 pageview
 parallelization
+parseable
 Patrik
 Peloton
 performant
@@ -306,6 +316,10 @@ stringify
 stringified
 subcomponent
 subcomponents
+subfolder
+subfolders
+subheader
+subheaders
 subkey
 subroutes
 subtree
@@ -326,6 +340,7 @@ templater
 Templater
 templaters
 Templaters
+TFRecord
 theia
 thumbsup
 todo
@@ -365,6 +380,7 @@ VSCode
 Wayfair
 Weaveworks
 Webpack
+widget's
 winston
 www
 WWW

--- a/STYLE.md
+++ b/STYLE.md
@@ -11,8 +11,8 @@ Our TypeScript style is inspired by the [style guidelines](https://github.com/Mi
 1. Use PascalCase for type names.
 1. Do not use `I` as a prefix for interface names.
 1. Use PascalCase for `enum` values.
-1. Use camelCase for function names.
-1. Use camelCase for property names and local variables.
+1. Use `camelCase` for function names.
+1. Use `camelCase` for property names and local variables.
 1. Do not use `_` as a prefix for private properties.
 1. Use whole words in names when possible.
 1. Give type parameters names prefixed with `T`, for example `Request<TBody>`.

--- a/docs/api/utility-apis.md
+++ b/docs/api/utility-apis.md
@@ -13,31 +13,31 @@ both with other plugins and the app itself.
 
 Backstage provides two primary methods for plugins to communicate across their
 boundaries in client-side code. The first one being the
-[createPlugin](../reference/core-plugin-api.createplugin.md) API along with the
+[`createPlugin`](../reference/core-plugin-api.createplugin.md) API along with the
 extensions that it can provide, and the second one being Utility APIs. While the
-[createPlugin](../reference/core-plugin-api.createplugin.md) API is focused on
+[`createPlugin`](../reference/core-plugin-api.createplugin.md) API is focused on
 the initialization plugins and the app, the Utility APIs provide ways for
 plugins to communicate during their entire life cycle.
 
 ## Consuming APIs
 
-Each Utility API is tied to an [ApiRef](../reference/core-plugin-api.apiref.md)
+Each Utility API is tied to an [`ApiRef`](../reference/core-plugin-api.apiref.md)
 instance, which is a global singleton object without any additional state or
 functionality, its only purpose is to reference Utility APIs.
-[ApiRef](../reference/core-plugin-api.apiref.md)s are created using
-[createApiRef](../reference/core-plugin-api.createapiref.md), which is exported
-by [@backstage/core-plugin-api](../reference/core-plugin-api.md). There are also
+[`ApiRef`](../reference/core-plugin-api.apiref.md)s are created using
+[`createApiRef`](../reference/core-plugin-api.createapiref.md), which is exported
+by [`@backstage/core-plugin-api`](../reference/core-plugin-api.md). There are also
 many predefined Utility APIs in
-[@backstage/core-plugin-api](../reference/core-plugin-api.md), and they're all
+[`@backstage/core-plugin-api`](../reference/core-plugin-api.md), and they're all
 exported with a name of the pattern `*ApiRef`, for example
-[errorApiRef](../reference/core-plugin-api.errorapiref.md).
+[`errorApiRef`](../reference/core-plugin-api.errorapiref.md).
 
 To access one of the Utility APIs inside a React component, use the
-[useApi](../reference/core-plugin-api.useapi.md) hook exported by
-[@backstage/core-plugin-api](../reference/core-plugin-api.md), or the
-[withApis](../reference/core-plugin-api.withapis.md) HOC if you prefer class
+[`useApi`](../reference/core-plugin-api.useapi.md) hook exported by
+[`@backstage/core-plugin-api`](../reference/core-plugin-api.md), or the
+[`withApis`](../reference/core-plugin-api.withapis.md) HOC if you prefer class
 components. For example, the
-[ErrorApi](../reference/core-plugin-api.errorapi.md) can be accessed like this:
+[`ErrorApi`](../reference/core-plugin-api.errorapi.md) can be accessed like this:
 
 ```tsx
 import React from 'react';
@@ -56,14 +56,14 @@ export const MyComponent = () => {
 ```
 
 Note that there is no explicit type given for
-[ErrorApi](../reference/core-plugin-api.errorapi.md). This is because the
-[errorApiRef](../reference/core-plugin-api.errorapiref.md) has the type
-embedded, and [useApi](../reference/core-plugin-api.useapi.md) is able to infer
+[`ErrorApi`](../reference/core-plugin-api.errorapi.md). This is because the
+[`errorApiRef`](../reference/core-plugin-api.errorapiref.md) has the type
+embedded, and [`useApi`](../reference/core-plugin-api.useapi.md) is able to infer
 the type.
 
 Also note that consuming Utility APIs is not limited to plugins, it can be done
 from any component inside Backstage, including the ones in
-[@backstage/core-plugin-api](../reference/core-plugin-api.md). The only
+[`@backstage/core-plugin-api`](../reference/core-plugin-api.md). The only
 requirement is that they are beneath the `AppProvider` in the react tree.
 
 ## Supplying APIs
@@ -71,15 +71,15 @@ requirement is that they are beneath the `AppProvider` in the react tree.
 ### API Factories
 
 APIs are registered in the form of
-[ApiFactories](../reference/core-plugin-api.apifactory.md), which encapsulate
+[`ApiFactory`](../reference/core-plugin-api.apifactory.md) instances, which encapsulate
 the process of instantiating an API. It is a collection of three things: the
-[ApiRef](../reference/core-plugin-api.apiref.md) of the API to instantiate, a
+[`ApiRef`](../reference/core-plugin-api.apiref.md) of the API to instantiate, a
 list of all required dependencies, and a factory function that returns a new API
 instance.
 
 For example, this is the default
-[ApiFactory](../reference/core-plugin-api.apifactory.md) for the
-[ErrorApi](../reference/core-plugin-api.errorapi.md):
+[`ApiFactory`](../reference/core-plugin-api.apifactory.md) for the
+[`ErrorApi`](../reference/core-plugin-api.errorapi.md):
 
 ```ts
 createApiFactory({
@@ -93,25 +93,25 @@ createApiFactory({
 });
 ```
 
-In this example the [errorApiRef](../reference/core-plugin-api.errorapiref.md)
+In this example the [`errorApiRef`](../reference/core-plugin-api.errorapiref.md)
 is our API, which encapsulates the
-[ErrorApi](../reference/core-plugin-api.errorapi.md) type. The
-[alertApiRef](../reference/core-plugin-api.alertapiref.md) is our single
+[`ErrorApi`](../reference/core-plugin-api.errorapi.md) type. The
+[`alertApiRef`](../reference/core-plugin-api.alertapiref.md) is our single
 dependency, which we give the name `alertApi`, and is then passed on to the
 factory function, which returns an implementation of the
-[ErrorApi](../reference/core-plugin-api.errorapi.md).
+[`ErrorApi`](../reference/core-plugin-api.errorapi.md).
 
-The [createApiFactory](../reference/core-plugin-api.createapifactory.md)
+The [`createApiFactory`](../reference/core-plugin-api.createapifactory.md)
 function is a thin wrapper that enables TypeScript type inference. You may
 notice that there are no type annotations in the above example, and that is
 because we're able to infer all types from the
-[ApiRef](../reference/core-plugin-api.apiref.md)s. TypeScript will make sure
+[`ApiRef`](../reference/core-plugin-api.apiref.md)s. TypeScript will make sure
 that the return value of the `factory` function matches the type embedded in
-`api`'s [ApiRef](../reference/core-plugin-api.apiref.md), in this case the
-[ErrorApi](../reference/core-plugin-api.errorapi.md). It will also match the
+`api`'s [`ApiRef`](../reference/core-plugin-api.apiref.md), in this case the
+[`ErrorApi`](../reference/core-plugin-api.errorapi.md). It will also match the
 types between the `deps` and the parameters of the `factory` function, again
 using the type embedded within the
-[ApiRef](../reference/core-plugin-api.apiref.md)s.
+[`ApiRef`](../reference/core-plugin-api.apiref.md)s.
 
 ## Registering API Factories
 
@@ -123,13 +123,13 @@ app, and the app itself.
 
 Starting with the Backstage core library, it provides implementations for all of
 the core APIs. The core APIs are the ones exported by
-[@backstage/core-plugin-api](../reference/core-plugin-api.md), such as the
-[errorApiRef](../reference/core-plugin-api.errorapiref.md) and
-[configApiRef](../reference/core-plugin-api.configapiref.md).
+[`@backstage/core-plugin-api`](../reference/core-plugin-api.md), such as the
+[`errorApiRef`](../reference/core-plugin-api.errorapiref.md) and
+[`configApiRef`](../reference/core-plugin-api.configapiref.md).
 
 The core APIs are loaded for any app created with
-[createApp](../reference/app-defaults.createapp.md) from
-[@backstage/core-plugin-api](../reference/app-defaults.md), which means that
+[`createApp`](../reference/app-defaults.createapp.md) from
+[`@backstage/core-plugin-api`](../reference/app-defaults.md), which means that
 there is no step that needs to be taken to include these APIs in an app.
 
 ### Plugin APIs
@@ -137,13 +137,13 @@ there is no step that needs to be taken to include these APIs in an app.
 In addition to the core APIs, plugins can define and export their own APIs.
 While doing so they should usually also provide default implementations of their
 own APIs, for example, the `catalog` plugin exports `catalogApiRef`, and also
-supplies a default [ApiFactory](../reference/core-plugin-api.apifactory.md) of
+supplies a default [`ApiFactory`](../reference/core-plugin-api.apifactory.md) of
 that API using the `CatalogClient`. There is one restriction to plugin-provided
 API Factories: plugins may not supply factories for core APIs, trying to do so
 will cause the app to refuse to start.
 
 Plugins supply their APIs through the `apis` option of
-[createPlugin](../reference/core-plugin-api.createplugin.md), for example:
+[`createPlugin`](../reference/core-plugin-api.createplugin.md), for example:
 
 ```ts
 export const techdocsPlugin = createPlugin({
@@ -168,7 +168,7 @@ Lastly, the app itself is the final point where APIs can be added, and what has
 the final say in what APIs will be loaded at runtime. The app may override the
 factories for any of the core or plugin APIs, with the exception of the config,
 app theme, and identity APIs. These are static APIs that are tied into the
-[createApp](../reference/app-defaults.createapp.md) implementation, and
+[`createApp`](../reference/app-defaults.createapp.md) implementation, and
 therefore not possible to override.
 
 Overriding APIs is useful for apps that want to switch out behavior to tailor it
@@ -231,19 +231,19 @@ const app = createApp({
 ```
 
 Note that the above line will cause an error if `IgnoreErrorApi` does not fully
-implement the [ErrorApi](../reference/core-plugin-api.errorapi.md), as it is
+implement the [`ErrorApi`](../reference/core-plugin-api.errorapi.md), as it is
 checked by the type embedded in the
-[errorApiRef](../reference/core-plugin-api.errorapiref.md) at compile time.
+[`errorApiRef`](../reference/core-plugin-api.errorapiref.md) at compile time.
 
 ## Defining custom Utility APIs
 
 Plugins are free to define their own Utility APIs. Simply define the TypeScript
 interface for the API, and create an
-[ApiRef](../reference/core-plugin-api.apiref.md) using
-[createApiRef](../reference/core-plugin-api.createapiref.md) exported from
-[@backstage/core-plugin-api](../reference/core-plugin-api.md). Also be sure to
+[`ApiRef`](../reference/core-plugin-api.apiref.md) using
+[`createApiRef`](../reference/core-plugin-api.createapiref.md) exported from
+[`@backstage/core-plugin-api`](../reference/core-plugin-api.md). Also be sure to
 provide at least one implementation of the API, and to declare a default factory
-for the API in [createPlugin](../reference/core-plugin-api.createplugin.md).
+for the API in [`createPlugin`](../reference/core-plugin-api.createplugin.md).
 
 Custom Utility APIs can be either public or private, which is up to the plugin
 to choose. Private APIs do not expose an external API surface, and it's
@@ -255,16 +255,16 @@ backwards compatibility of public APIs, as you may otherwise break apps that are
 using your plugin.
 
 To make an API public, simply export the
-[ApiRef](../reference/core-plugin-api.apiref.md) of the API, and any associated
+[`ApiRef`](../reference/core-plugin-api.apiref.md) of the API, and any associated
 types. To make an API private, just avoid exporting the
-[ApiRef](../reference/core-plugin-api.apiref.md), but still be sure to supply a
-default factory to [createPlugin](../reference/core-plugin-api.createplugin.md).
+[`ApiRef`](../reference/core-plugin-api.apiref.md), but still be sure to supply a
+default factory to [`createPlugin`](../reference/core-plugin-api.createplugin.md).
 
 Private APIs are useful for plugins that want to depend on other APIs outside of
 React components, but not have to expose an entire API surface to maintain. When
 using private APIs, it is fine to use the `typeof` of an implementing class as
 the type parameter passed to
-[createApiRef](../reference/core-plugin-api.createapiref.md), while public APIs
+[`createApiRef`](../reference/core-plugin-api.createapiref.md), while public APIs
 should always define a separate TypeScript interface type.
 
 Plugins may depend on APIs from other plugins, both in React components and as
@@ -273,13 +273,13 @@ dependencies between plugins.
 
 ## Architecture
 
-The [ApiRef](../reference/core-plugin-api.apiref.md) instances mentioned above
+The [`ApiRef`](../reference/core-plugin-api.apiref.md) instances mentioned above
 provide a point of indirection between consumers and producers of Utility APIs.
 It allows for plugins and components to depend on APIs in a type-safe way,
 without having a direct reference to a concrete implementation of the APIs. The
 Apps are also given a lot of flexibility in what implementations to provide. As
 long as they adhere to the contract established by an
-[ApiRef](../reference/core-plugin-api.apiref.md), they are free to choose any
+[`ApiRef`](../reference/core-plugin-api.apiref.md), they are free to choose any
 implementation they want.
 
 The figure below shows the relationship between
@@ -304,16 +304,16 @@ The indirection provided by Utility APIs also makes it straightforward to test
 components that depend on APIs, and to provide a standard common development
 environment for plugins. A proper test wrapper with mocked API implementations
 is not yet ready, but it will be provided as a part of
-[@backstage/test-utils](../reference/test-utils.md). It will provide mocked
+[`@backstage/test-utils`](../reference/test-utils.md). It will provide mocked
 variants of APIs, with additional methods for asserting a component's
 interaction with the API.
 
 The common development environment for plugins is included in
-[@backstage/dev-utils](../reference/dev-utils.md), where the exported
-[createDevApp](../reference/dev-utils.createdevapp.md) function creates an
+[`@backstage/dev-utils`](../reference/dev-utils.md), where the exported
+[`createDevApp`](../reference/dev-utils.createdevapp.md) function creates an
 application with implementations for all core APIs already present. Contrary to
 the method for wiring up Utility API implementations in an app created with
-[createApp](../reference/app-defaults.createapp.md),
-[createDevApp](../reference/dev-utils.createdevapp.md) uses automatic dependency
+[`createApp`](../reference/app-defaults.createapp.md),
+[`createDevApp`](../reference/dev-utils.createdevapp.md) uses automatic dependency
 injection. This is to make it possible to replace any API implementation, and
 having that be reflected in dependents of that API.

--- a/docs/architecture-decisions/adr003-avoid-default-exports.md
+++ b/docs/architecture-decisions/adr003-avoid-default-exports.md
@@ -15,7 +15,7 @@ thing well". The module would be consumed
 (`const localName = require('the-module');`) without having to know the internal
 structure.
 
-Now, ESModules are the primary authoring format. They have numerous benefits,
+Now, `ESModules` are the primary authoring format. They have numerous benefits,
 such as compile-time verification of exports, and standards-defined semantics.
 They have a similar mechanism known as "default exports", which allows for a
 consumer to `import localName from 'the-module';`. This is implicitly the same

--- a/docs/architecture-decisions/index.md
+++ b/docs/architecture-decisions/index.md
@@ -34,5 +34,5 @@ Records should be stored under the `architecture-decisions` directory.
 
 ## Superseding an ADR
 
-If an ADR supersedes an older ADR then the older ADR's status is changed to
-superseded by ADR-XXXX and links to the new ADR.
+If an ADR supersedes an older ADR then the status of the older ADR is changed to
+"superseded by ADR-XXXX", and links to the new ADR.

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -18,7 +18,7 @@ Settings for local development:
 
 - Name: Backstage (or your custom app name)
 - Redirect URI: `http://localhost:7007/api/auth/gitlab/handler/frame`
-- Scopes: read_user
+- Scopes: `read_user`
 
 ## Configuration
 

--- a/docs/conf/defining.md
+++ b/docs/conf/defining.md
@@ -138,7 +138,7 @@ may need to pass in all files using one or multiple `--config <path>` options.
 > to change for different deployment environments should be static
 > configuration, while it should otherwise be avoided.
 
-When defining configuration for your plugin, keep keys camelCased and stick to
+When defining configuration for your plugin, keep keys on `camelCase` form and stick to
 existing casing conventions such as `baseUrl` rather than `baseURL`.
 
 It is also usually best to prefer objects over arrays, as it makes it possible

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -217,11 +217,11 @@ for some dashboards, such as GKE.
 
 ###### required parameters for GKE
 
-| Name        | Description                                                              |
-| ----------- | ------------------------------------------------------------------------ |
-| projectId   | the ID of the GCP project containing your Kubernetes clusters            |
-| region      | the region of GCP containing your Kubernetes clusters                    |
-| clusterName | the name of your kubernetes cluster, within your `projectId` GCP project |
+| Name          | Description                                                              |
+| ------------- | ------------------------------------------------------------------------ |
+| `projectId`   | the ID of the GCP project containing your Kubernetes clusters            |
+| `region`      | the region of GCP containing your Kubernetes clusters                    |
+| `clusterName` | the name of your kubernetes cluster, within your `projectId` GCP project |
 
 Note that the GKE cluster locator can automatically provide the values for the
 `dashboardApp` and `dashboardParameters` options if you set the

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -6,7 +6,7 @@ description: Documentation on Customizing look and feel of the App
 
 Backstage ships with a default theme with a light and dark mode variant. The
 themes are provided as a part of the
-[@backstage/theme](https://www.npmjs.com/package/@backstage/theme) package,
+[`@backstage/theme`](https://www.npmjs.com/package/@backstage/theme) package,
 which also includes utilities for customizing the default theme, or creating
 completely new themes.
 
@@ -14,7 +14,7 @@ completely new themes.
 
 The easiest way to create a new theme is to use the `createTheme` function
 exported by the
-[@backstage/theme](https://www.npmjs.com/package/@backstage/theme) package. You
+[`@backstage/theme`](https://www.npmjs.com/package/@backstage/theme) package. You
 can use it to override some basic parameters of the default theme such as the
 color palette and font.
 
@@ -33,16 +33,16 @@ const myTheme = createTheme({
 
 If you want more control over the theme, and for example customize font sizes
 and margins, you can use the lower-level `createThemeOverrides` function
-exported by [@backstage/theme](https://www.npmjs.com/package/@backstage/theme)
+exported by [`@backstage/theme`](https://www.npmjs.com/package/@backstage/theme)
 in combination with
-[createTheme](https://material-ui.com/customization/theming/#createmuitheme-options-args-theme)
-from [@material-ui/core](https://www.npmjs.com/package/@material-ui/core). See
+[`createTheme`](https://material-ui.com/customization/theming/#createmuitheme-options-args-theme)
+from [`@material-ui/core`](https://www.npmjs.com/package/@material-ui/core). See
 the "Overriding Backstage and Material UI css rules" section below.
 
 You can also create a theme from scratch that matches the `BackstageTheme` type
-exported by [@backstage/theme](https://www.npmjs.com/package/@backstage/theme).
+exported by [`@backstage/theme`](https://www.npmjs.com/package/@backstage/theme).
 See the
-[material-ui docs on theming](https://material-ui.com/customization/theming/)
+[Material-UI docs on theming](https://material-ui.com/customization/theming/)
 for more information about how that can be done.
 
 ## Using your Custom Theme
@@ -79,7 +79,7 @@ const app = createApp({
 Note that your list of custom themes overrides the default themes. If you still
 want to use the default themes, they are exported as `lightTheme` and
 `darkTheme` from
-[@backstage/theme](https://www.npmjs.com/package/@backstage/theme).
+[`@backstage/theme`](https://www.npmjs.com/package/@backstage/theme).
 
 ## Example of a custom theme
 

--- a/docs/integrations/gerrit/locations.md
+++ b/docs/integrations/gerrit/locations.md
@@ -38,7 +38,7 @@ a structure with up to six elements:
   not set. The address used to clone a repo is the `cloneUrl` plus the repo name.
 - `gitilesBaseUrl` (optional): This is needed for creating a valid user-friendly URL
   that can be used for browsing the content of the provider. If not set a default
-  value will be created in the same way as the "baseUrl" option. There is no
+  value will be created in the same way as the `baseUrl` option. There is no
   requirement to have Gitiles for the Backstage Gerrit integration but without it
   some links in the Backstage UI will be broken.
 - `username` (optional): The Gerrit username to use in API requests. If

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -196,14 +196,14 @@ const App = () => (
 There are a couple of naming patterns to adhere to as you build plugins, which
 helps clarify the intent and usage of the exports.
 
-| Description           | Pattern         | Examples                                       |
-| --------------------- | --------------- | ---------------------------------------------- |
-| Top-level Pages       | \*Page          | CatalogIndexPage, SettingsPage, LighthousePage |
-| Entity Tab Content    | Entity\*Content | EntityJenkinsContent, EntityKubernetesContent  |
-| Entity Overview Card  | Entity\*Card    | EntitySentryCard, EntityPagerDutyCard          |
-| Entity Conditional    | is\*Available   | isPagerDutyAvailable, isJenkinsAvailable       |
-| Plugin Instance       | \*Plugin        | jenkinsPlugin, catalogPlugin                   |
-| Utility API Reference | \*ApiRef        | configApiRef, catalogApiRef                    |
+| Description           | Pattern           | Examples                                             |
+| --------------------- | ----------------- | ---------------------------------------------------- |
+| Top-level Pages       | `\*Page`          | `CatalogIndexPage`, `SettingsPage`, `LighthousePage` |
+| Entity Tab Content    | `Entity\*Content` | `EntityJenkinsContent`, `EntityKubernetesContent`    |
+| Entity Overview Card  | `Entity\*Card`    | `EntitySentryCard`, `EntityPagerDutyCard`            |
+| Entity Conditional    | `is\*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
+| Plugin Instance       | `\*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |
+| Utility API Reference | `\*ApiRef`        | `configApiRef`, `catalogApiRef`                      |
 
 ### Routing System
 
@@ -515,10 +515,10 @@ deprecated while making the new additions, to then be removed at a later point.
 Many export naming patterns have been changed to avoid import aliases and to
 clarify intent. Refer to the following table to formulate the new name:
 
-| Description          | Existing Pattern           | New Pattern     | Examples                                       |
-| -------------------- | -------------------------- | --------------- | ---------------------------------------------- |
-| Top-level Pages      | Router                     | \*Page          | CatalogIndexPage, SettingsPage, LighthousePage |
-| Entity Tab Content   | Router                     | Entity\*Content | EntityJenkinsContent, EntityKubernetesContent  |
-| Entity Overview Card | \*Card                     | Entity\*Card    | EntitySentryCard, EntityPagerDutyCard          |
-| Entity Conditional   | isPluginApplicableToEntity | is\*Available   | isPagerDutyAvailable, isJenkinsAvailable       |
-| Plugin Instance      | plugin                     | \*Plugin        | jenkinsPlugin, catalogPlugin                   |
+| Description          | Existing Pattern             | New Pattern       | Examples                                             |
+| -------------------- | ---------------------------- | ----------------- | ---------------------------------------------------- |
+| Top-level Pages      | `Router`                     | `\*Page`          | `CatalogIndexPage`, `SettingsPage`, `LighthousePage` |
+| Entity Tab Content   | `Router`                     | `Entity\*Content` | `EntityJenkinsContent`, `EntityKubernetesContent`    |
+| Entity Overview Card | `\*Card`                     | `Entity\*Card`    | `EntitySentryCard`, `EntityPagerDutyCard`            |
+| Entity Conditional   | `isPluginApplicableToEntity` | `is\*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
+| Plugin Instance      | `plugin`                     | `\*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |

--- a/docs/plugins/structure-of-a-plugin.md
+++ b/docs/plugins/structure-of-a-plugin.md
@@ -83,7 +83,7 @@ export const ExamplePage = examplePlugin.provide(
 
 This is where the plugin is created and where it creates and exports extensions
 that can be imported and used the app. See reference docs for
-[createPlugin](../reference/core-plugin-api.createplugin.md) or introduction to
+[`createPlugin`](../reference/core-plugin-api.createplugin.md) or introduction to
 the new [Composability System](./composability.md).
 
 ## Components

--- a/docs/plugins/url-reader.md
+++ b/docs/plugins/url-reader.md
@@ -174,14 +174,14 @@ which can be used to request the provider's API.
 `read` then makes an authenticated request to the provider API and returns the
 file's content.
 
-#### readUrl
+#### `readUrl`
 
 `readUrl` is a new interface that allows complex response objects and is
 intended to replace the `read` method. This new method is currently optional to
 implement which allows for a soft migration to `readUrl` instead of `read` in
 the future.
 
-#### readTree
+#### `readTree`
 
 `readTree` method also expects user-friendly URLs similar to `read` but the URL
 should point to a tree (could be the root of a repository or even a
@@ -241,8 +241,8 @@ without an `etag`, the response contains an ETag of the resource (should ideally
 forward the ETag returned by the provider). If the method is called with an
 `etag`, it first compares the ETag and returns a `NotModifiedError` in case the
 resource has not been modified. This approach is very similar to the actual
-[ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) and
-[If-None-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
+[`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) and
+[`If-None-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
 HTTP headers.
 
 ### 6. Debugging

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -38,7 +38,7 @@ Server-to-server authentication tokens issued from a TokenManager (specifically,
 
 ### Kubernetes
 
-Added support for `oidc` as authProvider for kubernetes authentication and added an optional `oidcTokenProvider` config value. This will allow users to authenticate to kubernetes clusters using ID tokens obtained from the configured auth provider in their Backstage instance. Contributed by @dbravovmw(https://github.com/dbravovmw). #11328(https://github.com/backstage/backstage/pull/11328)
+Added support for `oidc` as an auth provider for kubernetes authentication and added an optional `oidcTokenProvider` config value. This will allow users to authenticate to kubernetes clusters using ID tokens obtained from the configured auth provider in their Backstage instance. Contributed by @dbravovmw(https://github.com/dbravovmw). #11328(https://github.com/backstage/backstage/pull/11328)
 
 ### Misc
 

--- a/microsite/README.md
+++ b/microsite/README.md
@@ -167,7 +167,7 @@ For more information about blog posts, click [here](https://docusaurus.io/docs/e
 
 ### Adding items to your site's top navigation bar
 
-1. Add links to docs, custom pages or external links by editing the headerLinks field of `website/siteConfig.js`:
+1. Add links to docs, custom pages or external links by editing the `headerLinks` field of `website/siteConfig.js`:
 
 `website/siteConfig.js`
 

--- a/packages/techdocs-cli/src/example-docs/plugins/plugin-a/docs/index.md
+++ b/packages/techdocs-cli/src/example-docs/plugins/plugin-a/docs/index.md
@@ -1,4 +1,4 @@
 # Plugin A
 
-This is a description of Plugin A. This file exists to prove that glob'd
+This is a description of Plugin A. This file exists to prove that glob formed
 includes using the `*include` syntax work as expected.

--- a/packages/techdocs-cli/src/example-docs/plugins/plugin-b/docs/index.md
+++ b/packages/techdocs-cli/src/example-docs/plugins/plugin-b/docs/index.md
@@ -1,4 +1,4 @@
 # Plugin B
 
-This is a description of Plugin B. This file exists to prove that glob'd
+This is a description of Plugin B. This file exists to prove that glob formed
 includes using the `*include` syntax work as expected.

--- a/packages/theme/src/pageTheme.ts
+++ b/packages/theme/src/pageTheme.ts
@@ -23,7 +23,7 @@ import { PageTheme } from './types';
  *
  * How to add a shape:
  *
- * 1. Get the svg shape from figma, should be ~1400 wide, ~400 high
+ * 1. Get the SVG shape from figma, should be ~1400 wide, ~400 high
  *    and only the white-to-transparent mask, no colors.
  * 2. Run it through https://jakearchibald.github.io/svgomg/
  * 3. Run that through https://github.com/tigt/mini-svg-data-uri
@@ -62,7 +62,7 @@ export const colorVariants: Record<string, string[]> = {
  * @remarks
  *
  * As the background shapes and colors are decorative, we place them onto the
- * page as a css background-image instead of an html element of its own.
+ * page as a CSS `background-image` instead of an HTML element of its own.
  */
 export function genPageTheme(props: {
   colors: string[];

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -91,9 +91,9 @@ export AUTH_GITLAB_CLIENT_SECRET=x
 
 Add a new Okta application using the following URI conventions:
 
-Login redirect URI's: `http://localhost:7007/api/auth/okta/handler/frame`
-Logout redirect URI's: `http://localhost:7007/api/auth/okta/logout`
-Initiate login URI's: `http://localhost:7007/api/auth/okta/start`
+Login redirect URIs: `http://localhost:7007/api/auth/okta/handler/frame`
+Logout redirect URIs: `http://localhost:7007/api/auth/okta/logout`
+Initiate login URIs: `http://localhost:7007/api/auth/okta/start`
 
 Then configure the following environment variables to be used in the `app-config.yaml` file:
 

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -136,7 +136,7 @@ For showing cost breakdowns you can define a map of cloud products. They must be
 
 You can optionally supply a product `icon` to display in Cost Insights navigation. See the [type file](https://github.com/backstage/backstage/blob/master/plugins/cost-insights/src/types/Icon.ts) for supported types and Material UI icon [mappings](https://github.com/backstage/backstage/blob/master/plugins/cost-insights/src/utils/navigation.tsx).
 
-**Note:** Product keys should be unique and camelCased. Backstage does not support underscores in configuration keys.
+**Note:** Product keys should be unique and on `camelCase` form. Backstage does not support underscores in configuration keys.
 
 ```yaml
 ## ./app-config.yaml

--- a/plugins/dynatrace/README.md
+++ b/plugins/dynatrace/README.md
@@ -29,7 +29,7 @@ proxy:
       Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
 ```
 
-It also requires a baseUrl for rendering links to problems in the table like so:
+It also requires a `baseUrl` for rendering links to problems in the table like so:
 
 ```yaml
 dynatrace:

--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -37,7 +37,7 @@ Before you are able to start index stack overflow questions to search, you need 
 
 When you have your `packages/backend/src/plugins/search.ts` file ready to make modifications, add the following code snippet to add the `StackOverflowQuestionsCollatorFactory`. Note that you can modify the `requestParams`.
 
-> Note: if your baseUrl is set to the external stack overflow api `https://api.stackexchange.com/2.2`, you can find optional and required parameters under the official API documentation under [`Usage of /questions GET`](https://api.stackexchange.com/docs/questions)
+> Note: if your `baseUrl` is set to the external stack overflow api `https://api.stackexchange.com/2.2`, you can find optional and required parameters under the official API documentation under [`Usage of /questions GET`](https://api.stackexchange.com/docs/questions)
 
 ```ts
 indexBuilder.addCollator({

--- a/plugins/techdocs/src/reader/README.md
+++ b/plugins/techdocs/src/reader/README.md
@@ -17,4 +17,4 @@ export const updateH1Text = (): Transformer => {
 };
 ```
 
-The transformers are then registered in the Reader.tsx file. They are registered in two places, one place that runs before it's attached to the actual browser DOM (preTransformers) and once after (postTransfomers). Doing modifications is faster before it's attached, but doesn't allow us to do some things, such as attaching event listeners.
+The transformers are then registered in the Reader.tsx file. They are registered in two places, one place that runs before it's attached to the actual browser DOM (`preTransformer`s) and once after (`postTransformer`s). Doing modifications is faster before it's attached, but doesn't allow us to do some things, such as attaching event listeners.


### PR DESCRIPTION
Working down the false warnings a bit. After this, `docs/reference` is the only folder that has errors, and that's gotta be addressed separately somehow in the part of the api-extractor that writes breadcumbs.