### PR TITLE
fix: fix missing blobs for upgrade-backstage-app

### DIFF
--- a/contrib/scripts/upgrade-backstage-app/upgrade-backstage-app.sh
+++ b/contrib/scripts/upgrade-backstage-app/upgrade-backstage-app.sh
@@ -9,8 +9,7 @@ if [ "$CURRENT_VERSION" == "$TARGET_VERSION" ]; then
 else
     echo "Attempting upgrade from Backstage $CURRENT_VERSION (create-app $CREATE_APP_CURRENT_VERSION) to $TARGET_VERSION ($CREATE_APP_TARGET_VERSION)"
     rm -rf .upgrade && mkdir .upgrade
-    git remote add upgrade-helper https://github.com/backstage/upgrade-helper-diff.git
-    git fetch upgrade-helper
+    git fetch https://github.com/backstage/upgrade-helper-diff.git '+refs/heads/*:refs/remotes/upgrade-helper/*'
     curl -s https://raw.githubusercontent.com/backstage/upgrade-helper-diff/master/diffs/$CREATE_APP_CURRENT_VERSION..$CREATE_APP_TARGET_VERSION.diff > .upgrade/upgrade.diff
     git apply -3 .upgrade/upgrade.diff
     git mergetool

--- a/contrib/scripts/upgrade-backstage-app/upgrade-backstage-app.sh
+++ b/contrib/scripts/upgrade-backstage-app/upgrade-backstage-app.sh
@@ -9,6 +9,8 @@ if [ "$CURRENT_VERSION" == "$TARGET_VERSION" ]; then
 else
     echo "Attempting upgrade from Backstage $CURRENT_VERSION (create-app $CREATE_APP_CURRENT_VERSION) to $TARGET_VERSION ($CREATE_APP_TARGET_VERSION)"
     rm -rf .upgrade && mkdir .upgrade
+    git remote add upgrade-helper https://github.com/backstage/upgrade-helper-diff.git
+    git fetch upgrade-helper
     curl -s https://raw.githubusercontent.com/backstage/upgrade-helper-diff/master/diffs/$CREATE_APP_CURRENT_VERSION..$CREATE_APP_TARGET_VERSION.diff > .upgrade/upgrade.diff
     git apply -3 .upgrade/upgrade.diff
     git mergetool


### PR DESCRIPTION
3 way merge was failing because of missing ancestors. Fetching the upgrade-helper-diff repository as one of your app's remotes fixes the problem.

The upgrade-helper-diff contains a branch for each version with a clean app bootstrapped with the create-app script.

