### PR TITLE
Update README to replace deprecated defaultRefreshIntervalSeconds wit…

### DIFF
--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -41,7 +41,7 @@ When you have your `packages/backend/src/plugins/search.ts` file ready to make m
 
 ```ts
 indexBuilder.addCollator({
-  defaultRefreshIntervalSeconds: 600,
+  schedule,
   factory: StackOverflowQuestionsCollatorFactory.fromConfig(env.config, {
     logger: env.logger,
     requestParams: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update docs to remove reference to deprecated defaultRefreshIntervalSeconds, replace with schedule.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
