### PR TITLE
ErrorReporting conditional rendering

### DIFF
--- a/.changeset/chilly-flies-nail.md
+++ b/.changeset/chilly-flies-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Removed rendering for ErrorEmptyState in ErrorReporting component, so nothing is rendered when there are no errors. Also removed Divider on Kubernetes page.

--- a/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
+++ b/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
@@ -123,18 +123,14 @@ export const ErrorReporting = ({ detectedErrors }: ErrorReportingProps) => {
 
   return (
     <>
-      {errors.length === 0 ? (
-        <InfoCard title="Error Reporting">
-          <ErrorEmptyState />
-        </InfoCard>
-      ) : (
+      {errors.length !== 0 && 
         <Table
           title="Error Reporting"
           data={errors}
           columns={columns}
           options={{ paging: true, search: false }}
         />
-      )}
+      }
     </>
   );
 };

--- a/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
+++ b/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
@@ -15,9 +15,8 @@
  */
 import * as React from 'react';
 import { DetectedError, DetectedErrorsByCluster } from '../../error-detection';
-import { Chip, Typography, Grid } from '@material-ui/core';
-import EmptyStateImage from '../../assets/emptystate.svg';
-import { Table, TableColumn, InfoCard } from '@backstage/core-components';
+import { Chip } from '@material-ui/core';
+import { Table, TableColumn } from '@backstage/core-components';
 
 type ErrorReportingProps = {
   detectedErrors: DetectedErrorsByCluster;

--- a/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
+++ b/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
@@ -91,31 +91,6 @@ const sortBySeverity = (a: DetectedError, b: DetectedError) => {
   return 0;
 };
 
-export const ErrorEmptyState = () => {
-  return (
-    <Grid
-      container
-      justifyContent="space-around"
-      direction="row"
-      alignItems="center"
-      spacing={2}
-    >
-      <Grid item xs={4}>
-        <Typography variant="h5">
-          Nice! There are no errors to report!
-        </Typography>
-      </Grid>
-      <Grid item xs={4}>
-        <img
-          src={EmptyStateImage}
-          alt="EmptyState"
-          data-testid="emptyStateImg"
-        />
-      </Grid>
-    </Grid>
-  );
-};
-
 export const ErrorReporting = ({ detectedErrors }: ErrorReportingProps) => {
   const errors = Array.from(detectedErrors.values())
     .flat()
@@ -123,7 +98,7 @@ export const ErrorReporting = ({ detectedErrors }: ErrorReportingProps) => {
 
   return (
     <>
-      {errors.length !== 0 && 
+      {errors.length !== 0 &&
         <Table
           title="Error Reporting"
           data={errors}

--- a/plugins/kubernetes/src/components/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Divider, Grid, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import { Entity } from '@backstage/catalog-model';
 import { ErrorPanel } from './ErrorPanel';
 import { ErrorReporting } from './ErrorReporting';
@@ -81,9 +81,6 @@ export const KubernetesContent = ({
           <Grid container spacing={3} direction="column">
             <Grid item>
               <ErrorReporting detectedErrors={detectedErrors} />
-            </Grid>
-            <Grid item>
-              <Divider />
             </Grid>
             <Grid item>
               <Typography variant="h3">Your Clusters</Typography>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Removed rendering of ErrorEmptyState when there are no errors. Now nothing is rendered when you have no errors, and the Error table is rendered as usual when you have.
- Removed Divider between Grid components on the Kubernetes page for a cleaner look. 

Before: 
![image](https://user-images.githubusercontent.com/78484334/203515063-486072b5-cc73-438f-a8ef-40df14d4d0fc.png)

After:
![image](https://user-images.githubusercontent.com/78484334/203514922-64f3fb8a-c795-450a-a60c-467a597e9ea9.png)


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
