### PR TITLE
add more specific error handling for github actions

### DIFF
--- a/.changeset/calm-clouds-smoke.md
+++ b/.changeset/calm-clouds-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Add error panel when the plugin fails.

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -29,6 +29,7 @@ import {
   useRouteRef,
 } from '@backstage/core-plugin-api';
 import {
+  ErrorPanel,
   InfoCard,
   InfoCardVariants,
   Link,
@@ -76,6 +77,11 @@ export const RecentWorkflowRunsCard = (props: {
 
   const githubHost = hostname || 'github.com';
   const routeLink = useRouteRef(buildRouteRef);
+
+  if (error) {
+    return <ErrorPanel title={error.message} error={error} />;
+  }
+
   return (
     <InfoCard
       title="Recent Workflow Runs"

--- a/plugins/github-actions/src/components/useWorkflowRuns.ts
+++ b/plugins/github-actions/src/components/useWorkflowRuns.ts
@@ -87,7 +87,9 @@ export function useWorkflowRuns({
             runId: run.id,
           });
         } catch (e) {
-          errorApi.post(e);
+          errorApi.post(
+            new Error(`Failed to rerun the workflow: ${e.message}`),
+          );
         }
       },
       source: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3314,7 +3314,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/catalog-model@npm:^1.1.1, @backstage/catalog-model@npm:^1.1.2":
+"@backstage/catalog-model@npm:^1.1.2":
   version: 1.1.2
   resolution: "@backstage/catalog-model@npm:1.1.2"
   dependencies:
@@ -3599,7 +3599,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/core-components@npm:^0.11.1, @backstage/core-components@npm:^0.11.2":
+"@backstage/core-components@npm:^0.11.2":
   version: 0.11.2
   resolution: "@backstage/core-components@npm:0.11.2"
   dependencies:
@@ -3722,7 +3722,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/core-plugin-api@npm:^1.0.6, @backstage/core-plugin-api@npm:^1.0.7":
+"@backstage/core-plugin-api@npm:^1.0.7":
   version: 1.0.7
   resolution: "@backstage/core-plugin-api@npm:1.0.7"
   dependencies:
@@ -5066,7 +5066,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-catalog-react@npm:^1.1.4, @backstage/plugin-catalog-react@npm:^1.2.0":
+"@backstage/plugin-catalog-react@npm:^1.2.0":
   version: 1.2.0
   resolution: "@backstage/plugin-catalog-react@npm:1.2.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously the errorApi would post a message to the page. However it was unclear which plugin was causing the error. Instead this renders a panel with the full error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
