### PR TITLE
Made list-deprecations visible and stable

### DIFF
--- a/.changeset/chilled-moles-itch.md
+++ b/.changeset/chilled-moles-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated the `backstage-cli` so that the `list-deprecations` command is visible and also removed the "[EXPERIMENTAL]" tag.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -390,6 +390,7 @@ Commands:
   build [options]
   lint [options]
   clean
+  list-deprecations [options]
   test [options]
   help [command]
 ```
@@ -423,6 +424,16 @@ Options:
   --format <format>
   --since <ref>
   --fix
+  -h, --help
+```
+
+### `backstage-cli repo list-deprecations`
+
+```
+Usage: backstage-cli repo list-deprecations [options]
+
+Options:
+  --json
   -h, --help
 ```
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -66,8 +66,8 @@ export function registerRepoCommand(program: Command) {
     .action(lazy(() => import('./repo/clean').then(m => m.command)));
 
   command
-    .command('list-deprecations', { hidden: true })
-    .description('List deprecations. [EXPERIMENTAL]')
+    .command('list-deprecations')
+    .description('List deprecations')
     .option('--json', 'Output as JSON')
     .action(
       lazy(() => import('./repo/list-deprecations').then(m => m.command)),


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Updated the `backstage-cli` so that the `list-deprecations` command is visible and also removed the "[EXPERIMENTAL]" tag.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
