### PR TITLE
Make Azure DevOps Multiproject

### DIFF
--- a/.changeset/ninety-hats-serve.md
+++ b/.changeset/ninety-hats-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-azure': minor
+---
+
+This will add the ability to use Azure DevOps with multi project with a single value which is a new feature as previously this had to be done manually for each project that you wanted to add

--- a/.changeset/ninety-hats-serve.md
+++ b/.changeset/ninety-hats-serve.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-azure': minor
+'@backstage/plugin-catalog-backend-module-azure': patch
 ---
 
 This will add the ability to use Azure DevOps with multi project with a single value which is a new feature as previously this had to be done manually for each project that you wanted to add

--- a/.changeset/ninety-hats-serve.md
+++ b/.changeset/ninety-hats-serve.md
@@ -2,4 +2,29 @@
 '@backstage/plugin-catalog-backend-module-azure': patch
 ---
 
-This will add the ability to use Azure DevOps with multi project with a single value which is a new feature as previously this had to be done manually for each project that you wanted to add
+This will add the ability to use Azure DevOps with multi project with a single value which is a new feature as previously this had to be done manually for each project that you wanted to add.
+
+Right now you would have to fill in multiple values in the config to use multiple projects:
+
+```
+yourFirstProviderId: # identifies your dataset / provider independent of config changes
+    organization: myorg
+    project: 'firstProject' # this will match the firstProject project
+    repository: '*' # this will match all repos
+    path: /catalog-info.yaml
+yourSecondProviderId: # identifies your dataset / provider independent of config changes
+    organization: myorg
+    project: 'secondProject' # this will match the secondProject project
+    repository: '*' # this will match all repos
+    path: /catalog-info.yaml
+```
+
+With this change you can actually have all projects available where your PAT determines which you have access to, so that includes multiple projects:
+
+```
+yourFirstProviderId: # identifies your dataset / provider independent of config changes
+    organization: myorg
+    project: '*' # this will match all projects where your PAT has access to
+    repository: '*' # this will match all repos
+    path: /catalog-info.yaml
+```

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -47,6 +47,11 @@ catalog:
           frequency: { minutes: 30 }
           # supports ISO duration, "human duration" as used in code
           timeout: { minutes: 3 }
+      yourSecondProviderId: # identifies your dataset / provider independent of config changes
+        organization: myorg
+        project: '*' # this will match all projects
+        repository: '*' # this will match all repos
+        path: /catalog-info.yaml
       anotherProviderId: # another identifier
         organization: myorg
         project: myproject
@@ -62,7 +67,7 @@ The parameters available are:
 
 - **`host:`** _(optional)_ Leave empty for Cloud hosted, otherwise set to your self-hosted instance host.
 - **`organization:`** Your Organization slug (or Collection for on-premise users). Required.
-- **`project:`** Your project slug. Required.
+- **`project:`** Your project slug. Required. Wildcards are supported as show on the examples above. If not set, all projects will be searched.
 - **`repository:`** _(optional)_ The repository name. Wildcards are supported as show on the examples above. If not set, all repositories will be searched.
 - **`path:`** _(optional)_ Where to find catalog-info.yaml files. Defaults to /catalog-info.yaml.
 - **`schedule`** _(optional)_:

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -67,7 +67,7 @@ The parameters available are:
 
 - **`host:`** _(optional)_ Leave empty for Cloud hosted, otherwise set to your self-hosted instance host.
 - **`organization:`** Your Organization slug (or Collection for on-premise users). Required.
-- **`project:`** Your project slug. Required. Wildcards are supported as show on the examples above. If not set, all projects will be searched.
+- **`project:`** _(optional)_ Your project slug. Wildcards are supported as show on the examples above. If not set, all projects will be searched.
 - **`repository:`** _(optional)_ The repository name. Wildcards are supported as show on the examples above. If not set, all repositories will be searched.
 - **`path:`** _(optional)_ Where to find catalog-info.yaml files. Defaults to /catalog-info.yaml.
 - **`schedule`** _(optional)_:

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -149,7 +149,7 @@ When using a custom pattern, the target is composed of five parts:
 
 - The base instance URL, `https://dev.azure.com` in this case
 - The organization name which is required, `myorg` in this case
