### PR TITLE
[kubernetes-backend] support caFile on clusters defined in app-config

### DIFF
--- a/.changeset/kind-tips-pump.md
+++ b/.changeset/kind-tips-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Clusters declared in the app-config can now have their CA configured via a local filesystem path using the `caFile` property.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -31,6 +31,7 @@ kubernetes:
           dashboardUrl: http://127.0.0.1:64713 # url copied from running the command: minikube service kubernetes-dashboard -n kubernetes-dashboard
           dashboardApp: standard
           caData: ${K8S_CONFIG_CA_DATA}
+          caFile: '' # local path to CA file
           customResources:
             - group: 'argoproj.io'
               apiVersion: 'v1alpha1'
@@ -248,8 +249,8 @@ kubernetes:
 ##### `clusters.\*.caData` (optional)
 
 Base64-encoded certificate authority bundle in PEM format. The Kubernetes client
-will verify that TLS certificate presented by the API server is signed by this
-CA.
+will verify that the TLS certificate presented by the API server is signed by
+this CA.
 
 This value could be obtained via inspecting the kubeconfig file (usually
 at `~/.kube/config`) under `clusters[*].cluster.certificate-authority-data`. For
@@ -264,6 +265,14 @@ gcloud container clusters describe <YOUR_CLUSTER_NAME> \
 See also
 https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud
 for complete docs about GKE without `gcloud`.
+
+##### `clusters.\*.caFile` (optional)
+
+Filesystem path (on the host where the Backstage process is running) to a
+certificate authority bundle in PEM format. The Kubernetes client will verify
+that the TLS certificate presented by the API server is signed by this CA. Note
+that only clusters defined in the app-config via the [`config`](#config)
+cluster locator method can be configured in this way.
 
 ##### `clusters.\*.customResources` (optional)
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -78,6 +78,8 @@ export interface ClusterDetails {
   authProvider: string;
   // (undocumented)
   caData?: string | undefined;
+  // (undocumented)
+  caFile?: string | undefined;
   customResources?: CustomResourceMatcher[];
   dashboardApp?: string;
   dashboardParameters?: JsonObject;

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -54,6 +54,10 @@ export interface Config {
             skipTLSVerify?: boolean;
             /** @visibility frontend */
             skipMetricsLookup?: boolean;
+            /** @visibility secret  */
+            caData?: string;
+            /** @visibility secret  */
+            caFile?: string;
           }>;
         }
       | {

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -70,6 +70,7 @@
     "@types/aws4": "^1.5.1",
     "@types/http-proxy-middleware": "^0.19.3",
     "aws-sdk-mock": "^5.2.1",
+    "mock-fs": "^5.2.0",
     "msw": "^0.49.0",
     "supertest": "^6.1.3"
   },

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -55,6 +55,7 @@ describe('ConfigClusterLocator', () => {
         skipMetricsLookup: false,
         skipTLSVerify: false,
         caData: undefined,
+        caFile: undefined,
       },
     ]);
   });
@@ -95,6 +96,7 @@ describe('ConfigClusterLocator', () => {
         skipTLSVerify: false,
         skipMetricsLookup: true,
         caData: undefined,
+        caFile: undefined,
       },
       {
         name: 'cluster2',
@@ -104,6 +106,7 @@ describe('ConfigClusterLocator', () => {
         skipTLSVerify: true,
         skipMetricsLookup: false,
         caData: undefined,
+        caFile: undefined,
       },
     ]);
   });
