### PR TITLE
Fix cd path log message

### DIFF
--- a/.changeset/great-islands-fail.md
+++ b/.changeset/great-islands-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Change the log message to use appdir, it's more appropriate

--- a/.changeset/great-islands-fail.md
+++ b/.changeset/great-islands-fail.md
@@ -2,4 +2,4 @@
 '@backstage/create-app': minor
 ---
 
-Change the log message to use appdir, it's more appropriate
+Change the log message to use `appDir`, it's more appropriate

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -124,11 +124,15 @@ export default async (opts: OptionValues): Promise<void> => {
 
     Task.log();
     Task.log(
-      chalk.green(`🥇  Successfully created ${chalk.cyan(answers.name)}`),
+      chalk.green(
+        `🥇  Successfully created ${chalk.cyan(answers.name)} in ${chalk.cyan(
+          `${appDir}`,
+        )}`,
+      ),
     );
     Task.log();
     Task.section('All set! Now you might want to');
-    Task.log(`  Run the app: ${chalk.cyan(`cd ${answers.name} && yarn dev`)}`);
+    Task.log(`  Run the app: ${chalk.cyan(`cd ${appDir} && yarn dev`)}`);
     Task.log(
       '  Set up the software catalog: https://backstage.io/docs/features/software-catalog/configuration',
     );


### PR DESCRIPTION
Fix the `cd` path to use appdir instead, it's a more appropriate output in circumstances where the user inputs the `--path` arg

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [ ] ~~Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
