### PR TITLE
feat(scaffolder): add EntityFilterQuery support on Entity and Owner Picker components

### DIFF
--- a/.changeset/selfish-phones-smoke.md
+++ b/.changeset/selfish-phones-smoke.md
@@ -2,4 +2,32 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Added a new prop to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.
+Added the catalogFilter prop to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.
+
+The `allowedKinds` field has been deprecated. Use `catalogFilter` instead. This field allows users to specify a filter on the shape of [EntityFilterQuery](https://github.com/backstage/backstage/blob/774c42003782121d3d6b2aa5f2865d53370c160e/packages/catalog-client/src/types/api.ts#L74), which can be passed into the CatalogClient. See examples below:
+
+- Get all entities of kind `Group`
+
+  ```yaml
+  owner:
+    title: Owner
+    type: string
+    description: Owner of the component
+    ui:field: OwnerPicker
+    ui:options:
+      catalogFilter:
+        - kind: Group
+  ```
+
+- Get entities of kind `Group` and spec.type `team`
+  ```yaml
+  owner:
+    title: Owner
+    type: string
+    description: Owner of the component
+    ui:field: OwnerPicker
+    ui:options:
+      catalogFilter:
+        - kind: Group
+          spec.type: team
+  ```

--- a/.changeset/selfish-phones-smoke.md
+++ b/.changeset/selfish-phones-smoke.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Added the catalogFilter prop to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.
+Added `catalogFilter` field to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.
 
 The `allowedKinds` field has been deprecated. Use `catalogFilter` instead. This field allows users to specify a filter on the shape of [EntityFilterQuery](https://github.com/backstage/backstage/blob/774c42003782121d3d6b2aa5f2865d53370c160e/packages/catalog-client/src/types/api.ts#L74), which can be passed into the CatalogClient. See examples below:
 

--- a/.changeset/selfish-phones-smoke.md
+++ b/.changeset/selfish-phones-smoke.md
@@ -1,5 +1,9 @@
 ---
 '@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder-backend-module-cookiecutter': patch
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+'@backstage/plugin-scaffolder-backend-module-yeoman': patch
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Added `catalogFilter` field to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.

--- a/.changeset/selfish-phones-smoke.md
+++ b/.changeset/selfish-phones-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added a new prop to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.

--- a/.changeset/selfish-phones-smoke.md
+++ b/.changeset/selfish-phones-smoke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder': minor
 ---
 
 Added `catalogFilter` field to OwnerPicker and EntityPicker components to support filtering options by any field(s) of an entity.

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -44,8 +44,8 @@ spec:
           description: Owner of the component
           ui:field: OwnerPicker
           ui:options:
-            allowedKinds:
-              - Group
+            catalogFilter:
+              kind: Group
     - title: Choose a location
       required:
         - repoUrl
@@ -459,7 +459,7 @@ an owner for them. Ideally, users should be able to select an owner when they go
 through the scaffolder form from the users and groups already known to
 Backstage. The `OwnerPicker` is a custom field that generates a searchable list
 of groups and/or users already in the catalog to pick an owner from. You can
-specify which of the two kinds are listed in the `allowedKinds` option:
+specify which of the two kinds (or both) are listed in the `catalogFilter.kind` option:
 
 ```yaml
 owner:
@@ -468,8 +468,8 @@ owner:
   description: Owner of the component
   ui:field: OwnerPicker
   ui:options:
-    allowedKinds:
-      - Group
+    catalogFilter:
+      kind: [Group, User]
 ```
 
 ## `spec.steps` - `Action[]`

--- a/packages/app/src/components/scaffolder/defaultPreviewTemplate.ts
+++ b/packages/app/src/components/scaffolder/defaultPreviewTemplate.ts
@@ -31,8 +31,8 @@ parameters:
         description: Owner of the component
         ui:field: OwnerPicker
         ui:options:
-          allowedKinds:
-            - Group
+          catalogFilter:
+            kind: Group
   - title: Choose a location
     required:
       - repoUrl

--- a/plugins/scaffolder-backend-module-cookiecutter/README.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/README.md
@@ -73,16 +73,16 @@ spec:
           description: Owner of the component
           ui:field: OwnerPicker
           ui:options:
-            allowedKinds:
-              - Group
+            catalogFilter:
+              kind: Group
         system:
           title: System
           type: string
           description: System of the component
           ui:field: EntityPicker
           ui:options:
-            allowedKinds:
-              - System
+            catalogFilter:
+              kind: System
             defaultKind: System
 
     - title: Choose a location

--- a/plugins/scaffolder-backend-module-rails/README.md
+++ b/plugins/scaffolder-backend-module-rails/README.md
@@ -74,16 +74,16 @@ spec:
           description: Owner of the component
           ui:field: OwnerPicker
           ui:options:
-            allowedKinds:
-              - Group
+            catalogFilter:
+              kind: Group
         system:
           title: System
           type: string
           description: System of the component
           ui:field: EntityPicker
           ui:options:
-            allowedKinds:
-              - System
+            catalogFilter:
+              kind: System
             defaultKind: System
 
     - title: Choose a location

--- a/plugins/scaffolder-backend-module-yeoman/README.md
+++ b/plugins/scaffolder-backend-module-yeoman/README.md
@@ -73,16 +73,16 @@ spec:
           description: Owner of the component
           ui:field: OwnerPicker
           ui:options:
-            allowedKinds:
-              - Group
+            catalogFilter:
+              kind: Group
         system:
           title: System
           type: string
           description: System of the component
           ui:field: EntityPicker
           ui:options:
-            allowedKinds:
-              - System
+            catalogFilter:
+              kind: System
             defaultKind: System
 
     - title: Choose a location

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -39,8 +39,8 @@ spec:
           description: Owner of the component
           ui:field: OwnerPicker
           ui:options:
-            allowedKinds:
-              - Group
+            catalogFilter:
+              kind: Group
 
   steps:
     - id: fetch-base

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -88,6 +88,10 @@ export const EntityPickerFieldExtension: FieldExtensionComponent<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    catalogFilter?:
+      | Record<string, string | string[]>
+      | Record<string, string | string[]>[]
+      | undefined;
   }
 >;
 
@@ -99,6 +103,10 @@ export const EntityPickerFieldSchema: FieldSchema<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    catalogFilter?:
+      | Record<string, string | string[]>
+      | Record<string, string | string[]>[]
+      | undefined;
   }
 >;
 
