### PR TITLE
[Search] Add opensearch provider 14987

### DIFF
--- a/.changeset/seven-schools-speak.md
+++ b/.changeset/seven-schools-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': minor
+---
+
+Added support for self hosted OpenSearch via new provider

--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -117,7 +117,8 @@ within your instance. The configuration options are documented in the
 
 The underlying functionality uses either the official ElasticSearch client
 version 7.x (meaning that ElasticSearch version 7 is the only one confirmed to
-be supported), or the OpenSearch client, when the `aws` provider is configured.
+be supported), or the OpenSearch client, when the `aws` or `opensearch `provider
+is configured.
 
 Should you need to create your own bespoke search experiences that require more
 than just a query translator (such as faceted search or Relay pagination), you
@@ -197,6 +198,20 @@ search:
     cloudId: backstage-elastic:asdfqwertyasdfqwertyasdfqwertyasdfqwerty==
     auth:
       username: elastic
+      password: changeme
+```
+
+### OpenSearch
+
+OpenSearch can be self hosted for example with the [official docker image](https://hub.docker.com/r/opensearchproject/opensearch). The configuration requires only the node and authentication.
+
+```yaml
+search:
+  elasticsearch:
+    provider: opensearch
+    node: http://0.0.0.0:9200
+    auth:
+      username: opensearch
       password: changeme
 ```
 

--- a/plugins/search-backend-module-elasticsearch/api-report.md
+++ b/plugins/search-backend-module-elasticsearch/api-report.md
@@ -421,7 +421,7 @@ export interface OpenSearchElasticSearchClientOptions
   // (undocumented)
   nodes?: string | string[] | OpenSearchNodeOptions | OpenSearchNodeOptions[];
   // (undocumented)
-  provider?: 'aws';
+  provider?: 'aws' | 'opensearch';
 }
 
 // @public (undocumented)

--- a/plugins/search-backend-module-elasticsearch/config.d.ts
+++ b/plugins/search-backend-module-elasticsearch/config.d.ts
@@ -138,6 +138,35 @@ export interface Config {
       bearer: string;
     };*/
           }
+        /**
+         *  AWS = In house hosting Open Search
+         */
+          | {
+            provider: 'opensearch';
+            /**
+             * Node configuration.
+             * URL/URLS to OpenSearch node to connect to.
+             * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
+             */
+            node: string | string[];
+
+            /**
+             * Authentication credentials for OpenSearch
+             * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
+             */
+            auth?:
+              | {
+                  username: string;
+
+                  /**
+                   * @visibility secret
+                   */
+                  password: string;
+                }
+              | {
+                  apiKey: string;
+                };
+          }      
       );
     };
   };

--- a/plugins/search-backend-module-elasticsearch/config.d.ts
+++ b/plugins/search-backend-module-elasticsearch/config.d.ts
@@ -138,10 +138,11 @@ export interface Config {
       bearer: string;
     };*/
           }
+
         /**
          *  AWS = In house hosting Open Search
          */
-          | {
+        | {
             provider: 'opensearch';
             /**
              * Node configuration.
@@ -166,7 +167,7 @@ export interface Config {
               | {
                   apiKey: string;
                 };
-          }      
+          }
       );
     };
   };

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientOptions.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientOptions.ts
@@ -25,7 +25,7 @@ import type { ConnectionOptions as TLSConnectionOptions } from 'tls';
 export const isOpenSearchCompatible = (
   opts: ElasticSearchClientOptions,
 ): opts is OpenSearchElasticSearchClientOptions => {
-  return opts?.provider === 'aws';
+  return ['aws', 'opensearch'].includes(opts?.provider ?? '');
 };
 
 /**
@@ -50,7 +50,7 @@ export type ElasticSearchClientOptions =
  */
 export interface OpenSearchElasticSearchClientOptions
   extends BaseElasticSearchClientOptions {
-  provider?: 'aws';
+  provider?: 'aws' | 'opensearch';
   auth?: OpenSearchAuth;
   connection?: OpenSearchConnectionConstructor;
   node?: string | string[] | OpenSearchNodeOptions | OpenSearchNodeOptions[];

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
@@ -336,5 +336,24 @@ describe('ElasticSearchClientWrapper', () => {
         body: { actions: input.actions },
       });
     });
+
+    it('accepts provider "opensearch"', async () => {
+      osOptions = {
+        provider: 'opensearch',
+        node: 'https://my-opensearch-instance.address.com',
+        // todo(backstage/techdocs-core): Remove the following ts-ignore when
+        // @short.io/opensearch-mock is updated to work w/opensearch >= 2.0.0
+        // @ts-ignore
+        connection: mock.getConnection(),
+      };
+
+      const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
+      expect(OpenSearchClient).toHaveBeenCalledWith(osOptions);
+
+      const searchInput = { index: 'xyz', body: { eg: 'etc' } };
+      const result = (await wrapper.search(searchInput)) as any;
+      expect(result.client).toBe('os');
+      expect(result.args).toStrictEqual(searchInput);
+    });
   });
 });

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -150,6 +150,8 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       logger.info('Initializing Elastic.co ElasticSearch search engine.');
     } else if (options.provider === 'aws') {
       logger.info('Initializing AWS OpenSearch search engine.');
+    } else if (options.provider === 'opensearch') {
+      logger.info('Initializing OpenSearch search engine.');
     } else {
       logger.info('Initializing ElasticSearch search engine.');
     }
@@ -442,6 +444,24 @@ export async function createElasticSearchClientOptions(
       // @ts-ignore
       node: config.getString('node'),
       ...AWSConnection,
+      ...(sslConfig
+        ? {
+            ssl: {
+              rejectUnauthorized:
+                sslConfig?.getOptionalBoolean('rejectUnauthorized'),
+            },
+          }
+        : {}),
+    };
+  }
+  if (config.getOptionalString('provider') === 'opensearch') {
+    const authConfig = config.getConfig('auth');
+    return {
+      provider: 'opensearch',
+      auth: {
+        username: authConfig.getString('username'),
+        password: authConfig.getString('password'),
+      },
       ...(sslConfig
         ? {
             ssl: {

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -458,6 +458,7 @@ export async function createElasticSearchClientOptions(
     const authConfig = config.getConfig('auth');
     return {
       provider: 'opensearch',
+      node: config.getString('node'),
       auth: {
         username: authConfig.getString('username'),
         password: authConfig.getString('password'),


### PR DESCRIPTION
## Why / What

This patch continues the work started by jinnjwu on https://github.com/backstage/backstage/pull/14988 .

Backstage search currently supports the opensearch provider but only in one form. When supplying `aws` to your search provider config it assumes aws managed opensearch. This patch aims to support a hosted solution, for example [docker](https://hub.docker.com/r/opensearchproject/opensearch).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
