### PR TITLE
feat(splunk-on-call): use routing key instead of team name for triggered incidents

### DIFF
--- a/.changeset/funny-singers-serve.md
+++ b/.changeset/funny-singers-serve.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-splunk-on-call': minor
+---
+
+Use the routing key if it's available instead of team name when triggering incidents.
+
+BREAKING CHANGE:
+Before, the team name was used even if the routing key (with or without team) was used.
+Now, the routing key defined for the component will be used instead of the team name.

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { Entity } from '@backstage/catalog-model';
+import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
+import {
+  alertApiRef,
+  ConfigApi,
+  configApiRef,
+} from '@backstage/core-plugin-api';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
 import {
   splunkOnCallApiRef,
   SplunkOnCallClient,
@@ -33,13 +39,7 @@ import {
   MOCK_TEAM_NO_INCIDENTS,
 } from '../api/mocks';
 import { EntitySplunkOnCallCard } from './EntitySplunkOnCallCard';
-
-import {
-  alertApiRef,
-  ConfigApi,
-  configApiRef,
-} from '@backstage/core-plugin-api';
-import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
+import { expectTriggeredIncident } from './TriggerDialog/testUtils';
 
 const mockSplunkOnCallApi: Partial<SplunkOnCallClient> = {
   getUsers: async () => [],
@@ -167,8 +167,10 @@ describe('SplunkOnCallCard', () => {
     mockSplunkOnCallApi.getTeams = jest
       .fn()
       .mockImplementation(async () => [MOCK_TEAM]);
+    const mockTriggerAlarmFn = jest.fn();
+    mockSplunkOnCallApi.incidentAction = mockTriggerAlarmFn;
 
-    const { getByText, queryByTestId } = render(
+    const { getByRole, getByTestId, getByText, queryByTestId } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
           <EntityProvider entity={mockEntityWithRoutingKeyAnnotation}>
@@ -179,9 +181,22 @@ describe('SplunkOnCallCard', () => {
     );
     await waitFor(() => !queryByTestId('progress'));
     expect(getByText(`Team: ${MOCK_TEAM.name}`)).toBeInTheDocument();
+    expect(getByText('Create Incident')).toBeInTheDocument();
     await waitFor(
       () => expect(getByText('test-incident')).toBeInTheDocument(),
       { timeout: 2000 },
+    );
+
+    const createIncidentButton = await getByText('Create Incident');
+    await act(async () => {
+      fireEvent.click(createIncidentButton);
+    });
+    expect(getByRole('dialog')).toBeInTheDocument();
+
+    await expectTriggeredIncident(
+      'test-routing-key',
+      getByTestId,
+      mockTriggerAlarmFn,
     );
   });
 

--- a/plugins/splunk-on-call/src/components/TriggerDialog/TriggerDialog.test.tsx
+++ b/plugins/splunk-on-call/src/components/TriggerDialog/TriggerDialog.test.tsx
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
-import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
-import { splunkOnCallApiRef } from '../../api';
-import { TriggerDialog } from './TriggerDialog';
-
 import { ApiProvider } from '@backstage/core-app-api';
 import { alertApiRef } from '@backstage/core-plugin-api';
+import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { splunkOnCallApiRef } from '../../api';
+import { TriggerDialog } from './TriggerDialog';
+import { expectTriggeredIncident } from './testUtils';
 
 describe('TriggerDialog', () => {
   const mockTriggerAlarmFn = jest.fn();
@@ -38,7 +38,7 @@ describe('TriggerDialog', () => {
       wrapInTestApp(
         <ApiProvider apis={apis}>
           <TriggerDialog
-            team="Example"
+            routingKey="Example"
             showDialog
             handleDialog={() => {}}
             onIncidentCreated={() => {}}
@@ -53,34 +53,6 @@ describe('TriggerDialog', () => {
         exact: false,
       }),
     ).toBeInTheDocument();
-    const incidentType = getByTestId('trigger-incident-type');
-    const incidentId = getByTestId('trigger-incident-id');
-    const incidentDisplayName = getByTestId('trigger-incident-displayName');
-    const incidentMessage = getByTestId('trigger-incident-message');
-
-    await act(async () => {
-      fireEvent.change(incidentType, { target: { value: 'CRITICAL' } });
-      fireEvent.change(incidentId, { target: { value: 'incident-id' } });
-      fireEvent.change(incidentDisplayName, {
-        target: { value: 'incident-display-name' },
-      });
-      fireEvent.change(incidentMessage, {
-        target: { value: 'incident-message' },
-      });
-    });
-
-    // Trigger incident creation button
-    const triggerButton = getByTestId('trigger-button');
-    await act(async () => {
-      fireEvent.click(triggerButton);
-    });
-    expect(mockTriggerAlarmFn).toHaveBeenCalled();
-    expect(mockTriggerAlarmFn).toHaveBeenCalledWith({
-      incidentType: 'CRITICAL',
-      incidentId: 'incident-id',
-      routingKey: 'Example',
-      incidentDisplayName: 'incident-display-name',
-      incidentMessage: 'incident-message',
-    });
+    await expectTriggeredIncident('Example', getByTestId, mockTriggerAlarmFn);
   });
 });

--- a/plugins/splunk-on-call/src/components/TriggerDialog/TriggerDialog.tsx
+++ b/plugins/splunk-on-call/src/components/TriggerDialog/TriggerDialog.tsx
@@ -35,11 +35,11 @@ import {
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { splunkOnCallApiRef } from '../../api';
 import { Alert } from '@material-ui/lab';
-import { TriggerAlarmRequest } from '../../api/types';
+import { TriggerAlarmRequest } from '../../api';
 import { useApi, alertApiRef } from '@backstage/core-plugin-api';
 
 type Props = {
-  team: string;
+  routingKey: string;
   showDialog: boolean;
   handleDialog: () => void;
   onIncidentCreated: () => void;
@@ -76,7 +76,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 export const TriggerDialog = ({
-  team,
+  routingKey,
   showDialog,
   handleDialog,
   onIncidentCreated: onIncidentCreated,
@@ -221,7 +221,7 @@ export const TriggerDialog = ({
           id="details"
           multiline
           fullWidth
-          rows="2"
+          minRows="2"
           margin="normal"
           label="Incident message"
           variant="outlined"
@@ -242,7 +242,7 @@ export const TriggerDialog = ({
           variant="contained"
           onClick={() =>
             handleTriggerAlarm({
-              routingKey: team,
+              routingKey,
               incidentType,
               incidentDisplayName,
               incidentMessage,

--- a/plugins/splunk-on-call/src/components/TriggerDialog/testUtils.ts
+++ b/plugins/splunk-on-call/src/components/TriggerDialog/testUtils.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  act,
+  fireEvent,
+  Matcher,
+  MatcherOptions,
+} from '@testing-library/react';
+
+export async function expectTriggeredIncident(
+  routingKey: string,
+  getByTestId: (
+    id: Matcher,
+    options?: MatcherOptions | undefined,
+  ) => HTMLElement,
+  mockTriggerAlarmFn: any,
+): Promise<void> {
+  const incidentType = getByTestId('trigger-incident-type');
+  const incidentId = getByTestId('trigger-incident-id');
+  const incidentDisplayName = getByTestId('trigger-incident-displayName');
+  const incidentMessage = getByTestId('trigger-incident-message');
+
+  await act(async () => {
+    fireEvent.change(incidentType, { target: { value: 'CRITICAL' } });
+    fireEvent.change(incidentId, { target: { value: 'incident-id' } });
+    fireEvent.change(incidentDisplayName, {
+      target: { value: 'incident-display-name' },
+    });
+    fireEvent.change(incidentMessage, {
+      target: { value: 'incident-message' },
+    });
+  });
+
+  // Trigger incident creation button
+  const triggerButton = getByTestId('trigger-button');
+  await act(async () => {
+    fireEvent.click(triggerButton);
+  });
+
+  expect(mockTriggerAlarmFn).toHaveBeenCalled();
+  expect(mockTriggerAlarmFn).toHaveBeenCalledWith({
+    incidentType: 'CRITICAL',
+    incidentId: 'incident-id',
+    routingKey: routingKey,
+    incidentDisplayName: 'incident-display-name',
+    incidentMessage: 'incident-message',
+  });
+}


### PR DESCRIPTION
Use the routing key if it's available instead of team name when triggering incidents.

BREAKING CHANGE:
Before, the team name was used even if the routing key (with or without team) was used. Now, the routing key defined for the component will be used instead of the team name.

Closes: #14453
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
