### PR TITLE
Fix casing of EntityNamePicker validation error message

### DIFF
--- a/.changeset/good-doors-attend.md
+++ b/.changeset/good-doors-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed tiny grammar error in EntityNamePicker. The first letter of the description is now capatalised.

--- a/.changeset/good-doors-attend.md
+++ b/.changeset/good-doors-attend.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Fixed tiny grammar error in EntityNamePicker. The first letter of the description is now capatalised.
+Fixed tiny grammar error in EntityNamePicker. The first letter of the description is now capitalized.

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.ts
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.ts
@@ -23,7 +23,7 @@ export const entityNamePickerValidation = (
 ) => {
   if (!KubernetesValidatorFunctions.isValidObjectName(value)) {
     validation.addError(
-      'must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
+      'Must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
     );
   }
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The error message for `EntityNamePicker` has two sentences.  The first word of the second sentence is capitalised, but the first sentence was not.  This fixes the capitalisation of the first sentence.

Previous Message:
![image](https://user-images.githubusercontent.com/289860/198534185-7af12da3-8fd3-471f-a615-5e8758ff762f.png)

Do you want a change set for a typo fix like this?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))