### PR TITLE
workflows/ci: try lower jest worker memory limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - name: test all packages (and upload coverage)
         if: ${{ steps.yarn-lock.outcome == 'failure' }}
         run: |
-          yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=1300M --coverage
+          yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=800M --coverage
           bash <(curl -s https://codecov.io/bash) -N $(git rev-parse FETCH_HEAD)
         env:
           BACKSTAGE_NEXT_TESTS: 1


### PR DESCRIPTION
Trying this as a bit of a workaround for the flaky DB tests. This should cause the workers to restart more often and purge their state. It's slow down the tests a lil bit since 1.3GB seemed to be the optimal limit, but nothing too bad.