### PR TITLE
cli: Bump msw version in plugin templates

### DIFF
--- a/.changeset/gold-icons-cheat.md
+++ b/.changeset/gold-icons-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Bump `msw` version in default plugin/app templates

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -41,7 +41,7 @@
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
     "@types/supertest": "{{versionQuery '@types/supertest' '2.0.12'}}",
     "supertest": "{{versionQuery 'supertest' '6.2.4'}}",
-    "msw": "{{versionQuery 'msw' '0.47.0'}}"
+    "msw": "{{versionQuery 'msw' '0.49.0'}}"
   },
   "files": [
     "dist"

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -48,7 +48,7 @@
     "@testing-library/react": "{{versionQuery '@testing-library/react' '12.1.3'}}",
     "@testing-library/user-event": "{{versionQuery '@testing-library/user-event' '14.0.0'}}",
     "@types/node": "{{versionQuery '@types/node' '16.11.26'}}",
-    "msw": "{{versionQuery 'msw' '0.47.0'}}",
+    "msw": "{{versionQuery 'msw' '0.49.0'}}",
     "cross-fetch": "{{versionQuery 'cross-fetch' '3.1.5'}}"
   },
   "files": [


### PR DESCRIPTION
We bumped to 0.49.0 and we to keep versions aligned