### PR TITLE
.github/workflows: update PR stale message to not mislead

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -22,7 +22,8 @@ jobs:
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had
             recent activity from the author. It will be closed if no further activity occurs.
-            If you are the author and the PR has been closed, feel free to re-open the PR and continue the contribution!
+            If the PR was closed and you want it re-opened, let us know
+            and we'll re-open the PR so that you can continue the contribution!
           days-before-pr-stale: 7
           days-before-pr-close: 5
           exempt-pr-labels: after-vacations,will-fix


### PR DESCRIPTION
🧹 

Generally authors aren't able to re-open PRs if they have gone stale, so let's ask them to notify us instead.
