### PR TITLE
Documentation Fix node-postgres config options URL 

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -79,7 +79,7 @@ backend:
   database:
 -    client: better-sqlite3
 -    connection: ':memory:'
-+    # config options: https://node-postgres.com/api/client
++    # config options: https://node-postgres.com/apis/client
 +    client: pg
 +    connection:
 +      host: ${POSTGRES_HOST}


### PR DESCRIPTION
While following along with the getting started documentation, I found a typo in a URL on the `docs/getting-started/configuration.md` page. The link in the comment takes you to a 404 page. I found the correct link and created this pr. 

Signed-off-by: Michael Dunton <Mike-Dunton@users.noreply.github.com>

