### PR TITLE
docs: fix broken links

### DIFF
--- a/contrib/docs/tutorials/aws-deployment.md
+++ b/contrib/docs/tutorials/aws-deployment.md
@@ -1,7 +1,7 @@
 # Deploying Backstage on AWS using ECR and EKS
 
 Backstage documentation shows how to build a [Docker
-image](https://backstage.io/docs/getting-started/deployment-docker); this
+image](https://backstage.io/docs/deployment/docker); this
 tutorial shows how to deploy that Docker image to AWS using Elastic Container
 Registry (ECR) and Elastic Kubernetes Service (EKS). Amazon also supports
 deployments with Helm, covered in the [Helm
@@ -36,7 +36,7 @@ Go to [AWS IAM console](https://console.aws.amazon.com/iam/home) and select
 ## Publish a Backstage build
 
 Follow the [Docker
-image](https://backstage.io/docs/getting-started/deployment-docker)
+image](https://backstage.io/docs/deployment/docker)
 documentation to build a new Backstage Docker image:
 
 ```shell


### PR DESCRIPTION
The latest working link for building docker should be https://backstage.io/docs/deployment/docker.

Signed-off-by: Jeff Tian <jeff.tian@outlook.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
