### PR TITLE
Draft: Preliminary additions for disable auth / try it functionality

### DIFF
--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -35,6 +35,13 @@ $ yarn install  # fetch dependency packages - may take a while
 $ yarn tsc      # does a first run of type generation and checks
 ```
 
+If yarn install does not complete, you might need to download the following dependencies
+(list is of common missing dependencies, it is not exhaustive)
+pixman
+cairo
+pango
+canvas (npm dependency)
+
 ## Serving the Example App
 
 Open a terminal window and start the web app by using the following command from

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -41,7 +41,12 @@ export const ApiDefinitionCard = () => {
     return (
       <TabbedCard title={entityTitle}>
         <CardTab label={definitionWidget.title} key="widget">
-          {definitionWidget.component(entity.spec.definition)}
+          {definitionWidget.component(
+            entity.spec.definition,
+            (
+              (entity.metadata?.annotations?.swaggerPlugins as string) ?? ''
+            )?.split(','),
+          )}
         </CardTab>
         <CardTab label="Raw" key="raw">
           <PlainApiDefinitionWidget

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
@@ -23,7 +23,10 @@ import { GrpcApiDefinitionWidget } from '../GrpcApiDefinitionWidget';
 export type ApiDefinitionWidget = {
   type: string;
   title: string;
-  component: (definition: string) => React.ReactElement;
+  component: (
+    definition: string,
+    swaggerPlugins?: string[] | undefined,
+  ) => React.ReactElement;
   rawLanguage?: string;
 };
 
@@ -34,8 +37,11 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       type: 'openapi',
       title: 'OpenAPI',
       rawLanguage: 'yaml',
-      component: definition => (
-        <OpenApiDefinitionWidget definition={definition} />
+      component: (definition, swaggerPlugins) => (
+        <OpenApiDefinitionWidget
+          definition={definition}
+          plugins={swaggerPlugins}
+        />
       ),
     },
     {

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -28,6 +28,7 @@ const LazyOpenApiDefinition = React.lazy(() =>
 /** @public */
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
+  plugins?: string[];
 };
 
 /** @public */


### PR DESCRIPTION
Signed-off-by: awhiteman <awhiteman@qualtrics.com>

## Hey, I just made a Pull Request!

PR associated with this [issue](https://github.com/backstage/backstage/issues/14824). 

Originally was trying to allow the passing of a generic object containing any Swagger plugin to the UI for better customization. Due to the typing of the entity and the additions to the plugin, the approach was pivoted use the annotations instead. This PR leverages an annotation of API entities containing the names of the plugins for the Swagger UI. Specific plugin functionality can be implemented, however in this PR, the ability to disable the try it out and authorize buttons in the Swagger UI for an API (using the API plugin) were implemented.

Will loop back to add tests and changesets etc if the maintainers agree with this approach :).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
