### PR TITLE
add config options to allow warnings and omit messages

### DIFF
--- a/.changeset/lemon-coats-camp.md
+++ b/.changeset/lemon-coats-camp.md
@@ -1,0 +1,11 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Add new command options to the `api-report`
+
+- added `--allowWarnings` to continue processing packages if some packages have warnings
+- added `--omitMessages` to pass some warnings messages code to be omitted from the api-report.md files
+- The `paths` argument for this command now takes as default the value on `workspaces.packages` inside the root package.json
+- The `paths` argument now allow glob patterns
+- change the path resolution to use the `@backstage/cli-common` packages instead

--- a/.changeset/lemon-coats-camp.md
+++ b/.changeset/lemon-coats-camp.md
@@ -4,8 +4,9 @@
 
 Add new command options to the `api-report`
 
-- added `--allowWarnings` to continue processing packages if some packages have warnings
-- added `--omitMessages` to pass some warnings messages code to be omitted from the api-report.md files
+- added `--allow-warnings`, `-a` to continue processing packages if some packages have warnings
+- added `--omit-messages`, `-o` to pass some warnings messages code to be omitted from the api-report.md files
+- added `--paths`, `-p` to select packages path to process
 - The `paths` argument for this command now takes as default the value on `workspaces.packages` inside the root package.json
-- The `paths` argument now allow glob patterns
+- Removed the `paths` argument replaced by the option `--paths`
 - change the path resolution to use the `@backstage/cli-common` packages instead

--- a/.changeset/lemon-coats-camp.md
+++ b/.changeset/lemon-coats-camp.md
@@ -1,12 +1,11 @@
 ---
-'@backstage/repo-tools': minor
+'@backstage/repo-tools': patch
 ---
 
 Add new command options to the `api-report`
 
-- added `--allow-warnings`, `-a` to continue processing packages if some packages have warnings
+- added `--allow-warnings`, `-a` to continue processing packages if selected packages have warnings
+- added `--allow-all-warnings` to continue processing packages any packages have warnings
 - added `--omit-messages`, `-o` to pass some warnings messages code to be omitted from the api-report.md files
-- added `--paths`, `-p` to select packages path to process
 - The `paths` argument for this command now takes as default the value on `workspaces.packages` inside the root package.json
-- Removed the `paths` argument replaced by the option `--paths`
 - change the path resolution to use the `@backstage/cli-common` packages instead

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build:api-reports": "yarn build:api-reports:only --tsc",
-    "build:api-reports:only": "backstage-repo-tools api-reports --allow-warnings packages/core-components  plugins/catalog plugins/catalog-import plugins/git-release-manager plugins/jenkins plugins/kubernetes",
+    "build:api-reports:only": "backstage-repo-tools api-reports --allow-warnings 'packages/core-components,plugins/+(catalog|catalog-import|git-release-manager|jenkins|kubernetes)'",
     "build:api-docs": "LANG=en_EN yarn build:api-reports --docs",
     "tsc": "tsc",
     "tsc:full": "backstage-cli repo clean && tsc --skipLibCheck false --incremental false",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build:api-reports": "yarn build:api-reports:only --tsc",
-    "build:api-reports:only": "backstage-repo-tools api-reports",
+    "build:api-reports:only": "backstage-repo-tools api-reports --allow-warnings packages/core-components  plugins/catalog plugins/catalog-import plugins/git-release-manager plugins/jenkins plugins/kubernetes",
     "build:api-docs": "LANG=en_EN yarn build:api-reports --docs",
     "tsc": "tsc",
     "tsc:full": "backstage-cli repo clean && tsc --skipLibCheck false --incremental false",

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -12,7 +12,7 @@ Options:
   -h, --help
 
 Commands:
-  api-reports [options] [paths...]
+  api-reports [options]
   type-deps
   help [command]
 ```
@@ -20,14 +20,15 @@ Commands:
 ### `backstage-repo-tools api-reports`
 
 ```
-Usage: backstage-repo-tools api-reports [options] [paths...]
+Usage: backstage-repo-tools api-reports [options]
 
 Options:
