### PR TITLE
Add support for sending virtual pageviews on search events

### DIFF
--- a/.changeset/selfish-lizards-invent.md
+++ b/.changeset/selfish-lizards-invent.md
@@ -1,5 +1,6 @@
 ---
-'@backstage/plugin-analytics-module-ga': minor
+'@backstage/plugin-analytics-module-ga': patch
 ---
 
-Added support for sending virtual pageviews on `search` events
+Added support for sending virtual pageviews on `search` events in order to enable
+Site Search functionality in GA. For more information consult [README](/plugins/analytics-module-ga/README.md#enabling-site-search)

--- a/.changeset/selfish-lizards-invent.md
+++ b/.changeset/selfish-lizards-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-analytics-module-ga': minor
+---
+
+Added support for sending virtual pageviews on `search` events

--- a/plugins/analytics-module-ga/README.md
+++ b/plugins/analytics-module-ga/README.md
@@ -169,6 +169,31 @@ export const apis: AnyApiFactory[] = [
 ];
 ```
 
+### Enabling Site Search
+
+If you wish to see all of the search events in the [Site Search](https://support.google.com/analytics/answer/1012264)
+section of Google Analytics, you can enable sending virtual pageviews on every `search` event like so:
+
+```yaml
+app:
+  analytics:
+    ga:
+      virtualSearchPageView:
+        mode: only # Defaults to 'disabled'
+        mountPath: /virtual-search # Defaults to '/search'
+        queryParam: term # Defaults to 'query'
+```
+
+Available `mode`s are:
+
+- `disabled` - no virtual pageviews are sent, default behavior
+- `only` - sends virtual pageviews _instead_ of `search` events
+- `both` - sends both virtual pageviews _and_ `search` events
+
+Virtual pageviews will be sent to the path specified in the `mountPath`, and the search term will be
+set as the value for query parameter `queryParam`, e.g. the example config above will result in
+virtual pageviews being sent to `/virtual-search?term=SearchTermHere`.
+
 ### Debugging and Testing
 
 In pre-production environments, you may wish to set additional configurations

--- a/plugins/analytics-module-ga/README.md
+++ b/plugins/analytics-module-ga/README.md
@@ -181,7 +181,8 @@ app:
       virtualSearchPageView:
         mode: only # Defaults to 'disabled'
         mountPath: /virtual-search # Defaults to '/search'
-        queryParam: term # Defaults to 'query'
+        searchQuery: term # Defaults to 'query'
+        categoryQuery: sc # Omitted by default
 ```
 
 Available `mode`s are:
@@ -190,9 +191,10 @@ Available `mode`s are:
 - `only` - sends virtual pageviews _instead_ of `search` events
 - `both` - sends both virtual pageviews _and_ `search` events
 
-Virtual pageviews will be sent to the path specified in the `mountPath`, and the search term will be
-set as the value for query parameter `queryParam`, e.g. the example config above will result in
-virtual pageviews being sent to `/virtual-search?term=SearchTermHere`.
+Virtual pageviews will be sent to the path specified in the `mountPath`, the search term will be
+set as the value for query parameter `searchQuery` and category (if provided) will be set as the value for
+query parameter `categoryQuery`, e.g. the example config above will result in
+virtual pageviews being sent to `/virtual-search?term=SearchTermHere&sc=CategoryHere`.
 
 ### Debugging and Testing
 

--- a/plugins/analytics-module-ga/config.d.ts
+++ b/plugins/analytics-module-ga/config.d.ts
@@ -72,11 +72,17 @@ export interface Config {
            */
           mountPath?: string;
           /**
-           * Specifies which query param is used in the virtual pageview URL.
+           * Specifies which query param is used for the term query in the virtual pageview URL.
            * Defaults to `query`.
            * @visibility frontend
            */
-          queryParam?: string;
+          searchQuery?: string;
+          /**
+           * Specifies which query param is used for the category query in the virtual pageview URL.
+           * Skipped by default.
+           * @visibility frontend
+           */
+          categoryQuery?: string;
         };
 
         /**

--- a/plugins/analytics-module-ga/config.d.ts
+++ b/plugins/analytics-module-ga/config.d.ts
@@ -54,6 +54,32 @@ export interface Config {
         identity?: 'disabled' | 'optional' | 'required';
 
         /**
+         * Controls whether to send virtual pageviews on `search` events.
+         * Can be used to enable Site Search in GA.
+         */
+        virtualSearchPageView?: {
+          /**
+           * - `disabled`: (Default) no virtual pageviews are sent
+           * - `only`: Sends virtual pageview _instead_ of the `search` event
+           * - `both`: Sends both the `search` event _and_ the virtual pageview
+           * @visibility frontend
+           */
+          mode?: 'disabled' | 'only' | 'both';
+          /**
+           * Specifies on which path the main Search page is mounted.
+           * Defaults to `/search`.
+           * @visibility frontend
+           */
+          mountPath?: string;
+          /**
+           * Specifies which query param is used in the virtual pageview URL.
+           * Defaults to `query`.
+           * @visibility frontend
+           */
+          queryParam?: string;
+        };
+
+        /**
          * Whether or not to log analytics debug statements to the console.
          * Defaults to false.
          *

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.test.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.test.ts
@@ -25,6 +25,7 @@ describe('GoogleAnalytics', () => {
     pluginId: 'some-plugin',
     routeRef: 'unknown',
     releaseNum: 1337,
+    searchTypes: 'test category',
   };
   const trackingId = 'UA-000000-0';
   const basicValidConfig = new ConfigReader({
@@ -175,7 +176,7 @@ describe('GoogleAnalytics', () => {
       expect(command).toBe('send');
       expect(data).toMatchObject({
         hitType: 'pageview',
-        page: '/search?query=test search',
+        page: '/search?query=test+search',
       });
       expect(ReactGA.testModeAPI.calls).toHaveLength(2);
     });
@@ -203,7 +204,7 @@ describe('GoogleAnalytics', () => {
       expect(pageviewCommand).toBe('send');
       expect(pageViewData).toMatchObject({
         hitType: 'pageview',
-        page: '/search?query=test search',
+        page: '/search?query=test+search',
       });
       const [searchCommand, searchData] = ReactGA.testModeAPI.calls[2];
       expect(searchCommand).toBe('send');
@@ -215,7 +216,7 @@ describe('GoogleAnalytics', () => {
       });
     });
 
-    it('captures virtual pageviews on custom route with custom query param', () => {
+    it('captures virtual pageviews on custom route with custom search query and custom category', () => {
       const config = new ConfigReader({
         app: {
           analytics: {
@@ -225,7 +226,8 @@ describe('GoogleAnalytics', () => {
               virtualSearchPageView: {
                 mode: 'only',
                 mountPath: '/custom',
-                queryParam: 'term',
+                searchQuery: 'term',
+                categoryQuery: 'sc',
               },
             },
           },
@@ -242,7 +244,7 @@ describe('GoogleAnalytics', () => {
       expect(command).toBe('send');
       expect(data).toMatchObject({
         hitType: 'pageview',
-        page: '/custom?term=test search',
+        page: '/custom?term=test+search&sc=test+category',
       });
     });
 

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.test.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.test.ts
@@ -152,7 +152,7 @@ describe('GoogleAnalytics', () => {
       });
     });
 
-    it('captures virtual pageviews', () => {
+    it('captures virtual pageviews instead of search events', () => {
       const config = new ConfigReader({
         app: {
           analytics: {
@@ -177,6 +177,7 @@ describe('GoogleAnalytics', () => {
         hitType: 'pageview',
         page: '/search?query=test search',
       });
+      expect(ReactGA.testModeAPI.calls).toHaveLength(2);
     });
 
     it('captures virtual pageviews alongside search events', () => {

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
@@ -18,12 +18,16 @@ import ReactGA from 'react-ga';
 import {
   AnalyticsApi,
   AnalyticsContextValue,
-  AnalyticsEventAttributes,
   AnalyticsEvent,
+  AnalyticsEventAttributes,
   IdentityApi,
 } from '@backstage/core-plugin-api';
 import { Config } from '@backstage/config';
 import { DeferredCapture } from '../../../util';
+import {
+  parseVirtualSearchPageViewConfig,
+  VirtualSearchPageViewConfig,
+} from '../../../util/VirtualSearchPageView';
 
 type CustomDimensionOrMetricConfig = {
   type: 'dimension' | 'metric';
@@ -40,6 +44,7 @@ export class GoogleAnalytics implements AnalyticsApi {
   private readonly cdmConfig: CustomDimensionOrMetricConfig[];
   private customUserIdTransform?: (userEntityRef: string) => Promise<string>;
   private readonly capture: DeferredCapture;
+  private readonly virtualSearchPageView: VirtualSearchPageViewConfig;
 
   /**
    * Instantiate the implementation and initialize ReactGA.
@@ -51,6 +56,7 @@ export class GoogleAnalytics implements AnalyticsApi {
     identity: string;
     trackingId: string;
     scriptSrc?: string;
+    virtualSearchPageView: VirtualSearchPageViewConfig;
     testMode: boolean;
     debug: boolean;
   }) {
@@ -61,11 +67,13 @@ export class GoogleAnalytics implements AnalyticsApi {
       identityApi,
       userIdTransform = 'sha-256',
       scriptSrc,
+      virtualSearchPageView,
       testMode,
       debug,
     } = options;
 
     this.cdmConfig = cdmConfig;
+    this.virtualSearchPageView = virtualSearchPageView;
 
     // Initialize Google Analytics.
     ReactGA.initialize(trackingId, {
@@ -105,6 +113,9 @@ export class GoogleAnalytics implements AnalyticsApi {
     const scriptSrc = config.getOptionalString('app.analytics.ga.scriptSrc');
     const identity =
       config.getOptionalString('app.analytics.ga.identity') || 'disabled';
+    const virtualSearchPageView = parseVirtualSearchPageViewConfig(
+      config.getOptionalConfig('app.analytics.ga.virtualSearchPageView'),
+    );
     const debug = config.getOptionalBoolean('app.analytics.ga.debug') ?? false;
     const testMode =
       config.getOptionalBoolean('app.analytics.ga.testMode') ?? false;
@@ -134,6 +145,7 @@ export class GoogleAnalytics implements AnalyticsApi {
       identity,
       trackingId,
       scriptSrc,
+      virtualSearchPageView,
       cdmConfig,
       testMode,
       debug,
@@ -152,6 +164,17 @@ export class GoogleAnalytics implements AnalyticsApi {
     if (action === 'navigate' && context.extension === 'App') {
       this.capture.pageview(subject, customMetadata);
       return;
+    }
+
+    if (this.virtualSearchPageView.mode !== 'disabled' && action === 'search') {
+      const { mountPath, queryParam } = this.virtualSearchPageView;
+      this.capture.pageview(
+        `${mountPath}?${queryParam}=${subject}`,
+        customMetadata,
+      );
+      if (this.virtualSearchPageView.mode === 'only') {
+        return;
+      }
     }
 
     this.capture.event({

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
@@ -167,9 +167,15 @@ export class GoogleAnalytics implements AnalyticsApi {
     }
 
     if (this.virtualSearchPageView.mode !== 'disabled' && action === 'search') {
-      const { mountPath, queryParam } = this.virtualSearchPageView;
+      const { mountPath, searchQuery, categoryQuery } =
+        this.virtualSearchPageView;
+      const params = new URLSearchParams();
+      params.set(searchQuery, subject);
+      if (categoryQuery) {
+        params.set(categoryQuery, context.searchTypes?.toString() ?? '');
+      }
       this.capture.pageview(
-        `${mountPath}?${queryParam}=${subject}`,
+        `${mountPath}?${params.toString()}`,
         customMetadata,
       );
       if (this.virtualSearchPageView.mode === 'only') {

--- a/plugins/analytics-module-ga/src/util/VirtualSearchPageView.ts
+++ b/plugins/analytics-module-ga/src/util/VirtualSearchPageView.ts
@@ -20,7 +20,8 @@ type VirtualSearchPageViewType = 'disabled' | 'only' | 'both';
 export type VirtualSearchPageViewConfig = {
   mode: VirtualSearchPageViewType;
   mountPath: string;
-  queryParam: string;
+  searchQuery: string;
+  categoryQuery?: string;
 };
 
 function isVirtualSearchPageViewType(
@@ -38,6 +39,7 @@ export function parseVirtualSearchPageViewConfig(
       ? vspvModeString
       : 'disabled',
     mountPath: config?.getOptionalString('mountPath') ?? '/search',
-    queryParam: config?.getOptionalString('queryParam') ?? 'query',
+    searchQuery: config?.getOptionalString('searchQuery') ?? 'query',
+    categoryQuery: config?.getOptionalString('categoryQuery'),
   };
 }

--- a/plugins/analytics-module-ga/src/util/VirtualSearchPageView.ts
+++ b/plugins/analytics-module-ga/src/util/VirtualSearchPageView.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Config } from '@backstage/config';
+
+type VirtualSearchPageViewType = 'disabled' | 'only' | 'both';
+
+export type VirtualSearchPageViewConfig = {
+  mode: VirtualSearchPageViewType;
+  mountPath: string;
+  queryParam: string;
+};
+
+function isVirtualSearchPageViewType(
+  value: string | undefined,
+): value is VirtualSearchPageViewType {
+  return value === 'disabled' || value === 'only' || value === 'both';
+}
+
+export function parseVirtualSearchPageViewConfig(
+  config: Config | undefined,
+): VirtualSearchPageViewConfig {
+  const vspvModeString = config?.getOptionalString('mode');
+  return {
+    mode: isVirtualSearchPageViewType(vspvModeString)
+      ? vspvModeString
+      : 'disabled',
+    mountPath: config?.getOptionalString('mountPath') ?? '/search',
+    queryParam: config?.getOptionalString('queryParam') ?? 'query',
+  };
+}


### PR DESCRIPTION
Signed-off-by: Nikita Karpukhin <nikita.karpukhin@scout24.com>

## Hey, I just made a Pull Request!
GA's Site Search has a lot of useful functionality which we'd like to use, however it can only extract search queries from URLs. Backstage's sidebar search does not modify the URL in any way, so those search queries do not end up in the Site Search section. After some [discussion in Backstage's Discord](https://discord.com/channels/687207715902193673/1042829794091466813) it seems like the best approach to this problem is to send virtual pageviews to GA on `search` events.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
