### PR TITLE
RFC backend plugin lifecycle events

### DIFF
--- a/.changeset/old-keys-leave.md
+++ b/.changeset/old-keys-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Added `lifecycleFactory` implementation.

--- a/.changeset/silly-wolves-remember.md
+++ b/.changeset/silly-wolves-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Registered shutdown hook in experimental catalog plugin.

--- a/.changeset/twenty-dodos-wash.md
+++ b/.changeset/twenty-dodos-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added `lifecycleFactory` to default service factories.

--- a/.changeset/young-turkeys-relax.md
+++ b/.changeset/young-turkeys-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Added initial support for registering shutdown hooks via `lifecycleServiceRef`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
+import { BackendLifecycle } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
@@ -65,6 +66,11 @@ export const httpRouterFactory: (
 export type HttpRouterFactoryOptions = {
   indexPlugin?: string;
 };
+
+// @public (undocumented)
+export const lifecycleFactory: (
+  options?: undefined,
+) => ServiceFactory<BackendLifecycle>;
 
 // @public (undocumented)
 export const loggerFactory: (options?: undefined) => ServiceFactory<Logger>;

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -67,7 +67,7 @@ export type HttpRouterFactoryOptions = {
   indexPlugin?: string;
 };
 
-// @public (undocumented)
+// @public
 export const lifecycleFactory: (
   options?: undefined,
 ) => ServiceFactory<BackendLifecycle>;

--- a/packages/backend-app-api/src/services/implementations/index.ts
+++ b/packages/backend-app-api/src/services/implementations/index.ts
@@ -25,4 +25,5 @@ export { schedulerFactory } from './schedulerService';
 export { tokenManagerFactory } from './tokenManagerService';
 export { urlReaderFactory } from './urlReaderService';
 export { httpRouterFactory } from './httpRouterService';
+export { lifecycleFactory } from './lifecycleService';
 export type { HttpRouterFactoryOptions } from './httpRouterService';

--- a/packages/backend-app-api/src/services/implementations/lifecycleService.test.ts
+++ b/packages/backend-app-api/src/services/implementations/lifecycleService.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import { BackendLifecycleImpl } from './lifecycleService';
+
+describe('lifecycleService', () => {
+  it('should execute registered shutdown hook', async () => {
+    const service = new BackendLifecycleImpl(getVoidLogger());
+    const hook = jest.fn();
+    service.addShutdownHook({
+      pluginId: 'test',
+      fn: async () => {
+        hook();
+      },
+    });
+    // should not execute the hook more than once.
+    await service.shutdown();
+    await service.shutdown();
+    await service.shutdown();
+    expect(hook).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not throw errors', async () => {
+    const service = new BackendLifecycleImpl(getVoidLogger());
+    service.addShutdownHook({
+      pluginId: 'test',
+      fn: async () => {
+        throw new Error('oh no');
+      },
+    });
+    await expect(service.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend-app-api/src/services/implementations/lifecycleService.ts
+++ b/packages/backend-app-api/src/services/implementations/lifecycleService.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BackendLifecycle,
+  createServiceFactory,
+  lifecycleServiceRef,
+  loggerToWinstonLogger,
+  pluginMetadataServiceRef,
+  rootLoggerServiceRef,
+  ShutdownHookOptions,
+} from '@backstage/backend-plugin-api';
+import { Logger } from 'winston';
+
+class BackendLifecycleImpl {
+  constructor(private readonly logger: Logger) {}
+  #shutdownTasks: Array<ShutdownHookOptions & { pluginId: string }> = [];
+
+  addShutdownHook(options: ShutdownHookOptions & { pluginId: string }): void {
+    this.#shutdownTasks.push(options);
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(
+      this.#shutdownTasks.map(hook =>
+        hook
+          .fn()
+          .catch(e => {
+            this.logger.error(
+              `Shutdown hook registered by plugin '${hook.pluginId}' failed with: ${e}`,
+            );
+          })
+          .then(() =>
+            this.logger.debug(
+              `Successfully ran hook registered by plugin ${hook.pluginId}`,
+            ),
+          ),
+      ),
+    );
+  }
+}
+
+class PluginScopedLifecycleImpl implements BackendLifecycle {
+  constructor(
+    private readonly lifecycle: BackendLifecycleImpl,
+    private readonly pluginId: string,
+  ) {}
+  addShutdownHook(options: ShutdownHookOptions): void {
+    this.lifecycle.addShutdownHook({ ...options, pluginId: this.pluginId });
+  }
+}
+
+/** @public */
+export const lifecycleFactory = createServiceFactory({
+  service: lifecycleServiceRef,
+  deps: {
+    logger: rootLoggerServiceRef,
+    plugin: pluginMetadataServiceRef,
+  },
+  async factory({ logger }) {
+    const rootLifecycle = new BackendLifecycleImpl(
+      loggerToWinstonLogger(logger),
+    );
+    process.on('SIGTERM', async () => await rootLifecycle.shutdown());
+    return async ({ plugin }) => {
+      return new PluginScopedLifecycleImpl(rootLifecycle, plugin.getId());
+    };
+  },
+});

--- a/packages/backend-app-api/src/services/implementations/lifecycleService.ts
+++ b/packages/backend-app-api/src/services/implementations/lifecycleService.ts
@@ -25,7 +25,7 @@ import {
 import { Logger } from 'winston';
 
 const CALLBACKS = ['SIGTERM', 'SIGINT', 'beforeExit'];
-class BackendLifecycleImpl {
+export class BackendLifecycleImpl {
   constructor(private readonly logger: Logger) {
     CALLBACKS.map(signal => process.on(signal, () => this.shutdown()));
   }
@@ -76,7 +76,9 @@ class PluginScopedLifecycleImpl implements BackendLifecycle {
   }
 }
 
-/** @public */
+/**
+ * Allows plugins to register shutdown hooks that are run when the process is about to exit.
+ * @public */
 export const lifecycleFactory = createServiceFactory({
   service: lifecycleServiceRef,
   deps: {

--- a/packages/backend-app-api/src/services/implementations/lifecycleService.ts
+++ b/packages/backend-app-api/src/services/implementations/lifecycleService.ts
@@ -39,8 +39,8 @@ class BackendLifecycleImpl {
     this.logger.info(`Running ${this.#shutdownTasks.length} shutdown tasks...`);
     await Promise.all(
       this.#shutdownTasks.map(hook =>
-        hook
-          .fn()
+        Promise.resolve()
+          .then(() => hook.fn())
           .catch(e => {
             this.logger.error(
               `Shutdown hook registered by plugin '${hook.pluginId}' failed with: ${e}`,

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -22,6 +22,7 @@ import {
   databaseFactory,
   discoveryFactory,
   httpRouterFactory,
+  lifecycleFactory,
   loggerFactory,
   permissionsFactory,
   rootLoggerFactory,
@@ -43,6 +44,7 @@ export const defaultServiceFactories = [
   tokenManagerFactory,
   urlReaderFactory,
   httpRouterFactory,
+  lifecycleFactory,
 ];
 
 /**

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -25,6 +25,11 @@ export interface BackendFeature {
 }
 
 // @public (undocumented)
+export interface BackendLifecycle {
+  addShutdownHook(options: ShutdownHookOptions): void;
+}
+
+// @public (undocumented)
 export interface BackendModuleConfig<TOptions> {
   // (undocumented)
   moduleId: string;
@@ -159,6 +164,9 @@ export interface HttpRouterService {
 export const httpRouterServiceRef: ServiceRef<HttpRouterService, 'plugin'>;
 
 // @public (undocumented)
+export const lifecycleServiceRef: ServiceRef<BackendLifecycle, 'plugin'>;
+
+// @public (undocumented)
 export interface Logger {
   // (undocumented)
   child(fields: { [name: string]: string }): Logger;
@@ -233,6 +241,11 @@ export type ServiceRef<
   T: TService;
   toString(): string;
   $$ref: 'service';
+};
+
+// @public (undocumented)
+export type ShutdownHookOptions = {
+  fn: () => Promise<void>;
 };
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -26,8 +26,13 @@ export interface BackendFeature {
 
 // @public (undocumented)
 export interface BackendLifecycle {
-  addShutdownHook(options: ShutdownHookOptions): void;
+  addShutdownHook(options: BackendLifecycleShutdownHook): void;
 }
+
+// @public (undocumented)
+export type BackendLifecycleShutdownHook = {
+  fn: () => void | Promise<void>;
+};
 
 // @public (undocumented)
 export interface BackendModuleConfig<TOptions> {
@@ -241,11 +246,6 @@ export type ServiceRef<
   T: TService;
   toString(): string;
   $$ref: 'service';
-};
-
-// @public (undocumented)
-export type ShutdownHookOptions = {
-  fn: () => Promise<void>;
 };
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -28,4 +28,9 @@ export { permissionsServiceRef } from './permissionsServiceRef';
 export { schedulerServiceRef } from './schedulerServiceRef';
 export { rootLoggerServiceRef } from './rootLoggerServiceRef';
 export { pluginMetadataServiceRef } from './pluginMetadataServiceRef';
+export { lifecycleServiceRef } from './lifecycleServiceRef';
+export type {
+  BackendLifecycle,
+  ShutdownHookOptions,
+} from './lifecycleServiceRef';
 export type { PluginMetadata } from './pluginMetadataServiceRef';

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -31,6 +31,6 @@ export { pluginMetadataServiceRef } from './pluginMetadataServiceRef';
 export { lifecycleServiceRef } from './lifecycleServiceRef';
 export type {
   BackendLifecycle,
-  ShutdownHookOptions,
+  BackendLifecycleShutdownHook,
 } from './lifecycleServiceRef';
 export type { PluginMetadata } from './pluginMetadataServiceRef';

--- a/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createServiceRef } from '../system/types';
+
+/**
+ * @public
+ **/
+export type ShutdownHookOptions = {
+  fn: () => Promise<void>;
+};
+
+/**
+ * @public
+ **/
+export interface BackendLifecycle {
+  /**
+   * Register a function to be called and when the backend is shutting down.
+   */
+  addShutdownHook(options: ShutdownHookOptions): void;
+}
+
+/**
+ * @public
+ */
+export const lifecycleServiceRef = createServiceRef<BackendLifecycle>({
+  id: 'core.lifecycle',
+  scope: 'plugin',
+});

--- a/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
@@ -19,7 +19,7 @@ import { createServiceRef } from '../system/types';
 /**
  * @public
  **/
-export type ShutdownHookOptions = {
+export type BackendLifecycleShutdownHook = {
   fn: () => Promise<void>;
 };
 
@@ -30,7 +30,7 @@ export interface BackendLifecycle {
   /**
    * Register a function to be called when the backend is shutting down.
    */
-  addShutdownHook(options: ShutdownHookOptions): void;
+  addShutdownHook(options: BackendLifecycleShutdownHook): void;
 }
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
@@ -20,7 +20,7 @@ import { createServiceRef } from '../system/types';
  * @public
  **/
 export type BackendLifecycleShutdownHook = {
-  fn: () => Promise<void>;
+  fn: () => void | Promise<void>;
 };
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/lifecycleServiceRef.ts
@@ -28,7 +28,7 @@ export type ShutdownHookOptions = {
  **/
 export interface BackendLifecycle {
   /**
-   * Register a function to be called and when the backend is shutting down.
+   * Register a function to be called when the backend is shutting down.
    */
   addShutdownHook(options: ShutdownHookOptions): void;
 }


### PR DESCRIPTION
RFC(Request for comments)

I took a stab at an initial implementation of lifecycle events for plugins in the new backend system. This allows plugin to hook into the backend shutdown behaviour and register their own logic to allow for "clean shutdowns".

This is currently implemented as a lifecycle service trapping sigterm. It might be that we want this to be more "core" and not a service but I do like that fact that it can be overridden in it's entirety if someone would like to do some completely different.

All names and implementation is up for debate, feel free to suggest improvements.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
