### PR TITLE
github-pull-requests-board: sync changelog

### DIFF
--- a/.changeset/curvy-islands-marry.md
+++ b/.changeset/curvy-islands-marry.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-github-pull-requests-board': patch
----
-
-Replace the momentjs dependency with luxon.

--- a/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/plugins/github-pull-requests-board/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- 80d75adf3a: Replace the momentjs dependency with luxon.
 - 719ccbb963: Properly filter on relations instead of the spec, when finding by owner
 - Updated dependencies
   - @backstage/catalog-model@1.1.2


### PR DESCRIPTION
This was actually released in 1.7, but was missed due to a race where the version packages PR didn't have time to update.