### PR TITLE
Implement "Branch protection rules" support for "publish:github" action

### DIFF
--- a/.changeset/ten-hats-tickle.md
+++ b/.changeset/ten-hats-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Implement "Branch protection rules" support for "publish:github" action

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -198,6 +198,13 @@ export function createGithubRepoCreateAction(options: {
   allowMergeCommit?: boolean | undefined;
   allowAutoMerge?: boolean | undefined;
   requireCodeOwnerReviews?: boolean | undefined;
+  bypassPullRequestAllowances?:
+    | {
+        users?: string[] | undefined;
+        teams?: string[] | undefined;
+        apps?: string[] | undefined;
+      }
+    | undefined;
   requiredStatusCheckContexts?: string[] | undefined;
   requireBranchesToBeUpToDate?: boolean | undefined;
   repoVisibility?: 'internal' | 'private' | 'public' | undefined;
@@ -236,6 +243,13 @@ export function createGithubRepoPushAction(options: {
   gitAuthorName?: string | undefined;
   gitAuthorEmail?: string | undefined;
   requireCodeOwnerReviews?: boolean | undefined;
+  bypassPullRequestAllowances?:
+    | {
+        users?: string[];
+        teams?: string[];
+        apps?: string[];
+      }
+    | undefined;
   requiredStatusCheckContexts?: string[] | undefined;
   requireBranchesToBeUpToDate?: boolean | undefined;
   sourcePath?: string | undefined;
@@ -366,6 +380,13 @@ export function createPublishGithubAction(options: {
   allowMergeCommit?: boolean | undefined;
   allowAutoMerge?: boolean | undefined;
   sourcePath?: string | undefined;
+  bypassPullRequestAllowances?:
+    | {
+        users?: string[];
+        teams?: string[];
+        apps?: string[];
+      }
+    | undefined;
   requireCodeOwnerReviews?: boolean | undefined;
   requiredStatusCheckContexts?: string[] | undefined;
   requireBranchesToBeUpToDate?: boolean | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
@@ -52,6 +52,11 @@ export function createGithubRepoCreateAction(options: {
     allowMergeCommit?: boolean;
     allowAutoMerge?: boolean;
     requireCodeOwnerReviews?: boolean;
+    bypassPullRequestAllowances?: {
+      users?: string[];
+      teams?: string[];
+      apps?: string[];
+    };
     requiredStatusCheckContexts?: string[];
     requireBranchesToBeUpToDate?: boolean;
     repoVisibility?: 'private' | 'internal' | 'public';
@@ -85,6 +90,7 @@ export function createGithubRepoCreateAction(options: {
           homepage: inputProps.homepage,
           access: inputProps.access,
           requireCodeOwnerReviews: inputProps.requireCodeOwnerReviews,
+          bypassPullRequestAllowances: inputProps.bypassPullRequestAllowances,
           requiredStatusCheckContexts: inputProps.requiredStatusCheckContexts,
           requireBranchesToBeUpToDate: inputProps.requireBranchesToBeUpToDate,
           repoVisibility: inputProps.repoVisibility,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoPush.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoPush.ts
@@ -49,6 +49,13 @@ export function createGithubRepoPushAction(options: {
     gitAuthorName?: string;
     gitAuthorEmail?: string;
     requireCodeOwnerReviews?: boolean;
+    bypassPullRequestAllowances?:
+      | {
+          users?: string[];
+          teams?: string[];
+          apps?: string[];
+        }
+      | undefined;
     requiredStatusCheckContexts?: string[];
     requireBranchesToBeUpToDate?: boolean;
     sourcePath?: string;
@@ -65,6 +72,7 @@ export function createGithubRepoPushAction(options: {
           repoUrl: inputProps.repoUrl,
           requireCodeOwnerReviews: inputProps.requireCodeOwnerReviews,
           requiredStatusCheckContexts: inputProps.requiredStatusCheckContexts,
+          bypassPullRequestAllowances: inputProps.bypassPullRequestAllowances,
           requireBranchesToBeUpToDate: inputProps.requireBranchesToBeUpToDate,
           defaultBranch: inputProps.defaultBranch,
           protectDefaultBranch: inputProps.protectDefaultBranch,
@@ -94,6 +102,7 @@ export function createGithubRepoPushAction(options: {
         gitAuthorName,
         gitAuthorEmail,
         requireCodeOwnerReviews = false,
+        bypassPullRequestAllowances,
         requiredStatusCheckContexts = [],
         requireBranchesToBeUpToDate = true,
         token: providedToken,
@@ -131,6 +140,7 @@ export function createGithubRepoPushAction(options: {
         client,
         repo,
         requireCodeOwnerReviews,
+        bypassPullRequestAllowances,
         requiredStatusCheckContexts,
         requireBranchesToBeUpToDate,
         config,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -247,6 +247,13 @@ export async function initRepoPushAndProtect(
   client: Octokit,
   repo: string,
   requireCodeOwnerReviews: boolean,
+  bypassPullRequestAllowances:
+    | {
+        users?: string[];
+        teams?: string[];
+        apps?: string[];
+      }
+    | undefined,
   requiredStatusCheckContexts: string[],
   requireBranchesToBeUpToDate: boolean,
   config: Config,
@@ -289,6 +296,7 @@ export async function initRepoPushAndProtect(
         repoName: repo,
         logger,
         defaultBranch,
+        bypassPullRequestAllowances,
         requireCodeOwnerReviews,
         requiredStatusCheckContexts,
         requireBranchesToBeUpToDate,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
@@ -147,6 +147,35 @@ const protectEnforceAdmins = {
   type: 'boolean',
   description: `Enforce admins to adhere to default branch protection. The default value is 'true'`,
 };
+
+const bypassPullRequestAllowances = {
+  title: 'Bypass pull request requirements',
+  description:
+    'Allow specific users, teams, or apps to bypass pull request requirements.',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    apps: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    users: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+    teams: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+  },
+};
+
 const gitCommitMessage = {
   title: 'Git Commit Message',
   type: 'string',
@@ -174,6 +203,7 @@ export { gitCommitMessage };
 export { homepage };
 export { protectDefaultBranch };
 export { protectEnforceAdmins };
+export { bypassPullRequestAllowances };
 export { repoUrl };
 export { repoVisibility };
 export { requireCodeOwnerReviews };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -185,6 +185,11 @@ type BranchProtectionOptions = {
   logger: Logger;
   requireCodeOwnerReviews: boolean;
   requiredStatusCheckContexts?: string[];
+  bypassPullRequestAllowances?: {
+    users?: string[];
+    teams?: string[];
+    apps?: string[];
+  };
   requireBranchesToBeUpToDate?: boolean;
   defaultBranch?: string;
   enforceAdmins?: boolean;
@@ -196,6 +201,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   owner,
   logger,
   requireCodeOwnerReviews,
+  bypassPullRequestAllowances,
   requiredStatusCheckContexts = [],
   requireBranchesToBeUpToDate = true,
   defaultBranch = 'master',
@@ -226,6 +232,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         required_pull_request_reviews: {
           required_approving_review_count: 1,
           require_code_owner_reviews: requireCodeOwnerReviews,
+          bypass_pull_request_allowances: bypassPullRequestAllowances,
         },
       });
     } catch (e) {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -29,6 +29,7 @@ import {
 import * as inputProps from '../github/inputProperties';
 import * as outputProps from '../github/outputProperties';
 import { parseRepoUrl } from './util';
+
 /**
  * Creates a new action that initializes a git repository of the content in the workspace
  * and publishes it to GitHub.
@@ -59,6 +60,13 @@ export function createPublishGithubAction(options: {
     allowMergeCommit?: boolean;
     allowAutoMerge?: boolean;
     sourcePath?: string;
+    bypassPullRequestAllowances?:
+      | {
+          users?: string[];
+          teams?: string[];
+          apps?: string[];
+        }
+      | undefined;
     requireCodeOwnerReviews?: boolean;
     requiredStatusCheckContexts?: string[];
     requireBranchesToBeUpToDate?: boolean;
@@ -93,6 +101,7 @@ export function createPublishGithubAction(options: {
           description: inputProps.description,
           homepage: inputProps.homepage,
           access: inputProps.access,
+          bypassPullRequestAllowances: inputProps.bypassPullRequestAllowances,
           requireCodeOwnerReviews: inputProps.requireCodeOwnerReviews,
           requiredStatusCheckContexts: inputProps.requiredStatusCheckContexts,
           requireBranchesToBeUpToDate: inputProps.requireBranchesToBeUpToDate,
@@ -129,6 +138,7 @@ export function createPublishGithubAction(options: {
         homepage,
         access,
         requireCodeOwnerReviews = false,
+        bypassPullRequestAllowances,
         requiredStatusCheckContexts = [],
         requireBranchesToBeUpToDate = true,
         repoVisibility = 'private',
@@ -195,6 +205,7 @@ export function createPublishGithubAction(options: {
         client,
         repo,
         requireCodeOwnerReviews,
+        bypassPullRequestAllowances,
         requiredStatusCheckContexts,
         requireBranchesToBeUpToDate,
         config,


### PR DESCRIPTION
Signed-off-by: Tomas Baltusis <baltusis.t@gmail.com>

## Hey, I just made a Pull Request!

Small change in the built-in "publish:github" action.
Expanded action with "Branch protection rules" support capabilities.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
