### PR TITLE
Updating GitLab Auth provider docs about using a custom callbackUrl

### DIFF
--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -35,6 +35,8 @@ auth:
         clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
         ## uncomment if using self-hosted GitLab
         # audience: https://gitlab.company.com
+        ## uncomment if using a custom redirect URI
+        # callbackUrl: https://${BASE_URL}/api/auth/gitlab/handler/frame
 ```
 
 The GitLab provider is a structure with three configuration keys:
@@ -44,6 +46,9 @@ The GitLab provider is a structure with three configuration keys:
 - `clientSecret`: The Application secret
 - `audience` (optional): The base URL for the self-hosted GitLab instance, e.g.
   `https://gitlab.company.com`
+- `callbackUrl` (optional): The URL matching the Redirect URI registered when creating your GitLab OAuth App, e.g.
+  `https://$backstage.acme.corp/api/auth/gitlab/handler/frame`
+  Note: Due to a peculiarity with GitLab OAuth, ensure there is no trailing `/` after 'frame' in the URL.
 
 ## Adding the provider to the Backstage frontend
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the GitLab Auth Provider docs to clarify a configuration option we struggled with while setting up GitLab OAuth for our Backstage instance.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
