### PR TITLE
Added (optional) publicUrl to vault-backend plugin

### DIFF
--- a/.changeset/loud-snails-sleep.md
+++ b/.changeset/loud-snails-sleep.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-vault-backend': patch
 ---
 
-Added (optional) publicUrl to editUrl and showUrl in case baseUrl is an internal url
+Added (optional) public link option to entity vault card in case base link is internal

--- a/.changeset/loud-snails-sleep.md
+++ b/.changeset/loud-snails-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-vault-backend': patch
+---
+
+Added (optional) publicUrl to editUrl and showUrl in case baseUrl is an internal url

--- a/.changeset/loud-snails-sleep.md
+++ b/.changeset/loud-snails-sleep.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-vault-backend': patch
 ---
 
-Added (optional) public link option to entity vault card in case base link is internal
+Added (optional) config `vault.publicUrl` as alternative to `vault.baseUrl` for `editUrl` and `showUrl` in case `vault.baseUrl` is internal

--- a/plugins/vault-backend/README.md
+++ b/plugins/vault-backend/README.md
@@ -63,7 +63,8 @@ To get started, first you need a running instance of Vault. You can follow [this
 
    ```yaml
    vault:
-     baseUrl: http://your-vault-url
+     baseUrl: http://your-internal-vault-url.svc
+     publicUrl: https://your-vault-url.example.com
      token: <VAULT_TOKEN>
      secretEngine: 'customSecretEngine' # Optional. By default it uses 'secrets'
      kvVersion: <kv-version> # Optional. The K/V version that your instance is using. The available options are '1' or '2'

--- a/plugins/vault-backend/config.d.ts
+++ b/plugins/vault-backend/config.d.ts
@@ -24,6 +24,12 @@ export interface Config {
     baseUrl: string;
 
     /**
+     * The publicUrl for your Vault instance (Optional).
+     * @visibility frontend
+     */
+    publicUrl?: string;
+
+    /**
      * The token used by Backstage to access Vault.
      * @visibility secret
      */

--- a/plugins/vault-backend/src/config/config.test.ts
+++ b/plugins/vault-backend/src/config/config.test.ts
@@ -40,6 +40,7 @@ describe('GetVaultConfig', () => {
     const vaultConfig = getVaultConfig(config);
     expect(vaultConfig).toStrictEqual({
       baseUrl: 'http://www.example.com',
+      publicUrl: undefined,
       token: '123',
       kvVersion: 2,
       secretEngine: 'secrets',
@@ -59,6 +60,7 @@ describe('GetVaultConfig', () => {
     const vaultConfig = getVaultConfig(config);
     expect(vaultConfig).toStrictEqual({
       baseUrl: 'http://www.example.com',
+      publicUrl: undefined,
       token: '123',
       kvVersion: 1,
       secretEngine: 'test',

--- a/plugins/vault-backend/src/config/config.ts
+++ b/plugins/vault-backend/src/config/config.ts
@@ -28,6 +28,11 @@ export interface VaultConfig {
   baseUrl: string;
 
   /**
+   * The publicUrl for your Vault instance (Optional).
+   */
+  publicUrl?: string;
+
+  /**
    * The token used by Backstage to access Vault.
    */
   token: string;

--- a/plugins/vault-backend/src/config/config.ts
+++ b/plugins/vault-backend/src/config/config.ts
@@ -58,6 +58,7 @@ export interface VaultConfig {
 export function getVaultConfig(config: Config): VaultConfig {
   return {
     baseUrl: config.getString('vault.baseUrl'),
+    publicUrl: config.getOptionalString('vault.publicUrl'),
     token: config.getString('vault.token'),
     kvVersion: config.getOptionalNumber('vault.kvVersion') ?? 2,
     secretEngine: config.getOptionalString('vault.secretEngine') ?? 'secrets',

--- a/plugins/vault-backend/src/service/vaultApi.ts
+++ b/plugins/vault-backend/src/service/vaultApi.ts
@@ -135,11 +135,13 @@ export class VaultClient implements VaultApi {
             )),
           );
         } else {
+          const vaultUrl =
+            this.vaultConfig.publicUrl || this.vaultConfig.baseUrl;
           secrets.push({
             name: secret,
             path: secretPath,
-            editUrl: `${this.vaultConfig.baseUrl}/ui/vault/secrets/${this.vaultConfig.secretEngine}/edit/${secretPath}/${secret}`,
-            showUrl: `${this.vaultConfig.baseUrl}/ui/vault/secrets/${this.vaultConfig.secretEngine}/show/${secretPath}/${secret}`,
+            editUrl: `${vaultUrl}/ui/vault/secrets/${this.vaultConfig.secretEngine}/edit/${secretPath}/${secret}`,
+            showUrl: `${vaultUrl}/ui/vault/secrets/${this.vaultConfig.secretEngine}/show/${secretPath}/${secret}`,
           });
         }
       }),


### PR DESCRIPTION
Signed-off-by: Casper Thygesen <cth@trifork.com>

## Hey, I just made a Pull Request!

Right now our backstage can only access the internal vault instance 

```yaml
vault:
  baseUrl: http://vault.vault.svc:8200
```

Which means the links in the `plugins/vault/src/components/EntityVaultCard/EntityVaultCard.tsx` are not working for users.
Therefor I have added a `publicUrl` option which I will use to link to a public url for Vault that is protected by some external OpenID Connect security.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
