### PR TITLE
SupportButton: Add option to override items

### DIFF
--- a/.changeset/modern-mugs-shout.md
+++ b/.changeset/modern-mugs-shout.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Adds prop to SupportButton to override support config items and adds the option to show custom list items per page
+Add items prop to SupportButton. This prop can be used to override the items that would otherwise be grabbed from the config.

--- a/.changeset/modern-mugs-shout.md
+++ b/.changeset/modern-mugs-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Adds prop to SupportButton to override support config items and adds the option to show custom list items per page

--- a/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
@@ -24,9 +24,9 @@ import {
 import { SupportButton } from './SupportButton';
 import { configApiRef } from '@backstage/core-plugin-api';
 
-const configApi = {
-  getOptionalConfig: () =>
-    new MockConfigApi({
+const configApi = new MockConfigApi({
+  app: {
+    support: {
       url: 'https://github.com',
       items: [
         {
@@ -35,8 +35,9 @@ const configApi = {
           links: [{ title: 'Github Issues', url: '/issues' }],
         },
       ],
-    }),
-};
+    },
+  },
+});
 
 const SUPPORT_BUTTON_ID = 'support-button';
 const POPOVER_ID = 'support-button-popover';

--- a/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
@@ -15,31 +15,37 @@
  */
 
 import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
 import {
-  render,
-  act,
-  RenderResult,
-  waitFor,
-  fireEvent,
-  screen,
-} from '@testing-library/react';
-import { wrapInTestApp, renderInTestApp } from '@backstage/test-utils';
+  MockConfigApi,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
 import { SupportButton } from './SupportButton';
+import { configApiRef } from '@backstage/core-plugin-api';
+
+const configApi = {
+  getOptionalConfig: () =>
+    new MockConfigApi({
+      url: 'https://github.com',
+      items: [
+        {
+          title: 'Github',
+          icon: 'github',
+          links: [{ title: 'Github Issues', url: '/issues' }],
+        },
+      ],
+    }),
+};
 
 const SUPPORT_BUTTON_ID = 'support-button';
 const POPOVER_ID = 'support-button-popover';
 
 describe('<SupportButton />', () => {
   it('renders without exploding', async () => {
-    let renderResult: RenderResult;
+    await renderInTestApp(<SupportButton />);
 
-    await act(async () => {
-      renderResult = render(wrapInTestApp(<SupportButton />));
-    });
-
-    await waitFor(() =>
-      expect(renderResult.getByTestId(SUPPORT_BUTTON_ID)).toBeInTheDocument(),
-    );
+    expect(screen.getByTestId(SUPPORT_BUTTON_ID)).toBeInTheDocument();
   });
 
   it('supports passing a title', async () => {
@@ -48,26 +54,52 @@ describe('<SupportButton />', () => {
     expect(screen.getByText('Custom title')).toBeInTheDocument();
   });
 
+  it('supports passing link items through props', async () => {
+    await renderInTestApp(
+      <SupportButton
+        items={[
+          {
+            title: 'Documentation',
+            icon: 'description',
+            links: [{ title: 'Show docs', url: '/docs' }],
+          },
+        ]}
+      />,
+    );
+
+    const supportButton = screen.getByTestId(SUPPORT_BUTTON_ID);
+    expect(supportButton).toBeInTheDocument();
+
+    fireEvent.click(supportButton);
+
+    const documentationItem = screen.getByText('Documentation');
+    expect(documentationItem).toBeInTheDocument();
+  });
+
+  it('shows items from support config', async () => {
+    await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
+        <SupportButton />
+      </TestApiProvider>,
+    );
+
+    const supportButton = screen.getByTestId(SUPPORT_BUTTON_ID);
+    expect(supportButton).toBeInTheDocument();
+
+    fireEvent.click(supportButton);
+
+    const defaultGithubSupportConfig = screen.getByText('Github Issues');
+    expect(defaultGithubSupportConfig).toBeInTheDocument();
+  });
+
   it('shows popover on click', async () => {
-    let renderResult: RenderResult;
+    await renderInTestApp(<SupportButton />);
 
-    await act(async () => {
-      renderResult = render(wrapInTestApp(<SupportButton />));
-    });
+    const supportButton = screen.getByTestId(SUPPORT_BUTTON_ID);
+    expect(supportButton).toBeInTheDocument();
 
-    let button: HTMLElement;
+    fireEvent.click(supportButton);
 
-    await waitFor(() => {
-      expect(renderResult.getByTestId(SUPPORT_BUTTON_ID)).toBeInTheDocument();
-      button = renderResult.getByTestId(SUPPORT_BUTTON_ID);
-    });
-
-    await act(async () => {
-      fireEvent.click(button);
-    });
-
-    await waitFor(() => {
-      expect(renderResult.getByTestId(POPOVER_ID)).toBeInTheDocument();
-    });
+    expect(screen.getByTestId(POPOVER_ID)).toBeInTheDocument();
   });
 });

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -35,6 +35,7 @@ import { Link } from '../Link';
 
 type SupportButtonProps = {
   title?: string;
+  items?: SupportItem[];
   children?: React.ReactNode;
 };
 
@@ -82,8 +83,8 @@ const SupportListItem = ({ item }: { item: SupportItem }) => {
 };
 
 export function SupportButton(props: SupportButtonProps) {
-  const { title, children } = props;
-  const { items } = useSupportConfig();
+  const { title, items, children } = props;
+  const { items: configItems } = useSupportConfig();
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
@@ -150,10 +151,9 @@ export function SupportButton(props: SupportButtonProps) {
               {child}
             </ListItem>
           ))}
-          {items &&
-            items.map((item, i) => (
-              <SupportListItem item={item} key={`item-${i}`} />
-            ))}
+          {(items ?? configItems).map((item, i) => (
+            <SupportListItem item={item} key={`item-${i}`} />
+          ))}
         </List>
         <DialogActions>
           <Button color="primary" onClick={popoverCloseHandler}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR adds the possibility to add a custom list to the support button. This way you can have a different list in the popover depending on what page you add the support button in.
When you don't add the `items` prop it will default to the config implementation as it was before.

Also changed the tests to be more inline with each other...

For example:
```ts
<SupportButton
  items={[
    {
      title: 'Documentation',
      icon: 'description',
      links: [{ title: 'Show docs', url: '/docs' }],
    },
  ]}
/>,
```
Results in:
![image](https://user-images.githubusercontent.com/22071649/201931422-a76b62ad-418e-438e-a75e-25e8104c3c1a.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation (not necessary I think)
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
