### PR TITLE
Patch release of #14135

### DIFF
--- a/.changeset/brown-days-pretend.md
+++ b/.changeset/brown-days-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Fixed bug when sending data by Post in `runChecks` and `runBulkChecks` functions of the `TechInsightsClient` class, the default `Content-Type` used was `plain/text`

--- a/.changeset/brown-days-pretend.md
+++ b/.changeset/brown-days-pretend.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-tech-insights': patch
----
-
-Fixed bug when sending data by Post in `runChecks` and `runBulkChecks` functions of the `TechInsightsClient` class, the default `Content-Type` used was `plain/text`

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-app
 
+## 0.2.77
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-tech-insights@0.3.2
+
 ## 0.2.76
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.76",
+  "version": "0.2.77",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/plugins/tech-insights/CHANGELOG.md
+++ b/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-tech-insights
 
+## 0.3.2
+
+### Patch Changes
+
+- eaa02d457a: Fixed bug when sending data by Post in `runChecks` and `runBulkChecks` functions of the `TechInsightsClient` class, the default `Content-Type` used was `plain/text`
+
 ## 0.3.1
 
 ### Patch Changes

--- a/plugins/tech-insights/package.json
+++ b/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -105,13 +105,17 @@ export class TechInsightsClient implements TechInsightsApi {
     const url = await this.discoveryApi.getBaseUrl('tech-insights');
     const { token } = await this.identityApi.getCredentials();
 
-    const request = new Request(`${url}${path}`, init);
-    if (!request.headers.has('content-type')) {
-      request.headers.set('content-type', 'application/json');
+    const headers: HeadersInit = new Headers(init?.headers);
+    if (!headers.has('content-type'))
+      headers.set('content-type', 'application/json');
+    if (token && !headers.has('authorization')) {
+      headers.set('authorization', `Bearer ${token}`);
     }
-    if (token && !request.headers.has('authorization')) {
-      request.headers.set('authorization', `Bearer ${token}`);
-    }
+
+    const request = new Request(`${url}${path}`, {
+      ...init,
+      headers,
+    });
 
     return fetch(request).then(async response => {
       if (!response.ok) {


### PR DESCRIPTION
This release fixes an issue where `@backstage/plugin-tech-insights` was using the wrong content type in requests, causing them to fail.