### PR TITLE
Cleaned up deprecation in plugins/cost-insight

### DIFF
--- a/.changeset/old-sloths-warn.md
+++ b/.changeset/old-sloths-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Internal refactor to avoid usage of deprecated symbols

--- a/plugins/cost-insights/api-report.md
+++ b/plugins/cost-insights/api-report.md
@@ -17,8 +17,10 @@ import { Entity as Entity_2 } from '@backstage/plugin-cost-insights-common';
 import { ForwardRefExoticComponent } from 'react';
 import { Group as Group_2 } from '@backstage/plugin-cost-insights-common';
 import { Maybe as Maybe_2 } from '@backstage/plugin-cost-insights-common';
+import { Metric as Metric_2 } from '@backstage/plugin-cost-insights-common';
 import { MetricData as MetricData_2 } from '@backstage/plugin-cost-insights-common';
 import { PaletteOptions } from '@material-ui/core/styles/createPalette';
+import { Product as Product_2 } from '@backstage/plugin-cost-insights-common';
 import { Project as Project_2 } from '@backstage/plugin-cost-insights-common';
 import { PropsWithChildren } from 'react';
 import { ReactNode } from 'react';
@@ -233,8 +235,8 @@ export type ChartData = {
 // @public (undocumented)
 export type ConfigContextProps = {
   baseCurrency: Intl.NumberFormat;
-  metrics: Metric[];
-  products: Product[];
+  metrics: Metric_2[];
+  products: Product_2[];
   icons: Icon[];
   engineerCost: number;
   engineerThreshold: number;
@@ -426,21 +428,21 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
   getCatalogEntityDailyCost(
     entityRef: string,
     intervals: string,
-  ): Promise<Cost>;
+  ): Promise<Cost_2>;
   // (undocumented)
-  getDailyMetricData(metric: string, intervals: string): Promise<MetricData>;
+  getDailyMetricData(metric: string, intervals: string): Promise<MetricData_2>;
   // (undocumented)
-  getGroupDailyCost(group: string, intervals: string): Promise<Cost>;
+  getGroupDailyCost(group: string, intervals: string): Promise<Cost_2>;
   // (undocumented)
-  getGroupProjects(group: string): Promise<Project[]>;
+  getGroupProjects(group: string): Promise<Project_2[]>;
   // (undocumented)
   getLastCompleteBillingDate(): Promise<string>;
   // (undocumented)
-  getProductInsights(options: ProductInsightsOptions): Promise<Entity>;
+  getProductInsights(options: ProductInsightsOptions): Promise<Entity_2>;
   // (undocumented)
-  getProjectDailyCost(project: string, intervals: string): Promise<Cost>;
+  getProjectDailyCost(project: string, intervals: string): Promise<Cost_2>;
   // (undocumented)
-  getUserGroups(userId: string): Promise<Group[]>;
+  getUserGroups(userId: string): Promise<Group_2[]>;
 }
 
 // @public @deprecated (undocumented)

