### PR TITLE
Add link in docs to default icons for links

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -360,7 +360,7 @@ Fields of a link are:
 _NOTE_: The `icon` field value is meant to be a semantic key that will map to a
 specific icon that may be provided by an icon library (e.g. `material-ui`
 icons). These keys should be a sequence of `[a-z0-9A-Z]`, possibly separated by
-one of `[-_.]`. Backstage may support some basic icons out of the box, but the
+one of `[-_.]`. Backstage may support some basic icons out of the box such as those [defined in app-defaults](https://github.com/backstage/backstage/blob/master/packages/app-defaults/src/defaults/icons.tsx), but the
 Backstage integrator will ultimately be left to provide the appropriate icon
 component mappings. A generic fallback icon would be provided if a mapping
 cannot be resolved.


### PR DESCRIPTION
Signed-off-by: sblausten <sam@roadie.io>

## Hey, I just made a Pull Request!

Added a link to the default set of icons that can be referenced in an [entity links section](https://backstage.io/docs/features/software-catalog/descriptor-format#links-optional), to make it more clear what the defaults are that are available. See current doc section here https://backstage.io/docs/features/software-catalog/descriptor-format#links-optional

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
