### PR TITLE
Fix owner and lifecycle picker

### DIFF
--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
@@ -169,6 +169,7 @@ describe('<EntityLifecyclePicker/>', () => {
         value={{
           updateFilters,
           queryParameters: { lifecycles: ['experimental'] },
+          backendEntities: sampleEntities,
         }}
       >
         <EntityLifecyclePicker />
@@ -182,6 +183,8 @@ describe('<EntityLifecyclePicker/>', () => {
         value={{
           updateFilters,
           queryParameters: { lifecycles: ['production'] },
+          backendEntities: sampleEntities,
+          q,
         }}
       >
         <EntityLifecyclePicker />

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
@@ -184,7 +184,6 @@ describe('<EntityLifecyclePicker/>', () => {
           updateFilters,
           queryParameters: { lifecycles: ['production'] },
           backendEntities: sampleEntities,
-          q,
         }}
       >
         <EntityLifecyclePicker />
@@ -192,6 +191,23 @@ describe('<EntityLifecyclePicker/>', () => {
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
       lifecycles: new EntityLifecycleFilter(['production']),
+    });
+  });
+  it('removes lifecycles from filters if there are no available lifecycles', () => {
+    const updateFilters = jest.fn();
+    render(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { lifecycles: ['experimental'] },
+          backendEntities: [],
+        }}
+      >
+        <EntityLifecyclePicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      lifecycles: undefined,
     });
   });
 });

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -67,14 +67,6 @@ export const EntityLifecyclePicker = () => {
       : filters.lifecycles?.values ?? [],
   );
 
-  // Set selected lifecycles on query parameter updates; this happens at initial page load and from
-  // external updates to the page location.
-  useEffect(() => {
-    if (queryParamLifecycles.length) {
-      setSelectedLifecycles(queryParamLifecycles);
-    }
-  }, [queryParamLifecycles]);
-
   useEffect(() => {
     updateFilters({
       lifecycles: selectedLifecycles.length
@@ -83,17 +75,25 @@ export const EntityLifecyclePicker = () => {
     });
   }, [selectedLifecycles, updateFilters]);
 
-  const availableLifecycles = useMemo(() => {
-    const lifecycles = [
-      ...new Set(
-        backendEntities
-          .map((e: Entity) => e.spec?.lifecycle)
-          .filter(Boolean) as string[],
-      ),
-    ].sort();
-    if (lifecycles.length === 0) setSelectedLifecycles([]);
-    return lifecycles;
-  }, [backendEntities]);
+  const availableLifecycles = useMemo(
+    () =>
+      [
+        ...new Set(
+          backendEntities
+            .map((e: Entity) => e.spec?.lifecycle)
+            .filter(Boolean) as string[],
+        ),
+      ].sort(),
+    [backendEntities],
+  );
+
+  // Set selected lifecycles on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    if (queryParamLifecycles.length && availableLifecycles.length) {
+      setSelectedLifecycles(queryParamLifecycles);
+    }
+  }, [queryParamLifecycles, availableLifecycles]);
 
   if (!availableLifecycles.length) return null;
 

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -83,17 +83,17 @@ export const EntityLifecyclePicker = () => {
     });
   }, [selectedLifecycles, updateFilters]);
 
-  const availableLifecycles = useMemo(
-    () =>
-      [
-        ...new Set(
-          backendEntities
-            .map((e: Entity) => e.spec?.lifecycle)
-            .filter(Boolean) as string[],
-        ),
-      ].sort(),
-    [backendEntities],
-  );
+  const availableLifecycles = useMemo(() => {
+    const lifecycles = [
+      ...new Set(
+        backendEntities
+          .map((e: Entity) => e.spec?.lifecycle)
+          .filter(Boolean) as string[],
+      ),
+    ].sort();
+    if (lifecycles.length === 0) setSelectedLifecycles([]);
+    return lifecycles;
+  }, [backendEntities]);
 
   if (!availableLifecycles.length) return null;
 

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -67,13 +67,13 @@ export const EntityLifecyclePicker = () => {
       : filters.lifecycles?.values ?? [],
   );
 
