### PR TITLE
Get rid of `this-is-undefined-in-esm` warning

### DIFF
--- a/.changeset/grumpy-pigs-reflect.md
+++ b/.changeset/grumpy-pigs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Get rid of `this-is-undefined-in-esm` warning

--- a/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
+++ b/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
@@ -98,7 +98,7 @@ export const EntityListComponent = (props: EntityListComponentProps) => {
           <ListItem
             dense
             button={Boolean(onItemClick) as any}
-            onClick={() => onItemClick?.call(this, r.target)}
+            onClick={() => onItemClick?.(r.target)}
           >
             <ListItemIcon>{locationListItemIcon(r.target)}</ListItemIcon>
 


### PR DESCRIPTION
Closes #14294

I don't see any places where the value of `this` seems to have any particular meaning so I just removed it since things actually was a bit ugly to fix.