### PR TITLE
cli: give repo build config options lower priority

### DIFF
--- a/.changeset/large-flies-check.md
+++ b/.changeset/large-flies-check.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Allow passing `--config` option to `repo build` command
+Allow passing `--config` option to `repo build` command. The option will only be forwarded to packages with the package role `'frontend'`, and only if the build script in the package does not already have any `--config` options.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -18,12 +18,14 @@ import { assertError } from '@backstage/errors';
 import { Command } from 'commander';
 import { exitWithError } from '../lib/errors';
 
-const configOption = [
-  '--config <path>',
-  'Config files to load instead of app-config.yaml',
-  (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
-  Array<string>(),
-] as const;
+function configOption(msg = 'Config files to load instead of app-config.yaml') {
+  return [
+    '--config <path>',
+    msg,
+    (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
+    Array<string>(),
+  ] as const;
+}
 
 export function registerRepoCommand(program: Command) {
   const command = program
@@ -35,7 +37,11 @@ export function registerRepoCommand(program: Command) {
     .description(
       'Build packages in the project, excluding bundled app and backend packages.',
     )
-    .option(...configOption)
+    .option(
+      ...configOption(
+        "Config files for app packages that don't already override the config in their build script",
+      ),
+    )
     .option(
       '--all',
       'Build all packages, including bundled app and backend packages.',
@@ -97,7 +103,7 @@ export function registerScriptCommand(program: Command) {
   command
     .command('start')
     .description('Start a package for local development')
-    .option(...configOption)
+    .option(...configOption())
     .option('--role <name>', 'Run the command with an explicit package role')
     .option('--check', 'Enable type checking and linting if available')
     .option('--inspect', 'Enable debugger in Node.js environments')
@@ -319,7 +325,7 @@ export function registerCommands(program: Command) {
       '--format <format>',
       'Format to print the configuration in, either json or yaml [yaml]',
     )
-    .option(...configOption)
+    .option(...configOption())
     .description('Print the app configuration for the current package')
     .action(lazy(() => import('./config/print').then(m => m.default)));
 
@@ -332,7 +338,7 @@ export function registerCommands(program: Command) {
     .option('--lax', 'Do not require environment variables to be set')
     .option('--frontend', 'Only validate the frontend configuration')
     .option('--deprecated', 'Output deprecated configuration settings')
-    .option(...configOption)
+    .option(...configOption())
     .description(
       'Validate that the given configuration loads and matches schema',
     )

--- a/packages/cli/src/commands/repo/build.ts
+++ b/packages/cli/src/commands/repo/build.ts
@@ -153,9 +153,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           return;
         }
 
-        const configPaths = opts.config?.length
-          ? opts.config
-          : buildOptions.config ?? [];
+        const configPaths = buildOptions.config ?? opts.config ?? [];
 
         await buildFrontend({
           targetDir: pkg.dir,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Tweak on top of #14500. Something like this is needed because the change currently breaks the TechDocs embedded app. I'm feeling this is probably the most sensible solution, because explicit config flags really aren't needed at the package level once we roll this out. In case someone does want to use them, you can place them in a separate package script instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
