### PR TITLE
cli: explicit jest env resolution

### DIFF
--- a/.changeset/lovely-news-relax.md
+++ b/.changeset/lovely-news-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The built-in Jest configuration now always uses the Jest environments that are bundled with the CLI by default. This avoids a situation where Jest potentially picks up an incompatible version of the environment package from a different dependency in the project.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -54,14 +54,14 @@ function getRoleConfig(role) {
     case 'common-library':
     case 'frontend-plugin':
     case 'frontend-plugin-module':
-      return { testEnvironment: 'jsdom' };
+      return { testEnvironment: require.resolve('jest-environment-jsdom') };
     case 'cli':
     case 'backend':
     case 'node-library':
     case 'backend-plugin':
     case 'backend-plugin-module':
     default:
-      return { testEnvironment: 'node' };
+      return { testEnvironment: require.resolve('jest-environment-node') };
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where it was possible for Jest to pick up an incompatible environment in situations where there where competing dependencies that ended up at the `node_modules` root.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
