### PR TITLE
Refactored Report issue template in techdoc addons.

### DIFF
--- a/.changeset/thick-stingrays-wonder.md
+++ b/.changeset/thick-stingrays-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+---
+
+Refactored Report issue body in the tech-doc addons by getting the app title from `appconfig.yml` using `configApiRef`, In case `appTitle` not mentioned app Tile `new const` will default to `Backstage`

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
@@ -49,6 +49,8 @@ export const getTitle = (selection: Selection) => {
 };
 
 export const getBody = (selection: Selection, markdownUrl: string) => {
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.getOptional('app.title') || 'Backstage';
   const title = '## Documentation Feedback 📝';
   const subheading = '#### The highlighted text:';
   const commentHeading = '#### The comment on the text:';
@@ -59,8 +61,6 @@ export const getBody = (selection: Selection, markdownUrl: string) => {
     .split('\n')
     .map(line => `> ${line.trim()}`)
     .join('\n');
-  const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptional('app.title') || 'Backstage';
   const facts = [
     `${appTitle} URL: <${window.location.href}> \nMarkdown URL: <${markdownUrl}>`,
   ];

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
@@ -16,7 +16,7 @@
 
 import parseGitUrl from 'git-url-parse';
 
-import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   replaceGithubUrlType,
   replaceGitLabUrlType,
@@ -59,9 +59,10 @@ export const getBody = (selection: Selection, markdownUrl: string) => {
     .split('\n')
     .map(line => `> ${line.trim()}`)
     .join('\n');
-
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.getOptional('app.title') || 'Backstage';
   const facts = [
-    `Backstage URL: <${window.location.href}> \nMarkdown URL: <${markdownUrl}>`,
+    `${appTitle} URL: <${window.location.href}> \nMarkdown URL: <${markdownUrl}>`,
   ];
 
   return `${title}\n\n ${subheading} \n\n ${highlightedTextAsQuote}\n\n ${commentHeading} \n ${commentPlaceholder}\n\n ___\n${facts}`;


### PR DESCRIPTION
In tech-doc Addons  report issue's pull request template is hardcoded with Backstage URL as shown below, So refactored Report issue body in the tech-doc addons by getting the app title from `appconfig.yml` using `configApiRef`, In case `appTitle` not mentioned app Tile `new const` will default to `Backstage`

![image](https://user-images.githubusercontent.com/24265936/202184311-65200b6a-1ecf-42db-9810-26c34ee35197.png)

Co-authored-by: skgandikota <gsaikoushik@yahoo.com>
Co-authored-by: aswathysen <aswathy.sen@mnscorp.net>
Co-authored-by: kcheriyath <kamal.cheriyath@mnscorp.net>