### PR TITLE
fix(GithubMultiOrgProcessor): correctly apply team memberships

### DIFF
--- a/.changeset/clever-rivers-obey.md
+++ b/.changeset/clever-rivers-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fixes the assignment of group member references in `GithubMultiOrgProcessor` so membership relations are resolved correctly.

--- a/plugins/catalog-backend-module-github/src/lib/org.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/org.test.ts
@@ -79,7 +79,7 @@ describe('assignGroupsToUsers', () => {
         spec: {
           type: 'team',
           children: [],
-          members: ['u1', 'u2'],
+          members: ['default/u1', 'default/u2'],
         },
       },
       {

--- a/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.test.ts
@@ -85,7 +85,10 @@ describe('GithubOrgReaderProcessor', () => {
       mockClient
         .mockResolvedValueOnce({
           organization: {
-            membersWithRole: { pageInfo: { hasNextPage: false }, nodes: [{}] },
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [{ login: 'foo' }],
+            },
           },
         })
         .mockResolvedValueOnce({
@@ -93,7 +96,12 @@ describe('GithubOrgReaderProcessor', () => {
             teams: {
               pageInfo: { hasNextPage: false },
               nodes: [
-                { members: { pageInfo: { hasNextPage: false }, nodes: [{}] } },
+                {
+                  members: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [{ login: 'foo' }],
+                  },
+                },
               ],
             },
           },
@@ -134,7 +142,10 @@ describe('GithubOrgReaderProcessor', () => {
       mockClient
         .mockResolvedValueOnce({
           organization: {
-            membersWithRole: { pageInfo: { hasNextPage: false }, nodes: [{}] },
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [{ login: 'foo' }],
+            },
           },
         })
         .mockResolvedValueOnce({
@@ -142,7 +153,12 @@ describe('GithubOrgReaderProcessor', () => {
             teams: {
               pageInfo: { hasNextPage: false },
               nodes: [
-                { members: { pageInfo: { hasNextPage: false }, nodes: [{}] } },
+                {
+                  members: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [{ login: 'foo' }],
+                  },
+                },
               ],
             },
           },


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This PR fixes a few bugs introduced from https://github.com/backstage/backstage/pull/13640:
- Support for the `userNamespace` config option was mistakenly removed with the introduction of the `userTransformer`
- Group `spec.members` were applied without a namespace resulting in incorrectly applied relations since members inherit the namespace of the parent group [by default](https://backstage.io/docs/features/software-catalog/descriptor-format#specmembers-optional)
- Group `memberOf` relations were not applied to users across orgs if they have memberships in groups from multiple orgs

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
