### PR TITLE
plugin-lighthouse: fix form factor field not working

### DIFF
--- a/.changeset/many-mayflies-share.md
+++ b/.changeset/many-mayflies-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-lighthouse': patch
+---
+
+Fixed "Emulated Form Factor" field in the audit creation form not working with the latest version (1.0.2) of `lighthouse-audit-service`.

--- a/plugins/lighthouse/api-report.md
+++ b/plugins/lighthouse/api-report.md
@@ -72,6 +72,14 @@ export class FetchError extends Error {
 }
 
 // @public (undocumented)
+export enum FormFactor {
+  // (undocumented)
+  Desktop = 'desktop',
+  // (undocumented)
+  Mobile = 'mobile',
+}
+
+// @public (undocumented)
 const isLighthouseAvailable: (entity: Entity) => boolean;
 export { isLighthouseAvailable };
 export { isLighthouseAvailable as isPluginApplicableToEntity };
@@ -168,12 +176,23 @@ export class LighthouseRestApi implements LighthouseApi {
 export const Router: () => JSX.Element;
 
 // @public (undocumented)
+export type ScreenEmulation = {
+  mobile: boolean;
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+  disabled: boolean;
+} | null;
+
+// @public (undocumented)
 export interface TriggerAuditPayload {
   // (undocumented)
   options: {
     lighthouseConfig: {
       settings: {
-        emulatedFormFactor: string;
+        formFactor: FormFactor;
+        screenEmulation: ScreenEmulation;
+        emulatedFormFactor: FormFactor;
       };
     };
   };

--- a/plugins/lighthouse/api-report.md
+++ b/plugins/lighthouse/api-report.md
@@ -72,12 +72,7 @@ export class FetchError extends Error {
 }
 
 // @public (undocumented)
-export enum FormFactor {
-  // (undocumented)
-  Desktop = 'desktop',
-  // (undocumented)
-  Mobile = 'mobile',
-}
+export type FormFactor = 'mobile' | 'desktop';
 
 // @public (undocumented)
 const isLighthouseAvailable: (entity: Entity) => boolean;
@@ -141,6 +136,21 @@ export type LighthouseCategoryId =
   | 'best-practices';
 
 // @public (undocumented)
+export type LighthouseConfigSettings = {
+  formFactor: FormFactor;
+  screenEmulation:
+    | {
+        mobile: boolean;
+        width: number;
+        height: number;
+        deviceScaleFactor: number;
+        disabled: boolean;
+      }
+    | undefined;
+  emulatedFormFactor: FormFactor;
+};
+
+// @public (undocumented)
 export const LighthousePage: () => JSX.Element;
 
 // @public (undocumented)
@@ -176,24 +186,11 @@ export class LighthouseRestApi implements LighthouseApi {
 export const Router: () => JSX.Element;
 
 // @public (undocumented)
-export type ScreenEmulation = {
-  mobile: boolean;
-  width: number;
-  height: number;
-  deviceScaleFactor: number;
-  disabled: boolean;
-} | null;
-
-// @public (undocumented)
 export interface TriggerAuditPayload {
   // (undocumented)
   options: {
     lighthouseConfig: {
-      settings: {
-        formFactor: FormFactor;
-        screenEmulation: ScreenEmulation;
-        emulatedFormFactor: FormFactor;
-      };
+      settings: LighthouseConfigSettings;
     };
   };
   // (undocumented)

--- a/plugins/lighthouse/src/api.ts
+++ b/plugins/lighthouse/src/api.ts
@@ -86,12 +86,31 @@ export interface Website {
 export type WebsiteListResponse = LASListResponse<Website>;
 
 /** @public */
+export enum FormFactor {
+  Mobile = 'mobile',
+  Desktop = 'desktop',
+}
+
+/** @public */
+export type ScreenEmulation = {
+  mobile: boolean;
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+  disabled: boolean;
+} | null;
+
+/** @public */
 export interface TriggerAuditPayload {
   url: string;
   options: {
     lighthouseConfig: {
       settings: {
-        emulatedFormFactor: string;
+        // For lighthouse 7+
+        formFactor: FormFactor;
+        screenEmulation: ScreenEmulation;
+        // For lighthouse before 7
+        emulatedFormFactor: FormFactor;
       };
     };
   };

--- a/plugins/lighthouse/src/api.ts
+++ b/plugins/lighthouse/src/api.ts
@@ -86,32 +86,31 @@ export interface Website {
 export type WebsiteListResponse = LASListResponse<Website>;
 
 /** @public */
-export enum FormFactor {
-  Mobile = 'mobile',
-  Desktop = 'desktop',
-}
+export type FormFactor = 'mobile' | 'desktop';
 
 /** @public */
-export type ScreenEmulation = {
-  mobile: boolean;
-  width: number;
-  height: number;
-  deviceScaleFactor: number;
-  disabled: boolean;
-} | null;
+export type LighthouseConfigSettings = {
+  // For lighthouse 7+
+  formFactor: FormFactor;
+  screenEmulation:
+    | {
+        mobile: boolean;
+        width: number;
+        height: number;
+        deviceScaleFactor: number;
+        disabled: boolean;
+      }
+    | undefined;
+  // For lighthouse before 7
+  emulatedFormFactor: FormFactor;
+};
 
 /** @public */
 export interface TriggerAuditPayload {
   url: string;
   options: {
     lighthouseConfig: {
-      settings: {
-        // For lighthouse 7+
-        formFactor: FormFactor;
-        screenEmulation: ScreenEmulation;
-        // For lighthouse before 7
-        emulatedFormFactor: FormFactor;
-      };
+      settings: LighthouseConfigSettings;
     };
   };
 }

--- a/plugins/lighthouse/src/components/CreateAudit/index.tsx
+++ b/plugins/lighthouse/src/components/CreateAudit/index.tsx
@@ -25,7 +25,11 @@ import {
 } from '@material-ui/core';
 import React, { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FormFactor, lighthouseApiRef, ScreenEmulation } from '../../api';
+import {
+  FormFactor,
+  lighthouseApiRef,
+  LighthouseConfigSettings,
+} from '../../api';
 import { useQuery } from '../../utils';
 import LighthouseSupportButton from '../SupportButton';
 
@@ -65,9 +69,12 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const formFactorToScreenEmulationMap: Record<FormFactor, ScreenEmulation> = {
+const formFactorToScreenEmulationMap: Record<
+  FormFactor,
+  LighthouseConfigSettings['screenEmulation']
+> = {
   // the default is mobile, so no need to override
-  mobile: null,
+  mobile: undefined,
   // Values from lighthouse's cli "desktop" preset
   // https://github.com/GoogleChrome/lighthouse/blob/a6738e0033e7e5ca308b97c1c36f298b7d399402/lighthouse-core/config/constants.js#L71-L77
   desktop: {
@@ -87,7 +94,7 @@ export const CreateAuditContent = () => {
   const navigate = useNavigate();
   const [submitting, setSubmitting] = useState(false);
   const [url, setUrl] = useState<string>(query.get('url') || '');
-  const [formFactor, setFormFactor] = useState<FormFactor>(FormFactor.Mobile);
+  const [formFactor, setFormFactor] = useState<FormFactor>('mobile');
 
   const triggerAudit = useCallback(async (): Promise<void> => {
     setSubmitting(true);

--- a/plugins/lighthouse/src/components/CreateAudit/index.tsx
+++ b/plugins/lighthouse/src/components/CreateAudit/index.tsx
@@ -25,7 +25,7 @@ import {
 } from '@material-ui/core';
 import React, { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { lighthouseApiRef } from '../../api';
+import { FormFactor, lighthouseApiRef, ScreenEmulation } from '../../api';
 import { useQuery } from '../../utils';
 import LighthouseSupportButton from '../SupportButton';
 
@@ -65,6 +65,20 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const formFactorToScreenEmulationMap: Record<FormFactor, ScreenEmulation> = {
+  // the default is mobile, so no need to override
+  mobile: null,
+  // Values from lighthouse's cli "desktop" preset
+  // https://github.com/GoogleChrome/lighthouse/blob/a6738e0033e7e5ca308b97c1c36f298b7d399402/lighthouse-core/config/constants.js#L71-L77
+  desktop: {
+    mobile: false,
+    width: 1350,
+    height: 940,
+    deviceScaleFactor: 1,
+    disabled: false,
+  },
+};
+
 export const CreateAuditContent = () => {
   const errorApi = useApi(errorApiRef);
   const lighthouseApi = useApi(lighthouseApiRef);
@@ -73,7 +87,7 @@ export const CreateAuditContent = () => {
   const navigate = useNavigate();
   const [submitting, setSubmitting] = useState(false);
   const [url, setUrl] = useState<string>(query.get('url') || '');
-  const [emulatedFormFactor, setEmulatedFormFactor] = useState('mobile');
+  const [formFactor, setFormFactor] = useState<FormFactor>(FormFactor.Mobile);
 
   const triggerAudit = useCallback(async (): Promise<void> => {
     setSubmitting(true);
@@ -85,7 +99,9 @@ export const CreateAuditContent = () => {
         options: {
           lighthouseConfig: {
             settings: {
-              emulatedFormFactor,
+              formFactor,
+              emulatedFormFactor: formFactor,
+              screenEmulation: formFactorToScreenEmulationMap[formFactor],
             },
           },
         },
@@ -96,14 +112,7 @@ export const CreateAuditContent = () => {
     } finally {
       setSubmitting(false);
     }
-  }, [
-    url,
-    emulatedFormFactor,
-    lighthouseApi,
-    setSubmitting,
-    errorApi,
-    navigate,
-  ]);
+  }, [url, formFactor, lighthouseApi, setSubmitting, errorApi, navigate]);
 
   return (
     <>
@@ -146,8 +155,10 @@ export const CreateAuditContent = () => {
                     select
                     required
                     disabled={submitting}
-                    onChange={ev => setEmulatedFormFactor(ev.target.value)}
-                    value={emulatedFormFactor}
+                    onChange={ev =>
+                      setFormFactor(ev.target.value as FormFactor)
+                    }
+                    value={formFactor}
                     inputProps={{ 'aria-label': 'Emulated form factor' }}
                   >
                     <MenuItem value="mobile">Mobile</MenuItem>


### PR DESCRIPTION
## Issue

When triggering an audit :

![image](https://user-images.githubusercontent.com/29628106/207619951-51c60de6-9d52-4cfb-aba0-d931db9ed697.png)

The "Emulated Form Factor" field does not work if the `lighthouse-audit-service` backend is up to date (version 1.0.2).

This means that when selecting "Desktop", the audit will be emulating a mobile device and the report will show screenshots in mobile screen size.

## Fix

This PR fixes the issue with `lighthouse-audit-service` 1.0.2 while still being compatible with previous versions.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- ~~Added or updated documentation~~ bugfix
- [x] Tests for new functionality and regression tests for bug fixes
- ~~Screenshots attached (for UI changes)~~ no ui change
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
