### PR TITLE
workflows: add workflow for posting release information on PR merge

### DIFF
--- a/.github/workflows/automate_merge_message.yml
+++ b/.github/workflows/automate_merge_message.yml
@@ -1,0 +1,63 @@
+name: Automate merge message
+on:
+  pull_request:
+    branches: ['master']
+    types: ['closed']
+
+permissions:
+  pull-requests: write
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pages: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  message:
+    # prevent running towards forks, and only run on merged PRs
+    if: github.repository == 'backstage/backstage' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: '${{ github.event.pull_request.merge_commit_sha }}'
+
+      - name: fetch base
+        run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
+
+        # We avoid using the in-source script since this workflow has elevated permissions that we don't want to expose
+      - name: Generate Message
+        id: generate-message
+        run: |
+          rm -f generate.js
+          wget -O generate.js https://raw.githubusercontent.com/backstage/backstage/master/scripts/generate-merge-message.js 1>&2
+          node generate.js FETCH_HEAD > message.txt
+
+      - name: Post Message
+        uses: actions/github-script@v6
+        env:
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const owner = "backstage";
+            const repo = "backstage";
+            const body = require('fs').readFileSync('message.txt', 'utf8').trim();
+            const issue_number = Number(process.env.ISSUE_NUMBER);
+
+            if (!body) {
+              console.log(`skipping comment for #${issue_number}`);
+              return;
+            }
+
+            console.log(`creating comment for #${issue_number}`);
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });

--- a/scripts/generate-merge-message.js
+++ b/scripts/generate-merge-message.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { execFile: execFileCb } = require('child_process');
+const { promisify } = require('util');
+const { resolve: resolvePath } = require('path');
+
+const execFile = promisify(execFileCb);
+
+async function hasNewChangesets(ref) {
+  if (!ref) {
+    throw new Error('ref is required');
+  }
+
+  const { stdout } = await execFile('git', [
+    'diff',
+    '--compact-summary',
+    ref,
+    '.changeset/*.md',
+  ]);
+  return stdout.includes('(new)');
+}
+
+function getReleaseOfMonth(year, month) {
+  const base = new Date(Date.UTC(year, month));
+  const wednesdayOffset =
+    base.getUTCDay() > 3 ? 10 - base.getUTCDay() : 3 - base.getUTCDay();
+  const thirdWednesdayOffset = wednesdayOffset + 7 * 2;
+  const releaseOffset = thirdWednesdayOffset - 1;
+  const releaseDay = new Date(
+    Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), releaseOffset + 1),
+  );
+  return releaseDay;
+}
+
+function getReleaseSchedule() {
+  const firstReleaseYear = 2022;
+  const firstReleaseMonth = 2;
+
+  return Array(100)
+    .fill(0)
+    .map((_, i) => {
+      const date = getReleaseOfMonth(firstReleaseYear, firstReleaseMonth + i);
+      return { version: `1.${i}.0`, date };
+    });
+}
+
+function getCurrentRelease() {
+  const { version: releaseVersion } = require(resolvePath('package.json'));
+
+  const match = releaseVersion.match(/^(\d+\.\d+\.\d+)/);
+  if (!match) {
+    throw new Error(`Failed to parse release version, '${releaseVersion}'`);
+  }
+  const [versionStr] = match;
+  if (versionStr === releaseVersion) {
+    return releaseVersion;
+  }
+  const [major, minor] = versionStr.split('.').map(Number);
+  return `${major}.${minor - 1}.0`;
+}
+
+function findNextRelease(currentRelease, releaseSchedule) {
+  const currentIndex = releaseSchedule.findIndex(
+    r => r.version === currentRelease,
+  );
+  if (currentIndex === -1) {
+    throw new Error(
+      `Failed to find current release '${currentRelease}' in release schedule`,
+    );
+  }
+
+  return releaseSchedule[currentIndex + 1];
+}
+
+async function main() {
+  const [diffRef = 'origin/master'] = process.argv.slice(2);
+  const needsMessage = await hasNewChangesets(diffRef);
+  if (!needsMessage) {
+    return;
+  }
+
+  const currentRelease = getCurrentRelease();
+  const releaseSchedule = getReleaseSchedule();
+  const nextRelease = findNextRelease(currentRelease, releaseSchedule);
+
+  const scheduledDate = nextRelease.date
+    .toUTCString()
+    .replace(/\s*\d+:\d+:\d+.*/, '');
+  process.stdout.write(
+    [
+      'Thank you for contributing to Backstage! The changes in this pull request will be part',
+      `of the \`${nextRelease.version}\` release, scheduled for ${scheduledDate}.`,
+    ].join(' '),
+  );
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #14643. Skipped prereleases, didn't feel quite as useful so didn't want to do that upfront.

It posts the message whenever there's a new changeset in a PR that got merged

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
