### PR TITLE
workflows/deploy_packages: disable fail-fast

### DIFF
--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -12,6 +12,7 @@ jobs:
       needs_release: ${{ steps.release_check.outputs.needs_release }}
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16.x, 18.x]
 


### PR DESCRIPTION
Making it easier to re-trigger builds in case of flaky CI