### PR TITLE
fix(GitlabUrlReader) Include api key in resolveProjectToId request

### DIFF
--- a/.changeset/famous-crews-speak.md
+++ b/.changeset/famous-crews-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fixed GitlabUrlReader to include api tokens in API calls

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -44,6 +44,7 @@ const gitlabProcessor = new GitlabUrlReader(
         host: 'gitlab.com',
         apiBaseUrl: 'https://gitlab.com/api/v4',
         baseUrl: 'https://gitlab.com',
+        token: 'gl-dummy-token',
       }),
     ),
   ),
@@ -57,6 +58,7 @@ const hostedGitlabProcessor = new GitlabUrlReader(
         host: 'gitlab.mycompany.com',
         apiBaseUrl: 'https://gitlab.mycompany.com/api/v4',
         baseUrl: 'https://gitlab.mycompany.com',
+        token: 'gl-dummy-token',
       }),
     ),
   ),
@@ -654,6 +656,23 @@ describe('GitlabUrlReader', () => {
           ),
         ),
       ).rejects.toThrow(/^Unable to translate GitLab artifact URL:/);
+    });
+  });
+
+  describe('resolveProjectToId', () => {
+    it('should resolve the project path to a valid project id', async () => {
+      worker.use(
+        rest.get('*/api/v4/projects/some%2Fproject', (req, res, ctx) => {
+          // the private-token header must be included on API calls
+          expect(req.headers.get('private-token')).toBe('gl-dummy-token');
+          return res(ctx.status(200), ctx.json({ id: 12345 }));
+        }),
+      );
+      await expect(
+        (gitlabProcessor as any).resolveProjectToId(
+          new URL('https://gitlab.com/some/project'),
+        ),
+      ).resolves.toEqual(12345);
     });
   });
 });

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -311,6 +311,11 @@ export class GitlabUrlReader implements UrlReader {
       `${
         pathToProject.origin
       }${relativePath}/api/v4/projects/${encodeURIComponent(project)}`,
+      {
+        headers: {
+          ...getGitLabRequestOptions(this.integration.config).headers,
+        },
+      },
     );
     const data = await result.json();
     if (!result.ok) {

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -311,11 +311,7 @@ export class GitlabUrlReader implements UrlReader {
       `${
         pathToProject.origin
       }${relativePath}/api/v4/projects/${encodeURIComponent(project)}`,
-      {
-        headers: {
-          ...getGitLabRequestOptions(this.integration.config).headers,
-        },
-      },
+      getGitLabRequestOptions(this.integration.config),
     );
     const data = await result.json();
     if (!result.ok) {


### PR DESCRIPTION
Signed-off-by: Max Morton <mamorton@paloaltonetworks.com>

## Hey, I just made a Pull Request!

When testing my changes in `1.9.0-next.1` I found that I forgot to include the API token in the call to resolve project names to project ids.

I've added the correct functionality and tests to make sure this is fixed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
