### PR TITLE
fix: incorrect export type of GithubOrgEntityProvider

### DIFF
--- a/.changeset/slow-dragons-promise.md
+++ b/.changeset/slow-dragons-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix incorrectly exported GithubOrgEntityProvider as a type

--- a/plugins/catalog-backend-module-github/src/index.ts
+++ b/plugins/catalog-backend-module-github/src/index.ts
@@ -26,10 +26,8 @@ export { GithubDiscoveryProcessor } from './processors/GithubDiscoveryProcessor'
 export { GithubMultiOrgReaderProcessor } from './processors/GithubMultiOrgReaderProcessor';
 export { GithubOrgReaderProcessor } from './processors/GithubOrgReaderProcessor';
 export { GithubEntityProvider } from './providers/GithubEntityProvider';
-export type {
-  GithubOrgEntityProvider,
-  GithubOrgEntityProviderOptions,
-} from './providers/GithubOrgEntityProvider';
+export { GithubOrgEntityProvider } from './providers/GithubOrgEntityProvider';
+export type { GithubOrgEntityProviderOptions } from './providers/GithubOrgEntityProvider';
 export { githubEntityProviderCatalogModule } from './service/GithubEntityProviderCatalogModule';
 export {
   type GithubMultiOrgConfig,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It seems #13640 introduced a breaking change which makes it impossible to use the `GithubOrgEntityProvider` (with the fixed `Github` case). It causes a `Backend failed to start up TypeError: Cannot read properties of undefined (reading 'fromConfig')` error. After looking into this the class is exported as a type incorrectly.

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