-- The project name which is required, `myproject` in this case
+- The project name which is optional, `myproject` in this case. This defaults to \*, which scans all the projects where the token has access to.
 - The repository blob to scan, which accepts \* wildcard tokens and must be
   added after `_git/`. This can simply be `*` to scan all repositories in the
   project.

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -33,7 +33,7 @@ describe('azure', () => {
           (req, res, ctx) => {
             expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
             expect(req.body).toEqual({
-              searchText: 'path:/catalog-info.yaml repo:*',
+              searchText: 'path:/catalog-info.yaml repo:* proj:*',
               $skip: 0,
               $top: 1000,
             });
@@ -87,7 +87,7 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:*',
+            searchText: 'path:/catalog-info.yaml repo:* proj:*',
             $skip: 0,
             $top: 1000,
           });
@@ -127,7 +127,7 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:backstage',
+            searchText: 'path:/catalog-info.yaml repo:backstage: proj:*',
             $skip: 0,
             $top: 1000,
           });
@@ -170,7 +170,7 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:*',
+            searchText: 'path:/catalog-info.yaml repo:* proj:*',
             $skip: 0,
             $top: 1000,
           });

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -64,12 +64,18 @@ describe('azure', () => {
           repository: {
             name: 'backstage',
           },
+          project: {
+            name: '*',
+          },
         },
         {
           fileName: 'catalog-info.yaml',
           path: '/catalog-info.yaml',
           repository: {
             name: 'ios-app',
+          },
+          project: {
+            name: '*',
           },
         },
       ],
@@ -151,6 +157,9 @@ describe('azure', () => {
           repository: {
             name: 'backstage',
           },
+          project: {
+            name: '*',
+          },
         },
       ],
     };
@@ -189,6 +198,9 @@ describe('azure', () => {
         path: '/catalog-info.yaml',
         repository: {
           name: 'backstage',
+        },
+        project: {
+          name: '*',
         },
       }));
     };

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -65,7 +65,7 @@ describe('azure', () => {
             name: 'backstage',
           },
           project: {
-            name: '*',
+            name: 'backstage',
           },
         },
         {
@@ -75,7 +75,7 @@ describe('azure', () => {
             name: 'ios-app',
           },
           project: {
-            name: '*',
+            name: 'backstage',
           },
         },
       ],
