### PR TITLE
Use pluralize for catalog kind header component

### DIFF
--- a/.changeset/thin-donuts-join.md
+++ b/.changeset/thin-donuts-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add `pluralize()` to the catalog kind header component.

--- a/.changeset/thin-donuts-join.md
+++ b/.changeset/thin-donuts-join.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Add `pluralize()` to the catalog kind header component.
+Fixed Entity kind pluralisation in the `CatalogKindHeader` component.

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -49,6 +49,7 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "history": "^5.0.0",
     "lodash": "^4.17.21",
+    "pluralize": "^8.0.0",
     "react-helmet": "6.1.0",
     "react-use": "^17.2.4",
     "zen-observable": "^0.9.0"

--- a/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.test.tsx
+++ b/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.test.tsx
@@ -31,6 +31,7 @@ import {
 } from '@backstage/test-utils';
 import { CatalogKindHeader } from './CatalogKindHeader';
 import { errorApiRef } from '@backstage/core-plugin-api';
+import pluralize from 'pluralize';
 
 const entities: Entity[] = [
   {
@@ -96,7 +97,7 @@ describe('<CatalogKindHeader />', () => {
 
     entities.map(entity => {
       expect(
-        screen.getByRole('option', { name: `${entity.kind}s` }),
+        screen.getByRole('option', { name: `${pluralize(entity.kind)}` }),
       ).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.tsx
+++ b/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.tsx
@@ -31,6 +31,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import useAsync from 'react-use/lib/useAsync';
 import { useApi } from '@backstage/core-plugin-api';
+import pluralize from 'pluralize';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -132,7 +133,7 @@ export function CatalogKindHeader(props: CatalogKindHeaderProps) {
     >
       {Object.keys(options).map(kind => (
         <MenuItem value={kind} key={kind}>
-          {`${options[kind]}s`}
+          {`${pluralize(options[kind])}`}
         </MenuItem>
       ))}
     </Select>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,6 +4750,7 @@ __metadata:
     cross-fetch: ^3.1.5
     history: ^5.0.0
     lodash: ^4.17.21
+    pluralize: ^8.0.0
     react-helmet: 6.1.0
     react-use: ^17.2.4
     zen-observable: ^0.9.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It uses `pluralize()` for `CatalogKindHeader` component. We've added new entity kind `Technology`. Before this PR it shows `Technologys`, after it shows correctly `Technologies` :) 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
