### PR TITLE
core-app-api: add app.createRoot() to replace app.getProvider()

### DIFF
--- a/.changeset/fuzzy-rivers-search.md
+++ b/.changeset/fuzzy-rivers-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+Added a new `AppRouter` component that replaces the same component currently created through `app.getRouter()`.

--- a/.changeset/fuzzy-rivers-search.md
+++ b/.changeset/fuzzy-rivers-search.md
@@ -2,4 +2,49 @@
 '@backstage/core-app-api': minor
 ---
 
-Added a new `AppRouter` component that replaces the same component currently created through `app.getRouter()`.
+Added a new `AppRouter` component and `app.createRoot()` method that replaces `app.getRouter()` and `app.getProvider()`, which are now deprecated. The new `AppRouter` component is a drop-in replacement for the old router component, while the new `app.createRoot()` method is used instead of the old provider component.
+
+An old app setup might look like this:
+
+```tsx
+const app = createApp(/* ... */);
+
+const AppProvider = app.getProvider();
+const AppRouter = app.getRouter();
+
+const routes = ...;
+
+const App = () => (
+  <AppProvider>
+    <AlertDisplay />
+    <OAuthRequestDialog />
+    <AppRouter>
+      <Root>{routes}</Root>
+    </AppRouter>
+  </AppProvider>
+);
+
+export default App;
+```
+
+With these new APIs, the setup now looks like this:
+
+```tsx
+import { AppRouter } from '@backstage/core-app-api';
+
+const app = createApp(/* ... */);
+
+const routes = ...;
+
+export default app.createRoot(
+  <>
+    <AlertDisplay />
+    <OAuthRequestDialog />
+    <AppRouter>
+      <Root>{routes}</Root>
+    </AppRouter>
+  </>,
+);
+```
+
+Note that `app.createRoot()` accepts a React element, rather than a component.

--- a/.changeset/shy-birds-hammer.md
+++ b/.changeset/shy-birds-hammer.md
@@ -1,0 +1,17 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated the app template to use the new `AppRouter` component instead of `app.getRouter()`.
+
+To apply this change to an existing app, make the following change to `packages/app/src/App.tsx`:
+
+```diff
+-import { FlatRoutes } from '@backstage/core-app-api';
++import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
+
+ ...
+
+ const AppProvider = app.getProvider();
+-const AppRouter = app.getRouter();
+```

--- a/.changeset/shy-birds-hammer.md
+++ b/.changeset/shy-birds-hammer.md
@@ -2,7 +2,7 @@
 '@backstage/create-app': patch
 ---
 
-Updated the app template to use the new `AppRouter` component instead of `app.getRouter()`.
+Updated the app template to use the new `AppRouter` component instead of `app.getRouter()`, as well as `app.createRoot()` instead of `app.getProvider()`.
 
 To apply this change to an existing app, make the following change to `packages/app/src/App.tsx`:
 
@@ -12,6 +12,37 @@ To apply this change to an existing app, make the following change to `packages/
 
  ...
 
- const AppProvider = app.getProvider();
+-const AppProvider = app.getProvider();
 -const AppRouter = app.getRouter();
+
+ ...
+
+-const App = () => (
++export default app.createRoot(
+-  <AppProvider>
++  <>
+     <AlertDisplay />
+     <OAuthRequestDialog />
+     <AppRouter>
+       <Root>{routes}</Root>
+     </AppRouter>
+-  </AppProvider>
++  </>,
+ );
 ```
+
+The final export step should end up looking something like this:
+
+```tsx
+export default app.createRoot(
+  <>
+    <AlertDisplay />
+    <OAuthRequestDialog />
+    <AppRouter>
+      <Root>{routes}</Root>
+    </AppRouter>
+  </>,
+);
+```
+
+Note that `app.createRoot()` accepts a React element, rather than a component.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,7 +27,7 @@ import {
   RELATION_PROVIDES_API,
 } from '@backstage/catalog-model';
 import { createApp } from '@backstage/app-defaults';
