### PR TITLE
docs: fix /frame/handler => /handler/frame typo

### DIFF
--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -49,7 +49,7 @@ the user to initiate a login. This login request is done to the `/start`
 endpoint which is handled by the `start` method.
 
 The `start` method re-directs to the external auth provider who authenticates
-the request and re-directs the request to the `/frame/handler` endpoint, which
+the request and re-directs the request to the `/handler/frame` endpoint, which
 is handled by the `frameHandler` method.
 
 The `frameHandler` returns an HTML response, containing a script that does a


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix small typo where the `/handler/frame` path was referred to as `/frame/handler`.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
