### PR TITLE
repo-tools: remove lint rule overrides

### DIFF
--- a/.changeset/clean-peas-try.md
+++ b/.changeset/clean-peas-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+declare dependencies

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -37,6 +37,7 @@
     "@microsoft/api-extractor": "^7.23.0",
     "@microsoft/api-extractor-model": "^7.17.2",
     "@microsoft/tsdoc": "0.14.1",
+    "@microsoft/tsdoc-config": "0.16.1",
     "chalk": "^4.0.0",
     "commander": "^9.1.0",
     "fs-extra": "10.1.0",
@@ -50,6 +51,16 @@
     "@types/is-glob": "^4.0.2",
     "@types/mock-fs": "^4.13.0",
     "mock-fs": "^5.1.0"
+  },
+  "peerDependencies": {
+    "@rushstack/node-core-library": "*",
+    "prettier": "^2.8.1",
+    "typescript": "> 3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "files": [
     "bin",

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -22,7 +22,7 @@ import {
   join,
 } from 'path';
 import { execFile } from 'child_process';
-import prettier from 'prettier';
+import type prettierType from 'prettier';
 import fs from 'fs-extra';
 import {
   Extractor,
@@ -211,10 +211,19 @@ ApiReportGenerator.generateReviewFileContent =
       collector,
       ...moreArgs,
     );
-    return prettier.format(content, {
-      ...require('@spotify/prettier-config'),
-      parser: 'markdown',
-    });
+
+    try {
+      const prettier = require('prettier') as typeof prettierType;
+
+      const config = prettier.resolveConfig.sync(cliPaths.targetRoot) ?? {};
+      return prettier.format(content, {
+        ...config,
+        parser: 'markdown',
+      });
+    } catch (e) {
+      // console.warn('Failed to format API report with prettier', e);
+      return content;
+    }
   };
 
 export async function createTemporaryTsConfig(includedPackageDirs: string[]) {

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable no-restricted-imports */
 import {
   resolve as resolvePath,
   relative as relativePath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8512,6 +8512,7 @@ __metadata:
     "@microsoft/api-extractor": ^7.23.0
     "@microsoft/api-extractor-model": ^7.17.2
     "@microsoft/tsdoc": 0.14.1
+    "@microsoft/tsdoc-config": 0.16.1
     "@types/is-glob": ^4.0.2
     "@types/mock-fs": ^4.13.0
     chalk: ^4.0.0
@@ -8522,6 +8523,13 @@ __metadata:
     minimatch: ^5.1.1
     mock-fs: ^5.1.0
     ts-node: ^10.0.0
+  peerDependencies:
+    "@rushstack/node-core-library": "*"
+    prettier: ^2.8.1
+    typescript: "> 3.0.0"
+  peerDependenciesMeta:
+    prettier:
+      optional: true
   bin:
     backstage-repo-tools: bin/backstage-repo-tools
   languageName: unknown
@@ -11562,7 +11570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/tsdoc-config@npm:~0.16.1":
+"@microsoft/tsdoc-config@npm:0.16.1, @microsoft/tsdoc-config@npm:~0.16.1":
   version: 0.16.1
   resolution: "@microsoft/tsdoc-config@npm:0.16.1"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Realized there was a lint rule override in `repo-tools` that will cause a bunch of breakages for people trying to use the package. @djamaile, @Sarabadu could you have a look? 👀, feel free to hijack the branch if you want to

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
