### PR TITLE
Lint against dot-imports

### DIFF
--- a/.changeset/stale-wasps-do.md
+++ b/.changeset/stale-wasps-do.md
@@ -1,0 +1,17 @@
+---
+'@backstage/cli': minor
+---
+
+**BREAKING**: The linter now rejects imports from the index file of the current directory, or of any parent directory. These frequently lead to problematic circular imports.
+
+Example of a piece of code that will now be rejected:
+
+```ts
+import { MyClass } from '.';
+```
+
+It should instead be refactored to:
+
+```ts
+import { MyClass } from './MyClass';
+```

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -131,6 +131,13 @@ function createConfig(dir, extraConfig = {}) {
         2,
         {
           paths: [
+            ...['.', '..', '../..', '../../..', '../../../..', '../../../../..']
+              .flatMap(p => [p, `${p}/index`])
+              .map(p => ({
+                name: p,
+                message:
+                  'Do not import from the current index file or from index files in parent folders; this easily leads to circular dependencies. Please specify the path to the actual file you want to import instead.',
+              })),
             ...(restrictedImports ?? []),
             ...(restrictedSrcImports ?? []),
           ],


### PR DESCRIPTION
Is this controversial or inconvenient? Should I instead add it only to our local .eslintrc.js?