### PR TITLE
fix(docs): update listed contents of .dockerignore

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -108,10 +108,13 @@ root of the repo to speed up the build by reducing build context size:
 
 ```text
 .git
+.yarn/cache
+.yarn/install-state.gz
 node_modules
 packages/*/src
 packages/*/node_modules
 plugins
+*.local.yaml
 ```
 
 With the project built and the `.dockerignore` and `Dockerfile` in place, we are

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -108,6 +108,8 @@ root of the repo to speed up the build by reducing build context size:
 
 ```text
 .git
+.yarn/cache
+.yarn/install-state.gz
 node_modules
 packages/*/src
 packages/*/node_modules

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -108,8 +108,6 @@ root of the repo to speed up the build by reducing build context size:
 
 ```text
 .git
-.yarn/cache
-.yarn/install-state.gz
 node_modules
 packages/*/src
 packages/*/node_modules


### PR DESCRIPTION
It appears that further items have been added to out-of-the-box .dockerignore file created when running `@backstage/create-app`

Updated to reflect the current contents

was:
```
.git
node_modules
packages/*/src
packages/*/node_modules
plugins
```
now:
```
.git
.yarn/cache
.yarn/install-state.gz
node_modules
packages/*/src
packages/*/node_modules
plugins
*.local.yaml
```

Signed-off-by: Leena <19555355+sploschee@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
