### PR TITLE
Add support for aliases for k8s clusters

### DIFF
--- a/.changeset/good-emus-applaud.md
+++ b/.changeset/good-emus-applaud.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-kubernetes': minor
+'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-common': minor
+---
+
+Add support for aliases in k8s cluster naming

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -24,6 +24,7 @@ kubernetes:
       clusters:
         - url: http://127.0.0.1:9999
           name: minikube
+          alias: dev
           authProvider: 'serviceAccount'
           skipTLSVerify: false
           skipMetricsLookup: true
@@ -37,6 +38,7 @@ kubernetes:
               plural: 'rollouts'
         - url: http://127.0.0.2:9999
           name: aws-cluster-1
+          alias: eks
           authProvider: 'aws'
     - type: 'gke'
       projectId: 'gke-clusters'
@@ -147,6 +149,7 @@ kubernetes:
     - type: 'config'
       clusters:
         - name: test-cluster
+          alias: oidc-auth
           url: http://localhost:8080
           authProvider: oidc
           oidcTokenProvider: okta # This value needs to match a config under auth.providers
@@ -165,6 +168,14 @@ The following values are supported out-of-the-box by the frontend: `google`, `mi
 Take note that `oidcTokenProvider` is just the issuer for the token, you can use any
 of these with an OIDC enabled cluster, like using `microsoft` as the issuer for a EKS
 cluster.
+
+##### `clusters.\*.name`
+
+Specifies the name of the K8s cluster. This field for example for EKS is mandatory and needs to match the actual cluster name as it is part of the STS signed token.
+
+##### `clusters.\*.alias` (optional
+
+Specifies an alias for the K8s cluster. In some case the name of the cluster is not sufficient, especially in a multi cluster environments. The alias provides a way to annotate the cluster in the UI with a user friendly Identifier.
 
 ##### `clusters.\*.dashboardUrl` (optional)
 

--- a/plugins/kubernetes-backend/CHANGELOG.md
+++ b/plugins/kubernetes-backend/CHANGELOG.md
@@ -977,6 +977,7 @@
     clusters:
       - url: http://127.0.0.1:9999
         name: minikube
+        alias: dev
         authProvider: 'serviceAccount'
         serviceAccountToken:
           $env: K8S_MINIKUBE_TOKEN
@@ -996,6 +997,7 @@
         clusters:
           - url: http://127.0.0.1:9999
             name: minikube
+            alias: dev
             authProvider: 'serviceAccount'
             serviceAccountToken:
               $env: K8S_MINIKUBE_TOKEN

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -74,6 +74,8 @@ export class AzureIdentityKubernetesAuthTranslator
 // @alpha (undocumented)
 export interface ClusterDetails {
   // (undocumented)
+  alias?: string | undefined;
+  // (undocumented)
   authProvider: string;
   // (undocumented)
   caData?: string | undefined;

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -39,6 +39,8 @@ export interface Config {
             url: string;
             /** @visibility frontend */
             name: string;
+            /** @visibility frontend */
+            alias?: string;
             /** @visibility secret  */
             serviceAccountToken?: string;
             /** @visibility frontend */

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -36,6 +36,7 @@ describe('ConfigClusterLocator', () => {
       clusters: [
         {
           name: 'cluster1',
+          alias: 'alias1',
           url: 'http://localhost:8080',
           authProvider: 'serviceAccount',
         },
@@ -49,6 +50,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        alias: 'alias1',
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -64,6 +66,7 @@ describe('ConfigClusterLocator', () => {
       clusters: [
         {
           name: 'cluster1',
+          alias: 'alias1',
           serviceAccountToken: 'token',
           url: 'http://localhost:8080',
           authProvider: 'serviceAccount',
@@ -73,6 +76,7 @@ describe('ConfigClusterLocator', () => {
         },
         {
           name: 'cluster2',
+          alias: 'alias2',
           url: 'http://localhost:8081',
           authProvider: 'google',
           skipTLSVerify: true,
@@ -88,6 +92,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        alias: 'alias1',
         dashboardUrl: 'https://k8s.foo.com',
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
@@ -98,6 +103,7 @@ describe('ConfigClusterLocator', () => {
       },
       {
         name: 'cluster2',
+        alias: 'alias2',
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',
@@ -121,6 +127,7 @@ describe('ConfigClusterLocator', () => {
         {
           assumeRole: 'SomeRole',
           name: 'cluster2',
+          alias: 'alias2',
           url: 'http://localhost:8081',
           authProvider: 'aws',
           skipTLSVerify: true,
@@ -128,6 +135,7 @@ describe('ConfigClusterLocator', () => {
         {
           assumeRole: 'SomeRole',
           name: 'cluster2',
+          alias: 'alias2',
           externalId: 'SomeExternalId',
           url: 'http://localhost:8081',
           authProvider: 'aws',
@@ -144,6 +152,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: undefined,
         name: 'cluster1',
+        alias: undefined,
         serviceAccountToken: 'token',
         externalId: undefined,
         url: 'http://localhost:8080',
@@ -155,6 +164,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        alias: 'alias2',
         externalId: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
@@ -166,6 +176,7 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        alias: 'alias2',
         externalId: 'SomeExternalId',
         url: 'http://localhost:8081',
         serviceAccountToken: undefined,
@@ -182,6 +193,7 @@ describe('ConfigClusterLocator', () => {
       clusters: [
         {
           name: 'cluster1',
+          alias: undefined,
           url: 'http://localhost:8080',
           authProvider: 'serviceAccount',
           dashboardApp: 'gke',
@@ -201,6 +213,7 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        alias: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -237,6 +250,74 @@ describe('ConfigClusterLocator', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        alias: undefined,
+        serviceAccountToken: undefined,
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+        skipMetricsLookup: false,
+        skipTLSVerify: false,
+        caData: undefined,
+        dashboardApp: 'standard',
+        dashboardUrl: 'http://someurl',
+      },
+    ]);
+  });
+
+  it('one cluster without alias', async () => {
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+          dashboardApp: 'standard',
+          dashboardUrl: 'http://someurl',
+        },
+      ],
+    });
+
+    const sut = ConfigClusterLocator.fromConfig(config);
+
+    const result = await sut.getClusters();
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        alias: undefined,
+        serviceAccountToken: undefined,
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+        skipMetricsLookup: false,
+        skipTLSVerify: false,
+        caData: undefined,
+        dashboardApp: 'standard',
+        dashboardUrl: 'http://someurl',
+      },
+    ]);
+  });
+
+  it('one cluster with alias', async () => {
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          alias: 'alias1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+          dashboardApp: 'standard',
+          dashboardUrl: 'http://someurl',
+        },
+      ],
+    });
+
+    const sut = ConfigClusterLocator.fromConfig(config);
+
+    const result = await sut.getClusters();
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        alias: 'alias1',
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -32,6 +32,7 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
         const authProvider = c.getString('authProvider');
         const clusterDetails: ClusterDetails = {
           name: c.getString('name'),
+          alias: c.getOptionalString('alias'),
           url: c.getString('url'),
           serviceAccountToken: c.getOptionalString('serviceAccountToken'),
           skipTLSVerify: c.getOptionalBoolean('skipTLSVerify') ?? false,

--- a/plugins/kubernetes-backend/src/cluster-locator/LocalKubectlProxyLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/LocalKubectlProxyLocator.ts
@@ -25,6 +25,7 @@ export class LocalKubectlProxyClusterLocator
     this.clusterDetails = [
       {
         name: 'local',
+        alias: 'proxy',
         url: 'http:/localhost:8001',
         authProvider: 'localKubectlProxy',
         skipMetricsLookup: true,

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -31,12 +31,14 @@ describe('getCombinedClusterSupplier', () => {
               clusters: [
                 {
                   name: 'cluster1',
+                  alias: 'alias1',
                   serviceAccountToken: 'token',
                   url: 'http://localhost:8080',
                   authProvider: 'serviceAccount',
                 },
                 {
                   name: 'cluster2',
+                  alias: 'alias2',
                   url: 'http://localhost:8081',
                   authProvider: 'google',
                 },
@@ -54,6 +56,7 @@ describe('getCombinedClusterSupplier', () => {
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
+        alias: 'alias1',
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
@@ -63,6 +66,7 @@ describe('getCombinedClusterSupplier', () => {
       },
       {
         name: 'cluster2',
+        alias: 'alias2',
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',
@@ -83,12 +87,14 @@ describe('getCombinedClusterSupplier', () => {
               clusters: [
                 {
                   name: 'cluster1',
+                  alias: 'alias1',
                   serviceAccountToken: 'token',
                   url: 'http://localhost:8080',
                   authProvider: 'serviceAccount',
                 },
                 {
                   name: 'cluster2',
+                  alias: 'alias2',
                   url: 'http://localhost:8081',
                   authProvider: 'google',
                 },

--- a/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.test.ts
+++ b/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.test.ts
@@ -39,6 +39,7 @@ describe('MultiTenantConfigClusterLocator', () => {
         return [
           {
             name: 'cluster1',
+            alias: undefined,
             url: 'http://localhost:8080',
             authProvider: 'serviceAccount',
             serviceAccountToken: '12345',
@@ -56,6 +57,7 @@ describe('MultiTenantConfigClusterLocator', () => {
       clusters: [
         {
           name: 'cluster1',
+          alias: undefined,
           serviceAccountToken: '12345',
           url: 'http://localhost:8080',
           authProvider: 'serviceAccount',

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -199,6 +199,7 @@ describe('KubernetesBuilder', () => {
           {
             cluster: {
               name: someCluster.name,
+              alias: undefined,
             },
             errors: [],
             podMetrics: [],

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -31,6 +31,7 @@ export class KubernetesClientProvider {
   getKubeConfig(clusterDetails: ClusterDetails) {
     const cluster = {
       name: clusterDetails.name,
+      alias: clusterDetails.alias,
       server: clusterDetails.url,
       skipTLSVerify: clusterDetails.skipTLSVerify,
       caData: clusterDetails.caData,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -311,6 +311,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            alias: undefined,
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE],
@@ -463,6 +464,7 @@ describe('getKubernetesObjectsByEntity', () => {
         {
           cluster: {
             name: 'test-cluster',
+            alias: undefined,
           },
           errors: [],
           podMetrics: [POD_METRICS_FIXTURE, POD_METRICS_FIXTURE],
@@ -502,11 +504,13 @@ describe('getKubernetesObjectsByEntity', () => {
         clusters: [
           {
             name: 'test-cluster',
+            alias: undefined,
             authProvider: 'serviceAccount',
             dashboardUrl: 'https://k8s.foo.coom',
           },
           {
             name: 'other-cluster',
+            alias: undefined,
             authProvider: 'google',
           },
         ],
@@ -528,6 +532,7 @@ describe('getKubernetesObjectsByEntity', () => {
       items: [
         {
           cluster: {
+            alias: undefined,
             dashboardUrl: 'https://k8s.foo.coom',
             name: 'test-cluster',
           },
@@ -537,6 +542,7 @@ describe('getKubernetesObjectsByEntity', () => {
         },
         {
           cluster: {
+            alias: undefined,
             name: 'other-cluster',
           },
           errors: [],
@@ -551,14 +557,17 @@ describe('getKubernetesObjectsByEntity', () => {
       Promise.resolve({
         clusters: [
           {
+            alias: undefined,
             name: 'test-cluster',
             authProvider: 'serviceAccount',
           },
           {
+            alias: undefined,
             name: 'other-cluster',
             authProvider: 'google',
           },
           {
+            alias: undefined,
             name: 'empty-cluster',
             authProvider: 'google',
           },
@@ -581,6 +590,7 @@ describe('getKubernetesObjectsByEntity', () => {
       items: [
         {
           cluster: {
+            alias: undefined,
             name: 'test-cluster',
           },
           errors: [],
@@ -589,6 +599,7 @@ describe('getKubernetesObjectsByEntity', () => {
         },
         {
           cluster: {
+            alias: undefined,
             name: 'other-cluster',
           },
           errors: [],
@@ -603,18 +614,22 @@ describe('getKubernetesObjectsByEntity', () => {
       Promise.resolve({
         clusters: [
           {
+            alias: undefined,
             name: 'test-cluster',
             authProvider: 'serviceAccount',
           },
           {
+            alias: undefined,
             name: 'other-cluster',
             authProvider: 'google',
           },
           {
+            alias: undefined,
             name: 'empty-cluster',
             authProvider: 'google',
           },
           {
+            alias: undefined,
             name: 'error-cluster',
             authProvider: 'google',
           },
@@ -637,6 +652,7 @@ describe('getKubernetesObjectsByEntity', () => {
       items: [
         {
           cluster: {
+            alias: undefined,
             name: 'test-cluster',
           },
           errors: [],
@@ -645,6 +661,7 @@ describe('getKubernetesObjectsByEntity', () => {
         },
         {
           cluster: {
+            alias: undefined,
             name: 'other-cluster',
           },
           errors: [],
@@ -653,6 +670,7 @@ describe('getKubernetesObjectsByEntity', () => {
         },
         {
           cluster: {
+            alias: undefined,
             name: 'error-cluster',
           },
           errors: ['some random cluster error'],
@@ -680,11 +698,13 @@ describe('getKubernetesObjectsByEntity', () => {
       Promise.resolve({
         clusters: [
           {
+            alias: undefined,
             name: 'test-cluster',
             authProvider: 'serviceAccount',
             dashboardUrl: 'https://k8s.foo.coom',
           },
           {
+            alias: undefined,
             name: 'other-cluster',
             authProvider: 'google',
           },
@@ -727,6 +747,7 @@ describe('getKubernetesObjectsByEntity', () => {
       items: [
         {
           cluster: {
+            alias: undefined,
             dashboardUrl: 'https://k8s.foo.coom',
             name: 'test-cluster',
           },
@@ -736,6 +757,7 @@ describe('getKubernetesObjectsByEntity', () => {
         },
         {
           cluster: {
+            alias: undefined,
             name: 'other-cluster',
           },
           errors: [

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -322,6 +322,7 @@ export class KubernetesFanOutHandler {
     const objects: ClusterObjects = {
       cluster: {
         name: clusterDetails.name,
+        alias: clusterDetails.alias,
       },
       podMetrics: toClientSafePodMetrics(metrics),
       resources: result.responses,

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -153,6 +153,7 @@ export interface ClusterDetails {
    * Specifies the name of the Kubernetes cluster.
    */
   name: string;
+  alias?: string | undefined;
   url: string;
   authProvider: string;
   serviceAccountToken?: string | undefined;

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -56,6 +56,7 @@ export interface ClientPodStatus {
 
 // @public (undocumented)
 export interface ClusterAttributes {
+  alias?: string;
   dashboardApp?: string;
   dashboardParameters?: JsonObject;
   dashboardUrl?: string;

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -73,6 +73,10 @@ export interface ClusterAttributes {
    */
   name: string;
   /**
+   * Specifies an alias of the Kubernetes cluster.
+   */
+  alias?: string;
+  /**
    * Specifies the link to the Kubernetes dashboard managing this cluster.
    * @remarks
    * Note that you should specify the app used for the dashboard

--- a/plugins/kubernetes/CHANGELOG.md
+++ b/plugins/kubernetes/CHANGELOG.md
@@ -931,6 +931,7 @@
     clusters:
       - url: http://127.0.0.1:9999
         name: minikube
+        alias: dev
         authProvider: 'serviceAccount'
         serviceAccountToken:
           $env: K8S_MINIKUBE_TOKEN
@@ -950,6 +951,7 @@
         clusters:
           - url: http://127.0.0.1:9999
             name: minikube
+            alias: dev
             authProvider: 'serviceAccount'
             serviceAccountToken:
               $env: K8S_MINIKUBE_TOKEN

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -104,6 +104,8 @@ export interface DeploymentResources {
 // @alpha
 export interface DetectedError {
   // (undocumented)
+  alias: string | undefined;
+  // (undocumented)
   cluster: string;
   // (undocumented)
   kind: ErrorDetectableKind;

--- a/plugins/kubernetes/dev/index.tsx
+++ b/plugins/kubernetes/dev/index.tsx
@@ -103,8 +103,12 @@ class MockKubernetesClient implements KubernetesApi {
     };
   }
 
-  async getClusters(): Promise<{ name: string; authProvider: string }[]> {
-    return [{ name: 'mock-cluster', authProvider: 'serviceAccount' }];
+  async getClusters(): Promise<
+    { name: string; alias: string | undefined; authProvider: string }[]
+  > {
+    return [
+      { name: 'mock-cluster', alias: 'dev', authProvider: 'serviceAccount' },
+    ];
   }
 }
 

--- a/plugins/kubernetes/src/components/Cluster/Cluster.test.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.test.tsx
@@ -30,6 +30,7 @@ describe('Cluster', () => {
           {...({
             clusterObjects: {
               cluster: {
+                alias: undefined,
                 name: 'cluster-1',
               },
               resources: [

--- a/plugins/kubernetes/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.tsx
@@ -46,6 +46,7 @@ import { PodNamesWithMetricsContext } from '../../hooks/PodNamesWithMetrics';
 
 type ClusterSummaryProps = {
   clusterName: string;
+  clusterAlias: string | undefined;
   totalNumberOfPods: number;
   numberOfPodsWithErrors: number;
   children?: React.ReactNode;
@@ -53,9 +54,13 @@ type ClusterSummaryProps = {
 
 const ClusterSummary = ({
   clusterName,
+  clusterAlias,
   totalNumberOfPods,
   numberOfPodsWithErrors,
 }: ClusterSummaryProps) => {
+  const clusterFullName = clusterAlias
+    ? `${clusterName} (${clusterAlias})`
+    : `${clusterName}`;
   return (
     <Grid
       container
@@ -73,7 +78,7 @@ const ClusterSummary = ({
         spacing={0}
       >
         <Grid item xs>
-          <Typography variant="h3">{clusterName}</Typography>
+          <Typography variant="h3">{clusterFullName}</Typography>
           <Typography color="textSecondary" variant="body1">
             Cluster
           </Typography>
@@ -131,6 +136,7 @@ export const Cluster = ({ clusterObjects, podsWithErrors }: ClusterProps) => {
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <ClusterSummary
                   clusterName={clusterObjects.cluster.name}
+                  clusterAlias={clusterObjects.cluster.alias}
                   totalNumberOfPods={groupedResponses.pods.length}
                   numberOfPodsWithErrors={podsWithErrors.size}
                 />

--- a/plugins/kubernetes/src/components/ErrorPanel/ErrorPanel.test.tsx
+++ b/plugins/kubernetes/src/components/ErrorPanel/ErrorPanel.test.tsx
@@ -48,6 +48,7 @@ describe('ErrorPanel', () => {
           clustersWithErrors={[
             {
               cluster: {
+                alias: undefined,
                 name: 'THIS_CLUSTER',
               },
               resources: [],

--- a/plugins/kubernetes/src/components/ErrorPanel/ErrorPanel.tsx
+++ b/plugins/kubernetes/src/components/ErrorPanel/ErrorPanel.tsx
@@ -23,9 +23,12 @@ const clustersWithErrorsToErrorMessage = (
   clustersWithErrors: ClusterObjects[],
 ): React.ReactNode => {
   return clustersWithErrors.map((c, i) => {
+    const clusterFullName = c.cluster.alias
+      ? `${c.cluster.name} (${c.cluster.alias})`
+      : c.cluster.name;
     return (
       <div key={i}>
-        <Typography variant="body2">{`Cluster: ${c.cluster.name}`}</Typography>
+        <Typography variant="body2">{`Cluster: ${clusterFullName}`}</Typography>
         {c.errors.map((e, j) => {
           return (
             <Typography variant="body2" key={j}>

--- a/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
+++ b/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
@@ -27,7 +27,10 @@ const columns: TableColumn<DetectedError>[] = [
   {
     title: 'cluster',
     width: '10%',
-    render: (detectedError: DetectedError) => detectedError.cluster,
+    render: (detectedError: DetectedError) =>
+      detectedError.alias
+        ? `${detectedError.cluster} (${detectedError.alias})`
+        : detectedError.cluster,
   },
   {
     title: 'namespace',

--- a/plugins/kubernetes/src/components/KubernetesContent.test.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent.test.tsx
@@ -58,7 +58,7 @@ describe('KubernetesContent', () => {
       kubernetesObjects: {
         items: [
           {
-            cluster: { name: 'cluster-1' },
+            cluster: { name: 'cluster-1', alias: undefined },
             resources: [
               {
                 type: 'deployments',
@@ -107,7 +107,7 @@ describe('KubernetesContent', () => {
       kubernetesObjects: {
         items: [
           {
-            cluster: { name: 'cluster-1' },
+            cluster: { name: 'cluster-1', alias: undefined },
             resources: [
               {
                 type: 'deployments',
@@ -126,7 +126,7 @@ describe('KubernetesContent', () => {
             errors: [],
           },
           {
-            cluster: { name: 'cluster-a' },
+            cluster: { name: 'cluster-a', alias: undefined },
             resources: [
               {
                 type: 'deployments',

--- a/plugins/kubernetes/src/error-detection/common.ts
+++ b/plugins/kubernetes/src/error-detection/common.ts
@@ -27,6 +27,7 @@ export const detectErrorsInObjects = <T extends ErrorDetectable>(
   objects: T[],
   kind: ErrorDetectableKind,
   clusterName: string,
+  clusterAlias: string | undefined,
   errorMappers: ErrorMapper<T>[],
 ): DetectedError[] => {
   // Build up a map of errors
@@ -57,6 +58,7 @@ export const detectErrorsInObjects = <T extends ErrorDetectable>(
         } else {
           errors.set(dedupKey, {
             cluster: clusterName,
+            alias: clusterAlias,
             kind: kind,
             names: [name],
             message: message,

--- a/plugins/kubernetes/src/error-detection/deployments.ts
+++ b/plugins/kubernetes/src/error-detection/deployments.ts
@@ -40,10 +40,12 @@ const deploymentErrorMappers: ErrorMapper<V1Deployment>[] = [
 export const detectErrorsInDeployments = (
   deployments: V1Deployment[],
   clusterName: string,
+  clusterAlias: string | undefined,
 ): DetectedError[] =>
   detectErrorsInObjects(
     deployments,
     'Deployment',
     clusterName,
+    clusterAlias,
     deploymentErrorMappers,
   );

--- a/plugins/kubernetes/src/error-detection/error-detection.test.ts
+++ b/plugins/kubernetes/src/error-detection/error-detection.test.ts
@@ -38,7 +38,7 @@ const oneItem = (value: FetchResponse): ObjectsByEntityResponse => {
   return {
     items: [
       {
-        cluster: { name: CLUSTER_NAME },
+        cluster: { name: CLUSTER_NAME, alias: undefined },
         errors: [],
         podMetrics: [],
         resources: [value],
@@ -73,7 +73,7 @@ describe('detectErrors', () => {
     const result = detectErrors({
       items: [
         {
-          cluster: { name: 'cluster-a' },
+          cluster: { name: 'cluster-a', alias: undefined },
           errors: [],
           podMetrics: [],
           resources: [
@@ -84,7 +84,7 @@ describe('detectErrors', () => {
           ],
         },
         {
-          cluster: { name: 'cluster-b' },
+          cluster: { name: 'cluster-b', alias: 'B' },
           errors: [],
           podMetrics: [],
           resources: [
@@ -95,7 +95,7 @@ describe('detectErrors', () => {
           ],
         },
         {
-          cluster: { name: 'cluster-c' },
+          cluster: { name: 'cluster-c', alias: undefined },
           errors: [],
           podMetrics: [],
           resources: [
@@ -148,6 +148,7 @@ describe('detectErrors', () => {
 
     expect(err1).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Pod',
       message: [
         'container=other-side-car restarted 38 times',
@@ -160,6 +161,7 @@ describe('detectErrors', () => {
 
     expect(err2).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Pod',
       message: [
         'containers with unready status: [side-car other-side-car]',
@@ -172,6 +174,7 @@ describe('detectErrors', () => {
 
     expect(err3).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Pod',
       message: [
         'back-off 5m0s restarting failed container=other-side-car pod=dice-roller-canary-7d64cd756c-55rfq_default(65ad28e3-5d51-4b4b-9bf8-4cb069803034)',
@@ -184,6 +187,7 @@ describe('detectErrors', () => {
 
     expect(err4).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Pod',
       message: [
         'container=other-side-car exited with error code (1)',
@@ -208,6 +212,7 @@ describe('detectErrors', () => {
 
     expect(err1).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Pod',
       message: [
         'containers with unready status: [nginx]',
@@ -220,6 +225,7 @@ describe('detectErrors', () => {
 
     expect(err2).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Pod',
       message: ['configmap "some-cm" not found'],
       names: ['dice-roller-bad-cm-855bf85464-mg6xb'],
@@ -251,6 +257,7 @@ describe('detectErrors', () => {
 
     expect(err1).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'Deployment',
       message: ['Deployment does not have minimum availability.'],
       names: ['dice-roller-canary'],
@@ -282,6 +289,7 @@ describe('detectErrors', () => {
 
     expect(err1).toStrictEqual({
       cluster: 'cluster-a',
+      alias: undefined,
       kind: 'HorizontalPodAutoscaler',
       message: [
         'Current number of replicas (10) is equal to the configured max number of replicas (10)',

--- a/plugins/kubernetes/src/error-detection/error-detection.ts
+++ b/plugins/kubernetes/src/error-detection/error-detection.ts
@@ -38,13 +38,18 @@ export const detectErrors = (
     const groupedResponses = groupResponses(clusterResponse.resources);
 
     clusterErrors = clusterErrors.concat(
-      detectErrorsInPods(groupedResponses.pods, clusterResponse.cluster.name),
+      detectErrorsInPods(
+        groupedResponses.pods,
+        clusterResponse.cluster.name,
+        clusterResponse.cluster.alias,
+      ),
     );
 
     clusterErrors = clusterErrors.concat(
       detectErrorsInDeployments(
         groupedResponses.deployments,
         clusterResponse.cluster.name,
+        clusterResponse.cluster.alias,
       ),
     );
 
@@ -52,6 +57,7 @@ export const detectErrors = (
       detectErrorsInHpa(
         groupedResponses.horizontalPodAutoscalers,
         clusterResponse.cluster.name,
+        clusterResponse.cluster.alias,
       ),
     );
 

--- a/plugins/kubernetes/src/error-detection/hpas.ts
+++ b/plugins/kubernetes/src/error-detection/hpas.ts
@@ -41,10 +41,12 @@ const hpaErrorMappers: ErrorMapper<V1HorizontalPodAutoscaler>[] = [
 export const detectErrorsInHpa = (
   hpas: V1HorizontalPodAutoscaler[],
   clusterName: string,
+  clusterAlias: string | undefined,
 ): DetectedError[] =>
   detectErrorsInObjects(
     hpas,
     'HorizontalPodAutoscaler',
     clusterName,
+    clusterAlias,
     hpaErrorMappers,
   );

--- a/plugins/kubernetes/src/error-detection/pods.ts
+++ b/plugins/kubernetes/src/error-detection/pods.ts
@@ -91,5 +91,12 @@ const podErrorMappers: ErrorMapper<V1Pod>[] = [
 export const detectErrorsInPods = (
   pods: V1Pod[],
   clusterName: string,
+  clusterAlias: string | undefined,
 ): DetectedError[] =>
-  detectErrorsInObjects(pods, 'Pod', clusterName, podErrorMappers);
+  detectErrorsInObjects(
+    pods,
+    'Pod',
+    clusterName,
+    clusterAlias,
+    podErrorMappers,
+  );

--- a/plugins/kubernetes/src/error-detection/types.ts
+++ b/plugins/kubernetes/src/error-detection/types.ts
@@ -55,6 +55,7 @@ export type DetectedErrorsByCluster = Map<string, DetectedError[]>;
 export interface DetectedError {
   severity: ErrorSeverity;
   cluster: string;
+  alias: string | undefined;
   namespace: string;
   kind: ErrorDetectableKind;
   names: string[];

--- a/plugins/kubernetes/src/hooks/useCustomResources.test.ts
+++ b/plugins/kubernetes/src/hooks/useCustomResources.test.ts
@@ -48,7 +48,7 @@ const entityWithAuthToken = {
 const mockResponse = {
   items: [
     {
-      cluster: { name: 'some-cluster' },
+      cluster: { name: 'some-cluster', alias: undefined },
       resources: [
         {
           type: 'pods',

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.test.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.test.ts
@@ -38,7 +38,7 @@ const entityWithAuthToken = {
 const mockResponse = {
   items: [
     {
-      cluster: { name: 'some-cluster' },
+      cluster: { name: 'some-cluster', alias: undefined },
       resources: [
         {
           type: 'pods',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The name of the cluster is not always sufficient. In the case of EKS for example it is even possible to have multiple clusters with the exact same name, provided that they are in different accounts.  This PR allows the developers to pass an optional value `alias` in the k8s cluster configuration, which should then be visible in the errors, the exceptions and the generic cluster representation in the UI.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


![image](https://user-images.githubusercontent.com/29090864/202857936-cf997177-6173-4dc5-bf27-c7339a53005a.png)
