### PR TITLE
docs: update node versioning policy to be less optimistic

### DIFF
--- a/docs/overview/versioning-policy.md
+++ b/docs/overview/versioning-policy.md
@@ -144,9 +144,10 @@ following schedule for determining the [Node.js releases](https://nodejs.org/en/
 
 - At any given point in time we support exactly two adjacent even-numbered
   releases of Node.js, for example v12 and v14.
-- Three months before a Node.js release becomes _Active LTS_ we switch support
-  to that release and the previous one. This is halfway through the _Current LTS_
-  cycle for that release and occurs at the end of July every year.
+- Once a new Node.js release becomes _Active LTS_ we switch to support that
+  release and the previous one. The switch is not immediate but done as soon
+  as possible. You can find the Node.js version supported by each release
+  in the `engines` field in the root `package.json` of a new app.
 
 When we say _Supporting_ a Node.js release, that means the following:
 


### PR DESCRIPTION
Turns out our dependencies generally aren't ready to switch to new LTS releases until they become active, so let's update our versioning policy to match that. See #12558 for more context. 