### PR TITLE
Added WorkItem branch policy type

### DIFF
--- a/.changeset/heavy-fans-share.md
+++ b/.changeset/heavy-fans-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-common': patch
+---
+
+Added the azure devops branch policy typeid for Work Item Link

--- a/.changeset/heavy-fans-share.md
+++ b/.changeset/heavy-fans-share.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-azure-devops-common': patch
 ---
 
-Added the azure devops branch policy typeid for Work Item Link
+Added the azure devops branch PolicyTypeId for Work Item Link

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
@@ -126,6 +126,7 @@ export function convertPolicy(
       [PolicyTypeId.Comments]: PolicyType.Comments,
       [PolicyTypeId.RequiredReviewers]: PolicyType.RequiredReviewers,
       [PolicyTypeId.MergeStrategy]: PolicyType.MergeStrategy,
+      [PolicyTypeId.WorkItem]: PolicyType.WorkItem,
     } as Record<string, PolicyType | undefined>
   )[policyTypeId];
 
@@ -194,6 +195,9 @@ export function convertPolicy(
     case PolicyType.RequiredReviewers:
       break;
     case PolicyType.MergeStrategy:
+      break;
+    case PolicyType.WorkItem:
+      break;
     default:
       return undefined;
   }

--- a/plugins/azure-devops-common/api-report.md
+++ b/plugins/azure-devops-common/api-report.md
@@ -134,6 +134,8 @@ export enum PolicyType {
   RequiredReviewers = 'RequiredReviewers',
   // (undocumented)
   Status = 'Status',
+  // (undocumented)
+  WorkItem = 'WorkItem',
 }
 
 // @public (undocumented)
@@ -144,6 +146,7 @@ export enum PolicyTypeId {
   MinimumReviewers = 'fa4e907d-c16b-4a4c-9dfa-4906e5d171dd',
   RequiredReviewers = 'fd2167ab-b0be-447a-8ec8-39368250530e',
   Status = 'cbdc66da-9728-4af8-aada-9a5a32e4a226',
+  WorkItem = '40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e',
 }
 
 // @public (undocumented)

--- a/plugins/azure-devops-common/src/types.ts
+++ b/plugins/azure-devops-common/src/types.ts
@@ -265,6 +265,7 @@ export enum PolicyType {
   Comments = 'Comments',
   RequiredReviewers = 'RequiredReviewers',
   MergeStrategy = 'MergeStrategy',
+  WorkItem = 'WorkItem',
 }
 
 /** @public */

--- a/plugins/azure-devops-common/src/types.ts
+++ b/plugins/azure-devops-common/src/types.ts
@@ -293,6 +293,10 @@ export enum PolicyTypeId {
    * This policy ensures that pull requests use a consistent merge strategy.
    */
   MergeStrategy = 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+  /**
+   * This policy ensures that pull requests have work items linked to it.
+   */
+  WorkItem = '40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e',
 }
 
 /** @public */


### PR DESCRIPTION
Signed-off-by: David Söderlund <QuadmanSWE@gmail.com>

## Hey, I just made a Pull Request!

I've added the azure devops branch policy typeid for Work Item Link.
This policy type ensures that branches affected have work items from azure devops linked to them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
