### PR TITLE
fix: add default name for app creation

### DIFF
--- a/.changeset/cyan-donkeys-arrive.md
+++ b/.changeset/cyan-donkeys-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+added default project name for CI job compatibility

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -42,6 +42,7 @@ export default async (opts: OptionValues): Promise<void> => {
     {
       type: 'input',
       name: 'name',
+      default: 'backstage',
       message: chalk.blue('Enter a name for the app [required]'),
       validate: (value: any) => {
         if (!value) {


### PR DESCRIPTION
The PR adds a default to the app name argument. This makes it easy to integrate CI jobs. It doesn't particularly matter what the package name is. It just gets used in some minor output.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [ ] ~~Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
