### PR TITLE
fix(catalog/bitbucketCloud,events): fix repo:push topic not matching `BitbucketCloudEventRouter`

### DIFF
--- a/.changeset/stupid-gifts-serve.md
+++ b/.changeset/stupid-gifts-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+---
+
+Fix repo:push topic not matching `BitbucketCloudEventRouter`.

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/BitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/BitbucketCloudEntityProvider.ts
@@ -49,7 +49,7 @@ import * as uuid from 'uuid';
 import { Logger } from 'winston';
 
 const DEFAULT_BRANCH = 'master';
-const TOPIC_REPO_PUSH = 'bitbucketCloud/repo:push';
+const TOPIC_REPO_PUSH = 'bitbucketCloud.repo:push';
 
 /** @public */
 export const ANNOTATION_BITBUCKET_CLOUD_REPO_URL = 'bitbucket.org/repo-url';
@@ -211,9 +211,7 @@ export class BitbucketCloudEntityProvider
       return;
     }
 
-    if (params.metadata?.['x-event-key'] === 'repo:push') {
-      await this.onRepoPush(params.eventPayload as Events.RepoPushEvent);
-    }
+    await this.onRepoPush(params.eventPayload as Events.RepoPushEvent);
   }
 
   private canHandleEvents(): boolean {


### PR DESCRIPTION
The sub-topic separator was changed from `/` to `.` as part of the change and review process at the original PR introducing this capability.
Unfortunately, the adjustment at the entity provider was forgotten.

Additionally, this change adds a few missing test for the `onEvent`/`onRepoPush` feature.

Relates-to: PR #13931
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