@@ -87,7 +87,7 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:* proj:*',
+            searchText: 'path:/catalog-info.yaml repo:* proj:backstage',
             $skip: 0,
             $top: 1000,
           });

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -29,7 +29,7 @@ describe('azure', () => {
 
       server.use(
         rest.post(
-          `https://almsearch.dev.azure.com/shopify/engineering/_apis/search/codesearchresults`,
+          `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
           (req, res, ctx) => {
             expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
             expect(req.body).toEqual({
@@ -83,7 +83,7 @@ describe('azure', () => {
 
     server.use(
       rest.post(
-        `https://almsearch.dev.azure.com/shopify/engineering/_apis/search/codesearchresults`,
+        `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
@@ -126,7 +126,7 @@ describe('azure', () => {
 
     server.use(
       rest.post(
-        `https://almsearch.dev.azure.com/shopify/engineering/_apis/search/codesearchresults`,
+        `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
@@ -170,7 +170,7 @@ describe('azure', () => {
 
     server.use(
       rest.post(
-        `https://azuredevops.mycompany.com/shopify/engineering/_apis/search/codesearchresults`,
+        `https://azuredevops.mycompany.com/shopify/_apis/search/codesearchresults`,
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
@@ -204,19 +204,19 @@ describe('azure', () => {
           name: 'backstage',
         },
         project: {
-          name: '*',
+          name: 'engineering',
         },
       }));
     };
 
     server.use(
       rest.post(
-        `https://almsearch.dev.azure.com/shopify/engineering/_apis/search/codesearchresults`,
+        `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toMatchObject({
             searchText:
-              'proj:engineering path:/catalog-info.yaml repo:backstage',
+              'path:/catalog-info.yaml repo:backstage proj:engineering',
             $top: 1000,
           });
 

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -33,7 +33,7 @@ describe('azure', () => {
           (req, res, ctx) => {
             expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
             expect(req.body).toEqual({
-              searchText: 'path:/catalog-info.yaml repo:* proj:*',
+              searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
               $skip: 0,
               $top: 1000,
             });
@@ -87,7 +87,7 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:* proj:backstage',
+            searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
             $skip: 0,
             $top: 1000,
           });
@@ -130,7 +130,8 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:backstage: proj:*',
+            searchText:
+              'path:/catalog-info.yaml repo:backstage: proj:engineering',
             $skip: 0,
             $top: 1000,
           });
@@ -173,7 +174,7 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
-            searchText: 'path:/catalog-info.yaml repo:* proj:*',
+            searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
             $skip: 0,
             $top: 1000,
           });
@@ -214,7 +215,8 @@ describe('azure', () => {
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toMatchObject({
-            searchText: 'path:/catalog-info.yaml repo:backstage',
+            searchText:
+              'proj:engineering path:/catalog-info.yaml repo:backstage',
             $top: 1000,
           });
 

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -114,6 +114,9 @@ describe('azure', () => {
         {
           fileName: 'catalog-info.yaml',
           path: '/catalog-info.yaml',
+          project: {
+            name: '*',
+          },
           repository: {
             name: 'backstage',
           },

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -131,7 +131,7 @@ describe('azure', () => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
             searchText:
-              'path:/catalog-info.yaml repo:backstage: proj:engineering',
+              'path:/catalog-info.yaml repo:backstage proj:engineering',
             $skip: 0,
             $top: 1000,
           });

--- a/plugins/catalog-backend-module-azure/src/lib/azure.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.ts
@@ -31,6 +31,9 @@ export interface CodeSearchResultItem {
   repository: {
     name: string;
   };
+  project: {
+    name: string;
+  };
 }
 
 const isCloud = (host: string) => host === 'dev.azure.com';
@@ -47,7 +50,7 @@ export async function codeSearch(
   const searchBaseUrl = isCloud(azureConfig.host)
     ? 'https://almsearch.dev.azure.com'
     : `https://${azureConfig.host}`;
-  const searchUrl = `${searchBaseUrl}/${org}/${project}/_apis/search/codesearchresults?api-version=6.0-preview.1`;
+  const searchUrl = `${searchBaseUrl}/${org}/_apis/search/codesearchresults?api-version=6.0-preview.1`;
 
   let items: CodeSearchResultItem[] = [];
   let hasMorePages = true;
@@ -59,7 +62,7 @@ export async function codeSearch(
       }),
       method: 'POST',
       body: JSON.stringify({
-        searchText: `path:${path} repo:${repo || '*'}`,
+        searchText: `path:${path} repo:${repo || '*'} proj:${project || '*'}`,
         $skip: items.length,
         $top: PAGE_SIZE,
       }),

--- a/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.test.ts
@@ -135,6 +135,9 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         {
           fileName: 'catalog-info.yaml',
           path: '/catalog-info.yaml',
+          project: {
+            name: '*',
+          },
           repository: {
             name: 'backstage',
           },
@@ -142,6 +145,9 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         {
           fileName: 'catalog-info.yaml',
           path: '/src/catalog-info.yaml',
+          project: {
+            name: '*',
+          },
           repository: {
             name: 'ios-app',
           },
@@ -191,6 +197,9 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
           repository: {
             name: 'backstage',
           },
+          project: {
+            name: '*',
+          },
         },
       ]);
       const emitter = jest.fn();
@@ -228,6 +237,9 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
           path: '/src/main/catalog.yaml',
           repository: {
             name: 'backstage',
+          },
+          project: {
+            name: '*',
           },
         },
       ]);

