### PR TITLE
Handle missing commits in GitlabUrlReader.readTree

### DIFF
--- a/.changeset/mighty-parrots-hammer.md
+++ b/.changeset/mighty-parrots-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix `GitlabUrlReader.readTree` bug when there were no matching commits

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -188,8 +188,7 @@ export class GitlabUrlReader implements UrlReader {
       throw new Error(message);
     }
 
-    const commitSha = (await commitsGitlabResponse.json())[0].id;
-
+    const commitSha = (await commitsGitlabResponse.json())[0]?.id ?? '';
     if (etag && etag === commitSha) {
       throw new NotModifiedError();
     }


### PR DESCRIPTION
Fixes #8036

I considered whether it would make sense to explicitly detect the empty commits list and throwing a `NotFoundError` or so. But I wasn't sure that that would be entirely semantically correct, and expected the following archive read operation to be the one to emit better / more precise errors anyway if that somehow was needed.