### PR TITLE
cli: disable JSX transform for backend bundling

### DIFF
--- a/.changeset/pretty-melons-taste.md
+++ b/.changeset/pretty-melons-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+JSX and React Fast Refresh transforms are no longer enabled when bundling backend code.

--- a/packages/cli/src/lib/bundler/transforms.ts
+++ b/packages/cli/src/lib/bundler/transforms.ts
@@ -62,14 +62,16 @@ export const transforms = (options: TransformOptions): Transforms => {
               externalHelpers: !isBackend,
               parser: {
                 syntax: 'typescript',
-                tsx: true,
+                tsx: !isBackend,
                 dynamicImport: true,
               },
               transform: {
-                react: {
-                  runtime: 'automatic',
-                  refresh: isDev,
-                },
+                react: isBackend
+                  ? undefined
+                  : {
+                      runtime: 'automatic',
+                      refresh: isDev,
+                    },
               },
             },
           },
@@ -88,14 +90,16 @@ export const transforms = (options: TransformOptions): Transforms => {
               externalHelpers: !isBackend,
               parser: {
                 syntax: 'ecmascript',
-                jsx: true,
+                jsx: !isBackend,
                 dynamicImport: true,
               },
               transform: {
-                react: {
-                  runtime: 'automatic',
-                  refresh: isDev,
-                },
+                react: isBackend
+                  ? undefined
+                  : {
+                      runtime: 'automatic',
+                      refresh: isDev,
+                    },
               },
             },
           },
@@ -119,7 +123,7 @@ export const transforms = (options: TransformOptions): Transforms => {
               externalHelpers: !isBackend,
               parser: {
                 syntax: 'ecmascript',
-                jsx: true,
+                jsx: !isBackend,
                 dynamicImport: true,
               },
             },
@@ -188,11 +192,13 @@ export const transforms = (options: TransformOptions): Transforms => {
   const plugins = new Array<WebpackPluginInstance>();
 
   if (isDev) {
-    plugins.push(
-      new ReactRefreshPlugin({
-        overlay: { sockProtocol: 'ws' },
-      }),
-    );
+    if (!isBackend) {
+      plugins.push(
+        new ReactRefreshPlugin({
+          overlay: { sockProtocol: 'ws' },
+        }),
+      );
+    }
   } else {
     plugins.push(
       new MiniCssExtractPlugin({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To make sure no backend code is treated as React components, which otherwise leads to potential `$RefreshReg$ is not defined` errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
