### PR TITLE
Add default errorHandler() to vault-backend

### DIFF
--- a/.changeset/rude-mayflies-heal.md
+++ b/.changeset/rude-mayflies-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-vault-backend': patch
+---
+
+Added errorHandler() middleware to vault-backend to prevent errors to cause a crash

--- a/.changeset/rude-mayflies-heal.md
+++ b/.changeset/rude-mayflies-heal.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-vault-backend': patch
 ---
 
-Added errorHandler() middleware to vault-backend to prevent errors to cause a crash
+Added `errorHandler()` middleware to `router` to prevent crashes caused by fatal errors in plugin backend

--- a/plugins/vault-backend/src/service/VaultBuilder.ts
+++ b/plugins/vault-backend/src/service/VaultBuilder.ts
@@ -20,6 +20,7 @@ import { Logger } from 'winston';
 import express, { Router } from 'express';
 import { VaultClient } from './vaultApi';
 import { TaskRunner, PluginTaskScheduler } from '@backstage/backend-tasks';
+import { errorHandler } from '@backstage/backend-common';
 
 /**
  * Environment values needed by the VaultBuilder
@@ -145,6 +146,7 @@ export class VaultBuilder {
       res.json({ items: secrets });
     });
 
+    router.use(errorHandler());
     return router;
   }
 }


### PR DESCRIPTION
Right now any uncaught error causes backstage to crash
We should use `packages/backend-common/src/middleware/errorHandler.ts` middleware like the other backend plugins

Signed-off-by: Casper Thygesen <73483987+cthtrifork@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
