### PR TITLE
Make version bridge inspectable, to ease debugging

### DIFF
--- a/.changeset/early-jars-laugh.md
+++ b/.changeset/early-jars-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/version-bridge': minor
+---
+
+Debuggable/inspectable versioned values

--- a/.changeset/early-jars-laugh.md
+++ b/.changeset/early-jars-laugh.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/version-bridge': minor
+'@backstage/version-bridge': patch
 ---
 
 Debuggable/inspectable versioned values

--- a/packages/version-bridge/src/lib/VersionedValue.ts
+++ b/packages/version-bridge/src/lib/VersionedValue.ts
@@ -36,9 +36,27 @@ export function createVersionedValueMap<
   Versions extends { [version: number]: unknown },
 >(versions: Versions): VersionedValue<Versions> {
   Object.freeze(versions);
-  return {
+  const versionedValue: VersionedValue<Versions> = {
     atVersion(version) {
       return versions[version];
     },
   };
+  Object.defineProperty(versionedValue, '$value', {
+    configurable: false,
+    enumerable: true,
+    get() {
+      const highest = Object.keys(versions)
+        .map(v => parseInt(v, 10))
+        .sort((a, b) => b - a)[0];
+      return versions[highest];
+    },
+  });
+  Object.defineProperty(versionedValue, '$map', {
+    configurable: false,
+    enumerable: true,
+    get() {
+      return versions;
+    },
+  });
+  return versionedValue;
 }

--- a/packages/version-bridge/src/lib/VersionedValue.ts
+++ b/packages/version-bridge/src/lib/VersionedValue.ts
@@ -41,18 +41,8 @@ export function createVersionedValueMap<
       return versions[version];
     },
   };
-  Object.defineProperty(versionedValue, '$value', {
-    configurable: false,
-    enumerable: true,
-    get() {
-      const highest = Object.keys(versions)
-        .map(v => parseInt(v, 10))
-        .sort((a, b) => b - a)[0];
-      return versions[highest];
-    },
-  });
   Object.defineProperty(versionedValue, '$map', {
-    configurable: false,
+    configurable: true,
     enumerable: true,
     get() {
       return versions;


### PR DESCRIPTION
## Make versioned values inspectable/debuggable

When e.g. inspecting a React component tree, context with versioned values end up opaque. This is the React developer tools in the browser for a context provider:

<img width="680" alt="Skärmavbild 2022-10-28 kl  15 00 07" src="https://user-images.githubusercontent.com/5362579/198595841-c3e42854-5576-4505-8f5a-4e85902c40fc.png">

This PR will add the value `$value` to the (highest) versioned value, and a `$map` which is the raw version value map. Surely you could argue that this is reachable at run-time from code, it is, but it's not part of the types so it would likely not be erroneously misused.

Result:

<img width="779" alt="Skärmavbild 2022-10-28 kl  15 12 04" src="https://user-images.githubusercontent.com/5362579/198602107-df946526-fb28-4cf2-a3b9-4293971786b0.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
