### PR TITLE
Updated version badge in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Discord](https://img.shields.io/discord/687207715902193673)](https://discord.gg/EBHEGzX)
 ![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 [![Codecov](https://img.shields.io/codecov/c/github/backstage/backstage)](https://codecov.io/gh/backstage/backstage)
-[![](https://img.shields.io/npm/v/@backstage/core?label=Version)](https://github.com/backstage/backstage/releases)
+[![](https://img.shields.io/github/v/release/backstage/backstage)](https://github.com/backstage/backstage/releases)
 
 ## What is Backstage?
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The version badge in the readme was showing `v0.7.14`, which is a little out of date 😅.  The badge was tied to the now deprecated `@backstage/core` npm package. Updated the badge to be based directly on the latest release in github.

Previously
![image](https://user-images.githubusercontent.com/289860/198696777-9d1b067d-3e9b-4ada-9104-28356f24fc9d.png)

Now
![image](https://user-images.githubusercontent.com/289860/198696865-ca6010f3-b2db-48d8-ac0c-f0dcdce42171.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
