### PR TITLE
Add optional displayName parameter for kubernetes clusters

### DIFF
--- a/.changeset/nine-glasses-obey.md
+++ b/.changeset/nine-glasses-obey.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+---
+
+Add optional displayName parameter for kubernetes clusters

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -49,6 +49,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -88,6 +89,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         dashboardUrl: 'https://k8s.foo.com',
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
@@ -98,6 +100,7 @@ describe('ConfigClusterLocator', () => {
       },
       {
         name: 'cluster2',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',
@@ -144,6 +147,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: undefined,
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: 'token',
         externalId: undefined,
         url: 'http://localhost:8080',
@@ -155,6 +159,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        displayName: undefined,
         externalId: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
@@ -166,6 +171,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        displayName: undefined,
         externalId: 'SomeExternalId',
         url: 'http://localhost:8081',
         serviceAccountToken: undefined,
@@ -201,6 +207,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -237,6 +244,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -245,6 +253,36 @@ describe('ConfigClusterLocator', () => {
         caData: undefined,
         dashboardApp: 'standard',
         dashboardUrl: 'http://someurl',
+      },
+    ]);
+  });
+
+  it('one clusters with displayName parameter', async () => {
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          displayName: 'clustername1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+        },
+      ],
+    });
+
+    const sut = ConfigClusterLocator.fromConfig(config);
+
+    const result = await sut.getClusters();
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        displayName: 'clustername1',
+        serviceAccountToken: undefined,
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+        skipMetricsLookup: false,
+        skipTLSVerify: false,
+        caData: undefined,
       },
     ]);
   });

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -38,6 +38,7 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           skipMetricsLookup: c.getOptionalBoolean('skipMetricsLookup') ?? false,
           caData: c.getOptionalString('caData'),
           authProvider: authProvider,
