### PR TITLE
Fix Authenticate API Requests Example

### DIFF
--- a/contrib/docs/tutorials/authenticate-api-requests.md
+++ b/contrib/docs/tutorials/authenticate-api-requests.md
@@ -75,7 +75,7 @@ export const createAuthMiddleware = async (
         // Authorization header may be forwarded by plugin requests
         req.headers.authorization = `Bearer ${token}`;
       }
-      if (token && token !== req.cookies.token) {
+      if (token && token !== req.cookies?.token) {
         setTokenCookie(res, {
           token,
           secure,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When going through the `authenticate-api-requests` article, and booting up my server my app was failing with the following error:

```
[BACKEND] 2022-10-24T16:21:31.603Z search error Request failed with 401 Error type=taskManager task=search_index_software_catalog name=ResponseError response=[object Response] body=[object Object] cause=Error: Request failed with status 401 Unauthorized, Unauthorized stack=ResponseError: Request failed with 401 Error
[BACKEND]     at Function.fromResponse (/Users/hillmandj/Code/work/backstage-poc/node_modules/@backstage/errors/dist/index.cjs.js:151:12)
[BACKEND]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[BACKEND]     at async CatalogClient.requestRequired (/Users/hillmandj/Code/work/backstage-poc/node_modules/@backstage/catalog-client/dist/index.cjs.js:243:13)
[BACKEND]     at async CatalogClient.getEntities (/Users/hillmandj/Code/work/backstage-poc/node_modules/@backstage/catalog-client/dist/index.cjs.js:72:22)
[BACKEND]     at async DefaultCatalogCollatorFactory.execute (/Users/hillmandj/Code/work/backstage-poc/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:1009:25)
[BACKEND]     at async next (node:internal/streams/from:85:11)
```

Which after some debugging, seemed to be due to this:

```
[BACKEND]     TypeError: Cannot read properties of undefined (reading 'token')
[BACKEND]     at authMiddleware (webpack-internal:///./src/authMiddleware.ts:64:54)
[BACKEND]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

It turned out this was just due to `req.cookies.token` being an undefined property. This (really small) update fixed it, and will hopefully help others out when going through this tutorial

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