@@ -309,6 +317,10 @@ export const OwnerPickerFieldExtension: FieldExtensionComponent<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    catalogFilter?:
+      | Record<string, string | string[]>
+      | Record<string, string | string[]>[]
+      | undefined;
   }
 >;
 
@@ -319,6 +331,10 @@ export const OwnerPickerFieldSchema: FieldSchema<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    catalogFilter?:
+      | Record<string, string | string[]>
+      | Record<string, string | string[]>[]
+      | undefined;
   }
 >;
 

--- a/plugins/scaffolder/src/components/TemplateEditorPage/TemplateFormPreviewer.tsx
+++ b/plugins/scaffolder/src/components/TemplateEditorPage/TemplateFormPreviewer.tsx
@@ -53,8 +53,8 @@ parameters:
         description: Owner of the component
         ui:field: OwnerPicker
         ui:options:
-          allowedKinds:
-            - Group
+          catalogFilter:
+            kind: Group
   - title: Choose a location
     required:
       - repoUrl

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { type EntityFilterQuery } from '@backstage/catalog-client';
 import { useApi } from '@backstage/core-plugin-api';
 import {
   catalogApiRef,
@@ -44,6 +45,11 @@ export const EntityPicker = (props: EntityPickerProps) => {
     idSchema,
   } = props;
   const allowedKinds = uiSchema['ui:options']?.allowedKinds;
+
+  const catalogFilter: EntityFilterQuery | undefined =
+    uiSchema['ui:options']?.catalogFilter ||
+    (allowedKinds && { kind: allowedKinds });
+
   const defaultKind = uiSchema['ui:options']?.defaultKind;
   const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
 
@@ -51,7 +57,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   const { value: entities, loading } = useAsync(() =>
     catalogApi.getEntities(
-      allowedKinds ? { filter: { kind: allowedKinds } } : undefined,
+      catalogFilter ? { filter: catalogFilter } : undefined,
     ),
   );
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -29,10 +29,15 @@ export const entityQueryFilterExpressionSchema = z.record(
 export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
   z.string(),
   z.object({
+    /**
+     * @deprecated Use `catalogFilter` instead.
+     */
     allowedKinds: z
       .array(z.string())
       .optional()
-      .describe('List of kinds of entities to derive options from'),
+      .describe(
+        'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from',
+      ),
     defaultKind: z
       .string()
       .optional()

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -19,6 +19,13 @@ import { makeFieldSchemaFromZod } from '../utils';
 /**
  * @public
  */
+export const entityQueryFilterExpressionSchema = z.record(
+  z.string().or(z.array(z.string())),
+);
+
+/**
+ * @public
+ */
 export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
   z.string(),
   z.object({
@@ -42,6 +49,11 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'The default namespace. Options with this namespace will not be prefixed.',
       ),
+    catalogFilter: z
+      .array(entityQueryFilterExpressionSchema)
+      .or(entityQueryFilterExpressionSchema)
+      .optional()
+      .describe('List of key-value filter expression for entities'),
   }),
 );
 

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -33,14 +33,16 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
   } = props;
 
   const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
+  const allowedKinds = uiSchema['ui:options']?.allowedKinds;
+
+  const catalogFilter = uiSchema['ui:options']?.catalogFilter || {
+    kind: allowedKinds || ['Group', 'User'],
+  };
 
   const ownerUiSchema = {
     ...uiSchema,
     'ui:options': {
-      allowedKinds: (uiSchema['ui:options']?.allowedKinds || [
-        'Group',
-        'User',
-      ]) as string[],
+      catalogFilter,
       defaultKind: 'Group',
       allowArbitraryValues:
         uiSchema['ui:options']?.allowArbitraryValues ?? true,

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
@@ -23,12 +23,15 @@ import { entityQueryFilterExpressionSchema } from '../EntityPicker/schema';
 export const OwnerPickerFieldSchema = makeFieldSchemaFromZod(
   z.string(),
   z.object({
+    /**
+     * @deprecated Use `catalogFilter` instead.
+     */
     allowedKinds: z
       .array(z.string())
       .default(['Group', 'User'])
       .optional()
       .describe(
-        'List of kinds of entities to derive options from. Defaults to Group and User',
+        'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from. Defaults to Group and User',
       ),
     allowArbitraryValues: z
       .boolean()

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
@@ -15,6 +15,7 @@
  */
 import { z } from 'zod';
 import { makeFieldSchemaFromZod } from '../utils';
+import { entityQueryFilterExpressionSchema } from '../EntityPicker/schema';
 
 /**
  * @public
@@ -39,6 +40,11 @@ export const OwnerPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'The default namespace. Options with this namespace will not be prefixed.',
       ),
+    catalogFilter: z
+      .array(entityQueryFilterExpressionSchema)
+      .or(entityQueryFilterExpressionSchema)
+      .optional()
+      .describe('List of key-value filter expression for entities'),
   }),
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Solves: https://github.com/backstage/backstage/issues/14979 

- Added `catalogFilter` prop of type [`EntityFilterQuery`](https://github.com/backstage/backstage/blob/774c42003782121d3d6b2aa5f2865d53370c160e/packages/catalog-client/src/types/api.ts#L74) to the `EntityPicker` schema to allow users to filter entities as they want.
-  Updated `EntityPicker`'s dependent component `OwnerPicker` to also include the `catalogFilter` prop.
- Retro compatible with existing implementations. The `catalogFilter` prop only takes precedence over `allowedKinds` when provided. The below example results in a list of entities of `kind: Group` and `spec.type: team`
  ```yaml
    owner:
      title: Owner
      type: string
      description: Owner of the component
      ui:field: OwnerPicker
      ui:options:
        allowedKinds: 
          - User
        catalogFilter:
          - kind: Group
            spec.type: team
  ```

#### Open Questions

- Should we remove the `allowedKinds` prop?
- When and where are the components' schema being validated?

#### Testing

<details>
<summary>with allowedKinds</summary>
<img src="https://user-images.githubusercontent.com/5296417/206056967-529d4582-2697-431c-a61c-bb112e9e7e2e.png" />
<img src="https://user-images.githubusercontent.com/5296417/206058901-5e89a14b-d89c-4c45-90f7-6ee6cf669a8c.png" />
</details>

<details>
<summary>with catalogFilter - list of filter expressions</summary>
<img src="https://user-images.githubusercontent.com/5296417/206059965-4d71bc03-2f71-437f-87d4-0cb306ee9217.png" />
<img src="https://user-images.githubusercontent.com/5296417/206059964-02a04901-fda9-40f1-a19c-57ebe835d3da.png" />
</details>

<details>
<summary>with catalogFilter - single filter expression</summary>
<img src="https://user-images.githubusercontent.com/5296417/206059650-e47b8152-c21e-4388-88d0-2f1740922885.png" />
<img src="https://user-images.githubusercontent.com/5296417/206059647-e864ec5a-0d2d-4848-baee-3dd33881b36e.png" />
</details>


<details>
<summary>catalogFilter takes precedence over allowedKinds</summary>
<img src="https://user-images.githubusercontent.com/5296417/206060235-1c3934e8-d3b2-4b7e-b384-4c2afe34b2c9.png" />
<img src="https://user-images.githubusercontent.com/5296417/206060232-79c24e5f-f889-44f0-b2f8-96bd49a58023.png" />
</details>

<details>
<summary>with empty catalogFilter (filters by default Group and User kind)</summary>
<img src="https://user-images.githubusercontent.com/5296417/206058132-0e6e51ef-c35c-4f89-bc68-5b2a7466a09e.png" />
<img src="https://user-images.githubusercontent.com/5296417/206058135-8918bc55-3edc-45c8-b337-ababef122311.png" />

</details>

<details>
<summary>with catalogFilter (filtering by annotations)</summary>
<img width="632" alt="Screen Shot 2022-12-07 at 1 32 36 PM" src="https://user-images.githubusercontent.com/5296417/206301977-3a8a68ee-acd9-439d-b737-c719b7fcb564.png" />
<img width="833" alt="Screen Shot 2022-12-07 at 1 33 18 PM" src="https://user-images.githubusercontent.com/5296417/206301691-a2e6edb2-70b5-4ac4-bde9-d67959452eb2.png" />
<img width="448" alt="Screen Shot 2022-12-07 at 1 33 26 PM" src="https://user-images.githubusercontent.com/5296417/206301694-81b2dbcd-d000-4927-9324-4f58cf6201a3.png" />
<img width="1617" alt="Screen Shot 2022-12-07 at 1 33 40 PM" src="https://user-images.githubusercontent.com/5296417/206301724-cfee0bfb-0d1a-4880-864a-cf852902601c.png" />
</details>

<details>
<summary>with catalogFilter (filtering by tags)</summary>
<img width="576" alt="Screen Shot 2022-12-07 at 1 35 09 PM" src="https://user-images.githubusercontent.com/5296417/206302149-f74fb418-d72a-4b5c-a95b-374177b1d748.png">
<img width="448" alt="Screen Shot 2022-12-07 at 1 33 26 PM" src="https://user-images.githubusercontent.com/5296417/206302192-7bb39c20-7b04-4fcf-ae4c-7788382f3b03.png">
<img width="454" alt="Screen Shot 2022-12-07 at 1 33 52 PM" src="https://user-images.githubusercontent.com/5296417/206302193-b282450b-bcb1-4381-a448-bdc60292ac9b.png">
<img width="1611" alt="Screen Shot 2022-12-07 at 1 35 00 PM" src="https://user-images.githubusercontent.com/5296417/206302216-c5f62058-b03b-492d-9af1-9fc8867a1bcf.png">
</details>
      

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
