### PR TITLE
Revert "cli: allow passing --config option to repo build command"

### DIFF
--- a/.changeset/large-flies-check.md
+++ b/.changeset/large-flies-check.md
@@ -1,5 +1,0 @@
----
-'@backstage/cli': patch
----
-
-Allow passing `--config` option to `repo build` command

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -400,7 +400,6 @@ Commands:
 Usage: backstage-cli repo build [options]
 
 Options:
-  --config <path>
   --all
   --since <ref>
   -h, --help

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -35,7 +35,6 @@ export function registerRepoCommand(program: Command) {
     .description(
       'Build packages in the project, excluding bundled app and backend packages.',
     )
-    .option(...configOption)
     .option(
       '--all',
       'Build all packages, including bundled app and backend packages.',

--- a/packages/cli/src/commands/repo/build.ts
+++ b/packages/cli/src/commands/repo/build.ts
@@ -152,14 +152,9 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           );
           return;
         }
-
-        const configPaths = opts.config?.length
-          ? opts.config
-          : buildOptions.config ?? [];
-
         await buildFrontend({
           targetDir: pkg.dir,
-          configPaths,
+          configPaths: (buildOptions.config as string[]) ?? [],
           writeStats: Boolean(buildOptions.stats),
         });
       },


### PR DESCRIPTION
Potential replacement of #14512, simply reverting #14500