### PR TITLE
Removing forced capitalization for Entity types in the sidebar.

### DIFF
--- a/.changeset/happy-avocados-tan.md
+++ b/.changeset/happy-avocados-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Removed forced capitalization for Entity types in the catalog sidebar.

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { capitalize } from 'lodash';
 import { Entity } from '@backstage/catalog-model';
 import { EntityTypePicker } from './EntityTypePicker';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
@@ -99,11 +98,11 @@ describe('<EntityTypePicker/>', () => {
     const input = rendered.getByTestId('select');
     fireEvent.click(input);
 
-    await waitFor(() => rendered.getByText('Service'));
+    await waitFor(() => rendered.getByText('service'));
 
     entities.forEach(entity => {
       expect(
-        rendered.getByText(capitalize(entity.spec!.type as string)),
+        rendered.getByText(entity.spec!.type as string),
       ).toBeInTheDocument();
     });
   });
@@ -125,8 +124,8 @@ describe('<EntityTypePicker/>', () => {
     const input = rendered.getByTestId('select');
     fireEvent.click(input);
 
-    await waitFor(() => rendered.getByText('Service'));
-    fireEvent.click(rendered.getByText('Service'));
+    await waitFor(() => rendered.getByText('service'));
+    fireEvent.click(rendered.getByText('service'));
 
     expect(updateFilters).toHaveBeenLastCalledWith({
       type: new EntityTypeFilter(['service']),

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
@@ -132,7 +132,7 @@ describe('<EntityTypePicker/>', () => {
     });
 
     fireEvent.click(input);
-    fireEvent.click(rendered.getByText('All'));
+    fireEvent.click(rendered.getByText('all'));
 
     expect(updateFilters).toHaveBeenLastCalledWith({ type: undefined });
   });

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useEffect } from 'react';
-import capitalize from 'lodash/capitalize';
 import { Box } from '@material-ui/core';
 import { useEntityTypeFilter } from '../../hooks/useEntityTypeFilter';
 

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.tsx
@@ -54,10 +54,10 @@ export const EntityTypePicker = (props: EntityTypePickerProps) => {
   if (availableTypes.length === 0 || error) return null;
 
   const items = [
-    { value: 'all', label: 'All' },
+    { value: 'all', label: 'all' },
     ...availableTypes.map((type: string) => ({
       value: type,
-      label: capitalize(type),
+      label: type,
     })),
   ];
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This simply removes the forced capitalization of Entity Types in the sidebar. This is to resolve #14059 where the user observed the case of types in the sidebar vs the case of types in the entity table.

![image](https://user-images.githubusercontent.com/8186200/197367279-ed90d386-909e-42e2-ba08-308ca2fcf923.png)

#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
