### PR TITLE
Add field selection rendering of allowedProjects for BitbucketRepoPicker

### DIFF
--- a/.changeset/wet-tips-yawn.md
+++ b/.changeset/wet-tips-yawn.md
@@ -3,4 +3,8 @@
 '@backstage/plugin-scaffolder-backend': minor
 ---
 
-Add field selection rendering of allowed Projects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowed Projects
+Add field selection rendering of allowed Projects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowed Projects.
+
+Add comments about expected values for BitbucketRepoPicker: Projects and workspaces
+
+Update tests to cover null, empty list, and list values for allowed Bitbucket projects

--- a/.changeset/wet-tips-yawn.md
+++ b/.changeset/wet-tips-yawn.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
-Add field selection rendering of allowedProjects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowedProjects
+Add field selection rendering of allowed Projects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowed Projects

--- a/.changeset/wet-tips-yawn.md
+++ b/.changeset/wet-tips-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Add field selection rendering of allowedProjects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowedProjects

--- a/.changeset/wet-tips-yawn.md
+++ b/.changeset/wet-tips-yawn.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-scaffolder': minor
-'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Add field selection rendering of allowed Projects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowed Projects.

--- a/.changeset/wet-tips-yawn.md
+++ b/.changeset/wet-tips-yawn.md
@@ -2,8 +2,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-Add field selection rendering of allowed Projects for BitbucketRepoPicker. Allows a user to define allowed projects via the ui:field RepoUrlPicker ui:options allowed Projects.
-
-Add comments about expected values for BitbucketRepoPicker: Projects and workspaces
-
-Update tests to cover null, empty list, and list values for allowed Bitbucket projects
+The `RepoUrlPicker` field extension now has an `allowedProjects` option for narrowing the selection of Bitbucket URLs.

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -20,7 +20,15 @@ spec:
           ui:options:
             allowedHosts:
               - bitbucket.org
-              - server.bitbucket.com
+            allowedOwners:
+              - WORKSPACE1
+              - WORKSPACE2
+            allowedProjects:
+              - PROJECT1
+              - PROJECT2
+            allowedRepos:
+              - REPO1
+              - REPO2
     - title: Fill in some steps
       required:
         - name

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -20,15 +20,17 @@ spec:
           ui:options:
             allowedHosts:
               - bitbucket.org