+  -p --paths [paths...]
   --ci
   --tsc
   --docs
-  --allow-warnings [allowWarningsPaths...]
-  --omitMessages <messageCodes...>
+  -a, --allow-warnings [allowWarningsPaths...]
+  -o, --omit-messages <messageCodes...>
   -h, --help
 ```
 

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -12,7 +12,7 @@ Options:
   -h, --help
 
 Commands:
-  api-reports [options] [path...]
+  api-reports [options] [paths...]
   type-deps
   help [command]
 ```
@@ -20,14 +20,13 @@ Commands:
 ### `backstage-repo-tools api-reports`
 
 ```
-Usage: backstage-repo-tools api-reports [options] [path...]
+Usage: backstage-repo-tools api-reports [options] [paths...]
 
 Options:
   --ci
   --tsc
   --docs
   --allow-warnings [allowWarningsPaths...]
-  --folders <folders...>
   --omitMessages <messageCodes...>
   -h, --help
 ```

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -26,6 +26,9 @@ Options:
   --ci
   --tsc
   --docs
+  --allow-warnings [allowWarningsPaths...]
+  --folders <folders...>
+  --omitMessages <messageCodes...>
   -h, --help
 ```
 

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -12,7 +12,7 @@ Options:
   -h, --help
 
 Commands:
-  api-reports [options]
+  api-reports [options] [paths...]
   type-deps
   help [command]
 ```
@@ -20,15 +20,15 @@ Commands:
 ### `backstage-repo-tools api-reports`
 
 ```
-Usage: backstage-repo-tools api-reports [options]
+Usage: backstage-repo-tools api-reports [options] [paths...]
 
 Options:
-  -p --paths [paths...]
   --ci
   --tsc
   --docs
-  -a, --allow-warnings [allowWarningsPaths...]
-  -o, --omit-messages <messageCodes...>
+  -a, --allow-warnings <allowWarningsPaths>
+  --allow-all-warnings
+  -o, --omit-messages <messageCodes>
   -h, --help
 ```
 

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -30,6 +30,7 @@
     "backstage-repo-tools": "bin/backstage-repo-tools"
   },
   "dependencies": {
+    "@backstage/cli-common": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.17.11",

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -44,7 +44,10 @@
     "ts-node": "^10.0.0"
   },
   "devDependencies": {
-    "@types/is-glob": "^4.0.2"
+    "@backstage/cli": "workspace:^",
+    "@types/is-glob": "^4.0.2",
+    "@types/mock-fs": "^4.13.0",
+    "mock-fs": "^5.1.0"
   },
   "files": [
     "bin",

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -40,7 +40,9 @@
     "chalk": "^4.0.0",
     "commander": "^9.1.0",
     "fs-extra": "10.1.0",
+    "glob": "^8.0.3",
     "is-glob": "^4.0.3",
+    "minimatch": "^5.1.1",
     "ts-node": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -40,7 +40,11 @@
     "chalk": "^4.0.0",
     "commander": "^9.1.0",
     "fs-extra": "10.1.0",
+    "is-glob": "^4.0.3",
     "ts-node": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/is-glob": "^4.0.2"
   },
   "files": [
     "bin",

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -65,7 +65,7 @@ import {
 } from '@microsoft/api-documenter/lib/markdown/CustomMarkdownEmitter';
 import { IMarkdownEmitterContext } from '@microsoft/api-documenter/lib/markdown/MarkdownEmitter';
 import { AstDeclaration } from '@microsoft/api-extractor/lib/analyzer/AstDeclaration';
-import { paths as cliPaths } from '../../lib/paths';
+import { paths as cliPaths, resolvePackagePath } from '../../lib/paths';
 
 import g from 'glob';
 import isGlob from 'is-glob';
@@ -225,25 +225,6 @@ ApiReportGenerator.generateReviewFileContent =
       parser: 'markdown',
     });
   };
