### PR TITLE
Pass headerOptions to TemplatePage

### DIFF
--- a/.changeset/sour-plums-grow.md
+++ b/.changeset/sour-plums-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+fixed `headerOptions` not passed to `TemplatePage` component

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -163,6 +163,7 @@ export const Router = (props: RouterProps) => {
             <TemplatePage
               customFieldExtensions={fieldExtensions}
               layouts={customLayouts}
+              headerOptions={props.headerOptions}
             />
           </SecretsContextProvider>
         }

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -51,13 +51,21 @@ const useTemplateParameterSchema = (templateRef: string) => {
   return { schema: value, loading, error };
 };
 
+type Props = {
+  customFieldExtensions?: FieldExtensionOptions<any, any>[];
+  layouts?: LayoutOptions[];
+  headerOptions?: {
+    pageTitleOverride?: string;
+    title?: string;
+    subtitle?: string;
+  };
+};
+
 export const TemplatePage = ({
   customFieldExtensions = [],
   layouts = [],
-}: {
-  customFieldExtensions?: FieldExtensionOptions<any, any>[];
-  layouts?: LayoutOptions[];
-}) => {
+  headerOptions,
+}: Props) => {
   const apiHolder = useApiHolder();
   const secretsContext = useContext(SecretsContext);
   const errorApi = useApi(errorApiRef);
@@ -136,6 +144,7 @@ export const TemplatePage = ({
           pageTitleOverride="Create a New Component"
           title="Create a New Component"
           subtitle="Create new software components using standard templates"
+          {...headerOptions}
         />
         <Content>
           {loading && <LinearProgress data-testid="loading-progress" />}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
A follow-up on #13879 to pass `headerOptions` to the `TemplatePage` component, so the header title stays the same on Scaffolder and Template pages 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
