### PR TITLE
change .toMatchImageSnapshot to .matchImage

### DIFF
--- a/.changeset/calm-dolphins-joke.md
+++ b/.changeset/calm-dolphins-joke.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Change from cypress-plugin-snapshots to cypress-plugin-visual-regression-diff

--- a/packages/techdocs-cli/cypress/integration/backstage_serve.js
+++ b/packages/techdocs-cli/cypress/integration/backstage_serve.js
@@ -48,11 +48,11 @@ describe('TechDocs Live Preview - Backstage Serve', () => {
     cy.get('.md-footer').should('have.length', 1);
   });
 
-  it('toMatchImageSnapshot - Backstage TechDocs Page', () => {
+  it('matchImage - Backstage TechDocs Page', () => {
     cy.visit(
       `${Cypress.env('backstageBaseUrl')}/docs/default/component/local`,
     ).then(() => {
-      cy.document().toMatchImageSnapshot();
+      cy.document().matchImage();
     });
   });
 });

--- a/packages/techdocs-cli/cypress/integration/mkdocs_serve.js
+++ b/packages/techdocs-cli/cypress/integration/mkdocs_serve.js
@@ -42,7 +42,7 @@ describe('TechDocs Live Preview - MkDocs Serve', () => {
 
   it('toMatchImageSnapshot - MkDocs Page', () => {
     cy.visit(Cypress.env('mkDocsBaseUrl')).then(() => {
-      cy.document().toMatchImageSnapshot();
+      cy.document().matchImage();
     });
   });
 });

--- a/packages/techdocs-cli/cypress/plugins/index.js
+++ b/packages/techdocs-cli/cypress/plugins/index.js
@@ -27,7 +27,9 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const { initPlugin } = require('cypress-plugin-snapshots/plugin');
+const {
+  initPlugin,
+} = require('@frsource/cypress-plugin-visual-regression-diff/plugin');
 
 /**
  * @type {Cypress.PluginConfig}

--- a/packages/techdocs-cli/cypress/support/index.js
+++ b/packages/techdocs-cli/cypress/support/index.js
@@ -30,7 +30,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
-import 'cypress-plugin-snapshots/commands';
+import '@frsource/cypress-plugin-visual-regression-diff/commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
Signed-off-by: MALIN WIDÈN <malwi130@student.liu.se>

## Hey, I just made a Pull Request!

Update `.toMatchImageSnapshot` from `cypress-plugin-snapshots` to `.matchImage` from `cypress-plugin-visual-regression-diff` in techdocs-cli

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
