### PR TITLE
[Gitlab] Allow Backstage to refer to Gitlab job artifacts and naive API urls

### DIFF
--- a/.changeset/rich-balloons-leave.md
+++ b/.changeset/rich-balloons-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added the ability to understand Job Artifact URLs and raw API URLs to the GitLab integration

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -573,4 +573,86 @@ describe('GitlabUrlReader', () => {
       ).rejects.toThrow(NotModifiedError);
     });
   });
+
+  describe('getGitlabFetchUrl', () => {
+    beforeEach(() => {
+      worker.use(
+        rest.get(
+          '*/api/v4/projects/group%2Fsubgroup%2Fproject',
+          (_, res, ctx) => res(ctx.status(200), ctx.json({ id: 12345 })),
+        ),
+      );
+    });
+    it('should fall back to getGitLabFileFetchUrl for blob urls', async () => {
+      await expect(
+        gitlabProcessor.getGitlabFetchUrl(
+          'https://gitlab.com/group/subgroup/project/-/blob/branch/my/path/to/file.yaml',
+        ),
+      ).resolves.toEqual(
+        'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+      );
+    });
+    it('should work for job artifact urls', async () => {
+      await expect(
+        gitlabProcessor.getGitlabFetchUrl(
+          'https://gitlab.com/group/subgroup/project/-/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+        ),
+      ).resolves.toEqual(
+        'https://gitlab.com/api/v4/projects/12345/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+      );
+    });
+    it('should pass API urls naively', async () => {
+      const apiUrl = 'https://gitlab.com/api/v4/my/api/path';
+      await expect(gitlabProcessor.getGitlabFetchUrl(apiUrl)).resolves.toEqual(
+        apiUrl,
+      );
+    });
+    it('should fail on unfamiliar or non-Gitlab urls', async () => {
+      await expect(
+        gitlabProcessor.getGitlabFetchUrl(
+          'https://gitlab.com/some/random/endpoint',
+        ),
+      ).rejects.toThrow('Please provide full path to yaml file from GitLab');
+    });
+  });
+
+  describe('getGitlabArtfiactFetchUrl', () => {
+    beforeEach(() => {
+      worker.use(
+        rest.get(
+          '*/api/v4/projects/group%2Fsubgroup%2Fproject',
+          (_, res, ctx) => res(ctx.status(200), ctx.json({ id: 12345 })),
+        ),
+      );
+      worker.use(
+        rest.get(
+          '*/api/v4/projects/groupA%2Fsubgroup%2Fproject',
+          (_, res, ctx) => res(ctx.status(404)),
+        ),
+      );
+    });
+    it('should reject urls that are not for the job artifacts API', async () => {
+      await expect(
+        gitlabProcessor.getGitlabArtifactFetchUrl(
+          'https://gitlab.com/some/url',
+        ),
+      ).rejects.toThrow('Unable to process url as an GitLab artifact');
+    });
+    it('should work for job artifact urls', async () => {
+      await expect(
+        gitlabProcessor.getGitlabFetchUrl(
+          'https://gitlab.com/group/subgroup/project/-/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+        ),
+      ).resolves.toEqual(
+        'https://gitlab.com/api/v4/projects/12345/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+      );
+    });
+    it('errors in mapping the project ID should be captured', async () => {
+      await expect(
+        gitlabProcessor.getGitlabFetchUrl(
+          'https://gitlab.com/groupA/subgroup/project/-/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+        ),
+      ).rejects.toThrow(/^Unable to translate GitLab artifact URL:/);
+    });
+  });
 });


### PR DESCRIPTION
Signed-off-by: Max Morton <mamorton@paloaltonetworks.com>

## Hey, I just made a Pull Request!

This refers to the issue: [[Gitlab] Allow Backstage to refer to Gitlab artifacts](https://github.com/backstage/backstage/issues/14415)

This PR adds the ability for GitlabUrlReader to handle two more types of urls:
1. Job artifact urls (this is discussed in the issue)
2. **API-directed urls (this was not discussed and I can remove this)**

I did this by adding three functions to the GitlabUrlReader:
1. `getGitlabFetchUrl` - This decides whether we treat the URL as an API, artifact, or blob url
2. `getGitlabArtifactFetchUrl` - This handles job artifact urls
3. `resolveProjectToId` - private function which takes a url that points to a project and turns it into a project id number. This implementation is mostly duped from `getProjectId` in `core.ts`

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [N/A] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))