### PR TITLE
give the ability to supply a transformErrors function to the rjsf/core

### DIFF
--- a/.changeset/sour-flowers-care.md
+++ b/.changeset/sour-flowers-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+give the ability to supply a transform errors function to the Stepper form

--- a/.changeset/sour-flowers-care.md
+++ b/.changeset/sour-flowers-care.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-give the ability to supply a transform errors function to the Stepper form
+Adds the ability to supply a `transformErrors` function to the `Stepper` for `/next`

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -11,6 +11,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import type { ErrorTransformer } from '@rjsf/utils';
 import { Extension } from '@backstage/core-plugin-api';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
@@ -213,6 +214,7 @@ export type NextRouterProps = {
     TaskPageComponent?: React_2.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
+  transformErrors?: ErrorTransformer;
 };
 
 // @alpha

--- a/plugins/scaffolder/src/next/Router/Router.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.tsx
@@ -30,6 +30,7 @@ import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateGroupFilter } from '../TemplateListPage/TemplateGroups';
 import { nextSelectedTemplateRouteRef } from '../../routes';
 import { SecretsContextProvider } from '../../components/secrets/SecretsContext';
+import type { ErrorTransformer } from '@rjsf/utils';
 
 /**
  * The Props for the Scaffolder Router
@@ -44,6 +45,7 @@ export type NextRouterProps = {
     TaskPageComponent?: React.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
+  transformErrors?: ErrorTransformer;
 };
 
 /**

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -152,18 +152,6 @@ export const Stepper = (props: StepperProps) => {
             fields={extensions}
             showErrorList={false}
             transformErrors={props.transformErrors}
-            // this is needed because handleNext is really triggering the validation
-            // which only happens onSubmit
-            onChange={({ formData, schema }) => {
-              if (props.transformErrors) {
-                validator.validateFormData(
-                  formData,
-                  schema,
-                  undefined,
-                  props.transformErrors,
-                );
-              }
-            }}
           >
             <div className={styles.footer}>
               <Button

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -36,6 +36,7 @@ import { useTemplateSchema } from './useTemplateSchema';
 import { ReviewState } from './ReviewState';
 import validator from '@rjsf/validator-ajv8';
 import { selectedTemplateRouteRef } from '../../../routes';
+import type { ErrorTransformer } from '@rjsf/utils';
 
 const useStyles = makeStyles(theme => ({
   backButton: {
@@ -56,6 +57,7 @@ export interface StepperProps {
   manifest: TemplateParameterSchema;
   extensions: NextFieldExtensionOptions<any, any>[];
   onComplete: (values: Record<string, JsonValue>) => Promise<void>;
+  transformErrors?: ErrorTransformer;
 }
 
 // TODO(blam): We require here, as the types in this package depend on @rjsf/core explicitly
@@ -149,6 +151,19 @@ export const Stepper = (props: StepperProps) => {
             onSubmit={handleNext}
             fields={extensions}
             showErrorList={false}
+            transformErrors={props.transformErrors}
+            // this is needed because handleNext is really triggering the validation
+            // which only happens onSubmit
+            onChange={({ formData, schema }) => {
+              if (props.transformErrors) {
+                validator.validateFormData(
+                  formData,
+                  schema,
+                  undefined,
+                  props.transformErrors,
+                );
+              }
+            }}
           >
             <div className={styles.footer}>
               <Button

--- a/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
@@ -44,9 +44,11 @@ import {
 } from '../../routes';
 import { SecretsContext } from '../../components/secrets/SecretsContext';
 import { JsonValue } from '@backstage/types';
+import type { ErrorTransformer } from '@rjsf/utils';
 
 export interface TemplateWizardPageProps {
   customFieldExtensions: NextFieldExtensionOptions<any, any>[];
+  transformErrors?: ErrorTransformer;
 }
 
 const useStyles = makeStyles<BackstageTheme>(() => ({
@@ -137,6 +139,7 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
                 manifest={manifest}
                 extensions={props.customFieldExtensions}
                 onComplete={onComplete}
+                transformErrors={props.transformErrors}
               />
             </InfoCard>
           )}


### PR DESCRIPTION
…form

Signed-off-by: Paul Cowan <paul.cowan@cutting.scot>

## Hey, I just made a Pull Request!

The `@rjsf/core` `<Form />` component has a very handy prop [transformErrors](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/form-props/#transformerrors) that gets around the problem of the default error message for the error message for a `pattern` which includes the regex and breaks security.

This allows the user to pass a `transformErrors` prop to the `NextScaffolderPage`, which gets passed through to the `next/Stepper`.

Hopefully, the test in the PR conveys the intent well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
