### PR TITLE
Update running-backstage-locally.md

### DIFF
--- a/docs/getting-started/running-backstage-locally.md
+++ b/docs/getting-started/running-backstage-locally.md
@@ -48,7 +48,7 @@ of GitHub and run an initial install.
 
 ```bash
 # Start from your local development folder
-git clone --depth 1 git@github.com:backstage/backstage.git
+git clone --depth 1 https://github.com/backstage/backstage.git
 cd backstage
 
 # Install our dependencies


### PR DESCRIPTION
I was not able to clone on my new macbook, where github auth was not yet set up. This simple change makes the guide more accessible

