### PR TITLE
Fix the URL of Humanitec plugin

### DIFF
--- a/microsite/data/plugins/humanitec.yaml
+++ b/microsite/data/plugins/humanitec.yaml
@@ -6,7 +6,7 @@ category: Deployment # A single category e.g. CI, Machine Learning, Services, Mo
 description: |
   Show workloads, environments and resources deployed by Humanitec Platform Orchestrator. 
   Plugin includes an Entity ComponentCard, Backend API route and scaffolder actions.
-documentation: https://github.com/thefrontside/backstage/tree/main/plugins/humanitec
+documentation: https://github.com/thefrontside/playhouse/tree/main/plugins/humanitec
 iconUrl: img/humanitec-logo.png
 npmPackageName: '@frontside/backstage-plugin-humanitec'
 addedDate: '2022-06-22'


### PR DESCRIPTION
Signed-off-by: Taras Mankovski <taras@frontside.com>

## Hey, I just made a Pull Request!

The URL of the Frontside Backstage repo changed which broke the link.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
