### PR TITLE
fix(cli): Move generated `dependencies` to `[peer|dev]Dependencies`

### DIFF
--- a/.changeset/chilled-cats-sip.md
+++ b/.changeset/chilled-cats-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Plugins generated via cli have dependencies properly listed in `peerDependencies` and `devDependencies` instead of `dependencies`.

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -27,10 +27,9 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@backstage/backend-common": "{{versionQuery '@backstage/backend-common'}}",
     "@backstage/config": "{{versionQuery '@backstage/config'}}",
-    "@types/express": "{{versionQuery '@types/express' '4.17.13'}}",
     "express": "{{versionQuery 'express' '4.18.1'}}",
     "express-promise-router": "{{versionQuery 'express-promise-router' '4.1.0'}}",
     "winston": "{{versionQuery 'winston' '3.2.1'}}",
@@ -39,6 +38,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
+    "@types/express": "{{versionQuery '@types/express' '4.17.13'}}",
     "@types/supertest": "{{versionQuery '@types/supertest' '2.0.12'}}",
     "supertest": "{{versionQuery 'supertest' '6.2.4'}}",
     "msw": "{{versionQuery 'msw' '0.49.0'}}"

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -27,16 +27,14 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@backstage/core-components": "{{versionQuery '@backstage/core-components'}}",
     "@backstage/core-plugin-api": "{{versionQuery '@backstage/core-plugin-api'}}",
     "@backstage/theme": "{{versionQuery '@backstage/theme'}}",
     "@material-ui/core": "{{versionQuery '@material-ui/core' '4.12.2'}}",
     "@material-ui/icons": "{{versionQuery '@material-ui/icons' '4.9.1'}}",
     "@material-ui/lab": "{{versionQuery '@material-ui/lab' '4.0.0-alpha.57'}}",
-    "react-use": "{{versionQuery 'react-use' '17.2.4'}}"
-  },
-  "peerDependencies": {
+    "react-use": "{{versionQuery 'react-use' '17.2.4'}}",
     "react": "{{versionQuery 'react' '^16.13.1 || ^17.0.0'}}"
   },
   "devDependencies": {

--- a/packages/cli/templates/scaffolder-module/package.json.hbs
+++ b/packages/cli/templates/scaffolder-module/package.json.hbs
@@ -28,7 +28,7 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@backstage/plugin-scaffolder-backend": "{{versionQuery '@backstage/plugin-scaffolder-backend'}}"
   },
   "devDependencies": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When creating new plugins I've noticed that `@backstage/cli` is incorrectly listing host packages as `dependencies` resulting in multiple copies of the peer dependency. I think we don't want this behavior. All of the `dependencies` generated for new plugins should be already provided by the host package (`backend` or `app`) anyways, there's no need for a second copy.

Also there was `@types/*` package listed in `dependencies` which is definitely not needed in the runtime and should be in the `devDependecies`.

Of course yarn is clever enough to resolve this most of the times, but we may should do it properly anyways. :slightly_smiling_face:


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
