### PR TITLE
Fix sidebar icon alignment

### DIFF
--- a/.changeset/dirty-bees-explode.md
+++ b/.changeset/dirty-bees-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Update sidebar icon alignment

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -140,6 +140,7 @@ const makeSidebarStyles = (sidebarConfig: SidebarConfig) =>
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        lineHeight: '0',
       },
       searchRoot: {
         marginBottom: 12,
@@ -371,12 +372,14 @@ const SidebarItemBase = forwardRef<any, SidebarItemProps>((props, ref) => {
   const { isOpen } = useSidebarOpenState();
 
   const divStyle =
-    !isOpen && hasSubmenu ? { display: 'flex', marginLeft: '24px' } : {};
+    !isOpen && hasSubmenu
+      ? { display: 'flex', marginLeft: '20px' }
+      : { lineHeight: '0' };
 
   const displayItemIcon = (
     <Box style={divStyle}>
       <Icon fontSize="small" />
-      {!isOpen && hasSubmenu ? <ArrowRightIcon /> : <></>}
+      {!isOpen && hasSubmenu ? <ArrowRightIcon fontSize="small" /> : <></>}
     </Box>
   );
 


### PR DESCRIPTION
Sidebar icons aren't aligned with the accompanying text!

Before:
<img width="110" alt="image" src="https://user-images.githubusercontent.com/7963833/207408952-7c323dd8-26e9-4a88-9e40-b2790129ed66.png">

After:
https://user-images.githubusercontent.com/7963833/207409147-e65e9c95-c12f-4c5f-9206-781953f90109.mov

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
