### PR TITLE
feat: make engineer threshold configurable

### DIFF
--- a/.changeset/wicked-games-search.md
+++ b/.changeset/wicked-games-search.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-cost-insights': patch
 ---
 
-added an optional config entry to allow users to control the threshold value for the 'negligible' change in costs
+added an optional config entry `costInsights.engineerThreshold` to allow users to control the threshold value for the 'negligible' change in costs.

--- a/.changeset/wicked-games-search.md
+++ b/.changeset/wicked-games-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+added an optional config entry to allow users to control the threshold value for the 'negligible' change in costs

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -373,6 +373,7 @@ auth:
       development: {}
 costInsights:
   engineerCost: 200000
+  engineerThreshold: 0.5
   products:
     computeEngine:
       name: Compute Engine

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -222,6 +222,19 @@ costInsights:
       rate: 3.5
 ```
 
+### costChangeNegligibleThreshold (Optional; default 0.5)
+
+This threshold determines whether to show 'Negligible', or a percentage with a fraction of 'engineers' for cost savings or cost excess on top of the charts.  
+A threshold of 0.5 means that `Negligible` is shown when the difference in costs is lower than that fraction of engineers in that time frame,  
+and show `XX% or ~N engineers` when it's above the threshold.
+
+```yaml
+## ./app-config.yaml
+costInsights:
+  engineerCost: 200000
+  engineerThreshold: 0.5
+```
+
 ## Alerts
 
 The CostInsightsApi `getAlerts` method may return any type of alert or recommendation (called collectively "Action Items" in Cost Insights) that implements the [Alert type](https://github.com/backstage/backstage/blob/master/plugins/cost-insights/src/types/Alert.ts). This allows you to deliver any alerts or recommendations specific to your infrastructure or company migrations.

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -222,7 +222,7 @@ costInsights:
       rate: 3.5
 ```
 
-### engineerThreshold (Optional; default 0.5)
+### Engineer Threshold (Optional; default 0.5)
 
 This threshold determines whether to show 'Negligible', or a percentage with a fraction of 'engineers' for cost savings or cost excess on top of the charts.  
 A threshold of 0.5 means that `Negligible` is shown when the difference in costs is lower than that fraction of engineers in that time frame,  

--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -222,7 +222,7 @@ costInsights:
       rate: 3.5
 ```
 
-### costChangeNegligibleThreshold (Optional; default 0.5)
+### engineerThreshold (Optional; default 0.5)
 
 This threshold determines whether to show 'Negligible', or a percentage with a fraction of 'engineers' for cost savings or cost excess on top of the charts.  
 A threshold of 0.5 means that `Negligible` is shown when the difference in costs is lower than that fraction of engineers in that time frame,  

--- a/plugins/cost-insights/api-report.md
+++ b/plugins/cost-insights/api-report.md
@@ -237,6 +237,7 @@ export type ConfigContextProps = {
   products: Product[];
   icons: Icon[];
   engineerCost: number;
+  engineerThreshold: number;
   currencies: Currency[];
 };
 

--- a/plugins/cost-insights/config.d.ts
+++ b/plugins/cost-insights/config.d.ts
@@ -24,6 +24,11 @@ export interface Config {
     /**
      * @visibility frontend
      */
+    engineerThreshold: number;
+
+    /**
+     * @visibility frontend
+     */
     baseCurrency?: {
       /**
        * @visibility frontend

--- a/plugins/cost-insights/config.d.ts
+++ b/plugins/cost-insights/config.d.ts
@@ -24,7 +24,7 @@ export interface Config {
     /**
      * @visibility frontend
      */
-    engineerThreshold: number;
+    engineerThreshold?: number;
 
     /**
      * @visibility frontend

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
@@ -119,6 +119,8 @@ describe.each`
   ${ChangeThreshold.upper} | ${0.5}     | ${0.000001} | ${'less than an engineer'}
   ${ChangeThreshold.upper} | ${0.5}     | ${0.5}      | ${'Negligible'}
   ${3}                     | ${500_000} | ${0}        | ${`300% or ~30 engineers`}
