### PR TITLE
[Search] Add highlighting to StackOverflow result list item

### DIFF
--- a/.changeset/search-yet-another-wonderwall-cover.md
+++ b/.changeset/search-yet-another-wonderwall-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow': patch
+---
+
+The `<StackOverflowSearchResultListItem />` component is now able to highlight the result title and/or text when provided. To take advantage of this, pass in the `highlight` prop, similar to how it is done on other result list item components.

--- a/plugins/stack-overflow/api-report.md
+++ b/plugins/stack-overflow/api-report.md
@@ -8,6 +8,7 @@
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CardExtensionProps } from '@backstage/plugin-home';
 import { ReactNode } from 'react';
+import { ResultHighlight } from '@backstage/plugin-search-common';
 
 // @public
 export const HomePageStackOverflowQuestions: (
@@ -45,5 +46,6 @@ export const StackOverflowSearchResultListItem: (props: {
   result: any;
   icon?: ReactNode;
   rank?: number | undefined;
+  highlight?: ResultHighlight | undefined;
 }) => JSX.Element;
 ```

--- a/plugins/stack-overflow/package.json
+++ b/plugins/stack-overflow/package.json
@@ -27,6 +27,7 @@
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/plugin-home": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
+    "@backstage/plugin-search-react": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.stories.tsx
+++ b/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.stories.tsx
@@ -53,3 +53,23 @@ export const WithIcon = () => {
     />
   );
 };
+
+export const WithHighlight = () => {
+  return (
+    <StackOverflowSearchResultListItem
+      result={{
+        title: 'Customizing Spotify backstage UI',
+        text: 'Name of Author',
+        location: 'stackoverflow.question/1',
+        answers: 0,
+        tags: ['backstage'],
+      }}
+      icon={<StackOverflowIcon />}
+      highlight={{
+        fields: { title: '<xyz>Customizing</xyz> Spotify backstage ui' },
+        preTag: '<xyz>',
+        postTag: '</xyz>',
+      }}
+    />
+  );
+};

--- a/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.test.tsx
+++ b/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.test.tsx
@@ -78,4 +78,28 @@ describe('<StackOverflowSearchResultListItem/>', () => {
       value: 1,
     });
   });
+
+  it('should render highlight', async () => {
+    await renderInTestApp(
+      <StackOverflowSearchResultListItem
+        result={{
+          title: 'Customizing Spotify backstage UI',
+          text: 'Name of Author',
+          location: 'https://stackoverflow.com/questions/7',
+          answers: 0,
+          tags: ['backstage'],
+        }}
+        highlight={{
+          fields: {
+            title: 'Highlighted Title',
+            text: 'Highlighted Author',
+          },
+          preTag: '<xyz>',
+          postTag: '</xyz>',
+        }}
+      />,
+    );
+    expect(screen.getByText(/Highlighted Title/i)).toBeInTheDocument();
+    expect(screen.getByText(/Highlighted Author/i)).toBeInTheDocument();
+  });
 });

--- a/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.tsx
+++ b/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem/StackOverflowSearchResultListItem.tsx
@@ -26,17 +26,21 @@ import {
   Chip,
 } from '@material-ui/core';
 import { useAnalytics } from '@backstage/core-plugin-api';
+import { ResultHighlight } from '@backstage/plugin-search-common';
+import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
 
 type StackOverflowSearchResultListItemProps = {
   result: any; // TODO(emmaindal): type to StackOverflowDocument.
   icon?: React.ReactNode;
   rank?: number;
+  highlight?: ResultHighlight;
 };
 
 export const StackOverflowSearchResultListItem = (
   props: StackOverflowSearchResultListItemProps,
 ) => {
   const { location, title, text, answers, tags } = props.result;
+  const { highlight } = props;
   const analytics = useAnalytics();
 
   const handleClick = () => {
@@ -55,10 +59,31 @@ export const StackOverflowSearchResultListItem = (
             primaryTypographyProps={{ variant: 'h6' }}
             primary={
               <Link to={location} noTrack onClick={handleClick}>
-                {_unescape(title)}
+                {highlight?.fields?.title ? (
+                  <HighlightedSearchResultText
+                    text={highlight.fields.title}
+                    preTag={highlight.preTag}
+                    postTag={highlight.postTag}
+                  />
+                ) : (
+                  _unescape(title)
+                )}
               </Link>
             }
-            secondary={`Author: ${text}`}
+            secondary={
+              highlight?.fields?.text ? (
+                <>
+                  Author:{' '}
+                  <HighlightedSearchResultText
+                    text={highlight.fields.text}
+                    preTag={highlight.preTag}
+                    postTag={highlight.postTag}
+                  />
+                </>
+              ) : (
+                `Author: ${text}`
+              )
+            }
           />
           <Chip label={`Answer(s): ${answers}`} size="small" />
           {tags &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -7875,6 +7875,7 @@ __metadata:
     "@backstage/dev-utils": "workspace:^"
     "@backstage/plugin-home": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
+    "@backstage/plugin-search-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@material-ui/core": ^4.12.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As described!

### Highlighting the title

![highlight-title](https://user-images.githubusercontent.com/3496491/205927162-18d0207b-1465-455d-b327-12d4452d3007.png)

### Highlighting the text

![highlight-text](https://user-images.githubusercontent.com/3496491/205927192-4ee97fb5-f810-4a36-8f1f-cfebc1ccd828.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
