### PR TITLE
fix(TechDocsBuildLogs): properly render entire log

### DIFF
--- a/.changeset/lucky-apricots-dress.md
+++ b/.changeset/lucky-apricots-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix sizing of build log component to render all lines

--- a/plugins/techdocs/src/reader/components/TechDocsBuildLogs.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsBuildLogs.tsx
@@ -86,7 +86,9 @@ export const TechDocsBuildLogsDrawerContent = ({
           <Close />
         </IconButton>
       </Grid>
-      <LogViewer text={logText} classes={{ root: classes.logs }} />
+      <Grid item xs>
+        <LogViewer text={logText} classes={{ root: classes.logs }} />
+      </Grid>
     </Grid>
   );
 };


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

| Before | After |
| - | - |
| ![Screen Shot 2022-11-30 at 7 46 37 PM](https://user-images.githubusercontent.com/6998196/204951916-147323bf-304b-4edf-99b4-d8eb1b845eea.png) | ![Screen Shot 2022-11-30 at 7 45 33 PM](https://user-images.githubusercontent.com/6998196/204951936-785c93d7-3be7-4d23-a622-e994cfeb22f2.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