-import { FlatRoutes } from '@backstage/core-app-api';
+import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import {
   AlertDisplay,
   OAuthRequestDialog,
@@ -146,7 +146,6 @@ const app = createApp({
 });
 
 const AppProvider = app.getProvider();
-const AppRouter = app.getRouter();
 
 const routes = (
   <FlatRoutes>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -145,8 +145,6 @@ const app = createApp({
   },
 });
 
-const AppProvider = app.getProvider();
-
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
@@ -277,14 +275,12 @@ const routes = (
   </FlatRoutes>
 );
 
-const App = () => (
-  <AppProvider>
+export default app.createRoot(
+  <>
     <AlertDisplay transientTimeoutMs={2500} />
     <OAuthRequestDialog />
     <AppRouter>
       <Root>{routes}</Root>
     </AppRouter>
-  </AppProvider>
+  </>,
 );
-
-export default App;

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -262,6 +262,7 @@ export type AuthApiCreateOptions = {
 export type BackstageApp = {
   getPlugins(): BackstagePlugin[];
   getSystemIcon(key: string): IconComponent | undefined;
+  createRoot(element: JSX.Element): ComponentType<{}>;
   getProvider(): ComponentType<{}>;
   getRouter(): ComponentType<{}>;
 };

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -228,6 +228,9 @@ export type AppRouteBinder = <
 ) => void;
 
 // @public
+export function AppRouter({ children }: { children?: ReactNode }): JSX.Element;
+
+// @public
 export class AppThemeSelector implements AppThemeApi {
   constructor(themes: AppTheme[]);
   // (undocumented)

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -228,7 +228,13 @@ export type AppRouteBinder = <
 ) => void;
 
 // @public
-export function AppRouter({ children }: { children?: ReactNode }): JSX.Element;
+export function AppRouter(props: AppRouterProps): JSX.Element;
+
+// @public
+export interface AppRouterProps {
+  // (undocumented)
+  children?: ReactNode;
+}
 
 // @public
 export class AppThemeSelector implements AppThemeApi {

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -248,7 +248,23 @@ export class AppManager implements BackstageApp {
     return this.components;
   }
 
+  createRoot(element: JSX.Element): ComponentType<{}> {
+    const AppProvider = this.getProvider();
+    const AppRoot = () => {
+      return <AppProvider>{element}</AppProvider>;
+    };
+    return AppRoot;
+  }
+
+  #getProviderCalled = false;
   getProvider(): ComponentType<{}> {
+    if (this.#getProviderCalled) {
+      throw new Error(
+        'app.getProvider() or app.createRoot() has already been called, and can only be called once',
+      );
+    }
+    this.#getProviderCalled = true;
+
     const appContext = new AppContextImpl(this);
 
     // We only validate routes once

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -17,15 +17,10 @@
 import { AppConfig, Config } from '@backstage/config';
 import React, {
   ComponentType,
-  createContext,
   PropsWithChildren,
-  ReactElement,
-  useContext,
   useMemo,
   useRef,
-  useState,
 } from 'react';
-import { Route, Routes } from 'react-router-dom';
 import useAsync from 'react-use/lib/useAsync';
 import {
   ApiProvider,
@@ -34,7 +29,6 @@ import {
   LocalStorageFeatureFlags,
 } from '../apis';
 import {
-  useApi,
   AnyApiFactory,
   ApiHolder,
   IconComponent,
@@ -44,7 +38,6 @@ import {
   AppThemeApi,
   ConfigApi,
   featureFlagsApiRef,
-  IdentityApi,
   identityApiRef,
   BackstagePlugin,
 } from '@backstage/core-plugin-api';
@@ -61,7 +54,6 @@ import {
   routingV2Collector,
 } from '../routing/collectors';
 import { RoutingProvider } from '../routing/RoutingProvider';
-import { RouteTracker } from '../routing/RouteTracker';
 import {
   validateRouteParameters,
   validateRouteBindings,
@@ -74,53 +66,20 @@ import {
   AppContext,
   AppOptions,
   BackstageApp,
-  SignInPageProps,
 } from './types';
 import { AppThemeProvider } from './AppThemeProvider';
 import { defaultConfigLoader } from './defaultConfigLoader';
 import { ApiRegistry } from '../apis/system/ApiRegistry';
 import { resolveRouteBindings } from './resolveRouteBindings';
-import { BackstageRouteObject } from '../routing/types';
 import { isReactRouterBeta } from './isReactRouterBeta';
+import { InternalAppContext } from './InternalAppContext';
+import { AppRouter, getBasePath } from './AppRouter';
 
 type CompatiblePlugin =
   | BackstagePlugin
   | (Omit<BackstagePlugin, 'getFeatureFlags'> & {
       output(): Array<{ type: 'feature-flag'; name: string }>;
     });
-
-const InternalAppContext = createContext<{
-  routeObjects: BackstageRouteObject[];
-}>({ routeObjects: [] });
-
-/**
- * Get the app base path from the configured app baseUrl.
- *
- * The returned path does not have a trailing slash.
- */
-function getBasePath(configApi: Config) {
-  if (!isReactRouterBeta()) {
-    // When using rr v6 stable the base path is handled through the
-    // basename prop on the router component instead.
-    return '';
-  }
-
-  return readBasePath(configApi);
-}
-
-/**
- * Read the configured base path.
- *
- * The returned path does not have a trailing slash.
- */
-function readBasePath(configApi: ConfigApi) {
-  let { pathname } = new URL(
-    configApi.getOptionalString('app.baseUrl') ?? '/',
-    'http://sample.dev', // baseUrl can be specified as just a path
-  );
-  pathname = pathname.replace(/\/*$/, '');
-  return pathname;
-}
 
 function useConfigLoader(
   configLoader: AppConfigLoader | undefined,
@@ -413,7 +372,10 @@ export class AppManager implements BackstageApp {
                 basePath={getBasePath(loadedConfig.api)}
               >
                 <InternalAppContext.Provider
-                  value={{ routeObjects: routing.objects }}
+                  value={{
+                    routeObjects: routing.objects,
+                    appIdentityProxy: this.appIdentityProxy,
+                  }}
                 >
                   {children}
                 </InternalAppContext.Provider>
@@ -427,104 +389,6 @@ export class AppManager implements BackstageApp {
   }
 
   getRouter(): ComponentType<{}> {
-    const { Router: RouterComponent, SignInPage: SignInPageComponent } =
-      this.components;
-
-    // This wraps the sign-in page and waits for sign-in to be completed before rendering the app
-    const SignInPageWrapper = ({
-      component: Component,
-      children,
-    }: {
-      component: ComponentType<SignInPageProps>;
-      children: ReactElement;
-    }) => {
-      const [identityApi, setIdentityApi] = useState<IdentityApi>();
-      const configApi = useApi(configApiRef);
-      const basePath = getBasePath(configApi);
-
-      if (!identityApi) {
-        return <Component onSignInSuccess={setIdentityApi} />;
-      }
-
-      this.appIdentityProxy.setTarget(identityApi, {
-        signOutTargetUrl: basePath || '/',
-      });
-      return children;
-    };
-
-    const AppRouter = ({ children }: PropsWithChildren<{}>) => {
-      const configApi = useApi(configApiRef);
-      const basePath = readBasePath(configApi);
-      const mountPath = `${basePath}/*`;
-      const { routeObjects } = useContext(InternalAppContext);
-
-      // If the app hasn't configured a sign-in page, we just continue as guest.
-      if (!SignInPageComponent) {
-        this.appIdentityProxy.setTarget(
-          {
-            getUserId: () => 'guest',
-            getIdToken: async () => undefined,
-            getProfile: () => ({
-              email: 'guest@example.com',
-              displayName: 'Guest',
-            }),
-            getProfileInfo: async () => ({
-              email: 'guest@example.com',
-              displayName: 'Guest',
-            }),
-            getBackstageIdentity: async () => ({
-              type: 'user',
-              userEntityRef: 'user:default/guest',
-              ownershipEntityRefs: ['user:default/guest'],
-            }),
-            getCredentials: async () => ({}),
-            signOut: async () => {},
-          },
-          { signOutTargetUrl: basePath || '/' },
-        );
-
-        if (isReactRouterBeta()) {
-          return (
-            <RouterComponent>
-              <RouteTracker routeObjects={routeObjects} />
-              <Routes>
-                <Route path={mountPath} element={<>{children}</>} />
-              </Routes>
-            </RouterComponent>
-          );
-        }
-
-        return (
-          <RouterComponent basename={basePath}>
-            <RouteTracker routeObjects={routeObjects} />
-            {children}
-          </RouterComponent>
-        );
-      }
-
-      if (isReactRouterBeta()) {
-        return (
-          <RouterComponent>
-            <RouteTracker routeObjects={routeObjects} />
-            <SignInPageWrapper component={SignInPageComponent}>
-              <Routes>
-                <Route path={mountPath} element={<>{children}</>} />
-              </Routes>
-            </SignInPageWrapper>
-          </RouterComponent>
-        );
-      }
-
-      return (
-        <RouterComponent basename={basePath}>
-          <RouteTracker routeObjects={routeObjects} />
-          <SignInPageWrapper component={SignInPageComponent}>
-            <>{children}</>
-          </SignInPageWrapper>
-        </RouterComponent>
-      );
-    };
-
     return AppRouter;
   }
 

--- a/packages/core-app-api/src/app/AppRouter.test.tsx
+++ b/packages/core-app-api/src/app/AppRouter.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  AppComponents,
+  configApiRef,
+  IdentityApi,
+  identityApiRef,
+  SignInPageProps,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { InternalAppContext } from './InternalAppContext';
+import { MemoryRouter } from 'react-router-dom';
+import { AppIdentityProxy } from '../apis/implementations/IdentityApi/AppIdentityProxy';
+import { render, screen } from '@testing-library/react';
+import { AppRouter } from './AppRouter';
+import useAsync from 'react-use/lib/useAsync';
+import { AppContextProvider } from './AppContext';
+import { TestApiProvider } from '@backstage/test-utils';
+import { ConfigReader } from '@backstage/config';
+
+function UserRefDisplay() {
+  const identityApi = useApi(identityApiRef);
+  const { value } = useAsync(() => identityApi.getBackstageIdentity());
+  return <div>ref: {value?.userEntityRef}</div>;
+}
+
+describe('AppRouter', () => {
+  const mockComponents = {
+    Router: MemoryRouter,
+  } as AppComponents;
+
+  it('should fall back to guest if there is no sign-in page', async () => {
+    const appIdentityProxy = new AppIdentityProxy();
+
+    render(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, appIdentityProxy],
+          [configApiRef, new ConfigReader({})],
+        ]}
+      >
+        <InternalAppContext.Provider
+          value={{ routeObjects: [], appIdentityProxy }}
+        >
+          <AppContextProvider
+            appContext={{ getComponents: () => mockComponents } as any}
+          >
+            <AppRouter>
+              <UserRefDisplay />
+            </AppRouter>
+          </AppContextProvider>
+        </InternalAppContext.Provider>
+        ,
+      </TestApiProvider>,
+    );
+
+    await expect(
+      screen.findByText('ref: user:default/guest'),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it('should use the result from the sign-in page', async () => {
+    const appIdentityProxy = new AppIdentityProxy();
+
+    const SignInPage = (props: SignInPageProps) => {
+      props.onSignInSuccess({
+        getBackstageIdentity: async () => ({
+          type: 'user',
+          userEntityRef: 'user:default/test',
+          ownershipEntityRefs: ['user:default/test'],
+        }),
+      } as IdentityApi);
+      return null;
+    };
+
+    render(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, appIdentityProxy],
+          [configApiRef, new ConfigReader({})],
+        ]}
+      >
+        <InternalAppContext.Provider
+          value={{ routeObjects: [], appIdentityProxy }}
+        >
+          <AppContextProvider
+            appContext={
+              {
+                getComponents: () => ({ ...mockComponents, SignInPage }),
+              } as any
+            }
+          >
+            <AppRouter>
+              <UserRefDisplay />
+            </AppRouter>
+          </AppContextProvider>
+        </InternalAppContext.Provider>
+      </TestApiProvider>,
+    );
+
+    await expect(
+      screen.findByText('ref: user:default/test'),
+    ).resolves.toBeInTheDocument();
+  });
+});

--- a/packages/core-app-api/src/app/AppRouter.tsx
+++ b/packages/core-app-api/src/app/AppRouter.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext, ReactNode, ComponentType, useState } from 'react';
+import {
+  ConfigApi,
+  configApiRef,
+  IdentityApi,
+  SignInPageProps,
+  useApi,
+  useApp,
+} from '@backstage/core-plugin-api';
+import { InternalAppContext } from './InternalAppContext';
+import { isReactRouterBeta } from './isReactRouterBeta';
+import { RouteTracker } from '../routing/RouteTracker';
+import { Route, Routes } from 'react-router-dom';
+import { AppIdentityProxy } from '../apis/implementations/IdentityApi/AppIdentityProxy';
+
+/**
+ * Get the app base path from the configured app baseUrl.
+ *
+ * The returned path does not have a trailing slash.
+ */
+export function getBasePath(configApi: ConfigApi) {
+  if (!isReactRouterBeta()) {
+    // When using rr v6 stable the base path is handled through the
+    // basename prop on the router component instead.
+    return '';
+  }
+
+  return readBasePath(configApi);
+}
+
+/**
+ * Read the configured base path.
+ *
+ * The returned path does not have a trailing slash.
+ */
+function readBasePath(configApi: ConfigApi) {
+  let { pathname } = new URL(
+    configApi.getOptionalString('app.baseUrl') ?? '/',
+    'http://sample.dev', // baseUrl can be specified as just a path
+  );
+  pathname = pathname.replace(/\/*$/, '');
+  return pathname;
+}
+
+// This wraps the sign-in page and waits for sign-in to be completed before rendering the app
+function SignInPageWrapper({
+  component: Component,
+  appIdentityProxy,
+  children,
+}: {
+  component: ComponentType<SignInPageProps>;
+  appIdentityProxy: AppIdentityProxy;
+  children: ReactNode;
+}) {
+  const [identityApi, setIdentityApi] = useState<IdentityApi>();
+  const configApi = useApi(configApiRef);
+  const basePath = getBasePath(configApi);
+
+  if (!identityApi) {
+    return <Component onSignInSuccess={setIdentityApi} />;
+  }
+
+  appIdentityProxy.setTarget(identityApi, {
+    signOutTargetUrl: basePath || '/',
+  });
+  return <>{children}</>;
+}
+
+/**
+ * Props for the {@link AppRouter} component.
+ * @public
+ */
+export interface AppRouterProps {
+  children?: ReactNode;
+}
+
+/**
+ * App router and sign-in page wrapper.
+ *
+ * @public
+ * @remarks
+ *
+ * The AppRouter provides the routing context and renders the sign-in page.
+ * Until the user has successfully signed in, this component will render
+ * the sign-in page. Once the user has signed-in, it will instead render
+ * the app, while providing routing and route tracking for the app.
+ *
+ */
+export function AppRouter({ children }: { children?: ReactNode }) {
+  const { Router: RouterComponent, SignInPage: SignInPageComponent } =
+    useApp().getComponents();
+
+  const configApi = useApi(configApiRef);
+  const basePath = readBasePath(configApi);
+  const mountPath = `${basePath}/*`;
+  const internalAppContext = useContext(InternalAppContext);
+  if (!internalAppContext) {
+    throw new Error('AppRouter must be rendered within the AppProvider');
+  }
+  const { routeObjects, appIdentityProxy } = internalAppContext;
+
+  // If the app hasn't configured a sign-in page, we just continue as guest.
+  if (!SignInPageComponent) {
+    appIdentityProxy.setTarget(
+      {
+        getUserId: () => 'guest',
+        getIdToken: async () => undefined,
+        getProfile: () => ({
+          email: 'guest@example.com',
+          displayName: 'Guest',
+        }),
+        getProfileInfo: async () => ({
+          email: 'guest@example.com',
+          displayName: 'Guest',
+        }),
+        getBackstageIdentity: async () => ({
+          type: 'user',
+          userEntityRef: 'user:default/guest',
+          ownershipEntityRefs: ['user:default/guest'],
+        }),
+        getCredentials: async () => ({}),
+        signOut: async () => {},
+      },
+      { signOutTargetUrl: basePath || '/' },
+    );
+
+    if (isReactRouterBeta()) {
+      return (
+        <RouterComponent>
+          <RouteTracker routeObjects={routeObjects} />
+          <Routes>
+            <Route path={mountPath} element={<>{children}</>} />
+          </Routes>
+        </RouterComponent>
+      );
+    }
+
+    return (
+      <RouterComponent basename={basePath}>
+        <RouteTracker routeObjects={routeObjects} />
+        {children}
+      </RouterComponent>
+    );
+  }
+
+  if (isReactRouterBeta()) {
+    return (
+      <RouterComponent>
+        <RouteTracker routeObjects={routeObjects} />
+        <SignInPageWrapper
+          component={SignInPageComponent}
+          appIdentityProxy={appIdentityProxy}
+        >
+          <Routes>
+            <Route path={mountPath} element={<>{children}</>} />
+          </Routes>
+        </SignInPageWrapper>
+      </RouterComponent>
+    );
+  }
+
+  return (
+    <RouterComponent basename={basePath}>
+      <RouteTracker routeObjects={routeObjects} />
+      <SignInPageWrapper
+        component={SignInPageComponent}
+        appIdentityProxy={appIdentityProxy}
+      >
+        {children}
+      </SignInPageWrapper>
+    </RouterComponent>
+  );
+}

--- a/packages/core-app-api/src/app/AppRouter.tsx
+++ b/packages/core-app-api/src/app/AppRouter.tsx
@@ -100,9 +100,8 @@ export interface AppRouterProps {
  * Until the user has successfully signed in, this component will render
  * the sign-in page. Once the user has signed-in, it will instead render
  * the app, while providing routing and route tracking for the app.
- *
  */
-export function AppRouter({ children }: { children?: ReactNode }) {
+export function AppRouter(props: AppRouterProps) {
   const { Router: RouterComponent, SignInPage: SignInPageComponent } =
     useApp().getComponents();
 
@@ -145,7 +144,7 @@ export function AppRouter({ children }: { children?: ReactNode }) {
         <RouterComponent>
           <RouteTracker routeObjects={routeObjects} />
           <Routes>
-            <Route path={mountPath} element={<>{children}</>} />
+            <Route path={mountPath} element={<>{props.children}</>} />
           </Routes>
         </RouterComponent>
       );
@@ -154,7 +153,7 @@ export function AppRouter({ children }: { children?: ReactNode }) {
     return (
       <RouterComponent basename={basePath}>
         <RouteTracker routeObjects={routeObjects} />
-        {children}
+        {props.children}
       </RouterComponent>
     );
   }
@@ -168,7 +167,7 @@ export function AppRouter({ children }: { children?: ReactNode }) {
           appIdentityProxy={appIdentityProxy}
         >
           <Routes>
-            <Route path={mountPath} element={<>{children}</>} />
+            <Route path={mountPath} element={<>{props.children}</>} />
           </Routes>
         </SignInPageWrapper>
       </RouterComponent>
@@ -182,7 +181,7 @@ export function AppRouter({ children }: { children?: ReactNode }) {
         component={SignInPageComponent}
         appIdentityProxy={appIdentityProxy}
       >
-        {children}
+        {props.children}
       </SignInPageWrapper>
     </RouterComponent>
   );

--- a/packages/core-app-api/src/app/InternalAppContext.ts
+++ b/packages/core-app-api/src/app/InternalAppContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-export { AppRouter } from './AppRouter';
-export { createSpecializedApp } from './createSpecializedApp';
-export { defaultConfigLoader } from './defaultConfigLoader';
-export * from './types';
+import { createContext } from 'react';
+import { AppIdentityProxy } from '../apis/implementations/IdentityApi/AppIdentityProxy';
+import { BackstageRouteObject } from '../routing/types';
+
+export const InternalAppContext = createContext<
+  | undefined
+  | {
+      routeObjects: BackstageRouteObject[];
+      appIdentityProxy: AppIdentityProxy;
+    }
+>(undefined);

--- a/packages/core-app-api/src/app/index.ts
+++ b/packages/core-app-api/src/app/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { AppRouter } from './AppRouter';
+export type { AppRouterProps } from './AppRouter';
 export { createSpecializedApp } from './createSpecializedApp';
 export { defaultConfigLoader } from './defaultConfigLoader';
 export * from './types';

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -307,6 +307,8 @@ export type BackstageApp = {
   /**
    * Router component that should wrap the App Routes create with getRoutes()
    * and any other components that should only be available while signed in.
+   *
+   * @deprecated Import and use the {@link AppRouter} component from `@backstage/core-app-api` instead
    */
   getRouter(): ComponentType<{}>;
 };

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -299,8 +299,35 @@ export type BackstageApp = {
   getSystemIcon(key: string): IconComponent | undefined;
 
   /**
+   * Creates the root component that renders the entire app.
+   *
+   * @remarks
+   *
+   * This method must only be called once, and you have to provide it the entire
+   * app element tree. The element tree will be analyzed to discover plugins,
+   * routes, and other app features. The returned component will render all
+   * of the app elements wrapped within the app context provider.
+   *
+   * @example
+   * ```tsx
+   * export default app.createRoot(
+   *   <>
+   *     <AlertDisplay />
+   *     <OAuthRequestDialog />
+   *     <AppRouter>
+   *       <Root>{routes}</Root>
+   *     </AppRouter>
+   *   </>,
+   * );
+   * ```
+   */
+  createRoot(element: JSX.Element): ComponentType<{}>;
+
+  /**
    * Provider component that should wrap the Router created with getRouter()
    * and any other components that need to be within the app context.
+   *
+   * @deprecated Use {@link BackstageApp.createRoot} instead.
    */
   getProvider(): ComponentType<{}>;
 

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -53,8 +53,6 @@ const app = createApp({
   },
 });
 
-const AppProvider = app.getProvider();
-
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
@@ -96,14 +94,12 @@ const routes = (
   </FlatRoutes>
 );
 
-const App = () => (
-  <AppProvider>
+export default app.createRoot(
+  <>
     <AlertDisplay />
     <OAuthRequestDialog />
     <AppRouter>
       <Root>{routes}</Root>
     </AppRouter>
-  </AppProvider>
+  </>,
 );
-
-export default App;

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -29,7 +29,7 @@ import { Root } from './components/Root';
 
 import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
 import { createApp } from '@backstage/app-defaults';
-import { FlatRoutes } from '@backstage/core-app-api';
+import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
@@ -54,7 +54,6 @@ const app = createApp({
 });
 
 const AppProvider = app.getProvider();
-const AppRouter = app.getRouter();
 
 const routes = (
   <FlatRoutes>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a step towards removing the very awkward indirection of the `Provider` component in the `AppManager`. By switching it out with a `app.createRoot()` method we'll be able to analyze the app element tree immediately and only once. To make that API cleaner the `app.getRouter()` is refactored into a standalone `AppRouter` component that is decoupled from the app instance.

Delaying doc updates until this has been rolled out.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