-
-export async function resolvePackagePath(
-  packagePath: string,
-): Promise<string | undefined> {
-  const fullPackageDir = cliPaths.resolveTargetRoot(packagePath);
-
-  const stat = await fs.stat(fullPackageDir);
-  if (!stat.isDirectory()) {
-    return undefined;
-  }
-
-  try {
-    const packageJsonPath = join(fullPackageDir, 'package.json');
-    await fs.access(packageJsonPath);
-  } catch (_) {
-    return undefined;
-  }
-  return relativePath(cliPaths.targetRoot, fullPackageDir);
-}
 
 export async function findPackageDirs(selectedPaths: string[]) {
   const packageDirs = new Array<string>();

--- a/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
@@ -1,0 +1,505 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import mockFs from 'mock-fs';
+import { resolve as resolvePath } from 'path';
+import * as pathsLib from '../../lib/paths';
+
+import {
+  buildDocs,
+  runCliExtraction,
+  runApiExtraction,
+  categorizePackageDirs,
+} from './api-extractor';
+
+import { buildApiReports } from './api-reports';
+import { generateTSC } from './generateTSC';
+
+jest.mock('./generateTSC');
+// create mocks for the dependencies of the `buildApiReports` function
+jest.mock('./api-extractor', () => ({
+  createTemporaryTsConfig: jest.fn(),
+  categorizePackageDirs: jest.fn().mockImplementation(async (p: string[]) => {
+    console.log('categorizePackageDirs', p);
+    return {
+      tsPackageDirs: p,
+      cliPackageDirs: p,
+    };
+  }),
+  runApiExtraction: jest.fn(),
+  runCliExtraction: jest.fn(),
+  buildDocs: jest.fn(),
+}));
+
+const paths = pathsLib.paths;
+
+jest.spyOn(paths, 'targetRoot', 'get').mockReturnValue('/root');
+jest.spyOn(paths, 'resolveTargetRoot').mockImplementation((...path) => {
+  return resolvePath('/root', ...path);
+});
+
+describe('buildApiReports', () => {
+  beforeEach(() => {
+    mockFs({
+      [paths.targetRoot]: {
+        'package.json': JSON.stringify({
+          workspaces: { packages: ['packages/*', 'plugins/*'] },
+        }),
+        packages: {
+          'package-a': {
+            'package.json': '{}',
+          },
+          'package-b': {
+            'package.json': '{}',
+          },
+          'package-c': {},
+          'README.md': 'Hello World',
+        },
+        plugins: {
+          'plugin-a': {
+            'package.json': '{}',
+          },
+          'plugin-b': {
+            'package.json': '{}',
+          },
+          'plugin-c': {
+            'package.json': '{}',
+          },
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+    jest.clearAllMocks();
+  });
+  it('should run whitout any options', async () => {
+    const opts = {};
+
+    await buildApiReports(opts);
+
+    expect(categorizePackageDirs).toHaveBeenCalledWith([
+      'packages/package-a',
+      'packages/package-b',
+      'plugins/plugin-a',
+      'plugins/plugin-b',
+      'plugins/plugin-c',
+    ]);
+
+    expect(generateTSC).not.toHaveBeenCalled();
+    expect(runApiExtraction).toHaveBeenCalledWith({
+      packageDirs: [
+        'packages/package-a',
+        'packages/package-b',
+        'plugins/plugin-a',
+        'plugins/plugin-b',
+        'plugins/plugin-c',
+      ],
+      tsconfigFilePath: '/root/tsconfig.json',
+      allowWarnings: undefined,
+      omitMessages: [],
+      isLocalBuild: true,
+      outputDir: '/root/node_modules/.cache/api-extractor',
+    });
+    expect(runCliExtraction).toHaveBeenCalledWith({
+      packageDirs: [
+        'packages/package-a',
+        'packages/package-b',
+        'plugins/plugin-a',
+        'plugins/plugin-b',
+
+        'plugins/plugin-c',
+      ],
+      isLocalBuild: true,
+    });
+
+    expect(buildDocs).not.toHaveBeenCalled();
+  });
+
+  describe('paths', () => {
+    it('should generate API reports for one specific package', async () => {
+      const opts = {
+        paths: ['packages/package-a'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(categorizePackageDirs).toHaveBeenCalledWith([
+        'packages/package-a',
+      ]);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+      expect(runCliExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a'],
+        isLocalBuild: true,
+      });
+
+      expect(buildDocs).not.toHaveBeenCalled();
+    });
+    it('should generate API reports for multiple specific packages', async () => {
+      const opts = {
+        paths: ['packages/package-a', 'packages/package-b'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(categorizePackageDirs).toHaveBeenCalledWith([
+        'packages/package-a',
+        'packages/package-b',
+      ]);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+      expect(runCliExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        isLocalBuild: true,
+      });
+
+      expect(buildDocs).not.toHaveBeenCalled();
+    });
+    it('should generate API reports for all packages matching the glob pattern', async () => {
+      const opts = {
+        paths: ['packages/*'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(categorizePackageDirs).toHaveBeenCalledWith([
+        'packages/package-a',
+        'packages/package-b',
+      ]);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+      expect(runCliExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        isLocalBuild: true,
+      });
+
+      expect(buildDocs).not.toHaveBeenCalled();
+    });
+
+    it('should generate API reports for all packages matching multiple glob patterns', async () => {
+      const opts = {
+        paths: ['packages/*', 'plugins/*a'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(categorizePackageDirs).toHaveBeenCalledWith([
+        'packages/package-a',
+        'packages/package-b',
+        'plugins/plugin-a',
+      ]);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: [
+          'packages/package-a',
+          'packages/package-b',
+          'plugins/plugin-a',
+        ],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+      expect(runCliExtraction).toHaveBeenCalledWith({
+        packageDirs: [
+          'packages/package-a',
+          'packages/package-b',
+          'plugins/plugin-a',
+        ],
+        isLocalBuild: true,
+      });
+
+      expect(buildDocs).not.toHaveBeenCalled();
+    });
+
+    it('should generate API reports for specific packages and glob pattern', async () => {
+      const opts = {
+        paths: ['packages/package-a', 'plugins/*'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(categorizePackageDirs).toHaveBeenCalledWith([
+        'packages/package-a',
+        'plugins/plugin-a',
+        'plugins/plugin-b',
+        'plugins/plugin-c',
+      ]);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: [
+          'packages/package-a',
+          'plugins/plugin-a',
+          'plugins/plugin-b',
+          'plugins/plugin-c',
+        ],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+      expect(runCliExtraction).toHaveBeenCalledWith({
+        packageDirs: [
+          'packages/package-a',
+          'plugins/plugin-a',
+          'plugins/plugin-b',
+          'plugins/plugin-c',
+        ],
+        isLocalBuild: true,
+      });
+
+      expect(buildDocs).not.toHaveBeenCalled();
+    });
+  });
+  describe('allowWarnings', () => {
+    it('should accept boolean values', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        allowWarnings: true,
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: true,
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+
+    it('should accept single path value', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        allowWarnings: ['packages/package-a'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: ['packages/package-a'],
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+
+    it('should accept multiple path values as array', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        allowWarnings: ['packages/package-a', 'packages/package-b'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: ['packages/package-a', 'packages/package-b'],
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+
+    it('should accept multiple path values as comma separated string', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        allowWarnings: ['packages/package-a,packages/package-b'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: ['packages/package-a', 'packages/package-b'],
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+
+    it('should accept multiple path values as comma separated string with spaces', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        allowWarnings: ['packages/package-a, packages/package-b'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: ['packages/package-a', 'packages/package-b'],
+        omitMessages: [],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+  });
+  describe('omitMessages', () => {
+    it('should accept single message value', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        omitMessages: ['ae-missing-release-tag'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: ['ae-missing-release-tag'],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+
+    it('should accept multiple message values as array', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        omitMessages: ['ae-missing-release-tag', 'ae-missing-annotations'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: ['ae-missing-release-tag', 'ae-missing-annotations'],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+    it('should accept multiple message values as comma separated string', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        omitMessages: ['ae-missing-release-tag,ae-missing-annotations'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: ['ae-missing-release-tag', 'ae-missing-annotations'],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+
+    it('should accept multiple message values as comma separated string with spaces', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        omitMessages: ['ae-missing-release-tag, ae-missing-annotations'],
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: ['ae-missing-release-tag', 'ae-missing-annotations'],
+        isLocalBuild: true,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+    });
+  });
+  describe('isCI', () => {
+    it('should set localBuild to false if CI option is passed', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        ci: true,
+      };
+
+      await buildApiReports(opts);
+
+      expect(runApiExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        tsconfigFilePath: '/root/tsconfig.json',
+        allowWarnings: undefined,
+        omitMessages: [],
+        isLocalBuild: false,
+        outputDir: '/root/node_modules/.cache/api-extractor',
+      });
+      expect(runCliExtraction).toHaveBeenCalledWith({
+        packageDirs: ['packages/package-a', 'packages/package-b'],
+        isLocalBuild: false,
+      });
+    });
+  });
+  describe('docs', () => {
+    it('should run typedoc if docs option is passed', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        docs: true,
+      };
+
+      await buildApiReports(opts);
+
+      expect(buildDocs).toHaveBeenCalledWith({
+        inputDir: '/root/node_modules/.cache/api-extractor',
+        outputDir: '/root/docs/reference',
+      });
+    });
+  });
+  describe('tsc', () => {
+    it('should run tsc if tsc option is passed', async () => {
+      const opts = {
+        paths: ['packages/*'],
+        tsc: true,
+      };
+
+      await buildApiReports(opts);
+
+      expect(generateTSC).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/repo-tools/src/commands/api-reports/api-reports.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.ts
@@ -27,16 +27,29 @@ import {
   runCliExtraction,
   buildDocs,
 } from './api-extractor';
+import { paths as cliPaths } from '../../lib/paths';
 
 export default async (paths: string[], opts: OptionValues) => {
+  console.log(opts);
+  console.log({
+    ownDir: cliPaths.ownDir,
+    ownRoot: cliPaths.ownRoot,
+    targetDir: cliPaths.targetDir,
+    targetRoot: cliPaths.targetRoot,
+    'process.cwd()': process.cwd(),
+  });
   const tmpDir = resolvePath(
-    process.cwd(),
+    cliPaths.targetRoot,
     './node_modules/.cache/api-extractor',
   );
-  const projectRoot = resolvePath(process.cwd());
+
+  const projectRoot = resolvePath(cliPaths.targetRoot);
   const isCiBuild = opts.ci;
   const isDocsBuild = opts.docs;
   const runTsc = opts.tsc;
+  const packageRoots = opts.folders;
+  const allowWarnings: boolean | string[] = opts.allowWarnings;
+  const omitMessages = opts.omitMessages;
 
   const selectedPackageDirs = await findSpecificPackageDirs(paths);
 
@@ -85,7 +98,8 @@ export default async (paths: string[], opts: OptionValues) => {
     }
   }
 
-  const packageDirs = selectedPackageDirs ?? (await findPackageDirs());
+  const packageDirs =
+    selectedPackageDirs ?? (await findPackageDirs(packageRoots));
 
   const { tsPackageDirs, cliPackageDirs } = await categorizePackageDirs(
     projectRoot,
@@ -99,6 +113,8 @@ export default async (paths: string[], opts: OptionValues) => {
       outputDir: tmpDir,
       isLocalBuild: !isCiBuild,
       tsconfigFilePath,
+      allowWarnings,
+      omitMessages,
     });
   }
   if (cliPackageDirs.length > 0) {

--- a/packages/repo-tools/src/commands/api-reports/generateTSC.ts
+++ b/packages/repo-tools/src/commands/api-reports/generateTSC.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs-extra';
+import { spawnSync } from 'child_process';
+import { paths as cliPaths } from '../../lib/paths';
+
+/**
+ * Generates the TypeScript declaration files for the specified project, using the provided `tsconfig.json` file.
+ *
+ * Any existing declaration files in the `dist-types` directory will be deleted before generating the new ones.
+ *
+ * If the `tsc` command exits with a non-zero exit code, the process will be terminated with the same exit code.
+ *
+ * @param tsconfigFilePath {string} The path to the `tsconfig.json` file to use for generating the declaration files.
+ * @returns {Promise<void>} A promise that resolves when the declaration files have been generated.
+ */
+
+export async function generateTSC(tsconfigFilePath: string) {
+  await fs.remove(cliPaths.resolveTargetRoot('dist-types'));
+  const { status } = spawnSync(
+    'yarn',
+    [
+      'tsc',
+      ['--project', tsconfigFilePath],
+      ['--skipLibCheck', 'false'],
+      ['--incremental', 'false'],
+    ].flat(),
+    {
+      stdio: 'inherit',
+      shell: true,
+      cwd: cliPaths.targetRoot,
+    },
+  );
+  if (status !== 0) {
+    process.exit(status || undefined);
+  }
+}

--- a/packages/repo-tools/src/commands/api-reports/generateTypeDeclarations.ts
+++ b/packages/repo-tools/src/commands/api-reports/generateTypeDeclarations.ts
@@ -28,7 +28,7 @@ import { paths as cliPaths } from '../../lib/paths';
  * @returns {Promise<void>} A promise that resolves when the declaration files have been generated.
  */
 
-export async function generateTSC(tsconfigFilePath: string) {
+export async function generateTypeDeclarations(tsconfigFilePath: string) {
   await fs.remove(cliPaths.resolveTargetRoot('dist-types'));
   const { status } = spawnSync(
     'yarn',

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -24,6 +24,19 @@ export function registerCommands(program: Command) {
     .option('--ci', 'CI run checks that there is no changes on API reports')
     .option('--tsc', 'executes the tsc compilation before extracting the APIs')
     .option('--docs', 'generates the api documentation')
+    .option(
+      '--allow-warnings [allowWarningsPaths...]',
+      'continue processing packages after getting errors on selected packages',
+      false,
+    )
+    .option('--folders <folders...>', 'packages folder containers', [
+      'packages',
+      'plugins',
+    ])
+    .option(
+      '--omitMessages <messageCodes...>',
+      'select some message code to be omited on the API Extractor (i.e ae-cyclic-inherit-doc)',
+    )
     .description('Generate an API report for selected packages')
     .action(
       lazy(() => import('./api-reports/api-reports').then(m => m.default)),

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -21,21 +21,21 @@ import { exitWithError } from '../lib/errors';
 export function registerCommands(program: Command) {
   program
     .command('api-reports')
-    .argument(
-      '[paths...]',
-      'path of package folder to extract API reports, `workspaces.packages` from root packages.json by default',
+    .option(
+      '-p --paths [paths...]',
+      'paths of package folder to extract API reports, `workspaces.packages` from root packages.json by default. Allows glob patterns and comma separated values',
     )
     .option('--ci', 'CI run checks that there is no changes on API reports')
     .option('--tsc', 'executes the tsc compilation before extracting the APIs')
     .option('--docs', 'generates the api documentation')
     .option(
-      '--allow-warnings [allowWarningsPaths...]',
-      'continue processing packages after getting errors on selected packages',
+      '-a, --allow-warnings [allowWarningsPaths...]',
+      'continue processing packages after getting errors on selected packages Allows glob patterns and comma separated values (i.e. packages/core,plugins/core-*)',
       false,
     )
     .option(
-      '--omitMessages <messageCodes...>',
-      'select some message code to be omited on the API Extractor (i.e ae-cyclic-inherit-doc)',
+      '-o, --omit-messages <messageCodes...>',
+      'select some message code to be omited on the API Extractor (comma separated values i.e ae-cyclic-inherit-doc,ae-missing-getter )',
     )
     .description('Generate an API report for selected packages')
     .action(

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -20,7 +20,11 @@ import { exitWithError } from '../lib/errors';
 
 export function registerCommands(program: Command) {
   program
-    .command('api-reports [path...]')
+    .command('api-reports')
+    .argument(
+      '[paths...]',
+      'path of package folder to extract API reports, `workspaces.packages` from root packages.json by default',
+    )
     .option('--ci', 'CI run checks that there is no changes on API reports')
     .option('--tsc', 'executes the tsc compilation before extracting the APIs')
     .option('--docs', 'generates the api documentation')
@@ -29,10 +33,6 @@ export function registerCommands(program: Command) {
       'continue processing packages after getting errors on selected packages',
       false,
     )
-    .option('--folders <folders...>', 'packages folder containers', [
-      'packages',
-      'plugins',
-    ])
     .option(
       '--omitMessages <messageCodes...>',
       'select some message code to be omited on the API Extractor (i.e ae-cyclic-inherit-doc)',

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -39,7 +39,9 @@ export function registerCommands(program: Command) {
     )
     .description('Generate an API report for selected packages')
     .action(
-      lazy(() => import('./api-reports/api-reports').then(m => m.default)),
+      lazy(() =>
+        import('./api-reports/api-reports').then(m => m.buildApiReports),
+      ),
     );
 
   program

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -20,21 +20,21 @@ import { exitWithError } from '../lib/errors';
 
 export function registerCommands(program: Command) {
   program
-    .command('api-reports')
-    .option(
-      '-p --paths [paths...]',
-      'paths of package folder to extract API reports, `workspaces.packages` from root packages.json by default. Allows glob patterns and comma separated values',
-    )
+    .command('api-reports [paths...]')
     .option('--ci', 'CI run checks that there is no changes on API reports')
     .option('--tsc', 'executes the tsc compilation before extracting the APIs')
     .option('--docs', 'generates the api documentation')
     .option(
-      '-a, --allow-warnings [allowWarningsPaths...]',
+      '-a, --allow-warnings <allowWarningsPaths>',
       'continue processing packages after getting errors on selected packages Allows glob patterns and comma separated values (i.e. packages/core,plugins/core-*)',
+    )
+    .option(
+      '--allow-all-warnings',
+      'continue processing packages after getting errors on all packages',
       false,
     )
     .option(
-      '-o, --omit-messages <messageCodes...>',
+      '-o, --omit-messages <messageCodes>',
       'select some message code to be omited on the API Extractor (comma separated values i.e ae-cyclic-inherit-doc,ae-missing-getter )',
     )
     .description('Generate an API report for selected packages')

--- a/packages/repo-tools/src/lib/paths.test.ts
+++ b/packages/repo-tools/src/lib/paths.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import mockFs from 'mock-fs';
+import { resolve as resolvePath } from 'path';
+import { resolvePackagePath, paths } from './paths';
+
+describe('paths', () => {
+  jest.spyOn(paths, 'targetRoot', 'get').mockReturnValue('/root');
+  jest.spyOn(paths, 'resolveTargetRoot').mockImplementation((...path) => {
+    return resolvePath('/root', ...path);
+  });
+
+  beforeEach(() => {
+    mockFs({
+      [paths.targetRoot]: {
+        'package.json': JSON.stringify({ name: 'test' }),
+        packages: {
+          'package-a': {
+            'package.json': '{}',
+          },
+          'package-b': {
+            'package.json': '{}',
+          },
+          'package-c': {},
+          'README.md': 'Hello World',
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  describe('resolvePackagePath', () => {
+    it('should return undefined if the package does not exist or does not contain a package.json', async () => {
+      expect(await resolvePackagePath('packages/package-d')).toBeUndefined();
+      expect(await resolvePackagePath('packages/package-c')).toBeUndefined();
+    });
+    it('should return the path to the package if it exists and has a package.json', async () => {
+      expect(await resolvePackagePath('packages/package-a')).toBe(
+        'packages/package-a',
+      );
+      expect(await resolvePackagePath('packages/package-b')).toBe(
+        'packages/package-b',
+      );
+    });
+    it('should return undefined if the pat is not a directory', async () => {
+      expect(await resolvePackagePath('packages/README.md')).toBeUndefined();
+    });
+  });
+});

--- a/packages/repo-tools/src/lib/paths.ts
+++ b/packages/repo-tools/src/lib/paths.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findPaths } from '@backstage/cli-common';
+
+/* eslint-disable-next-line no-restricted-syntax */
+export const paths = findPaths(__dirname);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8467,6 +8467,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/repo-tools@workspace:packages/repo-tools"
   dependencies:
+    "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@manypkg/get-packages": ^1.1.3
@@ -8475,10 +8476,12 @@ __metadata:
     "@microsoft/api-extractor-model": ^7.17.2
     "@microsoft/tsdoc": 0.14.1
     "@types/is-glob": ^4.0.2
+    "@types/mock-fs": ^4.13.0
     chalk: ^4.0.0
     commander: ^9.1.0
     fs-extra: 10.1.0
     is-glob: ^4.0.3
+    mock-fs: ^5.1.0
     ts-node: ^10.0.0
   bin:
     backstage-repo-tools: bin/backstage-repo-tools

--- a/yarn.lock
+++ b/yarn.lock
@@ -8480,7 +8480,9 @@ __metadata:
     chalk: ^4.0.0
     commander: ^9.1.0
     fs-extra: 10.1.0
+    glob: ^8.0.3
     is-glob: ^4.0.3
+    minimatch: ^5.1.1
     mock-fs: ^5.1.0
     ts-node: ^10.0.0
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8474,9 +8474,11 @@ __metadata:
     "@microsoft/api-extractor": ^7.23.0
     "@microsoft/api-extractor-model": ^7.17.2
     "@microsoft/tsdoc": 0.14.1
+    "@types/is-glob": ^4.0.2
     chalk: ^4.0.0
     commander: ^9.1.0
     fs-extra: 10.1.0
+    is-glob: ^4.0.3
     ts-node: ^10.0.0
   bin:
     backstage-repo-tools: bin/backstage-repo-tools
@@ -14198,6 +14200,13 @@ __metadata:
   dependencies:
     ci-info: ^3.1.0
   checksum: 7c1f1f16c1fa2134de7400d82766c83fa76057261ba890628af77a09382ebb92d945bb077b98cfcf3d40ab1469c9ffbd2278112867edbe57aa655f53547eb139
+  languageName: node
+  linkType: hard
+
+"@types/is-glob@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@types/is-glob@npm:4.0.2"
+  checksum: 50b0a52b6d179781b36bfce35155e1e0dc66b62e2943153d7d7c7079c40ba6236528a254de8be6c52ff9a7a351996887802efd7fd763da3e2121315e4ffe2edf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8467,6 +8467,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/repo-tools@workspace:packages/repo-tools"
   dependencies:
+    "@backstage/cli-common": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@manypkg/get-packages": ^1.1.3
     "@microsoft/api-documenter": ^7.17.11


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

adding 3 config options to remove repo-specific hardcodes and allow or omit some warning messages

#### `--allow-warnings <allowWarningsPaths>` 
 Select some packages to allow warnings as if more than one just be comma separated values and glob pattern are allowed `--allow-warnings packages/my-package,plugins/*-plugin`


#### `--allow-warnings-all` 
 Allow warnings on all packages


#### ~~`--folders <folders...>`~~
~~by default will scan the `packages` and the `plugins` folders, but now we can select which folder we want to scan to find packages with i.e. `--folders packages plugins modules`~~

**Edit**: replaced the folder combat to use the command argument with glob patterns instead now the command can be called with specific packages or with glob patterns
```bash
backstage-repo-tools api-reports package/a plugins/b

backstage-repo-tools api-reports packages/*
```

#### `--omitMessages <messageCodes>`
this option will omit some messages from the api report extractor i.e. (`--omitMessages ae-forgotten-export,ae-wrong-input-file-type`) [see API extractor messages docs](https://api-extractor.com/pages/messages/ae-wrong-input-file-type/)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
