### PR TITLE
Add optional displayName parameter for kubernetes clusters

### DIFF
--- a/.changeset/nine-glasses-obey.md
+++ b/.changeset/nine-glasses-obey.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+---
+
+Add optional `displayName` parameter for kubernetes clusters

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -24,6 +24,7 @@ kubernetes:
       clusters:
         - url: http://127.0.0.1:9999
           name: minikube
+          displayName: mycluster
           authProvider: 'serviceAccount'
           skipTLSVerify: false
           skipMetricsLookup: true
@@ -94,7 +95,13 @@ The base URL to the Kubernetes control plane. Can be found by using the
 ##### `clusters.\*.name`
 
 A name to represent this cluster, this must be unique within the `clusters`
-array. Users will see this value in the Software Catalog Kubernetes plugin.
+array.
+Users will see this value in the Software Catalog Kubernetes plugin if `clusters.\*.displayName` is not set.
+
+##### `clusters.\*.displayName`
+
+An alternative name to represent this cluster.
+Users will see this value in the Software Catalog Kubernetes plugin if it's defined.
 
 ##### `clusters.\*.authProvider`
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -81,6 +81,7 @@ export interface ClusterDetails {
   dashboardApp?: string;
   dashboardParameters?: JsonObject;
   dashboardUrl?: string;
+  displayName?: string;
   name: string;
   oidcTokenProvider?: string | undefined;
   // (undocumented)

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -49,6 +49,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -88,6 +89,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         dashboardUrl: 'https://k8s.foo.com',
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
@@ -98,6 +100,7 @@ describe('ConfigClusterLocator', () => {
       },
       {
         name: 'cluster2',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',
@@ -144,6 +147,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: undefined,
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: 'token',
         externalId: undefined,
         url: 'http://localhost:8080',
@@ -155,6 +159,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        displayName: undefined,
         externalId: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
@@ -166,6 +171,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        displayName: undefined,
         externalId: 'SomeExternalId',
         url: 'http://localhost:8081',
         serviceAccountToken: undefined,
@@ -201,6 +207,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -237,6 +244,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -245,6 +253,36 @@ describe('ConfigClusterLocator', () => {
         caData: undefined,
         dashboardApp: 'standard',
         dashboardUrl: 'http://someurl',
+      },
+    ]);
+  });
+
+  it('one clusters with displayName parameter', async () => {
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          displayName: 'clustername1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+        },
+      ],
+    });
+
+    const sut = ConfigClusterLocator.fromConfig(config);
+
+    const result = await sut.getClusters();
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        displayName: 'clustername1',
+        serviceAccountToken: undefined,
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+        skipMetricsLookup: false,
+        skipTLSVerify: false,
+        caData: undefined,
       },
     ]);
   });

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -38,6 +38,7 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           skipMetricsLookup: c.getOptionalBoolean('skipMetricsLookup') ?? false,
           caData: c.getOptionalString('caData'),
           authProvider: authProvider,
