### PR TITLE
move zod back a step to avoid type issues

### DIFF
--- a/.changeset/fluffy-worms-arrive.md
+++ b/.changeset/fluffy-worms-arrive.md
@@ -1,0 +1,16 @@
+---
+'@backstage/backend-tasks': patch
+'@backstage/cli': patch
+'@backstage/core-app-api': patch
+'@backstage/core-components': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-permission-backend': patch
+'@backstage/plugin-permission-common': patch
+'@backstage/plugin-permission-node': patch
+'@backstage/plugin-playlist-backend': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-search-backend': patch
+---
+
+Move the `zod` dependency to a version that does not collide with other libraries

--- a/packages/backend-tasks/package.json
+++ b/packages/backend-tasks/package.json
@@ -43,7 +43,7 @@
     "luxon": "^3.0.0",
     "uuid": "^8.0.0",
     "winston": "^3.2.1",
-    "zod": "^3.9.5"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -125,7 +125,7 @@
     "yaml": "^2.0.0",
     "yml-loader": "^2.1.0",
     "yn": "^4.0.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/backend-common": "workspace:^",

--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15.7.2",
     "react-use": "^17.2.4",
     "zen-observable": "^0.10.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "peerDependencies": {
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -68,7 +68,7 @@
     "react-window": "^1.8.6",
     "remark-gfm": "^3.0.1",
     "zen-observable": "^0.10.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "peerDependencies": {
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -66,7 +66,7 @@
     "winston": "^3.2.1",
     "yaml": "^2.0.0",
     "yn": "^4.0.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -36,7 +36,7 @@
     "node-fetch": "^2.6.7",
     "winston": "^3.2.1",
     "yn": "^4.0.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/permission-common/package.json
+++ b/plugins/permission-common/package.json
@@ -46,7 +46,7 @@
     "@backstage/types": "workspace:^",
     "cross-fetch": "^3.1.5",
     "uuid": "^8.0.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -41,8 +41,8 @@
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "zod": "^3.11.6",
-    "zod-to-json-schema": "^3.18.1"
+    "zod": "~3.18.0",
+    "zod-to-json-schema": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/playlist-backend/package.json
+++ b/plugins/playlist-backend/package.json
@@ -40,7 +40,7 @@
     "uuid": "^8.2.0",
     "winston": "^3.2.1",
     "yn": "^4.0.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -79,7 +79,7 @@
     "winston": "^3.2.1",
     "yaml": "^2.0.0",
     "zen-observable": "^0.10.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -75,8 +75,8 @@
     "use-immer": "^0.7.0",
     "yaml": "^2.0.0",
     "zen-observable": "^0.10.0",
-    "zod": "^3.11.6",
-    "zod-to-json-schema": "^3.18.1"
+    "zod": "~3.18.0",
+    "zod-to-json-schema": "~3.18.0"
   },
   "peerDependencies": {
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -40,7 +40,7 @@
     "qs": "^6.10.1",
     "winston": "^3.2.1",
     "yn": "^4.0.0",
-    "zod": "^3.11.6"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,7 +3504,7 @@ __metadata:
     uuid: ^8.0.0
     wait-for-expect: ^3.0.2
     winston: ^3.2.1
-    zod: ^3.9.5
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -3720,7 +3720,7 @@ __metadata:
     yaml: ^2.0.0
     yml-loader: ^2.1.0
     yn: ^4.0.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   peerDependencies:
     "@microsoft/api-extractor": ^7.21.2
   peerDependenciesMeta:
@@ -3826,7 +3826,7 @@ __metadata:
     react-router-stable: "npm:react-router@^6.3.0"
     react-use: ^17.2.4
     zen-observable: ^0.10.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0
     react: ^16.13.1 || ^17.0.0
@@ -3998,7 +3998,7 @@ __metadata:
     react-window: ^1.8.6
     remark-gfm: ^3.0.1
     zen-observable: ^0.10.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0
     react: ^16.13.1 || ^17.0.0
@@ -5242,7 +5242,7 @@ __metadata:
     winston: ^3.2.1
     yaml: ^2.0.0
     yn: ^4.0.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -7035,7 +7035,7 @@ __metadata:
     supertest: ^6.1.6
     winston: ^3.2.1
     yn: ^4.0.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -7064,7 +7064,7 @@ __metadata:
     cross-fetch: ^3.1.5
     msw: ^0.49.0
     uuid: ^8.0.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -7085,8 +7085,8 @@ __metadata:
     express-promise-router: ^4.1.0
     msw: ^0.49.0
     supertest: ^6.1.3
-    zod: ^3.11.6
-    zod-to-json-schema: ^3.18.1
+    zod: ~3.18.0
+    zod-to-json-schema: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -7155,7 +7155,7 @@ __metadata:
     uuid: ^8.2.0
     winston: ^3.2.1
     yn: ^4.0.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -7417,7 +7417,7 @@ __metadata:
     winston: ^3.2.1
     yaml: ^2.0.0
     zen-observable: ^0.10.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -7491,8 +7491,8 @@ __metadata:
     use-immer: ^0.7.0
     yaml: ^2.0.0
     zen-observable: ^0.10.0
-    zod: ^3.11.6
-    zod-to-json-schema: ^3.18.1
+    zod: ~3.18.0
+    zod-to-json-schema: ~3.18.0
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0
     react: ^16.13.1 || ^17.0.0
@@ -7584,7 +7584,7 @@ __metadata:
     supertest: ^6.1.3
     winston: ^3.2.1
     yn: ^4.0.0
-    zod: ^3.11.6
+    zod: ~3.18.0
   languageName: unknown
   linkType: soft
 
@@ -38814,16 +38814,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.18.1":
-  version: 3.19.2
-  resolution: "zod-to-json-schema@npm:3.19.2"
+"zod-to-json-schema@npm:~3.18.0":
+  version: 3.18.2
+  resolution: "zod-to-json-schema@npm:3.18.2"
   peerDependencies:
-    zod: ^3.19.0
-  checksum: 3bcc6cbdaa30e78502a12ae04fdd8e57e42715afb9bb8dd2cb249fa9fe4bc7857580cac6bbfa3d4d9375fdfeb946661763a3e6365fd60cac962daacaf4b61554
+    zod: ^3.18.0
+  checksum: 10e84864a3ccc2e04500b9bc81369ed7c5b3ec068ea582a13369175ed40e785091a63ae7fa86ebb4ddf1bccd55c3dab32f4d3070bbcc3296e68305ff787c9df3
   languageName: node
   linkType: hard
 
-"zod@npm:^3.11.6, zod@npm:^3.9.5":
+"zod@npm:^3.11.6, zod@npm:~3.18.0":
   version: 3.18.0
   resolution: "zod@npm:3.18.0"
   checksum: 86a9a9928f4b40a07020d4b9832842fa4a70050c2d7bd1b2866bc1acfd734aa53a40f87a99a4312a637341a608b0105770c7a1f83b56df78e97691b4f5badcd8


### PR DESCRIPTION
Once `zod` goes to 3.20, it'll lead to type breakages (as can be seen in our end-to-end tests).

https://github.com/StefanTerdell/zod-to-json-schema/issues/31

https://github.com/colinhacks/zod/issues/1669