### PR TITLE
[cli]: Enable cache for production build using experimental env var

### DIFF
--- a/.changeset/fluffy-fans-sing.md
+++ b/.changeset/fluffy-fans-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add experimental environment variable to enable caching for production builds.

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -42,7 +42,6 @@ export async function buildBundle(options: BuildOptions) {
     isDev: false,
     baseUrl: resolveBaseUrl(options.frontendConfig),
   });
-  const compiler = webpack(config);
 
   const isCi = yn(process.env.CI, { default: false });
 
@@ -64,7 +63,7 @@ export async function buildBundle(options: BuildOptions) {
     );
   }
 
-  const { stats } = await build(compiler, isCi).catch(error => {
+  const { stats } = await build(config, isCi).catch(error => {
     console.log(chalk.red('Failed to compile.\n'));
     throw new Error(`Failed to compile.\n${error.message || error}`);
   });
@@ -90,10 +89,10 @@ export async function buildBundle(options: BuildOptions) {
   );
 }
 
-async function build(compiler: webpack.Compiler, isCi: boolean) {
+async function build(config: webpack.Configuration, isCi: boolean) {
   const stats = await new Promise<webpack.Stats | undefined>(
     (resolve, reject) => {
-      compiler.run((err, buildStats) => {
+      webpack(config, (err, buildStats) => {
         if (err) {
           if (err.message) {
             const { errors } = formatWebpackMessages({

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -216,7 +216,7 @@ export async function createConfig(
           cache: {
             type: 'filesystem',
             buildDependencies: {
-              config: [`${cliPaths.ownDir}/`],
+              config: [__filename],
             },
           },
         }

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -216,7 +216,7 @@ export async function createConfig(
           cache: {
             type: 'filesystem',
             buildDependencies: {
-              config: [__filename],
+              config: [`${cliPaths.ownDir}/`],
             },
           },
         }

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -36,6 +36,8 @@ import { runPlain } from '../run';
 import ESLintPlugin from 'eslint-webpack-plugin';
 import pickBy from 'lodash/pickBy';
 
+const BUILD_CACHE_ENV_VAR = 'BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE';
+
 export function resolveBaseUrl(config: Config): URL {
   const baseUrl = config.getString('app.baseUrl');
   try {
@@ -206,6 +208,16 @@ export async function createConfig(
         : {}),
     },
     plugins,
+    ...(process.env[BUILD_CACHE_ENV_VAR]
+      ? {
+          cache: {
+            type: 'filesystem',
+            buildDependencies: {
+              config: [__filename],
+            },
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -35,6 +35,7 @@ import { paths as cliPaths } from '../../lib/paths';
 import { runPlain } from '../run';
 import ESLintPlugin from 'eslint-webpack-plugin';
 import pickBy from 'lodash/pickBy';
+import yn from 'yn';
 
 const BUILD_CACHE_ENV_VAR = 'BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE';
 
@@ -148,6 +149,8 @@ export async function createConfig(
     require.resolve('react-refresh'),
   ];
 
+  const withCache = yn(process.env[BUILD_CACHE_ENV_VAR], { default: false });
+
   return {
     mode: isDev ? 'development' : 'production',
     profile: false,
@@ -208,7 +211,7 @@ export async function createConfig(
         : {}),
     },
     plugins,
-    ...(process.env[BUILD_CACHE_ENV_VAR]
+    ...(withCache
       ? {
           cache: {
             type: 'filesystem',


### PR DESCRIPTION
Signed-off-by: Marcus Eide <eide@spotify.com>

This PR enables [webpack cache](https://webpack.js.org/configuration/cache/) for production builds when using the `BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE` environment variable. The idea is that a persistent cache can be used across builds in a CI environment, something like [this](https://webpack.js.org/configuration/cache/#github-actions).

In order for the cache to populate, the webpack compiler needs to be created by providing it with a callback. It seems to require either a `compiler.close()` or a closure to finish low-priority work, such as the persistent caching. See https://github.com/webpack/webpack/issues/12342#issuecomment-754869202.

Speed was measured using the `SpeedMeasurePlugin`, and gives the following results on my local machine:

- Build on new master, without cache:
![Skärmavbild fresh master no cache](https://user-images.githubusercontent.com/18682151/207358978-5e201510-6cbb-4746-86fb-2512380118ca.png)

- Build on new master, with warmed up cache:
![Skärmavbild master with cache](https://user-images.githubusercontent.com/18682151/207359004-0a4d186e-49d1-4260-9f50-6ffa0865ff77.png)

- Build after some random changes in `packages/app` and `packages/core-app-api`, with warmed up cache:
![Skärmavbild with changes](https://user-images.githubusercontent.com/18682151/207359024-8418181d-a33f-4a34-914e-de28defe55d8.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
