### PR TITLE
get rid of circular imports

### DIFF
--- a/.changeset/orange-trees-peel.md
+++ b/.changeset/orange-trees-peel.md
@@ -1,0 +1,14 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/core-components': patch
+'@backstage/integration': patch
+'@backstage/plugin-auth-node': patch
+'@backstage/plugin-gcalendar': patch
+'@backstage/plugin-periskop': patch
+'@backstage/plugin-permission-common': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-xcmetrics': patch
+---
+
+Internal refactor of imports to avoid circular dependencies

--- a/packages/catalog-model/src/location/helpers.ts
+++ b/packages/catalog-model/src/location/helpers.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_SOURCE_LOCATION } from '.';
 import { Entity, stringifyEntityRef } from '../entity';
-import { ANNOTATION_LOCATION } from './annotation';
+import { ANNOTATION_LOCATION, ANNOTATION_SOURCE_LOCATION } from './annotation';
 
 /**
  * Parses a string form location reference.

--- a/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.test.tsx
+++ b/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.test.tsx
@@ -16,8 +16,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-
-import { OverflowTooltip } from '.';
+import { OverflowTooltip } from './OverflowTooltip';
 
 describe('<OverflowTooltip />', () => {
   it('renders without exploding', async () => {

--- a/packages/core-components/src/components/Table/Table.stories.tsx
+++ b/packages/core-components/src/components/Table/Table.stories.tsx
@@ -17,8 +17,8 @@
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { Link } from '../Link';
-import { SubvalueCell, Table, TableColumn } from '.';
-import { TableFilter } from './Table';
+import { SubvalueCell } from './SubvalueCell';
+import { Table, TableColumn, TableFilter } from './Table';
 
 export default {
   title: 'Data Display/Table',

--- a/packages/core-components/src/layout/HeaderTabs/HeaderTabs.test.tsx
+++ b/packages/core-components/src/layout/HeaderTabs/HeaderTabs.test.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { renderInTestApp } from '@backstage/test-utils';
-import { HeaderTabs } from '.';
-import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
+import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
+import { HeaderTabs } from './HeaderTabs';
 
 const mockTabs = [
   { id: 'overview', label: 'Overview' },

--- a/packages/core-components/src/layout/Page/Page.stories.tsx
+++ b/packages/core-components/src/layout/Page/Page.stories.tsx
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
+import { wrapInTestApp } from '@backstage/test-utils';
 import Box from '@material-ui/core/Box';
 import Chip from '@material-ui/core/Chip';
 import Grid from '@material-ui/core/Grid';
 import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 import React, { useState } from 'react';
-import { wrapInTestApp } from '@backstage/test-utils';
-import {
-  Content,
-  ContentHeader,
-  Header,
-  HeaderLabel,
-  HeaderTabs,
-  InfoCard,
-  Page,
-} from '..';
 import {
   GaugeCard,
   StatusOK,
@@ -38,6 +29,13 @@ import {
   TableColumn,
   TrendLine,
 } from '../../components';
+import { Content } from '../Content';
+import { ContentHeader } from '../ContentHeader';
+import { Header } from '../Header';
+import { HeaderLabel } from '../HeaderLabel';
+import { HeaderTabs } from '../HeaderTabs';
+import { InfoCard } from '../InfoCard';
+import { Page } from '../Page';
 
 export default {
   title: 'Plugins/Examples',

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -22,15 +22,11 @@ import MenuBookIcon from '@material-ui/icons/MenuBook';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import {
-  Sidebar,
-  SidebarExpandButton,
-  SidebarItem,
-  SidebarSearchField,
-  SidebarPinStateProvider,
-  SidebarSubmenu,
-  SidebarSubmenuItem,
-} from '.';
+import { Sidebar } from './Bar';
+import { SidebarExpandButton, SidebarItem, SidebarSearchField } from './Items';
+import { SidebarPinStateProvider } from './SidebarPinStateContext';
+import { SidebarSubmenu } from './SidebarSubmenu';
+import { SidebarSubmenuItem } from './SidebarSubmenuItem';
 
 async function renderScalableSidebar() {
   await renderInTestApp(

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -53,16 +53,13 @@ import {
   SidebarItemWithSubmenuContext,
   SidebarConfig,
 } from './config';
-import {
-  SidebarSubmenuItemProps,
-  SidebarSubmenuProps,
-  SidebarSubmenu,
-} from '.';
+import { SidebarSubmenuProps, SidebarSubmenu } from './SidebarSubmenu';
 import DoubleArrowLeft from './icons/DoubleArrowLeft';
 import DoubleArrowRight from './icons/DoubleArrowRight';
 import { isLocationMatch } from './utils';
 import { Location } from 'history';
 import { useSidebarOpenState } from './SidebarOpenStateContext';
+import { SidebarSubmenuItemProps } from './SidebarSubmenuItem';
 
 /** @public */
 export type SidebarItemClassKey =
