### PR TITLE
repo-tools: Quote markdown headers in api-docs

### DIFF
--- a/.changeset/thirty-llamas-whisper.md
+++ b/.changeset/thirty-llamas-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Updated api docs generation to be compatible with Docusaurus 2-alpha and 2.x.

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -840,7 +840,9 @@ export async function buildDocs({
           context.writer.writeLine('---');
           for (const [name, value] of Object.entries(node.values)) {
             if (value) {
-              context.writer.writeLine(`${name}: ${value}`);
+              context.writer.writeLine(
+                `${name}: "${String(value).replace(/\"/g, '')}"`,
+              );
             }
           }
           context.writer.writeLine('---');


### PR DESCRIPTION
Make sure sure that the markdown header is properly quoted to work across Docusaurus versions