### PR TITLE
Adding option to pass additional headers in ProxiedSignInPage

### DIFF
--- a/.changeset/violet-dots-relate.md
+++ b/.changeset/violet-dots-relate.md
@@ -1,5 +1,30 @@
 ---
-'@backstage/core-components': minor
+'@backstage/core-components': patch
 ---
 
-Added option to pass additional headers in ProxiedSignInPage
+Added option to pass additional headers to `<ProxiedSignInPage />`
+
+The <ProxiedSignInPage /> supports signing into Backstage with a Sign Page coming from an external provider e.g. Google IAP, AWS ALB, etc. The component makes requests to a single endpoint `/refresh` on the auth backend to fetch the logged in user session.
+
+If the provider in auth backend expects additional headers such as `x-provider-token`, there is now a way to configure that in `ProxiedSignInPage` using the optional `getHeaders` prop.
+
+Example -
+
+```tsx
+const app = createApp({
+  // ...
+  components: {
+    SignInPage: props => (
+      <ProxiedSignInPage
+        {...props}
+        provider="my-custom-provider"
+        getHeaders={async () => {
+          const someValue = await someFn();
+          return { 'x-some-key': someValue };
+        }}
+      />
+    ),
+  },
+  // ...
+});
+```

--- a/.changeset/violet-dots-relate.md
+++ b/.changeset/violet-dots-relate.md
@@ -2,29 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Added option to pass additional headers to `<ProxiedSignInPage />`
-
-The <ProxiedSignInPage /> supports signing into Backstage with a Sign Page coming from an external provider e.g. Google IAP, AWS ALB, etc. The component makes requests to a single endpoint `/refresh` on the auth backend to fetch the logged in user session.
-
-If the provider in auth backend expects additional headers such as `x-provider-token`, there is now a way to configure that in `ProxiedSignInPage` using the optional `getHeaders` prop.
-
-Example -
-
-```tsx
-const app = createApp({
-  // ...
-  components: {
-    SignInPage: props => (
-      <ProxiedSignInPage
-        {...props}
-        provider="my-custom-provider"
-        getHeaders={async () => {
-          const someValue = await someFn();
-          return { 'x-some-key': someValue };
-        }}
-      />
-    ),
-  },
-  // ...
-});
-```
+Added option to pass additional headers to `<ProxiedSignInPage />`, which are passed along with the request to the underlying provider

