### PR TITLE
core-app-api: tests + fix for WebStorage event notifications

### DIFF
--- a/packages/core-app-api/src/apis/implementations/StorageApi/WebStorage.ts
+++ b/packages/core-app-api/src/apis/implementations/StorageApi/WebStorage.ts
@@ -22,7 +22,7 @@ import {
 import { JsonValue, Observable } from '@backstage/types';
 import ObservableImpl from 'zen-observable';
 
-const buckets = new Map<string, WebStorage>();
+export const buckets = new Map<string, WebStorage>();
 
 /**
  * An implementation of the storage API, that uses the browser's local storage.
@@ -109,9 +109,16 @@ export class WebStorage implements StorageApi {
   }
 
   private handleStorageChange(eventKey: StorageEvent['key']) {
-    if (!eventKey?.startsWith(this.namespace)) return;
-    const key = eventKey?.replace(`${this.namespace}/`, '');
-    this.notifyChanges(key);
+    if (!eventKey?.startsWith(this.namespace)) {
+      return;
+    }
+    // Grab the part of this key that is local to this bucket
+    const trimmedKey = eventKey?.slice(`${this.namespace}/`.length);
+
+    // If the key still contains a slash, it means it's a sub-bucket
+    if (!trimmedKey.includes('/')) {
+      this.notifyChanges(decodeURIComponent(trimmedKey));
+    }
   }
 
   private getKeyName(key: string) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added test + a fix for #15040, piggybacking on that changeset

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
