### PR TITLE
[Azure-Devops-Backend] ignore case readme extension 

### DIFF
--- a/.changeset/metal-hairs-mix.md
+++ b/.changeset/metal-hairs-mix.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+- Adjusted the asset parser to accept case sensitive
+- Fixed fetching data that was using the deprecated function

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -408,14 +408,15 @@ export class AzureDevOpsApi {
     content: string;
   }> {
     const url = buildEncodedUrl(host, org, project, repo, 'README.md');
-    const response = await this.urlReader.read(url);
+    const response = await this.urlReader.readUrl(url);
+    const buffer = await response.buffer();
     const content = await replaceReadme(
       this.urlReader,
       host,
       org,
       project,
       repo,
-      response.toString(),
+      buffer.toString(),
     );
     return { url, content };
   }

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
@@ -247,10 +247,15 @@ describe('replaceReadme', () => {
     `;
 
     const reader: UrlReader = {
-      read: url => new Promise<Buffer>(resolve => resolve(Buffer.from(url))),
+      readUrl: url =>
+        Promise.resolve({
+          buffer: async () => Buffer.from(url),
+          etag: 'buffer',
+          stream: jest.fn(),
+        }),
       readTree: jest.fn(),
       search: jest.fn(),
-      readUrl: jest.fn(),
+      read: jest.fn(),
     };
 
     const result = await replaceReadme(

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
@@ -167,30 +167,30 @@ describe('extractAssets', () => {
   it('should return assets', () => {
     const readme = `  
     ## Images
-    ![Image 1](./images/sample-4(2).png)
+    ![Image 1](./images/sample-4(2).PNG)
     ![Image 2](./images/cdCSj+-012340.jpg)             
     ![Image 3](/images/test-4(2)))).jpeg)       
     ![Image 4](./images/test-2211jd.webp)    
-    ![Image 5](/images/sa)mple.gif)
+    ![Image 5](/images/sa)mple.GIf)
   `;
     const result = extractAssets(readme);
     expect(result).toEqual([
-      '[Image 1](./images/sample-4(2).png)',
+      '[Image 1](./images/sample-4(2).PNG)',
       '[Image 2](./images/cdCSj+-012340.jpg)',
       '[Image 3](/images/test-4(2)))).jpeg)',
       '[Image 4](./images/test-2211jd.webp)',
-      '[Image 5](/images/sa)mple.gif)',
+      '[Image 5](/images/sa)mple.GIf)',
     ]);
   });
 });
 
 describe('extractPartsFromAsset', () => {
   it('should return parts from asset - PNG', () => {
-    const result = extractPartsFromAsset('[Image 1](./images/sample-4(2).png)');
+    const result = extractPartsFromAsset('[Image 1](./images/sample-4(2).PNG)');
     expect(result).toEqual({
       label: 'Image 1',
       path: '/images/sample-4(2)',
-      ext: '.png',
+      ext: '.PNG',
     });
   });
 
@@ -207,12 +207,12 @@ describe('extractPartsFromAsset', () => {
 
   it('should return parts from asset - JPEG', () => {
     const result = extractPartsFromAsset(
-      '[Image 2](/images/test-4(2)))).jpeg)',
+      '[Image 2](/images/test-4(2)))).JpEg)',
     );
     expect(result).toEqual({
       label: 'Image 2',
       path: '/images/test-4(2))))',
-      ext: '.jpeg',
+      ext: '.JpEg',
     });
   });
 

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
@@ -223,8 +223,9 @@ export async function replaceReadme(
         const { label, path, ext } = extractPartsFromAsset(filePath);
         const data = mime.lookup(ext);
         const url = buildEncodedUrl(host, org, project, repo, path + ext);
-        const buffer = await urlReader.read(url);
-        const file = await buffer.toString('base64');
+        const response = await urlReader.readUrl(url);
+        const buffer = await response.buffer();
+        const file = buffer.toString('base64');
         return content.replace(
           filePath,
           `[${label}](data:${data};base64,${file})`,
@@ -320,7 +321,7 @@ export function extractPartsFromAsset(content: string): {
   ext: string;
 } {
   const regExp =
-    /\[(.*?)\]\((?!https?:\/\/)(.*?)(\.png|\.jpg|\.jpeg|\.gif|\.webp)(.*)\)/;
+    /\[(.*?)\]\((?!https?:\/\/)(.*?)(\.png|\.jpg|\.jpeg|\.gif|\.webp)(.*)\)/i;
   const [_, label, path, ext] = regExp.exec(content) || [];
   return {
     ext,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adjusted the asset parser to accept case sensitive.
Fixed fetching data that was using the deprecated function

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
