### PR TITLE
Patch release of #14771

### DIFF
--- a/.changeset/quick-horses-cry.md
+++ b/.changeset/quick-horses-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Update `UserProfileCard` and `GroupProfileCard` to not render links unless the `showLinks` prop is set. The primary component for rendering links are the `EntityLinksCard` from plugin-catalog.

--- a/.changeset/quick-horses-cry.md
+++ b/.changeset/quick-horses-cry.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-org': patch
----
-
-Update `UserProfileCard` and `GroupProfileCard` to not render links unless the `showLinks` prop is set. The primary component for rendering links are the `EntityLinksCard` from plugin-catalog.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.8.2",
+  "version": "1.8.3",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-app
 
+## 0.2.78
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-org@0.6.1
+
 ## 0.2.77
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.77",
+  "version": "0.2.78",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-org
 
+## 0.6.1
+
+### Patch Changes
+
+- eb286a2a78: Update `UserProfileCard` and `GroupProfileCard` to not render links unless the `showLinks` prop is set. The primary component for rendering links are the `EntityLinksCard` from plugin-catalog.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -13,6 +13,7 @@ import { InfoCardVariants } from '@backstage/core-components';
 // @public (undocumented)
 export const EntityGroupProfileCard: (props: {
   variant?: InfoCardVariants | undefined;
+  showLinks?: boolean | undefined;
 }) => JSX.Element;
 
 // @public (undocumented)
