### PR TITLE
Pass through the `formData` into the `formContext` for the `next` scaffolder

### DIFF
--- a/.changeset/moody-pots-end.md
+++ b/.changeset/moody-pots-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix `formData` not being present in the `next` version

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -143,6 +143,7 @@ export const Stepper = (props: StepperProps) => {
             validator={validator}
             extraErrors={errors as unknown as ErrorSchema}
             formData={formState}
+            formContext={{ formData: formState }}
             schema={steps[activeStep].schema}
             uiSchema={steps[activeStep].uiSchema}
             onSubmit={handleNext}


### PR DESCRIPTION
Fixes #14308