+          displayName: c.getOptionalString('displayName'),
         };
         const dashboardUrl = c.getOptionalString('dashboardUrl');
         if (dashboardUrl) {
@@ -49,6 +50,9 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
         }
         if (c.has('dashboardParameters')) {
           clusterDetails.dashboardParameters = c.get('dashboardParameters');
+        }
+        if (c.has('displayName')) {
+          clusterDetails.displayName = c.getOptionalString('displayName');
         }
 
         switch (authProvider) {

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -31,6 +31,7 @@ describe('getCombinedClusterSupplier', () => {
               clusters: [
                 {
                   name: 'cluster1',
+                  displayName: 'some-name',
                   serviceAccountToken: 'token',
                   url: 'http://localhost:8080',
                   authProvider: 'serviceAccount',
@@ -54,6 +55,7 @@ describe('getCombinedClusterSupplier', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        displayName: 'some-name',
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -63,6 +65,7 @@ describe('getCombinedClusterSupplier', () => {
       },
       {
         name: 'cluster2',
+        displayName: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -50,6 +50,7 @@ describe('KubernetesBuilder', () => {
     const clusters: ClusterDetails[] = [
       {
         name: 'some-cluster',
+        displayName: 'some-name',
         authProvider: 'serviceAccount',
         url: 'https://localhost:1234',
         serviceAccountToken: 'someToken',
@@ -95,6 +96,7 @@ describe('KubernetesBuilder', () => {
         items: [
           {
             name: 'some-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           {

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -266,6 +266,7 @@ export class KubernetesBuilder {
       res.json({
         items: clusterDetails.map(cd => ({
           name: cd.name,
+          displayName: cd.displayName,
           dashboardUrl: cd.dashboardUrl,
           authProvider: cd.authProvider,
           oidcTokenProvider: cd.oidcTokenProvider,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -80,6 +80,7 @@ const entity = {
 
 const cluster1 = {
   name: 'test-cluster',
+  displayName: 'some-name',
   authProvider: 'serviceAccount',
   customResources: [
     {
@@ -286,6 +287,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
         ],
@@ -311,6 +313,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -369,6 +372,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           cluster2,
@@ -405,6 +409,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
         ],
@@ -463,6 +468,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE, POD_METRICS_FIXTURE],
@@ -502,6 +508,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
             dashboardUrl: 'https://k8s.foo.coom',
           },
@@ -530,6 +537,7 @@ describe('getKubernetesObjectsByEntity', () => {
           cluster: {
             dashboardUrl: 'https://k8s.foo.coom',
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -552,6 +560,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           {
@@ -582,6 +591,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -604,6 +614,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           {
@@ -638,6 +649,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -681,6 +693,7 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
             dashboardUrl: 'https://k8s.foo.coom',
           },
@@ -729,6 +742,7 @@ describe('getKubernetesObjectsByEntity', () => {
           cluster: {
             dashboardUrl: 'https://k8s.foo.coom',
             name: 'test-cluster',
+            displayName: 'some-name',
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -791,6 +805,7 @@ describe('getCustomResourcesByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            displayName: 'some-name',
             authProvider: 'serviceAccount',
           },
           cluster2,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -336,6 +336,9 @@ export class KubernetesFanOutHandler {
     if (clusterDetails.dashboardParameters) {
       objects.cluster.dashboardParameters = clusterDetails.dashboardParameters;
     }
+    if (clusterDetails.displayName) {
+      objects.cluster.displayName = clusterDetails.displayName;
+    }
     return objects;
   }
 

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -204,6 +204,11 @@ export interface ClusterDetails {
    * Kubernetes resources.
    */
   customResources?: CustomResourceMatcher[];
+  /**
+   * Specifies the custom cluster name.
+   * If it's defined, displayName will be used as a cluster name instead of the name parameter.
+   */
+  displayName?: string;
 }
 
 /**

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -59,6 +59,7 @@ export interface ClusterAttributes {
   dashboardApp?: string;
   dashboardParameters?: JsonObject;
   dashboardUrl?: string;
+  displayName?: string;
   name: string;
 }
 

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -103,6 +103,11 @@ export interface ClusterAttributes {
    * This is used by the GKE formatter which requires the project, region and cluster name.
    */
   dashboardParameters?: JsonObject;
+  /**
+   * Specifies the custom cluster name.
+   * If it's defined, displayName will be used as a cluster name instead of the name parameter.
+   */
+  displayName?: string;
 }
 
 /** @public */

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -243,6 +243,7 @@ export interface KubernetesApi {
   getClusters(): Promise<
     {
       name: string;
+      displayName?: string;
       authProvider: string;
       oidcTokenProvider?: string | undefined;
     }[]
@@ -311,6 +312,7 @@ export class KubernetesBackendClient implements KubernetesApi {
   getClusters(): Promise<
     {
       name: string;
+      displayName: string;
       authProvider: string;
     }[]
   >;

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -97,7 +97,9 @@ export class KubernetesBackendClient implements KubernetesApi {
     });
   }
 
-  async getClusters(): Promise<{ name: string; authProvider: string }[]> {
+  async getClusters(): Promise<
+    { name: string; displayName: string; authProvider: string }[]
+  > {
     const { token: idToken } = await this.identityApi.getCredentials();
     const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}/clusters`;
 

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -33,6 +33,7 @@ export interface KubernetesApi {
   getClusters(): Promise<
     {
       name: string;
+      displayName?: string;
       authProvider: string;
       oidcTokenProvider?: string | undefined;
     }[]

--- a/plugins/kubernetes/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.tsx
@@ -46,6 +46,7 @@ import { PodNamesWithMetricsContext } from '../../hooks/PodNamesWithMetrics';
 
 type ClusterSummaryProps = {
   clusterName: string;
+  displayName?: string;
   totalNumberOfPods: number;
   numberOfPodsWithErrors: number;
   children?: React.ReactNode;
@@ -53,6 +54,7 @@ type ClusterSummaryProps = {
 
 const ClusterSummary = ({
   clusterName,
+  displayName,
   totalNumberOfPods,
   numberOfPodsWithErrors,
 }: ClusterSummaryProps) => {
@@ -73,7 +75,7 @@ const ClusterSummary = ({
         spacing={0}
       >
         <Grid item xs>
-          <Typography variant="h3">{clusterName}</Typography>
+          <Typography variant="h3">{displayName ?? clusterName}</Typography>
           <Typography color="textSecondary" variant="body1">
             Cluster
           </Typography>
@@ -131,6 +133,7 @@ export const Cluster = ({ clusterObjects, podsWithErrors }: ClusterProps) => {
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <ClusterSummary
                   clusterName={clusterObjects.cluster.name}
+                  displayName={clusterObjects.cluster.displayName}
                   totalNumberOfPods={groupedResponses.pods.length}
                   numberOfPodsWithErrors={podsWithErrors.size}
                 />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change adds a new optional parameter `displayName`. 
If `displayName` is defined, it will be used instead of the cluster name. 
This might be useful when we have multiple clusters with the same name:
<img width="1507" alt="Screenshot 2022-11-17 at 13 29 05" src="https://user-images.githubusercontent.com/11457338/202446708-41b781f0-5aa1-445b-a232-96d68cd7b2e8.png">

In the case of EKS configuration, we can't set custom cluster names in `app-config.yaml` as the cluster name is a part of the API request to AWS. This PR introduces a new configuration field that does not affect API calls but gives an opportunity to show an alternative cluster name in the UI.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
