### PR TITLE
[TechDocs] Analytics entity-awareness

### DIFF
--- a/.changeset/techdocs-analyze-clicks.md
+++ b/.changeset/techdocs-analyze-clicks.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+An analytics event matching the semantics of the `click` action is now captured when users click links within a TechDocs document.

--- a/.changeset/techdocs-analyze-entities.md
+++ b/.changeset/techdocs-analyze-entities.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-react': patch
+---
+
+Analytics events captured within the `<TechDocsReaderPageProvider>` now include the conventional `entityRef` context value, associating those events with their corresponding entity.

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -33,7 +33,11 @@ import {
   createVersionedValueMap,
 } from '@backstage/version-bridge';
 
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import {
+  AnalyticsContext,
+  configApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
 
 import { techdocsApiRef } from './api';
 import { TechDocsEntityMetadata, TechDocsMetadata } from './types';
@@ -141,9 +145,13 @@ export const TechDocsReaderPageProvider = memo(
     const versionedValue = createVersionedValueMap({ 1: value });
 
     return (
-      <TechDocsReaderPageContext.Provider value={versionedValue}>
-        {children instanceof Function ? children(value) : children}
-      </TechDocsReaderPageContext.Provider>
+      <AnalyticsContext
+        attributes={{ entityRef: stringifyEntityRef(entityRef) }}
+      >
+        <TechDocsReaderPageContext.Provider value={versionedValue}>
+          {children instanceof Function ? children(value) : children}
+        </TechDocsReaderPageContext.Provider>
+      </AnalyticsContext>
     );
   },
   (prevProps, nextProps) => {

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -21,7 +21,7 @@ import { useTheme, useMediaQuery } from '@material-ui/core';
 
 import { BackstageTheme } from '@backstage/theme';
 import { CompoundEntityRef } from '@backstage/catalog-model';
-import { useApi } from '@backstage/core-plugin-api';
+import { useAnalytics, useApi } from '@backstage/core-plugin-api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 
 import {
@@ -63,6 +63,7 @@ export const useTechDocsReaderDom = (
   const isMobileMedia = useMediaQuery(MOBILE_MEDIA_QUERY);
   const sanitizerTransformer = useSanitizerTransformer();
   const stylesTransformer = useStylesTransformer();
+  const analytics = useAnalytics();
 
   const techdocsStorageApi = useApi(techdocsStorageApiRef);
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
@@ -177,6 +178,12 @@ export const useTechDocsReaderDom = (
             const parsedUrl = new URL(url);
             const fullPath = `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
 
+            // capture link clicks within documentation
+            const linkText =
+              (event.target as HTMLAnchorElement | undefined)?.innerText || url;
+            const to = url.replace(window.location.origin, '');
+            analytics.captureEvent('click', linkText, { attributes: { to } });
+
             // hash exists when anchor is clicked on secondary sidebar
             if (parsedUrl.hash) {
               if (modifierActive) {
@@ -219,7 +226,7 @@ export const useTechDocsReaderDom = (
           onLoaded: () => {},
         }),
       ]),
-    [theme, navigate],
+    [theme, navigate, analytics],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow-up to #14118 that brings the same level of entity-awareness to TechDocs by:

- Passing `entityRef` analytics context within the reader provider.
- Capturing link clicks within TechDocs documents just like they're captured throughout the rest of Backstage

Events look something like this:

### Table of Contents Click

![Analytics Event when clicking a TOC link within TechDocs Site](https://user-images.githubusercontent.com/3496491/201325516-e1aa05e9-34fe-4043-9617-1707f7e1bb66.png)

### ReportIssue Addon Click

![Analytics Event when reporting an issue within TechDocs Site](https://user-images.githubusercontent.com/3496491/201325461-50be89da-645b-47ea-9bc5-7385e11eaf69.png)


### Search within TechDocs Site

![Analytics Event when Searching within TechDocs Site](https://user-images.githubusercontent.com/3496491/201325399-3e3c660e-8df3-4968-8d7c-8f462398e24e.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
