### PR TITLE
cli: fix coverage configuration and make next tests the new default

### DIFF
--- a/.changeset/fast-walls-explode.md
+++ b/.changeset/fast-walls-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated Jest coverage configuration to only apply either in the root project or package configuration, depending on whether repo or package tests are run.

--- a/.changeset/neat-insects-share.md
+++ b/.changeset/neat-insects-share.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli': minor
+---
+
+The Jest configuration that was previously enabled with `BACKSTAGE_NEXT_TESTS` is now enabled by default. To revert to the old configuration you can now instead set `BACKSTAGE_OLD_TESTS`.
+
+This new configuration uses the `babel` coverage provider rather than `v8`. It used to be that `v8` worked better when using Sucrase for transpilation, but now that we have switched to SWC, `babel` seems to work better. In addition, the new configuration also enables source maps by default, as they no longer have a negative impact on code coverage accuracy, and it also enables a modified Jest runtime with additional caching of script objects.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,6 @@ jobs:
         if: ${{ steps.yarn-lock.outcome == 'success' }}
         run: yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=1300M --since origin/master
         env:
-          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres13.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres9.ports[5432] }}
@@ -214,7 +213,6 @@ jobs:
           yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=800M --coverage
           bash <(curl -s https://codecov.io/bash) -N $(git rev-parse FETCH_HEAD)
         env:
-          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres13.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres9.ports[5432] }}

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -105,7 +105,6 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f packages/core-components/coverage/* -F core-components
           bash <(curl -s https://codecov.io/bash) -f packages/core-plugin-api/coverage/* -F core-plugin-api
         env:
-          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres13.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres9.ports[5432] }}

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -48,7 +48,6 @@ jobs:
       - name: test
         run: yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=1300M
         env:
-          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
 
       # credit: https://github.com/appleboy/discord-action/issues/3#issuecomment-731426861

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -21,11 +21,11 @@ const glob = require('util').promisify(require('glob'));
 const { version } = require('../package.json');
 
 const envOptions = {
-  nextTests: Boolean(process.env.BACKSTAGE_NEXT_TESTS),
+  oldTests: Boolean(process.env.BACKSTAGE_OLD_TESTS),
   enableSourceMaps: Boolean(process.env.ENABLE_SOURCE_MAPS),
 };
 
-if (envOptions.nextTests) {
+if (!envOptions.oldTests) {
   // Needed so that, at import-time, it can hook into Jest's internals.
   require('./jestCachingModuleLoader');
 }
@@ -135,7 +135,7 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.(mjs|cjs|js)$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || envOptions.nextTests,
+          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'ecmascript',
@@ -146,7 +146,7 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.jsx$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || envOptions.nextTests,
+          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'ecmascript',
@@ -163,7 +163,7 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.ts$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || envOptions.nextTests,
+          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -174,7 +174,7 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.tsx$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || envOptions.nextTests,
+          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -196,9 +196,9 @@ async function getProjectConfig(targetPath, extraConfig) {
     // A bit more opinionated
     testMatch: ['**/*.test.{js,jsx,ts,tsx,mjs,cjs}'],
 
-    runtime: envOptions.nextTests
-      ? require.resolve('./jestCachingModuleLoader')
-      : undefined,
+    runtime: envOptions.oldTests
+      ? undefined
+      : require.resolve('./jestCachingModuleLoader'),
 
     transformIgnorePatterns: [`/node_modules/(?:${transformIgnorePattern})/`],
     ...getRoleConfig(closestPkgJson?.backstage?.role),
@@ -236,7 +236,7 @@ async function getRootConfig() {
 
   const coverageConfig = {
     coverageDirectory: path.resolve(targetPath, 'coverage'),
-    coverageProvider: envOptions.nextTests ? 'babel' : 'v8',
+    coverageProvider: envOptions.oldTests ? 'v8' : 'babel',
     collectCoverageFrom: ['**/*.{js,jsx,ts,tsx,mjs,cjs}', '!**/*.d.ts'],
   };
 

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -25,11 +25,6 @@ const envOptions = {
   enableSourceMaps: Boolean(process.env.ENABLE_SOURCE_MAPS),
 };
 
-if (!envOptions.oldTests) {
-  // Needed so that, at import-time, it can hook into Jest's internals.
-  require('./jestCachingModuleLoader');
-}
-
 const transformIgnorePattern = [
   '@material-ui',
   'ajv',

--- a/packages/cli/config/jestCachingModuleLoader.js
+++ b/packages/cli/config/jestCachingModuleLoader.js
@@ -14,61 +14,11 @@
  * limitations under the License.
  */
 
-const fs = require('fs');
 const { default: JestRuntime } = require('jest-runtime');
 
-const fileTransformCache = new Map();
 const scriptTransformCache = new Map();
 
-let runtimeGeneration = 0;
-let isWatchMode;
-
 module.exports = class CachingJestRuntime extends JestRuntime {
-  // Each Jest run creates a new runtime, including when rerunning tests in
-  // watch mode. This keeps track of whether we've switched runtime instance.
-  __runtimeGeneration = runtimeGeneration++;
-
-  transformFile(filename, options) {
-    if (!isWatchMode) {
-      return super.transformFile(filename, options);
-    }
-
-    const entry = fileTransformCache.get(filename);
-    if (entry) {
-      // Only check modification time if it's from a different runtime generation
-      if (entry.generation === this.__runtimeGeneration) {
-        return entry.code;
-      }
-
-      // Keep track of the modification time of files so that we can properly
-      // reprocess them in watch mode.
-      const { mtimeMs } = fs.statSync(filename);
-      if (mtimeMs > entry.mtimeMs) {
-        const code = super.transformFile(filename, options);
-        fileTransformCache.set(filename, {
-          code,
-          mtimeMs,
-          generation: this.__runtimeGeneration,
-        });
-        return code;
-      }
-
-      fileTransformCache.set(filename, {
-        ...entry,
-        generation: this.__runtimeGeneration,
-      });
-      return entry.code;
-    }
-
-    const code = super.transformFile(filename, options);
-    fileTransformCache.set(filename, {
-      code,
-      mtimeMs: fs.statSync(filename).mtimeMs,
-      generation: this.__runtimeGeneration,
-    });
-    return code;
-  }
-
   // This may or may not be a good idea. Theoretically I don't know why this would impact
   // test correctness and flakiness, but it seems like it may introduce flakiness and strange failures.
   // It does seem to speed up test execution by a fair amount though.
@@ -83,12 +33,4 @@ module.exports = class CachingJestRuntime extends JestRuntime {
     }
     return script;
   }
-};
-
-// Inject hook into createHasteMap, as it's the only way that we can
-// determine (from our scope here) if we're in "watch mode" or not.
-const originalCreateHasteMap = JestRuntime.createHasteMap;
-JestRuntime.createHasteMap = (config, options = undefined) => {
-  isWatchMode = options && options.watch;
-  return originalCreateHasteMap(config, options);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The coverage configuration was always set on the sub-projects, which is each individual package. When running tests from the root the coverage configs in the projects are ignored, and the coverage config in the root config is used instead. The coverage config is now placed either in the root or in the project config itself, depending on how the tests are executed.

This also makes the `BACKSTAGE_NEXT_TESTS` the new default. After switching from Sucrase to SWC for transpilation this mode is a lot more stable, as the source maps and coverage providers all work much better. It's still possible to switch to the old config for now, using `BACKSTAGE_OLD_TESTS`.

I also got rid of the global file transform cache, since this is now implemented in Jest and no longer needed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
