### PR TITLE
Don't run CI checks on doc only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 on:
   pull_request:
     paths-ignore:
+      - '.changeset/**'
+      - 'contrib/**'
+      - 'docs/**'
       - 'microsite/**'
 
 concurrency:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed that a bunch of CI checks were being run on a docs only change for #14588 .
This PR updates the path exclusions of the CI job to match those used for the e2e job (specifically `verify_e2e-linux.yml`)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
