### PR TITLE
🚀 Make the Azure DevOps discovery multiproject

### DIFF
--- a/.changeset/clever-pillows-drive.md
+++ b/.changeset/clever-pillows-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Do not use deprecated `LocationSpec` from the `@backstage/plugin-catalog-node` package

--- a/.changeset/funny-numbers-compete.md
+++ b/.changeset/funny-numbers-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Use Json types from @backstage/types

--- a/.changeset/ninety-hats-serve.md
+++ b/.changeset/ninety-hats-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-azure': minor
+---
+
+This will add the ability to use Azure DevOps with multi project with a single value which is a new feature as previously this had to be done manually for each project that you wanted to add

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -241,6 +241,7 @@ pageview
 parallelization
 parseable
 Patrik
+pattison
 Peloton
 performant
 Performant

--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -159,7 +159,12 @@ Check out the numbered markings - let's go through them one by one.
    the outcome of that. This example issues a `fetch` to the right service and
    issues a full refresh of its entity bucket based on that.
 5. The method translates the foreign data model to the native `Entity` form, as
-   expected by the catalog.
+   expected by the catalog. Make sure that in this method you include the
+   `backstage.io/managed-by-location` and `backstage.io/managed-by-origin-location`
+   annotations on your `Entity`. If these are not present they will not show up
+   in the Catalog and you will see warnings in your logs. The
+   [Well-known Annotations](./well-known-annotations.md#backstageiomanaged-by-location)
+   documentation has guidance on what values to use for these.
 6. Finally, we issue a "mutation" to the catalog. This persists the entities in
    our own bucket, along with an optional `locationKey` that's used for conflict
    checks. But this is a bigger topic - mutations warrant their own explanatory

--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -159,10 +159,10 @@ Check out the numbered markings - let's go through them one by one.
    the outcome of that. This example issues a `fetch` to the right service and
    issues a full refresh of its entity bucket based on that.
 5. The method translates the foreign data model to the native `Entity` form, as
-   expected by the catalog. Make sure that in this method you include the
-   `backstage.io/managed-by-location` and `backstage.io/managed-by-origin-location`
-   annotations on your `Entity`. If these are not present they will not show up
-   in the Catalog and you will see warnings in your logs. The
+   expected by the catalog. The `Entity` must include the
+   `backstage.io/managed-by-location` and
+   `backstage.io/managed-by-origin-location annotations`; otherwise, it will not
+   appear in the Catalog and will generate warning logs. The
    [Well-known Annotations](./well-known-annotations.md#backstageiomanaged-by-location)
    documentation has guidance on what values to use for these.
 6. Finally, we issue a "mutation" to the catalog. This persists the entities in

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -47,6 +47,11 @@ catalog:
           frequency: { minutes: 30 }
           # supports ISO duration, "human duration" as used in code
           timeout: { minutes: 3 }
+      yourSecondProviderId: # identifies your dataset / provider independent of config changes
+        organization: myorg
+        project: '*' # this will match all projects
+        repository: '*' # this will match all repos
+        path: /catalog-info.yaml
       anotherProviderId: # another identifier
         organization: myorg
         project: myproject
@@ -62,7 +67,7 @@ The parameters available are:
 
 - **`host:`** _(optional)_ Leave empty for Cloud hosted, otherwise set to your self-hosted instance host.
 - **`organization:`** Your Organization slug (or Collection for on-premise users). Required.
-- **`project:`** Your project slug. Required.
+- **`project:`** Your project slug. Required. Wildcards are supported as show on the examples above. If not set, all projects will be searched.
 - **`repository:`** _(optional)_ The repository name. Wildcards are supported as show on the examples above. If not set, all repositories will be searched.
 - **`path:`** _(optional)_ Where to find catalog-info.yaml files. Defaults to /catalog-info.yaml.
 - **`schedule`** _(optional)_:

--- a/microsite/data/plugins/cloudsmith.yaml
+++ b/microsite/data/plugins/cloudsmith.yaml
@@ -1,0 +1,13 @@
+---
+title: Cloudsmith
+author: Roadie
+authorUrl: https://roadie.io
+category: CI/CD
+description: Show Cloudsmith Repository stats on your backstage homepage.
+documentation: https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-cloudsmith
+iconUrl: https://cloudsmith.com/img/cloudsmith-mini-dark.svg
+npmPackageName: '@roadiehq/backstage-plugin-cloudsmith'
+tags:
+  - dashboards
+  - monitoring
+addedDate: '2022-11-18'

--- a/plugins/catalog-backend-module-azure/src/lib/azure.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.ts
@@ -31,6 +31,9 @@ export interface CodeSearchResultItem {
   repository: {
     name: string;
   };
+  project: {
+    name: string;
+  };
 }
 
 const isCloud = (host: string) => host === 'dev.azure.com';
@@ -47,7 +50,7 @@ export async function codeSearch(
   const searchBaseUrl = isCloud(azureConfig.host)
     ? 'https://almsearch.dev.azure.com'
     : `https://${azureConfig.host}`;
-  const searchUrl = `${searchBaseUrl}/${org}/${project}/_apis/search/codesearchresults?api-version=6.0-preview.1`;
+  const searchUrl = `${searchBaseUrl}/${org}/_apis/search/codesearchresults?api-version=6.0-preview.1`;
 
   let items: CodeSearchResultItem[] = [];
   let hasMorePages = true;
@@ -59,7 +62,7 @@ export async function codeSearch(
       }),
       method: 'POST',
       body: JSON.stringify({
-        searchText: `path:${path} repo:${repo || '*'}`,
+        searchText: `path:${path} repo:${repo || '*'} proj:${project || '*'}`,
         $skip: items.length,
         $top: PAGE_SIZE,
       }),

--- a/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
@@ -166,17 +166,18 @@ export class AzureDevOpsEntityProvider implements EntityProvider {
   }
 
   private createLocationSpec(file: CodeSearchResultItem): LocationSpec {
+    const target = this.createObjectUrl(file);
+
     return {
       type: 'url',
-      target: this.createObjectUrl(file),
+      target: target,
       presence: 'required',
     };
   }
 
   private createObjectUrl(file: CodeSearchResultItem): string {
-    const baseUrl = `https://${this.config.host}/${this.config.organization}/${this.config.project}`;
-    return encodeURI(
-      `${baseUrl}/_git/${file.repository.name}?path=${file.path}`,
-    );
+    const baseUrl = `https://${this.config.host}/${this.config.organization}`;
+    const encodedUri = `${baseUrl}/${file.project.name}/_git/${file.repository.name}?path=${file.path}`;
+    return encodedUri;
   }
 }

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -37,7 +37,7 @@ import { EntityRelationSpec } from '@backstage/plugin-catalog-node';
 import { GetEntitiesRequest } from '@backstage/catalog-client';
 import { JsonValue } from '@backstage/types';
 import { LocationEntityV1alpha1 } from '@backstage/catalog-model';
-import { LocationSpec } from '@backstage/plugin-catalog-node';
+import { LocationSpec as LocationSpec_2 } from '@backstage/plugin-catalog-common';
 import { Logger } from 'winston';
 import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
@@ -86,9 +86,9 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
   // (undocumented)
   preProcessEntity(
     entity: Entity,
-    location: LocationSpec,
+    location: LocationSpec_2,
     _: CatalogProcessorEmit,
-    originLocation: LocationSpec,
+    originLocation: LocationSpec_2,
   ): Promise<Entity>;
 }
 
