### PR TITLE
Kubernetes error indicator

### DIFF
--- a/.changeset/lemon-chicken-look.md
+++ b/.changeset/lemon-chicken-look.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+---
+
+When fetching objects from one cluster fails for a non-HTTP-status-related
+reason (like an ENOTFOUND or other system/socket error), Backstage now surfaces
+the failure in the frontend, gracefully merged with any successfully-fetched
+objects.

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -323,6 +323,14 @@ export type KubernetesObjectTypes =
   | 'daemonsets';
 
 // @alpha
+export interface KubernetesRejectionHandler {
+  onRejected: (
+    reason: any,
+    resourcePath?: string,
+  ) => Promise<KubernetesFetchError>;
+}
+
+// @alpha
 export interface KubernetesServiceLocator {
   // (undocumented)
   getClustersByEntity(

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -303,6 +303,8 @@ export interface KubernetesObjectsProviderOptions {
   // (undocumented)
   objectTypesToFetch?: ObjectToFetch[];
   // (undocumented)
+  rejectionHandler: KubernetesRejectionHandler;
+  // (undocumented)
   serviceLocator: KubernetesServiceLocator;
 }
 

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -121,6 +121,7 @@ export class KubernetesBuilder {
         serviceLocator,
         customResources,
         objectTypesToFetch: this.getObjectTypesToFetch(),
+        rejectionHandler: new KubernetesErrorIndicator(logger),
       });
 
     const router = this.buildRouter(

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -37,6 +37,7 @@ import {
   KubernetesFanOutHandler,
 } from './KubernetesFanOutHandler';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
+import { KubernetesErrorIndicator } from './KubernetesErrorIndicator';
 import { addResourceRoutesToRouter } from '../routes/resourcesRoutes';
 import { CatalogApi } from '@backstage/catalog-client';
 
@@ -202,7 +203,7 @@ export class KubernetesBuilder {
   protected buildFetcher(): KubernetesFetcher {
     return new KubernetesClientBasedFetcher({
       kubernetesClientProvider: new KubernetesClientProvider(),
-      logger: this.env.logger,
+      rejectionHandler: new KubernetesErrorIndicator(this.env.logger),
     });
   }
 

--- a/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.test.ts
@@ -91,7 +91,7 @@ describe('KubernetesErrorIndicator', () => {
 
       const result = sut
         .onRejected({ code: 'ERRORCODE', message: 'something failed' })
-        .catch(sut.onRejected);
+        .catch(sut.onRejected.bind(sut));
 
       return expect(result).resolves.toStrictEqual({
         errorType: 'UNKNOWN_ERROR',
@@ -106,7 +106,9 @@ describe('KubernetesErrorIndicator', () => {
     };
     const sut = new KubernetesErrorIndicator(logger);
 
-    const result = sut.onRejected(notFoundReason).catch(sut.onRejected);
+    const result = sut
+      .onRejected(notFoundReason)
+      .catch(sut.onRejected.bind(sut));
 
     return expect(result).resolves.toStrictEqual({
       errorType: 'ADDR_NOT_FOUND',
@@ -121,7 +123,9 @@ describe('KubernetesErrorIndicator', () => {
     };
     const sut = new KubernetesErrorIndicator(logger);
 
-    const result = sut.onRejected(timedOutReason).catch(sut.onRejected);
+    const result = sut
+      .onRejected(timedOutReason)
+      .catch(sut.onRejected.bind(sut));
 
     return expect(result).resolves.toStrictEqual({
       errorType: 'TIMED_OUT',

--- a/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Logger } from 'winston';
+import { getVoidLogger } from '@backstage/backend-common';
+import { HttpError } from '@kubernetes/client-node';
+import { KubernetesErrorIndicator } from './KubernetesErrorIndicator';
+import { IncomingMessage } from 'http';
+
+describe('KubernetesErrorIndicator', () => {
+  const logger: Logger = getVoidLogger();
+
+  describe('onRejected', () => {
+    describe('with a Kubernetes HttpError', () => {
+      it('resolves', () => {
+        const httpError = new HttpError(
+          undefined as unknown as IncomingMessage,
+          undefined,
+          400,
+        );
+
+        const result = new KubernetesErrorIndicator(logger, {
+          400: 'BAD_REQUEST',
+        }).onRejected(httpError);
+
+        return expect(result).resolves.toStrictEqual({
+          errorType: 'BAD_REQUEST',
+          statusCode: 400,
+        });
+      });
+      it('resolves unknown status code', () => {
+        const httpError = new HttpError(
+          undefined as unknown as IncomingMessage,
+          undefined,
+          900,
+        );
+
+        const result = new KubernetesErrorIndicator(logger, {}).onRejected(
+          httpError,
+        );
+
+        return expect(result).resolves.toStrictEqual({
+          errorType: 'UNKNOWN_ERROR',
+          statusCode: 900,
+        });
+      });
+      it('logs a warning', async () => {
+        const warn = jest.spyOn(logger, 'warn');
+
+        await new KubernetesErrorIndicator(logger, {}).onRejected(
+          new HttpError(
+            undefined as unknown as IncomingMessage,
+            { kind: 'Status', code: 777 },
+            777,
+          ),
+          '/some/path',
+        );
+
+        expect(warn).toHaveBeenCalledWith(
+          'statusCode=777 for resource /some/path body=[{"kind":"Status","code":777}]',
+        );
+      });
+    });
+
+    it('rejects non-http errors', () => {
+      const nonHttpError = new Error();
+
+      const result = new KubernetesErrorIndicator(logger).onRejected(
+        nonHttpError,
+      );
+
+      return expect(result).rejects.toBe(nonHttpError);
+    });
+  });
+  describe('when the rejection reason was previously intercepted', () => {
+    it('resolves as UNKNOWN_ERROR', () => {
+      const sut = new KubernetesErrorIndicator(logger);
+
+      const result = sut
+        .onRejected({ code: 'ERRORCODE', message: 'something failed' })
+        .catch(sut.onRejected);
+
+      return expect(result).resolves.toStrictEqual({
+        errorType: 'UNKNOWN_ERROR',
+        message: 'something failed',
+      });
+    });
+  });
+  it('resolves ENOTFOUND as ADDR_NOT_FOUND with hostname', () => {
+    const notFoundReason = {
+      code: 'ENOTFOUND',
+      hostname: 'foo.bar.baz',
+    };
+    const sut = new KubernetesErrorIndicator(logger);
+
+    const result = sut.onRejected(notFoundReason).catch(sut.onRejected);
+
+    return expect(result).resolves.toStrictEqual({
+      errorType: 'ADDR_NOT_FOUND',
+      hostname: 'foo.bar.baz',
+    });
+  });
+  it('resolves ETIMEDOUT as TIMED_OUT with address and port', () => {
+    const timedOutReason = {
+      code: 'ETIMEDOUT',
+      address: 'timeout.com',
+      port: 1234,
+    };
+    const sut = new KubernetesErrorIndicator(logger);
+
+    const result = sut.onRejected(timedOutReason).catch(sut.onRejected);
+
+    return expect(result).resolves.toStrictEqual({
+      errorType: 'TIMED_OUT',
+      address: 'timeout.com',
+      port: 1234,
+    });
+  });
+  it('rejects unintercepted reasons', () => {
+    const reason = { code: 'ERRORCODE', message: 'something failed' };
+
+    const result = new KubernetesErrorIndicator(logger).onRejected(reason);
+
+    return expect(result).rejects.toBe(reason);
+  });
+});

--- a/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.ts
@@ -43,10 +43,10 @@ export class KubernetesErrorIndicator implements KubernetesRejectionHandler {
     this.logger = logger;
     this.statusCodeErrorTypes = statusCodeErrorTypes;
   }
-  public onRejected: (
+  public onRejected(
     reason: any,
     resourcePath?: string,
-  ) => Promise<KubernetesFetchError> = (reason, resourcePath) => {
+  ): Promise<KubernetesFetchError> {
     if (reason.name === 'HttpError' && reason.statusCode) {
       const { body } = reason as HttpError;
       this.logger.warn(
@@ -65,7 +65,7 @@ export class KubernetesErrorIndicator implements KubernetesRejectionHandler {
     }
     this.mark(reason);
     return Promise.reject(reason);
-  };
+  }
   private surface(reason: any): KubernetesFetchError {
     switch (reason.code) {
       case 'ENOTFOUND':

--- a/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesErrorIndicator.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Logger } from 'winston';
+import {
+  KubernetesFetchError,
+  KubernetesErrorTypes,
+} from '@backstage/plugin-kubernetes-common';
+import { KubernetesRejectionHandler } from '../types/types';
+import { HttpError } from '@kubernetes/client-node';
+
+const knownStatusCodeErrors: Record<number, KubernetesErrorTypes> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED_ERROR',
+  404: 'NOT_FOUND',
+  500: 'SYSTEM_ERROR',
+};
+
+export class KubernetesErrorIndicator implements KubernetesRejectionHandler {
+  private readonly logger: Logger;
+  private readonly statusCodeErrorTypes: Record<number, KubernetesErrorTypes>;
+  private readonly signature: string = 'KubernetesFetchError';
+  constructor(
+    logger: Logger,
+    statusCodeErrorTypes: Record<
+      number,
+      KubernetesErrorTypes
+    > = knownStatusCodeErrors,
+  ) {
+    this.logger = logger;
+    this.statusCodeErrorTypes = statusCodeErrorTypes;
+  }
+  public onRejected: (
+    reason: any,
+    resourcePath?: string,
+  ) => Promise<KubernetesFetchError> = (reason, resourcePath) => {
+    if (reason.name === 'HttpError' && reason.statusCode) {
+      const { body } = reason as HttpError;
+      this.logger.warn(
+        `statusCode=${
+          reason.statusCode
+        } for resource ${resourcePath} body=[${JSON.stringify(body)}]`,
+      );
+      return Promise.resolve({
+        errorType:
+          this.statusCodeErrorTypes[reason.statusCode] || 'UNKNOWN_ERROR',
+        statusCode: reason.statusCode,
+      });
+    }
+    if (this.didIntercept(reason)) {
+      return Promise.resolve(this.surface(reason));
+    }
+    this.mark(reason);
+    return Promise.reject(reason);
+  };
+  private surface(reason: any): KubernetesFetchError {
+    switch (reason.code) {
+      case 'ENOTFOUND':
+        // Nodejs will generally set a hostname attribute on dns errors:
+        // https://github.com/nodejs/node/blob/3d1bdc954dadfd64117a251bfcde6f237c30fd68/lib/internal/errors.js#L703
+        return { errorType: 'ADDR_NOT_FOUND', hostname: reason.hostname };
+      case 'ETIMEDOUT':
+        // Nodejs will generally set `address` and `port` attributes on errors
+        // raised during `Socket.connect`:
+        // https://github.com/nodejs/node/blob/590cf569fefbe5cb2356dac47177ff79a46a9492/lib/net.js#L1036
+        return {
+          errorType: 'TIMED_OUT',
+          address: reason.address,
+          port: reason.port,
+        };
+      default:
+        return { errorType: 'UNKNOWN_ERROR', message: reason.message };
+    }
+  }
+  private didIntercept(reason: any): boolean {
+    return reason.signature === this.signature;
+  }
+  private mark(reason: any) {
+    reason.signature = this.signature;
+  }
+}

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -44,13 +44,86 @@ const POD_METRICS_FIXTURE = {
 };
 
 const mockFetch = (mock: jest.Mock) => {
-  mock.mockImplementation((params: ObjectFetchParams) =>
-    Promise.resolve(
-      generateMockResourcesAndErrors(
-        params.serviceId,
-        params.clusterDetails.name,
-      ),
-    ),
+  mock.mockImplementation(
+    ({ serviceId, clusterDetails }: ObjectFetchParams) => {
+      const clusterName = clusterDetails.name;
+      if (clusterName === 'empty-cluster') {
+        return Promise.resolve({
+          errors: [],
+          responses: [
+            {
+              type: 'pods',
+              resources: [],
+            },
+            {
+              type: 'configmaps',
+              resources: [],
+            },
+            {
+              type: 'services',
+              resources: [],
+            },
+          ],
+        });
+      } else if (clusterName === 'error-cluster') {
+        return Promise.resolve({
+          errors: ['some random cluster error'],
+          responses: [
+            {
+              type: 'pods',
+              resources: [],
+            },
+            {
+              type: 'configmaps',
+              resources: [],
+            },
+            {
+              type: 'services',
+              resources: [],
+            },
+          ],
+        });
+      }
+
+      return Promise.resolve({
+        errors: [],
+        responses: [
+          {
+            type: 'pods',
+            resources: [
+              {
+                metadata: {
+                  name: `my-pods-${serviceId}-${clusterName}`,
+                  namespace: `ns-${serviceId}-${clusterName}`,
+                },
+              },
+            ],
+          },
+          {
+            type: 'configmaps',
+            resources: [
+              {
+                metadata: {
+                  name: `my-configmaps-${serviceId}-${clusterName}`,
+                  namespace: `ns-${serviceId}-${clusterName}`,
+                },
+              },
+            ],
+          },
+          {
+            type: 'services',
+            resources: [
+              {
+                metadata: {
+                  name: `my-services-${serviceId}-${clusterName}`,
+                  namespace: `ns-${serviceId}-${clusterName}`,
+                },
+              },
+            ],
+          },
+        ],
+      });
+    },
   );
 };
 
@@ -190,88 +263,6 @@ function generatePodStatus(
         ],
       };
     }),
-  };
-}
-
-function generateMockResourcesAndErrors(
-  serviceId: string,
-  clusterName: string,
-) {
-  if (clusterName === 'empty-cluster') {
-    return {
-      errors: [],
-      responses: [
-        {
-          type: 'pods',
-          resources: [],
-        },
-        {
-          type: 'configmaps',
-          resources: [],
-        },
-        {
-          type: 'services',
-          resources: [],
-        },
-      ],
-    };
-  } else if (clusterName === 'error-cluster') {
-    return {
-      errors: ['some random cluster error'],
-      responses: [
-        {
-          type: 'pods',
-          resources: [],
-        },
-        {
-          type: 'configmaps',
-          resources: [],
-        },
-        {
-          type: 'services',
-          resources: [],
-        },
-      ],
-    };
-  }
-
-  return {
-    errors: [],
-    responses: [
-      {
-        type: 'pods',
-        resources: [
-          {
-            metadata: {
-              name: `my-pods-${serviceId}-${clusterName}`,
-              namespace: `ns-${serviceId}-${clusterName}`,
-            },
-          },
-        ],
-      },
-      {
-        type: 'configmaps',
-        resources: [
-          {
-            metadata: {
-              name: `my-configmaps-${serviceId}-${clusterName}`,
-              namespace: `ns-${serviceId}-${clusterName}`,
-            },
-          },
-        ],
-      },
-      {
-        type: 'services',
-        resources: [
-          {
-            metadata: {
-              name: `my-services-${serviceId}-${clusterName}`,
-              namespace: `ns-${serviceId}-${clusterName}`,
-            },
-          },
-        ],
-      },
-    ],
   };
 }
 

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -243,6 +243,7 @@ export interface KubernetesObjectsProviderOptions {
   serviceLocator: KubernetesServiceLocator;
   customResources: CustomResource[];
   objectTypesToFetch?: ObjectToFetch[];
+  rejectionHandler: KubernetesRejectionHandler;
 }
 
 /**

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -280,3 +280,20 @@ export interface KubernetesObjectsProvider {
     customResourcesByEntity: CustomResourcesByEntity,
   ): Promise<ObjectsByEntityResponse>;
 }
+
+/**
+ * Used to handle promise rejections arising while fetching Kubernetes objects,
+ * converting them to KubernetesFetchErrors to be surfaced by the frontend
+ * @alpha
+ */
+export interface KubernetesRejectionHandler {
+  /**
+   * Handle a rejection. Implementations must resolve any reasons that they
+   * previously rejected; i.e. `onRejected(reason).catch(onRejected)` should
+   * never reject.
+   */
+  onRejected: (
+    reason: any,
+    resourcePath?: string,
+  ) => Promise<KubernetesFetchError>;
+}

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -176,17 +176,36 @@ export interface JobsFetchResponse {
 }
 
 // @public (undocumented)
+export interface KubernetesAddrNotFoundError {
+  // (undocumented)
+  errorType: 'ADDR_NOT_FOUND';
+  // (undocumented)
+  hostname?: string;
+}
+
+// @public (undocumented)
 export type KubernetesErrorTypes =
   | 'BAD_REQUEST'
   | 'UNAUTHORIZED_ERROR'
   | 'NOT_FOUND'
   | 'SYSTEM_ERROR'
+  | 'TIMED_OUT'
+  | 'ADDR_NOT_FOUND'
   | 'UNKNOWN_ERROR';
 
 // @public (undocumented)
-export interface KubernetesFetchError {
+export type KubernetesFetchError =
+  | KubernetesHttpError
+  | KubernetesTimeoutError
+  | KubernetesAddrNotFoundError
+  | KubernetesUnknownError;
+
+// @public (undocumented)
+export interface KubernetesHttpError {
   // (undocumented)
   errorType: KubernetesErrorTypes;
+  // (undocumented)
+  message?: string;
   // (undocumented)
   resourcePath?: string;
   // (undocumented)
@@ -209,6 +228,24 @@ export interface KubernetesRequestBody {
   auth?: KubernetesRequestAuth;
   // (undocumented)
   entity: Entity;
+}
+
+// @public (undocumented)
+export interface KubernetesTimeoutError {
+  // (undocumented)
+  address: string;
+  // (undocumented)
+  errorType: 'TIMED_OUT';
+  // (undocumented)
+  port?: number;
+}
+
+// @public (undocumented)
+export interface KubernetesUnknownError {
+  // (undocumented)
+  errorType: 'UNKNOWN_ERROR';
+  // (undocumented)
+  message: string;
 }
 
 // @public (undocumented)

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -223,10 +223,37 @@ export interface PodStatusFetchResponse {
 }
 
 /** @public */
-export interface KubernetesFetchError {
+export type KubernetesFetchError =
+  | KubernetesHttpError
+  | KubernetesTimeoutError
+  | KubernetesAddrNotFoundError
+  | KubernetesUnknownError;
+
+/** @public */
+export interface KubernetesHttpError {
   errorType: KubernetesErrorTypes;
   statusCode?: number;
   resourcePath?: string;
+  message?: string;
+}
+
+/** @public */
+export interface KubernetesTimeoutError {
+  errorType: 'TIMED_OUT';
+  address: string;
+  port?: number;
+}
+
+/** @public */
+export interface KubernetesAddrNotFoundError {
+  errorType: 'ADDR_NOT_FOUND';
+  hostname?: string;
+}
+
+/** @public */
+export interface KubernetesUnknownError {
+  errorType: 'UNKNOWN_ERROR';
+  message: string;
 }
 
 /** @public */
@@ -235,6 +262,8 @@ export type KubernetesErrorTypes =
   | 'UNAUTHORIZED_ERROR'
   | 'NOT_FOUND'
   | 'SYSTEM_ERROR'
+  | 'TIMED_OUT'
+  | 'ADDR_NOT_FOUND'
   | 'UNKNOWN_ERROR';
 
 /** @public */

--- a/plugins/kubernetes/src/components/ErrorPanel/ErrorPanel.test.tsx
+++ b/plugins/kubernetes/src/components/ErrorPanel/ErrorPanel.test.tsx
@@ -20,36 +20,14 @@ import { wrapInTestApp } from '@backstage/test-utils';
 import { ErrorPanel } from './ErrorPanel';
 
 describe('ErrorPanel', () => {
-  it('render with error message', async () => {
-    const { getByText } = render(
-      wrapInTestApp(
-        <ErrorPanel
-          entityName="THIS_ENTITY"
-          errorMessage="SOME_ERROR_MESSAGE"
-        />,
-      ),
-    );
-
-    // title
-    expect(
-      getByText(
-        'There was a problem retrieving some Kubernetes resources for the entity: THIS_ENTITY. This could mean that the Error Reporting card is not completely accurate.',
-      ),
-    ).toBeInTheDocument();
-
-    // message
-    expect(getByText('Errors: SOME_ERROR_MESSAGE')).toBeInTheDocument();
-  });
-  it('render with cluster errors', async () => {
+  it('displays path and status code when a cluster has an HTTP error', async () => {
     const { getByText } = render(
       wrapInTestApp(
         <ErrorPanel
           entityName="THIS_ENTITY"
           clustersWithErrors={[
             {
-              cluster: {
-                name: 'THIS_CLUSTER',
-              },
+              cluster: { name: 'THIS_CLUSTER' },
               resources: [],
               podMetrics: [],
               errors: [
@@ -80,5 +58,116 @@ describe('ErrorPanel', () => {
         "Error fetching Kubernetes resource: 'some/resource', error: SYSTEM_ERROR, status code: 500",
       ),
     ).toBeInTheDocument();
+  });
+  it('displays address and port when a cluster has a timeout error', async () => {
+    const { getByText } = render(
+      wrapInTestApp(
+        <ErrorPanel
+          entityName="THIS_ENTITY"
+          clustersWithErrors={[
+            {
+              cluster: { name: 'THIS_CLUSTER' },
+              resources: [],
+              podMetrics: [],
+              errors: [
+                { errorType: 'TIMED_OUT', address: 'timeout.com', port: 443 },
+              ],
+            },
+          ]}
+        />,
+      ),
+    );
+
+    expect(getByText('Cluster: THIS_CLUSTER')).toBeInTheDocument();
+    expect(
+      getByText(
+        "Timed out attempting to connect to Kubernetes API at address 'timeout.com' on port 443",
+      ),
+    ).toBeInTheDocument();
+  });
+  it('displays hostname when a cluster has a DNS error', async () => {
+    const { getByText } = render(
+      wrapInTestApp(
+        <ErrorPanel
+          entityName="THIS_ENTITY"
+          clustersWithErrors={[
+            {
+              cluster: { name: 'THIS_CLUSTER' },
+              resources: [],
+              podMetrics: [],
+              errors: [
+                {
+                  errorType: 'ADDR_NOT_FOUND',
+                  hostname: 'foo.bar.baz',
+                },
+              ],
+            },
+          ]}
+        />,
+      ),
+    );
+
+    expect(getByText('Cluster: THIS_CLUSTER')).toBeInTheDocument();
+    expect(
+      getByText("Could not resolve Kubernetes API hostname: 'foo.bar.baz'"),
+    ).toBeInTheDocument();
+  });
+  it('displays message for unknown non-HTTP errors', async () => {
+    const { getByText } = render(
+      wrapInTestApp(
+        <ErrorPanel
+          entityName="THIS_ENTITY"
+          clustersWithErrors={[
+            {
+              cluster: { name: 'THIS_CLUSTER' },
+              resources: [],
+              podMetrics: [],
+              errors: [
+                {
+                  errorType: 'UNKNOWN_ERROR',
+                  message: 'description of error',
+                },
+              ],
+            },
+          ]}
+        />,
+      ),
+    );
+
+    // title
+    expect(
+      getByText(
+        'There was a problem retrieving some Kubernetes resources for the entity: THIS_ENTITY. This could mean that the Error Reporting card is not completely accurate.',
+      ),
+    ).toBeInTheDocument();
+
+    // message
+    expect(getByText('Errors:')).toBeInTheDocument();
+    expect(getByText('Cluster: THIS_CLUSTER')).toBeInTheDocument();
+    expect(
+      getByText(
+        'Error communicating with Kubernetes: UNKNOWN_ERROR, message: description of error',
+      ),
+    ).toBeInTheDocument();
+  });
+  it('displays error message', async () => {
+    const { getByText } = render(
+      wrapInTestApp(
+        <ErrorPanel
+          entityName="THIS_ENTITY"
+          errorMessage="SOME_ERROR_MESSAGE"
+        />,
+      ),
+    );
+
+    // title
+    expect(
+      getByText(
+        'There was a problem retrieving some Kubernetes resources for the entity: THIS_ENTITY. This could mean that the Error Reporting card is not completely accurate.',
+      ),
+    ).toBeInTheDocument();
+
+    // message
+    expect(getByText('Errors: SOME_ERROR_MESSAGE')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #13794.
There's a decent bit of refactoring in here and a lot of the decisions are discussed at some length in the commit messages -- mostly I really wanted to avoid catching any old promise rejection and surfacing it in the UI -- unfortunately I couldn't find a way to narrow to purely `error` events coming from the socket used by `@kubernetes/client-node` to talk to k8s, but I added some logic to make sure that it's at least only promise rejections coming from that library.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
