### PR TITLE
wait for initialize to complete before finalize

### DIFF
--- a/.changeset/gorgeous-hairs-applaud.md
+++ b/.changeset/gorgeous-hairs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Wait for indexer initialization before finalizing indexing.

--- a/plugins/search-backend-node/src/indexing/BatchSearchEngineIndexer.ts
+++ b/plugins/search-backend-node/src/indexing/BatchSearchEngineIndexer.ts
@@ -110,12 +110,13 @@ export abstract class BatchSearchEngineIndexer extends Writable {
    * @internal
    */
   async _final(done: (error?: Error | null) => void) {
-    const maybeError = await this.initialized;
-    if (maybeError) {
-      done(maybeError);
-      return;
-    }
     try {
+      const maybeError = await this.initialized;
+      if (maybeError) {
+        done(maybeError);
+        return;
+      }
+
       // Index any remaining documents.
       if (this.currentBatch.length) {
         await this.index(this.currentBatch);

--- a/plugins/search-backend-node/src/indexing/BatchSearchEngineIndexer.ts
+++ b/plugins/search-backend-node/src/indexing/BatchSearchEngineIndexer.ts
@@ -110,6 +110,11 @@ export abstract class BatchSearchEngineIndexer extends Writable {
    * @internal
    */
   async _final(done: (error?: Error | null) => void) {
+    const maybeError = await this.initialized;
+    if (maybeError) {
+      done(maybeError);
+      return;
+    }
     try {
       // Index any remaining documents.
       if (this.currentBatch.length) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

wait for initialise to complete before finalize.

The constructor of the BatchSearchEngineIndexer starts a promise to initialise the indexer implementation (it might be pg or whatever)

Then if it is finished before the promise completes and no items are indexed it doesn't allow the pg indexer to close the transaction.

This was resulting in the following error:

```
TypeError: Cannot read properties of undefined (reading 'rollback')
    at PgSearchEngineIndexer.finalize (/usr/src/app/node_modules/@backstage/plugin-search-backend-module-pg/dist/index.cjs.js:157:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async PgSearchEngineIndexer._final (/usr/src/app/node_modules/@backstage/plugin-search-backend-node/dist/index.cjs.js:244:7)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