+  // Set selected lifecycles on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
   useEffect(() => {
-    updateFilters({
-      lifecycles: selectedLifecycles.length
-        ? new EntityLifecycleFilter(selectedLifecycles)
-        : undefined,
-    });
-  }, [selectedLifecycles, updateFilters]);
+    if (queryParamLifecycles.length) {
+      setSelectedLifecycles(queryParamLifecycles);
+    }
+  }, [queryParamLifecycles]);
 
   const availableLifecycles = useMemo(
     () =>
@@ -87,17 +87,14 @@ export const EntityLifecyclePicker = () => {
     [backendEntities],
   );
 
-  // Set selected lifecycles on query parameter updates; this happens at initial page load and from
-  // external updates to the page location.
   useEffect(() => {
-    if (queryParamLifecycles.length && availableLifecycles.length) {
-      setSelectedLifecycles(queryParamLifecycles);
-    }
-  }, [queryParamLifecycles, availableLifecycles]);
-
-  useEffect(() => {
-    if (!availableLifecycles.length) setSelectedLifecycles([]);
-  }, [availableLifecycles]);
+    updateFilters({
+      lifecycles:
+        selectedLifecycles.length && availableLifecycles.length
+          ? new EntityLifecycleFilter(selectedLifecycles)
+          : undefined,
+    });
+  }, [selectedLifecycles, updateFilters, availableLifecycles]);
 
   if (!availableLifecycles.length) return null;
 

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -95,6 +95,10 @@ export const EntityLifecyclePicker = () => {
     }
   }, [queryParamLifecycles, availableLifecycles]);
 
+  useEffect(() => {
+    if (!availableLifecycles.length) setSelectedLifecycles([]);
+  }, [availableLifecycles]);
+
   if (!availableLifecycles.length) return null;
 
   return (

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -183,6 +183,7 @@ describe('<EntityOwnerPicker/>', () => {
         value={{
           updateFilters,
           queryParameters: { owners: ['team-a'] },
+          backendEntities: sampleEntities,
         }}
       >
         <EntityOwnerPicker />
@@ -196,6 +197,7 @@ describe('<EntityOwnerPicker/>', () => {
         value={{
           updateFilters,
           queryParameters: { owners: ['team-b'] },
+          backendEntities: sampleEntities,
         }}
       >
         <EntityOwnerPicker />

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -207,4 +207,21 @@ describe('<EntityOwnerPicker/>', () => {
       owners: new EntityOwnerFilter(['team-b']),
     });
   });
+  it('removes owners from filters if there are none available', () => {
+    const updateFilters = jest.fn();
+    render(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { owners: ['team-a'] },
+          backendEntities: [],
+        }}
+      >
+        <EntityOwnerPicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: undefined,
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -99,6 +99,10 @@ export const EntityOwnerPicker = () => {
     }
   }, [queryParamOwners, availableOwners]);
 
+  useEffect(() => {
+    if (!availableOwners.length) setSelectedOwners([]);
+  }, [availableOwners]);
+
   if (!availableOwners.length) return null;
 
   return (

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -67,13 +67,13 @@ export const EntityOwnerPicker = () => {
     queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
   );
 
+  // Set selected owners on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
   useEffect(() => {
-    updateFilters({
-      owners: selectedOwners.length
-        ? new EntityOwnerFilter(selectedOwners)
-        : undefined,
-    });
-  }, [selectedOwners, updateFilters]);
+    if (queryParamOwners.length) {
+      setSelectedOwners(queryParamOwners);
+    }
+  }, [queryParamOwners]);
 
   const availableOwners = useMemo(
     () =>
@@ -91,17 +91,14 @@ export const EntityOwnerPicker = () => {
     [backendEntities],
   );
 
-  // Set selected owners on query parameter updates; this happens at initial page load and from
-  // external updates to the page location.
   useEffect(() => {
-    if (queryParamOwners.length && availableOwners.length) {
-      setSelectedOwners(queryParamOwners);
-    }
-  }, [queryParamOwners, availableOwners]);
-
-  useEffect(() => {
-    if (!availableOwners.length) setSelectedOwners([]);
-  }, [availableOwners]);
+    updateFilters({
+      owners:
+        selectedOwners.length && availableOwners.length
+          ? new EntityOwnerFilter(selectedOwners)
+          : undefined,
+    });
+  }, [selectedOwners, updateFilters, availableOwners]);
 
   if (!availableOwners.length) return null;
 

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -83,21 +83,21 @@ export const EntityOwnerPicker = () => {
     });
   }, [selectedOwners, updateFilters]);
 
