### PR TITLE
core-app-api: immediately register discovered feature flags

### DIFF
--- a/.changeset/gentle-ligers-help.md
+++ b/.changeset/gentle-ligers-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Tweak feature flag registration so that it happens immediately before the first rendering of the app, rather than just after.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

@kurtaking discovered this as part of #14801. Feature flags currently aren't available on the first render, instead they're registered in the effect hook just after the app renders.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