@@ -151,6 +154,7 @@ describe('ConfigClusterLocator', () => {
         skipTLSVerify: false,
         skipMetricsLookup: false,
         caData: undefined,
+        caFile: undefined,
       },
       {
         assumeRole: 'SomeRole',
@@ -162,6 +166,7 @@ describe('ConfigClusterLocator', () => {
         skipTLSVerify: true,
         skipMetricsLookup: false,
         caData: undefined,
+        caFile: undefined,
       },
       {
         assumeRole: 'SomeRole',
@@ -173,6 +178,7 @@ describe('ConfigClusterLocator', () => {
         skipTLSVerify: true,
         skipMetricsLookup: false,
         caData: undefined,
+        caFile: undefined,
       },
     ]);
   });
@@ -207,6 +213,7 @@ describe('ConfigClusterLocator', () => {
         skipMetricsLookup: false,
         skipTLSVerify: false,
         caData: undefined,
+        caFile: undefined,
         dashboardApp: 'gke',
         dashboardParameters: {
           projectId: 'some-project',
@@ -243,6 +250,7 @@ describe('ConfigClusterLocator', () => {
         skipMetricsLookup: false,
         skipTLSVerify: false,
         caData: undefined,
+        caFile: undefined,
         dashboardApp: 'standard',
         dashboardUrl: 'http://someurl',
       },

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -37,6 +37,7 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           skipTLSVerify: c.getOptionalBoolean('skipTLSVerify') ?? false,
           skipMetricsLookup: c.getOptionalBoolean('skipMetricsLookup') ?? false,
           caData: c.getOptionalString('caData'),
+          caFile: c.getOptionalString('caFile'),
           authProvider: authProvider,
         };
         const dashboardUrl = c.getOptionalString('dashboardUrl');

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -60,6 +60,7 @@ describe('getCombinedClusterSupplier', () => {
         skipMetricsLookup: false,
         skipTLSVerify: false,
         caData: undefined,
+        caFile: undefined,
       },
       {
         name: 'cluster2',
@@ -69,6 +70,7 @@ describe('getCombinedClusterSupplier', () => {
         skipMetricsLookup: false,
         skipTLSVerify: false,
         caData: undefined,
+        caFile: undefined,
       },
     ]);
   });

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -31,12 +31,13 @@ import { ClusterDetails } from '../types/types';
  */
 export class KubernetesClientProvider {
   // visible for testing
-  getKubeConfig(clusterDetails: ClusterDetails) {
+  getKubeConfig(clusterDetails: ClusterDetails): KubeConfig {
     const cluster: Cluster = {
       name: clusterDetails.name,
       server: clusterDetails.url,
       skipTLSVerify: clusterDetails.skipTLSVerify || false,
       caData: clusterDetails.caData,
+      caFile: clusterDetails.caFile,
     };
 
     // TODO configure

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -15,10 +15,13 @@
  */
 
 import {
+  Cluster,
+  Context,
   CoreV1Api,
+  CustomObjectsApi,
   KubeConfig,
   Metrics,
-  CustomObjectsApi,
+  User,
 } from '@kubernetes/client-node';
 import { ClusterDetails } from '../types/types';
 
@@ -29,26 +32,26 @@ import { ClusterDetails } from '../types/types';
 export class KubernetesClientProvider {
   // visible for testing
   getKubeConfig(clusterDetails: ClusterDetails) {
-    const cluster = {
+    const cluster: Cluster = {
       name: clusterDetails.name,
       server: clusterDetails.url,
-      skipTLSVerify: clusterDetails.skipTLSVerify,
+      skipTLSVerify: clusterDetails.skipTLSVerify || false,
       caData: clusterDetails.caData,
     };
 
     // TODO configure
-    const user = {
+    const user: User = {
       name: 'backstage',
       token: clusterDetails.serviceAccountToken,
     };
 
-    const context = {
+    const context: Context = {
       name: `${clusterDetails.name}`,
       user: user.name,
       cluster: cluster.name,
     };
 
-    const kc = new KubeConfig();
+    const kc: KubeConfig = new KubeConfig();
     if (clusterDetails.serviceAccountToken) {
       kc.loadFromOptions({
         clusters: [cluster],
@@ -63,19 +66,19 @@ export class KubernetesClientProvider {
     return kc;
   }
 
-  getCoreClientByClusterDetails(clusterDetails: ClusterDetails) {
+  getCoreClientByClusterDetails(clusterDetails: ClusterDetails): CoreV1Api {
     const kc = this.getKubeConfig(clusterDetails);
 
     return kc.makeApiClient(CoreV1Api);
   }
 
-  getMetricsClient(clusterDetails: ClusterDetails) {
+  getMetricsClient(clusterDetails: ClusterDetails): Metrics {
     const kc = this.getKubeConfig(clusterDetails);
 
     return new Metrics(kc);
   }
 
-  getCustomObjectsClient(clusterDetails: ClusterDetails) {
+  getCustomObjectsClient(clusterDetails: ClusterDetails): CustomObjectsApi {
     const kc = this.getKubeConfig(clusterDetails);
 
     return kc.makeApiClient(CustomObjectsApi);

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -167,6 +167,7 @@ export interface ClusterDetails {
    */
   skipMetricsLookup?: boolean;
   caData?: string | undefined;
+  caFile?: string | undefined;
   /**
    * Specifies the link to the Kubernetes dashboard managing this cluster.
    * @remarks

--- a/yarn.lock
+++ b/yarn.lock
@@ -6742,6 +6742,7 @@ __metadata:
     http-proxy-middleware: ^2.0.6
     lodash: ^4.17.21
     luxon: ^3.0.0
+    mock-fs: ^5.2.0
     morgan: ^1.10.0
     msw: ^0.49.0
     node-fetch: ^2.6.7
@@ -29069,7 +29070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mock-fs@npm:^5.1.0, mock-fs@npm:^5.1.1":
+"mock-fs@npm:^5.1.0, mock-fs@npm:^5.1.1, mock-fs@npm:^5.2.0":
   version: 5.2.0
   resolution: "mock-fs@npm:5.2.0"
   checksum: c25835247bd26fa4e0189addd61f98973f61a72741e4d2a5694b143a2069b84978443a7ac0fdb1a71aead99273ec22ff4e9c968de11bbd076db020264c5b8312


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #13768

I tested this out locally using the following steps:
1. I created a kind cluster with `kind create cluster`
1. I wrote out the CA for that cluster to a local file with
    ```console
    kubectl config view --raw -o jsonpath='{.clusters[?(@.name == "kind-kind")].cluster.certificate-authority-data}' | base64 -d > kind.pem
    ```
1. I ran `kubectl apply -f backstage.yml` where `backstage.yml` is:
    ```yaml
    apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: backstage
    spec:
      replicas: 1
      selector:
        matchLabels:
          app: backstage
      template:
        metadata:
          labels:
            app: backstage
        spec:
          containers:
          - image: nginx
            imagePullPolicy: Always
            name: nginx
    ```
1. I created `kubernetes.yaml` in the root of this repo:
    ```yaml
    apiVersion: backstage.io/v1alpha1
    kind: Component
    metadata:
      name: demo-backstage
      annotations:
        'backstage.io/kubernetes-label-selector': 'app=backstage'
    spec:
      type: service
      lifecycle: stable
      owner: user:guest
    ```
1. I have `app-config.local.yaml`:
    ```yaml
    kubernetes:
      clusterLocatorMethods:
        - type: config
          clusters:
            - url: https://127.0.0.1:<port of kind apiserver>
              name: kind
              authProvider: serviceAccount
              serviceAccountToken: <token for SA with the role at https://backstage.io/docs/features/kubernetes/configuration#role-based-access-control>
              caFile: ../../kind.pem
    catalog:
      locations:
        - type: file
          target: ../../kubernetes.yaml
    ```
1. I run `yarn start-backend`
1. In another terminal, I run
    ```console
    curl localhost:7007/api/kubernetes/services/demo-backstage \
      -H 'content-type: application/json' \
      -d '{"entity":{"metadata":{"annotations":{"backstage.io/kubernetes-label-selector":"app=backstage"}}}}'
    ```
    And objects are successfully returned!
  
Before this change, the same sequence of steps would result in
```text
{
  "error": "unable to verify the first certificate"
}
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] ~Screenshots attached (for UI changes)~ backend only
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
