### PR TITLE
configurable noHtml5Validate prop for NextScaffolderPage

### DIFF
--- a/.changeset/eighty-pans-remain.md
+++ b/.changeset/eighty-pans-remain.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-configurable noHtml5Validate prop for NextScaffolderPage
+Added `noHtml5Validate` prop to `FormProps` on `NextScaffolderPage`

--- a/.changeset/eighty-pans-remain.md
+++ b/.changeset/eighty-pans-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+configurable noHtml5Validate prop for NextScaffolderPage

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -168,7 +168,10 @@ export interface FieldSchema<TReturn, TUiOptions> {
 }
 
 // @alpha
-export type FormProps = Pick<FormProps_3, 'transformErrors'>;
+export type FormProps = Pick<
+  FormProps_3,
+  'transformErrors' | 'noHtml5Validate'
+>;
 
 // @public
 export type LayoutComponent<_TInputProps> = () => null;

--- a/plugins/scaffolder/src/next/Router/Router.test.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.test.tsx
@@ -58,7 +58,12 @@ describe('Router', () => {
       const transformErrorsMock = jest.fn();
 
       await renderInTestApp(
-        <Router FormProps={{ transformErrors: transformErrorsMock, noHtml5Validate: true }} />,
+        <Router
+          FormProps={{
+            transformErrors: transformErrorsMock,
+            noHtml5Validate: true,
+          }}
+        />,
         {
           routeEntries: ['/templates/default/foo'],
         },
@@ -66,15 +71,13 @@ describe('Router', () => {
 
       const mock = TemplateWizardPage as jest.Mock;
 
-      const [
-        {
-          FormProps,
-        },
-      ] = mock.mock.calls[0];
+      const [{ FormProps }] = mock.mock.calls[0];
 
-      expect(FormProps).toEqual({transformErrors: transformErrorsMock, noHtml5Validate: true});
+      expect(FormProps).toEqual({
+        transformErrors: transformErrorsMock,
+        noHtml5Validate: true,
+      });
     });
-
 
     it('should extract the fieldExtensions and pass them through', async () => {
       const mockComponent = () => null;

--- a/plugins/scaffolder/src/next/Router/Router.test.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.test.tsx
@@ -54,11 +54,11 @@ describe('Router', () => {
       expect(TemplateWizardPage).toHaveBeenCalled();
     });
 
-    it('should pass through the transformErrors property', async () => {
+    it('should pass through the FormProps property', async () => {
       const transformErrorsMock = jest.fn();
 
       await renderInTestApp(
-        <Router FormProps={{ transformErrors: transformErrorsMock }} />,
+        <Router FormProps={{ transformErrors: transformErrorsMock, noHtml5Validate: true }} />,
         {
           routeEntries: ['/templates/default/foo'],
         },
@@ -68,12 +68,13 @@ describe('Router', () => {
 
       const [
         {
-          FormProps: { transformErrors },
+          FormProps,
         },
       ] = mock.mock.calls[0];
 
-      expect(transformErrors).toEqual(transformErrors);
+      expect(FormProps).toEqual({transformErrors: transformErrorsMock, noHtml5Validate: true});
     });
+
 
     it('should extract the fieldExtensions and pass them through', async () => {
       const mockComponent = () => null;

--- a/plugins/scaffolder/src/next/types.ts
+++ b/plugins/scaffolder/src/next/types.ts
@@ -20,4 +20,7 @@ import type { FormProps as SchemaFormProps } from '@rjsf/core-v5';
  *
  * @alpha
  */
-export type FormProps = Pick<SchemaFormProps, 'transformErrors'>;
+export type FormProps = Pick<
+  SchemaFormProps,
+  'transformErrors' | 'noHtml5Validate'
+>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

HTML5 validation is on by default in the `@rjsf/material-ui-v5` Form in `next/Stepper` because the `noHtml5Validate` prop is not set on the `<Form />` component.

The contrary is true in the `MultiJsonForm` where `noHtml5Validate` is true and only true.

This PR makes it configurable by adding a `noHtml5Validate` validate prop to the `NextScaffolderPage`.

I could set it to true on the form and remove the prop as an even simpler PR.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
