### PR TITLE
Adding unauthorised error reporting to Stack Overflow API requests, stack-overflow-backend plugin

### DIFF
--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -169,9 +169,8 @@ export class StackOverflowQuestionsCollatorFactory
         page = page + 1;
       }
       else {
-        this.logger.warn(
-          `GET request to ${this.baseUrl}/questions${params}${apiKeyParam}&page=${page} failed`, `\n`,
-          `Error ${data.error_id}, ${data.error_name}. ${data.error_message}`,
+        this.logger.error(
+          `GET request to ${this.baseUrl}/questions${params}${apiKeyParam}&page=${page} failed:\n Error ${data.error_id}, ${data.error_name}. ${data.error_message}`,
         );
         break;
       }

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -155,17 +155,27 @@ export class StackOverflowQuestionsCollatorFactory
       );
 
       const data = await res.json();
-      for (const question of data.items) {
-        yield {
-          title: question.title,
-          location: question.link,
-          text: question.owner.display_name,
-          tags: question.tags,
-          answers: question.answer_count,
-        };
+      if (data.error_id == null) {
+        for (const question of data.items) {
+          yield {
+            title: question.title,
+            location: question.link,
+            text: question.owner.display_name,
+            tags: question.tags,
+            answers: question.answer_count,
+          };
+        }
+        hasMorePages = data.has_more;
+        page = page + 1;
       }
-      hasMorePages = data.has_more;
-      page = page + 1;
+      else {
+        this.logger.warn(
+          `GET request to ${this.baseUrl}/questions${params}${apiKeyParam}&page=${page} failed`, `\n`,
+          `Error ${data.error_id}, ${data.error_name}. ${data.error_message}`,
+        );
+        break;
+      }
+
     }
   }
 }


### PR DESCRIPTION
## Adding unauthorised error reporting to Stack Overflow API requests, stack-overflow-backend plugin

This branch only affects the stack-overflow-backend plugin, altering only the `backstage/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts` file

Previous error output when Stack Overflow authentication is incorrectly configured:
```
[1] 2022-12-06T11:39:36.752Z search error Collating documents for stack-overflow failed: TypeError: data.items is not iterable type=plugin documentType=stack-overflow
[1] 2022-12-06T11:39:36.752Z search error data.items is not iterable type=taskManager task=search_index_stack_overflow stack=TypeError: data.items is not iterable
[1]     at StackOverflowQuestionsCollatorFactory.execute (/home/harry/platform-services/dev-portal/node_modules/@backstage/plugin-stack-overflow-backend/dist/index.cjs.js:82:35)
[1]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[1]     at async next (node:internal/streams/from:85:11)
```

Output after changes:
```
[1] 2022-12-06T11:41:22.385Z search error GET request to https://api.stackexchange.com/2.2/questions?site=stackoverflow&team=stackoverflow.com%2Fc%2Fihsm-solutions&pagesize=100&key=[REDACTED]&page=1 failed:
[1]  Error 400, bad_parameter. `key` doesn't match a known application type=plugin documentType=stack-overflow
[1] 2022-12-06T11:41:22.386Z search info Collating documents for stack-overflow succeeded type=plugin documentType=stack-overflow
```

---
'@backstage/stack-overflow-backend': minor
---

Added error reporting in StackOverflowQuestionsCollatorFactory object for failed API request.
