### PR TITLE
Added Y axis for metric data

### DIFF
--- a/.changeset/beige-chairs-wink.md
+++ b/.changeset/beige-chairs-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Added Y axis for metric data, with relevant formatting and data domain

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewChart.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewChart.tsx
@@ -43,7 +43,7 @@ import {
   isInvalid,
 } from '../../utils/graphs';
 import { useCostOverviewStyles as useStyles } from '../../utils/styles';
-import { groupByDate, toDataMax, trendFrom } from '../../utils/charts';
+import { groupByDate, trendFrom } from '../../utils/charts';
 import { aggregationSort } from '../../utils/sort';
 import { CostOverviewLegend } from './CostOverviewLegend';
 import { TooltipRenderer } from '../../types';
@@ -135,6 +135,7 @@ export const CostOverviewChart = ({
   };
 
   const { hideTrendLine } = useCostInsightsOptions();
+  const localizedTickFormatter = formatGraphValue(baseCurrency);
 
   return (
     <Box display="flex" flexDirection="column">
@@ -161,16 +162,19 @@ export const CostOverviewChart = ({
           <YAxis
             domain={[() => 0, 'dataMax']}
             tick={{ fill: styles.axis.fill }}
-            tickFormatter={formatGraphValue(baseCurrency)}
+            tickFormatter={localizedTickFormatter}
             width={styles.yAxis.width}
             yAxisId={data.dailyCost.dataKey}
           />
           {metric && (
             <YAxis
-              hide
-              domain={[() => 0, toDataMax(data.metric.dataKey, chartData)]}
+              domain={['auto', 'auto']}
               width={styles.yAxis.width}
               yAxisId={data.metric.dataKey}
+              tickFormatter={(value: any, index: number) =>
+                localizedTickFormatter(value, index, data.metric.format)
+              }
+              orientation="right"
             />
           )}
           <Area


### PR DESCRIPTION
Signed-off-by: Kévin Gomez <contact@kevingomez.fr>

## Hey, I just made a Pull Request!

Metrics displayed in the cost overview graphs can have different domains and value ranges. Not having an axis for these metrics can make misinterpreting these graphs a common issue.

Before:

![cost_metric_before](https://user-images.githubusercontent.com/66958/206881001-bc18f63e-1982-468f-ad66-bf5d6e56f17f.png)

After:

![cost_metric_after](https://user-images.githubusercontent.com/66958/206881006-3e141124-ed05-4a8d-8835-5b0ed64d1e8e.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
