### PR TITLE
microsite-next: Add Sidebar, make references compatible

### DIFF
--- a/microsite-next/package.json
+++ b/microsite-next/package.json
@@ -4,9 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "examples": "docusaurus-examples",
-    "start": "docusaurus start",
-    "build": "docusaurus build",
+    "start": "node scripts/pre-build.js && docusaurus start",
+    "build": "node scripts/pre-build.js && docusaurus build",
     "prettier:check": "prettier --check .",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
@@ -20,7 +19,8 @@
   "devDependencies": {
     "@spotify/prettier-config": "^14.0.0",
     "js-yaml": "^4.1.0",
-    "prettier": "^2.6.2"
+    "prettier": "^2.6.2",
+    "replace": "^1.2.2"
   },
   "prettier": "@spotify/prettier-config",
   "dependencies": {

--- a/microsite-next/scripts/pre-build.js
+++ b/microsite-next/scripts/pre-build.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const replace = require('replace');
+const { existsSync, writeFileSync, mkdirSync } = require('fs');
+const path = require('path');
+
+const PLACEHOLDER = `---
+id: "index"
+title: "Package Index"
+description: "Index of all Backstage Packages"
+---
+Run \`yarn build:api-docs\` to generate the API docs.
+`;
+
+async function main() {
+  const referencesDir = '../docs/reference';
+  if (existsSync(referencesDir)) {
+    console.log('Removing HTML comments from docs/reference folder');
+    await replace({
+      regex: '<!--(.*?)-->',
+      replacement: '',
+      paths: [referencesDir],
+      recursive: true,
+      silent: false,
+    });
+  } else {
+    mkdirSync(referencesDir);
+    writeFileSync(path.join(referencesDir, 'index.md'), PLACEHOLDER);
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});

--- a/microsite-next/scripts/pre-build.js
+++ b/microsite-next/scripts/pre-build.js
@@ -30,7 +30,7 @@ async function main() {
   const referencesDir = '../docs/reference';
   if (existsSync(referencesDir)) {
     console.log('Removing HTML comments from docs/reference folder');
-    await replace({
+    replace({
       regex: '<!--(.*?)-->',
       replacement: '',
       paths: [referencesDir],

--- a/microsite-next/sidebars.json
+++ b/microsite-next/sidebars.json
@@ -1,1 +1,366 @@
-{}
+{
+  "releases": {
+    "Release Notes": [
+      "releases/v1.8.0",
+      "releases/v1.7.0",
+      "releases/v1.6.0",
+      "releases/v1.5.0",
+      "releases/v1.4.0",
+      "releases/v1.3.0",
+      "releases/v1.2.0",
+      "releases/v1.1.0",
+      "releases/v1.0.0"
+    ]
+  },
+  "docs": {
+    "Overview": [
+      "overview/what-is-backstage",
+      "overview/architecture-overview",
+      "overview/roadmap",
+      "overview/vision",
+      "overview/background",
+      "overview/adopting",
+      "overview/versioning-policy",
+      "overview/threat-model",
+      "overview/support",
+      "overview/glossary",
+      "overview/logos"
+    ],
+    "Getting Started": [
+      "getting-started/index",
+      "getting-started/configuration",
+      "getting-started/create-an-app",
+      "getting-started/running-backstage-locally",
+      {
+        "type": "category",
+        "label": "App configuration",
+        "items": [
+          "getting-started/configure-app-with-plugins",
+          "getting-started/app-custom-theme",
+          "getting-started/homepage"
+        ]
+      },
+      "getting-started/keeping-backstage-updated",
+      "getting-started/concepts",
+      "getting-started/contributors",
+      "getting-started/project-structure"
+    ],
+    "Local Development": [
+      {
+        "type": "category",
+        "label": "CLI",
+        "items": [
+          "local-dev/cli-overview",
+          "local-dev/cli-build-system",
+          "local-dev/cli-commands"
+        ]
+      },
+      "local-dev/linking-local-packages"
+    ],
+    "Core Features": [
+      {
+        "type": "category",
+        "label": "Software Catalog",
+        "items": [
+          "features/software-catalog/software-catalog-overview",
+          "features/software-catalog/life-of-an-entity",
+          "features/software-catalog/configuration",
+          "features/software-catalog/system-model",
+          "features/software-catalog/descriptor-format",
+          "features/software-catalog/references",
+          "features/software-catalog/well-known-annotations",
+          "features/software-catalog/well-known-relations",
+          "features/software-catalog/well-known-statuses",
+          "features/software-catalog/extending-the-model",
+          "features/software-catalog/external-integrations",
+          "features/software-catalog/catalog-customization",
+          "features/software-catalog/software-catalog-api"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Kubernetes",
+        "items": [
+          "features/kubernetes/overview",
+          "features/kubernetes/installation",
+          "features/kubernetes/configuration",
+          "features/kubernetes/authentication",
+          "features/kubernetes/troubleshooting"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Software Templates",
+        "items": [
+          "features/software-templates/software-templates-index",
+          "features/software-templates/configuration",
+          "features/software-templates/adding-templates",
+          "features/software-templates/writing-templates",
+          "features/software-templates/input-examples",
+          "features/software-templates/builtin-actions",
+          "features/software-templates/writing-custom-actions",
+          "features/software-templates/writing-custom-field-extensions",
+          "features/software-templates/writing-custom-step-layouts",
+          "features/software-templates/migrating-from-v1beta2-to-v1beta3"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Backstage Search",
+        "items": [
+          "features/search/search-overview",
+          "features/search/getting-started",
+          "features/search/concepts",
+          "features/search/architecture",
+          "features/search/search-engines",
+          "features/search/how-to-guides"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "TechDocs",
+        "items": [
+          "features/techdocs/techdocs-overview",
+          "features/techdocs/getting-started",
+          "features/techdocs/concepts",
+          "features/techdocs/addons",
+          "features/techdocs/architecture",
+          "features/techdocs/creating-and-publishing",
+          "features/techdocs/configuration",
+          "features/techdocs/using-cloud-storage",
+          "features/techdocs/configuring-ci-cd",
+          "features/techdocs/cli",
+          "features/techdocs/how-to-guides",
+          "features/techdocs/troubleshooting",
+          "features/techdocs/faqs"
+        ]
+      }
+    ],
+    "Integrations": [
+      "integrations/index",
+      {
+        "type": "category",
+        "label": "AWS S3",
+        "items": [
+          "integrations/aws-s3/locations",
+          "integrations/aws-s3/discovery"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Azure",
+        "items": [
+          "integrations/azure/locations",
+          "integrations/azure/discovery",
+          "integrations/azure/org"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Bitbucket Cloud",
+        "items": [
+          "integrations/bitbucketCloud/locations",
+          "integrations/bitbucketCloud/discovery"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Bitbucket Server",
+        "items": [
+          "integrations/bitbucketServer/locations",
+          "integrations/bitbucketServer/discovery"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Datadog",
+        "items": ["integrations/datadog-rum/installation"]
+      },
+      {
+        "type": "category",
+        "label": "Gerrit",
+        "items": [
+          "integrations/gerrit/locations",
+          "integrations/gerrit/discovery"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "GitHub",
+        "items": [
+          "integrations/github/locations",
+          "integrations/github/discovery",
+          "integrations/github/org",
+          "integrations/github/github-apps"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "GitLab",
+        "items": [
+          "integrations/gitlab/locations",
+          "integrations/gitlab/discovery"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Gitea",
+        "items": ["integrations/gitea/locations"]
+      },
+      {
+        "type": "category",
+        "label": "Google GCS",
+        "items": ["integrations/google-cloud-storage/locations"]
+      },
+      {
+        "type": "category",
+        "label": "LDAP",
+        "items": ["integrations/ldap/org"]
+      }
+    ],
+    "Plugins": [
+      "plugins/index",
+      "plugins/existing-plugins",
+      "plugins/create-a-plugin",
+      "plugins/plugin-development",
+      "plugins/structure-of-a-plugin",
+      "plugins/integrating-plugin-into-software-catalog",
+      "plugins/integrating-search-into-plugins",
+      "plugins/composability",
+      "plugins/customization",
+      "plugins/analytics",
+      "plugins/feature-flags",
+      {
+        "type": "category",
+        "label": "Backends and APIs",
+        "items": [
+          "plugins/proxying",
+          "plugins/backend-plugin",
+          "plugins/call-existing-api",
+          "plugins/url-reader",
+          "plugins/new-backend-system"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Testing",
+        "items": ["plugins/testing"]
+      },
+      {
+        "type": "category",
+        "label": "Publishing",
+        "items": [
+          "plugins/publish-private",
+          "plugins/add-to-marketplace",
+          "plugins/observability"
+        ]
+      }
+    ],
+    "Configuration": [
+      "conf/index",
+      "conf/reading",
+      "conf/writing",
+      "conf/defining"
+    ],
+    "Auth and identity": [
+      "auth/index",
+      {
+        "type": "category",
+        "label": "Included providers",
+        "items": [
+          "auth/auth0/provider",
+          "auth/atlassian/provider",
+          "auth/bitbucket/provider",
+          "auth/microsoft/provider",
+          "auth/github/provider",
+          "auth/gitlab/provider",
+          "auth/google/provider",
+          "auth/google/gcp-iap-auth",
+          "auth/okta/provider",
+          "auth/onelogin/provider",
+          "auth/oauth2-proxy/provider"
+        ]
+      },
+      "auth/identity-resolver",
+      "auth/oauth",
+      "auth/oidc",
+      "auth/add-auth-provider",
+      "auth/service-to-service-auth",
+      "auth/troubleshooting",
+      "auth/glossary"
+    ],
+    "Permissions": [
+      "permissions/overview",
+      "permissions/concepts",
+      "permissions/getting-started",
+      "permissions/writing-a-policy",
+      "permissions/frontend-integration",
+      "permissions/custom-rules",
+      {
+        "type": "category",
+        "label": "Tutorial: using Permissions in your plugin",
+        "items": [
+          "permissions/plugin-authors/01-setup",
+          "permissions/plugin-authors/02-adding-a-basic-permission-check",
+          "permissions/plugin-authors/03-adding-a-resource-permission-check",
+          "permissions/plugin-authors/04-authorizing-access-to-paginated-data",
+          "permissions/plugin-authors/05-frontend-authorization"
+        ]
+      }
+    ],
+    "Deployment": [
+      "deployment/index",
+      "deployment/scaling",
+      "deployment/docker",
+      "deployment/k8s",
+      "deployment/heroku"
+    ],
+    "Designing for Backstage": [
+      "dls/design",
+      "dls/component-design-guidelines",
+      "dls/contributing-to-storybook",
+      "dls/figma"
+    ],
+    "API Reference": [
+      {
+        "type": "category",
+        "label": "Guides",
+        "items": ["api/utility-apis"]
+      },
+      {
+        "type": "category",
+        "label": "API Reference",
+        "items": ["reference/index"]
+      },
+      "api/deprecations"
+    ],
+    "Tutorials": [
+      "tutorials/journey",
+      "tutorials/quickstart-app-plugin",
+      "tutorials/react-router-stable-migration",
+      "tutorials/package-role-migration",
+      "tutorials/migrating-away-from-core",
+      "tutorials/configuring-plugin-databases",
+      "tutorials/switching-sqlite-postgres",
+      "tutorials/using-backstage-proxy-within-plugin",
+      "tutorials/yarn-migration"
+    ],
+    "Architecture Decision Records (ADRs)": [
+      "architecture-decisions/adrs-overview",
+      "architecture-decisions/adrs-adr001",
+      "architecture-decisions/adrs-adr002",
+      "architecture-decisions/adrs-adr003",
+      "architecture-decisions/adrs-adr004",
+      "architecture-decisions/adrs-adr005",
+      "architecture-decisions/adrs-adr006",
+      "architecture-decisions/adrs-adr007",
+      "architecture-decisions/adrs-adr008",
+      "architecture-decisions/adrs-adr009",
+      "architecture-decisions/adrs-adr010",
+      "architecture-decisions/adrs-adr011",
+      "architecture-decisions/adrs-adr012",
+      "architecture-decisions/adrs-adr013"
+    ],
+    "FAQ": ["FAQ"]
+  }
+}

--- a/microsite-next/yarn.lock
+++ b/microsite-next/yarn.lock
@@ -3573,6 +3573,7 @@ __metadata:
     prettier: ^2.6.2
     react: ^17.0.2
     react-dom: ^17.0.2
+    replace: ^1.2.2
   languageName: unknown
   linkType: soft
 
@@ -3827,6 +3828,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase@npm:^5.0.0":
+  version: 5.3.1
+  resolution: "camelcase@npm:5.3.1"
+  checksum: e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^6.2.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
@@ -3860,7 +3868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0":
+"chalk@npm:2.4.2, chalk@npm:^2.0.0":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -4018,6 +4026,17 @@ __metadata:
     "@colors/colors":
       optional: true
   checksum: 09897f68467973f827c04e7eaadf13b55f8aec49ecd6647cc276386ea660059322e2dd8020a8b6b84d422dbdd619597046fa89cbbbdc95b2cea149a2df7c096c
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cliui@npm:6.0.0"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.0
+    wrap-ansi: ^6.2.0
+  checksum: 4fcfd26d292c9f00238117f39fc797608292ae36bac2168cfee4c85923817d0607fe21b3329a8621e01aedf512c99b7eaa60e363a671ffd378df6649fb48ae42
   languageName: node
   linkType: hard
 
@@ -4594,6 +4613,13 @@ __metadata:
     supports-color:
       optional: true
   checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "decamelize@npm:1.2.0"
+  checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
   languageName: node
   linkType: hard
 
@@ -5355,7 +5381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.0.0":
+"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
   dependencies:
@@ -5541,6 +5567,13 @@ __metadata:
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
   checksum: a7437e58c6be12aa6c90f7730eac7fa9833dc78872b4ad2963d2031b00a3367a93f98aec75f9aaac7220848e4026d67a8655e870b24f20a543d103c0d65952ec
+  languageName: node
+  linkType: hard
+
+"get-caller-file@npm:^2.0.1":
+  version: 2.0.5
+  resolution: "get-caller-file@npm:2.0.5"
+  checksum: b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
   languageName: node
   linkType: hard
 
@@ -7161,6 +7194,15 @@ __metadata:
   version: 1.0.1
   resolution: "minimalistic-assert@npm:1.0.1"
   checksum: cc7974a9268fbf130fb055aff76700d7e2d8be5f761fb5c60318d0ed010d839ab3661a533ad29a5d37653133385204c503bfac995aaa4236f4e847461ea32ba7
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:3.0.5":
+  version: 3.0.5
+  resolution: "minimatch@npm:3.0.5"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: a3b84b426eafca947741b864502cee02860c4e7b145de11ad98775cfcf3066fef422583bc0ffce0952ddf4750c1ccf4220b1556430d4ce10139f66247d87d69e
   languageName: node
   linkType: hard
 
@@ -8982,6 +9024,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"replace@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "replace@npm:1.2.2"
+  dependencies:
+    chalk: 2.4.2
+    minimatch: 3.0.5
+    yargs: ^15.3.1
+  bin:
+    replace: bin/replace.js
+    search: bin/search.js
+  checksum: 1d69f43937a5fdf9dea278e78d6f3b51c1889ba5135bd201918bbda6330684adf8276e8e90e1c021034420dd4df239e51c23ca40752cb9bc6180c153d6d46a37
+  languageName: node
+  linkType: hard
+
+"require-directory@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "require-directory@npm:2.1.1"
+  checksum: fb47e70bf0001fdeabdc0429d431863e9475e7e43ea5f94ad86503d918423c1543361cc5166d713eaa7029dd7a3d34775af04764bebff99ef413111a5af18c80
+  languageName: node
+  linkType: hard
+
 "require-from-string@npm:^2.0.2":
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
@@ -8993,6 +9056,13 @@ __metadata:
   version: 0.1.2
   resolution: "require-like@npm:0.1.2"
   checksum: edb8331f05fd807381a75b76f6cca9f0ce8acaa2e910b7e116541799aa970bfbc64fde5fd6adb3a6917dba346f8386ebbddb81614c24e8dad1b4290c7af9535e
+  languageName: node
+  linkType: hard
+
+"require-main-filename@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "require-main-filename@npm:2.0.0"
+  checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
   languageName: node
   linkType: hard
 
@@ -10623,6 +10693,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-module@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "which-module@npm:2.0.0"
+  checksum: 809f7fd3dfcb2cdbe0180b60d68100c88785084f8f9492b0998c051d7a8efe56784492609d3f09ac161635b78ea29219eb1418a98c15ce87d085bce905705c9c
+  languageName: node
+  linkType: hard
+
 "which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
@@ -10676,6 +10753,17 @@ __metadata:
   version: 2.0.0
   resolution: "wildcard@npm:2.0.0"
   checksum: 1f4fe4c03dfc492777c60f795bbba597ac78794f1b650d68f398fbee9adb765367c516ebd4220889b6a81e9626e7228bbe0d66237abb311573c2ee1f4902a5ad
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: ^4.0.0
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+  checksum: 6cd96a410161ff617b63581a08376f0cb9162375adeb7956e10c8cd397821f7eb2a6de24eb22a0b28401300bf228c86e50617cd568209b5f6775b93c97d2fe3a
   languageName: node
   linkType: hard
 
@@ -10775,6 +10863,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"y18n@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "y18n@npm:4.0.3"
+  checksum: 014dfcd9b5f4105c3bb397c1c8c6429a9df004aa560964fb36732bfb999bfe83d45ae40aeda5b55d21b1ee53d8291580a32a756a443e064317953f08025b1aa4
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^4.0.0":
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
@@ -10786,6 +10881,35 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^18.1.2":
+  version: 18.1.3
+  resolution: "yargs-parser@npm:18.1.3"
+  dependencies:
+    camelcase: ^5.0.0
+    decamelize: ^1.2.0
+  checksum: 60e8c7d1b85814594d3719300ecad4e6ae3796748b0926137bfec1f3042581b8646d67e83c6fc80a692ef08b8390f21ddcacb9464476c39bbdf52e34961dd4d9
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^15.3.1":
+  version: 15.4.1
+  resolution: "yargs@npm:15.4.1"
+  dependencies:
+    cliui: ^6.0.0
+    decamelize: ^1.2.0
+    find-up: ^4.1.0
+    get-caller-file: ^2.0.1
+    require-directory: ^2.1.1
+    require-main-filename: ^2.0.0
+    set-blocking: ^2.0.0
+    string-width: ^4.2.0
+    which-module: ^2.0.0
+    y18n: ^4.0.0
+    yargs-parser: ^18.1.2
+  checksum: 40b974f508d8aed28598087720e086ecd32a5fd3e945e95ea4457da04ee9bdb8bdd17fd91acff36dc5b7f0595a735929c514c40c402416bbb87c03f6fb782373
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add current sidebar to the new microsite.
- Fixes reference docs compatibility by stripping out html comments which isn't allowed in docu 2.x.
- Adds placeholder /docs/reference page if api docs is not generated since docu 2.x require them to be available at build time. 