### PR TITLE
workflow/snyk: increase memory size to to 7gb

### DIFF
--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [14.x]
 
     env:
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=7168
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
runners have 8gb so let's give this a try to see if it's high enough.