### PR TITLE
feat(catalog): add option for extra actions/header icon links at AboutCard

### DIFF
--- a/.changeset/clean-timers-collect.md
+++ b/.changeset/clean-timers-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Add option for extra actions and/or header icon links at the `EntityAboutCard`.

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -11,11 +11,13 @@ import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
+import { IconLinkVerticalProps } from '@backstage/core-components';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { InfoCardVariants } from '@backstage/core-components';
 import { Observable } from '@backstage/types';
 import { Overrides } from '@material-ui/core/styles/overrides';
 import { default as React_2 } from 'react';
+import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { ResultHighlight } from '@backstage/plugin-search-common';
 import { RouteRef } from '@backstage/core-plugin-api';
@@ -29,6 +31,10 @@ import { UserListFilterKind } from '@backstage/plugin-catalog-react';
 
 // @public
 export interface AboutCardProps {
+  // (undocumented)
+  extraActions?: ReactElement<any, any>;
+  // (undocumented)
+  extraHeaderIconLinks?: IconLinkVerticalProps[];
   // (undocumented)
   variant?: InfoCardVariants;
 }

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -47,7 +47,7 @@ import {
 import CachedIcon from '@material-ui/icons/Cached';
 import DocsIcon from '@material-ui/icons/Description';
 import EditIcon from '@material-ui/icons/Edit';
-import React, { useCallback } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import { viewTechDocRouteRef } from '../../routes';
 import { AboutContent } from './AboutContent';
 
@@ -77,6 +77,8 @@ const useStyles = makeStyles({
  * @public
  */
 export interface AboutCardProps {
+  extraActions?: ReactElement<any, any>;
+  extraHeaderIconLinks?: IconLinkVerticalProps[];
   variant?: InfoCardVariants;
 }
 
@@ -119,6 +121,11 @@ export function AboutCard(props: AboutCardProps) {
         name: entity.metadata.name,
       }),
   };
+  const headerIconLinks = [
+    viewInSource,
+    viewInTechDocs,
+    ...(props.extraHeaderIconLinks ?? []),
+  ];
 
   let cardClass = '';
   if (variant === 'gridItem') {
@@ -149,6 +156,7 @@ export function AboutCard(props: AboutCardProps) {
         title="About"
         action={
           <>
+            {props.extraActions}
             {allowRefresh && (
               <IconButton
                 aria-label="Refresh"
@@ -169,7 +177,7 @@ export function AboutCard(props: AboutCardProps) {
             </IconButton>
           </>
         }
-        subheader={<HeaderIconLinkRow links={[viewInSource, viewInTechDocs]} />}
+        subheader={<HeaderIconLinkRow links={headerIconLinks} />}
       />
       <Divider />
       <CardContent className={cardContentClass}>


### PR DESCRIPTION
Allows to add extra actions (next to refresh and edit) and/or extra header icon links (next to "View Source" and "View TechDocs") to the EntityAboutCard.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![Screen Shot 2022-11-09 at 20 36 46](https://user-images.githubusercontent.com/2513586/200928898-e6d30fc6-f2b5-4366-87ef-4726eff16d3d.png)
