### PR TITLE
Fix for TechDocs header disappearing

### DIFF
--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -66,6 +66,8 @@ export type TechDocsReaderPageValue = {
   setTitle: Dispatch<SetStateAction<string>>;
   subtitle: string;
   setSubtitle: Dispatch<SetStateAction<string>>;
+  readerState: string;
+  setReaderState: Dispatch<SetStateAction<string>>;
   /**
    * @deprecated property can be passed down directly to the `TechDocsReaderPageContent` instead.
    */
@@ -81,6 +83,8 @@ const defaultTechDocsReaderPageValue: TechDocsReaderPageValue = {
   metadata: { loading: true },
   entityMetadata: { loading: true },
   entityRef: { kind: '', name: '', namespace: '' },
+  readerState: '',
+  setReaderState: () => {},
 };
 
 const TechDocsReaderPageContext = createVersionedContext<{
@@ -114,14 +118,15 @@ export const TechDocsReaderPageProvider = memo(
   ({ entityRef, children }: TechDocsReaderPageProviderProps) => {
     const techdocsApi = useApi(techdocsApiRef);
     const config = useApi(configApiRef);
+    const [readerState, setReaderState] = useState('');
 
     const metadata = useAsync(async () => {
       return techdocsApi.getTechDocsMetadata(entityRef);
-    }, [entityRef]);
+    }, [entityRef, readerState]);
 
     const entityMetadata = useAsync(async () => {
       return techdocsApi.getEntityMetadata(entityRef);
-    }, [entityRef]);
+    }, [entityRef, readerState]);
 
     const [title, setTitle] = useState(defaultTechDocsReaderPageValue.title);
     const [subtitle, setSubtitle] = useState(
@@ -141,6 +146,8 @@ export const TechDocsReaderPageProvider = memo(
       setTitle,
       subtitle,
       setSubtitle,
+      readerState,
+      setReaderState,
     };
     const versionedValue = createVersionedValueMap({ 1: value });
 

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -76,6 +76,7 @@ export const TechDocsReaderPageHeader = (
     entityRef,
     metadata: { value: metadata, loading: metadataLoading },
     entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
+    readerState,
   } = useTechDocsReaderPage();
 
   useEffect(() => {
@@ -154,11 +155,17 @@ export const TechDocsReaderPageHeader = (
     </>
   );
 
+  // Avoid showing the header before we know whether it is ready / needs to be re-built.
+  // This way, we avoid the header flickering for docs that haven't been built yet.
+  const contentNotReady =
+    !readerState ||
+    readerState === 'CHECKING' ||
+    readerState === 'INITIAL_BUILD';
   // If there is no entity or techdocs metadata, there's no reason to show the
   // header (hides the header on 404 error pages).
   const noEntMetadata = !entityMetadataLoading && entityMetadata === undefined;
   const noTdMetadata = !metadataLoading && metadata === undefined;
-  if (noEntMetadata || noTdMetadata) return null;
+  if (noEntMetadata || noTdMetadata || contentNotReady) return null;
 
   return (
     <Header

--- a/plugins/techdocs/src/reader/components/TechDocsReaderProvider.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderProvider.tsx
@@ -52,9 +52,11 @@ export const TechDocsReaderProvider = ({
   children,
 }: TechDocsReaderProviderProps) => {
   const { '*': path = '' } = useParams();
-  const { entityRef } = useTechDocsReaderPage();
+  const { entityRef, setReaderState } = useTechDocsReaderPage();
   const { kind, namespace, name } = entityRef;
   const value = useReaderState(kind, namespace, name, path);
+
+  setReaderState(value.state);
 
   return (
     <TechDocsReaderContext.Provider value={value}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've investigated #13346 and came up with this workaround. This is not intended to be merged, but rather to start a discussion on how this could be fixed properly. Admittedly, my React-Fu is not strong enough, so I'll need some help with that.

### The problem

1. The `TechDocsReaderPageHeader` component contains a condition to not render the header if no metadata is available
2. The metadata is sourced from `TechDocsReaderPageContext` (part of plugin-techdocs-react)
3. The re-build functionality triggers a context update, but for a different context, namely `TechDocsReaderContext` (part of plugin-techdocs)
4. As a result, `TechDocsReaderPageContext` is not updated after documentation finishes building, so no metadata is available, and thus the header does not show.

### The solution?

As mentioned above, unsure about this one.

* Maybe something similar to what I'm doing, only without needlessly duplicating the `content` would suffice?
* I don't fully understand why these two contexts exist in separation, so maybe merging them would also be an option?


### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


### P.S.

I accidentally created this PR from the wrong user account. Should I close it and open a new one? 🤔 