@@ -32,11 +33,13 @@ export const EntityOwnershipCard: (props: {
 // @public (undocumented)
 export const EntityUserProfileCard: (props: {
   variant?: InfoCardVariants | undefined;
+  showLinks?: boolean | undefined;
 }) => JSX.Element;
 
 // @public (undocumented)
 export const GroupProfileCard: (props: {
   variant?: InfoCardVariants;
+  showLinks?: boolean;
 }) => JSX.Element;
 
 // @public (undocumented)
@@ -75,5 +78,6 @@ export const OwnershipCard: (props: {
 // @public (undocumented)
 export const UserProfileCard: (props: {
   variant?: InfoCardVariants;
+  showLinks?: boolean;
 }) => JSX.Element;
 ```

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-org",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -15,43 +15,44 @@
  */
 
 import {
+  ANNOTATION_EDIT_URL,
+  ANNOTATION_LOCATION,
   GroupEntity,
   RELATION_CHILD_OF,
   RELATION_PARENT_OF,
-  ANNOTATION_LOCATION,
   stringifyEntityRef,
-  ANNOTATION_EDIT_URL,
 } from '@backstage/catalog-model';
-import {
-  catalogApiRef,
-  EntityRefLinks,
-  getEntityRelations,
-  useEntity,
-} from '@backstage/plugin-catalog-react';
-import {
-  Box,
-  Grid,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  Tooltip,
-  IconButton,
-} from '@material-ui/core';
-import AccountTreeIcon from '@material-ui/icons/AccountTree';
-import EmailIcon from '@material-ui/icons/Email';
-import GroupIcon from '@material-ui/icons/Group';
-import EditIcon from '@material-ui/icons/Edit';
-import CachedIcon from '@material-ui/icons/Cached';
-import Alert from '@material-ui/lab/Alert';
-import React, { useCallback } from 'react';
 import {
   Avatar,
   InfoCard,
   InfoCardVariants,
   Link,
 } from '@backstage/core-components';
+import {
+  Box,
+  Grid,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+} from '@material-ui/core';
+import {
+  EntityRefLinks,
+  catalogApiRef,
+  getEntityRelations,
+  useEntity,
+} from '@backstage/plugin-catalog-react';
+import React, { useCallback } from 'react';
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+
+import AccountTreeIcon from '@material-ui/icons/AccountTree';
+import Alert from '@material-ui/lab/Alert';
+import CachedIcon from '@material-ui/icons/Cached';
+import EditIcon from '@material-ui/icons/Edit';
+import EmailIcon from '@material-ui/icons/Email';
+import GroupIcon from '@material-ui/icons/Group';
 import { LinksGroup } from '../../Meta';
 
 const CardTitle = (props: { title: string }) => (
@@ -62,7 +63,10 @@ const CardTitle = (props: { title: string }) => (
 );
 
 /** @public */
-export const GroupProfileCard = (props: { variant?: InfoCardVariants }) => {
+export const GroupProfileCard = (props: {
+  variant?: InfoCardVariants;
+  showLinks?: boolean;
+}) => {
   const catalogApi = useApi(catalogApiRef);
   const alertApi = useApi(alertApiRef);
   const { entity: group } = useEntity<GroupEntity>();
@@ -191,7 +195,7 @@ export const GroupProfileCard = (props: { variant?: InfoCardVariants }) => {
                 secondary="Child Groups"
               />
             </ListItem>
-            <LinksGroup links={links} />
+            {props?.showLinks && <LinksGroup links={links} />}
           </List>
         </Grid>
       </Grid>

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
@@ -156,7 +156,7 @@ describe('Edit Button', () => {
     expect(rendered.getByRole('button')).toBeInTheDocument();
   });
 
-  it('Should show the extra fields if either links or extra profile are filled', async () => {
+  it('Should not show links by default', async () => {
     const annotations: Record<string, string> = {
       'backstage.io/edit-url': 'https://example.com/user.yaml',
     };
@@ -198,6 +198,60 @@ describe('Edit Button', () => {
       wrapInTestApp(
         <EntityProvider entity={userEntity}>
           <UserProfileCard variant="gridItem" />
+        </EntityProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      ),
+    );
+    expect(rendered.queryByText('Slack')).toBeNull();
+    expect(rendered.queryByText('Google')).toBeNull();
+  });
+
+  it('Should show the links if showLinks is set', async () => {
+    const annotations: Record<string, string> = {
+      'backstage.io/edit-url': 'https://example.com/user.yaml',
+    };
+    const userEntity: UserEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        name: 'calum.leavy',
+        description: 'Super awesome human',
+        annotations,
+        links: [
+          {
+            url: 'slack://user?team=T00000000&id=U00000000',
+            title: 'Slack',
+            icon: 'message',
+          },
+          {
+            url: 'https://www.google.com',
+            title: 'Google',
+          },
+        ],
+      },
+      spec: {
+        profile: {
+          displayName: 'Calum Leavy',
+          email: 'calum-leavy@example.com',
+        },
+        memberOf: ['ExampleGroup'],
+      },
+      relations: [
+        {
+          type: 'memberOf',
+          targetRef: 'group:default/examplegroup',
+        },
+      ],
+    };
+
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <EntityProvider entity={userEntity}>
+          <UserProfileCard showLinks variant="gridItem" />
         </EntityProvider>,
         {
           mountedRoutes: {

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -15,15 +15,16 @@
  */
 
 import {
+  ANNOTATION_EDIT_URL,
   RELATION_MEMBER_OF,
   UserEntity,
-  ANNOTATION_EDIT_URL,
 } from '@backstage/catalog-model';
 import {
-  EntityRefLinks,
-  getEntityRelations,
-  useEntity,
-} from '@backstage/plugin-catalog-react';
+  Avatar,
+  InfoCard,
+  InfoCardVariants,
+  Link,
+} from '@backstage/core-components';
 import {
   Box,
   Grid,
@@ -34,19 +35,19 @@ import {
   ListItemText,
   Tooltip,
 } from '@material-ui/core';
+import {
+  EntityRefLinks,
+  getEntityRelations,
+  useEntity,
+} from '@backstage/plugin-catalog-react';
+
+import Alert from '@material-ui/lab/Alert';
 import EditIcon from '@material-ui/icons/Edit';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
-import PersonIcon from '@material-ui/icons/Person';
-import Alert from '@material-ui/lab/Alert';
-import React from 'react';
-import {
-  Avatar,
-  InfoCard,
-  InfoCardVariants,
-  Link,
-} from '@backstage/core-components';
 import { LinksGroup } from '../../Meta';
+import PersonIcon from '@material-ui/icons/Person';
+import React from 'react';
 
 const CardTitle = (props: { title?: string }) =>
   props.title ? (
@@ -57,7 +58,10 @@ const CardTitle = (props: { title?: string }) =>
   ) : null;
 
 /** @public */
-export const UserProfileCard = (props: { variant?: InfoCardVariants }) => {
+export const UserProfileCard = (props: {
+  variant?: InfoCardVariants;
+  showLinks?: boolean;
+}) => {
   const { entity: user } = useEntity<UserEntity>();
   if (!user) {
     return <Alert severity="error">User not found</Alert>;
@@ -130,7 +134,7 @@ export const UserProfileCard = (props: { variant?: InfoCardVariants }) => {
               </ListItemText>
             </ListItem>
 
-            <LinksGroup links={links} />
+            {props?.showLinks && <LinksGroup links={links} />}
           </List>
         </Grid>
       </Grid>


### PR DESCRIPTION
This release fixes an issue where the org plugins `UserProfileCard` and `GroupProfileCard` rendered all entity links by default making it UI very verbose in some situations. To still display links in these cards set the `showLinks` prop.