### PR TITLE
feat(catalog/bitbucketCloud,events): improve refresh for updated catalog files

### DIFF
--- a/.changeset/beige-chairs-repair.md
+++ b/.changeset/beige-chairs-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+---
+
+Refresh (potentially) updated catalog files on `repo:push` more efficiently.

--- a/plugins/catalog-backend-module-bitbucket-cloud/package.json
+++ b/plugins/catalog-backend-module-bitbucket-cloud/package.json
@@ -45,7 +45,6 @@
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
-    "p-limit": "^3.1.0",
     "uuid": "^8.0.0",
     "winston": "^3.2.1"
   },

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/BitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/BitbucketCloudEntityProvider.test.ts
@@ -22,11 +22,7 @@ import {
 } from '@backstage/backend-tasks';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { CatalogApi } from '@backstage/catalog-client';
-import {
-  Entity,
-  LocationEntity,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
+import { Entity, LocationEntity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import {
   EntityProviderConnection,
@@ -458,7 +454,6 @@ describe('BitbucketCloudEntityProvider', () => {
           items: [keptModule, removedModule],
         };
       },
-      refreshEntity: jest.fn(),
     };
     const provider = BitbucketCloudEntityProvider.fromConfig(defaultConfig, {
       catalogApi: catalogApi as any as CatalogApi,
@@ -557,11 +552,12 @@ describe('BitbucketCloudEntityProvider', () => {
       },
     ];
 
-    expect(catalogApi.refreshEntity).toHaveBeenCalledTimes(1);
-    expect(catalogApi.refreshEntity).toHaveBeenCalledWith(
-      stringifyEntityRef(keptModule),
-      { token: 'fake-token' },
-    );
+    expect(entityProviderConnection.refresh).toHaveBeenCalledTimes(1);
+    expect(entityProviderConnection.refresh).toHaveBeenCalledWith({
+      keys: [
+        'url:https://bitbucket.org/test-ws/test-repo/src/main/kept-module/catalog-custom.yaml',
+      ],
+    });
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
       type: 'delta',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4485,7 +4485,6 @@ __metadata:
     "@backstage/plugin-events-node": "workspace:^"
     luxon: ^3.0.0
     msw: ^0.49.0
-    p-limit: ^3.1.0
     uuid: ^8.0.0
     winston: ^3.2.1
   languageName: unknown


### PR DESCRIPTION
Refresh (potentially) updated catalog files on `repo:push` more efficiently.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