--- a/.changeset/violet-dots-relate.md
+++ b/.changeset/violet-dots-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Added option to pass additional headers in ProxiedSignInPage

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -150,6 +150,31 @@ const app = createApp({
 });
 ```
 
+If the provider in auth backend expects additional headers such as `x-provider-token`, there is now a way to configure that in `ProxiedSignInPage` using the optional `headers` prop.
+
+Example:
+
+```tsx
+<ProxiedSignInPage
+  {...props}
+  provider="my-custom-provider"
+  headers={{ 'x-some-key': someValue }}
+/>
+```
+
+Headers can also be returned in an async manner:
+
+```tsx
+<ProxiedSignInPage
+  {...props}
+  provider="my-custom-provider"
+  headers={async () => {
+    const someValue = await someFn();
+    return { 'x-some-key': someValue };
+  }}
+/>
+```
+
 A downside of this method is that it can be cumbersome to set up for local development.
 As a workaround for this, it's possible to dynamically select the sign-in page based on
 what environment the app is running in, and then use a different sign-in method for local

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -807,6 +807,7 @@ export const ProxiedSignInPage: (
 // @public
 export type ProxiedSignInPageProps = SignInPageProps & {
   provider: string;
+  getHeaders?: () => Promise<HeadersInit>;
 };
 
 // Warning: (ae-missing-release-tag) "Ranker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -807,7 +807,7 @@ export const ProxiedSignInPage: (
 // @public
 export type ProxiedSignInPageProps = SignInPageProps & {
   provider: string;
-  getHeaders?: () => Promise<HeadersInit>;
+  headers?: RefreshHeaders;
 };
 
 // Warning: (ae-missing-release-tag) "Ranker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1533,4 +1533,5 @@ export type WarningPanelClassKey =
 // src/components/TabbedLayout/RoutedTabs.d.ts:9:5 - (ae-forgotten-export) The symbol "SubRoute" needs to be exported by the entry point index.d.ts
 // src/components/Table/Table.d.ts:20:5 - (ae-forgotten-export) The symbol "SelectedFilters" needs to be exported by the entry point index.d.ts
 // src/layout/ErrorBoundary/ErrorBoundary.d.ts:8:5 - (ae-forgotten-export) The symbol "SlackChannel" needs to be exported by the entry point index.d.ts
+// src/layout/ProxiedSignInPage/ProxiedSignInPage.d.ts:19:5 - (ae-forgotten-export) The symbol "RefreshHeaders" needs to be exported by the entry point index.d.ts
 ```

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -807,7 +807,7 @@ export const ProxiedSignInPage: (
 // @public
 export type ProxiedSignInPageProps = SignInPageProps & {
   provider: string;
-  headers?: RefreshHeaders;
+  headers?: HeadersInit | (() => HeadersInit) | (() => Promise<HeadersInit>);
 };
 
 // Warning: (ae-missing-release-tag) "Ranker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1533,5 +1533,4 @@ export type WarningPanelClassKey =
 // src/components/TabbedLayout/RoutedTabs.d.ts:9:5 - (ae-forgotten-export) The symbol "SubRoute" needs to be exported by the entry point index.d.ts
 // src/components/Table/Table.d.ts:20:5 - (ae-forgotten-export) The symbol "SelectedFilters" needs to be exported by the entry point index.d.ts
 // src/layout/ErrorBoundary/ErrorBoundary.d.ts:8:5 - (ae-forgotten-export) The symbol "SlackChannel" needs to be exported by the entry point index.d.ts
-// src/layout/ProxiedSignInPage/ProxiedSignInPage.d.ts:19:5 - (ae-forgotten-export) The symbol "RefreshHeaders" needs to be exported by the entry point index.d.ts
 ```

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.test.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.test.ts
@@ -209,7 +209,7 @@ describe('ProxiedSignInIdentity', () => {
       expect(getHeaders).toHaveBeenCalledTimes(1);
       expect(serverCalled).toHaveBeenCalledTimes(1);
 
-      expect(req1).not.toBeUndefined();
+      expect(req1!).not.toBeUndefined();
       // required header should be present
       expect(req1!.headers.get('x-requested-with')).toEqual('XMLHttpRequest');
       // optional header should be present when passed

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
@@ -51,6 +51,7 @@ export function tokenToExpiry(jwtToken: string | undefined): Date {
 type ProxiedSignInIdentityOptions = {
   provider: string;
   discoveryApi: typeof discoveryApiRef.T;
+  getHeaders?: () => Promise<HeadersInit>;
 };
 
 type State =
@@ -192,6 +193,7 @@ export class ProxiedSignInIdentity implements IdentityApi {
 
   async fetchSession(): Promise<ProxiedSession> {
     const baseUrl = await this.options.discoveryApi.getBaseUrl('auth');
+    const headers = await this.options.getHeaders?.();
 
     // Note that we do not use the fetchApi here, since this all happens before
     // sign-in completes so there can be no automatic token injection and
@@ -200,7 +202,7 @@ export class ProxiedSignInIdentity implements IdentityApi {
       `${baseUrl}/${this.options.provider}/refresh`,
       {
         signal: this.abortController.signal,
-        headers: { 'x-requested-with': 'XMLHttpRequest' },
+        headers: { ...headers, 'x-requested-with': 'XMLHttpRequest' },
         credentials: 'include',
       },
     );

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
@@ -48,15 +48,10 @@ export function tokenToExpiry(jwtToken: string | undefined): Date {
   return new Date(payload.exp * 1000 - DEFAULTS.tokenExpiryMarginMillis);
 }
 
-export type RefreshHeaders =
-  | HeadersInit
-  | (() => HeadersInit)
-  | (() => Promise<HeadersInit>);
-
 type ProxiedSignInIdentityOptions = {
   provider: string;
   discoveryApi: typeof discoveryApiRef.T;
-  headers?: RefreshHeaders;
+  headers?: HeadersInit | (() => HeadersInit) | (() => Promise<HeadersInit>);
 };
 
 type State =

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -23,7 +23,7 @@ import React from 'react';
 import { useAsync, useMountEffect } from '@react-hookz/web';
 import { ErrorPanel } from '../../components/ErrorPanel';
 import { Progress } from '../../components/Progress';
-import { ProxiedSignInIdentity, RefreshHeaders } from './ProxiedSignInIdentity';
+import { ProxiedSignInIdentity } from './ProxiedSignInIdentity';
 
 /**
  * Props for {@link ProxiedSignInPage}.
@@ -41,7 +41,7 @@ export type ProxiedSignInPageProps = SignInPageProps & {
    * Optional headers which are passed along with the request to the
    * underlying provider
    */
-  headers?: RefreshHeaders;
+  headers?: HeadersInit | (() => HeadersInit) | (() => Promise<HeadersInit>);
 };
 
 /**

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -36,6 +36,12 @@ export type ProxiedSignInPageProps = SignInPageProps & {
    * a properly configured auth provider ID in the auth backend.
    */
   provider: string;
+
+  /**
+   * An optional function which returns a promise resolving with any headers
+   * that need to be added to the call made to /refresh endpoint.
+   */
+  getHeaders?: () => Promise<HeadersInit>;
 };
 
 /**
@@ -60,6 +66,7 @@ export const ProxiedSignInPage = (props: ProxiedSignInPageProps) => {
     const identity = new ProxiedSignInIdentity({
       provider: props.provider,
       discoveryApi,
+      getHeaders: props.getHeaders,
     });
 
     await identity.start();

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -23,7 +23,7 @@ import React from 'react';
 import { useAsync, useMountEffect } from '@react-hookz/web';
 import { ErrorPanel } from '../../components/ErrorPanel';
 import { Progress } from '../../components/Progress';
-import { ProxiedSignInIdentity } from './ProxiedSignInIdentity';
+import { ProxiedSignInIdentity, RefreshHeaders } from './ProxiedSignInIdentity';
 
 /**
  * Props for {@link ProxiedSignInPage}.
@@ -38,10 +38,10 @@ export type ProxiedSignInPageProps = SignInPageProps & {
   provider: string;
 
   /**
-   * An optional function which returns a promise resolving with any headers
-   * that need to be added to the call made to /refresh endpoint.
+   * Optional headers which are passed along with the request to the
+   * underlying provider
    */
-  getHeaders?: () => Promise<HeadersInit>;
+  headers?: RefreshHeaders;
 };
 
 /**
@@ -66,7 +66,7 @@ export const ProxiedSignInPage = (props: ProxiedSignInPageProps) => {
     const identity = new ProxiedSignInIdentity({
       provider: props.provider,
       discoveryApi,
-      getHeaders: props.getHeaders,
+      headers: props.headers,
     });
 
     await identity.start();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We, at [Harness](https://harness.io/), have a requirement to be able to pass custom headers along with the `/refresh` call being made to our custom non-oauth Authentication Provider via the `ProxiedSignInPage` component.

We have Backstage embedded in our platform, where users login using the Harness SignIn page and get an identity from Harness. In order to make the Backstage sign in flow work, we need to be able to pass a token from the Backstage frontend to the corresponding backend so that it is aware of the logged in user.

This change adds an async function  `getHeaders()` as a prop to the `<ProxiedSignInPage />` component, which will get called to get the headers to be added before hitting the `/refresh` endpoint. These custom headers are then pre-pended to the existing headers being passed.

Example usage:

```jsx
<ProxiedSignInPage 
    {...props} 
    provider="ProviderA"
    getHeaders={async () => {
        const someValue = await someFn();
        return { 'x-some-key': someValue }
    }}
/>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
