### PR TITLE
Make EntityRelationsGraph visible without having to scroll vertically

### DIFF
--- a/.changeset/tricky-bananas-carry.md
+++ b/.changeset/tricky-bananas-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Make sure that entity relations graph only fills out visible space on the page.

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -45,7 +45,6 @@ const useStyles = makeStyles<Theme, { height: number | undefined }>(
       display: 'flex',
       flexDirection: 'column',
       maxHeight: height,
-      minHeight: height,
     }),
     graph: {
       flex: 1,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles(
     },
     graph: {
       width: '100%',
-      flex: 1,
+      minHeight: '100%',
       // Right now there is no good way to style edges between nodes, we have to
       // fallback to these hacks:
       '& path[marker-end]': {
@@ -149,6 +149,7 @@ export const EntityRelationsGraph = (props: {
           labelOffset={theme.spacing(1)}
           zoom={zoom}
           curve={curve}
+          fit="contain"
         />
       )}
     </div>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR is related to #13897. 

As suggested in #13897 we should use the same solution as in in #11429 to fill the visible space with the graph. When applied this fix will make sure the EntityRelationsGraph only fills the visible space on the page so that the user does not have to scroll down to see the graph.

Here is how it looks with the new fix: 

https://user-images.githubusercontent.com/64839037/203619496-82c6124b-037a-4744-9eba-b30a4107f872.mp4

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
