### PR TITLE
Make AlertDisplay not crash on undefined error message

### DIFF
--- a/.changeset/modern-jokes-attack.md
+++ b/.changeset/modern-jokes-attack.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Made AlertDisplay not crash on undefined error messages
+Made AlertDisplay not crash on undefined messages

--- a/.changeset/modern-jokes-attack.md
+++ b/.changeset/modern-jokes-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Made AlertDisplay not crash on undefined error messages

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -42,7 +42,7 @@ export type AlertDisplayProps = {
 
 /** @public */
 export function AlertDisplay(props: AlertDisplayProps) {
-  const [messages, setMessages] = useState<Array<AlertMessage>>([]);
+  const [messages, setMessages] = useState<Array<Partial<AlertMessage>>>([]);
   const alertApi = useApi(alertApiRef);
 
   const { anchorOrigin = { vertical: 'top', horizontal: 'center' } } = props;
@@ -83,7 +83,7 @@ export function AlertDisplay(props: AlertDisplayProps) {
         severity={firstMessage.severity}
       >
         <span>
-          {firstMessage.message.toString()}
+          {`${firstMessage?.message}`}
           {messages.length > 1 && (
             <em>{` (${messages.length - 1} older ${pluralize(
               'message',

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -83,7 +83,7 @@ export function AlertDisplay(props: AlertDisplayProps) {
         severity={firstMessage.severity}
       >
         <span>
-          {`${firstMessage?.message}`}
+          {String(firstMessage.message)}
           {messages.length > 1 && (
             <em>{` (${messages.length - 1} older ${pluralize(
               'message',

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -42,7 +42,7 @@ export type AlertDisplayProps = {
 
 /** @public */
 export function AlertDisplay(props: AlertDisplayProps) {
-  const [messages, setMessages] = useState<Array<Partial<AlertMessage>>>([]);
+  const [messages, setMessages] = useState<Array<AlertMessage>>([]);
   const alertApi = useApi(alertApiRef);
 
   const { anchorOrigin = { vertical: 'top', horizontal: 'center' } } = props;


### PR DESCRIPTION
When code (incorrectly) posts an error with `undefined` error message, the `AlertDisplay` crashes when doing `.toString()`. This PR will make it at least not crash.

One can argue that crashing (well, throwing) on invalid (type-breaking) properties is a good thing, and it is, generally. But not in error _handling/displaying_ logic.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
