### PR TITLE
Adding optional string array of topics to publish gitlab action

### DIFF
--- a/.changeset/large-spies-doubt.md
+++ b/.changeset/large-spies-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Adds the ability to pass (an optional) array of strings that will be applied to the newly scaffolded repository as topic labels.

--- a/.changeset/large-spies-doubt.md
+++ b/.changeset/large-spies-doubt.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Adds the ability to pass (an optional) array of strings that will be applied to the newly scaffolded repository as topic labels.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -422,6 +422,7 @@ export function createPublishGitlabAction(options: {
   gitAuthorName?: string | undefined;
   gitAuthorEmail?: string | undefined;
   setUserAsOwner?: boolean | undefined;
+  topics?: string[] | undefined;
 }>;
 
 // @public

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -183,11 +183,8 @@ export function createPublishGitlabAction(options: {
         namespace_id: targetNamespace,
         name: repo,
         visibility: repoVisibility,
+        ...(topics.length ? { topics } : {}),
       });
-
-      if (topics.length) {
-        await client.Projects.edit(projectId, { topics });
-      }
 
       // When setUserAsOwner is true the input token is expected to come from an unprivileged user GitLab
       // OAuth flow. In this case GitLab works in a way that allows the unprivileged user to

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -44,6 +44,7 @@ export function createPublishGitlabAction(options: {
     gitAuthorName?: string;
     gitAuthorEmail?: string;
     setUserAsOwner?: boolean;
+    topics?: string[];
   }>({
     id: 'publish:gitlab',
     description:
@@ -99,6 +100,14 @@ export function createPublishGitlabAction(options: {
             description:
               'Set the token user as owner of the newly created repository. Requires a token authorized to do the edit in the integration configuration for the matching host',
           },
+          topics: {
+            title: 'Topic labels',
+            description: 'Topic labels to apply on the repository.',
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
         },
       },
       output: {
@@ -128,6 +137,7 @@ export function createPublishGitlabAction(options: {
         gitAuthorName,
         gitAuthorEmail,
         setUserAsOwner = false,
+        topics = [],
       } = ctx.input;
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
 
@@ -174,6 +184,8 @@ export function createPublishGitlabAction(options: {
         name: repo,
         visibility: repoVisibility,
       });
+
+      await client.Projects.edit(projectId, {topics});
 
       // When setUserAsOwner is true the input token is expected to come from an unprivileged user GitLab
       // OAuth flow. In this case GitLab works in a way that allows the unprivileged user to

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -186,7 +186,7 @@ export function createPublishGitlabAction(options: {
       });
 
       if (topics.length) {
-        await client.Projects.edit(projectId, {topics});
+        await client.Projects.edit(projectId, { topics });
       }
 
       // When setUserAsOwner is true the input token is expected to come from an unprivileged user GitLab

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -185,7 +185,9 @@ export function createPublishGitlabAction(options: {
         visibility: repoVisibility,
       });
 
-      await client.Projects.edit(projectId, {topics});
+      if (topics.length) {
+        await client.Projects.edit(projectId, {topics});
+      }
 
       // When setUserAsOwner is true the input token is expected to come from an unprivileged user GitLab
       // OAuth flow. In this case GitLab works in a way that allows the unprivileged user to


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding the ability to pass (an optional) array of strings that will be applied to the newly scaffolded repository as topic labels. This is something we had to build a custom scaffolder action for since all our repos are required to have certain topics applied to them. It seemed like this should be something that was possible in the built-in scaffolder actions instead of something exclusive to us.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