--- a/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.test.ts
@@ -164,6 +164,9 @@ describe('AzureDevOpsEntityProvider', () => {
           repository: {
             name: 'myrepo',
           },
+          project: {
+            name: 'myproject',
+          },
         },
       ],
       'https://dev.azure.com/myorganization/myproject',
@@ -189,12 +192,18 @@ describe('AzureDevOpsEntityProvider', () => {
           repository: {
             name: 'myrepo',
           },
+          project: {
+            name: 'myproject',
+          },
         },
         {
           fileName: 'catalog-info.yaml',
           path: '/catalog-info.yaml',
           repository: {
             name: 'myotherrepo',
+          },
+          project: {
+            name: 'myproject',
           },
         },
       ],
@@ -277,12 +286,18 @@ describe('AzureDevOpsEntityProvider', () => {
           repository: {
             name: 'myrepo',
           },
+          project: {
+            name: 'myproject',
+          },
         },
         {
           fileName: 'catalog-info.yaml',
           path: '/catalog-info.yaml',
           repository: {
             name: 'myotherrepo',
+          },
+          project: {
+            name: 'myproject',
           },
         },
       ],

--- a/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
@@ -166,17 +166,18 @@ export class AzureDevOpsEntityProvider implements EntityProvider {
   }
 
   private createLocationSpec(file: CodeSearchResultItem): LocationSpec {
+    const target = this.createObjectUrl(file);
+
     return {
       type: 'url',
-      target: this.createObjectUrl(file),
+      target: target,
       presence: 'required',
     };
   }
 
   private createObjectUrl(file: CodeSearchResultItem): string {
-    const baseUrl = `https://${this.config.host}/${this.config.organization}/${this.config.project}`;
-    return encodeURI(
-      `${baseUrl}/_git/${file.repository.name}?path=${file.path}`,
-    );
+    const baseUrl = `https://${this.config.host}/${this.config.organization}`;
+    const encodedUri = `${baseUrl}/${file.project.name}/_git/${file.repository.name}?path=${file.path}`;
+    return encodedUri;
   }
 }

--- a/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
@@ -176,8 +176,9 @@ export class AzureDevOpsEntityProvider implements EntityProvider {
   }
 
   private createObjectUrl(file: CodeSearchResultItem): string {
-    const baseUrl = `https://${this.config.host}/${this.config.organization}`;
-    const encodedUri = `${baseUrl}/${file.project.name}/_git/${file.repository.name}?path=${file.path}`;
-    return encodedUri;
+    const baseUrl = `https://${this.config.host}/${this.config.organization}/${file.project.name}`;
+    return encodeURI(
+      `${baseUrl}/_git/${file.repository.name}?path=${file.path}`,
+    );
   }
 }


### PR DESCRIPTION
Signed-off-by: Marc Bruins <marc@marcbruins.nl>

## Hey, I just made my First Backstage Pull Request!

This change will make the Azure DevOps discovery usable for all Project inside an Azure DevOps organisation with the use of a wildcard `*`

Instead of doing this numerous times:

```
      yourSecondProviderId: # identifies your dataset / provider independent of config changes
        organization: myorg
        project: 'project2' # only one project!
        repository: '*' # this will match all repos
        path: /catalog-info.yaml
```

you can do:

```
      yourSecondProviderId: # identifies your dataset / provider independent of config changes
        organization: myorg
        project: '*' #  all project inside your azure devops organisation
        repository: '*' # this will match all repos
        path: /catalog-info.yaml
```

The change is pretty straight forward and I'm happy to my first contributions to backstage. It's also backward compatible which is ofcourse nice 👍 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
