### PR TITLE
scaffolder/next: fix the return type for `createNextScaffolderFieldExtension`

### DIFF
--- a/.changeset/tidy-avocados-ring.md
+++ b/.changeset/tidy-avocados-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix the return type for the `createNextScaffodlerFieldExtension` type as before it wasn't a component type for the extension

--- a/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
+++ b/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 import React from 'react';
-import type { FieldValidation } from '@rjsf/core';
+import type { FieldValidation } from '@rjsf/utils';
 import {
+  createNextScaffolderFieldExtension,
   createScaffolderFieldExtension,
   FieldExtensionComponentProps,
+  NextFieldExtensionComponentProps,
   scaffolderPlugin,
 } from '@backstage/plugin-scaffolder';
 
@@ -64,7 +66,7 @@ export const LowerCaseValuePickerFieldExtension = scaffolderPlugin.provide(
 );
 
 const MockDelayComponent = (
-  props: FieldExtensionComponentProps<{ test?: string }>,
+  props: NextFieldExtensionComponentProps<{ test?: string }>,
 ) => {
   const { onChange, formData, rawErrors } = props;
   return (
@@ -80,7 +82,7 @@ const MockDelayComponent = (
 };
 
 export const DelayingComponentFieldExtension = scaffolderPlugin.provide(
-  createScaffolderFieldExtension({
+  createNextScaffolderFieldExtension({
     name: 'DelayingComponent',
     component: MockDelayComponent,
     validation: async (

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -42,7 +42,7 @@ export function createNextScaffolderFieldExtension<
   TInputProps extends UIOptionsType = {},
 >(
   options: NextFieldExtensionOptions<TReturnValue, TInputProps>,
-): Extension<NextFieldExtensionComponentProps<TReturnValue, TInputProps>>;
+): Extension<FieldExtensionComponent<TReturnValue, TInputProps>>;
 
 // @public
 export function createScaffolderFieldExtension<

--- a/plugins/scaffolder/src/extensions/index.tsx
+++ b/plugins/scaffolder/src/extensions/index.tsx
@@ -72,7 +72,7 @@ export function createNextScaffolderFieldExtension<
   TInputProps extends UIOptionsType = {},
 >(
   options: NextFieldExtensionOptions<TReturnValue, TInputProps>,
-): Extension<NextFieldExtensionComponentProps<TReturnValue, TInputProps>> {
+): Extension<React.ComponentType> {
   return {
     expose() {
       const FieldExtensionDataHolder: any = () => null;

--- a/plugins/scaffolder/src/extensions/index.tsx
+++ b/plugins/scaffolder/src/extensions/index.tsx
@@ -72,7 +72,7 @@ export function createNextScaffolderFieldExtension<
   TInputProps extends UIOptionsType = {},
 >(
   options: NextFieldExtensionOptions<TReturnValue, TInputProps>,
-): Extension<React.ComponentType> {
+): Extension<FieldExtensionComponent<TReturnValue, TInputProps>> {
   return {
     expose() {
       const FieldExtensionDataHolder: any = () => null;


### PR DESCRIPTION
The `Extension<>` generic returns the type passed in, and we actually need to return the correct type here to avoid JSX complaining that the thing returned is not a `React.ComponentType`;

`JSX element type 'TestComponent' does not have any construct or call signatures.`