### PR TITLE
use nunjucks "square bracket syntax" for steps in docs

### DIFF
--- a/.changeset/dirty-ads-refuse.md
+++ b/.changeset/dirty-ads-refuse.md
@@ -1,0 +1,6 @@
+---
+'@backstage/create-app': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Change step output template examples to use square bracket syntax.

--- a/.changeset/dirty-ads-refuse.md
+++ b/.changeset/dirty-ads-refuse.md
@@ -1,4 +1,7 @@
 ---
+'@backstage/plugin-scaffolder-backend-module-cookiecutter': patch
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+'@backstage/plugin-scaffolder-backend-module-yeoman': patch
 '@backstage/create-app': patch
 '@backstage/plugin-scaffolder-backend': patch
 ---

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -703,7 +703,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: '{{ steps["publish"].output.repoContentsUrl }}'
+        repoContentsUrl: {{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 ```
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -703,7 +703,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: '{{ steps.publish.output.repoContentsUrl }}'
+        repoContentsUrl: '{{ steps["publish"].output.repoContentsUrl }}'
         catalogInfoPath: '/catalog-info.yaml'
 ```
 

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -76,7 +76,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 ```
 

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -76,7 +76,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 ```
 

--- a/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
+++ b/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
@@ -169,14 +169,14 @@ These should be moved to `links` under the `output` object instead.
 
 ```diff
   output:
--   remoteUrl: '{{ steps.publish.output.remoteUrl }}'
--   entityRef: '{{ steps.register.output.entityRef }}'
+-   remoteUrl: '{{ steps["publish"].output.remoteUrl }}'
+-   entityRef: '{{ steps["register"].output.entityRef }}'
 +   links:
 +     - title: Repository
-+       url: ${{ steps.publish.output.remoteUrl }}
++       url: ${{ steps["publish"].output.remoteUrl }}
 +     - title: Open in catalog
 +       icon: catalog
-+       entityRef: ${{ steps.register.output.entityRef }}
++       entityRef: ${{ steps["register"].output.entityRef }}
 
 ```
 
@@ -206,7 +206,7 @@ Alternatively, it's possible to keep the `dash-case` syntax and use brackets for
 
 ```yaml
 input:
-  repoUrl: ${{ steps['my-custom-action'].output.repoUrl }}
+  repoUrl: ${{ steps["my-custom-action"].output.repoUrl }}
 ```
 
 ### Summary

--- a/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
+++ b/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
@@ -169,14 +169,14 @@ These should be moved to `links` under the `output` object instead.
 
 ```diff
   output:
--   remoteUrl: '{{ steps["publish"].output.remoteUrl }}'
--   entityRef: '{{ steps["register"].output.entityRef }}'
+-   remoteUrl: {{ steps['publish'].output.remoteUrl }}
+-   entityRef: {{ steps['register'].output.entityRef }}
 +   links:
 +     - title: Repository
-+       url: ${{ steps["publish"].output.remoteUrl }}
++       url: ${{ steps['publish'].output.remoteUrl }}
 +     - title: Open in catalog
 +       icon: catalog
-+       entityRef: ${{ steps["register"].output.entityRef }}
++       entityRef: ${{ steps['register'].output.entityRef }}
 
 ```
 
@@ -206,7 +206,7 @@ Alternatively, it's possible to keep the `dash-case` syntax and use brackets for
 
 ```yaml
 input:
-  repoUrl: ${{ steps["my-custom-action"].output.repoUrl }}
+  repoUrl: ${{ steps['my-custom-action'].output.repoUrl }}
 ```
 
 ### Summary

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -88,17 +88,17 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   # some outputs which are saved along with the job for use in the frontend
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps["publish"].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+        entityRef: ${{ steps["register"].output.entityRef }}
 ```
 
 Let's dive in and pick apart what each of these sections do and what they are.
@@ -505,10 +505,10 @@ The main two that are used are the following:
 output:
   links:
     - title: Repository
-      url: ${{ steps.publish.output.remoteUrl }} # link to the remote repository
+      url: ${{ steps["publish"].output.remoteUrl }} # link to the remote repository
     - title: Open in catalog
       icon: catalog
-      entityRef: ${{ steps.register.output.entityRef }} # link to the entity that has been ingested to the catalog
+      entityRef: ${{ steps["register"].output.entityRef }} # link to the entity that has been ingested to the catalog
 ```
 
 ## The templating syntax

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -88,17 +88,17 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   # some outputs which are saved along with the job for use in the frontend
   output:
     links:
       - title: Repository
-        url: ${{ steps["publish"].output.remoteUrl }}
+        url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps["register"].output.entityRef }}
+        entityRef: ${{ steps['register'].output.entityRef }}
 ```
 
 Let's dive in and pick apart what each of these sections do and what they are.
@@ -505,10 +505,10 @@ The main two that are used are the following:
 output:
   links:
     - title: Repository
-      url: ${{ steps["publish"].output.remoteUrl }} # link to the remote repository
+      url: ${{ steps['publish'].output.remoteUrl }} # link to the remote repository
     - title: Open in catalog
       icon: catalog
-      entityRef: ${{ steps["register"].output.entityRef }} # link to the entity that has been ingested to the catalog
+      entityRef: ${{ steps['register'].output.entityRef }} # link to the entity that has been ingested to the catalog
 ```
 
 ## The templating syntax