--- a/plugins/cost-insights/src/example/alerts/KubernetesMigrationAlert.tsx
+++ b/plugins/cost-insights/src/example/alerts/KubernetesMigrationAlert.tsx
@@ -24,9 +24,11 @@ import {
   AlertOptions,
   AlertStatus,
   AlertSnoozeFormData,
+} from '../../types';
+import {
   ChangeStatistic,
   Entity,
-} from '../../types';
+} from '@backstage/plugin-cost-insights-common';
 import {
   KubernetesMigrationDismissForm,
   KubernetesMigrationDismissFormData,

--- a/plugins/cost-insights/src/example/client.ts
+++ b/plugins/cost-insights/src/example/client.ts
@@ -19,15 +19,17 @@ import { DateTime } from 'luxon';
 import { CostInsightsApi, ProductInsightsOptions } from '../api';
 import {
   Alert,
-  Cost,
   DEFAULT_DATE_FORMAT,
+  ProjectGrowthData,
+  UnlabeledDataflowData,
+} from '../types';
+import {
   Entity,
   Group,
   MetricData,
   Project,
-  ProjectGrowthData,
-  UnlabeledDataflowData,
-} from '../types';
+  Cost,
+} from '@backstage/plugin-cost-insights-common';
 import { KubernetesMigrationAlert } from './alerts';
 import { ProjectGrowthAlert, UnlabeledDataflowAlert } from '../alerts';
 import {

--- a/plugins/cost-insights/src/example/components/KubernetesMigrationAlertCard/KubernetesMigrationBarChart.tsx
+++ b/plugins/cost-insights/src/example/components/KubernetesMigrationAlertCard/KubernetesMigrationBarChart.tsx
@@ -19,9 +19,9 @@ import { BarChart } from '../../../components';
 import {
   BarChartOptions,
   CostInsightsTheme,
-  Entity,
   ResourceData,
 } from '../../../types';
+import { Entity } from '@backstage/plugin-cost-insights-common';
 import { useTheme } from '@material-ui/core';
 
 type MigrationBarChartProps = {

--- a/plugins/cost-insights/src/example/components/KubernetesMigrationAlertCard/KubernetesMigrationBarChartLegend.tsx
+++ b/plugins/cost-insights/src/example/components/KubernetesMigrationAlertCard/KubernetesMigrationBarChartLegend.tsx
@@ -17,7 +17,8 @@
 import React from 'react';
 import { Box, useTheme } from '@material-ui/core';
 import { CostGrowth, LegendItem } from '../../../components';
-import { ChangeStatistic, CostInsightsTheme, Duration } from '../../../types';
+import { CostInsightsTheme, Duration } from '../../../types';
+import { ChangeStatistic } from '@backstage/plugin-cost-insights-common';
 import { monthOf } from '../../../utils/formatters';
 
 export type MigrationBarChartLegendProps = {

--- a/plugins/cost-insights/src/example/forms/KubernetesMigrationDismissForm.tsx
+++ b/plugins/cost-insights/src/example/forms/KubernetesMigrationDismissForm.tsx
@@ -28,7 +28,8 @@ import {
   FormGroup,
   Typography,
 } from '@material-ui/core';
-import { AlertFormProps, Entity } from '../../types';
+import { AlertFormProps } from '../../types';
+import { Entity } from '@backstage/plugin-cost-insights-common';
 import { KubernetesMigrationAlert } from '../alerts';
 import { findAlways } from '../../utils/assert';
 

--- a/plugins/cost-insights/src/forms/AlertDismissForm.tsx
+++ b/plugins/cost-insights/src/forms/AlertDismissForm.tsx
@@ -37,8 +37,8 @@ import {
   AlertDismissReason,
   AlertDismissOptions,
   AlertDismissFormData,
-  Maybe,
 } from '../types';
+import { Maybe } from '@backstage/plugin-cost-insights-common';
 import { useAlertDialogStyles as useStyles } from '../utils/styles';
 
 export type AlertDismissFormProps = AlertFormProps<Alert, AlertDismissFormData>;

--- a/plugins/cost-insights/src/forms/AlertSnoozeForm.tsx
+++ b/plugins/cost-insights/src/forms/AlertSnoozeForm.tsx
@@ -35,10 +35,10 @@ import {
   AlertFormProps,
   Duration,
   DEFAULT_DATE_FORMAT,
-  Maybe,
   AlertSnoozeFormData,
   AlertSnoozeOptions,
 } from '../types';
+import { Maybe } from '@backstage/plugin-cost-insights-common';
 import { useAlertDialogStyles as useStyles } from '../utils/styles';
 import { intervalsOf } from '../utils/duration';
 

--- a/plugins/cost-insights/src/hooks/useConfig.tsx
+++ b/plugins/cost-insights/src/hooks/useConfig.tsx
@@ -22,7 +22,8 @@ import React, {
   useState,
 } from 'react';
 import { Config as BackstageConfig } from '@backstage/config';
-import { Currency, EngineerThreshold, Icon, Metric, Product } from '../types';
+import { Currency, EngineerThreshold, Icon } from '../types';
+import { Metric, Product } from '@backstage/plugin-cost-insights-common';
 import { getIcon } from '../utils/navigation';
 import { validateCurrencies, validateMetrics } from '../utils/config';
 import { createCurrencyFormat, defaultCurrencies } from '../utils/currency';

--- a/plugins/cost-insights/src/hooks/useFilters.tsx
+++ b/plugins/cost-insights/src/hooks/useFilters.tsx
@@ -23,7 +23,8 @@ import React, {
   useState,
 } from 'react';
 import { Alert } from '@material-ui/lab';
-import { Maybe, PageFilters, ProductFilters } from '../types';
+import { PageFilters, ProductFilters } from '../types';
+import { Maybe } from '@backstage/plugin-cost-insights-common';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   stringify,

--- a/plugins/cost-insights/src/hooks/useGroups.tsx
+++ b/plugins/cost-insights/src/hooks/useGroups.tsx
@@ -23,7 +23,7 @@ import React, {
 import { Alert } from '@material-ui/lab';
 import { costInsightsApiRef } from '../api';
 import { MapLoadingToProps, useLoading } from './useLoading';
-import { Group, Maybe } from '../types';
+import { Group, Maybe } from '@backstage/plugin-cost-insights-common';
 import { DefaultLoadingAction } from '../utils/loading';
 import { useApi, identityApiRef } from '@backstage/core-plugin-api';
 import { DEFAULT_NAMESPACE, parseEntityRef } from '@backstage/catalog-model';

--- a/plugins/cost-insights/src/hooks/useLastCompleteBillingDate.tsx
+++ b/plugins/cost-insights/src/hooks/useLastCompleteBillingDate.tsx
@@ -25,7 +25,7 @@ import { Alert } from '@material-ui/lab';
 import { costInsightsApiRef } from '../api';
 import { MapLoadingToProps, useLoading } from './useLoading';
 import { DefaultLoadingAction } from '../utils/loading';
-import { Maybe } from '../types';
+import { Maybe } from '@backstage/plugin-cost-insights-common';
 import { useApi } from '@backstage/core-plugin-api';
 
 type BillingDateProviderLoadingProps = {

--- a/plugins/cost-insights/src/hooks/useScroll.tsx
+++ b/plugins/cost-insights/src/hooks/useScroll.tsx
@@ -20,7 +20,7 @@ import React, {
   useContext,
   PropsWithChildren,
 } from 'react';
-import { Maybe } from '../types';
+import { Maybe } from '@backstage/plugin-cost-insights-common';
 
 export type ScrollTo = Maybe<string>;
 

--- a/plugins/cost-insights/src/testUtils/mockData.ts
+++ b/plugins/cost-insights/src/testUtils/mockData.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { DateAggregation, Entity } from '../types';
+import {
+  DateAggregation,
+  Entity,
+} from '@backstage/plugin-cost-insights-common';
 
 export const MockAggregatedDailyCosts: DateAggregation[] = [
   {

--- a/plugins/cost-insights/src/testUtils/products.ts
+++ b/plugins/cost-insights/src/testUtils/products.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, Product } from '../types';
+import { Entity, Product } from '@backstage/plugin-cost-insights-common';
 import { findAlways } from '../utils/assert';
 
 type mockEntityRenderer<T> = (entity: T) => T;

--- a/plugins/cost-insights/src/testUtils/testUtils.ts
+++ b/plugins/cost-insights/src/testUtils/testUtils.ts
@@ -16,14 +16,13 @@
 
 import { DateTime } from 'luxon';
 import regression, { DataPoint } from 'regression';
+import { Duration, DEFAULT_DATE_FORMAT } from '../types';
 import {
   ChangeStatistic,
-  Duration,
   Entity,
   Trendline,
   DateAggregation,
-  DEFAULT_DATE_FORMAT,
-} from '../types';
+} from '@backstage/plugin-cost-insights-common';
 import { inclusiveEndDateOf, inclusiveStartDateOf } from '../utils/duration';
 import {
   MockComputeEngineInsights,

--- a/plugins/cost-insights/src/utils/alerts.tsx
+++ b/plugins/cost-insights/src/utils/alerts.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Alert, AlertForm, AlertStatus, Maybe } from '../types';
+import { Alert, AlertForm, AlertStatus } from '../types';
+import { Maybe } from '@backstage/plugin-cost-insights-common';
 import { AlertAcceptForm, AlertDismissForm, AlertSnoozeForm } from '../forms';
 
 const createAlertHandler = (status?: AlertStatus) => (alert: Alert) =>

--- a/plugins/cost-insights/src/utils/change.test.ts
+++ b/plugins/cost-insights/src/utils/change.test.ts
@@ -20,8 +20,8 @@ import {
   ChangeThreshold,
   EngineerThreshold,
   Duration,
-  Cost,
 } from '../types';
+import { Cost } from '@backstage/plugin-cost-insights-common';
 import { MockAggregatedDailyCosts, trendlineOf, changeOf } from '../testUtils';
 
 const GrowthMap = {

--- a/plugins/cost-insights/src/utils/change.ts
+++ b/plugins/cost-insights/src/utils/change.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
+import { ChangeThreshold, GrowthType, Duration } from '../types';
 import {
   Cost,
   ChangeStatistic,
-  ChangeThreshold,
-  GrowthType,
   MetricData,
-  Duration,
   DateAggregation,
-} from '../types';
+} from '@backstage/plugin-cost-insights-common';
 import { DateTime, Duration as LuxonDuration } from 'luxon';
 import { inclusiveStartDateOf } from './duration';
 import { notEmpty } from './assert';

--- a/plugins/cost-insights/src/utils/charts.ts
+++ b/plugins/cost-insights/src/utils/charts.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { DateAggregation, Trendline, ChartData } from '../types';
+import {
+  DateAggregation,
+  Trendline,
+} from '@backstage/plugin-cost-insights-common';
+import { ChartData } from '../types';
 
 export function trendFrom(trendline: Trendline, date: number): number {
   return trendline.slope * (date / 1000) + trendline.intercept;

--- a/plugins/cost-insights/src/utils/config.ts
+++ b/plugins/cost-insights/src/utils/config.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Metric, Currency } from '../types';
+import { Currency } from '../types';
+import { Metric } from '@backstage/plugin-cost-insights-common';
 
 export function validateMetrics(metrics: Metric[]) {
   const defaults = metrics.filter(metric => metric.default);

--- a/plugins/cost-insights/src/utils/filters.ts
+++ b/plugins/cost-insights/src/utils/filters.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Duration, Group, PageFilters } from '../types';
+import { Duration, PageFilters } from '../types';
+import { Group } from '@backstage/plugin-cost-insights-common';
 
 export function getDefaultPageFilters(groups: Group[]): PageFilters {
   return {

--- a/plugins/cost-insights/src/utils/formatters.ts
+++ b/plugins/cost-insights/src/utils/formatters.ts
@@ -16,7 +16,8 @@
 
 import { DateTime, Duration as LuxonDuration } from 'luxon';
 import pluralize from 'pluralize';
-import { ChangeStatistic, Duration } from '../types';
+import { Duration } from '../types';
+import { ChangeStatistic } from '@backstage/plugin-cost-insights-common';
 import { inclusiveEndDateOf, inclusiveStartDateOf } from './duration';
 import { notEmpty } from './assert';
 

--- a/plugins/cost-insights/src/utils/graphs.ts
+++ b/plugins/cost-insights/src/utils/graphs.ts
@@ -16,7 +16,8 @@
 
 import { TooltipProps } from 'recharts';
 import { Payload } from 'recharts/types/component/DefaultTooltipContent';
-import { AlertCost, DataKey, Entity, ResourceData } from '../types';
+import { AlertCost, DataKey, ResourceData } from '../types';
+import { Entity } from '@backstage/plugin-cost-insights-common';
 import {
   currencyFormatter,
   dateFormatter,

--- a/plugins/cost-insights/src/utils/history.ts
+++ b/plugins/cost-insights/src/utils/history.ts
@@ -16,7 +16,8 @@
 
 import qs from 'qs';
 import * as yup from 'yup';
-import { Duration, Group, PageFilters } from '../types';
+import { Duration, PageFilters } from '../types';
+import { Group } from '@backstage/plugin-cost-insights-common';
 import { getDefaultPageFilters } from '../utils/filters';
 import { ConfigContextProps } from '../hooks/useConfig';
 

--- a/plugins/cost-insights/src/utils/loading.ts
+++ b/plugins/cost-insights/src/utils/loading.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Duration, Entity, Loading, Maybe, Product } from '../types';
+import { Duration, Loading } from '../types';
+import { Entity, Maybe, Product } from '@backstage/plugin-cost-insights-common';
 import { DEFAULT_DURATION } from './duration';
 
 export type ProductState = {

--- a/plugins/cost-insights/src/utils/sort.ts
+++ b/plugins/cost-insights/src/utils/sort.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DateAggregation, ResourceData } from '../types';
+import { ResourceData } from '../types';
+import { DateAggregation } from '@backstage/plugin-cost-insights-common';
 import { ProductState } from './loading';
 
 export const aggregationSort = (

--- a/plugins/cost-insights/src/utils/sum.ts
+++ b/plugins/cost-insights/src/utils/sum.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DateAggregation } from '../types';
+import { DateAggregation } from '@backstage/plugin-cost-insights-common';
 
 export const aggregationSum = (aggregation: DateAggregation[]) =>
   aggregation.reduce((total, curAgg) => total + curAgg.amount, 0);


### PR DESCRIPTION
Signed-off-by: Simon <simme.jakobsson@gmail.com>

## Hey, I just made a Pull Request!

I've cleaned up all deprecation within the folder plugin/cost-insights for #14602 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
