### PR TITLE
fix: allow overriding of StackOverflow configuration

### DIFF
--- a/.changeset/olive-eyes-sing.md
+++ b/.changeset/olive-eyes-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow-backend': minor
+---
+
+Enable configuration override for StackOverflow backend plugin when instantiating the search indexer. This makes it possible to set different configuration for frontend and backend of the plugin.

--- a/plugins/stack-overflow-backend/package.json
+++ b/plugins/stack-overflow-backend/package.json
@@ -32,12 +32,18 @@
     "clean": "backstage-cli package clean"
   },
   "dependencies": {
-    "@backstage/cli": "workspace:^",
+    "@backstage/backend-common": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "node-fetch": "^2.6.7",
     "qs": "^6.9.4",
     "winston": "^3.2.1"
+  },
+  "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
+    "@backstage/cli": "workspace:^",
+    "@backstage/plugin-search-backend-node": "workspace:^",
+    "msw": "^0.49.0"
   },
   "files": [
     "dist",

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.test.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getVoidLogger } from '@backstage/backend-common';
+import {
+  StackOverflowQuestionsCollatorFactory,
+  StackOverflowQuestionsCollatorFactoryOptions,
+} from './StackOverflowQuestionsCollatorFactory';
+import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
+import { TestPipeline } from '@backstage/plugin-search-backend-node';
+import { ConfigReader } from '@backstage/config';
+import { Readable } from 'stream';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+const logger = getVoidLogger();
+
+const mockQuestion = {
+  items: [
+    {
+      tags: ['backstage'],
+      owner: {
+        display_name: 'The Riddler',
+      },
+      answer_count: 1,
+      link: 'https://stack.overflow.local/questions/2911',
+      title: 'This is the first question',
+    },
+  ],
+  has_more: false,
+};
+
+const mockOverrideQuestion = {
+  items: [
+    {
+      tags: ['backstage'],
+      owner: {
+        display_name: 'The Riddler',
+      },
+      answer_count: 1,
+      link: 'https://stack.overflow.local/questions/1',
+      title: 'This is the first question',
+    },
+    {
+      tags: ['backstage'],
+      owner: {
+        display_name: 'The Riddler',
+      },
+      answer_count: 1,
+      link: 'https://stack.overflow.local/questions/2',
+      title: 'this is another question',
+    },
+  ],
+  has_more: false,
+};
+
+describe('StackOverflowQuestionsCollatorFactory', () => {
+  const config = new ConfigReader({
+    stackoverflow: {
+      baseUrl: 'http://stack.overflow.local',
+    },
+  });
+
+  const defaultOptions: StackOverflowQuestionsCollatorFactoryOptions = {
+    logger,
+    requestParams: {
+      tagged: ['developer-portal'],
+      pagesize: 100,
+      order: 'desc',
+      sort: 'activity',
+    },
+  };
+
+  it('has expected type', () => {
+    const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
+      config,
+      defaultOptions,
+    );
+    expect(factory.type).toBe('stack-overflow');
+  });
+
+  describe('getCollator', () => {
+    const worker = setupServer();
+    setupRequestMockHandlers(worker);
+
+    afterEach(async () => {
+      worker.resetHandlers();
+    });
+
+    afterAll(async () => {
+      worker.close();
+    });
+
+    it('returns a readable stream', async () => {
+      const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
+        config,
+        defaultOptions,
+      );
+      const collator = await factory.getCollator();
+      expect(collator).toBeInstanceOf(Readable);
+    });
+
+    it('fetches from the configured endpoint', async () => {
+      worker.use(
+        rest.get('http://stack.overflow.local/questions', (_, res, ctx) =>
+          res(ctx.status(200), ctx.json(mockQuestion)),
+        ),
+      );
+      const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
+        config,
+        defaultOptions,
+      );
+      const collator = await factory.getCollator();
+      const pipeline = TestPipeline.fromCollator(collator);
+      const { documents } = await pipeline.execute();
+
+      expect(documents).toHaveLength(mockQuestion.items.length);
+    });
+
+    it('fetches from the overridden endpoint', async () => {
+      worker.use(
+        rest.get('http://stack.overflow.override/questions', (_, res, ctx) =>
+          res(ctx.status(200), ctx.json(mockOverrideQuestion)),
+        ),
+      );
+      const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
+        logger,
+        baseUrl: 'http://stack.overflow.override',
+        requestParams: defaultOptions.requestParams,
+      });
+      const collator = await factory.getCollator();
+
+      const pipeline = TestPipeline.fromCollator(collator);
+      const { documents } = await pipeline.execute();
+
+      expect(documents).toHaveLength(mockOverrideQuestion.items.length);
+    });
+  });
+});

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.test.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.test.ts
@@ -95,14 +95,6 @@ describe('StackOverflowQuestionsCollatorFactory', () => {
     const worker = setupServer();
     setupRequestMockHandlers(worker);
 
-    afterEach(async () => {
-      worker.resetHandlers();
-    });
-
-    afterAll(async () => {
-      worker.close();
-    });
-
     it('returns a readable stream', async () => {
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
         config,

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -95,11 +95,11 @@ export class StackOverflowQuestionsCollatorFactory
       'https://api.stackexchange.com/2.2';
     const maxPage = options.maxPage || 100;
     return new StackOverflowQuestionsCollatorFactory({
-      ...options,
       baseUrl,
       maxPage,
       apiKey,
       apiAccessToken,
+      ...options,
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7845,9 +7845,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-stack-overflow-backend@workspace:plugins/stack-overflow-backend"
   dependencies:
+    "@backstage/backend-common": "workspace:^"
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/plugin-search-backend-node": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
+    msw: ^0.49.0
     node-fetch: ^2.6.7
     qs: ^6.9.4
     winston: ^3.2.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I am currently working on integrating our backstage instance with a private stackoverflow instance.

To make the frontend work I have proxied the private SO API via the proxy functionality. 

But for the backend this means that it will try to go out and hit the public DNS and will require authentication. 

To combat this I want to be able to configure the proxy URL for the frontend and the public URL for the backend. Therefor I want to be able to override the config when instantiating the search indexer. Like this 

```
  indexBuilder.addCollator({
    schedule,
    factory: StackOverflowQuestionsCollatorFactory.fromConfig(env.config, {
      logger: env.logger,
      baseUrl: env.config.get('stackoverflow.backendBaseUrl'),
      requestParams: {
        tagged: ['my-tag'],
        pagesize: 100,
        order: 'desc',
        sort: 'activity',
      },
    }),
  });
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
