### PR TITLE
[Search] Preserve existing index if latest index run contains no documents

### DIFF
--- a/.changeset/search-antibacterial-wipe.md
+++ b/.changeset/search-antibacterial-wipe.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-search-backend-module-pg': minor
+---
+
+Added the option to pass a logger to `PgSearchEngine` during instantiation. You may do so as follows:
+
+```diff
+const searchEngine = await PgSearchEngine.fromConfig(env.config, {
+  database: env.database,
++ logger: env.logger,
+});
+```

--- a/.changeset/search-with-alcohol.md
+++ b/.changeset/search-with-alcohol.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': minor
+'@backstage/plugin-search-backend-module-pg': minor
+'@backstage/plugin-search-backend-node': minor
+---
+
+The search engine now better handles the case when it receives 0 documents at index-time. Prior to this change, the indexer would replace any existing index with an empty index, effectively deleting it. Now instead, a warning is logged, and any existing index is left alone (preserving the index from the last successful indexing attempt).

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -252,6 +252,7 @@ export class ElasticSearchSearchEngine implements SearchEngine {
 
   async getIndexer(type: string) {
     const alias = this.constructSearchAlias(type);
+    const indexerLogger = this.logger.child({ documentType: type });
 
     const indexer = new ElasticSearchSearchEngineIndexer({
       type,
@@ -259,13 +260,13 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       indexSeparator: this.indexSeparator,
       alias,
       elasticSearchClientWrapper: this.elasticSearchClientWrapper,
-      logger: this.logger,
+      logger: indexerLogger,
       batchSize: this.batchSize,
     });
 
     // Attempt cleanup upon failure.
     indexer.on('error', async e => {
-      this.logger.error(`Failed to index documents for type ${type}`, e);
+      indexerLogger.error(`Failed to index documents for type ${type}`, e);
       let cleanupError: Error | undefined;
 
       // In some cases, a failure may have occurred before the indexer was able
@@ -296,11 +297,13 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       });
 
       if (cleanupError) {
-        this.logger.error(
+        indexerLogger.error(
           `Unable to clean up elastic index ${indexer.indexName}: ${cleanupError}`,
         );
       } else {
-        this.logger.info(`Removed partial, failed index ${indexer.indexName}`);
+        indexerLogger.info(
+          `Removed partial, failed index ${indexer.indexName}`,
+        );
       }
     });
 

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.test.ts
@@ -176,6 +176,26 @@ describe('ElasticSearchSearchEngineIndexer', () => {
     expect(deleteSpy).toHaveBeenCalled();
   });
 
+  it('handles when no documents are received', async () => {
+    await TestPipeline.fromIndexer(indexer).withDocuments([]).execute();
+
+    // Older indices should have been queried for.
+    expect(catSpy).toHaveBeenCalled();
+
+    // A new index should have been created.
+    const createdIndex = createSpy.mock.calls[0][0].path.slice(1);
+    expect(createdIndex).toContain('some-type-index__');
+
+    // No documents should have been sent
+    expect(bulkSpy).not.toHaveBeenCalled();
+
+    // Alias should not have been rotated.
+    expect(aliasesSpy).not.toHaveBeenCalled();
+
+    // Old index should not be cleaned up.
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
   it('handles bulk and batching during indexing', async () => {
     const documents = range(550).map(i => ({
       title: `Hello World ${i}`,

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.test.ts
@@ -183,8 +183,12 @@ describe('ElasticSearchSearchEngineIndexer', () => {
     expect(catSpy).toHaveBeenCalled();
 
     // A new index should have been created.
-    const createdIndex = createSpy.mock.calls[0][0].path.slice(1);
-    expect(createdIndex).toContain('some-type-index__');
+    expect(createSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: expect.stringContaining('some-type-index__'),
+      }),
+    );
 
     // No documents should have been sent
     expect(bulkSpy).not.toHaveBeenCalled();

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
@@ -131,6 +131,24 @@ export class ElasticSearchSearchEngineIndexer extends BatchSearchEngineIndexer {
     // Wait for the bulk helper to finish processing.
     const result = await this.bulkResult;
 
+    // Warn that no documents were indexed, early return so that alias swapping
+    // does not occur, and clean up the empty index we just created.
+    if (this.processed === 0) {
+      this.logger.warn(
+        `Index for ${this.type} was not ${
+          this.removableIndices.length ? 'replaced' : 'created'
+        }: indexer received 0 documents`,
+      );
+      try {
+        await this.elasticSearchClientWrapper.deleteIndex({
+          index: this.indexName,
+        });
+      } catch (error) {
+        this.logger.error(`Unable to clean up elastic index: ${error}`);
+      }
+      return;
+    }
+
     // Rotate main alias upon completion. Apply permanent secondary alias so
     // stale indices can be referenced for deletion in case initial attempt
     // fails. Allow errors to bubble up so that we can clean up the created index.

--- a/plugins/search-backend-module-pg/api-report.md
+++ b/plugins/search-backend-module-pg/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { IndexableResultSet } from '@backstage/plugin-search-common';
 import { Knex } from 'knex';
+import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { SearchEngine } from '@backstage/plugin-search-common';
 import { SearchQuery } from '@backstage/plugin-search-common';
@@ -84,11 +85,12 @@ export interface DocumentResultRow {
 // @public (undocumented)
 export class PgSearchEngine implements SearchEngine {
   // @deprecated
-  constructor(databaseStore: DatabaseStore, config: Config);
+  constructor(databaseStore: DatabaseStore, config: Config, logger?: Logger);
   // @deprecated (undocumented)
   static from(options: {
     database: PluginDatabaseManager;
     config: Config;
+    logger?: Logger;
   }): Promise<PgSearchEngine>;
   // (undocumented)
   static fromConfig(
@@ -126,6 +128,7 @@ export type PgSearchEngineIndexerOptions = {
   batchSize: number;
   type: string;
   databaseStore: DatabaseStore;
+  logger?: Logger;
 };
 
 // @public
@@ -144,6 +147,7 @@ export type PgSearchHighlightOptions = {
 // @public
 export type PgSearchOptions = {
   database: PluginDatabaseManager;
+  logger?: Logger;
 };
 
 // @public (undocumented)

--- a/plugins/search-backend-module-pg/package.json
+++ b/plugins/search-backend-module-pg/package.json
@@ -29,7 +29,8 @@
     "@backstage/plugin-search-common": "workspace:^",
     "knex": "^2.0.0",
     "lodash": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngineIndexer.test.ts
+++ b/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngineIndexer.test.ts
@@ -81,6 +81,15 @@ describe('PgSearchEngineIndexer', () => {
     expect(database.completeInsert).toHaveBeenCalledWith(tx, 'my-type');
   });
 
+  it('should rollback transaction if no documents indexed', async () => {
+    await TestPipeline.fromIndexer(indexer).withDocuments([]).execute();
+
+    expect(database.getTransaction).toHaveBeenCalledTimes(1);
+    expect(database.insertDocuments).not.toHaveBeenCalled();
+    expect(database.completeInsert).not.toHaveBeenCalled();
+    expect(tx.rollback).toHaveBeenCalled();
+  });
+
   it('should close out stream and bubble up error on prepare', async () => {
     const expectedError = new Error('Prepare error');
     const documents = [

--- a/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngineIndexer.ts
+++ b/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngineIndexer.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import { getVoidLogger } from '@backstage/backend-common';
 import { BatchSearchEngineIndexer } from '@backstage/plugin-search-backend-node';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { Knex } from 'knex';
+import { Logger } from 'winston';
 import { DatabaseStore } from '../database';
 
 /** @public */
@@ -24,10 +26,12 @@ export type PgSearchEngineIndexerOptions = {
   batchSize: number;
   type: string;
   databaseStore: DatabaseStore;
+  logger?: Logger;
 };
 
 /** @public */
 export class PgSearchEngineIndexer extends BatchSearchEngineIndexer {
+  private logger: Logger;
   private store: DatabaseStore;
   private type: string;
   private tx: Knex.Transaction | undefined;
@@ -36,6 +40,7 @@ export class PgSearchEngineIndexer extends BatchSearchEngineIndexer {
     super({ batchSize: options.batchSize });
     this.store = options.databaseStore;
     this.type = options.type;
+    this.logger = options.logger || getVoidLogger();
   }
 
   async initialize(): Promise<void> {

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -153,12 +153,37 @@ export class LunrSearchEngine implements SearchEngine {
 
   async getIndexer(type: string) {
     const indexer = new LunrSearchEngineIndexer();
+    const indexerLogger = this.logger.child({ documentType: type });
+    let errorThrown: Error | undefined;
+
+    indexer.on('error', err => {
+      errorThrown = err;
+    });
 
     indexer.on('close', () => {
       // Once the stream is closed, build the index and store the documents in
       // memory for later retrieval.
-      this.lunrIndices[type] = indexer.buildIndex();
-      this.docStore = { ...this.docStore, ...indexer.getDocumentStore() };
+      const newDocuments = indexer.getDocumentStore();
+      const docStoreExists = this.lunrIndices[type] !== undefined;
+      const documentsIndexed = Object.keys(newDocuments).length;
+
+      // Do not set the index if there was an error or if no documents were
+      // indexed. This ensures search continues to work for an index, even in
+      // case of transient issues in underlying collators.
+      if (!errorThrown && documentsIndexed > 0) {
+        this.lunrIndices[type] = indexer.buildIndex();
+        this.docStore = { ...this.docStore, ...newDocuments };
+      } else {
+        indexerLogger.warn(
+          `Index for ${type} was not ${
+            docStoreExists ? 'replaced' : 'created'
+          }: ${
+            errorThrown
+              ? 'an error was encountered'
+              : 'indexer received 0 documents'
+          }`,
+        );
+      }
     });
 
     return indexer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7535,6 +7535,7 @@ __metadata:
     knex: ^2.0.0
     lodash: ^4.17.21
     uuid: ^8.3.2
+    winston: ^3.2.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What / Why

Currently, all three search engine implementations have a subtle flaw that can cause headaches in production: if a collator completes, does not throw an error, but also does not provide any documents, then the search engine treats it as a success and dutifully removes the old index, replacing it with an empty index (effectively deleting it).  ...This results in Backstage end-users no longer being able to search for the contents normally found in that index.

In an ideal world, the collator would be written defensively enough to have thrown an error, rather than returning an empty set of documents...  However in reality, we can't expect collators to be written perfectly, and emergent issues are bound to pop up anyway.

As an example: the default TechDocs collator first checks the Software Catalog for entities annotated with the techdocs-ref, then collates documents for all of those entities.  ...If there's a bug in the Catalog that mis-annotates entities (such that no entity is annotated at all), there's no way for the TechDocs collator to know about the upstream bug, and it's thus not clear that it should be responsible for thowing an error.

## Proposal

Rather than treating this as an error state (in collators, search engines, or at the platform level), the proposal is to accept that this can happen from time to time and act in the interest of end-users by checking for this situation and preventing the index rotation process from happening.  A `warning` message gets logged to mark the unusual situation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
