### PR TITLE
Set repository to private when visibility is non-public

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -147,7 +147,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
         })
       : client.rest.repos.createForAuthenticatedUser({
           name: repo,
-          private: repoVisibility === 'private',
+          private: repoVisibility !== 'public',
           description: description,
           delete_branch_on_merge: deleteBranchOnMerge,
           allow_merge_commit: allowMergeCommit,


### PR DESCRIPTION
When repoVisibility=internal, non-organization repositories are left public. Whoops.

Alternatively, internal could be rejected for non-organization repos

Signed-off-by: Kyle Leonhard <kyle.leonhard@snowflake.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
