### PR TITLE
added a by-refs batch endpoint for entities

### DIFF
--- a/.changeset/fast-lies-remain.md
+++ b/.changeset/fast-lies-remain.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Added new `POST /entities/by-refs` endpoint, which allows you to efficiently
+batch-fetch entities by their entity ref. This can be useful e.g. in graphql
+resolvers or similar contexts where you need to fetch many entities at the same
+time.

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -80,6 +80,36 @@ export type EntitiesResponse = {
   pageInfo: PageInfo;
 };
 
+/**
+ * A request for a batch of entities.
+ */
+export interface EntitiesBatchRequest {
+  /**
+   * The refs for which to fetch entities.
+   */
+  entityRefs: string[];
+  /**
+   * Any additional filters to apply in the selection of the entities.
+   */
+  filter?: EntityFilter;
+  /**
+   * Strips out only the parts of the entity bodies to include in the response.
+   */
+  fields?: (entity: Entity) => Entity;
+  /**
+   * The optional token that authorizes the action.
+   */
+  authorizationToken?: string;
+}
+
+export interface EntitiesBatchResponse {
+  /**
+   * The list of entities, in the same order as the refs in the request. Entries
+   * that are null signify that no entity existed with that ref.
+   */
+  items: Array<Entity | null>;
+}
+
 export type EntityAncestryResponse = {
   rootEntityRef: string;
   items: Array<{
@@ -129,6 +159,11 @@ export interface EntitiesCatalog {
    * @param request - Request options
    */
   entities(request?: EntitiesRequest): Promise<EntitiesResponse>;
+
+  /**
+   * Fetches a batch of entities.
+   */
+  entitiesBatch(request: EntitiesBatchRequest): Promise<EntitiesBatchResponse>;
 
   /**
    * Removes a single entity.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -23,6 +23,8 @@ import { InputError, NotFoundError } from '@backstage/errors';
 import { Knex } from 'knex';
 import lodash from 'lodash';
 import {
+  EntitiesBatchRequest,
+  EntitiesBatchResponse,
   EntitiesCatalog,
   EntitiesRequest,
   EntitiesResponse,
@@ -235,6 +237,38 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       entities,
       pageInfo,
     };
+  }
+
+  async entitiesBatch(
+    request: EntitiesBatchRequest,
+  ): Promise<EntitiesBatchResponse> {
+    const lookup = new Map<string, Entity>();
+
+    for (const chunk of lodash.chunk(request.entityRefs, 200)) {
+      let query = this.database<DbFinalEntitiesRow>('final_entities')
+        .innerJoin<DbRefreshStateRow>('refresh_state', {
+          'refresh_state.entity_id': 'final_entities.entity_id',
+        })
+        .select({
+          entityRef: 'refresh_state.entity_ref',
+          entity: 'final_entities.final_entity',
+        })
+        .whereIn('refresh_state.entity_ref', chunk);
+      if (request?.filter) {
+        query = parseFilter(request.filter, query, this.database);
+      }
+      for (const row of await query) {
+        lookup.set(row.entityRef, row.entity ? JSON.parse(row.entity) : null);
+      }
+    }
+
+    let items = request.entityRefs.map(ref => lookup.get(ref) ?? null);
+
+    if (request.fields) {
+      items = items.map(e => e && request.fields!(e));
+    }
+
+    return { items };
   }
 
   async removeEntityByUid(uid: string): Promise<void> {

--- a/plugins/catalog-backend/src/service/request/entitiesBatchRequest.ts
+++ b/plugins/catalog-backend/src/service/request/entitiesBatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,20 @@
  * limitations under the License.
  */
 
-export { entitiesBatchRequest } from './entitiesBatchRequest';
-export { basicEntityFilter } from './basicEntityFilter';
-export { parseEntityFilterParams } from './parseEntityFilterParams';
-export { parseEntityPaginationParams } from './parseEntityPaginationParams';
-export { parseEntityTransformParams } from './parseEntityTransformParams';
+import { InputError } from '@backstage/errors';
+import { Request } from 'express';
+import { z } from 'zod';
+
+const schema = z.object({
+  entityRefs: z.array(z.string()),
+});
+
+export function entitiesBatchRequest(req: Request) {
+  try {
+    return schema.parse(req.body);
+  } catch (error) {
+    throw new InputError(
+      `Malformed request body (did you remember to specify an application/json content type?), ${error.message}`,
+    );
+  }
+}


### PR DESCRIPTION
This is on top of #14618.

The request shape is

```json
{
  "entityRefs": [
    "component:default/one",
    "component:default/two",
    "component:default/does-not-exist"
  ]
}
```

And the response, where the items are in the same order as requested, or null where it didn't exist:

```js
{
  "items": [
    { /* complete entity */ },
    { /* complete entity */ },
    null
  ]
}
```
