### PR TITLE
[Search] Improve index cleanup on error

### DIFF
--- a/.changeset/search-lieutenant-dangle.md
+++ b/.changeset/search-lieutenant-dangle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Fixed a bug that prevented indices from being cleaned up under some circumstances, which could have led to shard exhaustion.


### PR DESCRIPTION
## What / Why

The Elasticsearch indexer works by creating an index during initialization, pushing documents to it, then swapping a search alias once everything is complete (cleaning up the old index at the end of it all).  In case an error is encountered at index-time, the index that was created during initialization is deleted prior to any alias swapping.

#14810 highlights an edge-case where it's possible for a collator to have thrown an error before the ES indexer had finished initialization.  Consequently, the indexer's error handler would be called and complete before the index had been fully created, leaving behind a dangling index.

This PR updates the error handler to _assume_ that an index has been created (because one should have been), and allow delete attempts to be retried up to 5 times.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
