### PR TITLE
Updating newsletter subscribe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Check out [the documentation](https://backstage.io/docs/getting-started) on how 
 - [Code of Conduct](CODE_OF_CONDUCT.md) - This is how we roll
 - [Adopters](ADOPTERS.md) - Companies already using Backstage
 - [Blog](https://backstage.io/blog/) - Announcements and updates
-- [Newsletter](https://mailchi.mp/spotify/backstage-community) - Subscribe to our email newsletter
+- [Newsletter](https://spoti.fi/backstagenewsletter) - Subscribe to our email newsletter
 - [Backstage Community Sessions](https://github.com/backstage/community) - Join monthly meetups and explore Backstage community
 - Give us a star ⭐️ - If you are using Backstage or think it is an interesting project, we would love a star ❤️
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replacing the old newsletter signup link with a short link to the current signup form.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
