### PR TITLE
Added custom provider annotation details

### DIFF
--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -159,7 +159,12 @@ Check out the numbered markings - let's go through them one by one.
    the outcome of that. This example issues a `fetch` to the right service and
    issues a full refresh of its entity bucket based on that.
 5. The method translates the foreign data model to the native `Entity` form, as
-   expected by the catalog.
+   expected by the catalog. Make sure that in this method you include the
+   `backstage.io/managed-by-location` and `backstage.io/managed-by-origin-location`
+   annotations on your `Entity`. If these are not present they will not show up
+   in the Catalog and you will see warnings in your logs. The
+   [Well-known Annotations](./well-known-annotations.md#backstageiomanaged-by-location)
+   documentation has guidance on what values to use for these.
 6. Finally, we issue a "mutation" to the catalog. This persists the entities in
    our own bucket, along with an optional `locationKey` that's used for conflict
    checks. But this is a bigger topic - mutations warrant their own explanatory

--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -159,10 +159,10 @@ Check out the numbered markings - let's go through them one by one.
    the outcome of that. This example issues a `fetch` to the right service and
    issues a full refresh of its entity bucket based on that.
 5. The method translates the foreign data model to the native `Entity` form, as
-   expected by the catalog. Make sure that in this method you include the
-   `backstage.io/managed-by-location` and `backstage.io/managed-by-origin-location`
-   annotations on your `Entity`. If these are not present they will not show up
-   in the Catalog and you will see warnings in your logs. The
+   expected by the catalog. The `Entity` must include the
+   `backstage.io/managed-by-location` and
+   `backstage.io/managed-by-origin-location annotations`; otherwise, it will not
+   appear in the Catalog and will generate warning logs. The
    [Well-known Annotations](./well-known-annotations.md#backstageiomanaged-by-location)
    documentation has guidance on what values to use for these.
 6. Finally, we issue a "mutation" to the catalog. This persists the entities in


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Added details about the fact that you need to make sure to add the `backstage.io/managed-by-location` and `backstage.io/managed-by-origin-location` annotations to your entities when you create a custom provider seeing as if they are not provided your entities won't show up in the Catalog and you'll start to see warnings in the logs.

This was noted on Discord: https://discord.com/channels/687207715902193673/1037085190557806622

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