@@ -100,7 +100,7 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   // (undocumented)
   getProcessorName(): string;
   // (undocumented)
-  preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
+  preProcessEntity(entity: Entity, location: LocationSpec_2): Promise<Entity>;
 }
 
 // @public (undocumented)
@@ -110,7 +110,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
   // (undocumented)
   postProcessEntity(
     entity: Entity,
-    _location: LocationSpec,
+    _location: LocationSpec_2,
     emit: CatalogProcessorEmit,
   ): Promise<Entity>;
   // (undocumented)
@@ -284,7 +284,7 @@ export class CodeOwnersProcessor implements CatalogProcessor {
   // (undocumented)
   getProcessorName(): string;
   // (undocumented)
-  preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
+  preProcessEntity(entity: Entity, location: LocationSpec_2): Promise<Entity>;
 }
 
 // @alpha
@@ -409,7 +409,7 @@ export class FileReaderProcessor implements CatalogProcessor {
   getProcessorName(): string;
   // (undocumented)
   readLocation(
-    location: LocationSpec,
+    location: LocationSpec_2,
     optional: boolean,
     emit: CatalogProcessorEmit,
     parser: CatalogProcessorParser,
@@ -431,7 +431,7 @@ export class LocationEntityProcessor implements CatalogProcessor {
   // (undocumented)
   postProcessEntity(
     entity: Entity,
-    location: LocationSpec,
+    location: LocationSpec_2,
     emit: CatalogProcessorEmit,
   ): Promise<Entity>;
 }
@@ -441,18 +441,19 @@ export type LocationEntityProcessorOptions = {
   integrations: ScmIntegrationRegistry;
 };
 
-export { LocationSpec };
+// @public @deprecated
+export type LocationSpec = LocationSpec_2;
 
 // @public (undocumented)
 export function locationSpecToLocationEntity(opts: {
-  location: LocationSpec;
+  location: LocationSpec_2;
   parentEntity?: Entity;
 }): LocationEntityV1alpha1;
 
 // @public (undocumented)
 export function parseEntityYaml(
   data: Buffer,
-  location: LocationSpec,
+  location: LocationSpec_2,
 ): Iterable<CatalogProcessorResult>;
 
 // @alpha
@@ -518,7 +519,7 @@ export class PlaceholderProcessor implements CatalogProcessor {
   // (undocumented)
   preProcessEntity(
     entity: Entity,
-    location: LocationSpec,
+    location: LocationSpec_2,
     emit: CatalogProcessorEmit,
   ): Promise<Entity>;
 }
@@ -574,7 +575,7 @@ export class UrlReaderProcessor implements CatalogProcessor {
   getProcessorName(): string;
   // (undocumented)
   readLocation(
-    location: LocationSpec,
+    location: LocationSpec_2,
     optional: boolean,
     emit: CatalogProcessorEmit,
     parser: CatalogProcessorParser,

--- a/plugins/catalog-backend/src/index.ts
+++ b/plugins/catalog-backend/src/index.ts
@@ -22,7 +22,6 @@
 
 export type {
   DeferredEntity,
-  LocationSpec,
   EntityRelationSpec,
   CatalogProcessor,
   CatalogProcessorParser,
@@ -48,3 +47,19 @@ export * from './processing';
 export * from './search';
 export * from './service';
 export * from './util';
+
+import { LocationSpec as NonDeprecatedLocationSpec } from '@backstage/plugin-catalog-common';
+
+/**
+ * Holds the entity location information.
+ *
+ * @remarks
+ *
+ *  `presence` flag: when using repo importer plugin, location is being created before the component yaml file is merged to the main branch.
+ *  This flag is then set to indicate that the file can be not present.
+ *  default value: 'required'.
+ *
+ * @public
+ * @deprecated use the same type from `@backstage/plugin-catalog-common` instead
+ */
+export type LocationSpec = NonDeprecatedLocationSpec;

--- a/plugins/catalog-backend/src/ingestion/CatalogRules.ts
+++ b/plugins/catalog-backend/src/ingestion/CatalogRules.ts
@@ -17,7 +17,7 @@
 import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import path from 'path';
-import { LocationSpec } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 
 /**
  * Rules to apply to catalog entities.

--- a/plugins/catalog-backend/src/modules/codeowners/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/modules/codeowners/CodeOwnersProcessor.ts
@@ -22,7 +22,8 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import { Logger } from 'winston';
-import { CatalogProcessor, LocationSpec } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { findCodeOwnerByTarget } from './lib';
 
 const ALLOWED_KINDS = ['API', 'Component', 'Domain', 'Resource', 'System'];

--- a/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
@@ -25,10 +25,10 @@ import {
 } from '@backstage/catalog-model';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { identity, merge, pickBy } from 'lodash';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessor,
   CatalogProcessorEmit,
-  LocationSpec,
 } from '@backstage/plugin-catalog-node';
 
 /** @public */

--- a/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -21,7 +22,8 @@ import {
 } from '@backstage/integration';
 import parseGitUrl from 'git-url-parse';
 import { identity, merge, pickBy } from 'lodash';
-import { CatalogProcessor, LocationSpec } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 
 const GITHUB_ACTIONS_ANNOTATION = 'github.com/project-slug';
 const GITLAB_ACTIONS_ANNOTATION = 'gitlab.com/project-slug';

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
@@ -48,10 +48,10 @@ import {
   UserEntity,
   userEntityV1alpha1Validator,
 } from '@backstage/catalog-model';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessor,
   CatalogProcessorEmit,
-  LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
 

--- a/plugins/catalog-backend/src/modules/core/FileReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/FileReaderProcessor.ts
@@ -18,11 +18,11 @@ import fs from 'fs-extra';
 import g from 'glob';
 import path from 'path';
 import { promisify } from 'util';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessor,
   CatalogProcessorEmit,
   CatalogProcessorParser,
-  LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
 

--- a/plugins/catalog-backend/src/modules/core/LocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/LocationEntityProcessor.ts
@@ -17,11 +17,11 @@
 import { Entity, LocationEntity } from '@backstage/catalog-model';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import path from 'path';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   processingResult,
   CatalogProcessor,
   CatalogProcessorEmit,
-  LocationSpec,
 } from '@backstage/plugin-catalog-node';
 
 export function toAbsoluteUrl(

--- a/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
@@ -19,10 +19,10 @@ import { Entity } from '@backstage/catalog-model';
 import { JsonValue } from '@backstage/types';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import yaml from 'yaml';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessor,
   CatalogProcessorEmit,
-  LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
 

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
@@ -20,6 +20,7 @@ import { assertError } from '@backstage/errors';
 import parseGitUrl from 'git-url-parse';
 import limiterFactory from 'p-limit';
 import { Logger } from 'winston';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessor,
   CatalogProcessorCache,
@@ -27,7 +28,6 @@ import {
   CatalogProcessorEntityResult,
   CatalogProcessorParser,
   CatalogProcessorResult,
-  LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
 

--- a/plugins/catalog-backend/src/modules/util/parse.ts
+++ b/plugins/catalog-backend/src/modules/util/parse.ts
@@ -17,10 +17,10 @@
 import { Entity, stringifyLocationRef } from '@backstage/catalog-model';
 import lodash from 'lodash';
 import yaml from 'yaml';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessorParser,
   CatalogProcessorResult,
-  LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
 

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -32,10 +32,10 @@ import { JsonValue } from '@backstage/types';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import path from 'path';
 import { Logger } from 'winston';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   CatalogProcessor,
   CatalogProcessorParser,
-  LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
 import {

--- a/plugins/catalog-backend/src/processing/util.ts
+++ b/plugins/catalog-backend/src/processing/util.ts
@@ -27,7 +27,7 @@ import { JsonObject, JsonValue } from '@backstage/types';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import path from 'path';
-import { LocationSpec } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 
 export function isLocationEntity(entity: Entity): entity is LocationEntity {
   return entity.kind === 'Location';

--- a/plugins/catalog-backend/src/util/conversion.ts
+++ b/plugins/catalog-backend/src/util/conversion.ts
@@ -23,7 +23,7 @@ import {
   stringifyLocationRef,
 } from '@backstage/catalog-model';
 import { createHash } from 'crypto';
-import { LocationSpec } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 
 export function locationSpecToMetadataName(location: LocationSpec) {
   const hash = createHash('sha1')

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -23,9 +23,10 @@ import {
   stringifyEntityRef,
   UserEntity,
 } from '@backstage/catalog-model';
-import { Config, JsonObject, JsonValue } from '@backstage/config';
+import { Config } from '@backstage/config';
 import { InputError, NotFoundError, stringifyError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
+import { JsonObject, JsonValue } from '@backstage/types';
 import {
   TaskSpec,
   TemplateEntityV1beta3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18382,20 +18382,20 @@ __metadata:
   linkType: hard
 
 "css-loader@npm:^6.5.1":
-  version: 6.7.1
-  resolution: "css-loader@npm:6.7.1"
+  version: 6.7.2
+  resolution: "css-loader@npm:6.7.2"
   dependencies:
     icss-utils: ^5.1.0
-    postcss: ^8.4.7
+    postcss: ^8.4.18
     postcss-modules-extract-imports: ^3.0.0
     postcss-modules-local-by-default: ^4.0.0
     postcss-modules-scope: ^3.0.0
     postcss-modules-values: ^4.0.0
     postcss-value-parser: ^4.2.0
-    semver: ^7.3.5
+    semver: ^7.3.8
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 170fdbc630a05a43679ef60fa97694766b568dbde37adccc0faafa964fc675f08b976bc68837bb73b61d60240e8d2cbcbf51540fe94ebc9dafc56e7c46ba5527
+  checksum: f3c980cc9c033a02e60df7e5a2f33a1e8c2c3dd552f017485d2d81b383be623ae8c4189404e7a4a7403b52744683ae4b516def0f7ccf125c2b198cb647e46543
   languageName: node
   linkType: hard
 
@@ -30704,7 +30704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.0, postcss@npm:^8.4.7":
+"postcss@npm:^8.1.0, postcss@npm:^8.4.18":
   version: 8.4.19
   resolution: "postcss@npm:8.4.19"
   dependencies:
@@ -33287,14 +33287,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:~7.3.0":
-  version: 7.3.7
-  resolution: "semver@npm:7.3.7"
+"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:~7.3.0":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11584,16 +11584,16 @@ __metadata:
   linkType: hard
 
 "@rjsf/validator-ajv8@npm:^5.0.0-beta.12":
-  version: 5.0.0-beta.12
-  resolution: "@rjsf/validator-ajv8@npm:5.0.0-beta.12"
+  version: 5.0.0-beta.13
+  resolution: "@rjsf/validator-ajv8@npm:5.0.0-beta.13"
   dependencies:
-    ajv: ^8.11.0
     ajv-formats: ^2.1.1
+    ajv8: "npm:ajv@^8.11.0"
     lodash: ^4.17.15
     lodash-es: ^4.17.15
   peerDependencies:
-    "@rjsf/utils": ^5.0.0-beta.1
-  checksum: 2acd420fdd099b35e534c4086ce5d3759574a8b4dc4b4a21ca35e85b023e6d9688aab1dbfca9381bdbf4aecbe3eb195e27453e8dd9cc70712fe2652e1496840c
+    "@rjsf/utils": ^5.0.0-beta.12
+  checksum: e0a51e25845745da628794dadef2c7ffc910d26cb99a90fa763d4a5593b554b084c578a73ed688d02defbeb5ddec38066caae527f5dc8dabba7f012cec31e8a3
   languageName: node
   linkType: hard
 
@@ -15101,6 +15101,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv8@npm:ajv@^8.11.0, ajv@npm:^8.0.0, ajv@npm:^8.10.0, ajv@npm:^8.6.3, ajv@npm:^8.8.0":
+  version: 8.11.2
+  resolution: "ajv@npm:8.11.2"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 53435bf79ee7d1eabba8085962dba4c08d08593334b304db7772887f0b7beebc1b3d957432f7437ed4b60e53b5d966a57b439869890209c50fed610459999e3e
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.10.0, ajv@npm:^6.10.1, ajv@npm:^6.12.2, ajv@npm:^6.12.4, ajv@npm:^6.12.5, ajv@npm:^6.5.5, ajv@npm:^6.7.0, ajv@npm:~6.12.6":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -15110,18 +15122,6 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.0, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.6.3, ajv@npm:^8.8.0":
-  version: 8.11.2
-  resolution: "ajv@npm:8.11.2"
-  dependencies:
-    fast-deep-equal: ^3.1.1
-    json-schema-traverse: ^1.0.0
-    require-from-string: ^2.0.2
-    uri-js: ^4.2.2
-  checksum: 53435bf79ee7d1eabba8085962dba4c08d08593334b304db7772887f0b7beebc1b3d957432f7437ed4b60e53b5d966a57b439869890209c50fed610459999e3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made my First Backstage Pull Request!

This change will make the Azure DevOps discovery usable for all Project inside an Azure DevOps organisation with the use of a wildcard `*`

Instead of doing this numerous times:

```
      yourSecondProviderId: # identifies your dataset / provider independent of config changes
        organization: myorg
        project: 'project2' # only one project!
        repository: '*' # this will match all repos
        path: /catalog-info.yaml
```

you can do:

```
      yourSecondProviderId: # identifies your dataset / provider independent of config changes
        organization: myorg
        project: '*' #  all project inside your azure devops organisation
        repository: '*' # this will match all repos
        path: /catalog-info.yaml
```

The change is pretty straight forward and I'm happy to my first contributions to backstage. It's also backward compatible which is ofcourse nice 👍 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