+          displayName: c.getOptionalString('displayName'),
         };
         const dashboardUrl = c.getOptionalString('dashboardUrl');
         if (dashboardUrl) {
@@ -49,6 +50,9 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
         }
         if (c.has('dashboardParameters')) {
           clusterDetails.dashboardParameters = c.get('dashboardParameters');
+        }
+        if (c.has('displayName')) {
+          clusterDetails.displayName = c.get('displayName');
         }
 
         switch (authProvider) {

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -31,6 +31,7 @@ describe('getCombinedClusterSupplier', () => {
               clusters: [
                 {
                   name: 'cluster1',
+                  displayName: 'some-name',
                   serviceAccountToken: 'token',
                   url: 'http://localhost:8080',
                   authProvider: 'serviceAccount',
@@ -54,6 +55,7 @@ describe('getCombinedClusterSupplier', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: 'some-name',
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -63,6 +65,7 @@ describe('getCombinedClusterSupplier', () => {
       },
       {
         name: 'cluster2',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -50,6 +50,7 @@ describe('KubernetesBuilder', () => {
     const clusters: ClusterDetails[] = [
       {
         name: 'some-cluster',
+        displayName: 'some-name',
         authProvider: 'serviceAccount',
         url: 'https://localhost:1234',
         serviceAccountToken: 'someToken',
@@ -95,6 +96,7 @@ describe('KubernetesBuilder', () => {
         items: [
           {
             name: 'some-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           {

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -266,6 +266,7 @@ export class KubernetesBuilder {
       res.json({
         items: clusterDetails.map(cd => ({
           name: cd.name,
+          displayName: cd.displayName,
           dashboardUrl: cd.dashboardUrl,
           authProvider: cd.authProvider,
           oidcTokenProvider: cd.oidcTokenProvider,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -80,6 +80,7 @@ const entity = {
 
 const cluster1 = {
   name: 'test-cluster',
+  displayName: 'some-name',
   authProvider: 'serviceAccount',
   customResources: [
     {
@@ -286,6 +287,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
         ],
@@ -311,6 +313,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -369,6 +372,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           cluster2,
@@ -405,6 +409,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
         ],
@@ -463,6 +468,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE, POD_METRICS_FIXTURE],
@@ -502,6 +508,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
             dashboardUrl: 'https://k8s.foo.coom',
           },
@@ -530,6 +537,7 @@ describe('getKubernetesObjectsByEntity', () => {
           cluster: {
             dashboardUrl: 'https://k8s.foo.coom',
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -552,6 +560,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           {
@@ -582,6 +591,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -604,6 +614,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           {
@@ -638,6 +649,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -681,6 +693,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
             dashboardUrl: 'https://k8s.foo.coom',
           },
@@ -729,6 +742,7 @@ describe('getKubernetesObjectsByEntity', () => {
           cluster: {
             dashboardUrl: 'https://k8s.foo.coom',
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -791,6 +805,7 @@ describe('getCustomResourcesByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           cluster2,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -336,6 +336,9 @@ export class KubernetesFanOutHandler {
     if (clusterDetails.dashboardParameters) {
       objects.cluster.dashboardParameters = clusterDetails.dashboardParameters;
     }
+    if (clusterDetails.displayName) {
+      objects.cluster.displayName = clusterDetails.displayName;
+    }
     return objects;
   }
 

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -204,6 +204,11 @@ export interface ClusterDetails {
    * Kubernetes resources.
    */
   customResources?: CustomResourceMatcher[];
+  /**
+   * Specifies the custom cluster name.
+   * If it's defined, displayName will be used as a cluster name instead of @name.
+   */
+  displayName?: string;
 }
 
 /**

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -103,6 +103,11 @@ export interface ClusterAttributes {
    * This is used by the GKE formatter which requires the project, region and cluster name.
    */
   dashboardParameters?: JsonObject;
+  /**
+   * Specifies the custom cluster name.
+   * If it's defined, displayName will be used as a cluster name instead of @name.
+   */
+  displayName?: string;
 }
 
 /** @public */

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -97,7 +97,9 @@ export class KubernetesBackendClient implements KubernetesApi {
     });
   }
 
-  async getClusters(): Promise<{ name: string; authProvider: string }[]> {
+  async getClusters(): Promise<
+    { name: string; displayName: string; authProvider: string }[]
+  > {
     const { token: idToken } = await this.identityApi.getCredentials();
     const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}/clusters`;
 

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -33,6 +33,7 @@ export interface KubernetesApi {
   getClusters(): Promise<
     {
       name: string;
+      displayName?: string | undefined;
       authProvider: string;
       oidcTokenProvider?: string | undefined;
     }[]

--- a/plugins/kubernetes/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.tsx
@@ -46,6 +46,7 @@ import { PodNamesWithMetricsContext } from '../../hooks/PodNamesWithMetrics';
 
 type ClusterSummaryProps = {
   clusterName: string;
+  displayName?: string | undefined;
   totalNumberOfPods: number;
   numberOfPodsWithErrors: number;
   children?: React.ReactNode;
@@ -53,6 +54,7 @@ type ClusterSummaryProps = {
 
 const ClusterSummary = ({
   clusterName,
+  displayName,
   totalNumberOfPods,
   numberOfPodsWithErrors,
 }: ClusterSummaryProps) => {
@@ -73,7 +75,9 @@ const ClusterSummary = ({
         spacing={0}
       >
         <Grid item xs>
-          <Typography variant="h3">{clusterName}</Typography>
+          <Typography variant="h3">
+            {displayName ? displayName : clusterName}
+          </Typography>
           <Typography color="textSecondary" variant="body1">
             Cluster
           </Typography>
@@ -131,6 +135,7 @@ export const Cluster = ({ clusterObjects, podsWithErrors }: ClusterProps) => {
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <ClusterSummary
                   clusterName={clusterObjects.cluster.name}
+                  displayName={clusterObjects.cluster.displayName}
                   totalNumberOfPods={groupedResponses.pods.length}
                   numberOfPodsWithErrors={podsWithErrors.size}
                 />


### PR DESCRIPTION
This change adds a new optional parameter `displayName`. 
If `displayName` is defined, it will be used instead of the cluster name. 
This might be useful when we have multiple clusters with the same name.

<img width="1328" alt="Screenshot 2022-11-16 at 14 29 22" src="https://user-images.githubusercontent.com/11457338/202196611-64c3d3ac-e9bf-45de-b326-953c249f1d97.png">

Example cluster config:

```
kubernetes:
  serviceLocatorMethod:
    type: 'multiTenant'
  clusterLocatorMethods:
    - type: 'config'
      clusters:
        - url: https://foobart.gr7.eu-central-1.eks.amazonaws.com
          name: dmytro
          displayName: helloworld
          authProvider: 'aws'
          skipTLSVerify: true
          region: eu-central-1
```

Signed-off-by: Dmytro Sydorov <dmytro.sydorov@bonial.com>