-            allowedOwners:
-              - WORKSPACE1
-              - WORKSPACE2
-            allowedProjects:
-              - PROJECT1
-              - PROJECT2
-            allowedRepos:
-              - REPO1
-              - REPO2
+            # The rest of these options are optional.
+            # You can read more at: https://backstage.io/docs/reference/plugin-scaffolder.repourlpickerfieldextension
+            # allowedOwners:
+            #   - WORKSPACE1
+            #   - WORKSPACE2
+            # allowedProjects:
+            #   - PROJECT1
+            #   - PROJECT2
+            # allowedRepos:
+            #   - REPO1
+            #   - REPO2
     - title: Fill in some steps
       required:
         - name

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -340,6 +340,7 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent<
   {
     allowedOwners?: string[] | undefined;
     allowedOrganizations?: string[] | undefined;
+    allowedProjects?: string[] | undefined;
     allowedRepos?: string[] | undefined;
     allowedHosts?: string[] | undefined;
     requestUserCredentials?:
@@ -365,6 +366,7 @@ export const RepoUrlPickerFieldSchema: FieldSchema<
   {
     allowedOwners?: string[] | undefined;
     allowedOrganizations?: string[] | undefined;
+    allowedProjects?: string[] | undefined;
     allowedRepos?: string[] | undefined;
     allowedHosts?: string[] | undefined;
     requestUserCredentials?:

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
@@ -57,21 +57,6 @@ describe('BitbucketRepoPicker', () => {
     expect(getAllByRole('textbox')).toHaveLength(1);
   });
 
-  it('renders a select if there is a list of allowed projects', async () => {
-    const allowedProjects = ['project1', 'project2'];
-    const { findByText } = render(
-      <BitbucketRepoPicker
-        onChange={jest.fn()}
-        rawErrors={[]}
-        state={{ host: 'bitbucket.org', repoName: 'repo' }}
-        allowedProjects={allowedProjects}
-      />,
-    );
-
-    expect(await findByText('project1')).toBeInTheDocument();
-    expect(await findByText('project2')).toBeInTheDocument();
-  });
-
   describe('workspace field', () => {
     it('calls onChange when the workspace changes', () => {
       const onChange = jest.fn();
@@ -107,6 +92,48 @@ describe('BitbucketRepoPicker', () => {
       fireEvent.change(projectInput, { target: { value: 'test-project' } });
 
       expect(onChange).toHaveBeenCalledWith({ project: 'test-project' });
+    });
+
+    it('Does not render a select if the list of allowed projects does not exist', async () => {
+      const { getAllByRole } = render(
+        <BitbucketRepoPicker
+          onChange={jest.fn()}
+          rawErrors={[]}
+          state={{ host: 'bitbucket.org', repoName: 'repo' }}
+        />,
+      );
+
+      expect(getAllByRole('textbox')).toHaveLength(2);
+      expect(getAllByRole('textbox')[1]).toHaveValue('');
+    });
+
+    it('Does not render a select if the list of allowed projects is empty', async () => {
+      const { getAllByRole } = render(
+        <BitbucketRepoPicker
+          onChange={jest.fn()}
+          rawErrors={[]}
+          state={{ host: 'bitbucket.org', repoName: 'repo' }}
+          allowedProjects={[]}
+        />,
+      );
+
+      expect(getAllByRole('textbox')).toHaveLength(2);
+      expect(getAllByRole('textbox')[1]).toHaveValue('');
+    });
+
+    it('Does render a select if there is a list of allowed projects', async () => {
+      const allowedProjects = ['project1', 'project2'];
+      const { findByText } = render(
+        <BitbucketRepoPicker
+          onChange={jest.fn()}
+          rawErrors={[]}
+          state={{ host: 'bitbucket.org', repoName: 'repo' }}
+          allowedProjects={allowedProjects}
+        />,
+      );
+
+      expect(await findByText('project1')).toBeInTheDocument();
+      expect(await findByText('project2')).toBeInTheDocument();
     });
   });
 });

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
@@ -56,6 +56,22 @@ describe('BitbucketRepoPicker', () => {
 
     expect(getAllByRole('textbox')).toHaveLength(1);
   });
+
+  it('renders a select if there is a list of allowed projects', async () => {
+    const allowedProjects = ['project1', 'project2'];
+    const { findByText } = render(
+      <BitbucketRepoPicker
+        onChange={jest.fn()}
+        rawErrors={[]}
+        state={{ host: 'bitbucket.org', repoName: 'repo' }}
+        allowedProjects={allowedProjects}
+      />,
+    );
+
+    expect(await findByText('project1')).toBeInTheDocument();
+    expect(await findByText('project2')).toBeInTheDocument();
+  });
+
   describe('workspace field', () => {
     it('calls onChange when the workspace changes', () => {
       const onChange = jest.fn();

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -21,6 +21,15 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
+/**
+ * The underlying component that is rendered in the form for the `BitbucketRepoPicker`
+ * field extension.
+ *
+ * @public
+ * @param allowedOwners - Allowed workspaces for the Bitbucket cloud repository
+ * @param allowedProjects - Allowed projects for the Bitbucket cloud repository
+ *
+ */
 export const BitbucketRepoPicker = (props: {
   allowedOwners?: string[];
   allowedProjects?: string[];

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -23,14 +23,24 @@ import { RepoUrlPickerState } from './types';
 
 export const BitbucketRepoPicker = (props: {
   allowedOwners?: string[];
+  allowedProjects?: string[];
   onChange: (state: RepoUrlPickerState) => void;
   state: RepoUrlPickerState;
   rawErrors: string[];
 }) => {
-  const { allowedOwners = [], onChange, rawErrors, state } = props;
+  const {
+    allowedOwners = [],
+    allowedProjects = [],
+    onChange,
+    rawErrors,
+    state,
+  } = props;
   const { host, workspace, project } = state;
   const ownerItems: SelectItem[] = allowedOwners
     ? allowedOwners?.map(i => ({ label: i, value: i }))
+    : [];
+  const projectItems: SelectItem[] = allowedProjects
+    ? allowedProjects?.map(i => ({ label: i, value: i }))
     : [];
 
   useEffect(() => {
@@ -69,7 +79,7 @@ export const BitbucketRepoPicker = (props: {
             </>
           )}
           <FormHelperText>
-            The Organization that this repo will belong to
+            The Workspace that this repo will belong to
           </FormHelperText>
         </FormControl>
       )}
@@ -78,12 +88,27 @@ export const BitbucketRepoPicker = (props: {
         required
         error={rawErrors?.length > 0 && !project}
       >
-        <InputLabel htmlFor="projectInput">Project</InputLabel>
-        <Input
-          id="projectInput"
-          onChange={e => onChange({ project: e.target.value })}
-          value={project}
-        />
+        {allowedProjects?.length ? (
+          <Select
+            native
+            label="Allowed Projects"
+            onChange={s =>
+              onChange({ project: String(Array.isArray(s) ? s[0] : s) })
+            }
+            disabled={allowedProjects.length === 1}
+            selected={project}
+            items={projectItems}
+          />
+        ) : (
+          <>
+            <InputLabel htmlFor="projectInput">Project</InputLabel>
+            <Input
+              id="projectInput"
+              onChange={e => onChange({ project: e.target.value })}
+              value={project}
+            />
+          </>
+        )}
         <FormHelperText>
           The Project that this repo will belong to
         </FormHelperText>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -60,12 +60,16 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
     () => uiSchema?.['ui:options']?.allowedOwners ?? [],
     [uiSchema],
   );
+  const allowedProjects = useMemo(
+    () => uiSchema?.['ui:options']?.allowedProjects ?? [],
+    [uiSchema],
+  );
   const allowedRepos = useMemo(
     () => uiSchema?.['ui:options']?.allowedRepos ?? [],
     [uiSchema],
   );
 
-  const { owner, organization, repoName } = state;
+  const { owner, organization, project, repoName } = state;
 
   useEffect(() => {
     onChange(serializeRepoPickerUrl(state));
@@ -89,6 +93,15 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
       }));
     }
   }, [setState, allowedOwners, owner]);
+
+  useEffect(() => {
+    if (allowedProjects.length > 0 && !project) {
+      setState(prevState => ({
+        ...prevState,
+        project: allowedProjects[0],
+      }));
+    }
+  }, [setState, allowedProjects, project]);
 
   useEffect(() => {
     if (allowedRepos.length > 0 && !repoName) {
@@ -169,6 +182,7 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
       {hostType === 'bitbucket' && (
         <BitbucketRepoPicker
           allowedOwners={allowedOwners}
+          allowedProjects={allowedProjects}
           rawErrors={rawErrors}
           state={state}
           onChange={updateLocalState}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/schema.ts
@@ -34,6 +34,10 @@ export const RepoUrlPickerFieldSchema = makeFieldSchemaFromZod(
       .array(z.string())
       .optional()
       .describe('List of allowed owners in the given SCM platform'),
+    allowedProjects: z
+      .array(z.string())
+      .optional()
+      .describe('List of allowed projects in the given SCM platform'),
     allowedRepos: z
       .array(z.string())
       .optional()


### PR DESCRIPTION
Signed-off-by: Andrew Kundrock <akundrock@somalogic.com>

## Hey, I just made a Pull Request!

Add allowedProjects to the repoUrlPicker/BitbucketRepoPicker schema. This allows a developer to specify which projects are allowed in Bitbucket Cloud. I find this to be helpful to control where a repo can be selected via dropdown list.

Projects only seem to be used by Bitbucket Cloud and needed to be added to the ZOD schema

![image](https://user-images.githubusercontent.com/74791007/205401555-2110f70e-2f0d-4622-bc54-716abdf520f4.png)


#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
