### PR TITLE
pass through transformErrors to TemplateWizardPage

### DIFF
--- a/.changeset/perfect-garlics-care.md
+++ b/.changeset/perfect-garlics-care.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Pass through transformErrors to TemplateWizardPage
+Pass through `transformErrors` to `TemplateWizardPage`

--- a/.changeset/perfect-garlics-care.md
+++ b/.changeset/perfect-garlics-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Pass through transformErrors to TemplateWizardPage

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -110,9 +110,9 @@ export type EntityPickerUiOptions =
 export const EntityTagsPickerFieldExtension: FieldExtensionComponent<
   string[],
   {
-    helperText?: string | undefined;
-    kinds?: string[] | undefined;
     showCounts?: boolean | undefined;
+    kinds?: string[] | undefined;
+    helperText?: string | undefined;
   }
 >;
 
@@ -120,9 +120,9 @@ export const EntityTagsPickerFieldExtension: FieldExtensionComponent<
 export const EntityTagsPickerFieldSchema: FieldSchema<
   string[],
   {
-    helperText?: string | undefined;
-    kinds?: string[] | undefined;
     showCounts?: boolean | undefined;
+    kinds?: string[] | undefined;
+    helperText?: string | undefined;
   }
 >;
 

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -110,9 +110,9 @@ export type EntityPickerUiOptions =
 export const EntityTagsPickerFieldExtension: FieldExtensionComponent<
   string[],
   {
-    showCounts?: boolean | undefined;
-    kinds?: string[] | undefined;
     helperText?: string | undefined;
+    kinds?: string[] | undefined;
+    showCounts?: boolean | undefined;
   }
 >;
 
