### PR TITLE
Make diagram scale to viewport without growing on its own

### DIFF
--- a/.changeset/thick-stingrays-smile.md
+++ b/.changeset/thick-stingrays-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Makes the `GroupsDiagram` not grown on screen on its own.

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -43,12 +43,11 @@ import useAsync from 'react-use/lib/useAsync';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   graph: {
-    height: '100%',
-    position: 'absolute',
     minHeight: '100%',
+    flex: 1,
   },
   graphWrapper: {
-    position: 'relative',
+    display: 'flex',
     height: '100%',
   },
   organizationNode: {

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -43,9 +43,12 @@ import useAsync from 'react-use/lib/useAsync';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   graph: {
+    height: '100%',
+    position: 'absolute',
     minHeight: '100%',
   },
   graphWrapper: {
+    position: 'relative',
     height: '100%',
   },
   organizationNode: {


### PR DESCRIPTION
Signed-off-by: Maximilian Vorbrodt <maximilian.vorbrodt@hotmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR is realted to #15129.

Make sure the graph in explore group tab content doesn't move/grow on its own. The solution always shows the entire graph visible when loading in the page. 

One drawback of this is if the user makes the window smaller than what it was when the page was initially loaded the user will still have to scroll down. However, this can easily be fixed by simply refreshing the page (see video below). I also believe that users that go to look at the graph will not naturally gravitate towards making the window size smaller (if anything they would probably make the window larger to see more of the graph) and therefore this should not really be an issue. 

As the bug makes it difficult to work with larger graphs in this directory, I feel that it is important to quickly fix this issue so that the graph can be made useful again.



https://user-images.githubusercontent.com/64839037/208294075-ffed636f-0419-4f36-a957-4f8096dcfd5d.mp4



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
