### PR TITLE
feat(search): allow max page limit to be configurable

### DIFF
--- a/.changeset/two-buckets-do.md
+++ b/.changeset/two-buckets-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Allow max page limit for search results to be configurable

--- a/plugins/search-backend/config.d.ts
+++ b/plugins/search-backend/config.d.ts
@@ -18,6 +18,11 @@ export interface Config {
   /** Configuration options for the search plugin */
   search?: {
     /**
+     * Sets the maximum max page limit size. Defaults to 100.
+     */
+    maxPageLimit?: number;
+
+    /**
      * Options related to the search integration with the Backstage permissions system
      */
     permissions?: {

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -48,6 +48,7 @@
     "supertest": "^6.1.3"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ]
 }

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -59,7 +59,10 @@ describe('createRouter', () => {
         'first-type': {},
         'second-type': {},
       },
-      config: new ConfigReader({ permissions: { enabled: false } }),
+      config: new ConfigReader({
+        permissions: { enabled: false },
+        search: { maxPageLimit: 200 },
+      }),
       permissions: mockPermissionEvaluator,
       logger,
     });
@@ -112,8 +115,8 @@ describe('createRouter', () => {
       });
     });
 
-    it('should accept per page value under or equal to 100', async () => {
-      const response = await request(app).get(`/query?pageLimit=30`);
+    it('should accept per page value under or equal to configured max', async () => {
+      const response = await request(app).get(`/query?pageLimit=200`);
 
       expect(response.status).toEqual(200);
       expect(response.body).toMatchObject({
@@ -121,13 +124,13 @@ describe('createRouter', () => {
       });
     });
 
-    it('should reject per page value over 100', async () => {
-      const response = await request(app).get(`/query?pageLimit=200`);
+    it('should reject per page value over configured max', async () => {
+      const response = await request(app).get(`/query?pageLimit=300`);
 
       expect(response.status).toEqual(400);
       expect(response.body).toMatchObject({
         error: {
-          message: /The page limit "200" is greater than "100"/i,
+          message: /The page limit "300" is greater than "200"/i,
         },
       });
     });

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -62,7 +62,7 @@ export type RouterOptions = {
   logger: Logger;
 };
 
-const maxPageLimit = 100;
+const defaultMaxPageLimit = 100;
 const allowedLocationProtocols = ['http:', 'https:'];
 
 /**
@@ -72,6 +72,9 @@ export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const { engine: inputEngine, types, permissions, config, logger } = options;
+
+  const maxPageLimit =
+    config.getOptionalNumber('search.maxPageLimit') ?? defaultMaxPageLimit;
 
   const requestSchema = z.object({
     term: z.string().default(''),


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This change allows integrators to configure the max page limit size instead of being constrained to the current hard coded limit


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
