### PR TITLE
Bump @azure/identity in techdocs-node

### DIFF
--- a/.changeset/forty-baboons-burn.md
+++ b/.changeset/forty-baboons-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Bump dependency @azure/identity to next minor

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/backstage/backstage/issues"
   },
   "dependencies": {
-    "@azure/identity": "^2.0.1",
+    "@azure/identity": "^2.1.0",
     "@azure/storage-blob": "^12.5.0",
     "@backstage/backend-common": "workspace:^",
     "@backstage/catalog-model": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,7 +1290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/identity@npm:^2.0.1, @azure/identity@npm:^2.0.4, @azure/identity@npm:^2.1.0":
+"@azure/identity@npm:^2.0.4, @azure/identity@npm:^2.1.0":
   version: 2.1.0
   resolution: "@azure/identity@npm:2.1.0"
   dependencies:
@@ -7598,7 +7598,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-techdocs-node@workspace:plugins/techdocs-node"
   dependencies:
-    "@azure/identity": ^2.0.1
+    "@azure/identity": ^2.1.0
     "@azure/storage-blob": ^12.5.0
     "@backstage/backend-common": "workspace:^"
     "@backstage/catalog-model": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumping the dependency to `@azure/identity` to solve this bug: https://github.com/backstage/backstage/issues/14697

changelog for this version: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/CHANGELOG.md#210-2022-07-08

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