-  const availableOwners = useMemo(
-    () =>
-      [
-        ...new Set(
-          backendEntities
-            .flatMap((e: Entity) =>
-              getEntityRelations(e, RELATION_OWNED_BY).map(o =>
-                humanizeEntityRef(o, { defaultKind: 'group' }),
-              ),
-            )
-            .filter(Boolean) as string[],
-        ),
-      ].sort(),
-    [backendEntities],
-  );
+  const availableOwners = useMemo(() => {
+    const owners = [
+      ...new Set(
+        backendEntities
+          .flatMap((e: Entity) =>
+            getEntityRelations(e, RELATION_OWNED_BY).map(o =>
+              humanizeEntityRef(o, { defaultKind: 'group' }),
+            ),
+          )
+          .filter(Boolean) as string[],
+      ),
+    ].sort();
+    if (owners.length === 0) setSelectedOwners([]);
+    return owners;
+  }, [backendEntities]);
 
   if (!availableOwners.length) return null;
 

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -67,14 +67,6 @@ export const EntityOwnerPicker = () => {
     queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
   );
 
-  // Set selected owners on query parameter updates; this happens at initial page load and from
-  // external updates to the page location.
-  useEffect(() => {
-    if (queryParamOwners.length) {
-      setSelectedOwners(queryParamOwners);
-    }
-  }, [queryParamOwners]);
-
   useEffect(() => {
     updateFilters({
       owners: selectedOwners.length
@@ -83,21 +75,29 @@ export const EntityOwnerPicker = () => {
     });
   }, [selectedOwners, updateFilters]);
 
-  const availableOwners = useMemo(() => {
-    const owners = [
-      ...new Set(
-        backendEntities
-          .flatMap((e: Entity) =>
-            getEntityRelations(e, RELATION_OWNED_BY).map(o =>
-              humanizeEntityRef(o, { defaultKind: 'group' }),
-            ),
-          )
-          .filter(Boolean) as string[],
-      ),
-    ].sort();
-    if (owners.length === 0) setSelectedOwners([]);
-    return owners;
-  }, [backendEntities]);
+  const availableOwners = useMemo(
+    () =>
+      [
+        ...new Set(
+          backendEntities
+            .flatMap((e: Entity) =>
+              getEntityRelations(e, RELATION_OWNED_BY).map(o =>
+                humanizeEntityRef(o, { defaultKind: 'group' }),
+              ),
+            )
+            .filter(Boolean) as string[],
+        ),
+      ].sort(),
+    [backendEntities],
+  );
+
+  // Set selected owners on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    if (queryParamOwners.length && availableOwners.length) {
+      setSelectedOwners(queryParamOwners);
+    }
+  }, [queryParamOwners, availableOwners]);
 
   if (!availableOwners.length) return null;
 


### PR DESCRIPTION
Signed-off-by: Sarah Medeiros <smedeiros@wayfair.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This is still a work in progress. 

I have been working on issue #12081 and this is my not fully implemented, proposed solution. Any feedback is appreciated.

**Bug:** Catalog table filters are not cleared when changing entity kind
**Why does this happen?** When the kind changes, the selected filters persist, even if that filter is not relevant to that kind. This creates a confusing experience for the user because no entities are shown (which they may not expect) and that picker disappears because it does not apply to that kind.   

**Solution:** When setting the available options in the picker, if there are none (example no owners), then also update the selected options to be an empty array. This clears out the option that was previously selected when that filter does not apply to that kind.
This fix would need to happen in each picker file, but I didn't make all of those changes yet. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

**Not working**
https://user-images.githubusercontent.com/14253893/206046296-517b4b26-53cd-4c94-ac55-90337327dca4.mov

**Working**

https://user-images.githubusercontent.com/14253893/206494044-cf61ad5c-35dd-4b73-9ccd-799cd86715e5.mov


