### PR TITLE
Add API Access Token option to Stack Overflow backend plugin

### DIFF
--- a/.changeset/short-turtles-dream.md
+++ b/.changeset/short-turtles-dream.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-stack-overflow-backend': minor
+'@backstage/plugin-stack-overflow-backend': patch
 ---
 
-Added option to supply API Access Token
+Added option to supply API Access Token. This is required in addition to an API key when trying to access the data for a private Stack Overflow Team.

--- a/.changeset/short-turtles-dream.md
+++ b/.changeset/short-turtles-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow-backend': minor
+---
+
+Added option to supply API Access Token

--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -15,9 +15,11 @@ stackoverflow:
   baseUrl: https://api.stackexchange.com/2.2 # alternative: your internal stack overflow instance
 ```
 
-### Stack Overflow for Teams (private stack overflow instance)
+### Stack Overflow for Teams
 
-If you have a private stack overflow instance you will need to supply an API key as well. You can read more about how to set this up by going to [Stack Overflows Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api)
+If you have an private Stack Overflow instance and/or a private Stack Overflow Team you will need to supply an API key. You can read more about how to set this up by going to [Stack Overflow's Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).
+
+A private Stack Overflow Team requires both an API key and an API Access Token. Step 3 ("Generate an Access Token via OAuth") from the previously mentioned Help Page explains the process for generating an API Access Token with no expiration.
 
 ```yaml
 stackoverflow:

--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -17,7 +17,7 @@ stackoverflow:
 
 ### Stack Overflow for Teams
 
-If you have an private Stack Overflow instance and/or a private Stack Overflow Team you will need to supply an API key. You can read more about how to set this up by going to [Stack Overflow's Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).
+If you have a private Stack Overflow instance and/or a private Stack Overflow Team you will need to supply an API key. You can read more about how to set this up by going to [Stack Overflow's Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).
 
 A private Stack Overflow Team requires both an API key and an API Access Token. Step 3 ("Generate an Access Token via OAuth") from the previously mentioned Help Page explains the process for generating an API Access Token with no expiration.
 

--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -23,6 +23,7 @@ If you have a private stack overflow instance you will need to supply an API key
 stackoverflow:
   baseUrl: https://api.stackexchange.com/2.2 # alternative: your internal stack overflow instance
   apiKey: $STACK_OVERFLOW_API_KEY
+  apiAccessToken: $STACK_OVERFLOW_API_ACCESS_TOKEN
 ```
 
 ## Areas of Responsibility

--- a/plugins/stack-overflow-backend/api-report.md
+++ b/plugins/stack-overflow-backend/api-report.md
@@ -43,6 +43,7 @@ export type StackOverflowQuestionsCollatorFactoryOptions = {
   baseUrl?: string;
   maxPage?: number;
   apiKey?: string;
+  apiAccessToken?: string;
   requestParams: StackOverflowQuestionsRequestParams;
   logger: Logger;
 };

--- a/plugins/stack-overflow-backend/config.d.ts
+++ b/plugins/stack-overflow-backend/config.d.ts
@@ -25,9 +25,15 @@ export interface Config {
     baseUrl?: string;
 
     /**
-     * The api key to authenticate to Stack Overflow API
+     * The API key to authenticate to Stack Overflow API
      * @visibility secret
      */
     apiKey?: string;
+
+    /**
+     * The API Access Token to authenticate to Stack Overflow API
+     * @visibility secret
+     */
+    apiAccessToken?: string;
   };
 }

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -52,6 +52,7 @@ export type StackOverflowQuestionsCollatorFactoryOptions = {
   baseUrl?: string;
   maxPage?: number;
   apiKey?: string;
+  apiAccessToken?: string;
   requestParams: StackOverflowQuestionsRequestParams;
   logger: Logger;
 };
@@ -67,6 +68,7 @@ export class StackOverflowQuestionsCollatorFactory
   protected requestParams: StackOverflowQuestionsRequestParams;
   private readonly baseUrl: string | undefined;
   private readonly apiKey: string | undefined;
+  private readonly apiAccessToken: string | undefined;
   private readonly maxPage: number | undefined;
   private readonly logger: Logger;
   public readonly type: string = 'stack-overflow';
@@ -74,6 +76,7 @@ export class StackOverflowQuestionsCollatorFactory
   private constructor(options: StackOverflowQuestionsCollatorFactoryOptions) {
     this.baseUrl = options.baseUrl;
     this.apiKey = options.apiKey;
+    this.apiAccessToken = options.apiAccessToken;
     this.maxPage = options.maxPage;
     this.requestParams = options.requestParams;
     this.logger = options.logger.child({ documentType: this.type });
@@ -84,6 +87,7 @@ export class StackOverflowQuestionsCollatorFactory
     options: StackOverflowQuestionsCollatorFactoryOptions,
   ) {
     const apiKey = config.getOptionalString('stackoverflow.apiKey');
+    const apiAccessToken = config.getOptionalString('stackoverflow.apiAccessToken');
     const baseUrl =
       config.getOptionalString('stackoverflow.baseUrl') ||
       'https://api.stackexchange.com/2.2';
@@ -93,6 +97,7 @@ export class StackOverflowQuestionsCollatorFactory
       baseUrl,
       maxPage,
       apiKey,
+      apiAccessToken,
     });
   }
 
@@ -138,6 +143,11 @@ export class StackOverflowQuestionsCollatorFactory
       }
       const res = await fetch(
         `${this.baseUrl}/questions${params}${apiKeyParam}&page=${page}`,
+        this.apiAccessToken ? {
+          headers: {
+            'X-API-Access-Token': this.apiAccessToken,
+          },
+        } : undefined,
       );
 
       const data = await res.json();

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -87,7 +87,9 @@ export class StackOverflowQuestionsCollatorFactory
     options: StackOverflowQuestionsCollatorFactoryOptions,
   ) {
     const apiKey = config.getOptionalString('stackoverflow.apiKey');
-    const apiAccessToken = config.getOptionalString('stackoverflow.apiAccessToken');
+    const apiAccessToken = config.getOptionalString(
+      'stackoverflow.apiAccessToken',
+    );
     const baseUrl =
       config.getOptionalString('stackoverflow.baseUrl') ||
       'https://api.stackexchange.com/2.2';
@@ -143,11 +145,13 @@ export class StackOverflowQuestionsCollatorFactory
       }
       const res = await fetch(
         `${this.baseUrl}/questions${params}${apiKeyParam}&page=${page}`,
-        this.apiAccessToken ? {
-          headers: {
-            'X-API-Access-Token': this.apiAccessToken,
-          },
-        } : undefined,
+        this.apiAccessToken
+          ? {
+              headers: {
+                'X-API-Access-Token': this.apiAccessToken,
+              },
+            }
+          : undefined,
       );
 
       const data = await res.json();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
In order to use this plugin with a private Stack Overflow Team, the `X-API-Access-Token` header must be set.

Then requests like the following will work:
```
https://api.stackexchange.com/2.2/questions?pagesize=100&site=stackoverflow&team=<team>&key=<key>
```

Without the header, the following error occurs:
```json
{
    "error_id": 403,
    "error_message": "Access token is required to query Team specific data",
    "error_name": "access_denied"
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
