### PR TITLE
Permit customizing the header name for the IAP jwt

### DIFF
--- a/.changeset/great-icons-greet.md
+++ b/.changeset/great-icons-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Add support for custom JWT header name in GCP IAP auth.

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -26,6 +26,7 @@ auth:
   providers:
     gcp-iap:
       audience: '/projects/<project number>/global/backendServices/<backend service id>'
+      jwtHeader: x-custom-header # Optional: Only if you are using a custom header for the IAP JWT
 ```
 
 You can find the project number and service ID in the Google Cloud Console.

--- a/plugins/auth-backend/src/providers/gcp-iap/helpers.test.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/helpers.test.ts
@@ -95,19 +95,19 @@ describe('helpers', () => {
         parseRequestToken(7, undefined as any),
       ).rejects.toMatchObject({
         name: 'AuthenticationError',
-        message: 'Missing Google IAP header: x-goog-iap-jwt-assertion',
+        message: 'Missing Google IAP header',
       });
       await expect(
         parseRequestToken(undefined, undefined as any),
       ).rejects.toMatchObject({
         name: 'AuthenticationError',
-        message: 'Missing Google IAP header: x-goog-iap-jwt-assertion',
+        message: 'Missing Google IAP header',
       });
       await expect(
         parseRequestToken('', undefined as any),
       ).rejects.toMatchObject({
         name: 'AuthenticationError',
-        message: 'Missing Google IAP header: x-goog-iap-jwt-assertion',
+        message: 'Missing Google IAP header',
       });
     });
 

--- a/plugins/auth-backend/src/providers/gcp-iap/helpers.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/helpers.ts
@@ -17,7 +17,7 @@
 import { AuthenticationError } from '@backstage/errors';
 import { OAuth2Client, TokenPayload } from 'google-auth-library';
 import { AuthHandler } from '../types';
-import { GcpIapResult, IAP_JWT_HEADER } from './types';
+import { GcpIapResult } from './types';
 
 export function createTokenValidator(
   audience: string,
@@ -52,9 +52,7 @@ export async function parseRequestToken(
   tokenValidator: (token: string) => Promise<TokenPayload>,
 ): Promise<GcpIapResult> {
   if (typeof jwtToken !== 'string' || !jwtToken) {
-    throw new AuthenticationError(
-      `Missing Google IAP header: ${IAP_JWT_HEADER}`,
-    );
+    throw new AuthenticationError('Missing Google IAP header');
   }
 
   let payload: TokenPayload;

--- a/plugins/auth-backend/src/providers/gcp-iap/provider.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/provider.ts
@@ -29,24 +29,27 @@ import {
   defaultAuthHandler,
   parseRequestToken,
 } from './helpers';
-import { GcpIapResponse, GcpIapResult, IAP_JWT_HEADER } from './types';
+import { GcpIapResponse, GcpIapResult, DEFAULT_IAP_JWT_HEADER } from './types';
 
 export class GcpIapProvider implements AuthProviderRouteHandlers {
   private readonly authHandler: AuthHandler<GcpIapResult>;
   private readonly signInResolver: SignInResolver<GcpIapResult>;
   private readonly tokenValidator: (token: string) => Promise<TokenPayload>;
   private readonly resolverContext: AuthResolverContext;
+  private readonly jwtHeader: string;
 
   constructor(options: {
     authHandler: AuthHandler<GcpIapResult>;
     signInResolver: SignInResolver<GcpIapResult>;
     tokenValidator: (token: string) => Promise<TokenPayload>;
     resolverContext: AuthResolverContext;
+    jwtHeader?: string;
   }) {
     this.authHandler = options.authHandler;
     this.signInResolver = options.signInResolver;
     this.tokenValidator = options.tokenValidator;
     this.resolverContext = options.resolverContext;
+    this.jwtHeader = options?.jwtHeader || DEFAULT_IAP_JWT_HEADER;
   }
 
   async start() {}
@@ -55,7 +58,7 @@ export class GcpIapProvider implements AuthProviderRouteHandlers {
 
   async refresh(req: express.Request, res: express.Response): Promise<void> {
     const result = await parseRequestToken(
-      req.header(IAP_JWT_HEADER),
+      req.header(this.jwtHeader),
       this.tokenValidator,
     );
 
@@ -103,6 +106,7 @@ export const gcpIap = createAuthProviderIntegration({
   }) {
     return ({ config, resolverContext }) => {
       const audience = config.getString('audience');
+      const jwtHeader = config.getOptionalString('jwtHeader');
 
       const authHandler = options.authHandler ?? defaultAuthHandler;
       const signInResolver = options.signIn.resolver;
@@ -113,6 +117,7 @@ export const gcpIap = createAuthProviderIntegration({
         signInResolver,
         tokenValidator,
         resolverContext,
+        jwtHeader,
       });
     };
   },

--- a/plugins/auth-backend/src/providers/gcp-iap/types.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/types.ts
@@ -20,7 +20,7 @@ import { AuthResponse } from '../types';
 /**
  * The header name used by the IAP.
  */
-export const IAP_JWT_HEADER = 'x-goog-iap-jwt-assertion';
+export const DEFAULT_IAP_JWT_HEADER = 'x-goog-iap-jwt-assertion';
 
 /**
  * The data extracted from an IAP token.


### PR DESCRIPTION
This creates a new configuration parameter `jwtHeader` for the gcp-iap auth provider. This allows setting a custom header to look in for the IAP issued JWT.

example usage in config:

```yaml
auth:
  providers:
    gcp-iap:
      audience: '/projects/<project number>/global/backendServices/<backend service id>'
      jwtHeader: x-custom-header # Optional: Only if you are using a custom header for the IAP JWT 
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
