### PR TITLE
feat: add eslint-plugin-jest to backend template

### DIFF
--- a/.changeset/yellow-brooms-repeat.md
+++ b/.changeset/yellow-brooms-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Include eslint-plugin-jest in scaffolded backstage plugin

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
     "@types/supertest": "{{versionQuery '@types/supertest' '2.0.12'}}",
+    "eslint-plugin-jest": "{{versionQuery 'eslint-plugin-jest' '27.1.6'}}",
     "supertest": "{{versionQuery 'supertest' '6.2.4'}}",
     "msw": "{{versionQuery 'msw' '0.49.0'}}"
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add eslint-plugin-jest to new backend plugins created by `npx backstage-cli new`.

When creating a new backstage plugin it prints an error as such:

```
    Error: Failed to load plugin 'jest' declared in '.eslintrc.js': Cannot find module 'eslint-plugin-jest'
    Require stack:
       - ...omitted.../plugin-backend/__placeholder__.js
       Referenced from: ...omitted.../plugin-backend/.eslintrc.js

    Warning: Failed to execute command yarn lint --fix

    🎉  Successfully created backend-plugin
```

This aims to fix that by including eslint-plugin-jest as a devDependency

Signed-off-by: Rickard Dybeck <dybeck@spotify.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
