### PR TITLE
Fix lighthouse navigate to a wrong URL

### DIFF
--- a/.changeset/ninety-bags-turn.md
+++ b/.changeset/ninety-bags-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-lighthouse': patch
+---
+
+Fixed bug in Lighthouse Plugin where audit list item and create audit button navigated to a wrong URL.

--- a/plugins/lighthouse/src/components/AuditView/index.test.tsx
+++ b/plugins/lighthouse/src/components/AuditView/index.test.tsx
@@ -149,6 +149,28 @@ describe('AuditView', () => {
         ).toHaveAttribute('href', `/audit/${a.id}`);
       });
     });
+
+    it('navigates to the next report with respect to the base path', async () => {
+      // TODO: I would need help here. How to set the base path for the test?
+      const basePath = `/lighthouse`;
+      const rendered = render(
+        wrapInTestApp(
+          <ApiProvider apis={apis}>
+            <AuditView />
+          </ApiProvider>,
+          { routeEntries: [basePath] },
+        ),
+      );
+
+      await rendered.findByTestId('audit-sidebar');
+
+      websiteResponse.audits.forEach(a => {
+        expect(
+          rendered.getByText(formatTime(a.timeCreated)).parentElement
+            ?.parentElement,
+        ).toHaveAttribute('href', `${basePath}/audits/${a.id}`);
+      });
+    });
   });
 
   describe('when the request for the website by id is pending', () => {

--- a/plugins/lighthouse/src/components/AuditView/index.test.tsx
+++ b/plugins/lighthouse/src/components/AuditView/index.test.tsx
@@ -168,7 +168,7 @@ describe('AuditView', () => {
         expect(
           rendered.getByText(formatTime(a.timeCreated)).parentElement
             ?.parentElement,
-        ).toHaveAttribute('href', `${basePath}/audits/${a.id}`);
+        ).toHaveAttribute('href', `${basePath}/audit/${a.id}`);
       });
     });
   });

--- a/plugins/lighthouse/src/components/AuditView/index.tsx
+++ b/plugins/lighthouse/src/components/AuditView/index.tsx
@@ -47,7 +47,8 @@ import {
   Page,
   Progress,
 } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, useRouteRef } from '@backstage/core-plugin-api';
+import { rootRouteRef } from '../../plugin';
 
 // TODO(freben): move all of this out of index
 
@@ -67,29 +68,35 @@ interface AuditLinkListProps {
   audits?: Audit[];
   selectedId: string;
 }
-const AuditLinkList = ({ audits = [], selectedId }: AuditLinkListProps) => (
-  <List
-    data-testid="audit-sidebar"
-    component="nav"
-    aria-label="lighthouse audit history"
-  >
-    {audits.map(audit => (
-      <ListItem
-        key={audit.id}
-        selected={audit.id === selectedId}
-        button
-        component={Link}
-        replace
-        to={resolvePath(generatePath('audit/:id', { id: audit.id }), '../')}
-      >
-        <ListItemIcon>
-          <AuditStatusIcon audit={audit} />
-        </ListItemIcon>
-        <ListItemText primary={formatTime(audit.timeCreated)} />
-      </ListItem>
-    ))}
-  </List>
-);
+const AuditLinkList = ({ audits = [], selectedId }: AuditLinkListProps) => {
+  const fromPath = useRouteRef(rootRouteRef)?.() ?? '../';
+  return (
+    <List
+      data-testid="audit-sidebar"
+      component="nav"
+      aria-label="lighthouse audit history"
+    >
+      {audits.map(audit => (
+        <ListItem
+          key={audit.id}
+          selected={audit.id === selectedId}
+          button
+          component={Link}
+          replace
+          to={resolvePath(
+            generatePath('audit/:id', { id: audit.id }),
+            fromPath,
+          )}
+        >
+          <ListItemIcon>
+            <AuditStatusIcon audit={audit} />
+          </ListItemIcon>
+          <ListItemText primary={formatTime(audit.timeCreated)} />
+        </ListItem>
+      ))}
+    </List>
+  );
+};
 
 const AuditView = ({ audit }: { audit?: Audit }) => {
   const classes = useStyles();
@@ -119,6 +126,7 @@ const AuditView = ({ audit }: { audit?: Audit }) => {
 
 export const AuditViewContent = () => {
   const lighthouseApi = useApi(lighthouseApiRef);
+  const fromPath = useRouteRef(rootRouteRef)?.() ?? '../';
   const params = useParams() as { id: string };
   const classes = useStyles();
   const navigate = useNavigate();
@@ -178,7 +186,7 @@ export const AuditViewContent = () => {
         <Button
           variant="contained"
           color="primary"
-          onClick={() => navigate(`../${createAuditButtonUrl}`)}
+          onClick={() => navigate(resolvePath(createAuditButtonUrl, fromPath))}
         >
           Create New Audit
         </Button>

--- a/plugins/lighthouse/src/components/AuditView/index.tsx
+++ b/plugins/lighthouse/src/components/AuditView/index.tsx
@@ -80,7 +80,7 @@ const AuditLinkList = ({ audits = [], selectedId }: AuditLinkListProps) => (
         button
         component={Link}
         replace
-        to={resolvePath(generatePath('audit/:id', { id: audit.id }), '../../')}
+        to={resolvePath(generatePath('audit/:id', { id: audit.id }), '../')}
       >
         <ListItemIcon>
           <AuditStatusIcon audit={audit} />
@@ -178,7 +178,7 @@ export const AuditViewContent = () => {
         <Button
           variant="contained"
           color="primary"
-          onClick={() => navigate(`../../${createAuditButtonUrl}`)}
+          onClick={() => navigate(`../${createAuditButtonUrl}`)}
         >
           Create New Audit
         </Button>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR will fix the issue #15231 where audit list item and create audit button navigated to a wrong URL.

With `resolvePath(generatePath('audit/:id', { id: audit.id }), '../../')` we navigate from `/<base-url>/audit/<id>` to `/audit/<id>` but this is wrong because the base path will be removed. Therefore we use `useRouteRef`, this will navigate to the right url with respect to the base path.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
