### PR TITLE
Make ownership boxes all the same size

### DIFF
--- a/.changeset/eighty-melons-walk.md
+++ b/.changeset/eighty-melons-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Made all the ownership boxes the same size

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -42,6 +42,7 @@ const useStyles = makeStyles((theme: BackstageTheme) =>
       '&:hover': {
         boxShadow: theme.shadows[4],
       },
+      height: '100%',
     },
     bold: {
       fontWeight: theme.typography.fontWeightBold,
@@ -75,7 +76,6 @@ const EntityCountTile = ({
         display="flex"
         flexDirection="column"
         alignItems="center"
-        style={{ height: '100%' }}
       >
         <Typography className={classes.bold} variant="h6">
           {counter}

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -75,6 +75,7 @@ const EntityCountTile = ({
         display="flex"
         flexDirection="column"
         alignItems="center"
+        style={{ height: '100%' }}
       >
         <Typography className={classes.bold} variant="h6">
           {counter}


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

This tiny PR makes all the ownership boxes the same size, picture show it best:

Before:

![Screenshot 2022-12-09 at 2 48 26 PM](https://user-images.githubusercontent.com/67169551/206795340-25f2f0e9-408f-413b-936a-fe0bd9772330.png)

After:

![Screenshot 2022-12-09 at 2 54 38 PM](https://user-images.githubusercontent.com/67169551/206795364-620e087a-038b-4aab-b253-581f258071b8.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
