### PR TITLE
[Search] Fix max listeners exceeded warning

### DIFF
--- a/.changeset/heavy-frogs-confess.md
+++ b/.changeset/heavy-frogs-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Fix the scheduler "max listeners exceeded" warning by having "abort controllers" per task instead of having a single one for all tasks (previously we used the same controller for all collators, logging the warning every time we had more than 10 collators running in parallel).

--- a/.changeset/heavy-frogs-confess.md
+++ b/.changeset/heavy-frogs-confess.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-search-backend-node': patch
----
-
-Fix the scheduler "max listeners exceeded" warning by having "abort controllers" per task instead of having a single one for all tasks (previously we used the same controller for all collators, logging the warning every time we had more than 10 collators running in parallel).

--- a/.changeset/search-heavy-frogs-confess.md
+++ b/.changeset/search-heavy-frogs-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Fixed a bug that could cause a `max listeners exceeded warning` to be logged when more than 10 collators were running simultaneously.

--- a/plugins/search-backend-node/src/Scheduler.test.ts
+++ b/plugins/search-backend-node/src/Scheduler.test.ts
@@ -204,4 +204,40 @@ describe('Scheduler', () => {
       );
     });
   });
+
+  describe('stop', () => {
+    it('should abort tasks on stop', () => {
+      const run = jest.fn();
+
+      // Add tasks and interval to schedule
+      testScheduler.addToSchedule({
+        id: '1',
+        task: jest.fn(),
+        scheduledRunner: { run },
+      });
+      testScheduler.addToSchedule({
+        id: '2',
+        task: jest.fn(),
+        scheduledRunner: { run },
+      });
+
+      // Starts scheduling process
+      testScheduler.start();
+
+      const signals = run.mock.calls.map(([options]) => options.signal);
+
+      expect(signals).toHaveLength(2);
+
+      for (const signal of signals) {
+        expect(signal.aborted).toBeFalsy();
+      }
+
+      // Stops scheduling process
+      testScheduler.stop();
+
+      for (const signal of signals) {
+        expect(signal.aborted).toBeTruthy();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Signed-off-by: Camila Belo <camilaibs@gmail.com>

## Hey, I just made a Pull Request!

Possibly related https://github.com/backstage/backstage/issues/13882

Fixed a bug that could cause a `max listeners exceeded warning` to be logged when more than 10 collators were running simultaneously.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
