### PR TITLE
Add bitbucket cloud scaffolder action "bitbucket-cloud:repo:create"

### DIFF
--- a/.changeset/old-mirrors-kneel.md
+++ b/.changeset/old-mirrors-kneel.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added a new scaffolder-backend action 'bitbucket-cloud:repo:create'.
+This new action is essentially a clone of the 'publish:bitbucket-cloud' action. The idea is to write a few new actions for better support into Bitbucket Cloud.
+
+The new 'bitbucket-cloud:repo:create' adds functionality to enable bitbucket pipelines (CI/CD) on a repository at creation

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/bitbucketCloudRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/bitbucketCloudRepoCreate.test.ts
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('../helpers');
+
+import { createBitbucketCloudRepoCreateAction } from './bitbucketCloudRepoCreate';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
+import { ScmIntegrations } from '@backstage/integration';
+import { ConfigReader } from '@backstage/config';
+import { getVoidLogger } from '@backstage/backend-common';
+import { PassThrough } from 'stream';
+import { initRepoAndPush } from '../helpers';
+
+describe('bitbucketCloud:repo:create', () => {
+  const config = new ConfigReader({
+    integrations: {
+      bitbucketCloud: [
+        {
+          username: 'u',
+          appPassword: 'p',
+        },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  const action = createBitbucketCloudRepoCreateAction({ integrations, config });
+  const mockContext = {
+    input: {
+      repoUrl: 'bitbucket.org?workspace=workspace&project=project&repo=repo',
+      repoVisibility: 'private' as const,
+      enablePipeline: false as const,
+    },
+    workspacePath: 'wsp',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+  const server = setupServer();
+  setupRequestMockHandlers(server);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should throw an error when the repoUrl is not well formed', async () => {
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          repoUrl: 'bitbucket.org?project=project&repo=repo',
+        },
+      }),
+    ).rejects.toThrow(/missing workspace/);
+
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          repoUrl: 'bitbucket.org?workspace=workspace&repo=repo',
+        },
+      }),
+    ).rejects.toThrow(/missing project/);
+
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          repoUrl: 'bitbucket.org?workspace=workspace&project=project',
+        },
+      }),
+    ).rejects.toThrow(/missing repo/);
+  });
+
+  it('should throw if there is no integration config provided', async () => {
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          repoUrl: 'missing.com?workspace=workspace&project=project&repo=repo',
+        },
+      }),
+    ).rejects.toThrow(/No matching integration configuration/);
+  });
+
+  it('should throw if there is no token in the integration config that is returned', async () => {
+    const configNoCreds = new ConfigReader({
+      integrations: {
+        bitbucketCloud: [],
+      },
+    });
+
+    const integrationsNoCreds = ScmIntegrations.fromConfig(configNoCreds);
+    const actionNoCreds = createBitbucketCloudRepoCreateAction({
+      integrations: integrationsNoCreds,
+      config: configNoCreds,
+    });
+
+    await expect(actionNoCreds.handler(mockContext)).rejects.toThrow(
+      /Authorization has not been provided for Bitbucket Cloud/,
+    );
+  });
+
+  it('should call the correct APIs with pipelines disabled', async () => {
+    expect.assertions(2);
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(req.body).toEqual({
+            is_private: true,
+            scm: 'git',
+            project: { key: 'project' },
+          });
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/repo',
+                  },
+                ],
+              },
+            }),
+          );
+        },
+      ),
+    );
+
+    await action.handler(mockContext);
+  });
+
+  it('should call the correct APIs with pipelines enabled', async () => {
+    expect.assertions(4);
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(req.body).toEqual({
+            is_private: true,
+            scm: 'git',
+            project: { key: 'project' },
+          });
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/repo',
+                  },
+                ],
+              },
+            }),
+          );
+        },
+      ),
+      rest.put(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/pipelines_config',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(req.body).toEqual({
+            enabled: true,
+            repository: {},
+          });
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              enabled: true,
+              repository: {},
+            }),
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        enablePipeline: true,
+      },
+    });
+  });
+
+  it('should work if the token is provided through ctx.input', async () => {
+    expect.assertions(2);
+    const token = 'user-token';
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          expect(req.body).toEqual({
+            is_private: true,
+            scm: 'git',
+            project: { key: 'project' },
+          });
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/repo',
+                  },
+                ],
+              },
+            }),
+          );
+        },
+      ),
+    );
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        token: token,
+      },
+    });
+  });
+
+  it('should call initAndPush with the correct values', async () => {
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await action.handler(mockContext);
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://bitbucket.org/workspace/cloneurl',
+      defaultBranch: 'master',
+      auth: { username: 'u', password: 'p' },
+      logger: mockContext.logger,
+      gitAuthorInfo: {},
+    });
+  });
+
+  it('should call initAndPush with the correct default branch', async () => {
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://bitbucket.org/workspace/cloneurl',
+      defaultBranch: 'main',
+      auth: { username: 'u', password: 'p' },
+      logger: mockContext.logger,
+      gitAuthorInfo: {},
+    });
+  });
+
+  it('should call initAndPush with the configured defaultAuthor', async () => {
+    const customAuthorConfig = new ConfigReader({
+      integrations: {
+        bitbucketCloud: [
+          {
+            username: 'u',
+            appPassword: 'p',
+          },
+        ],
+      },
+      scaffolder: {
+        defaultAuthor: {
+          name: 'Test',
+          email: 'example@example.com',
+        },
+      },
+    });
+
+    const customAuthorIntegrations =
+      ScmIntegrations.fromConfig(customAuthorConfig);
+    const customAuthorAction = createBitbucketCloudRepoCreateAction({
+      integrations: customAuthorIntegrations,
+      config: customAuthorConfig,
+    });
+
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await customAuthorAction.handler(mockContext);
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://bitbucket.org/workspace/cloneurl',
+      auth: { username: 'u', password: 'p' },
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
+    });
+  });
+
+  it('should call initAndPush with the configured defaultCommitMessage', async () => {
+    const customAuthorConfig = new ConfigReader({
+      integrations: {
+        bitbucketCloud: [
+          {
+            username: 'u',
+            appPassword: 'p',
+          },
+        ],
+      },
+      scaffolder: {
+        defaultCommitMessage: 'Test commit message',
+      },
+    });
+
+    const customAuthorIntegrations =
+      ScmIntegrations.fromConfig(customAuthorConfig);
+    const customAuthorAction = createBitbucketCloudRepoCreateAction({
+      integrations: customAuthorIntegrations,
+      config: customAuthorConfig,
+    });
+
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await customAuthorAction.handler(mockContext);
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://bitbucket.org/workspace/cloneurl',
+      auth: { username: 'u', password: 'p' },
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      commitMessage: 'Test commit message',
+      gitAuthorInfo: { email: undefined, name: undefined },
+    });
+  });
+
+  it('should call outputs with the correct urls', async () => {
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await action.handler(mockContext);
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://bitbucket.org/workspace/cloneurl',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repoContentsUrl',
+      'https://bitbucket.org/workspace/repo/src/master',
+    );
+  });
+
+  it('should call outputs with the correct urls with correct default branch', async () => {
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://bitbucket.org/workspace/cloneurl',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repoContentsUrl',
+      'https://bitbucket.org/workspace/repo/src/main',
+    );
+  });
+});

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/bitbucketCloudRepoCreate.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/bitbucketCloudRepoCreate.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ScmIntegrationRegistry } from '@backstage/integration';
+import { initRepoAndPush } from '../helpers';
+import { createTemplateAction } from '../../createTemplateAction';
+import { getRepoSourceDirectory } from '../publish/util';
+import { Config } from '@backstage/config';
+import { getBitbucketCloudConfig } from './util';
+import {
+  bitbucketCloudEnablePipeline,
+  bitbucketCloudCreateRepository,
+} from './helpers';
+
+/**
+ * Creates a new action that initializes a git repository of the content in the workspace
+ * and publishes it to Bitbucket Cloud.
+ * @public
+ */
+export function createBitbucketCloudRepoCreateAction(options: {
+  integrations: ScmIntegrationRegistry;
+  config: Config;
+}) {
+  const { integrations, config } = options;
+
+  return createTemplateAction<{
+    repoUrl: string;
+    description?: string;
+    defaultBranch?: string;
+    enablePipeline?: boolean;
+    repoVisibility?: 'private' | 'public';
+    sourcePath?: string;
+    token?: string;
+  }>({
+    id: 'bitbucketCloud:repo:create',
+    description:
+      'Initializes a git repository of the content in the workspace, and publishes it to Bitbucket Cloud.',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['repoUrl'],
+        properties: {
+          repoUrl: {
+            title: 'Repository Location',
+            type: 'string',
+          },
+          description: {
+            title: 'Repository Description',
+            type: 'string',
+          },
+          repoVisibility: {
+            title: 'Repository Visibility',
+            type: 'string',
+            enum: ['private', 'public'],
+          },
+          defaultBranch: {
+            title: 'Default Branch',
+            type: 'string',
+            description: `Sets the default branch on the repository. The default value is 'master'`,
+          },
+          sourcePath: {
+            title: 'Source Path',
+            description:
+              'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the repository.',
+            type: 'string',
+          },
+          enablePipeline: {
+            title: 'Enable Bitbucket pipeline',
+            description:
+              'Enable Bitbucket pipelines on this repository. Default is False',
+            type: 'boolean',
+          },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description:
+              'The token to use for authorization to BitBucket Cloud',
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          remoteUrl: {
+            title: 'A URL to the repository with the provider',
+            type: 'string',
+          },
+          repoContentsUrl: {
+            title: 'A URL to the root of the repository',
+            type: 'string',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const {
+        description,
+        defaultBranch = 'master',
+        enablePipeline = false,
+        repoVisibility = 'private',
+        token,
+        repoUrl,
+      } = ctx.input;
+
+      const {
+        apiBaseUrl,
+        authorization,
+        integrationConfig,
+        project,
+        repo,
+        workspace,
+      } = getBitbucketCloudConfig({ repoUrl, token, integrations });
+
+      // Use Bitbucket API to create a new repository
+      const { remoteUrl, repoContentsUrl } =
+        await bitbucketCloudCreateRepository({
+          authorization,
+          workspace: workspace || '',
+          project,
+          repo,
+          repoVisibility,
+          mainBranch: defaultBranch,
+          description,
+          apiBaseUrl,
+        });
+
+      const gitAuthorInfo = {
+        name: config.getOptionalString('scaffolder.defaultAuthor.name'),
+        email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+      };
+
+      let auth;
+
+      if (ctx.input.token) {
+        auth = {
+          username: 'x-token-auth',
+          password: ctx.input.token,
+        };
+      } else {
+        if (
+          !integrationConfig.config.username ||
+          !integrationConfig.config.appPassword
+        ) {
+          throw new Error(
+            'Credentials for Bitbucket Cloud integration required for this action.',
+          );
+        }
+
+        auth = {
+          username: integrationConfig.config.username,
+          password: integrationConfig.config.appPassword,
+        };
+      }
+      // Use isomorphic-git to push workspace to new repository
+      await initRepoAndPush({
+        dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
+        remoteUrl,
+        auth,
+        defaultBranch,
+        logger: ctx.logger,
+        commitMessage: config.getOptionalString(
+          'scaffolder.defaultCommitMessage',
+        ),
+        gitAuthorInfo,
+      });
+      // Use Bitbucket API to enable pipeline
+      if (enablePipeline) {
+        await bitbucketCloudEnablePipeline({
+          workspace,
+          repo,
+          authorization,
+          apiBaseUrl,
+        });
+      }
+
+      ctx.output('remoteUrl', remoteUrl);
+      ctx.output('repoContentsUrl', repoContentsUrl);
+      ctx.output('enablePipeline', enablePipeline);
+    },
+  });
+}

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/helpers.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fetch, { Response, RequestInit } from 'node-fetch';
+
+/**
+ * Uses the Bitbucket Cloud REST API to create a new repository.
+ * @public
+ */
+export const bitbucketCloudCreateRepository = async (opts: {
+  workspace: string;
+  project: string;
+  repo: string;
+  description?: string;
+  repoVisibility: 'private' | 'public';
+  mainBranch: string;
+  authorization: string;
+  apiBaseUrl: string;
+}) => {
+  const {
+    workspace,
+    project,
+    repo,
+    description,
+    repoVisibility,
+    mainBranch,
+    authorization,
+    apiBaseUrl,
+  } = opts;
+
+  const options: RequestInit = {
+    method: 'POST',
+    body: JSON.stringify({
+      scm: 'git',
+      description: description,
+      is_private: repoVisibility === 'private',
+      project: { key: project },
+    }),
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/repositories/${workspace}/${repo}`,
+      options,
+    );
+  } catch (e) {
+    throw new Error(`Unable to create repository, ${e}`);
+  }
+
+  if (response.status !== 200) {
+    throw new Error(
+      `Unable to create repository, ${response.status} ${
+        response.statusText
+      }, ${await response.text()}`,
+    );
+  }
+
+  const r = await response.json();
+  let remoteUrl = '';
+  for (const link of r.links.clone) {
+    if (link.name === 'https') {
+      remoteUrl = link.href;
+    }
+  }
+
+  // "mainbranch.name" cannot be set neither at create nor update of the repo
+  // the first pushed branch will be set as "main branch" then
+  const repoContentsUrl = `${r.links.html.href}/src/${mainBranch}`;
+  return { remoteUrl, repoContentsUrl };
+};
+
+export const bitbucketCloudEnablePipeline = async (opts: {
+  workspace: string;
+  repo: string;
+  authorization: string;
+  apiBaseUrl: string;
+}) => {
+  const { workspace, repo, authorization, apiBaseUrl } = opts;
+
+  const options: RequestInit = {
+    method: 'PUT',
+    body: JSON.stringify({
+      enabled: true,
+      repository: {},
+    }),
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/repositories/${workspace}/${repo}/pipelines_config`,
+      options,
+    );
+  } catch (e) {
+    throw new Error(`Unable to enable pipelines, ${e}`);
+  }
+
+  if (response.status !== 200) {
+    throw new Error(
+      `Unable to enable pipelines, ${response.status} ${
+        response.statusText
+      }, ${await response.text()}`,
+    );
+  }
+
+  const r = await response.json();
+
+  return { pipelineEnabled: r.enabled };
+};

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createBitbucketCloudRepoCreateAction } from './bitbucketCloudRepoCreate';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/util.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/bitbucket-cloud/util.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InputError } from '@backstage/errors';
+import { parseRepoUrl } from '../publish/util';
+import { ScmIntegrationRegistry } from '@backstage/integration';
+
+const getAuthorizationHeader = (config: {
+  username?: string;
+  appPassword?: string;
+  token?: string;
+}) => {
+  if (config.username && config.appPassword) {
+    const buffer = Buffer.from(
+      `${config.username}:${config.appPassword}`,
+      'utf8',
+    );
+
+    return `Basic ${buffer.toString('base64')}`;
+  }
+
+  if (config.token) {
+    return `Bearer ${config.token}`;
+  }
+
+  throw new Error(
+    `Authorization has not been provided for Bitbucket Cloud. Please add either username + appPassword to the Integrations config or a user login auth token`,
+  );
+};
+
+export function getBitbucketCloudConfig(config: {
+  repoUrl: string;
+  token?: string;
+  integrations: ScmIntegrationRegistry;
+}) {
+  const { workspace, project, repo, host } = parseRepoUrl(
+    config.repoUrl,
+    config.integrations,
+  );
+
+  if (!workspace) {
+    throw new InputError(
+      `Invalid URL provider was included in the repo URL to create ${config.repoUrl}, missing workspace`,
+    );
+  }
+
+  if (!project) {
+    throw new InputError(
+      `Invalid URL provider was included in the repo URL to create ${config.repoUrl}, missing project`,
+    );
+  }
+
+  const integrationConfig = config.integrations.bitbucketCloud.byHost(host);
+  if (!integrationConfig) {
+    throw new InputError(
+      `No matching integration configuration for host ${host}, please check your integrations config`,
+    );
+  }
+
+  const authorization = getAuthorizationHeader(
+    config.token ? { token: config.token } : integrationConfig.config,
+  );
+
+  const apiBaseUrl = integrationConfig.config.apiBaseUrl;
+
+  return {
+    apiBaseUrl: apiBaseUrl,
+    authorization: authorization,
+    integrationConfig: integrationConfig,
+    project: project,
+    repo: repo,
+    workspace: workspace,
+  };
+}

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -43,6 +43,7 @@ import {
   createGithubRepoPushAction,
   createGithubWebhookAction,
 } from './github';
+import { createBitbucketCloudRepoCreateAction } from './bitbucket-cloud';
 import {
   createPublishAzureAction,
   createPublishBitbucketAction,
@@ -183,6 +184,10 @@ export const createBuiltinActions = (
       integrations,
       config,
       githubCredentialsProvider,
+    }),
+    createBitbucketCloudRepoCreateAction({
+      integrations,
+      config,
     }),
   ];
 


### PR DESCRIPTION
Signed-off-by: Andrew Kundrock <akundrock@somalogic.com>

## Hey, I just made a Pull Request!

This PR adds a new sub folder in the scaffolder-backend actions to separate advanced functions for Bitbucket Cloud. The first "action" is "bitbucket-cloud:repo:create"

The new action is essentially a clone of the existing "publish:bitbucket-cloud" action but breaks out a few helper functions and tests so their functions are easier to understand. Additionally, I have added the ability to "enable Bitbucket Pipelines" upon repo creation. In the future, I would like to see additional options on the action to allow for default branch permissions, etc.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


