### PR TITLE
fix(explore): update to only link title in search results

### DIFF
--- a/.changeset/dry-radios-live.md
+++ b/.changeset/dry-radios-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Update search links to only have header as linkable text

--- a/plugins/explore/src/components/ToolSearchResultListItem/ToolSearchResultListItem.tsx
+++ b/plugins/explore/src/components/ToolSearchResultListItem/ToolSearchResultListItem.tsx
@@ -69,7 +69,7 @@ export function ToolSearchResultListItem(props: ToolSearchResultListItemProps) {
   };
 
   return (
-    <Link noTrack to={result.location} onClick={handleClick}>
+    <>
       <ListItem alignItems="flex-start">
         {props.icon && <ListItemIcon>{props.icon}</ListItemIcon>}
         <div className={classes.flexContainer}>
@@ -77,15 +77,17 @@ export function ToolSearchResultListItem(props: ToolSearchResultListItemProps) {
             className={classes.itemText}
             primaryTypographyProps={{ variant: 'h6' }}
             primary={
-              props.highlight?.fields.title ? (
-                <HighlightedSearchResultText
-                  text={props.highlight.fields.title}
-                  preTag={props.highlight.preTag}
-                  postTag={props.highlight.postTag}
-                />
-              ) : (
-                result.title
-              )
+              <Link noTrack to={result.location} onClick={handleClick}>
+                {props.highlight?.fields.title ? (
+                  <HighlightedSearchResultText
+                    text={props.highlight.fields.title}
+                    preTag={props.highlight.preTag}
+                    postTag={props.highlight.postTag}
+                  />
+                ) : (
+                  result.title
+                )}
+              </Link>
             }
             secondary={
               props.highlight?.fields.text ? (
@@ -108,6 +110,6 @@ export function ToolSearchResultListItem(props: ToolSearchResultListItemProps) {
         </div>
       </ListItem>
       <Divider component="li" />
-    </Link>
+    </>
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow up from #14389 which makes the `ToolSearchResultListItem` consistent with changes in #14615

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

<img width="959" alt="image" src="https://user-images.githubusercontent.com/6507159/204693937-a625a488-d16b-4717-baba-b2ccc29dba77.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
