### PR TITLE
Use backend.baseUrl when redirecting in local publisher

### DIFF
--- a/plugins/techdocs-node/src/stages/publish/local.ts
+++ b/plugins/techdocs-node/src/stages/publish/local.ts
@@ -197,7 +197,7 @@ export class LocalPublish implements PublisherBase {
 
     // Redirect middleware ensuring that requests to case-sensitive entity
     // triplet paths are always sent to lower-case versions.
-    router.use((req, res, next) => {
+    router.use(async (req, res, next) => {
       // If legacy path casing is on, let the request immediately continue.
       if (this.legacyPathCasing) {
         return next();
@@ -225,7 +225,12 @@ export class LocalPublish implements PublisherBase {
       }
 
       // Otherwise, redirect to the new path.
-      return res.redirect(301, req.baseUrl + newPath);
+      return res.redirect(
+        301,
+        `${await this.discovery.getExternalBaseUrl(
+          'techdocs',
+        )}/static/docs${newPath}`,
+      );
     });
     router.use(
       express.static(this.staticDocsDir, {


### PR DESCRIPTION
Relates to https://github.com/backstage/backstage/issues/12031

When running the TechDocs backend behind a proxy that rewrites parts of the path, they will be missing on redirects.

This PR adds the origin of the request based on `backend.baseUrl` in `app-config.yaml` to the redirect location.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
