### PR TITLE
refactor(stitcher): optimize to be more memory efficient

### DIFF
--- a/.changeset/eight-tables-hunt.md
+++ b/.changeset/eight-tables-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Optimize `Stitcher` process to be more memory efficient


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Issue
The backend node process runs into heap out of memory crashes when processing entities with large number of relations. For us, we have a scenario that runs into this where we have some `Group` entities whose members include all of our `User` entities. This is sourced from our GitHub instance that have "master teams" that include every user in our enterprise server (~6k `hasMember` relations). 

## Fix
Optimize the `Stitcher` code to not expand queried DB rows by avoiding `join` queries with the relations table. This can be fetched separately instead to avoid duplicate row data being loaded into memory. Applying this small optimization allowed us to fully process our entities within the default node memory limit. 

## Alternative Workaround
Bump the default node memory limit via `NODE_OPTIONS=--max-old-space-size=<new-limit>`. For our use case this required bumping up to 8gb to successfully process our entities.
 
## Diagnosis
Please let me know if I might've misunderstood anything in my diagnosis below 🙏 

We encountered the out of memory issue when updating to the latest release (v1.8). We determined the cause was due to this [change](https://github.com/backstage/backstage/pull/13640) which modified the behavior of the `GithubMultiOrgProcessor` which we use. Previously this processor only defined `spec.memberOf` relations on individual `User` entities but with this change, `spec.members` relations are also now defined for `Group` entities.

The following describes my understanding of the behavior of the stitching process before and after this change and how it highlighted the memory inefficiency:

### Before `GithubMultiOrgProcessor` Refactors
- Groups are emitted first and are processed & stitched without issue since they have no defined relations (yet)
- Each user are emitted with the `memberOf` relation so relations originate from `User` entities only
- As each user is processed and stitched, it causes the "master" group to be restitched to include the new user in its relations
  - The [DB query](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/stitching/Stitcher.ts#L87-L121) in the `Stitcher` code loads a low number of rows into memory for 
    - The `User` since a user won't have many `memberOf` relations
    - The "master" `Group` since the number of `member` relations are only as many as the number of `User` entities processed so far in the pipeline 

### After `GithubMultiOrgProcessor` Refactors
- Both `Group` and `User` entities emit membership relations
- Groups are emitted first and processed & stitched with all relations inserted into the `relations` table
  - Stitching pulls all DB rows into memory which is ok if this is the only thing being stitched 
- As each `User` is processed, this causes the "master" `Group` to be re-stitched which results in:
  - All DB rows being fetched into memory again each time the "master" `Group` is re-stitched
  - Multiple `User` entities may be processed in [parallel](https://github.com/backstage/backstage/blob/3228a8a95153fa914860d17a145703de4c65d8ff/plugins/catalog-backend/src/processing/TaskPipeline.ts#L86-L102) which mean the "master" `Group` is re-stitched for every user
  - Eventually node will run out of memory and result in a heap dump when too many parallel iterations of the `Group` is stitched at the same time

Below is a snapshot of the heap profile taken right before the out of memory crash which confirms the behavior described above:

![Screen Shot 2022-11-21 at 4 50 32 PM](https://user-images.githubusercontent.com/6998196/203418522-80540080-e1cf-4f7a-95ab-605c75286cd6.png)
- The Array allocations (in red) correspond to multiple parallel executions of the `Stitcher` fetching DB rows into memory
- The inspection of the contents of the elements of these arrays (in blue) confirms that these are the rows that are the result of "join expansion" with the `relations` table. Each row is nearly identical loading redundant data aside from the relation properties
- The memory consumption of the `processedEntity` property (in yellow) shows that this stringified representation of the entity definition consumes the majority of the memory allocation and is the key culprit of the inefficient memory usage

### Additional Notes
This should only occur the first time users are ingested since there is [logic](https://github.com/backstage/backstage/blob/3228a8a95153fa914860d17a145703de4c65d8ff/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts#L225-L239) that prevents stitching of previously processed relations (though it does not detect duplicate relations that [originate](https://github.com/backstage/backstage/blob/0d13d1946c6c6cc45ee394d3c4b8f2aee97269e7/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts#L129) from another entity, ie. it doesn't stop a `User` from re-triggering the stitching of the `Group` even if their relation (that originated from the `Group`) has already been stitched, this seems to be [caught later on](https://github.com/backstage/backstage/blob/3228a8a95153fa914860d17a145703de4c65d8ff/plugins/catalog-backend/src/stitching/Stitcher.ts#L197-L202)). However we ran into this as a side effect of the recent bugs introduced 
 in `GithubMultiOrgProcessor` (see [fix](https://github.com/backstage/backstage/pull/14736) for more info) that corrupted the old relations and triggered everything to be re-stitched. Those bugs ended up as a blessing in disguise as this inefficiency probably would've continued to go unnoticed without them 😅 

Applicable to https://github.com/backstage/backstage/issues/14574 under performance issues.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
