### PR TITLE
ignore processors emitting entities that are their own children

### DIFF
--- a/.changeset/smart-zoos-wash.md
+++ b/.changeset/smart-zoos-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Ignore attempts at emitting the current entity as a child of itself.

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -258,13 +258,22 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
       },
     };
 
+    const child: Entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: {
+        name: 'Test2',
+        namespace: 'test1',
+      },
+    };
+
     it('enforces catalog rules', async () => {
       const integrations = ScmIntegrations.fromConfig(new ConfigReader({}));
       const processor: jest.Mocked<CatalogProcessor> = {
         getProcessorName: jest.fn(),
         validateEntityKind: jest.fn(async () => true),
         readLocation: jest.fn(async (_l, _o, emit) => {
-          emit(processingResult.entity({ type: 't', target: 't' }, entity));
+          emit(processingResult.entity({ type: 't', target: 't' }, child));
           return true;
         }),
       };
@@ -300,7 +309,7 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
         getProcessorName: jest.fn(),
         validateEntityKind: jest.fn(async () => true),
         readLocation: jest.fn(async (_l, _o, emit) => {
-          emit(processingResult.entity({ type: 't', target: 't' }, entity));
+          emit(processingResult.entity({ type: 't', target: 't' }, child));
           return true;
         }),
       };

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -187,7 +187,7 @@ export class DefaultCatalogProcessingOrchestrator
           res = await processor.preProcessEntity(
             res,
             context.location,
-            context.collector.onEmit,
+            context.collector.forProcessor(processor),
             context.originLocation,
             context.cache.forProcessor(processor),
           );
@@ -300,7 +300,7 @@ export class DefaultCatalogProcessingOrchestrator
 
     for (const maybeRelativeTarget of targets) {
       if (type === 'file' && maybeRelativeTarget.endsWith(path.sep)) {
-        context.collector.onEmit(
+        context.collector.generic()(
           processingResult.inputError(
             context.location,
             `LocationEntityProcessor cannot handle ${type} type location with target ${context.location.target} that ends with a path separator`,
@@ -326,7 +326,7 @@ export class DefaultCatalogProcessingOrchestrator
                 presence,
               },
               presence === 'optional',
-              context.collector.onEmit,
+              context.collector.forProcessor(processor),
               this.options.parser,
               context.cache.forProcessor(processor, target),
             );
@@ -365,7 +365,7 @@ export class DefaultCatalogProcessingOrchestrator
           res = await processor.postProcessEntity(
             res,
             context.location,
-            context.collector.onEmit,
+            context.collector.forProcessor(processor),
             context.cache.forProcessor(processor),
           );
         } catch (e) {

--- a/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
@@ -19,6 +19,7 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   stringifyLocationRef,
+  stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { assertError } from '@backstage/errors';
 import { Logger } from 'winston';
@@ -86,6 +87,17 @@ export class ProcessorOutputCollector {
         assertError(e);
         this.logger.debug(`Envelope validation failed at ${location}, ${e}`);
         this.errors.push(e);
+        return;
+      }
+
+      // The processor contract says you should return the "trunk" (current)
+      // entity, not emit it. But it happens that this is misunderstood or
+      // accidentally forgotten. This can lead to circular references which at
+      // best is wasteful, so we try to be helpful by ignoring such emitted
+      // entities.
+      if (
+        stringifyEntityRef(entity) === stringifyEntityRef(this.parentEntity)
+      ) {
         return;
       }
 


### PR DESCRIPTION
This seems to have happened on a number of occasions. Example: https://discord.com/channels/687207715902193673/1051941589662052443/1052220380154187897