### PR TITLE
integrations: add allowedInstallationOwners to config schema

### DIFF
--- a/.changeset/weak-ears-jam.md
+++ b/.changeset/weak-ears-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Added `integrations.github.apps.allowedInstallationOwners` to the configuration schema.

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -189,6 +189,14 @@ export interface Config {
          * @visibility secret
          */
         clientSecret: string;
+        /**
+         * List of installation owners allowed to be used by this GitHub app. The GitHub UI does not provide a way to list the installations.
+         * However you can list the installations with the GitHub API. You can find the list of installations here:
+         * https://api.github.com/app/installations
+         * The relevant documentation for this is here.
+         * https://docs.github.com/en/rest/reference/apps#list-installations-for-the-authenticated-app--code-samples
+         */
+        allowedInstallationOwners?: string[];
       }>;
     }>;
 


### PR DESCRIPTION
🧹 , from here: https://github.com/backstage/backstage/blob/a79cb9de0c1679d47c50a12aad5332e4f101dc1c/packages/integration/src/github/config.ts#L111