### PR TITLE
renovate: Ignore yarn dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,5 +21,9 @@
       groupName: 'SVGR monorepo packages',
       rangeStrategy: 'replace',
     },
+    {
+      matchSourceUrls: ['https://github.com/yarnpkg/berry'],
+      excludePackagePatterns: ['^@yarnpkg', '^yarn'],
+    },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,9 +21,10 @@
       groupName: 'SVGR monorepo packages',
       rangeStrategy: 'replace',
     },
+    // We update yarn packages manually as it's gzip'd and we don't want to pollute the repository too much.
     {
       matchSourceUrls: ['https://github.com/yarnpkg/berry'],
-      excludePackagePatterns: ['^@yarnpkg', '^yarn'],
+      enabled: false,
     },
   ],
 }


### PR DESCRIPTION
Update https://docs.renovatebot.com/presets-monorepo/#monorepoyarn to exclude yarn packages using https://docs.renovatebot.com/configuration-options/#excludepackagenames