### PR TITLE
backend-common: fix single host discovery for single-string listen config

### DIFF
--- a/.changeset/smart-radios-change.md
+++ b/.changeset/smart-radios-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fixed `SingleHostDiscovery` so that it properly handles single-string `backend.listen` configurations such as `:80`.

--- a/packages/backend-common/src/discovery/SingleHostDiscovery.test.ts
+++ b/packages/backend-common/src/discovery/SingleHostDiscovery.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { SingleHostDiscovery } from './SingleHostDiscovery';
+
+describe('SingleHostDiscovery', () => {
+  it('is created from config', async () => {
+    const discovery = SingleHostDiscovery.fromConfig(
+      new ConfigReader({
+        backend: {
+          baseUrl: 'http://localhost:40',
+          listen: { port: 80, host: 'localhost' },
+        },
+      }),
+    );
+
+    await expect(discovery.getBaseUrl('catalog')).resolves.toBe(
+      'http://localhost:80/api/catalog',
+    );
+    await expect(discovery.getExternalBaseUrl('catalog')).resolves.toBe(
+      'http://localhost:40/api/catalog',
+    );
+  });
+
+  it('can configure the base path', async () => {
+    const discovery = SingleHostDiscovery.fromConfig(
+      new ConfigReader({
+        backend: {
+          baseUrl: 'http://localhost:40',
+          listen: { port: 80, host: 'localhost' },
+        },
+      }),
+      { basePath: '/service' },
+    );
+
+    await expect(discovery.getBaseUrl('catalog')).resolves.toBe(
+      'http://localhost:80/service/catalog',
+    );
+    await expect(discovery.getExternalBaseUrl('catalog')).resolves.toBe(
+      'http://localhost:40/service/catalog',
+    );
+  });
+
+  it.each([
+    [{ listen: ':80' }, 'http://localhost:80'],
+    [{ listen: ':40', https: true }, 'https://localhost:40'],
+    [{ listen: '127.0.0.1:80' }, 'http://127.0.0.1:80'],
+    [{ listen: '127.0.0.1:80', https: true }, 'https://127.0.0.1:80'],
+    [{ listen: '0.0.0.0:40' }, 'http://127.0.0.1:40'],
+    [{ listen: { port: 80 } }, 'http://localhost:80'],
+    [{ listen: { port: 8000 } }, 'http://localhost:8000'],
+    [{ listen: { port: 80, host: '0.0.0.0' } }, 'http://127.0.0.1:80'],
+    [{ listen: { port: 80, host: '::' } }, 'http://localhost:80'],
+    [{ listen: { port: 80, host: '::1' } }, 'http://[::1]:80'],
+    [{ listen: { port: 90, host: '::2' }, https: true }, 'https://[::2]:90'],
+  ])('resolves internal baseUrl for %j as %s', async (config, expected) => {
+    const discovery = SingleHostDiscovery.fromConfig(
+      new ConfigReader({
+        backend: {
+          baseUrl: 'http://localhost:40',
+          ...config,
+        },
+      }),
+    );
+
+    await expect(discovery.getBaseUrl('catalog')).resolves.toBe(
+      `${expected}/api/catalog`,
+    );
+  });
+});

--- a/packages/backend-common/src/discovery/SingleHostDiscovery.ts
+++ b/packages/backend-common/src/discovery/SingleHostDiscovery.ts
@@ -50,7 +50,7 @@ export class SingleHostDiscovery implements PluginEndpointDiscovery {
 
     // Translate bind-all to localhost, and support IPv6
     let host = listenHost;
-    if (host === '::') {
+    if (host === '::' || host === '') {
       // We use localhost instead of ::1, since IPv6-compatible systems should default
       // to using IPv6 when they see localhost, but if the system doesn't support IPv6
       // things will still work.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns out the single host discovery was broken for configs such as `listen: ':80'`, because it generates an internal base url that is `http://:80/api/<plugin>`, which ofc doesn't work.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
