### PR TITLE
Making the scaffolder template more dynamic.

### DIFF
--- a/.changeset/wise-rocks-sing.md
+++ b/.changeset/wise-rocks-sing.md
@@ -5,4 +5,4 @@
 
 Making the scaffolder template more dynamic.
 
-More information about it in writing-templates.md section "Hide sections or fields based on other fields".
+More information about it in writing-templates.md section "Hide steps based on the fields".

--- a/.changeset/wise-rocks-sing.md
+++ b/.changeset/wise-rocks-sing.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Making the scaffolder template more dynamic.
+
+More information about it in writing-templates.md section "Hide sections or fields based on other fields".

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -299,10 +299,10 @@ your first step would be shown. The same goes for the nested properties in the
 spec. Make sure to use the key `backstage:featureFlag` in your templates if
 you want to use this functionality.
 
-### Hide sections or fields based on other fields
+### Hide steps based on the fields
 
-Based on other fields you can hide sections or even only fields of your
-template. This is a good use case if you want to make your form more dynamic.
+Based on the fields you can hide the steps of your template.
+This is a good use case if you want to make your form more dynamic.
 To use it let's look at the following template:
 
 ```yaml
@@ -321,9 +321,6 @@ spec:
         enableExtraSection:
           title: Enable an extra section
           type: boolean
-        enableExtraSectionDescription:
-          title: Enable description in an extra section
-          type: boolean
     - title: Toggleable section
       required:
         - someName
@@ -333,16 +330,9 @@ spec:
           title: Some name
           type: string
           ui:field: EntityNamePicker
-        someDescription:
-          title: Some description
-          type: string
-          ui:field: EntityNamePicker
-          backstage:visible: enableExtraSectionDescription
 ```
 
-If you have a checked field `enableExtraSection` then
-`Toggleable section` would be shown. The same goes for the nested property `enableExtraSectionDescription`, which
-makes the field `someDescription` visible based on the value of `enableExtraSectionDescription`.
+If you have a checked field `enableExtraSection` then `Toggleable section` would be shown.
 
 ### The Repository Picker
 

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -299,6 +299,51 @@ your first step would be shown. The same goes for the nested properties in the
 spec. Make sure to use the key `backstage:featureFlag` in your templates if
 you want to use this functionality.
 
+### Hide sections or fields based on other fields
+
+Based on other fields you can hide sections or even only fields of your
+template. This is a good use case if you want to make your form more dynamic.
+To use it let's look at the following template:
+
+```yaml
+spec:
+  type: website
+  owner: team-a
+  parameters:
+    - title: Fill in some steps
+      required:
+        - name
+      properties:
+        name:
+          title: Name
+          type: string
+          ui:field: EntityNamePicker
+        enableExtraSection:
+          title: Enable an extra section
+          type: boolean
+        enableExtraSectionDescription:
+          title: Enable description in an extra section
+          type: boolean
+    - title: Toggleable section
+      required:
+        - someName
+      backstage:visible: enableExtraSection
+      properties:
+        someName:
+          title: Some name
+          type: string
+          ui:field: EntityNamePicker
+        someDescription:
+          title: Some description
+          type: string
+          ui:field: EntityNamePicker
+          backstage:visible: enableExtraSectionDescription
+```
+
+If you have a checked field `enableExtraSection` then
+`Toggleable section` would be shown. The same goes for the nested property `enableExtraSectionDescription`, which
+makes the field `someDescription` visible based on the value of `enableExtraSectionDescription`.
+
 ### The Repository Picker
 
 In order to make working with repository providers easier, we've built a custom

--- a/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
@@ -11,4 +11,3 @@ spec:
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/pull-request/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/springboot-grpc-template/template.yaml
-    - https://github.com/acierto/software-templates/blob/main/scaffolder-templates/docs-template-experiment/template.yaml

--- a/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
@@ -11,3 +11,4 @@ spec:
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/pull-request/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/springboot-grpc-template/template.yaml
+    - https://github.com/acierto/software-templates/blob/main/scaffolder-templates/docs-template-experiment/template.yaml

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -133,6 +133,8 @@ export const MultistepJsonForm = (props: Props) => {
   const errorApi = useApi(errorApiRef);
   const featureFlagApi = useApi(featureFlagsApiRef);
   const featureFlagKey = 'backstage:featureFlag';
+  const visibleKey = 'backstage:visible';
+
   const filterOutProperties = (step: Step): Step => {
     const filteredStep = cloneDeep(step);
     const removedPropertyKeys: Array<string> = [];
@@ -143,6 +145,14 @@ export const MultistepJsonForm = (props: Props) => {
             if (value[featureFlagKey]) {
               if (featureFlagApi.isActive(value[featureFlagKey])) {
                 return true;
+              }
+              removedPropertyKeys.push(key);
+              return false;
+            } else if (value[visibleKey]) {
+              for (const formKey in formData) {
+                if (formKey === value[visibleKey]) {
+                  return Boolean(formData[formKey]);
+                }
               }
               removedPropertyKeys.push(key);
               return false;
@@ -168,6 +178,10 @@ export const MultistepJsonForm = (props: Props) => {
       return (
         typeof featureFlag !== 'string' || featureFlagApi.isActive(featureFlag)
       );
+    })
+    .filter(step => {
+      const visible = step.schema[visibleKey];
+      return typeof visible !== 'string' || formData[visible];
     })
     .map(filterOutProperties);
 

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -148,14 +148,6 @@ export const MultistepJsonForm = (props: Props) => {
               }
               removedPropertyKeys.push(key);
               return false;
-            } else if (value[visibleKey]) {
-              for (const formKey in formData) {
-                if (formKey === value[visibleKey]) {
-                  return Boolean(formData[formKey]);
-                }
-              }
-              removedPropertyKeys.push(key);
-              return false;
             }
             return true;
           },


### PR DESCRIPTION
Signed-off-by: bnechyporenko <bnechyporenko@bol.com>

## Hey, I just made a Pull Request!

As a user I would like to have some steps to be visible/hidden based on the values provided in another fields (togglers). 

Example of template using this feature: https://github.com/acierto/software-templates/blob/main/scaffolder-templates/docs-template-experiment/template.yaml:

![Screenshot 2022-10-27 at 15 50 36](https://user-images.githubusercontent.com/2265094/198303002-6966d9e3-a175-436c-b184-d47d8367b306.png)


![Screenshot 2022-10-27 at 15 50 30](https://user-images.githubusercontent.com/2265094/198302992-5dcd035b-ca31-40df-b4c5-069415ba30ee.png)

Enabling/disabling the checkbox reflects the change in the form immediately. 

A bit more of context about that request.

We would like in bol.com to give a possibility to provision new services in GCP with a bunch of pre-configured resources. 
But which exactly resources will be included to the service will be decided in the wizard. 

So that when the user wish to include for example PubSub, this checkbox has to be checked and the appropriate step will be present to fill in details about PubSub. But if it's not required for this service to include PubSub, it's possible to exclude it, and no need to feel in those details, and even see unnecessary steps/fields in the wizard. 

https://react-jsonschema-form.readthedocs.io/en/latest/usage/dependencies/ supports only dynamic fields inside the same step. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
