### PR TITLE
Deprecations catalog backend

### DIFF
--- a/.changeset/light-turtles-yawn.md
+++ b/.changeset/light-turtles-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Removed deprecated types that are exported in plugins/catalog-backend/src/ingestion/index.ts. Also fixed deprecated use of "substr" into "substring" in the files plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts and plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts.

--- a/.changeset/light-turtles-yawn.md
+++ b/.changeset/light-turtles-yawn.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Removed deprecated types that are exported in plugins/catalog-backend/src/ingestion/index.ts. Also fixed deprecated use of "substr" into "substring" in the files plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts and plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts.
+Removed deprecated types that are exported in plugins/catalog-backend/src/ingestion/index.ts. Also fixed deprecated use of substr into substring in the files plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts and plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts.

--- a/.changeset/light-turtles-yawn.md
+++ b/.changeset/light-turtles-yawn.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Removed deprecated types that are exported in plugins/catalog-backend/src/ingestion/index.ts. Also fixed deprecated use of substr into substring in the files plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts and plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts.
+Fixed deprecated use of `substr` into `substring`.

--- a/plugins/catalog-backend/src/ingestion/index.ts
+++ b/plugins/catalog-backend/src/ingestion/index.ts
@@ -15,11 +15,6 @@
  */
 
 export type {
-  AnalyzeLocationEntityField,
-  AnalyzeLocationExistingEntity,
-  AnalyzeLocationGenerateEntity,
-  AnalyzeLocationRequest,
-  AnalyzeLocationResponse,
   LocationAnalyzer,
   ScmLocationAnalyzer,
   AnalyzeOptions,

--- a/plugins/catalog-backend/src/ingestion/index.ts
+++ b/plugins/catalog-backend/src/ingestion/index.ts
@@ -15,6 +15,11 @@
  */
 
 export type {
+  AnalyzeLocationEntityField,
+  AnalyzeLocationExistingEntity,
+  AnalyzeLocationGenerateEntity,
+  AnalyzeLocationRequest,
+  AnalyzeLocationResponse,
   LocationAnalyzer,
   ScmLocationAnalyzer,
   AnalyzeOptions,

--- a/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
@@ -107,7 +107,7 @@ export class PlaceholderProcessor implements CatalogProcessor {
         return [data, false];
       }
 
-      const resolverKey = keys[0].substr(1);
+      const resolverKey = keys[0].substring(1);
       const resolverValue = data[keys[0]];
 
       const resolver = this.options.resolvers[resolverKey];

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
@@ -63,9 +63,13 @@ export function parseEntityFilterString(
     const equalsIndex = statement.indexOf('=');
 
     const key =
-      equalsIndex === -1 ? statement : statement.substr(0, equalsIndex).trim();
+      equalsIndex === -1
+        ? statement
+        : statement.substring(0, equalsIndex).trim();
     const value =
-      equalsIndex === -1 ? undefined : statement.substr(equalsIndex + 1).trim();
+      equalsIndex === -1
+        ? undefined
+        : statement.substring(equalsIndex + 1).trim();
     if (!key) {
       throw new InputError(
         `Invalid filter, '${statement}' is not a valid statement (expected a string on the form a=b or a= or a)`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Cleaned up deprecations in `plugins/catalog-backend` for issue #14602. Changed the use of `substr` into `substring`. 
#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
