### PR TITLE
Update versioning policy to treat utility/service API additions as non-breaking

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -171,6 +171,37 @@ Exported types can be marked with either `@public`, `@alpha` or `@beta` release 
 
 If a package does not have this configuration, then all exported types are considered stable, even if they are marked as `@alpha` or `@beta`.
 
+#### Changes that are not Considered Breaking
+
+There are a few exceptions that are not considered breaking in the [versioning policy](https://backstage.io/docs/overview/versioning-policy),
+primarily regarding Utility APIs and Backend Service interfaces (referred to "contracts" below) that are supplied by the
+Backstage core packages.
+
+Example of a non-breaking change to a contract which has a default
+implementation, since consumers typically only interact with that contract as
+callers of existing methods:
+
+```diff
+ export interface MyService {
+   oldMethod(): void;
++  newMethod(): void;
+ }
+```
+
+Changes such as these must still be marked with `**BREAKING PRODUCERS**:` in the
+changelog, to highlight them for those who might be implementing custom
+implementations of those contracts or putting mocks of the contract in tests.
+
+Example of a breaking change to a contract, which affects existing consumers and
+therefore makes it NOT fall under these exceptions:
+
+```diff
+ export interface MyService {
+-   oldMethod(): void;
++   oldMethod(): Promise<void>;
+ }
+```
+
 #### Type Contract Direction
 
 An important distinction to make when looking at changes to an API Report is the direction of the contract of a changed type, that is, whether it's used as input or output from the user's point of view. In the next two sections we'll dive into the different directions of a type contract, and how it affects whether a change is breaking or not.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -171,9 +171,9 @@ Exported types can be marked with either `@public`, `@alpha` or `@beta` release 
 
 If a package does not have this configuration, then all exported types are considered stable, even if they are marked as `@alpha` or `@beta`.
 
-#### Changes that are not Considered Breaking
+#### Changes that are Not Considered Breaking
 
-There are a few exceptions that are not considered breaking in the [versioning policy](https://backstage.io/docs/overview/versioning-policy),
+There are a few exceptions that are not considered breaking in the [versioning policy](https://backstage.io/docs/overview/versioning-policy#changes-that-are-not-considered-breaking),
 primarily regarding Utility APIs and Backend Service interfaces (referred to "contracts" below) that are supplied by the
 Backstage core packages.
 

--- a/docs/overview/versioning-policy.md
+++ b/docs/overview/versioning-policy.md
@@ -99,7 +99,7 @@ This versioning is completely decoupled from the Backstage release versioning,
 meaning you might for example have `@backstage/core-plugin-api` version `3.1.4`
 be part of the `1.12` Backstage release.
 
-Following versioning policy applies to all packages:
+The following versioning policy applies to all packages:
 
 - Breaking changes are noted in the changelog, and documentation is updated.
 - Breaking changes are prefixed with `**BREAKING**: ` in the changelog.
@@ -119,6 +119,25 @@ For packages at version `1.0.0` or above, the following policy also applies:
 - Exports that have been marked as `@alpha` or `@beta` may receive breaking
   changes without a deprecation period, but the changes must still adhere to
   semver.
+
+### Changes that are not Considered Breaking
+
+There are a few changes that would typically be considered breaking changes, but
+that we make exceptions for. This is both to be able to evolve the project more
+rapidly, also because the alternative ends up having a bigger impact on users.
+
+For all Utility APIs and Backend Services that _have_ a built-in implementation,
+we only consider the API stability for consumers of those interfaces. This means
+that it is not considered a breaking change to break the contract for producers
+of the interface.
+
+Changes that fall under the above rule, must be marked with
+`**BREAKING PRODUCERS**:` in the changelog.
+
+For any case of dependency injection, it is not considered a breaking change to
+add a dependency on a Utility API or Backend Service that is provided by the
+framework. This includes any dependency that is provided by the
+`@backstage/app-defaults` and `@backstage/backend-defaults` packages.
 
 ### Release Stages
 

--- a/docs/overview/versioning-policy.md
+++ b/docs/overview/versioning-policy.md
@@ -120,7 +120,7 @@ For packages at version `1.0.0` or above, the following policy also applies:
   changes without a deprecation period, but the changes must still adhere to
   semver.
 
-### Changes that are not Considered Breaking
+### Changes that are Not Considered Breaking
 
 There are a few changes that would typically be considered breaking changes, but
 that we make exceptions for. This is both to be able to evolve the project more


### PR DESCRIPTION
This updates the versioning policy to be more lax for Utility APIs and Backend Services, such that it's not considered a breaking change if a contract update is non-breaking when regarding it as an input type.

An example of this is #14619, which adds a new method to the Catalog client API contract. This is not a type that adopters typically want to make custom implementations of, and a default implementation is already shipped in any typical installation. Thus, adding a new method is unlikely to affect anybody (in a breaking manner) who only consumed any of the pre-existing methods.

A counterexample would be the Tech Radar API. That's an interface that an adopter really needs to make a custom implementation of, to supply data to the plugin. Breaking that interface does imply that people's implementations will be incomplete and having to be updated when bumping to the new version.

We considered several strategies and alternatives, and this is what we eventually arrived at. Feedback is welcome!