### PR TITLE
ApiReference docs improvements

### DIFF
--- a/.changeset/slow-eggs-grab.md
+++ b/.changeset/slow-eggs-grab.md
@@ -1,0 +1,8 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Api reference documentation improvements
+
+- breadcrumbs links semantics as code spans
+- new `@config` annotation to describe related config keys

--- a/.changeset/warm-parents-notice.md
+++ b/.changeset/warm-parents-notice.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-proxy-backend': patch
 ---
 
-Add documentation to de api reference
+Documented the `createRouter` method.

--- a/.changeset/warm-parents-notice.md
+++ b/.changeset/warm-parents-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Add documentation to de api reference

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -1037,7 +1037,7 @@ export async function buildDocs({
                 configuration,
                 text: ' > ',
               }),
-              new DocCodeSpanLink({ 
+              new DocCodeSpanLink({
                 configuration,
                 tagName: '@link',
                 linkText: hierarchyItem.displayName,

--- a/plugins/proxy-backend/api-report.md
+++ b/plugins/proxy-backend/api-report.md
@@ -8,7 +8,7 @@ import express from 'express';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 
-// @public (undocumented)
+// @public
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public (undocumented)

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -178,7 +178,24 @@ export function buildMiddleware(
   return createProxyMiddleware(filter, fullConfig);
 }
 
-/** @public */
+/**
+ * Creates a new {@link https://expressjs.com/en/api.html#router | "express router"} that proxy each target configured under the `proxy` key of the config
+ * @example
+ * ```ts
+ * let router = await createRouter({logger, config, discovery});
+ * ```
+ * @config
+ * ```yaml
+ * proxy:
+ *  simple-example: http://simple.example.com:8080 # Opt 1 Simple URL String
+ *  '/larger-example/v1': # Opt 2 `http-proxy-middleware` compatible object
+ *    target: http://larger.example.com:8080/svc.v1
+ *    headers:
+ *      Authorization: Bearer ${EXAMPLE_AUTH_TOKEN}
+ *```
+ * @see https://backstage.io/docs/plugins/proxying
+ * @public
+ */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR aims to add some improvements to the apiReference documentation:

### db00b1a91de7fdb0b9961d263f56a6c761821842 writes the breadcrumbs with backticks:
  - show all but `Home` names in breadcrumbs monospaced
  - avoid spellchecking on breadcrumbs

|Previous | 
|---|
| <img width="790" alt="image" src="https://user-images.githubusercontent.com/1770453/203435262-658be107-65fb-416e-943a-5b4a40a422b6.png">|
|<img width="381" alt="image" src="https://user-images.githubusercontent.com/1770453/203435535-880f19d6-6b56-4c62-8ec1-13fbf6f3be58.png">|

| New |
 |---|
 |  <img width="804" alt="image" src="https://user-images.githubusercontent.com/1770453/203435086-d9cbd199-fc51-4654-9bc0-dcd677bded68.png"> |
|<img width="416" alt="image" src="https://user-images.githubusercontent.com/1770453/203435716-de5515ac-c9dc-41fe-9df4-5339bbc3aaf8.png">|

### f17709fa7710c68932d188e426294730347fed3b add a new custom doc annotation to show related configs needed 

| Api reference Docs |
|---|
|<img width="807" alt="image" src="https://user-images.githubusercontent.com/1770453/203436285-174be264-9634-4acd-83c8-37f57698c9cb.png">|

| code comments |
|---|
|<img width="716" alt="image" src="https://user-images.githubusercontent.com/1770453/203436700-3e5dc92c-0ced-451f-a821-8f0aea3096d8.png">|




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
