### PR TITLE
Update EntityTagFilter to use 'some' instead of 'every'

### DIFF
--- a/.changeset/pretty-eyes-press.md
+++ b/.changeset/pretty-eyes-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Updated the EntityTagFilter so that it will include all components that contain any of the selected tags, instead of only components that contain all selected tags.

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -19,6 +19,7 @@ import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import {
   EntityErrorFilter,
   EntityOrphanFilter,
+  EntityTagFilter,
   EntityTextFilter,
 } from './filters';
 
@@ -140,5 +141,19 @@ describe('EntityErrorFilter', () => {
     const filter = new EntityErrorFilter(true);
     expect(filter.filterEntity(error)).toBeTruthy();
     expect(filter.filterEntity(entities[1])).toBeFalsy();
+  });
+});
+
+describe('EntityTagFilter', () => {
+  it('should filter on a single tag', () => {
+    const singleTagFilter = new EntityTagFilter(['react']);
+    expect(singleTagFilter.filterEntity(entities[0])).toBeTruthy();
+    expect(singleTagFilter.filterEntity(entities[1])).toBeFalsy();
+  });
+
+  it('should filter on multiple tags', () => {
+    const multipleTagFilter = new EntityTagFilter(['react', 'java']);
+    expect(multipleTagFilter.filterEntity(entities[0])).toBeTruthy();
+    expect(multipleTagFilter.filterEntity(entities[1])).toBeTruthy();
   });
 });

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -68,7 +68,7 @@ export class EntityTagFilter implements EntityFilter {
   constructor(readonly values: string[]) {}
 
   filterEntity(entity: Entity): boolean {
-    return this.values.every(v => (entity.metadata.tags ?? []).includes(v));
+    return this.values.some(v => (entity.metadata.tags ?? []).includes(v));
   }
 
   toQueryValue(): string[] {


### PR DESCRIPTION
Signed-off-by: Donner, Lauren [USA] <Donner_Lauren@bah.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR changes the behavior of the EntityTagFilter to include all components that match any of the tags chosen.

Because tags can be used to classify catalog entries in various ways, when filtering on multiple tags it stands to reason we would want to find any component that contains any one of those tags, to cast a wide net to discover what we’re looking for. 

If, for example, a user is searching for a component related to artificial intelligence, I would expect the user to be able to find my component by checking both “ai” and “artificial-intelligence” in the tag filters even if my component only has the “ai” tag or only has the “artificial-intelligence” tag, but not both. 

Or, if a user selects 4 tags and a component has 3/4 of those tags, I would think that component would still be relevant to what they’re searching for.
 This would also be more consistent with how filters work when using them in /entities, which uses an “or” relationship for filters.
 If a user is searching for something using tags, I think it makes more sense for it to match any of the tags selected, not just components with every single tag in the list.

<img width="1579" alt="image" src="https://user-images.githubusercontent.com/40272553/204391654-88617209-68ec-49bc-a4ef-6fac5d8263b8.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))