@@ -214,7 +211,7 @@ function useMemoStyles(sidebarConfig: SidebarConfig) {
 
 /**
  * Evaluates the routes of the SubmenuItems & nested DropdownItems.
- * The reeveluation is only triggered, if the `locationPathname` changes, as `useElementFilter` uses memorization.
+ * The reevaluation is only triggered, if the `locationPathname` changes, as `useElementFilter` uses memorization.
  *
  * @param submenu SidebarSubmenu component
  * @param location Location

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.test.tsx
@@ -21,13 +21,11 @@ import LayersIcon from '@material-ui/icons/Layers';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
-import {
-  MobileSidebar,
-  Sidebar,
-  SidebarGroup,
-  SidebarItem,
-  SidebarPage,
-} from '.';
+import { Sidebar } from './Bar';
+import { SidebarItem } from './Items';
+import { MobileSidebar } from './MobileSidebar';
+import { SidebarPage } from './Page';
+import { SidebarGroup } from './SidebarGroup';
 
 const MobileSidebarWithGroups = () => (
   <SidebarPage>

--- a/packages/core-components/src/layout/Sidebar/Sidebar.stories.tsx
+++ b/packages/core-components/src/layout/Sidebar/Sidebar.stories.tsx
@@ -24,19 +24,19 @@ import CloudQueueIcon from '@material-ui/icons/CloudQueue';
 import AcUnitIcon from '@material-ui/icons/AcUnit';
 import AppsIcon from '@material-ui/icons/Apps';
 import React, { ComponentType } from 'react';
+import { SidebarPage } from './Page';
+import { Sidebar } from './Bar';
+import { SidebarGroup } from './SidebarGroup';
 import {
-  Sidebar,
   SidebarDivider,
-  SidebarGroup,
   SidebarExpandButton,
-  SidebarIntro,
   SidebarItem,
-  SidebarPage,
   SidebarSearchField,
   SidebarSpace,
-  SidebarSubmenu,
-  SidebarSubmenuItem,
-} from '.';
+} from './Items';
+import { SidebarIntro } from './Intro';
+import { SidebarSubmenu } from './SidebarSubmenu';
+import { SidebarSubmenuItem } from './SidebarSubmenuItem';
 
 const routeRef = createRouteRef({
   id: 'storybook.test-route',

--- a/packages/core-components/src/layout/Sidebar/SidebarGroup.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarGroup.test.tsx
@@ -20,8 +20,10 @@ import LayersIcon from '@material-ui/icons/Layers';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
+import { SidebarItem } from './Items';
 import { MobileSidebarContext } from './MobileSidebar';
-import { SidebarGroup, SidebarItem, SidebarPage } from '.';
+import { SidebarPage } from './Page';
+import { SidebarGroup } from './SidebarGroup';
 
 const SidebarGroupWithItems = () => (
   <SidebarPage>

--- a/packages/core-components/src/layout/Sidebar/SidebarGroup.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarGroup.tsx
@@ -22,10 +22,10 @@ import BottomNavigationAction, {
 import { makeStyles } from '@material-ui/core/styles';
 import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useSidebarPinState } from '.';
 import { Link } from '../../components';
 import { SidebarConfigContext, SidebarConfig } from './config';
 import { MobileSidebarContext } from './MobileSidebar';
+import { useSidebarPinState } from './SidebarPinStateContext';
 
 /**
  * Props for the `SidebarGroup`

--- a/packages/integration/src/gerrit/GerritIntegration.ts
+++ b/packages/integration/src/gerrit/GerritIntegration.ts
@@ -20,7 +20,7 @@ import {
   GerritIntegrationConfig,
   readGerritIntegrationConfigs,
 } from './config';
-import { parseGerritGitilesUrl, builldGerritGitilesUrl } from './core';
+import { parseGerritGitilesUrl, buildGerritGitilesUrl } from './core';
 
 /**
  * A Gerrit based integration.
@@ -61,7 +61,7 @@ export class GerritIntegration implements ScmIntegration {
     let updated;
     if (url.startsWith('/')) {
       const { branch, project } = parseGerritGitilesUrl(this.config, base);
-      return builldGerritGitilesUrl(this.config, project, branch, url);
+      return buildGerritGitilesUrl(this.config, project, branch, url);
     }
     if (url) {
       updated = new URL(url, base);

--- a/packages/integration/src/gerrit/core.test.ts
+++ b/packages/integration/src/gerrit/core.test.ts
@@ -20,7 +20,7 @@ import fetch from 'cross-fetch';
 import { setupRequestMockHandlers } from '@backstage/test-utils';
 import { GerritIntegrationConfig } from './config';
 import {
-  builldGerritGitilesUrl,
+  buildGerritGitilesUrl,
   getGerritBranchApiUrl,
   getGerritCloneRepoUrl,
   getGerritRequestOptions,
@@ -33,14 +33,14 @@ describe('gerrit core', () => {
   const worker = setupServer();
   setupRequestMockHandlers(worker);
 
-  describe('builldGerritGitilesUrl', () => {
+  describe('buildGerritGitilesUrl', () => {
     it('can create an url from arguments', () => {
       const config: GerritIntegrationConfig = {
         host: 'gerrit.com',
         gitilesBaseUrl: 'https://gerrit.com/gitiles',
       };
       expect(
-        builldGerritGitilesUrl(config, 'repo', 'dev', 'catalog-info.yaml'),
+        buildGerritGitilesUrl(config, 'repo', 'dev', 'catalog-info.yaml'),
       ).toEqual(
         'https://gerrit.com/gitiles/repo/+/refs/heads/dev/catalog-info.yaml',
       );

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { trimStart } from 'lodash';
-import { GerritIntegrationConfig } from '.';
+import { GerritIntegrationConfig } from './config';
 
 const GERRIT_BODY_PREFIX = ")]}'";
 
@@ -79,7 +80,7 @@ export function parseGerritGitilesUrl(
  * @param filePath - The absolute file path.
  * @public
  */
-export function builldGerritGitilesUrl(
+export function buildGerritGitilesUrl(
   config: GerritIntegrationConfig,
   project: string,
   branch: string,

--- a/plugins/auth-node/src/DefaultIdentityClient.ts
+++ b/plugins/auth-node/src/DefaultIdentityClient.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { AuthenticationError } from '@backstage/errors';
 import {
@@ -24,12 +25,12 @@ import {
   jwtVerify,
 } from 'jose';
 import { GetKeyFunction } from 'jose/dist/types/types';
-
 import {
   BackstageIdentityResponse,
   IdentityApiGetIdentityRequest,
 } from './types';
-import { getBearerTokenFromAuthorizationHeader, IdentityApi } from '.';
+import { getBearerTokenFromAuthorizationHeader } from './getBearerTokenFromAuthorizationHeader';
+import { IdentityApi } from './IdentityApi';
 
 const CLOCK_MARGIN_S = 10;
 

--- a/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.test.tsx
+++ b/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.test.tsx
@@ -30,8 +30,8 @@ import {
 import { setupServer } from 'msw/node';
 import { DateTime } from 'luxon';
 import { siteMock } from '../../mocks/mocks';
-import { azureSiteApiRef } from '../..';
 import { AzureSitesOverviewTable } from './AzureSitesOverviewTable';
+import { azureSiteApiRef } from '../../api';
 
 const errorApiMock = { post: jest.fn(), error$: jest.fn() };
 const identityApiMock = (getCredentials: any) => ({

--- a/plugins/gcalendar/src/components/CalendarCard/HomePageCalendar.test.tsx
+++ b/plugins/gcalendar/src/components/CalendarCard/HomePageCalendar.test.tsx
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
 
+import React from 'react';
 import { googleAuthApiRef, storageApiRef } from '@backstage/core-plugin-api';
 import {
   MockStorageApi,
   TestApiProvider,
   renderInTestApp,
 } from '@backstage/test-utils';
-
-import { HomePageCalendar } from '.';
-import { gcalendarApiRef, gcalendarPlugin } from '../..';
+import { HomePageCalendar } from './HomePageCalendar';
+import { gcalendarApiRef } from '../../api';
+import { gcalendarPlugin } from '../../plugin';
 
 describe('<HomePageCalendar />', () => {
   const primaryCalendar = {

--- a/plugins/gcalendar/src/components/CalendarCard/SignInContent.tsx
+++ b/plugins/gcalendar/src/components/CalendarCard/SignInContent.tsx
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
-
 import { Box, Button, styled } from '@material-ui/core';
-
 import { CalendarEvent } from './CalendarEvent';
 import { eventsMock } from './signInEventMock';
-import { GCalendarEvent } from '../..';
+import { GCalendarEvent } from '../../api';
 
 type Props = {
   handleAuthClick: React.MouseEventHandler<HTMLElement>;

--- a/plugins/periskop/src/components/EntityPeriskopErrorsCard/EntityPeriskopErrorsCard.tsx
+++ b/plugins/periskop/src/components/EntityPeriskopErrorsCard/EntityPeriskopErrorsCard.tsx
@@ -34,7 +34,7 @@ import {
   Link,
 } from '@backstage/core-components';
 import useAsync from 'react-use/lib/useAsync';
-import { periskopApiRef } from '../..';
+import { periskopApiRef } from '../../plugin';
 import { AggregatedError, NotFoundInInstance } from '../../types';
 
 /**

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -15,8 +15,7 @@
  */
 
 import { JsonPrimitive } from '@backstage/types';
-import { ResourcePermission } from '.';
-import { Permission } from './permission';
+import { Permission, ResourcePermission } from './permission';
 
 /**
  * A request with a UUID identifier, so that batched responses can be matched up with the original

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubIssuesLabel.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubIssuesLabel.test.ts
@@ -23,7 +23,7 @@ import {
 import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '@backstage/backend-common';
 import { PassThrough } from 'stream';
-import { TemplateAction } from '../..';
+import { TemplateAction } from '../../types';
 
 const mockOctokit = {
   rest: {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
@@ -23,7 +23,7 @@ import {
 import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '@backstage/backend-common';
 import { PassThrough } from 'stream';
-import { TemplateAction } from '../..';
+import { TemplateAction } from '../../types';
 
 const mockOctokit = {
   rest: {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JsonObject, Observable } from '@backstage/types';
-import ObservableImpl from 'zen-observable';
+
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
+import { JsonObject, Observable } from '@backstage/types';
 import { Logger } from 'winston';
+import ObservableImpl from 'zen-observable';
 import {
+  SerializedTask,
+  SerializedTaskEvent,
+  TaskBroker,
+  TaskBrokerDispatchOptions,
   TaskCompletionState,
   TaskContext,
   TaskSecrets,
   TaskStore,
-  TaskBroker,
-  SerializedTaskEvent,
-  SerializedTask,
 } from './types';
-import { TaskBrokerDispatchOptions } from '.';
 
 /**
  * TaskManager

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
@@ -17,7 +17,8 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import request from 'supertest';
-import { createCacheMiddleware, TechDocsCache } from '.';
+import { createCacheMiddleware } from './cacheMiddleware';
+import { TechDocsCache } from './TechDocsCache';
 
 /**
  * Mocks cached HTTP response.

--- a/plugins/techdocs/src/reader/transformers/addGitFeedbackLink.ts
+++ b/plugins/techdocs/src/reader/transformers/addGitFeedbackLink.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Transformer } from './index';
+import type { Transformer } from './transformer';
 import {
   replaceGithubUrlType,
   ScmIntegrationRegistry,

--- a/plugins/techdocs/src/reader/transformers/addSidebarToggle.ts
+++ b/plugins/techdocs/src/reader/transformers/addSidebarToggle.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Transformer } from './index';
+import type { Transformer } from './transformer';
 import MenuIcon from '@material-ui/icons/Menu';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/plugins/techdocs/src/reader/transformers/scrollIntoNavigation.test.ts
+++ b/plugins/techdocs/src/reader/transformers/scrollIntoNavigation.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { scrollIntoNavigation } from '.';
+import { scrollIntoNavigation } from './scrollIntoNavigation';
 import { createTestShadowDom, FIXTURES } from '../../test-utils';
 
 jest.useFakeTimers();

--- a/plugins/xcmetrics/src/utils/buildData.ts
+++ b/plugins/xcmetrics/src/utils/buildData.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { formatDuration } from '.';
+import { formatDuration } from './format';
 import { BuildCount, BuildTime } from '../api';
 
 export const getErrorRatios = (buildCounts?: BuildCount[]) => {


### PR DESCRIPTION
I'll be adding a lint rule for this in a separate PR, since it may be controversial (or need a separate release cycle)