### PR TITLE
backend-plugin-api: update logger interface with more methods and meta

### DIFF
--- a/.changeset/chilly-bees-dream.md
+++ b/.changeset/chilly-bees-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Updated logger implementations to match interface changes.

--- a/.changeset/wicked-paws-help.md
+++ b/.changeset/wicked-paws-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Updated `LoggerService` interface with more log methods and meta.

--- a/packages/backend-app-api/src/services/implementations/rootLoggerService.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLoggerService.ts
@@ -20,6 +20,7 @@ import {
   LoggerService,
   coreServices,
 } from '@backstage/backend-plugin-api';
+import { LogMeta } from '@backstage/backend-plugin-api';
 import { Logger as WinstonLogger } from 'winston';
 
 class BackstageLogger implements LoggerService {
@@ -29,12 +30,24 @@ class BackstageLogger implements LoggerService {
 
   private constructor(private readonly winston: WinstonLogger) {}
 
-  info(message: string, ...meta: any[]): void {
-    this.winston.info(message, ...meta);
+  error(message: string, meta?: LogMeta): void {
+    this.winston.error(message, meta);
   }
 
-  child(fields: { [name: string]: string }): LoggerService {
-    return new BackstageLogger(this.winston.child(fields));
+  warn(message: string, meta?: LogMeta): void {
+    this.winston.warn(message, meta);
+  }
+
+  info(message: string, meta?: LogMeta): void {
+    this.winston.info(message, meta);
+  }
+
+  debug(message: string, meta?: LogMeta): void {
+    this.winston.debug(message, meta);
+  }
+
+  child(meta: LogMeta): LoggerService {
+    return new BackstageLogger(this.winston.child(meta));
   }
 }
 

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -205,9 +205,15 @@ export type LifecycleServiceShutdownHook = {
 // @public (undocumented)
 export interface LoggerService {
   // (undocumented)
-  child(fields: { [name: string]: string }): LoggerService;
+  child(meta: LogMeta): LoggerService;
   // (undocumented)
-  info(message: string): void;
+  debug(message: string, meta?: LogMeta): void;
+  // (undocumented)
+  error(message: string, meta?: LogMeta): void;
+  // (undocumented)
+  info(message: string, meta?: LogMeta): void;
+  // (undocumented)
+  warn(message: string, meta?: LogMeta): void;
 }
 
 // @public (undocumented)
@@ -218,6 +224,13 @@ export function loggerToWinstonLogger(
   logger: LoggerService,
   opts?: TransportStreamOptions,
 ): Logger;
+
+// @public (undocumented)
+export type LogMeta =
+  | Error
+  | {
+      [name: string]: any;
+    };
 
 // @public (undocumented)
 export type PermissionsService = PermissionEvaluator | PermissionAuthorizer;

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -207,13 +207,13 @@ export interface LoggerService {
   // (undocumented)
   child(meta: LogMeta): LoggerService;
   // (undocumented)
-  debug(message: string, meta?: LogMeta): void;
+  debug(message: string, meta?: Error | LogMeta): void;
   // (undocumented)
-  error(message: string, meta?: LogMeta): void;
+  error(message: string, meta?: Error | LogMeta): void;
   // (undocumented)
-  info(message: string, meta?: LogMeta): void;
+  info(message: string, meta?: Error | LogMeta): void;
   // (undocumented)
-  warn(message: string, meta?: LogMeta): void;
+  warn(message: string, meta?: Error | LogMeta): void;
 }
 
 // @public (undocumented)
@@ -226,11 +226,9 @@ export function loggerToWinstonLogger(
 ): Logger;
 
 // @public (undocumented)
-export type LogMeta =
-  | Error
-  | {
-      [name: string]: any;
-    };
+export type LogMeta = {
+  [name: string]: unknown;
+};
 
 // @public (undocumented)
 export type PermissionsService = PermissionEvaluator | PermissionAuthorizer;

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -26,7 +26,7 @@ export type {
   LifecycleService,
   LifecycleServiceShutdownHook,
 } from './lifecycleServiceRef';
-export type { LoggerService } from './loggerServiceRef';
+export type { LoggerService, LogMeta } from './loggerServiceRef';
 export type { PermissionsService } from './permissionsServiceRef';
 export type { PluginMetadataService } from './pluginMetadataServiceRef';
 export type { RootLoggerService } from './rootLoggerServiceRef';

--- a/packages/backend-plugin-api/src/services/definitions/loggerServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/loggerServiceRef.ts
@@ -19,16 +19,16 @@ import { createServiceRef } from '../system/types';
 /**
  * @public
  */
-export type LogMeta = Error | { [name: string]: any };
+export type LogMeta = { [name: string]: unknown };
 
 /**
  * @public
  */
 export interface LoggerService {
-  error(message: string, meta?: LogMeta): void;
-  warn(message: string, meta?: LogMeta): void;
-  info(message: string, meta?: LogMeta): void;
-  debug(message: string, meta?: LogMeta): void;
+  error(message: string, meta?: Error | LogMeta): void;
+  warn(message: string, meta?: Error | LogMeta): void;
+  info(message: string, meta?: Error | LogMeta): void;
+  debug(message: string, meta?: Error | LogMeta): void;
 
   child(meta: LogMeta): LoggerService;
 }

--- a/packages/backend-plugin-api/src/services/definitions/loggerServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/loggerServiceRef.ts
@@ -19,9 +19,18 @@ import { createServiceRef } from '../system/types';
 /**
  * @public
  */
+export type LogMeta = Error | { [name: string]: any };
+
+/**
+ * @public
+ */
 export interface LoggerService {
-  info(message: string): void;
-  child(fields: { [name: string]: string }): LoggerService;
+  error(message: string, meta?: LogMeta): void;
+  warn(message: string, meta?: LogMeta): void;
+  info(message: string, meta?: LogMeta): void;
+  debug(message: string, meta?: LogMeta): void;
+
+  child(meta: LogMeta): LoggerService;
 }
 
 /**

--- a/packages/backend-plugin-api/src/services/helpers/loggerToWinstonLogger.ts
+++ b/packages/backend-plugin-api/src/services/helpers/loggerToWinstonLogger.ts
@@ -26,23 +26,27 @@ class BackstageLoggerTransport extends Transport {
     super(opts);
   }
 
-  log(info: any, callback: VoidFunction) {
-    const { level, message, ...meta } = info;
+  log(info: unknown, callback: VoidFunction) {
+    if (typeof info !== 'object' || info === null) {
+      callback();
+      return;
+    }
+    const { level, message, ...meta } = info as { [name: string]: unknown };
     switch (level) {
       case 'error':
-        this.backstageLogger.error(message, meta);
+        this.backstageLogger.error(String(message), meta);
         break;
       case 'warn':
-        this.backstageLogger.warn(message, meta);
+        this.backstageLogger.warn(String(message), meta);
         break;
       case 'info':
-        this.backstageLogger.info(message, meta);
+        this.backstageLogger.info(String(message), meta);
         break;
       case 'debug':
-        this.backstageLogger.debug(message, meta);
+        this.backstageLogger.debug(String(message), meta);
         break;
       default:
-        this.backstageLogger.info(message, meta);
+        this.backstageLogger.info(String(message), meta);
     }
     callback();
   }

--- a/packages/backend-plugin-api/src/services/helpers/loggerToWinstonLogger.ts
+++ b/packages/backend-plugin-api/src/services/helpers/loggerToWinstonLogger.ts
@@ -26,9 +26,24 @@ class BackstageLoggerTransport extends Transport {
     super(opts);
   }
 
-  log(info: { message: string }, callback: VoidFunction) {
-    // TODO: add support for levels and fields
-    this.backstageLogger.info(info.message);
+  log(info: any, callback: VoidFunction) {
+    const { level, message, ...meta } = info;
+    switch (level) {
+      case 'error':
+        this.backstageLogger.error(message, meta);
+        break;
+      case 'warn':
+        this.backstageLogger.warn(message, meta);
+        break;
+      case 'info':
+        this.backstageLogger.info(message, meta);
+        break;
+      case 'debug':
+        this.backstageLogger.debug(message, meta);
+        break;
+      default:
+        this.backstageLogger.info(message, meta);
+    }
     callback();
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

More comprehensive logging interface with different log levels and meta.

We settled on allowing nested meta objects since the Winston JSON output supports that. The regular pretty formatter doesn't though, so we'll consider adding a workaround for that.

Only a single meta object is allowed, because that's what our current Winston logger supports in practice anyway, any additional meta objects after the first are thrown away.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
