### PR TITLE
Added --skip-install parameter to backstage-cli versions:bump

### DIFF
--- a/.changeset/witty-pears-explode.md
+++ b/.changeset/witty-pears-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added --skip-install parameter to backstage-cli versions:bump

--- a/.changeset/witty-pears-explode.md
+++ b/.changeset/witty-pears-explode.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Added --skip-install parameter to backstage-cli versions:bump
+Added `--skip-install` parameter to `backstage-cli versions:bump`

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -569,6 +569,7 @@ Usage: backstage-cli versions:bump [options]
 Options:
   --pattern <glob>
   --release <version|next|main>
+  --skip-install
   -h, --help
 ```
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -365,6 +365,7 @@ export function registerCommands(program: Command) {
       'Bump to a specific Backstage release line or version',
       'main',
     )
+    .option('--skip-install', 'Skips yarn install step')
     .description('Bump Backstage packages to the latest versions')
     .action(lazy(() => import('./versions/bump').then(m => m.default)));
 

--- a/packages/cli/src/commands/versions/bump.test.ts
+++ b/packages/cli/src/commands/versions/bump.test.ts
@@ -222,6 +222,102 @@ describe('bump', () => {
     });
   });
 
+  it('should bump backstage dependencies but not them installed', async () => {
+    mockFs({
+      '/yarn.lock': lockfileMock,
+      '/package.json': JSON.stringify({
+        workspaces: {
+          packages: ['packages/*'],
+        },
+      }),
+      '/packages/a/package.json': JSON.stringify({
+        name: 'a',
+        dependencies: {
+          '@backstage/core': '^1.0.5',
+        },
+      }),
+      '/packages/b/package.json': JSON.stringify({
+        name: 'b',
+        dependencies: {
+          '@backstage/core': '^1.0.3',
+          '@backstage/theme': '^1.0.0',
+        },
+      }),
+    });
+
+    jest
+      .spyOn(paths, 'resolveTargetRoot')
+      .mockImplementation((...path) => resolvePath('/', ...path));
+    jest.spyOn(runObj, 'run').mockResolvedValue(undefined);
+    worker.use(
+      rest.get(
+        'https://versions.backstage.io/v1/tags/main/manifest.json',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.json({
+              packages: [],
+            }),
+          ),
+      ),
+    );
+    const { log: logs } = await withLogCollector(['log'], async () => {
+      await bump({
+        pattern: null,
+        release: 'main',
+        skipInstall: true,
+      } as unknown as Command);
+    });
+    expect(logs.filter(Boolean)).toEqual([
+      'Using default pattern glob @backstage/*',
+      'Checking for updates of @backstage/core',
+      'Checking for updates of @backstage/theme',
+      'Checking for updates of @backstage/core-api',
+      'Some packages are outdated, updating',
+      'unlocking @backstage/core@^1.0.3 ~> 1.0.6',
+      'unlocking @backstage/core-api@^1.0.6 ~> 1.0.7',
+      'unlocking @backstage/core-api@^1.0.3 ~> 1.0.7',
+      'bumping @backstage/core in a to ^1.0.6',
+      'bumping @backstage/core in b to ^1.0.6',
+      'bumping @backstage/theme in b to ^2.0.0',
+      'Skipping yarn install',
+      '⚠️  The following packages may have breaking changes:',
+      '  @backstage/theme : 1.0.0 ~> 2.0.0',
+      '    https://github.com/backstage/backstage/blob/master/packages/theme/CHANGELOG.md',
+      'Version bump complete!',
+    ]);
+
+    expect(mockFetchPackageInfo).toHaveBeenCalledTimes(3);
+    expect(mockFetchPackageInfo).toHaveBeenCalledWith('@backstage/core');
+    expect(mockFetchPackageInfo).toHaveBeenCalledWith('@backstage/core-api');
+    expect(mockFetchPackageInfo).toHaveBeenCalledWith('@backstage/theme');
+
+    expect(runObj.run).not.toHaveBeenCalledWith(
+      'yarn',
+      ['install'],
+      expect.any(Object),
+    );
+
+    const lockfileContents = await fs.readFile('/yarn.lock', 'utf8');
+    expect(lockfileContents).toBe(lockfileMockResult);
+
+    const packageA = await fs.readJson('/packages/a/package.json');
+    expect(packageA).toEqual({
+      name: 'a',
+      dependencies: {
+        '@backstage/core': '^1.0.6',
+      },
+    });
+    const packageB = await fs.readJson('/packages/b/package.json');
+    expect(packageB).toEqual({
+      name: 'b',
+      dependencies: {
+        '@backstage/core': '^1.0.6',
+        '@backstage/theme': '^2.0.0',
+      },
+    });
+  });
+
   it('should prefer dependency versions from release manifest', async () => {
     mockFs({
       '/yarn.lock': lockfileMock,

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -255,7 +255,13 @@ export default async (opts: OptionValues) => {
       );
     }
 
-    await runYarnInstall();
+    if (opts.skipInstall === undefined) {
+      await runYarnInstall();
+    } else {
+      console.log();
+
+      console.log(chalk.yellow(`Skipping yarn install`));
+    }
 
     if (breakingUpdates.size > 0) {
       console.log();

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -255,7 +255,7 @@ export default async (opts: OptionValues) => {
       );
     }
 
-    if (opts.skipInstall === undefined) {
+    if (!opts.skipInstall) {
       await runYarnInstall();
     } else {
       console.log();


### PR DESCRIPTION
Signed-off-by: Brett Wright <brett.wright@nine.com.au>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Added the `--skip-install` parameter to `backstage-cli versions:bump`. 

This change allow you to skip the installation of the yarn packages when running the `backstage-cli versions:bump`

closes https://github.com/backstage/backstage/issues/15230

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ]  Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
