### PR TITLE
feat(search): Don't close dialog on ctrl+click at quick search

### DIFF
--- a/.changeset/neat-buses-type.md
+++ b/.changeset/neat-buses-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Improved usability of quick search when opening items in new tab

--- a/packages/app/src/components/search/SearchModal.tsx
+++ b/packages/app/src/components/search/SearchModal.tsx
@@ -80,13 +80,29 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
   const { focusContent } = useContent();
   const { transitions } = useTheme();
 
-  const handleResultClick = () => {
-    toggleModal();
+  const isOpenNewTabOrWindow = (
+    event: React.MouseEvent | React.KeyboardEvent,
+  ): boolean =>
+    // open new tab (linux or windows)
+    event.ctrlKey === true ||
+    // open new wab (macos)
+    event.metaKey === true ||
+    // open new window
+    event.shiftKey === true ||
+    // open new tab (middle/wheel click)
+    ('button' in event ? event.button === 1 : false);
+
+  const handleResultClick = (
+    event: React.MouseEvent | React.KeyboardEvent,
+  ): void => {
+    if (!isOpenNewTabOrWindow(event)) {
+      toggleModal();
+    }
     setTimeout(focusContent, transitions.duration.leavingScreen);
   };
 
-  const handleKeyPress = () => {
-    handleResultClick();
+  const handleKeyPress = (event: React.KeyboardEvent): void => {
+    handleResultClick(event);
   };
 
   return (
@@ -163,13 +179,7 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
             >
               <Grid item>
                 <Link
-                  onClick={() => {
-                    toggleModal();
-                    setTimeout(
-                      focusContent,
-                      transitions.duration.leavingScreen,
-                    );
-                  }}
+                  onClick={handleResultClick}
                   to={`${getSearchLink()}?query=${term}`}
                 >
                   <span className={classes.viewResultsLink}>

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -39,6 +39,7 @@ import {
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { Link, useContent } from '@backstage/core-components';
 import { rootRouteRef } from '../../plugin';
+import { isOpenNewTabOrWindow } from '../util';
 
 /**
  * @public
@@ -100,13 +101,17 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
   const { focusContent } = useContent();
   const { transitions } = useTheme();
 
-  const handleResultClick = () => {
-    toggleModal();
+  const handleResultClick = (
+    event: React.MouseEvent | React.KeyboardEvent,
+  ): void => {
+    if (!isOpenNewTabOrWindow(event)) {
+      toggleModal();
+    }
     setTimeout(focusContent, transitions.duration.leavingScreen);
   };
 
-  const handleKeyPress = () => {
-    handleResultClick();
+  const handleKeyPress = (event: React.KeyboardEvent): void => {
+    handleResultClick(event);
   };
 
   return (
@@ -125,10 +130,7 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
         >
           <Grid item>
             <Link
-              onClick={() => {
-                toggleModal();
-                setTimeout(focusContent, transitions.duration.leavingScreen);
-              }}
+              onClick={handleResultClick}
               to={`${getSearchLink()}?query=${term}`}
             >
               <span className={classes.viewResultsLink}>View Full Results</span>

--- a/plugins/search/src/components/util.ts
+++ b/plugins/search/src/components/util.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import qs from 'qs';
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { rootRouteRef } from '../plugin';
 
@@ -32,3 +32,15 @@ export const useNavigateToQuery = () => {
     [navigate, searchRoute],
   );
 };
+
+export const isOpenNewTabOrWindow = (
+  event: React.MouseEvent | React.KeyboardEvent,
+): boolean =>
+  // open new tab (linux or windows)
+  event.ctrlKey === true ||
+  // open new wab (macos)
+  event.metaKey === true ||
+  // open new window
+  event.shiftKey === true ||
+  // open new tab (middle/wheel click)
+  ('button' in event ? event.button === 1 : false);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This patch closes #14903. A suggestion to improve user experience while using quick search.

After opening quick search, if you need to go though multiple results by clicking <kbd>ctrl</kbd>/<kbd>cmd</kbd> + click to open new tabs, the quick search dialogs closes.

With this it is kept open, so you can go through the other results without having to open the quick search again:
![Screen Recording 2022-11-29 at 14 02 32](https://user-images.githubusercontent.com/187639/204536959-f3009750-0dc4-48d0-9f0c-da2d1d3ee9c3.gif)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] 🧪 Tests!
