### PR TITLE
Patch release of #14648

### DIFF
--- a/.changeset/slow-dragons-promise.md
+++ b/.changeset/slow-dragons-promise.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-github': patch
----
-
-Fix incorrectly exported GithubOrgEntityProvider as a type

--- a/.changeset/slow-dragons-promise.md
+++ b/.changeset/slow-dragons-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix incorrectly exported GithubOrgEntityProvider as a type

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.8.0",
+  "version": "1.8.1",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.2.1
+
+### Patch Changes
+
+- 781e49839a: Fix incorrectly exported GithubOrgEntityProvider as a type
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-github/src/index.ts
+++ b/plugins/catalog-backend-module-github/src/index.ts
@@ -26,10 +26,8 @@ export { GithubDiscoveryProcessor } from './processors/GithubDiscoveryProcessor'
 export { GithubMultiOrgReaderProcessor } from './processors/GithubMultiOrgReaderProcessor';
 export { GithubOrgReaderProcessor } from './processors/GithubOrgReaderProcessor';
 export { GithubEntityProvider } from './providers/GithubEntityProvider';
-export type {
-  GithubOrgEntityProvider,
-  GithubOrgEntityProviderOptions,
-} from './providers/GithubOrgEntityProvider';
+export { GithubOrgEntityProvider } from './providers/GithubOrgEntityProvider';
+export type { GithubOrgEntityProviderOptions } from './providers/GithubOrgEntityProvider';
 export { githubEntityProviderCatalogModule } from './service/GithubEntityProviderCatalogModule';
 export {
   type GithubMultiOrgConfig,


### PR DESCRIPTION
This release fixes an issue where using the `GithubOrgEntityProvider` from `@backstage/plugin-catalog-backend-module-github` would break at runtime.