### PR TITLE
Inject optional CatalogApi in auth-backend createRouter function. 

### DIFF
--- a/.changeset/wicked-pumas-nail.md
+++ b/.changeset/wicked-pumas-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Inject optional `CatalogApi` into auth-backend `createRouter` function. This will enable developers to use customized `CatalogApi` when creating the router.

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -670,6 +670,8 @@ export const readState: (stateString: string) => OAuthState;
 // @public (undocumented)
 export interface RouterOptions {
   // (undocumented)
+  catalogApi?: CatalogApi;
+  // (undocumented)
   config: Config;
   // (undocumented)
   database: PluginDatabaseManager;

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -28,7 +28,7 @@ import {
   TokenManager,
 } from '@backstage/backend-common';
 import { assertError, NotFoundError } from '@backstage/errors';
-import { CatalogClient } from '@backstage/catalog-client';
+import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { createOidcRouter, TokenFactory, KeyStores } from '../identity';
 import session from 'express-session';
@@ -48,6 +48,7 @@ export interface RouterOptions {
   tokenManager: TokenManager;
   tokenFactoryAlgorithm?: string;
   providerFactories?: ProviderFactories;
+  catalogApi?: CatalogApi;
 }
 
 /** @public */
@@ -62,6 +63,7 @@ export async function createRouter(
     tokenManager,
     tokenFactoryAlgorithm,
     providerFactories,
+    catalogApi,
   } = options;
   const router = Router();
 
@@ -78,7 +80,6 @@ export async function createRouter(
     logger: logger.child({ component: 'token-factory' }),
     algorithm: tokenFactoryAlgorithm,
   });
-  const catalogApi = new CatalogClient({ discoveryApi: discovery });
 
   const secret = config.getOptionalString('auth.session.secret');
   if (secret) {
@@ -127,7 +128,8 @@ export async function createRouter(
           logger,
           resolverContext: CatalogAuthResolverContext.create({
             logger,
-            catalogApi,
+            catalogApi:
+              catalogApi ?? new CatalogClient({ discoveryApi: discovery }),
             tokenIssuer,
             tokenManager,
           }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Adds on optional CatalogApi parameter to createRouter function in auth-backend plugin to let users inject their CatalogApi if needed.
 
Closes [#14186](https://github.com/backstage/backstage/issues/14186)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
