### PR TITLE
Remove app.googleAnalyticsTrackingId and related scripts

### DIFF
--- a/.changeset/four-snails-raise.md
+++ b/.changeset/four-snails-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Removed googleAnalyticsTrackingId configSchema.

--- a/.changeset/lucky-falcons-dress.md
+++ b/.changeset/lucky-falcons-dress.md
@@ -1,0 +1,38 @@
+---
+'@backstage/create-app': patch
+---
+
+The [Analytics API](https://backstage.io/docs/plugins/analytics) is the recommended way to track usage in Backstage; an optionally installable [Google Analytics module](https://github.com/backstage/backstage/tree/master/plugins/analytics-module-ga#installation) has superseded the old app.googleAnalyticsTrackingId config and its corresponding script tags in packages/app/public/index.html.
+
+For an existing installation where you want to remove the redundant app.googleAnalyticsTrackingId, you should make the following adjustment to `packages/app/public/index.html`:
+
+```diff
+    <title><%= config.getString('app.title') %></title>
+-   <% if (config.has('app.googleAnalyticsTrackingId')) { %>
+-   <script
+-       async
+-       src="https://www.googletagmanager.com/gtag/js?id=<%= config.getString('app.googleAnalyticsTrackingId') %>"
+-   ></script>
+-   <script>
+-       window.dataLayer = window.dataLayer || [];
+-       function gtag() {
+-       dataLayer.push(arguments);
+-       }
+-       gtag('js', new Date());
+-       gtag(
+-       'config',
+-       '<%= config.getString("app.googleAnalyticsTrackingId") %>',
+-       );
+-   </script>
+-   <% } %>
+</head>
+```
+
+Additionally, you should make the following adjustment to `app-config.yaml`:
+
+```diff
+app:
+  title: Backstage Example App
+  baseUrl: http://localhost:3000
+- googleAnalyticsTrackingId: # UA-000000-0
+```

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,7 +1,6 @@
 app:
   title: Backstage Example App
   baseUrl: http://localhost:3000
-  googleAnalyticsTrackingId: # UA-000000-0
   #datadogRum:
   #  clientToken: '123456789'
   #  applicationId: qwerty

--- a/contrib/chart/backstage/templates/backstage-app-config.yaml
+++ b/contrib/chart/backstage/templates/backstage-app-config.yaml
@@ -13,7 +13,6 @@ metadata:
 data:
   APP_CONFIG_app_baseUrl: {{ .Values.appConfig.app.baseUrl | quote | quote }}
   APP_CONFIG_app_title: {{ .Values.appConfig.app.title | quote | quote }}
-  APP_CONFIG_app_googleAnalyticsTrackingId: {{ .Values.appConfig.app.googleAnalyticsTrackingId | quote | quote }}
   APP_CONFIG_backend_baseUrl: {{ .Values.appConfig.backend.baseUrl | quote | quote }}
   APP_CONFIG_backend_cors_origin: {{ .Values.appConfig.backend.cors.origin | quote | quote }}
   APP_CONFIG_techdocs_storageUrl: {{ .Values.appConfig.techdocs.storageUrl | quote | quote }}

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -92,7 +92,6 @@ appConfig:
   app:
     baseUrl: https://demo.example.com
     title: Backstage
-    googleAnalyticsTrackingId:
   backend:
     baseUrl: https://demo.example.com
     listen:

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -44,24 +44,7 @@
     />
     <title><%= config.getString('app.title') %></title>
 
-    <% if (config.has('app.googleAnalyticsTrackingId')) { %>
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=<%= config.getString('app.googleAnalyticsTrackingId') %>"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag(
-        'config',
-        '<%= config.getString("app.googleAnalyticsTrackingId") %>',
-      );
-    </script>
-    <% } %> <% if (config.has('app.datadogRum')) { %>
+    <% if (config.has('app.datadogRum')) { %>
     <script>
       (function (h, o, u, n, d) {
         h = h[d] = h[d] || {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -196,14 +196,6 @@
             "type": "string",
             "visibility": "frontend"
           },
-          "googleAnalyticsTrackingId": {
-            "type": "string",
-            "visibility": "frontend",
-            "description": "Tracking ID for Google Analytics",
-            "examples": [
-              "UA-000000-0"
-            ]
-          },
           "datadogRum": {
             "type": "object",
             "description": "Datadog RUM events configuration",

--- a/packages/create-app/templates/default-app/packages/app/public/index.html
+++ b/packages/create-app/templates/default-app/packages/app/public/index.html
@@ -43,24 +43,6 @@
       color="#5bbad5"
     />
     <title><%= config.getString('app.title') %></title>
-    <% if (config.has('app.googleAnalyticsTrackingId')) { %>
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=<%= config.getString('app.googleAnalyticsTrackingId') %>"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag(
-        'config',
-        '<%= config.getString("app.googleAnalyticsTrackingId") %>',
-      );
-    </script>
-    <% } %>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/plugins/config-schema/dev/example-schema.json
+++ b/plugins/config-schema/dev/example-schema.json
@@ -19,12 +19,6 @@
           "visibility": "frontend",
           "description": "The title of the app."
         },
-        "googleAnalyticsTrackingId": {
-          "type": "string",
-          "visibility": "frontend",
-          "description": "Tracking ID for Google Analytics",
-          "examples": ["UA-000000-0"]
-        },
         "listen": {
           "type": "object",
           "description": "Listening configuration for local development",


### PR DESCRIPTION
The analytics plugin removed the need for app.googleAnalyticsTrackingId and the script tags in packages/app/public/index.html. More context: https://discord.com/channels/687207715902193673/1007303347914690610/1014108244664401952

Signed-off-by: Elizabeth Hobbs <elizabeth.hobbs94@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
