### PR TITLE
Catalog graph improvement

### DIFF
--- a/.changeset/wicked-masks-explain.md
+++ b/.changeset/wicked-masks-explain.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-graph': patch
+---
+
+Added owned by filter to catalog-graph

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -73,7 +73,6 @@ export const EntityCatalogGraphCard: (props: {
   unidirectional?: boolean | undefined;
   mergeRelations?: boolean | undefined;
   kinds?: string[] | undefined;
-  ownedBy?: string[] | undefined;
   relations?: string[] | undefined;
   direction?: Direction | undefined;
   height?: number | undefined;
@@ -111,6 +110,7 @@ export const EntityRelationsGraph: (props: {
   unidirectional?: boolean | undefined;
   mergeRelations?: boolean | undefined;
   kinds?: string[] | undefined;
+  ownedBy?: string[] | undefined;
   relations?: string[] | undefined;
   direction?: Direction | undefined;
   onNodeClick?:

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -24,6 +24,7 @@ export const CatalogGraphPage: (props: {
     | {
         selectedRelations?: string[] | undefined;
         selectedKinds?: string[] | undefined;
+        selectedOwnedBy?: string[] | undefined;
         rootEntityRefs?: string[] | undefined;
         maxDepth?: number | undefined;
         unidirectional?: boolean | undefined;
@@ -72,6 +73,7 @@ export const EntityCatalogGraphCard: (props: {
   unidirectional?: boolean | undefined;
   mergeRelations?: boolean | undefined;
   kinds?: string[] | undefined;
+  ownedBy?: string[] | undefined;
   relations?: string[] | undefined;
   direction?: Direction | undefined;
   height?: number | undefined;

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -44,6 +44,7 @@ import { CurveFilter } from './CurveFilter';
 import { DirectionFilter } from './DirectionFilter';
 import { MaxDepthFilter } from './MaxDepthFilter';
 import { SelectedKindsFilter } from './SelectedKindsFilter';
+import { SelectedOwnedByFilter } from './SelectedOwnedByFilter';
 import { SelectedRelationsFilter } from './SelectedRelationsFilter';
 import { SwitchFilter } from './SwitchFilter';
 import { useCatalogGraphPage } from './useCatalogGraphPage';
@@ -108,6 +109,7 @@ export const CatalogGraphPage = (props: {
   initialState?: {
     selectedRelations?: string[];
     selectedKinds?: string[];
+    selectedOwnedBy?: string[];
     rootEntityRefs?: string[];
     maxDepth?: number;
     unidirectional?: boolean;
@@ -127,6 +129,8 @@ export const CatalogGraphPage = (props: {
     setMaxDepth,
     selectedKinds,
     setSelectedKinds,
+    selectedOwnedBy,
+    setSelectedOwnedBy,
     selectedRelations,
     setSelectedRelations,
     unidirectional,
@@ -207,6 +211,10 @@ export const CatalogGraphPage = (props: {
                 onChange={setSelectedRelations}
                 relationPairs={relationPairs}
               />
+              <SelectedOwnedByFilter
+                value={selectedOwnedBy}
+                onChange={setSelectedOwnedBy}
+              />
               <DirectionFilter value={direction} onChange={setDirection} />
               <CurveFilter value={curve} onChange={setCurve} />
               <SwitchFilter
@@ -244,6 +252,11 @@ export const CatalogGraphPage = (props: {
                 relations={
                   selectedRelations && selectedRelations.length > 0
                     ? selectedRelations
+                    : undefined
+                }
+                ownedBy={
+                  selectedOwnedBy && selectedOwnedBy.length > 0
+                    ? selectedOwnedBy
                     : undefined
                 }
                 mergeRelations={mergeRelations}

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -146,7 +146,7 @@ describe('<SelectedOwnedByFilter/>', () => {
     await userEvent.click(screen.getByText('service-with-owner'));
 
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith(undefined);
+      expect(onChange).toHaveBeenCalledWith(catalogApi);
     });
   });
 

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -148,11 +148,9 @@ describe('<SelectedOwnedByFilter/>', () => {
     );
     await userEvent.click(screen.getByLabelText('Open'));
 
-    await waitFor(() =>
-      expect(screen.getByText('Resource')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('system')).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('Resource'));
+    await userEvent.click(screen.getByText('system'));
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(undefined);

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -133,8 +133,8 @@ describe('<SelectedOwnedByFilter/>', () => {
       </ApiProvider>,
     );
 
-    expect(screen.getByText('User')).toBeInTheDocument();
-    expect(screen.getByText('Component')).toBeInTheDocument();
+    expect(screen.getByText('user')).toBeInTheDocument();
+    expect(screen.getByText('component')).toBeInTheDocument();
   });
   it('should return undefined if all values are selected', async () => {
     const onChange = jest.fn();

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -123,32 +123,6 @@ describe('<SelectedOwnedByFilter/>', () => {
     expect(screen.getByText('user')).toBeInTheDocument();
     expect(screen.getByText('group')).toBeInTheDocument();
   });
-  it('should return undefined if all values are selected', async () => {
-    const onChange = jest.fn();
-    await renderWithEffects(
-      <ApiProvider apis={apis}>
-        <SelectedOwnedByFilter
-          value={[
-            'service-with-owner',
-            'service-with-incomplete-data',
-            'service-with-user-owner',
-          ]}
-          onChange={onChange}
-        />
-      </ApiProvider>,
-    );
-    await userEvent.click(screen.getByLabelText('Open'));
-
-    await waitFor(() =>
-      expect(screen.getByText('service-with-owner')).toBeInTheDocument(),
-    );
-
-    await userEvent.click(screen.getByText('service-with-owner'));
-
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith(catalogApi);
-    });
-  });
 
   it('should return all values when cleared', async () => {
     const onChange = jest.fn();

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -15,12 +15,7 @@
  */
 
 import { GetEntityFacetsResponse } from '@backstage/catalog-client';
-import {
-  RELATION_CHILD_OF,
-  RELATION_OWNED_BY,
-  RELATION_HAS_MEMBER,
-} from '@backstage/catalog-model';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithEffects, TestApiRegistry } from '@backstage/test-utils';
 import { AlertApi, alertApiRef } from '@backstage/core-plugin-api';

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RELATION_CHILD_OF, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { SelectedOwnedByFilter } from './SelectedOwnedByFilter';
+
+describe('<SelectedOwnedByFilter/>', () => {
+  test('should render current value', () => {
+    render(
+      <SelectedOwnedByFilter
+        value={[RELATION_OWNED_BY, RELATION_CHILD_OF]}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(RELATION_OWNED_BY)).toBeInTheDocument();
+    expect(screen.getByText(RELATION_CHILD_OF)).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.test.tsx
@@ -25,6 +25,15 @@ import { ApiProvider } from '@backstage/core-app-api';
 import { SelectedOwnedByFilter } from './SelectedOwnedByFilter';
 import { RELATION_OWNED_BY } from '@backstage/catalog-model';
 
+const getEntitiesMock = jest.fn();
+jest.mock('@backstage/catalog-client', () => {
+  return {
+    CatalogClient: jest
+      .fn()
+      .mockImplementation(() => ({ getEntities: getEntitiesMock })),
+  };
+});
+
 const catalogApi = {
   getEntities: jest.fn().mockResolvedValue({
     items: [
@@ -96,6 +105,12 @@ const apis = TestApiRegistry.from(
 );
 
 describe('<SelectedOwnedByFilter/>', () => {
+  beforeEach(() => {
+    getEntitiesMock.mockResolvedValue(catalogApi);
+  });
+  afterEach(() => {
+    getEntitiesMock.mockClear();
+  });
   it('should not explode while loading', async () => {
     const { baseElement } = await renderWithEffects(
       <ApiProvider apis={apis}>

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedOwnedByFilter.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  makeStyles,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Autocomplete } from '@material-ui/lab';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+
+const useStyles = makeStyles({
+  formControl: {
+    maxWidth: 300,
+  },
+});
+
+export type Props = {
+  value: string[] | undefined;
+  onChange: (value: string[] | undefined) => void;
+};
+
+export const SelectedOwnedByFilter = ({ value, onChange }: Props) => {
+  const classes = useStyles();
+  const alertApi = useApi(alertApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const { error, value: ownedby } = useAsync(async () => {
+    return await catalogApi
+      .getEntities({
+        filter: { kind: ['Group', 'User'] },
+        fields: ['kind', 'metadata.name', 'metadata.namespace'],
+      })
+      .then(response =>
+        response.items.map(entity => stringifyEntityRef(entity)),
+      );
+  });
+
+  useEffect(() => {
+    if (error) {
+      alertApi.post({
+        message: `Failed to load entity kinds`,
+        severity: 'error',
+      });
+    }
+  }, [error, alertApi]);
+
+  const normalizedOwnedby = useMemo(
+    () =>
+      ownedby
+        ? ownedby.map(owner => owner.toLocaleLowerCase('en-US'))
+        : ownedby,
+    [ownedby],
+  );
+
+  const handleChange = useCallback(
+    (_: unknown, v: string[]) => {
+      onChange(
+        normalizedOwnedby && normalizedOwnedby.every(r => v.includes(r))
+          ? undefined
+          : v,
+      );
+    },
+    [normalizedOwnedby, onChange],
+  );
+
+  const handleEmpty = useCallback(() => {
+    onChange(value?.length ? value : undefined);
+  }, [value, onChange]);
+
+  if (!ownedby?.length || !normalizedOwnedby?.length || error) {
+    return null;
+  }
+
+  return (
+    <Box pb={1} pt={1}>
+      <Typography variant="button">Ownedby</Typography>
+      <Autocomplete
+        className={classes.formControl}
+        multiple
+        limitTags={4}
+        disableCloseOnSelect
+        aria-label="Ownedby"
+        options={normalizedOwnedby}
+        value={value ?? normalizedOwnedby}
+        getOptionLabel={owner =>
+          ownedby[normalizedOwnedby.indexOf(owner)] ?? owner
+        }
+        onChange={handleChange}
+        onBlur={handleEmpty}
+        renderOption={(option, { selected }) => (
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                checkedIcon={<CheckBoxIcon fontSize="small" />}
+                checked={selected}
+              />
+            }
+            label={ownedby[normalizedOwnedby.indexOf(option)] ?? option}
+          />
+        )}
+        size="small"
+        popupIcon={<ExpandMoreIcon data-testid="selected-ownedby-expand" />}
+        renderInput={params => <TextField {...params} variant="outlined" />}
+      />
+    </Box>
+  );
+};

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/useCatalogGraphPage.ts
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/useCatalogGraphPage.ts
@@ -38,6 +38,8 @@ export type CatalogGraphPageValue = {
   setMaxDepth: Dispatch<React.SetStateAction<number>>;
   selectedRelations: string[] | undefined;
   setSelectedRelations: Dispatch<React.SetStateAction<string[] | undefined>>;
+  selectedOwnedBy: string[] | undefined;
+  setSelectedOwnedBy: Dispatch<React.SetStateAction<string[] | undefined>>;
   selectedKinds: string[] | undefined;
   setSelectedKinds: Dispatch<React.SetStateAction<string[] | undefined>>;
   unidirectional: boolean;
@@ -60,6 +62,7 @@ export function useCatalogGraphPage({
   initialState?: {
     selectedRelations?: string[] | undefined;
     selectedKinds?: string[] | undefined;
+    selectedOwnedBy?: string[] | undefined;
     rootEntityRefs?: string[];
     maxDepth?: number;
     unidirectional?: boolean;
@@ -76,6 +79,7 @@ export function useCatalogGraphPage({
         {}) as {
         selectedRelations?: string[] | string;
         selectedKinds?: string[] | string;
+        selectedOwnedBy?: string[] | undefined;
         rootEntityRefs?: string[] | string;
         maxDepth?: string[] | string;
         unidirectional?: string[] | string;
@@ -112,6 +116,13 @@ export function useCatalogGraphPage({
       ? query.selectedKinds
       : initialState?.selectedKinds
     )?.map(k => k.toLocaleLowerCase('en-US')),
+  );
+  const [selectedOwnedBy, setSelectedOwnedBy] = useState<string[] | undefined>(
+    () =>
+      (Array.isArray(query.selectedOwnedBy)
+        ? query.selectedOwnedBy
+        : initialState?.selectedOwnedBy
+      )?.map(k => k.toLocaleLowerCase('en-US')),
   );
   const [unidirectional, setUnidirectional] = useState<boolean>(() =>
     typeof query.unidirectional === 'string'
@@ -167,6 +178,10 @@ export function useCatalogGraphPage({
       setSelectedRelations(query.selectedRelations);
     }
 
+    if (Array.isArray(query.selectedOwnedBy)) {
+      setSelectedOwnedBy(query.selectedOwnedBy);
+    }
+
     if (typeof query.unidirectional === 'string') {
       setUnidirectional(query.unidirectional === 'true');
     }
@@ -190,6 +205,7 @@ export function useCatalogGraphPage({
     setMaxDepth,
     setSelectedKinds,
     setSelectedRelations,
+    setSelectedOwnedBy,
     setUnidirectional,
     setMergeRelations,
     setDirection,
@@ -209,6 +225,7 @@ export function useCatalogGraphPage({
         maxDepth: isFinite(maxDepth) ? maxDepth : '∞',
         selectedKinds,
         selectedRelations,
+        selectedOwnedBy,
         unidirectional,
         mergeRelations,
         direction,
@@ -238,6 +255,7 @@ export function useCatalogGraphPage({
     maxDepth,
     selectedKinds,
     selectedRelations,
+    selectedOwnedBy,
     unidirectional,
     mergeRelations,
     direction,
@@ -252,6 +270,8 @@ export function useCatalogGraphPage({
     setMaxDepth,
     selectedRelations,
     setSelectedRelations,
+    selectedOwnedBy,
+    setSelectedOwnedBy,
     selectedKinds,
     setSelectedKinds,
     unidirectional,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -77,6 +77,7 @@ export const EntityRelationsGraph = (props: {
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
+  ownedBy?: string[];
   relations?: string[];
   direction?: Direction;
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
@@ -93,6 +94,7 @@ export const EntityRelationsGraph = (props: {
     unidirectional = true,
     mergeRelations = true,
     kinds,
+    ownedBy,
     relations,
     direction = Direction.LEFT_RIGHT,
     onNodeClick,
@@ -121,6 +123,7 @@ export const EntityRelationsGraph = (props: {
     unidirectional,
     mergeRelations,
     kinds,
+    ownedBy,
     relations,
     onNodeClick,
     relationPairs,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationGraph.ts
@@ -24,13 +24,19 @@ import { useEntityStore } from './useEntityStore';
  */
 export function useEntityRelationGraph({
   rootEntityRefs,
-  filter: { maxDepth = Number.POSITIVE_INFINITY, relations, kinds } = {},
+  filter: {
+    maxDepth = Number.POSITIVE_INFINITY,
+    relations,
+    kinds,
+    ownedBy,
+  } = {},
 }: {
   rootEntityRefs: string[];
   filter?: {
     maxDepth?: number;
     relations?: string[];
     kinds?: string[];
+    ownedBy?: string[];
   };
 }): {
   entities?: { [ref: string]: Entity };
@@ -68,7 +74,12 @@ export function useEntityRelationGraph({
                   rel.targetRef.startsWith(
                     `${kind.toLocaleLowerCase('en-US')}:`,
                   ),
-                ))
+                )) &&
+              (!ownedBy ||
+                (rel.type === 'ownedBy' &&
+                  ownedBy.includes(rel.targetRef.split('/').slice(-1)[0])) ||
+                (rel.type === 'ownerOf' &&
+                  ownedBy.includes(entity.metadata.name)))
             ) {
               if (!processedEntityRefs.has(rel.targetRef)) {
                 nextDepthRefQueue.push(rel.targetRef);
@@ -83,7 +94,15 @@ export function useEntityRelationGraph({
     }
 
     requestEntities([...expectedEntities]);
-  }, [entities, rootEntityRefs, maxDepth, relations, kinds, requestEntities]);
+  }, [
+    entities,
+    rootEntityRefs,
+    maxDepth,
+    relations,
+    kinds,
+    ownedBy,
+    requestEntities,
+  ]);
 
   return {
     entities,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
@@ -29,6 +29,7 @@ export function useEntityRelationNodesAndEdges({
   unidirectional = true,
   mergeRelations = true,
   kinds,
+  ownedBy,
   relations,
   onNodeClick,
   relationPairs = ALL_RELATION_PAIRS,
@@ -38,6 +39,7 @@ export function useEntityRelationNodesAndEdges({
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
+  ownedBy?: string[];
   relations?: string[];
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
   relationPairs?: RelationPairs;
@@ -56,6 +58,7 @@ export function useEntityRelationNodesAndEdges({
     filter: {
       maxDepth,
       kinds,
+      ownedBy,
       relations,
     },
   });


### PR DESCRIPTION
## Added owned by filter to catalog-graph

Adding filters for the Owner (owned by) so that we can see a subset of the catalog graph

- Added **ownedby** filter box just like kinds and relations
- By default, it has all the group(owners) options
- We can filter out entities owned by a particular group

#### 🚀 re-opened PR: https://github.com/backstage/backstage/pull/14130

Thanks