--- a/packages/create-app/templates/default-app/examples/template/template.yaml
+++ b/packages/create-app/templates/default-app/examples/template/template.yaml
@@ -61,14 +61,14 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps["publish"].output.remoteUrl }}
+        url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}

--- a/packages/create-app/templates/default-app/examples/template/template.yaml
+++ b/packages/create-app/templates/default-app/examples/template/template.yaml
@@ -71,4 +71,4 @@ spec:
         url: ${{ steps["publish"].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps["register"].output.entityRef }}
+        entityRef: ${{ steps['register'].output.entityRef }}

--- a/packages/create-app/templates/default-app/examples/template/template.yaml
+++ b/packages/create-app/templates/default-app/examples/template/template.yaml
@@ -61,14 +61,14 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps["publish"].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+        entityRef: ${{ steps["register"].output.entityRef }}

--- a/plugins/scaffolder-backend-module-cookiecutter/README.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/README.md
@@ -129,7 +129,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
     - name: Results
@@ -141,10 +141,10 @@ spec:
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+        entityRef: ${{ steps['register'].output.entityRef }}
 ```
 
 You can also visit the `/create/actions` route in your Backstage application to find out more about the parameters this action accepts when it's installed to configure how you like.

--- a/plugins/scaffolder-backend-module-rails/README.md
+++ b/plugins/scaffolder-backend-module-rails/README.md
@@ -206,7 +206,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
     - name: Results
@@ -218,10 +218,10 @@ spec:
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+        entityRef: ${{ steps['register'].output.entityRef }}
 ```
 
 ### What you need to run that action

--- a/plugins/scaffolder-backend-module-yeoman/README.md
+++ b/plugins/scaffolder-backend-module-yeoman/README.md
@@ -126,7 +126,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
     - name: Results
@@ -138,10 +138,10 @@ spec:
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+        entityRef: ${{ steps['register'].output.entityRef }}
 ```
 
 You can also visit the `/create/actions` route in your Backstage application to find out more about the parameters this action accepts when it's installed to configure how you like.

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -68,13 +68,13 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   output:
     links:
       - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
+        url: ${{ steps["publish"].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+        entityRef: ${{ steps["register"].output.entityRef }}

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -74,7 +74,7 @@ spec:
   output:
     links:
       - title: Repository
-        url: ${{ steps["publish"].output.remoteUrl }}
+        url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps["register"].output.entityRef }}
+        entityRef: ${{ steps['register'].output.entityRef }}

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -68,7 +68,7 @@ spec:
       name: Register
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps["publish"].output.repoContentsUrl }}
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
         catalogInfoPath: '/catalog-info.yaml'
 
   output:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

use nunjucks "square bracket syntax" for steps in docs.

This PR might be contentious or not. I am not sure.

There are lots of examples in the docs with step ids containing the dash symbol "-" (a special charactor in nunjucks) and also examples looking up step outputs using the dot syntax. While not I think this leads users to assume that steps with dashes in their ids can be looked up with the dot syntax. However in this case it returns the string "NaN" which is very confusing and provides little information for the user to determine how to solve the problem.

By changing the examples for step outputs, I hope it will help users to avoid this mistake.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
