### PR TITLE
Add links in README to reference Sonarqube FE/BE

### DIFF
--- a/.changeset/witty-phones-chew.md
+++ b/.changeset/witty-phones-chew.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-sonarqube-backend': patch
 ---
 
-Sonarqube doc change to link FE/BE changes needed
+Added links to the frontend and backend plugins in the readme.

--- a/.changeset/witty-phones-chew.md
+++ b/.changeset/witty-phones-chew.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-sonarqube': patch
+'@backstage/plugin-sonarqube-backend': patch
+---
+
+Sonarqube doc change to link FE/BE changes needed

--- a/plugins/sonarqube-backend/README.md
+++ b/plugins/sonarqube-backend/README.md
@@ -137,3 +137,7 @@ sonarqube:
       baseUrl: https://special-project-sonarqube.example.com
       apiKey: abcdef0123456789abcedf0123456789ab
 ```
+
+## Links
+
+- [Sonarqube Frontend](../sonarqube/README.md)

--- a/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/README.md
@@ -58,3 +58,7 @@ spec:
 ```
 
 `YOUR_INSTANCE_NAME/` is optional and will query the default instance if not provided.
+
+## Links
+
+- [Sonarqube Backend](../sonarqube-backend/README.md)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The doc link from Backstage.io plugins sonarqube lead to the Frontend readme https://github.com/backstage/backstage/blob/master/plugins/sonarqube/README.md. Although it's probably common knowledge to always check if there's a backend element of the plugin, adding links to the READMEs help new users.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] Added or updated documentation
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
