### PR TITLE
Catalog graph: customize the node color

### DIFF
--- a/.changeset/short-needles-move.md
+++ b/.changeset/short-needles-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+customized catalog graph node color

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -15,7 +15,7 @@
  */
 import { DependencyGraphTypes } from '@backstage/core-components';
 import { humanizeEntityRef } from '@backstage/plugin-catalog-react';
-import { BackstageTheme } from '@backstage/theme';
+//import { BackstageTheme } from '@backstage/theme';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -22,19 +22,23 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 import { EntityKindIcon } from './EntityKindIcon';
 import { EntityNodeData } from './types';
 import { createTheme, Theme } from '@material-ui/core';
+import { Palette } from '@material-ui/core/styles/createPalette';
 import {
-  Palette,
-} from '@material-ui/core/styles/createPalette';
-import { blue, green, grey, orange, purple, red } from '@material-ui/core/colors';
+  blue,
+  green,
+  grey,
+  orange,
+  purple,
+  red,
+} from '@material-ui/core/colors';
 
-
-//in mui v5 
+//in mui v5
 import { PaletteOptions } from '@material-ui/core/styles/createPalette';
 
 declare module '@material-ui/core/styles/createPalette' {
   interface PaletteOptions {
     catalogGraph?: {
-      component?: string ;
+      component?: string;
       domain?: string;
       system?: string;
       location?: string;
@@ -42,7 +46,7 @@ declare module '@material-ui/core/styles/createPalette' {
       group?: string;
       user?: string;
       template?: string;
-      api?: string ;
+      api?: string;
     };
   }
 }

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -25,7 +25,7 @@ import { createTheme, Theme } from '@material-ui/core';
 import {
   Palette,
 } from '@material-ui/core/styles/createPalette';
-import { red } from '@material-ui/core/colors';
+import { blue, green, grey, orange, purple, red } from '@material-ui/core/colors';
 
 
 //in mui v5 
@@ -53,49 +53,44 @@ interface customTheme extends Theme {
   palette: graphPalette;
 }
 
-const customTheme: customTheme = createTheme({
+const customNodeTheme: customTheme = createTheme({
   palette: {
-    primary: {
-      main: red[300],
-    },
     catalogGraph: {
-      component: red[300],
-      domain: '#FF0000',
-      system: '#0000ff',
-      location: '#FF0000',
-      resource: '#fefefe',
-      group: '#fefefe',
-      user: '#ffffff',
-      template: '#fefefe',
-      api: '#00008B',
+      component: red[500],
+      domain: green[300],
+      system: purple[500],
+      location: orange[300],
+      resource: purple[300],
+      group: blue[500],
+      user: grey[300],
+      template: red[300],
+      api: green[500],
     },
   },
 });
 
 const useStyles = makeStyles((theme: customTheme) => ({
   node: {
-    fill: theme.palette.primary.main,
-    // fill: theme?.palette?.catalogGraph?['api'],
-    // fill: (props: { [key: string]: undefined }) =>
-    //   theme.palette.catalogGraph?.system,
+    fill: (props: { [key: string]: undefined }) =>
+      props?.kind && customNodeTheme.palette?.catalogGraph
+        ? customNodeTheme.palette.catalogGraph?.[props?.kind]
+        : theme.palette.grey[300],
     stroke: theme.palette.catalogGraph?.domain,
 
     '&.primary': {
-      fill: theme.palette.grey[300],
-      // fill: (props: { [key: string]: undefined }) =>
-      //   props?.kind && theme.palette.catalogGraph
-      //     ? theme.palette.catalogGraph[props?.kind]
-      //     : theme.palette.primary.light,
+      fill: (props: { [key: string]: undefined }) =>
+        props?.kind && customNodeTheme.palette.catalogGraph
+          ? customNodeTheme.palette.catalogGraph?.[props?.kind]
+          : theme.palette.grey[300],
       stroke: theme.palette.grey[300],
     },
     '&.secondary': {
-      fill: theme.palette.grey[300],
-      // fill: (props: { [key: string]: undefined }) =>
-      //   props?.kind && theme.palette.catalogGraph
-      //     ? theme.palette.catalogGraph[props?.kind]
-      //     : theme.palette.secondary.light,
-      stroke: theme.palette.grey[300]
-    }
+      fill: (props: { [key: string]: undefined }) =>
+        props?.kind && customNodeTheme.palette.catalogGraph
+          ? customNodeTheme.palette.catalogGraph?.[props?.kind]
+          : theme.palette.grey[300],
+      stroke: theme.palette.grey[300],
+    },
   },
   text: {
     fill: theme.palette.getContrastText(theme.palette.grey[300]),
@@ -114,47 +109,6 @@ const useStyles = makeStyles((theme: customTheme) => ({
     cursor: 'pointer',
   },
 }));
-
-// const useStyles = makeStyles((theme: BackstageTheme) => ({
-//   node: {
-//     fill: (props: { [key: string]: undefined }) =>
-//       props?.kind && theme.palette.catalogGraph
-//         ? theme.palette.catalogGraph[props?.kind]
-//         : theme.palette.grey[300],
-//     stroke: theme.palette.grey[300],
-
-//     '&.primary': {
-//       fill: (props: { [key: string]: undefined }) =>
-//         props?.kind && theme.palette.catalogGraph
-//           ? theme.palette.catalogGraph[props?.kind]
-//           : theme.palette.primary.light,
-//       stroke: theme.palette.primary.light,
-//     },
-//     '&.secondary': {
-//       fill: (props: { [key: string]: undefined }) =>
-//         props?.kind && theme.palette.catalogGraph
-//           ? theme.palette.catalogGraph[props?.kind]
-//           : theme.palette.secondary.light,
-//       stroke: theme.palette.secondary.light,
-//     },
-//   },
-//   text: {
-//     fill: theme.palette.getContrastText(theme.palette.grey[300]),
-
-//     '&.primary': {
-//       fill: theme.palette.primary.contrastText,
-//     },
-//     '&.secondary': {
-//       fill: theme.palette.secondary.contrastText,
-//     },
-//     '&.focused': {
-//       fontWeight: 'bold',
-//     },
-//   },
-//   clickable: {
-//     cursor: 'pointer',
-//   },
-// }));
 
 export function CustomNode({
   node: {
@@ -208,8 +162,8 @@ export function CustomNode({
       <rect
         className={classNames(
           classes.node,
-          // color === 'primary' && 'primary',
-          // color === 'secondary' && 'secondary',
+          color === 'primary' && 'primary',
+          color === 'secondary' && 'secondary',
         )}
         width={paddedWidth}
         height={paddedHeight}

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -21,20 +21,81 @@ import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { EntityKindIcon } from './EntityKindIcon';
 import { EntityNodeData } from './types';
+import { createTheme, Theme } from '@material-ui/core';
+import {
+  Palette,
+} from '@material-ui/core/styles/createPalette';
+import { red } from '@material-ui/core/colors';
 
-const useStyles = makeStyles((theme: BackstageTheme) => ({
+
+//in mui v5 
+import { PaletteOptions } from '@material-ui/core/styles/createPalette';
+
+declare module '@material-ui/core/styles/createPalette' {
+  interface PaletteOptions {
+    catalogGraph?: {
+      component?: string ;
+      domain?: string;
+      system?: string;
+      location?: string;
+      resource?: string;
+      group?: string;
+      user?: string;
+      template?: string;
+      api?: string ;
+    };
+  }
+}
+
+type graphPalette = Palette & PaletteOptions;
+
+interface customTheme extends Theme {
+  palette: graphPalette;
+}
+
+const customTheme: customTheme = createTheme({
+  palette: {
+    primary: {
+      main: red[300],
+    },
+    catalogGraph: {
+      component: red[300],
+      domain: '#FF0000',
+      system: '#0000ff',
+      location: '#FF0000',
+      resource: '#fefefe',
+      group: '#fefefe',
+      user: '#ffffff',
+      template: '#fefefe',
+      api: '#00008B',
+    },
+  },
+});
+
+const useStyles = makeStyles((theme: customTheme) => ({
   node: {
-    fill: theme.palette.grey[300],
-    stroke: theme.palette.grey[300],
+    fill: theme.palette.primary.main,
+    // fill: theme?.palette?.catalogGraph?['api'],
+    // fill: (props: { [key: string]: undefined }) =>
+    //   theme.palette.catalogGraph?.system,
+    stroke: theme.palette.catalogGraph?.domain,
 
     '&.primary': {
-      fill: theme.palette.primary.light,
-      stroke: theme.palette.primary.light,
+      fill: theme.palette.grey[300],
+      // fill: (props: { [key: string]: undefined }) =>
+      //   props?.kind && theme.palette.catalogGraph
+      //     ? theme.palette.catalogGraph[props?.kind]
+      //     : theme.palette.primary.light,
+      stroke: theme.palette.grey[300],
     },
     '&.secondary': {
-      fill: theme.palette.secondary.light,
-      stroke: theme.palette.secondary.light,
-    },
+      fill: theme.palette.grey[300],
+      // fill: (props: { [key: string]: undefined }) =>
+      //   props?.kind && theme.palette.catalogGraph
+      //     ? theme.palette.catalogGraph[props?.kind]
+      //     : theme.palette.secondary.light,
+      stroke: theme.palette.grey[300]
+    }
   },
   text: {
     fill: theme.palette.getContrastText(theme.palette.grey[300]),
@@ -54,6 +115,47 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
   },
 }));
 
+// const useStyles = makeStyles((theme: BackstageTheme) => ({
+//   node: {
+//     fill: (props: { [key: string]: undefined }) =>
+//       props?.kind && theme.palette.catalogGraph
+//         ? theme.palette.catalogGraph[props?.kind]
+//         : theme.palette.grey[300],
+//     stroke: theme.palette.grey[300],
+
+//     '&.primary': {
+//       fill: (props: { [key: string]: undefined }) =>
+//         props?.kind && theme.palette.catalogGraph
+//           ? theme.palette.catalogGraph[props?.kind]
+//           : theme.palette.primary.light,
+//       stroke: theme.palette.primary.light,
+//     },
+//     '&.secondary': {
+//       fill: (props: { [key: string]: undefined }) =>
+//         props?.kind && theme.palette.catalogGraph
+//           ? theme.palette.catalogGraph[props?.kind]
+//           : theme.palette.secondary.light,
+//       stroke: theme.palette.secondary.light,
+//     },
+//   },
+//   text: {
+//     fill: theme.palette.getContrastText(theme.palette.grey[300]),
+
+//     '&.primary': {
+//       fill: theme.palette.primary.contrastText,
+//     },
+//     '&.secondary': {
+//       fill: theme.palette.secondary.contrastText,
+//     },
+//     '&.focused': {
+//       fontWeight: 'bold',
+//     },
+//   },
+//   clickable: {
+//     cursor: 'pointer',
+//   },
+// }));
+
 export function CustomNode({
   node: {
     id,
@@ -66,7 +168,10 @@ export function CustomNode({
     onClick,
   },
 }: DependencyGraphTypes.RenderNodeProps<EntityNodeData>) {
-  const classes = useStyles();
+  const styleProps: any = {
+    kind: kind?.toLocaleLowerCase('en-US'),
+  };
+  const classes = useStyles({ ...styleProps });
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const idRef = useRef<SVGTextElement | null>(null);
@@ -103,8 +208,8 @@ export function CustomNode({
       <rect
         className={classNames(
           classes.node,
-          color === 'primary' && 'primary',
-          color === 'secondary' && 'secondary',
+          // color === 'primary' && 'primary',
+          // color === 'secondary' && 'secondary',
         )}
         width={paddedWidth}
         height={paddedHeight}

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -15,7 +15,6 @@
  */
 import { DependencyGraphTypes } from '@backstage/core-components';
 import { humanizeEntityRef } from '@backstage/plugin-catalog-react';
-//import { BackstageTheme } from '@backstage/theme';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';
@@ -32,7 +31,6 @@ import {
   red,
 } from '@material-ui/core/colors';
 
-//in mui v5
 import { PaletteOptions } from '@material-ui/core/styles/createPalette';
 
 declare module '@material-ui/core/styles/createPalette' {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To increase readability on catalog graphs, I'd like to be able to customize the color of the node on the basis of kind (e.g team, component, service, resource, etc.)of my graph.

<img width="1498" alt="Screenshot 2022-10-27 at 9 56 28 AM" src="https://user-images.githubusercontent.com/35890623/198191456-bdb690bb-9cc0-45c1-85f1-1cce91e07022.png">

Related PR: https://github.com/backstage/backstage/pull/12034

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off
-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