+  ${3}                     | ${500_000} | ${0.5}      | ${`300% or ~30 engineers`}
+  ${3}                     | ${500_000} | ${29}       | ${'300% or ~30 engineers'}
   ${3}                     | ${500_000} | ${30}       | ${'Negligible'}
 `('<CostGrowth />', ({ ratio, amount, threshold, expected }) => {
   it(`should display the correct difference the threshold is different. ratio: ${ratio} threshold:${threshold} expected:${expected}`, async () => {

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
@@ -17,7 +17,7 @@
 import React, { PropsWithChildren } from 'react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { CostGrowth } from './CostGrowth';
-import { Currency, CurrencyType, Duration } from '../../types';
+import { ChangeThreshold, Currency, CurrencyType, Duration } from '../../types';
 import { findAlways } from '../../utils/assert';
 import { MockConfigProvider, MockCurrencyProvider } from '../../testUtils';
 import { defaultCurrencies } from '../../utils/currency';
@@ -33,11 +33,16 @@ const MockContext = ({
   children,
   currency,
   engineerCost,
+  engineerThreshold,
 }: PropsWithChildren<{
   currency: Currency;
   engineerCost: number;
+  engineerThreshold?: number;
 }>) => (
-  <MockConfigProvider engineerCost={engineerCost}>
+  <MockConfigProvider
+    engineerCost={engineerCost}
+    engineerThreshold={engineerThreshold ?? 0.5}
+  >
     <MockCurrencyProvider currency={currency}>{children}</MockCurrencyProvider>
   </MockConfigProvider>
 );
@@ -98,6 +103,31 @@ describe.each`
   it(`formats ${carbon.unit}s correctly for ${expected}`, async () => {
     const { getByText } = await renderInTestApp(
       <MockContext engineerCost={engineerCost} currency={carbon}>
+        <CostGrowth change={{ ratio, amount }} duration={Duration.P30D} />
+      </MockContext>,
+    );
+    expect(getByText(expected)).toBeInTheDocument();
+  });
+});
+
+describe.each`
+  ratio                    | amount     | threshold   | expected
+  ${0}                     | ${0}       | ${0}        | ${'less than an engineer'}
+  ${0}                     | ${0}       | ${200}      | ${'Negligible'}
+  ${ChangeThreshold.lower} | ${0.5}     | ${0}        | ${'less than an engineer'}
+  ${ChangeThreshold.lower} | ${0.5}     | ${0.5}      | ${'Negligible'}
+  ${ChangeThreshold.upper} | ${0.5}     | ${0.000001} | ${'less than an engineer'}
+  ${ChangeThreshold.upper} | ${0.5}     | ${0.5}      | ${'Negligible'}
+  ${3}                     | ${500_000} | ${0}        | ${`300% or ~ 30 engineers`}
+  ${3}                     | ${500_000} | ${30}       | ${'Negligible'}
+`('<CostGrowth />', ({ ratio, amount, threshold, expected }) => {
+  it(`should display the correct difference the threshold is different. ratio: ${ratio} threshold:${threshold} expected:${expected}`, async () => {
+    const { getByText } = await renderInTestApp(
+      <MockContext
+        engineerCost={200_000}
+        engineerThreshold={threshold}
+        currency={engineers}
+      >
         <CostGrowth change={{ ratio, amount }} duration={Duration.P30D} />
       </MockContext>,
     );

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
@@ -118,7 +118,7 @@ describe.each`
   ${ChangeThreshold.lower} | ${0.5}     | ${0.5}      | ${'Negligible'}
   ${ChangeThreshold.upper} | ${0.5}     | ${0.000001} | ${'less than an engineer'}
   ${ChangeThreshold.upper} | ${0.5}     | ${0.5}      | ${'Negligible'}
-  ${3}                     | ${500_000} | ${0}        | ${`300% or ~ 30 engineers`}
+  ${3}                     | ${500_000} | ${0}        | ${`300% or ~30 engineers`}
   ${3}                     | ${500_000} | ${30}       | ${'Negligible'}
 `('<CostGrowth />', ({ ratio, amount, threshold, expected }) => {
   it(`should display the correct difference the threshold is different. ratio: ${ratio} threshold:${threshold} expected:${expected}`, async () => {

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowth.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowth.tsx
@@ -16,11 +16,7 @@
 
 import React from 'react';
 import classnames from 'classnames';
-import {
-  CurrencyType,
-  Duration,
-  GrowthType,
-} from '../../types';
+import { CurrencyType, Duration, GrowthType } from '../../types';
 import { ChangeStatistic } from '@backstage/plugin-cost-insights-common';
 import { rateOf } from '../../utils/currency';
 import { growthOf } from '../../utils/change';

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowth.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowth.tsx
@@ -19,7 +19,6 @@ import classnames from 'classnames';
 import {
   CurrencyType,
   Duration,
-  EngineerThreshold,
   GrowthType,
 } from '../../types';
 import { ChangeStatistic } from '@backstage/plugin-cost-insights-common';
@@ -42,7 +41,7 @@ export const CostGrowth = (props: CostGrowthProps) => {
   const { change, duration } = props;
 
   const styles = useStyles();
-  const { engineerCost } = useConfig();
+  const { engineerCost, engineerThreshold } = useConfig();
   const [currency] = useCurrency();
 
   // Only display costs in absolute values
@@ -55,7 +54,7 @@ export const CostGrowth = (props: CostGrowthProps) => {
 
   // If a ratio cannot be calculated, don't format.
   const growth = notEmpty(change.ratio)
-    ? growthOf({ ratio: change.ratio, amount: engineers })
+    ? growthOf({ ratio: change.ratio, amount: engineers }, engineerThreshold)
     : null;
   // Determine if growth is significant enough to highlight
   const classes = classnames({
@@ -63,7 +62,7 @@ export const CostGrowth = (props: CostGrowthProps) => {
     [styles.savings]: growth === GrowthType.Savings,
   });
 
-  if (engineers < EngineerThreshold) {
+  if (engineers < engineerThreshold) {
     return <span className={classes}>Negligible</span>;
   }
 

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.test.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.test.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { CostGrowthIndicator } from './CostGrowthIndicator';
 import { ChangeThreshold, EngineerThreshold } from '../../types';
+import { MockConfigProvider } from '../../testUtils';
 
 describe.each`
   ratio                           | amount                     | ariaLabel
@@ -30,7 +31,9 @@ describe.each`
 `('growthOf', ({ ratio, amount, ariaLabel }) => {
   it(`should display the correct indicator for ${ariaLabel}`, async () => {
     const { getByLabelText } = await renderInTestApp(
-      <CostGrowthIndicator change={{ ratio, amount }} />,
+      <MockConfigProvider engineerThreshold={EngineerThreshold}>
+        <CostGrowthIndicator change={{ ratio, amount }} />
+      </MockConfigProvider>,
     );
     expect(getByLabelText(ariaLabel)).toBeInTheDocument();
   });
@@ -48,7 +51,9 @@ describe.each`
 `('growthOf', ({ ratio, amount }) => {
   it('should display the correct indicator for negligible growth', async () => {
     const { queryByLabelText } = await renderInTestApp(
-      <CostGrowthIndicator change={{ ratio, amount }} />,
+      <MockConfigProvider engineerThreshold={EngineerThreshold}>
+        <CostGrowthIndicator change={{ ratio, amount }} />
+      </MockConfigProvider>,
     );
     expect(queryByLabelText('savings')).not.toBeInTheDocument();
     expect(queryByLabelText('excess')).not.toBeInTheDocument();

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.tsx
@@ -40,6 +40,7 @@ export const CostGrowthIndicator = (props: CostGrowthIndicatorProps) => {
   const { change, formatter, className, ...extraProps } = props;
 
   const classes = useStyles();
+
   const growth = growthOf(change, engineerThreshold);
 
   const classNames = classnames(classes.indicator, className, {

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.tsx
@@ -23,6 +23,7 @@ import { growthOf } from '../../utils/change';
 import { GrowthType } from '../../types';
 import { useCostGrowthStyles as useStyles } from '../../utils/styles';
 import { ChangeStatistic, Maybe } from '@backstage/plugin-cost-insights-common';
+import { useConfig } from '../../hooks';
 
 /** @public */
 export type CostGrowthIndicatorProps = TypographyProps & {
@@ -35,10 +36,11 @@ export type CostGrowthIndicatorProps = TypographyProps & {
 
 /** @public */
 export const CostGrowthIndicator = (props: CostGrowthIndicatorProps) => {
+  const { engineerThreshold } = useConfig();
   const { change, formatter, className, ...extraProps } = props;
 
   const classes = useStyles();
-  const growth = growthOf(change);
+  const growth = growthOf(change, engineerThreshold);
 
   const classNames = classnames(classes.indicator, className, {
     [classes.excess]: growth === GrowthType.Excess,

--- a/plugins/cost-insights/src/hooks/useConfig.tsx
+++ b/plugins/cost-insights/src/hooks/useConfig.tsx
@@ -70,6 +70,7 @@ export type ConfigContextProps = {
   products: Product[];
   icons: Icon[];
   engineerCost: number;
+  engineerThreshold: number;
   currencies: Currency[];
 };
 
@@ -83,6 +84,7 @@ const defaultState: ConfigContextProps = {
   products: [],
   icons: [],
   engineerCost: 0,
+  engineerThreshold: 0.5,
   currencies: defaultCurrencies,
 };
 
@@ -183,11 +185,19 @@ export const ConfigProvider = ({ children }: PropsWithChildren<{}>) => {
       return c.getNumber('costInsights.engineerCost');
     }
 
+    function getEngineerThreshold(): number {
+      return (
+        c.getOptionalNumber('costInsights.engineerThreshold') ??
+        defaultState.engineerThreshold
+      );
+    }
+
     function getConfig() {
       const baseCurrency = getBaseCurrency();
       const products = getProducts();
       const metrics = getMetrics();
       const engineerCost = getEngineerCost();
+      const engineerThreshold = getEngineerThreshold();
       const icons = getIcons();
       const currencies = getCurrencies();
 
@@ -200,6 +210,7 @@ export const ConfigProvider = ({ children }: PropsWithChildren<{}>) => {
         metrics,
         products,
         engineerCost,
+        engineerThreshold,
         icons,
         currencies,
       }));

--- a/plugins/cost-insights/src/hooks/useConfig.tsx
+++ b/plugins/cost-insights/src/hooks/useConfig.tsx
@@ -22,7 +22,7 @@ import React, {
   useState,
 } from 'react';
 import { Config as BackstageConfig } from '@backstage/config';
-import { Currency, Icon, Metric, Product } from '../types';
+import { Currency, EngineerThreshold, Icon, Metric, Product } from '../types';
 import { getIcon } from '../utils/navigation';
 import { validateCurrencies, validateMetrics } from '../utils/config';
 import { createCurrencyFormat, defaultCurrencies } from '../utils/currency';
@@ -84,7 +84,7 @@ const defaultState: ConfigContextProps = {
   products: [],
   icons: [],
   engineerCost: 0,
-  engineerThreshold: 0.5,
+  engineerThreshold: EngineerThreshold,
   currencies: defaultCurrencies,
 };
 

--- a/plugins/cost-insights/src/testUtils/providers.tsx
+++ b/plugins/cost-insights/src/testUtils/providers.tsx
@@ -31,7 +31,7 @@ import {
   ScrollContext,
   ScrollContextProps,
 } from '../hooks';
-import { Duration } from '../types';
+import { Duration, EngineerThreshold } from '../types';
 import { createCurrencyFormat } from '../utils/currency';
 
 export type MockFilterProviderProps = PropsWithChildren<
@@ -95,7 +95,7 @@ export const MockConfigProvider = (props: MockConfigProviderProps) => {
     products: [],
     icons: [],
     engineerCost: 0,
-    engineerThreshold: 0.5,
+    engineerThreshold: EngineerThreshold,
     currencies: [],
   };
 

--- a/plugins/cost-insights/src/testUtils/providers.tsx
+++ b/plugins/cost-insights/src/testUtils/providers.tsx
@@ -95,6 +95,7 @@ export const MockConfigProvider = (props: MockConfigProviderProps) => {
     products: [],
     icons: [],
     engineerCost: 0,
+    engineerThreshold: 0.5,
     currencies: [],
   };
 

--- a/plugins/cost-insights/src/utils/change.test.ts
+++ b/plugins/cost-insights/src/utils/change.test.ts
@@ -63,7 +63,7 @@ describe.each`
     expected: GrowthType;
   }) => {
     it(`should display ${GrowthMap[expected]}`, () => {
-      expect(growthOf({ ratio, amount })).toBe(expected);
+      expect(growthOf({ ratio, amount }, EngineerThreshold)).toBe(expected);
     });
   },
 );

--- a/plugins/cost-insights/src/utils/change.ts
+++ b/plugins/cost-insights/src/utils/change.ts
@@ -18,7 +18,6 @@ import {
   Cost,
   ChangeStatistic,
   ChangeThreshold,
-  EngineerThreshold,
   GrowthType,
   MetricData,
   Duration,
@@ -29,8 +28,11 @@ import { inclusiveStartDateOf } from './duration';
 import { notEmpty } from './assert';
 
 // Used for displaying status colors
-export function growthOf(change: ChangeStatistic): GrowthType {
-  const exceedsEngineerThreshold = Math.abs(change.amount) >= EngineerThreshold;
+export function growthOf(
+  change: ChangeStatistic,
+  engineerThreshold: number,
+): GrowthType {
+  const exceedsEngineerThreshold = Math.abs(change.amount) >= engineerThreshold;
 
   if (notEmpty(change.ratio)) {
     if (exceedsEngineerThreshold && change.ratio >= ChangeThreshold.upper) {
@@ -41,9 +43,12 @@ export function growthOf(change: ChangeStatistic): GrowthType {
       return GrowthType.Savings;
     }
   } else {
-    if (exceedsEngineerThreshold && change.amount > 0) return GrowthType.Excess;
-    if (exceedsEngineerThreshold && change.amount < 0)
+    if (exceedsEngineerThreshold && change.amount > 0) {
+      return GrowthType.Excess;
+    }
+    if (exceedsEngineerThreshold && change.amount < 0) {
       return GrowthType.Savings;
+    }
   }
 
   return GrowthType.Negligible;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

We would like to configure the threshold used in the Cost Insights plugin that determines whether the change label is shown as `Negligible`. The main reason for us is that projects with little cloud costs now always show Negligible, while the change might still be relevant.

![image](https://user-images.githubusercontent.com/5969237/203964395-e4788060-13ce-4ccb-8f19-4153651a0f22.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
