### PR TITLE
fix(search): update to only link title in search results

### DIFF
--- a/.changeset/old-tips-cough.md
+++ b/.changeset/old-tips-cough.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-adr': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-stack-overflow': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Update search links to only have header as linkable text

--- a/plugins/adr/src/search/AdrSearchResultListItem.tsx
+++ b/plugins/adr/src/search/AdrSearchResultListItem.tsx
@@ -64,20 +64,24 @@ export function AdrSearchResultListItem(props: {
   };
 
   return (
-    <Link noTrack to={result.location} onClick={handleClick}>
+    <>
       <ListItem alignItems="flex-start" className={classes.flexContainer}>
         <ListItemText
           className={classes.itemText}
           primaryTypographyProps={{ variant: 'h6' }}
           primary={
             highlight?.fields.title ? (
-              <HighlightedSearchResultText
-                text={highlight.fields.title}
-                preTag={highlight.preTag}
-                postTag={highlight.postTag}
-              />
+              <Link noTrack to={result.location} onClick={handleClick}>
+                <HighlightedSearchResultText
+                  text={highlight.fields.title}
+                  preTag={highlight.preTag}
+                  postTag={highlight.postTag}
+                />
+              </Link>
             ) : (
-              result.title
+              <Link noTrack to={result.location} onClick={handleClick}>
+                {result.title}
+              </Link>
             )
           }
           secondary={
@@ -116,6 +120,6 @@ export function AdrSearchResultListItem(props: {
         </Box>
       </ListItem>
       <Divider component="li" />
-    </Link>
+    </>
   );
 }

--- a/plugins/adr/src/search/AdrSearchResultListItem.tsx
+++ b/plugins/adr/src/search/AdrSearchResultListItem.tsx
@@ -70,19 +70,17 @@ export function AdrSearchResultListItem(props: {
           className={classes.itemText}
           primaryTypographyProps={{ variant: 'h6' }}
           primary={
-            highlight?.fields.title ? (
-              <Link noTrack to={result.location} onClick={handleClick}>
+            <Link noTrack to={result.location} onClick={handleClick}>
+              {highlight?.fields.title ? (
                 <HighlightedSearchResultText
-                  text={highlight.fields.title}
-                  preTag={highlight.preTag}
-                  postTag={highlight.postTag}
+                  text={highlight?.fields.title || ''}
+                  preTag={highlight?.preTag || ''}
+                  postTag={highlight?.postTag || ''}
                 />
-              </Link>
-            ) : (
-              <Link noTrack to={result.location} onClick={handleClick}>
-                {result.title}
-              </Link>
-            )
+              ) : (
+                result.title
+              )}
+            </Link>
           }
           secondary={
             <span

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -71,7 +71,7 @@ export function CatalogSearchResultListItem(
   };
 
   return (
-    <Link noTrack to={result.location} onClick={handleClick}>
+    <>
       <ListItem alignItems="flex-start">
         {props.icon && <ListItemIcon>{props.icon}</ListItemIcon>}
         <div className={classes.flexContainer}>
@@ -80,13 +80,17 @@ export function CatalogSearchResultListItem(
             primaryTypographyProps={{ variant: 'h6' }}
             primary={
               props.highlight?.fields.title ? (
-                <HighlightedSearchResultText
-                  text={props.highlight.fields.title}
-                  preTag={props.highlight.preTag}
-                  postTag={props.highlight.postTag}
-                />
+                <Link noTrack to={result.location} onClick={handleClick}>
+                  <HighlightedSearchResultText
+                    text={props.highlight.fields.title}
+                    preTag={props.highlight.preTag}
+                    postTag={props.highlight.postTag}
+                  />
+                </Link>
               ) : (
-                result.title
+                <Link noTrack to={result.location} onClick={handleClick}>
+                  {result.title}
+                </Link>
               )
             }
             secondary={
@@ -112,6 +116,6 @@ export function CatalogSearchResultListItem(
         </div>
       </ListItem>
       <Divider component="li" />
-    </Link>
+    </>
   );
 }

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -60,6 +60,7 @@ export function CatalogSearchResultListItem(
   props: CatalogSearchResultListItemProps,
 ) {
   const result = props.result as any;
+  const highlight = props.highlight as ResultHighlight;
 
   const classes = useStyles();
   const analytics = useAnalytics();
@@ -79,26 +80,24 @@ export function CatalogSearchResultListItem(
             className={classes.itemText}
             primaryTypographyProps={{ variant: 'h6' }}
             primary={
-              props.highlight?.fields.title ? (
-                <Link noTrack to={result.location} onClick={handleClick}>
+              <Link noTrack to={result.location} onClick={handleClick}>
+                {highlight?.fields.title ? (
                   <HighlightedSearchResultText
-                    text={props.highlight.fields.title}
-                    preTag={props.highlight.preTag}
-                    postTag={props.highlight.postTag}
+                    text={highlight.fields.title}
+                    preTag={highlight.preTag}
+                    postTag={highlight.postTag}
                   />
-                </Link>
-              ) : (
-                <Link noTrack to={result.location} onClick={handleClick}>
-                  {result.title}
-                </Link>
-              )
+                ) : (
+                  result.title
+                )}
+              </Link>
             }
             secondary={
-              props.highlight?.fields.text ? (
+              highlight?.fields.text ? (
                 <HighlightedSearchResultText
-                  text={props.highlight.fields.text}
-                  preTag={props.highlight.preTag}
-                  postTag={props.highlight.postTag}
+                  text={highlight.fields.text}
+                  preTag={highlight.preTag}
+                  postTag={highlight.postTag}
                 />
               ) : (
                 result.text

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -72,19 +72,17 @@ export const DefaultResultListItemComponent = ({
         <ListItemText
           primaryTypographyProps={{ variant: 'h6' }}
           primary={
-            highlight?.fields.title ? (
-              <Link noTrack to={result.location} onClick={handleClick}>
+            <Link noTrack to={result.location} onClick={handleClick}>
+              {highlight?.fields.title ? (
                 <HighlightedSearchResultText
-                  text={highlight.fields.title}
-                  preTag={highlight.preTag}
-                  postTag={highlight.postTag}
+                  text={highlight?.fields.title || ''}
+                  preTag={highlight?.preTag || ''}
+                  postTag={highlight?.postTag || ''}
                 />
-              </Link>
-            ) : (
-              <Link noTrack to={result.location} onClick={handleClick}>
-                {result.title}
-              </Link>
-            )
+              ) : (
+                result.title
+              )}
+            </Link>
           }
           secondary={
             <span

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -66,20 +66,24 @@ export const DefaultResultListItemComponent = ({
   };
 
   return (
-    <Link noTrack to={result.location} onClick={handleClick}>
+    <>
       <ListItem alignItems="center">
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
         <ListItemText
           primaryTypographyProps={{ variant: 'h6' }}
           primary={
             highlight?.fields.title ? (
-              <HighlightedSearchResultText
-                text={highlight.fields.title}
-                preTag={highlight.preTag}
-                postTag={highlight.postTag}
-              />
+              <Link noTrack to={result.location} onClick={handleClick}>
+                <HighlightedSearchResultText
+                  text={highlight.fields.title}
+                  preTag={highlight.preTag}
+                  postTag={highlight.postTag}
+                />
+              </Link>
             ) : (
-              result.title
+              <Link noTrack to={result.location} onClick={handleClick}>
+                {result.title}
+              </Link>
             )
           }
           secondary={
@@ -106,7 +110,7 @@ export const DefaultResultListItemComponent = ({
         {secondaryAction && <Box alignItems="flex-end">{secondaryAction}</Box>}
       </ListItem>
       <Divider />
-    </Link>
+    </>
   );
 };
 

--- a/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.tsx
+++ b/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.tsx
@@ -47,13 +47,17 @@ export const StackOverflowSearchResultListItem = (
   };
 
   return (
-    <Link to={location} noTrack onClick={handleClick}>
+    <>
       <ListItem alignItems="center">
         {props.icon && <ListItemIcon>{props.icon}</ListItemIcon>}
         <Box flexWrap="wrap">
           <ListItemText
             primaryTypographyProps={{ variant: 'h6' }}
-            primary={_unescape(title)}
+            primary={
+              <Link to={location} noTrack onClick={handleClick}>
+                {_unescape(title)}
+              </Link>
+            }
             secondary={`Author: ${text}`}
           />
           <Chip label={`Answer(s): ${answers}`} size="small" />
@@ -64,6 +68,6 @@ export const StackOverflowSearchResultListItem = (
         </Box>
       </ListItem>
       <Divider />
-    </Link>
+    </>
   );
 };

--- a/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
@@ -81,6 +81,15 @@ export const TechDocsSearchResultListItem = (
     });
   };
 
+  const LinkWrapper = ({ children }: PropsWithChildren<{}>) =>
+    asLink ? (
+      <Link noTrack to={result.location} onClick={handleClick}>
+        {children}
+      </Link>
+    ) : (
+      <>{children}</>
+    );
+
   const TextItem = () => {
     const resultTitle = highlight?.fields.title ? (
       <HighlightedSearchResultText
@@ -118,11 +127,11 @@ export const TechDocsSearchResultListItem = (
         primaryTypographyProps={{ variant: 'h6' }}
         primary={
           title ? (
-            title
+            <LinkWrapper>{title}</LinkWrapper>
           ) : (
-            <>
+            <LinkWrapper>
               {resultTitle} | {entityTitle ?? resultName} docs
-            </>
+            </LinkWrapper>
           )
         }
         secondary={
@@ -149,15 +158,6 @@ export const TechDocsSearchResultListItem = (
     );
   };
 
-  const LinkWrapper = ({ children }: PropsWithChildren<{}>) =>
-    asLink ? (
-      <Link noTrack to={result.location} onClick={handleClick}>
-        {children}
-      </Link>
-    ) : (
-      <>{children}</>
-    );
-
   const ListItemWrapper = ({ children }: PropsWithChildren<{}>) =>
     asListItem ? (
       <>
@@ -172,10 +172,8 @@ export const TechDocsSearchResultListItem = (
     );
 
   return (
-    <LinkWrapper>
-      <ListItemWrapper>
-        <TextItem />
-      </ListItemWrapper>
-    </LinkWrapper>
+    <ListItemWrapper>
+      <TextItem />
+    </ListItemWrapper>
   );
 };

--- a/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
@@ -126,13 +126,15 @@ export const TechDocsSearchResultListItem = (
         className={classes.itemText}
         primaryTypographyProps={{ variant: 'h6' }}
         primary={
-          title ? (
-            <LinkWrapper>{title}</LinkWrapper>
-          ) : (
-            <LinkWrapper>
-              {resultTitle} | {entityTitle ?? resultName} docs
-            </LinkWrapper>
-          )
+          <LinkWrapper>
+            {title ? (
+              title
+            ) : (
+              <>
+                {resultTitle} | {entityTitle ?? resultName} docs
+              </>
+            )}
+          </LinkWrapper>
         }
         secondary={
           <span


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change updates the way that the search page displays links.  When a user opens the search modal window, the entire block of text is a link.  This change makes it so that only the primary text (header) is a link. This aligns with how many web sites work and makes it more readable for users when hovering over the text.

Previous:
![previous version with link for the entire block](https://user-images.githubusercontent.com/536405/201691437-533e5a62-2616-40fe-a05f-f6923e9ebb21.png)


Updated:
![Updated version with link for only the header](https://user-images.githubusercontent.com/536405/201693943-e03c9612-60d9-4ec9-b37a-3f29eefd649e.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