@@ -120,9 +120,9 @@ export const EntityTagsPickerFieldExtension: FieldExtensionComponent<
 export const EntityTagsPickerFieldSchema: FieldSchema<
   string[],
   {
-    showCounts?: boolean | undefined;
-    kinds?: string[] | undefined;
     helperText?: string | undefined;
+    kinds?: string[] | undefined;
+    showCounts?: boolean | undefined;
   }
 >;
 

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -267,7 +267,8 @@ export type NextRouterProps = {
     TaskPageComponent?: React_2.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
-} & FormProps;
+  FormProps?: FormProps;
+};
 
 // @alpha
 export const NextScaffolderPage: (

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -11,7 +11,6 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import type { ErrorTransformer } from '@rjsf/utils';
 import { Extension } from '@backstage/core-plugin-api';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
@@ -19,7 +18,8 @@ import { FieldProps } from '@rjsf/core';
 import { FieldProps as FieldProps_2 } from '@rjsf/utils';
 import { FieldValidation } from '@rjsf/core';
 import { FieldValidation as FieldValidation_2 } from '@rjsf/utils';
-import type { FormProps } from '@rjsf/core';
+import type { FormProps as FormProps_2 } from '@rjsf/core';
+import type { FormProps as FormProps_3 } from '@rjsf/core-v5';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { JsonObject } from '@backstage/types';
 import { JSONSchema7 } from 'json-schema';
@@ -167,6 +167,9 @@ export interface FieldSchema<TReturn, TUiOptions> {
   readonly uiOptionsType: TUiOptions;
 }
 
+// @alpha
+export type FormProps = Pick<FormProps_3, 'transformErrors'>;
+
 // @public
 export type LayoutComponent<_TInputProps> = () => null;
 
@@ -179,7 +182,7 @@ export interface LayoutOptions<P = any> {
 }
 
 // @public
-export type LayoutTemplate<T = any> = FormProps<T>['ObjectFieldTemplate'];
+export type LayoutTemplate<T = any> = FormProps_2<T>['ObjectFieldTemplate'];
 
 // @public
 export type ListActionsResponse = Array<{
@@ -264,8 +267,7 @@ export type NextRouterProps = {
     TaskPageComponent?: React_2.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
-  transformErrors?: ErrorTransformer;
-};
+} & FormProps;
 
 // @alpha
 export const NextScaffolderPage: (

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -74,6 +74,7 @@ export type { TaskPageProps } from './components/TaskPage';
 export { NextScaffolderPage } from './plugin';
 export type { NextRouterProps } from './next';
 export type { TemplateGroupFilter } from './next';
+export type { FormProps } from './next';
 export {
   createNextScaffolderFieldExtension,
   type NextCustomFieldValidator,

--- a/plugins/scaffolder/src/next/Router/Router.test.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.test.tsx
@@ -54,6 +54,20 @@ describe('Router', () => {
       expect(TemplateWizardPage).toHaveBeenCalled();
     });
 
+    it('should pass through the transformErrors property', async () => {
+      const transformErrorsMock = jest.fn();
+
+      await renderInTestApp(<Router transformErrors={transformErrorsMock} />, {
+        routeEntries: ['/templates/default/foo'],
+      });
+
+      const mock = TemplateWizardPage as jest.Mock;
+
+      const [{ transformErrors }] = mock.mock.calls[0];
+
+      expect(transformErrors).toEqual(transformErrors);
+    });
+
     it('should extract the fieldExtensions and pass them through', async () => {
       const mockComponent = () => null;
       const CustomFieldExtension = scaffolderPlugin.provide(

--- a/plugins/scaffolder/src/next/Router/Router.test.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.test.tsx
@@ -57,13 +57,20 @@ describe('Router', () => {
     it('should pass through the transformErrors property', async () => {
       const transformErrorsMock = jest.fn();
 
-      await renderInTestApp(<Router transformErrors={transformErrorsMock} />, {
-        routeEntries: ['/templates/default/foo'],
-      });
+      await renderInTestApp(
+        <Router FormProps={{ transformErrors: transformErrorsMock }} />,
+        {
+          routeEntries: ['/templates/default/foo'],
+        },
+      );
 
       const mock = TemplateWizardPage as jest.Mock;
 
-      const [{ transformErrors }] = mock.mock.calls[0];
+      const [
+        {
+          FormProps: { transformErrors },
+        },
+      ] = mock.mock.calls[0];
 
       expect(transformErrors).toEqual(transformErrors);
     });

--- a/plugins/scaffolder/src/next/Router/Router.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.tsx
@@ -93,7 +93,10 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
         path={nextSelectedTemplateRouteRef.path}
         element={
           <SecretsContextProvider>
-            <TemplateWizardPage customFieldExtensions={fieldExtensions} />
+            <TemplateWizardPage
+              customFieldExtensions={fieldExtensions}
+              transformErrors={props.transformErrors}
+            />
           </SecretsContextProvider>
         }
       />

--- a/plugins/scaffolder/src/next/Router/Router.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.tsx
@@ -45,7 +45,8 @@ export type NextRouterProps = {
     TaskPageComponent?: React.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
-} & FormProps;
+  FormProps?: FormProps;
+};
 
 /**
  * The Scaffolder Router
@@ -94,7 +95,7 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
           <SecretsContextProvider>
             <TemplateWizardPage
               customFieldExtensions={fieldExtensions}
-              transformErrors={props.transformErrors}
+              FormProps={props.FormProps}
             />
           </SecretsContextProvider>
         }

--- a/plugins/scaffolder/src/next/Router/Router.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.tsx
@@ -30,7 +30,7 @@ import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateGroupFilter } from '../TemplateListPage/TemplateGroups';
 import { nextSelectedTemplateRouteRef } from '../../routes';
 import { SecretsContextProvider } from '../../components/secrets/SecretsContext';
-import type { ErrorTransformer } from '@rjsf/utils';
+import type { FormProps } from '../types';
 
 /**
  * The Props for the Scaffolder Router
@@ -45,8 +45,7 @@ export type NextRouterProps = {
     TaskPageComponent?: React.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
-  transformErrors?: ErrorTransformer;
-};
+} & FormProps;
 
 /**
  * The Scaffolder Router

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
@@ -174,7 +174,7 @@ describe('Stepper', () => {
         manifest={manifest}
         extensions={[]}
         onComplete={jest.fn()}
-        transformErrors={transformErrors}
+        FormProps={{ transformErrors }}
       />,
     );
 

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -36,9 +36,9 @@ import { useTemplateSchema } from './useTemplateSchema';
 import { ReviewState } from './ReviewState';
 import validator from '@rjsf/validator-ajv8';
 import { selectedTemplateRouteRef } from '../../../routes';
-import type { ErrorTransformer } from '@rjsf/utils';
 import { getDefaultFormState } from '@rjsf/utils';
 import { useFormData } from './useFormData';
+import { FormProps } from '../../types';
 
 const useStyles = makeStyles(theme => ({
   backButton: {
@@ -55,12 +55,11 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export interface StepperProps {
+export type StepperProps = {
   manifest: TemplateParameterSchema;
   extensions: NextFieldExtensionOptions<any, any>[];
   onComplete: (values: Record<string, JsonValue>) => Promise<void>;
-  transformErrors?: ErrorTransformer;
-}
+} & FormProps;
 
 // TODO(blam): We require here, as the types in this package depend on @rjsf/core explicitly
 // which is what we're using here as the default types, it needs to depend on @rjsf/core-v5 because

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -59,7 +59,8 @@ export type StepperProps = {
   manifest: TemplateParameterSchema;
   extensions: NextFieldExtensionOptions<any, any>[];
   onComplete: (values: Record<string, JsonValue>) => Promise<void>;
-} & FormProps;
+  FormProps?: FormProps;
+};
 
 // TODO(blam): We require here, as the types in this package depend on @rjsf/core explicitly
 // which is what we're using here as the default types, it needs to depend on @rjsf/core-v5 because
@@ -164,7 +165,7 @@ export const Stepper = (props: StepperProps) => {
             onSubmit={handleNext}
             fields={extensions}
             showErrorList={false}
-            transformErrors={props.transformErrors}
+            {...(props.FormProps ?? {})}
           >
             <div className={styles.footer}>
               <Button

--- a/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
@@ -48,7 +48,8 @@ import type { FormProps } from '../types';
 
 export type TemplateWizardPageProps = {
   customFieldExtensions: NextFieldExtensionOptions<any, any>[];
-} & FormProps;
+  FormProps?: FormProps;
+};
 
 const useStyles = makeStyles<BackstageTheme>(() => ({
   markdown: {
@@ -138,7 +139,7 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
                 manifest={manifest}
                 extensions={props.customFieldExtensions}
                 onComplete={onComplete}
-                transformErrors={props.transformErrors}
+                FormProps={props.FormProps}
               />
             </InfoCard>
           )}

--- a/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
@@ -44,12 +44,11 @@ import {
 } from '../../routes';
 import { SecretsContext } from '../../components/secrets/SecretsContext';
 import { JsonValue } from '@backstage/types';
-import type { ErrorTransformer } from '@rjsf/utils';
+import type { FormProps } from '../types';
 
-export interface TemplateWizardPageProps {
+export type TemplateWizardPageProps = {
   customFieldExtensions: NextFieldExtensionOptions<any, any>[];
-  transformErrors?: ErrorTransformer;
-}
+} & FormProps;
 
 const useStyles = makeStyles<BackstageTheme>(() => ({
   markdown: {

--- a/plugins/scaffolder/src/next/types.ts
+++ b/plugins/scaffolder/src/next/types.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Router';
-export * from './TemplateListPage';
-export * from './TemplateWizardPage';
+import type { FormProps as SchemaFormProps } from '@rjsf/core-v5';
 
-export type { FormProps } from './types';
+/**
+ * Any `@rjsf/core` form properties that are publicly exposed to the `NextScaffolderpage`
+ *
+ * @alpha
+ */
+export type FormProps = Pick<SchemaFormProps, 'transformErrors'>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In #14667 I neglected to pass through the `transformErrors` prop from the `NextScaffolderPage` to the `TemplateWizardPage` .

This PR corrects that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
