### PR TITLE
enable multi-processor validation of entity kinds

### DIFF
--- a/.changeset/rude-pugs-deny.md
+++ b/.changeset/rude-pugs-deny.md
@@ -1,0 +1,27 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+The catalog no longer stops after the first processor `validateEntityKind`
+method returns `true` when validating entity kind shapes. Instead, it continues
+through all registered processors that have this method, and requires that _at
+least one_ of them returned true.
+
+The old behavior of stopping early made it harder to extend existing core kinds
+with additional fields, since the `BuiltinKindsEntityProcessor` is always
+present at the top of the processing chain and ensures that your additional
+validation code would never be run.
+
+This is technically a breaking change, although it should not affect anybody
+under normal circumstances, except if you had problematic validation code that
+you were unaware that it was not being run. That code may now start to exhibit
+those problems.
+
+If you need to disable this new behavior, `CatalogBuilder` as used in your
+`packages/backend/src/plugins/catalog.ts` file now has a
+`useLegacySingleProcessorValidation()` method to go back to the old behavior.
+
+```diff
+ const builder = await CatalogBuilder.create(env);
++builder.useLegacySingleProcessorValidation();
+```

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -133,7 +133,7 @@ export class CatalogBuilder {
     ...permissionRules: Array<
       CatalogPermissionRule | Array<CatalogPermissionRule>
     >
-  ): void;
+  ): this;
   addProcessor(
     ...processors: Array<CatalogProcessor | Array<CatalogProcessor>>
   ): CatalogBuilder;
@@ -164,6 +164,7 @@ export class CatalogBuilder {
       errors: Error[];
     }) => Promise<void> | void;
   }): void;
+  useLegacySingleProcessorValidation(): this;
 }
 
 // @alpha

--- a/plugins/catalog-backend/src/integration.test.ts
+++ b/plugins/catalog-backend/src/integration.test.ts
@@ -245,6 +245,7 @@ class TestHarness {
       logger,
       parser: defaultEntityDataParser,
       policy: EntityPolicies.allOf([]),
+      legacySingleProcessorValidation: false,
     });
     const stitcher = new Stitcher(db, logger);
     const catalog = new DefaultEntitiesCatalog(db, stitcher);

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -154,6 +154,7 @@ export class CatalogBuilder {
   private locationAnalyzer: LocationAnalyzer | undefined = undefined;
   private readonly permissionRules: CatalogPermissionRule[];
   private allowedLocationType: string[];
+  private legacySingleProcessorValidation = false;
 
   /**
    * Creates a catalog builder.
@@ -384,6 +385,7 @@ export class CatalogBuilder {
     >
   ) {
     this.permissionRules.push(...permissionRules.flat());
+    return this;
   }
 
   /**
@@ -393,6 +395,15 @@ export class CatalogBuilder {
    */
   setAllowedLocationTypes(allowedLocationTypes: string[]): CatalogBuilder {
     this.allowedLocationType = allowedLocationTypes;
+    return this;
+  }
+
+  /**
+   * Enables the legacy behaviour of canceling validation early whenever only a
+   * single processor declares an entity kind to be valid.
+   */
+  useLegacySingleProcessorValidation(): this {
+    this.legacySingleProcessorValidation = true;
     return this;
   }
 
@@ -429,6 +440,7 @@ export class CatalogBuilder {
       logger,
       parser,
       policy,
+      legacySingleProcessorValidation: this.legacySingleProcessorValidation,
     });
     const stitcher = new Stitcher(dbClient, logger);
     const unauthorizedEntitiesCatalog = new DefaultEntitiesCatalog(


### PR DESCRIPTION
As discussed in the catalog SIG. See the changeset for motivation.