### PR TITLE
Use promise Router & add known error in Vault backend

### DIFF
--- a/.changeset/twelve-meals-smell.md
+++ b/.changeset/twelve-meals-smell.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-vault-backend': patch
+---
+
+Use `express-promise-router` to catch errors properly.
+Add `403` error as a known one. It will now return a `NotAllowed` error.

--- a/plugins/vault-backend/src/service/VaultBuilder.ts
+++ b/plugins/vault-backend/src/service/VaultBuilder.ts
@@ -17,7 +17,8 @@
 import { Config } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { Logger } from 'winston';
-import express, { Router } from 'express';
+import express from 'express';
+import Router from 'express-promise-router';
 import { VaultClient } from './vaultApi';
 import { TaskRunner, PluginTaskScheduler } from '@backstage/backend-tasks';
 import { errorHandler } from '@backstage/backend-common';

--- a/plugins/vault-backend/src/service/vaultApi.ts
+++ b/plugins/vault-backend/src/service/vaultApi.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { NotFoundError } from '@backstage/errors';
+import { NotAllowedError, NotFoundError } from '@backstage/errors';
 import fetch from 'node-fetch';
 import plimit from 'p-limit';
 import { getVaultConfig, VaultConfig } from '../config';
@@ -103,6 +103,8 @@ export class VaultClient implements VaultApi {
       return (await response.json()) as T;
     } else if (response.status === 404) {
       throw new NotFoundError(`No secrets found in path '${path}'`);
+    } else if (response.status === 403) {
+      throw new NotAllowedError(response.statusText);
     }
     throw new Error(
       `Unexpected error while fetching secrets from path '${path}'`,


### PR DESCRIPTION
Signed-off-by: ivgo <ivgo@spreadgroup.com>

## Hey, I just made a Pull Request!

Even though the `errorHandler()` was added to the Router, it was still causing the backend to crash. In one internal plugin we needed to use `express-promise-router` instead, so the errors are caught properly. This is what this PR does.

As well, I'm adding the `403` error as a know one, so it will return the `NotAllowed` internal backstage error when that happens.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
