### PR TITLE
Allow custom repository roles to be used

### DIFF
--- a/.changeset/cool-islands-laugh.md
+++ b/.changeset/cool-islands-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Allow custom repository roles to be configured on github repos

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -212,11 +212,11 @@ export function createGithubRepoCreateAction(options: {
     | (
         | {
             user: string;
-            access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+            access: string;
           }
         | {
             team: string;
-            access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+            access: string;
           }
         | {
             username: string;
@@ -397,11 +397,11 @@ export function createPublishGithubAction(options: {
     | (
         | {
             user: string;
-            access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+            access: string;
           }
         | {
             team: string;
-            access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+            access: string;
           }
         | {
             username: string;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
@@ -63,11 +63,11 @@ export function createGithubRepoCreateAction(options: {
     collaborators?: Array<
       | {
           user: string;
-          access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+          access: string;
         }
       | {
           team: string;
-          access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+          access: string;
         }
       | {
           /** @deprecated This field is deprecated in favor of team */

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -109,11 +109,11 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
     | (
         | {
             user: string;
-            access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+            access: string;
           }
         | {
             team: string;
-            access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+            access: string;
           }
         | {
             /** @deprecated This field is deprecated in favor of team */

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
@@ -110,7 +110,6 @@ const collaborators = {
       access: {
         type: 'string',
         description: 'The type of access for the user',
-        enum: ['push', 'pull', 'admin', 'maintain', 'triage'],
       },
       user: {
         type: 'string',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -75,11 +75,11 @@ export function createPublishGithubAction(options: {
     collaborators?: Array<
       | {
           user: string;
-          access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+          access: string;
         }
       | {
           team: string;
-          access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
+          access: string;
         }
       | {
           /** @deprecated This field is deprecated in favor of team */


### PR DESCRIPTION
Signed-off-by: Kyle Leonhard <kyle.leonhard@snowflake.com>

## Hey, I just made a Pull Request!

This PR modifies collaborators.access to allow custom repository roles to be used.

In addition to the stock permissions, organizations may define custom roles. By removing the enum restriction, users can pass whichever custom roles they prefer.

API reference: https://octokit.github.io/rest.js/v19

> The permission to grant the collaborator. Only valid on organization-owned repositories. We accept the following permissions to be set: pull, triage, push, maintain, admin and you can also specify a custom repository role name, if the owning organization has defined any.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
