### PR TITLE
backend-plugin-api: export all service refs via a single coreServices object

### DIFF
--- a/.changeset/empty-taxis-run.md
+++ b/.changeset/empty-taxis-run.md
@@ -1,0 +1,22 @@
+---
+'@backstage/backend-app-api': patch
+'@backstage/plugin-app-backend': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-backend-module-aws': patch
+'@backstage/plugin-catalog-backend-module-azure': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-server': patch
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+'@backstage/plugin-catalog-backend-module-github': patch
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-catalog-node': patch
+'@backstage/plugin-events-backend': patch
+'@backstage/plugin-events-backend-module-aws-sqs': patch
+'@backstage/plugin-events-backend-module-github': patch
+'@backstage/plugin-events-backend-module-gitlab': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Refactored to use `coreServices` from `@backstage/backend-plugin-api`.

--- a/.changeset/many-bikes-press.md
+++ b/.changeset/many-bikes-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': minor
+---
+
+**BREAKING**: All core service references are now exported via a single `coreServices` object. For example, the `loggerServiceRef` is now accessed via `coreServices.logger` instead.

--- a/packages/backend-app-api/src/services/implementations/cacheService.ts
+++ b/packages/backend-app-api/src/services/implementations/cacheService.ts
@@ -16,18 +16,16 @@
 
 import { CacheManager } from '@backstage/backend-common';
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
-  pluginMetadataServiceRef,
-  cacheServiceRef,
 } from '@backstage/backend-plugin-api';
 
 /** @public */
 export const cacheFactory = createServiceFactory({
-  service: cacheServiceRef,
+  service: coreServices.cache,
   deps: {
-    config: configServiceRef,
-    plugin: pluginMetadataServiceRef,
+    config: coreServices.config,
+    plugin: coreServices.pluginMetadata,
   },
   async factory({ config }) {
     const cacheManager = CacheManager.fromConfig(config);

--- a/packages/backend-app-api/src/services/implementations/configService.ts
+++ b/packages/backend-app-api/src/services/implementations/configService.ts
@@ -16,17 +16,16 @@
 
 import { loadBackendConfig } from '@backstage/backend-common';
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
   loggerToWinstonLogger,
-  rootLoggerServiceRef,
 } from '@backstage/backend-plugin-api';
 
 /** @public */
 export const configFactory = createServiceFactory({
-  service: configServiceRef,
+  service: coreServices.config,
   deps: {
-    logger: rootLoggerServiceRef,
+    logger: coreServices.rootLogger,
   },
   async factory({ logger }) {
     const config = await loadBackendConfig({

--- a/packages/backend-app-api/src/services/implementations/databaseService.ts
+++ b/packages/backend-app-api/src/services/implementations/databaseService.ts
@@ -16,18 +16,16 @@
 
 import { DatabaseManager } from '@backstage/backend-common';
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
-  databaseServiceRef,
-  pluginMetadataServiceRef,
 } from '@backstage/backend-plugin-api';
 
 /** @public */
 export const databaseFactory = createServiceFactory({
-  service: databaseServiceRef,
+  service: coreServices.database,
   deps: {
-    config: configServiceRef,
-    plugin: pluginMetadataServiceRef,
+    config: coreServices.config,
+    plugin: coreServices.pluginMetadata,
   },
   async factory({ config }) {
     const databaseManager = DatabaseManager.fromConfig(config);

--- a/packages/backend-app-api/src/services/implementations/discoveryService.ts
+++ b/packages/backend-app-api/src/services/implementations/discoveryService.ts
@@ -16,16 +16,15 @@
 
 import { SingleHostDiscovery } from '@backstage/backend-common';
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
-  discoveryServiceRef,
 } from '@backstage/backend-plugin-api';
 
 /** @public */
 export const discoveryFactory = createServiceFactory({
-  service: discoveryServiceRef,
+  service: coreServices.discovery,
   deps: {
-    config: configServiceRef,
+    config: coreServices.config,
   },
   async factory({ config }) {
     const discovery = SingleHostDiscovery.fromConfig(config);

--- a/packages/backend-app-api/src/services/implementations/httpRouterService.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouterService.ts
@@ -16,9 +16,7 @@
 
 import {
   createServiceFactory,
-  httpRouterServiceRef,
-  configServiceRef,
-  pluginMetadataServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import Router from 'express-promise-router';
 import { Handler } from 'express';
@@ -36,10 +34,10 @@ export type HttpRouterFactoryOptions = {
 
 /** @public */
 export const httpRouterFactory = createServiceFactory({
-  service: httpRouterServiceRef,
+  service: coreServices.httpRouter,
   deps: {
-    config: configServiceRef,
-    plugin: pluginMetadataServiceRef,
+    config: coreServices.config,
+    plugin: coreServices.pluginMetadata,
   },
   async factory({ config }, options?: HttpRouterFactoryOptions) {
     const defaultPluginId = options?.indexPlugin ?? 'app';

--- a/packages/backend-app-api/src/services/implementations/lifecycleService.ts
+++ b/packages/backend-app-api/src/services/implementations/lifecycleService.ts
@@ -16,10 +16,8 @@
 import {
   BackendLifecycle,
   createServiceFactory,
-  lifecycleServiceRef,
+  coreServices,
   loggerToWinstonLogger,
-  pluginMetadataServiceRef,
-  rootLoggerServiceRef,
   BackendLifecycleShutdownHook,
 } from '@backstage/backend-plugin-api';
 import { Logger } from 'winston';
@@ -80,10 +78,10 @@ class PluginScopedLifecycleImpl implements BackendLifecycle {
  * Allows plugins to register shutdown hooks that are run when the process is about to exit.
  * @public */
 export const lifecycleFactory = createServiceFactory({
-  service: lifecycleServiceRef,
+  service: coreServices.lifecycle,
   deps: {
-    logger: rootLoggerServiceRef,
-    plugin: pluginMetadataServiceRef,
+    logger: coreServices.rootLogger,
+    plugin: coreServices.pluginMetadata,
   },
   async factory({ logger }) {
     const rootLifecycle = new BackendLifecycleImpl(

--- a/packages/backend-app-api/src/services/implementations/loggerService.ts
+++ b/packages/backend-app-api/src/services/implementations/loggerService.ts
@@ -16,17 +16,15 @@
 
 import {
   createServiceFactory,
-  loggerServiceRef,
-  pluginMetadataServiceRef,
-  rootLoggerServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 
 /** @public */
 export const loggerFactory = createServiceFactory({
-  service: loggerServiceRef,
+  service: coreServices.logger,
   deps: {
-    rootLogger: rootLoggerServiceRef,
-    plugin: pluginMetadataServiceRef,
+    rootLogger: coreServices.rootLogger,
+    plugin: coreServices.pluginMetadata,
   },
   async factory({ rootLogger }) {
     return async ({ plugin }) => {

--- a/packages/backend-app-api/src/services/implementations/permissionsService.ts
+++ b/packages/backend-app-api/src/services/implementations/permissionsService.ts
@@ -15,21 +15,18 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
-  discoveryServiceRef,
-  permissionsServiceRef,
-  tokenManagerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 
 /** @public */
 export const permissionsFactory = createServiceFactory({
-  service: permissionsServiceRef,
+  service: coreServices.permissions,
   deps: {
-    config: configServiceRef,
-    discovery: discoveryServiceRef,
-    tokenManager: tokenManagerServiceRef,
+    config: coreServices.config,
+    discovery: coreServices.discovery,
+    tokenManager: coreServices.tokenManager,
   },
   async factory({ config }) {
     return async ({ discovery, tokenManager }) => {

--- a/packages/backend-app-api/src/services/implementations/rootLoggerService.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLoggerService.ts
@@ -18,7 +18,7 @@ import { createRootLogger } from '@backstage/backend-common';
 import {
   createServiceFactory,
   Logger,
-  rootLoggerServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { Logger as WinstonLogger } from 'winston';
 
@@ -40,7 +40,7 @@ class BackstageLogger implements Logger {
 
 /** @public */
 export const rootLoggerFactory = createServiceFactory({
-  service: rootLoggerServiceRef,
+  service: coreServices.rootLogger,
   deps: {},
   async factory() {
     return BackstageLogger.fromWinston(createRootLogger());

--- a/packages/backend-app-api/src/services/implementations/schedulerService.ts
+++ b/packages/backend-app-api/src/services/implementations/schedulerService.ts
@@ -15,19 +15,17 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
-  pluginMetadataServiceRef,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { TaskScheduler } from '@backstage/backend-tasks';
 
 /** @public */
 export const schedulerFactory = createServiceFactory({
-  service: schedulerServiceRef,
+  service: coreServices.scheduler,
   deps: {
-    config: configServiceRef,
-    plugin: pluginMetadataServiceRef,
+    config: coreServices.config,
+    plugin: coreServices.pluginMetadata,
   },
   async factory({ config }) {
     const taskScheduler = TaskScheduler.fromConfig(config);

--- a/packages/backend-app-api/src/services/implementations/tokenManagerService.ts
+++ b/packages/backend-app-api/src/services/implementations/tokenManagerService.ts
@@ -15,20 +15,18 @@
  */
 
 import {
-  configServiceRef,
-  loggerServiceRef,
+  coreServices,
   createServiceFactory,
-  tokenManagerServiceRef,
   loggerToWinstonLogger,
 } from '@backstage/backend-plugin-api';
 import { ServerTokenManager } from '@backstage/backend-common';
 
 /** @public */
 export const tokenManagerFactory = createServiceFactory({
-  service: tokenManagerServiceRef,
+  service: coreServices.tokenManager,
   deps: {
-    config: configServiceRef,
-    logger: loggerServiceRef,
+    config: coreServices.config,
+    logger: coreServices.logger,
   },
   async factory() {
     return async ({ config, logger }) => {

--- a/packages/backend-app-api/src/services/implementations/urlReaderService.ts
+++ b/packages/backend-app-api/src/services/implementations/urlReaderService.ts
@@ -16,19 +16,17 @@
 
 import { UrlReaders } from '@backstage/backend-common';
 import {
-  configServiceRef,
+  coreServices,
   createServiceFactory,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  urlReaderServiceRef,
 } from '@backstage/backend-plugin-api';
 
 /** @public */
 export const urlReaderFactory = createServiceFactory({
-  service: urlReaderServiceRef,
+  service: coreServices.urlReader,
   deps: {
-    config: configServiceRef,
-    logger: loggerServiceRef,
+    config: coreServices.config,
+    logger: coreServices.logger,
   },
   async factory() {
     return async ({ config, logger }) => {

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
@@ -18,7 +18,7 @@ import {
   createServiceRef,
   createServiceFactory,
   ServiceRef,
-  pluginMetadataServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { ServiceRegistry } from './ServiceRegistry';
 
@@ -172,7 +172,7 @@ describe('ServiceRegistry', () => {
     const ref = createServiceRef<{ pluginId: string }>({ id: 'x' });
     const factory = createServiceFactory({
       service: ref,
-      deps: { meta: pluginMetadataServiceRef },
+      deps: { meta: coreServices.pluginMetadata },
       async factory() {
         return async ({ meta }) => ({ pluginId: meta.getId() });
       },

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -17,7 +17,7 @@
 import {
   ServiceFactory,
   ServiceRef,
-  pluginMetadataServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { stringifyError } from '@backstage/errors';
 
@@ -65,10 +65,10 @@ export class ServiceRegistry {
     pluginId: string,
   ): Promise<ServiceFactory> | undefined {
     // Special case handling of the plugin metadata service, generating a custom factory for it each time
-    if (ref.id === pluginMetadataServiceRef.id) {
+    if (ref.id === coreServices.pluginMetadata.id) {
       return Promise.resolve({
         scope: 'plugin',
-        service: pluginMetadataServiceRef,
+        service: coreServices.pluginMetadata,
         deps: {},
         factory: async () => async () => ({
           getId() {
@@ -114,7 +114,7 @@ export class ServiceRegistry {
 
   #checkForMissingDeps(factory: ServiceFactory, pluginId: string) {
     const missingDeps = Object.values(factory.deps).filter(ref => {
-      if (ref.id === pluginMetadataServiceRef.id) {
+      if (ref.id === coreServices.pluginMetadata.id) {
         return false;
       }
       if (this.#providedFactories.get(ref.id)) {

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -76,10 +76,29 @@ export interface BackendRegistrationPoints {
 }
 
 // @public (undocumented)
-export const cacheServiceRef: ServiceRef<PluginCacheManager, 'plugin'>;
+const cacheServiceRef: ServiceRef<PluginCacheManager, 'plugin'>;
 
 // @public (undocumented)
-export const configServiceRef: ServiceRef<Config, 'root'>;
+const configServiceRef: ServiceRef<Config, 'root'>;
+
+declare namespace coreServices {
+  export {
+    configServiceRef as config,
+    httpRouterServiceRef as httpRouter,
+    loggerServiceRef as logger,
+    urlReaderServiceRef as urlReader,
+    cacheServiceRef as cache,
+    databaseServiceRef as database,
+    discoveryServiceRef as discovery,
+    tokenManagerServiceRef as tokenManager,
+    permissionsServiceRef as permissions,
+    schedulerServiceRef as scheduler,
+    rootLoggerServiceRef as rootLogger,
+    pluginMetadataServiceRef as pluginMetadata,
+    lifecycleServiceRef as lifecycle,
+  };
+}
+export { coreServices };
 
 // @public
 export function createBackendModule<
@@ -146,10 +165,10 @@ export function createServiceRef<T>(options: {
 }): ServiceRef<T, 'root'>;
 
 // @public (undocumented)
-export const databaseServiceRef: ServiceRef<PluginDatabaseManager, 'plugin'>;
+const databaseServiceRef: ServiceRef<PluginDatabaseManager, 'plugin'>;
 
 // @public (undocumented)
-export const discoveryServiceRef: ServiceRef<PluginEndpointDiscovery, 'plugin'>;
+const discoveryServiceRef: ServiceRef<PluginEndpointDiscovery, 'plugin'>;
 
 // @public
 export type ExtensionPoint<T> = {
@@ -166,10 +185,10 @@ export interface HttpRouterService {
 }
 
 // @public (undocumented)
-export const httpRouterServiceRef: ServiceRef<HttpRouterService, 'plugin'>;
+const httpRouterServiceRef: ServiceRef<HttpRouterService, 'plugin'>;
 
 // @public (undocumented)
-export const lifecycleServiceRef: ServiceRef<BackendLifecycle, 'plugin'>;
+const lifecycleServiceRef: ServiceRef<BackendLifecycle, 'plugin'>;
 
 // @public (undocumented)
 export interface Logger {
@@ -180,7 +199,7 @@ export interface Logger {
 }
 
 // @public (undocumented)
-export const loggerServiceRef: ServiceRef<Logger, 'plugin'>;
+const loggerServiceRef: ServiceRef<Logger, 'plugin'>;
 
 // @public (undocumented)
 export function loggerToWinstonLogger(
@@ -189,7 +208,7 @@ export function loggerToWinstonLogger(
 ): Logger_2;
 
 // @public (undocumented)
-export const permissionsServiceRef: ServiceRef<
+const permissionsServiceRef: ServiceRef<
   PermissionAuthorizer | PermissionEvaluator,
   'plugin'
 >;
@@ -201,13 +220,13 @@ export interface PluginMetadata {
 }
 
 // @public (undocumented)
-export const pluginMetadataServiceRef: ServiceRef<PluginMetadata, 'plugin'>;
+const pluginMetadataServiceRef: ServiceRef<PluginMetadata, 'plugin'>;
 
 // @public (undocumented)
-export const rootLoggerServiceRef: ServiceRef<Logger, 'root'>;
+const rootLoggerServiceRef: ServiceRef<Logger, 'root'>;
 
 // @public (undocumented)
-export const schedulerServiceRef: ServiceRef<PluginTaskScheduler, 'plugin'>;
+const schedulerServiceRef: ServiceRef<PluginTaskScheduler, 'plugin'>;
 
 // @public (undocumented)
 export type ServiceFactory<TService = unknown> =
@@ -249,7 +268,7 @@ export type ServiceRef<
 };
 
 // @public (undocumented)
-export const tokenManagerServiceRef: ServiceRef<TokenManager, 'plugin'>;
+const tokenManagerServiceRef: ServiceRef<TokenManager, 'plugin'>;
 
 // @public (undocumented)
 export type TypesToServiceRef<T> = {
@@ -257,5 +276,5 @@ export type TypesToServiceRef<T> = {
 };
 
 // @public (undocumented)
-export const urlReaderServiceRef: ServiceRef<UrlReader, 'plugin'>;
+const urlReaderServiceRef: ServiceRef<UrlReader, 'plugin'>;
 ```

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { configServiceRef as config } from './configServiceRef';
+export { httpRouterServiceRef as httpRouter } from './httpRouterServiceRef';
+export { loggerServiceRef as logger } from './loggerServiceRef';
+export { urlReaderServiceRef as urlReader } from './urlReaderServiceRef';
+export { cacheServiceRef as cache } from './cacheServiceRef';
+export { databaseServiceRef as database } from './databaseServiceRef';
+export { discoveryServiceRef as discovery } from './discoveryServiceRef';
+export { tokenManagerServiceRef as tokenManager } from './tokenManagerServiceRef';
+export { permissionsServiceRef as permissions } from './permissionsServiceRef';
+export { schedulerServiceRef as scheduler } from './schedulerServiceRef';
+export { rootLoggerServiceRef as rootLogger } from './rootLoggerServiceRef';
+export { pluginMetadataServiceRef as pluginMetadata } from './pluginMetadataServiceRef';
+export { lifecycleServiceRef as lifecycle } from './lifecycleServiceRef';

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -14,21 +14,11 @@
  * limitations under the License.
  */
 
-export { configServiceRef } from './configServiceRef';
-export { httpRouterServiceRef } from './httpRouterServiceRef';
+import * as coreServices from './coreServices';
+
+export { coreServices };
 export type { HttpRouterService } from './httpRouterServiceRef';
-export { loggerServiceRef } from './loggerServiceRef';
 export type { Logger } from './loggerServiceRef';
-export { urlReaderServiceRef } from './urlReaderServiceRef';
-export { cacheServiceRef } from './cacheServiceRef';
-export { databaseServiceRef } from './databaseServiceRef';
-export { discoveryServiceRef } from './discoveryServiceRef';
-export { tokenManagerServiceRef } from './tokenManagerServiceRef';
-export { permissionsServiceRef } from './permissionsServiceRef';
-export { schedulerServiceRef } from './schedulerServiceRef';
-export { rootLoggerServiceRef } from './rootLoggerServiceRef';
-export { pluginMetadataServiceRef } from './pluginMetadataServiceRef';
-export { lifecycleServiceRef } from './lifecycleServiceRef';
 export type {
   BackendLifecycle,
   BackendLifecycleShutdownHook,

--- a/plugins/app-backend/src/service/appPlugin.test.ts
+++ b/plugins/app-backend/src/service/appPlugin.test.ts
@@ -17,7 +17,7 @@
 import mockFs from 'mock-fs';
 import { resolve as resolvePath } from 'path';
 import fetch from 'node-fetch';
-import { configServiceRef } from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { appPlugin } from './appPlugin';
 import {
@@ -51,7 +51,7 @@ describe('appPlugin', () => {
     await startTestBackend({
       services: [
         [
-          configServiceRef,
+          coreServices.config,
           new ConfigReader({
             backend: {
               listen: { port },

--- a/plugins/app-backend/src/service/appPlugin.ts
+++ b/plugins/app-backend/src/service/appPlugin.ts
@@ -16,12 +16,9 @@
 
 import express from 'express';
 import {
-  configServiceRef,
+  coreServices,
   createBackendPlugin,
-  databaseServiceRef,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  httpRouterServiceRef,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './router';
 
@@ -78,10 +75,10 @@ export const appPlugin = createBackendPlugin({
   register(env, options: AppPluginOptions) {
     env.registerInit({
       deps: {
-        logger: loggerServiceRef,
-        config: configServiceRef,
-        database: databaseServiceRef,
-        httpRouter: httpRouterServiceRef,
+        logger: coreServices.logger,
+        config: coreServices.config,
+        database: coreServices.database,
+        httpRouter: coreServices.httpRouter,
       },
       async init({ logger, config, database, httpRouter }) {
         const {

--- a/plugins/catalog-backend-module-aws/src/service/AwsS3EntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-aws/src/service/AwsS3EntityProviderCatalogModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -66,9 +62,9 @@ describe('awsS3EntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [awsS3EntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-aws/src/service/AwsS3EntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-aws/src/service/AwsS3EntityProviderCatalogModule.ts
@@ -15,11 +15,9 @@
  */
 
 import {
+  coreServices,
   createBackendModule,
   loggerToWinstonLogger,
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { AwsS3EntityProvider } from '../providers';
@@ -35,10 +33,10 @@ export const awsS3EntityProviderCatalogModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
+        config: coreServices.config,
         catalog: catalogProcessingExtensionPoint,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ config, catalog, logger, scheduler }) {
         catalog.addEntityProvider(

--- a/plugins/catalog-backend-module-azure/src/service/AzureDevOpsEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-azure/src/service/AzureDevOpsEntityProviderCatalogModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -69,9 +65,9 @@ describe('azureDevOpsEntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [azureDevOpsEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-azure/src/service/AzureDevOpsEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-azure/src/service/AzureDevOpsEntityProviderCatalogModule.ts
@@ -17,9 +17,7 @@
 import {
   createBackendModule,
   loggerToWinstonLogger,
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { AzureDevOpsEntityProvider } from '../providers';
@@ -35,10 +33,10 @@ export const azureDevOpsEntityProviderCatalogModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
+        config: coreServices.config,
         catalog: catalogProcessingExtensionPoint,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ config, catalog, logger, scheduler }) {
         catalog.addEntityProvider(

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/service/BitbucketCloudEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/service/BitbucketCloudEntityProviderCatalogModule.test.ts
@@ -20,13 +20,7 @@ import {
   PluginEndpointDiscovery,
   TokenManager,
 } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  discoveryServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-  tokenManagerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -84,11 +78,11 @@ describe('bitbucketCloudEntityProviderCatalogModule', () => {
         [eventsExtensionPoint, eventsExtensionPointImpl],
       ],
       services: [
-        [configServiceRef, config],
-        [discoveryServiceRef, discovery],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
-        [tokenManagerServiceRef, tokenManager],
+        [coreServices.config, config],
+        [coreServices.discovery, discovery],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
+        [coreServices.tokenManager, tokenManager],
       ],
       features: [bitbucketCloudEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/service/BitbucketCloudEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/service/BitbucketCloudEntityProviderCatalogModule.ts
@@ -15,12 +15,9 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  schedulerServiceRef,
-  tokenManagerServiceRef,
 } from '@backstage/backend-plugin-api';
 import {
   catalogProcessingExtensionPoint,
@@ -40,13 +37,13 @@ export const bitbucketCloudEntityProviderCatalogModule = createBackendModule({
       deps: {
         catalog: catalogProcessingExtensionPoint,
         catalogApi: catalogServiceRef,
-        config: configServiceRef,
+        config: coreServices.config,
         // TODO(pjungermann): How to make this optional for those which only want the provider without event support?
         //  Do we even want to support this?
         events: eventsExtensionPoint,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
-        tokenManager: tokenManagerServiceRef,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
+        tokenManager: coreServices.tokenManager,
       },
       async init({
         catalog,

--- a/plugins/catalog-backend-module-bitbucket-server/src/service/BitbucketServerEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/service/BitbucketServerEntityProviderCatalogModule.test.ts
@@ -16,11 +16,7 @@
 
 import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -73,9 +69,9 @@ describe('bitbucketServerEntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [bitbucketServerEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-bitbucket-server/src/service/BitbucketServerEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/service/BitbucketServerEntityProviderCatalogModule.ts
@@ -15,11 +15,9 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { BitbucketServerEntityProvider } from '../providers';
@@ -34,9 +32,9 @@ export const bitbucketServerEntityProviderCatalogModule = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: configServiceRef,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        config: coreServices.config,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ catalog, config, logger, scheduler }) {
         const winstonLogger = loggerToWinstonLogger(logger);

--- a/plugins/catalog-backend-module-gerrit/src/service/GerritEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/service/GerritEntityProviderCatalogModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -79,9 +75,9 @@ describe('gerritEntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [gerritEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-gerrit/src/service/GerritEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-gerrit/src/service/GerritEntityProviderCatalogModule.ts
@@ -15,11 +15,9 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { GerritEntityProvider } from '../providers/GerritEntityProvider';
@@ -34,9 +32,9 @@ export const gerritEntityProviderCatalogModule = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: configServiceRef,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        config: coreServices.config,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ catalog, config, logger, scheduler }) {
         const winstonLogger = loggerToWinstonLogger(logger);

--- a/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -66,9 +62,9 @@ describe('githubEntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [githubEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-github/src/service/GithubEntityProviderCatalogModule.ts
@@ -17,9 +17,7 @@
 import {
   createBackendModule,
   loggerToWinstonLogger,
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { GithubEntityProvider } from '../providers/GithubEntityProvider';
@@ -36,9 +34,9 @@ export const githubEntityProviderCatalogModule = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: configServiceRef,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        config: coreServices.config,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ catalog, config, logger, scheduler }) {
         catalog.addEntityProvider(

--- a/plugins/catalog-backend-module-gitlab/src/service/GitlabDiscoveryEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/service/GitlabDiscoveryEntityProviderCatalogModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -78,9 +74,9 @@ describe('gitlabDiscoveryEntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [gitlabDiscoveryEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-gitlab/src/service/GitlabDiscoveryEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-gitlab/src/service/GitlabDiscoveryEntityProviderCatalogModule.ts
@@ -17,9 +17,7 @@
 import {
   createBackendModule,
   loggerToWinstonLogger,
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { GitlabDiscoveryEntityProvider } from '../providers';
@@ -35,10 +33,10 @@ export const gitlabDiscoveryEntityProviderCatalogModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
+        config: coreServices.config,
         catalog: catalogProcessingExtensionPoint,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ config, catalog, logger, scheduler }) {
         catalog.addEntityProvider(

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/incrementalIngestionEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/incrementalIngestionEntityProviderCatalogModule.test.ts
@@ -15,13 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  databaseServiceRef,
-  httpRouterServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
@@ -56,11 +50,11 @@ describe('bitbucketServerEntityProviderCatalogModule', () => {
         [catalogProcessingExtensionPoint, { addEntityProvider }],
       ],
       services: [
-        [configServiceRef, new ConfigReader({})],
-        [databaseServiceRef, database],
-        [httpRouterServiceRef, httpRouter],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, new ConfigReader({})],
+        [coreServices.database, database],
+        [coreServices.httpRouter, httpRouter],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [
         incrementalIngestionEntityProviderCatalogModule({

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/incrementalIngestionEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/incrementalIngestionEntityProviderCatalogModule.ts
@@ -15,12 +15,8 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  databaseServiceRef,
-  httpRouterServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import {
@@ -50,11 +46,11 @@ export const incrementalIngestionEntityProviderCatalogModule =
       env.registerInit({
         deps: {
           catalog: catalogProcessingExtensionPoint,
-          config: configServiceRef,
-          database: databaseServiceRef,
-          httpRouter: httpRouterServiceRef,
-          logger: loggerServiceRef,
-          scheduler: schedulerServiceRef,
+          config: coreServices.config,
+          database: coreServices.database,
+          httpRouter: coreServices.httpRouter,
+          logger: coreServices.logger,
+          scheduler: coreServices.scheduler,
         },
         async init({
           catalog,

--- a/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
@@ -27,7 +27,7 @@ import {
   tokenManagerFactory,
   urlReaderFactory,
 } from '@backstage/backend-app-api';
-import { configServiceRef } from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { catalogPlugin } from '@backstage/plugin-catalog-backend';
@@ -62,7 +62,7 @@ async function main() {
 
   await startTestBackend({
     services: [
-      [configServiceRef, new ConfigReader(config)],
+      [coreServices.config, new ConfigReader(config)],
       databaseFactory(),
       discoveryFactory(),
       httpRouterFactory(),

--- a/plugins/catalog-backend-module-msgraph/src/service/MicrosoftGraphOrgEntityProviderCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/service/MicrosoftGraphOrgEntityProviderCatalogModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import {
   PluginTaskScheduler,
   TaskScheduleDefinition,
@@ -71,9 +67,9 @@ describe('awsS3EntityProviderCatalogModule', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [microsoftGraphOrgEntityProviderCatalogModule()],
     });

--- a/plugins/catalog-backend-module-msgraph/src/service/MicrosoftGraphOrgEntityProviderCatalogModule.ts
+++ b/plugins/catalog-backend-module-msgraph/src/service/MicrosoftGraphOrgEntityProviderCatalogModule.ts
@@ -15,11 +15,9 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import {
@@ -72,9 +70,9 @@ export const microsoftGraphOrgEntityProviderCatalogModule = createBackendModule(
       env.registerInit({
         deps: {
           catalog: catalogProcessingExtensionPoint,
-          config: configServiceRef,
-          logger: loggerServiceRef,
-          scheduler: schedulerServiceRef,
+          config: coreServices.config,
+          logger: coreServices.logger,
+          scheduler: coreServices.scheduler,
         },
         async init({ catalog, config, logger, scheduler }) {
           catalog.addEntityProvider(

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 import {
-  configServiceRef,
   createBackendPlugin,
-  databaseServiceRef,
-  loggerServiceRef,
+  coreServices,
   loggerToWinstonLogger,
-  permissionsServiceRef,
-  urlReaderServiceRef,
-  httpRouterServiceRef,
-  lifecycleServiceRef,
 } from '@backstage/backend-plugin-api';
 import { CatalogBuilder } from './CatalogBuilder';
 import {
@@ -73,13 +67,13 @@ export const catalogPlugin = createBackendPlugin({
 
     env.registerInit({
       deps: {
-        logger: loggerServiceRef,
-        config: configServiceRef,
-        reader: urlReaderServiceRef,
-        permissions: permissionsServiceRef,
-        database: databaseServiceRef,
-        httpRouter: httpRouterServiceRef,
-        lifecycle: lifecycleServiceRef,
+        logger: coreServices.logger,
+        config: coreServices.config,
+        reader: coreServices.urlReader,
+        permissions: coreServices.permissions,
+        database: coreServices.database,
+        httpRouter: coreServices.httpRouter,
+        lifecycle: coreServices.lifecycle,
       },
       async init({
         logger,

--- a/plugins/catalog-node/src/catalogService.test.ts
+++ b/plugins/catalog-node/src/catalogService.test.ts
@@ -18,7 +18,7 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import {
   createBackendModule,
   createServiceFactory,
-  discoveryServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { CatalogClient } from '@backstage/catalog-client';
@@ -29,7 +29,7 @@ describe('catalogServiceRef', () => {
     expect.assertions(1);
 
     const mockDiscoveryFactory = createServiceFactory({
-      service: discoveryServiceRef,
+      service: coreServices.discovery,
       deps: {},
       factory: async ({}) => {
         return async () => jest.fn() as unknown as PluginEndpointDiscovery;

--- a/plugins/catalog-node/src/catalogService.ts
+++ b/plugins/catalog-node/src/catalogService.ts
@@ -17,7 +17,7 @@
 import {
   createServiceFactory,
   createServiceRef,
-  discoveryServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 
@@ -31,7 +31,7 @@ export const catalogServiceRef = createServiceRef<CatalogApi>({
     createServiceFactory({
       service,
       deps: {
-        discoveryApi: discoveryServiceRef,
+        discoveryApi: coreServices.discovery,
       },
       async factory() {
         return async ({ discoveryApi }) => {

--- a/plugins/events-backend-module-aws-sqs/src/service/AwsSqsConsumingEventPublisherEventsModule.test.ts
+++ b/plugins/events-backend-module-aws-sqs/src/service/AwsSqsConsumingEventPublisherEventsModule.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import {
-  configServiceRef,
-  loggerServiceRef,
-  schedulerServiceRef,
-} from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { eventsExtensionPoint } from '@backstage/plugin-events-node';
@@ -68,9 +64,9 @@ describe('awsSqsEventsModule', () => {
     await startTestBackend({
       extensionPoints: [[eventsExtensionPoint, extensionPoint]],
       services: [
-        [configServiceRef, config],
-        [loggerServiceRef, getVoidLogger()],
-        [schedulerServiceRef, scheduler],
+        [coreServices.config, config],
+        [coreServices.logger, getVoidLogger()],
+        [coreServices.scheduler, scheduler],
       ],
       features: [awsSqsConsumingEventPublisherEventsModule()],
     });

--- a/plugins/events-backend-module-aws-sqs/src/service/AwsSqsConsumingEventPublisherEventsModule.ts
+++ b/plugins/events-backend-module-aws-sqs/src/service/AwsSqsConsumingEventPublisherEventsModule.ts
@@ -15,11 +15,9 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  loggerServiceRef,
   loggerToWinstonLogger,
-  schedulerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { eventsExtensionPoint } from '@backstage/plugin-events-node';
 import { AwsSqsConsumingEventPublisher } from '../publisher/AwsSqsConsumingEventPublisher';
@@ -35,10 +33,10 @@ export const awsSqsConsumingEventPublisherEventsModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
+        config: coreServices.config,
         events: eventsExtensionPoint,
-        logger: loggerServiceRef,
-        scheduler: schedulerServiceRef,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
       },
       async init({ config, events, logger, scheduler }) {
         const winstonLogger = loggerToWinstonLogger(logger);

--- a/plugins/events-backend-module-github/src/service/GithubWebhookEventsModule.test.ts
+++ b/plugins/events-backend-module-github/src/service/GithubWebhookEventsModule.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { configServiceRef } from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import {
@@ -59,7 +59,7 @@ describe('githubWebhookEventsModule', () => {
 
     await startTestBackend({
       extensionPoints: [[eventsExtensionPoint, extensionPoint]],
-      services: [[configServiceRef, config]],
+      services: [[coreServices.config, config]],
       features: [githubWebhookEventsModule()],
     });
 

--- a/plugins/events-backend-module-github/src/service/GithubWebhookEventsModule.ts
+++ b/plugins/events-backend-module-github/src/service/GithubWebhookEventsModule.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { eventsExtensionPoint } from '@backstage/plugin-events-node';
@@ -34,7 +34,7 @@ export const githubWebhookEventsModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
+        config: coreServices.config,
         events: eventsExtensionPoint,
       },
       async init({ config, events }) {

--- a/plugins/events-backend-module-gitlab/src/service/GitlabWebhookEventsModule.test.ts
+++ b/plugins/events-backend-module-gitlab/src/service/GitlabWebhookEventsModule.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { configServiceRef } from '@backstage/backend-plugin-api';
+import { coreServices } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import {
@@ -54,7 +54,7 @@ describe('gitlabWebhookEventsModule', () => {
 
     await startTestBackend({
       extensionPoints: [[eventsExtensionPoint, extensionPoint]],
-      services: [[configServiceRef, config]],
+      services: [[coreServices.config, config]],
       features: [gitlabWebhookEventsModule()],
     });
 

--- a/plugins/events-backend-module-gitlab/src/service/GitlabWebhookEventsModule.ts
+++ b/plugins/events-backend-module-gitlab/src/service/GitlabWebhookEventsModule.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { eventsExtensionPoint } from '@backstage/plugin-events-node';
@@ -36,7 +36,7 @@ export const gitlabWebhookEventsModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: configServiceRef,
+        config: coreServices.config,
         events: eventsExtensionPoint,
       },
       async init({ config, events }) {

--- a/plugins/events-backend/src/service/EventsPlugin.test.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.test.ts
@@ -17,10 +17,8 @@
 import { errorHandler, getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import {
-  configServiceRef,
+  coreServices,
   createBackendModule,
-  httpRouterServiceRef,
-  loggerServiceRef,
 } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { eventsExtensionPoint } from '@backstage/plugin-events-node';
@@ -73,9 +71,9 @@ describe('eventPlugin', () => {
     await startTestBackend({
       extensionPoints: [],
       services: [
-        [configServiceRef, config],
-        [httpRouterServiceRef, httpRouter],
-        [loggerServiceRef, getVoidLogger()],
+        [coreServices.config, config],
+        [coreServices.httpRouter, httpRouter],
+        [coreServices.logger, getVoidLogger()],
       ],
       features: [eventsPlugin(), testModule()],
     });

--- a/plugins/events-backend/src/service/EventsPlugin.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.ts
@@ -15,10 +15,8 @@
  */
 
 import {
-  configServiceRef,
   createBackendPlugin,
-  httpRouterServiceRef,
-  loggerServiceRef,
+  coreServices,
   loggerToWinstonLogger,
 } from '@backstage/backend-plugin-api';
 import {
@@ -89,9 +87,9 @@ export const eventsPlugin = createBackendPlugin({
 
     env.registerInit({
       deps: {
-        config: configServiceRef,
-        logger: loggerServiceRef,
-        router: httpRouterServiceRef,
+        config: coreServices.config,
+        logger: coreServices.logger,
+        router: coreServices.httpRouter,
       },
       async init({ config, logger, router }) {
         const winstonLogger = loggerToWinstonLogger(logger);

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 import {
-  configServiceRef,
   createBackendPlugin,
-  databaseServiceRef,
-  loggerServiceRef,
+  coreServices,
   loggerToWinstonLogger,
-  permissionsServiceRef,
-  urlReaderServiceRef,
-  httpRouterServiceRef,
   createExtensionPoint,
 } from '@backstage/backend-plugin-api';
 import { ScmIntegrations } from '@backstage/integration';
@@ -86,12 +81,12 @@ export const scaffolderPlugin = createBackendPlugin({
 
     env.registerInit({
       deps: {
-        logger: loggerServiceRef,
-        config: configServiceRef,
-        reader: urlReaderServiceRef,
-        permissions: permissionsServiceRef,
-        database: databaseServiceRef,
-        httpRouter: httpRouterServiceRef,
+        logger: coreServices.logger,
+        config: coreServices.config,
+        reader: coreServices.urlReader,
+        permissions: coreServices.permissions,
+        database: coreServices.database,
+        httpRouter: coreServices.httpRouter,
         catalogClient: catalogServiceRef,
       },
       async init({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹 , proposing this for better discoverability and fewer imports to juggle around. Just suggesting this for the core services specifically at this point, not as a general naming pattern.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
