### PR TITLE
add CTA for office hours

### DIFF
--- a/microsite/pages/en/index.js
+++ b/microsite/pages/en/index.js
@@ -45,13 +45,21 @@ class Index extends React.Component {
                   ship high-quality code quickly — without compromising
                   autonomy.
                 </Block.Paragraph>
-                <Block.LinkButton
-                  href={
-                    'https://github.com/backstage/backstage#getting-started'
-                  }
-                >
-                  GitHub
-                </Block.LinkButton>
+                <Block.Container wrapped>
+                  <Block.LinkButton
+                    style={{ marginRight: '2rem' }}
+                    href={
+                      'https://github.com/backstage/backstage#getting-started'
+                    }
+                  >
+                    GitHub
+                  </Block.LinkButton>
+                  <Block.LinkButton
+                    href={'https://info.backstage.spotify.com/office-hours'}
+                  >
+                    Office Hours
+                  </Block.LinkButton>
+                </Block.Container>
               </Block.TextBox>
               <Block.Graphics>
                 <Block.Graphic


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Backstage Marketing (Tori) requested that we add an `Office Hours` CTA next to `Github` on backstage.io. 

![image](https://user-images.githubusercontent.com/72715376/206748712-366a33e8-867b-40d2-9554-a892d9f88ea6.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
