### PR TITLE
Refactored Report issue template in techdoc addons.

### DIFF
--- a/.changeset/tender-parrots-cover.md
+++ b/.changeset/tender-parrots-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+---
+
+Refactored Report issue body in the tech-doc addons by getting the app title from `appconfig.yml` using `configApiRef`, In case `appTitle` not mentioned app Tile `new const` will default to `Backstage`

--- a/.changeset/tender-parrots-cover.md
+++ b/.changeset/tender-parrots-cover.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-module-addons-contrib': patch
 ---
 
-Refactored Report issue body in the tech-doc addons by getting the app title from `appconfig.yml` using `configApiRef`, In case `appTitle` not mentioned app Tile `new const` will default to `Backstage`
+Use `app.title` from `app-config.yaml` when creating new Documentation Feedback issue. `Backstage` is the default value.

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
@@ -16,7 +16,7 @@
 
 import parseGitUrl from 'git-url-parse';
 
-import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   replaceGithubUrlType,
   replaceGitLabUrlType,
@@ -48,7 +48,11 @@ export const getTitle = (selection: Selection) => {
   return `Documentation feedback: ${text}${ellipsis}`;
 };
 
-export const getBody = (selection: Selection, markdownUrl: string) => {
+export const getBody = (
+  selection: Selection,
+  markdownUrl: string,
+  appTitle: string,
+) => {
   const title = '## Documentation Feedback 📝';
   const subheading = '#### The highlighted text:';
   const commentHeading = '#### The comment on the text:';
@@ -61,7 +65,7 @@ export const getBody = (selection: Selection, markdownUrl: string) => {
     .join('\n');
 
   const facts = [
-    `Backstage URL: <${window.location.href}> \nMarkdown URL: <${markdownUrl}>`,
+    `${appTitle} URL: <${window.location.href}> \nMarkdown URL: <${markdownUrl}>`,
   ];
 
   return `${title}\n\n ${subheading} \n\n ${highlightedTextAsQuote}\n\n ${commentHeading} \n ${commentPlaceholder}\n\n ___\n${facts}`;
@@ -73,7 +77,8 @@ export const useGitTemplate = (debounceTime?: number) => {
   const [editLink] = useShadowRootElements([PAGE_EDIT_LINK_SELECTOR]);
   const url = (editLink as HTMLAnchorElement)?.href ?? '';
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
-
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.getOptional('app.title') || 'Backstage';
   if (!selection || !url) return initialTemplate;
 
   const type = scmIntegrationsApi.byUrl(url)?.type;
@@ -82,7 +87,7 @@ export const useGitTemplate = (debounceTime?: number) => {
 
   return {
     title: getTitle(selection),
-    body: getBody(selection, resolveBlobUrl(url, type)),
+    body: getBody(selection, resolveBlobUrl(url, type), appTitle),
   };
 };
 

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
@@ -78,7 +78,7 @@ export const useGitTemplate = (debounceTime?: number) => {
   const url = (editLink as HTMLAnchorElement)?.href ?? '';
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
   const configApi = useApi(configApiRef);
-  let appTitle: string = configApi.getOptional('app.title') || 'Backstage';
+  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
   if (!selection || !url) return initialTemplate;
 
   const type = scmIntegrationsApi.byUrl(url)?.type;

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
@@ -78,7 +78,7 @@ export const useGitTemplate = (debounceTime?: number) => {
   const url = (editLink as HTMLAnchorElement)?.href ?? '';
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
   const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptional('app.title') || 'Backstage';
+  let appTitle: string = configApi.getOptional('app.title') || 'Backstage';
   if (!selection || !url) return initialTemplate;
 
   const type = scmIntegrationsApi.byUrl(url)?.type;


### PR DESCRIPTION
In tech-doc Addons  report issue's pull request template is hardcoded with Backstage URL as shown below, So refactored Report issue body in the tech-doc addons by getting the app title from `appconfig.yml` using `configApiRef`, In case `appTitle` not mentioned app Tile `new const` will default to `Backstage`

![image](https://user-images.githubusercontent.com/24265936/202184311-65200b6a-1ecf-42db-9810-26c34ee35197.png)

Co-authored-by: kcheriyath <kamal.cheriyath@mnscorp.net>
Co-authored-by: aswathysen <aswathy.sen@mnscorp.net>
Co-authored-by: skgandikota <gsaikoushik@yahoo.com>