### PR TITLE
Make githubCredentialsProvider overrideable in GithubLocationAnalyzer

### DIFF
--- a/.changeset/famous-cobras-suffer.md
+++ b/.changeset/famous-cobras-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added the githubCredentialsProvider property to the GithubLocationAnalyzerOptions to be able to override the GithubCredentialsProvider.

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -128,6 +128,7 @@ export type GithubLocationAnalyzerOptions = {
   config: Config;
   discovery: PluginEndpointDiscovery;
   tokenManager: TokenManager;
+  githubCredentialsProvider?: GithubCredentialsProvider;
 };
 
 // @public

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
@@ -39,6 +39,7 @@ export type GithubLocationAnalyzerOptions = {
   config: Config;
   discovery: PluginEndpointDiscovery;
   tokenManager: TokenManager;
+  githubCredentialsProvider?: GithubCredentialsProvider;
 };
 
 /** @public */
@@ -52,6 +53,7 @@ export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
     this.catalogClient = new CatalogClient({ discoveryApi: options.discovery });
     this.integrations = ScmIntegrations.fromConfig(options.config);
     this.githubCredentialsProvider =
+      options.githubCredentialsProvider ||
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
     this.tokenManager = options.tokenManager;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds support to be able to override the GithubCredentialsProvider in the GithubLocationAnalyzer. It currently uses the DefaultGithubCredentialsProvider and there is not an option to use our own implementation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
