### PR TITLE
Add support for disabling Gitub wiki, issues and projects

### DIFF
--- a/.changeset/sharp-poets-count.md
+++ b/.changeset/sharp-poets-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Add support for disabling Github repository wiki, issues and projects

--- a/.changeset/sharp-poets-count.md
+++ b/.changeset/sharp-poets-count.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Add support for disabling Github repository wiki, issues and projects

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -225,6 +225,9 @@ export function createGithubRepoCreateAction(options: {
           }
       )[]
     | undefined;
+  hasProjects?: boolean | undefined;
+  hasWiki?: boolean | undefined;
+  hasIssues?: boolean | undefined;
   token?: string | undefined;
   topics?: string[] | undefined;
 }>;
@@ -412,6 +415,9 @@ export function createPublishGithubAction(options: {
           }
       )[]
     | undefined;
+  hasProjects?: boolean | undefined;
+  hasWiki?: boolean | undefined;
+  hasIssues?: boolean | undefined;
   token?: string | undefined;
   topics?: string[] | undefined;
 }>;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
@@ -152,6 +152,60 @@ describe('github:repo:create', () => {
       allow_auto_merge: false,
       visibility: 'private',
     });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: true,
+        hasProjects: true,
+        hasIssues: true,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createInOrg,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      org: 'owner',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      visibility: 'private',
+      has_wiki: true,
+      has_projects: true,
+      has_issues: true,
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: false,
+        hasProjects: false,
+        hasIssues: false,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createInOrg,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      org: 'owner',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      visibility: 'private',
+      has_wiki: false,
+      has_projects: false,
+      has_issues: false,
+    });
   });
 
   it('should call the githubApis with the correct values for createForAuthenticatedUser', async () => {
@@ -216,6 +270,56 @@ describe('github:repo:create', () => {
       allow_merge_commit: true,
       allow_rebase_merge: true,
       allow_auto_merge: false,
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: true,
+        hasProjects: true,
+        hasIssues: true,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      has_wiki: true,
+      has_projects: true,
+      has_issues: true,
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: false,
+        hasProjects: false,
+        hasIssues: false,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      has_wiki: false,
+      has_projects: false,
+      has_issues: false,
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
@@ -162,9 +162,7 @@ describe('github:repo:create', () => {
         hasIssues: true,
       },
     });
-    expect(
-      mockOctokit.rest.repos.createInOrg,
-    ).toHaveBeenCalledWith({
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith({
       description: 'description',
       name: 'repo',
       org: 'owner',
@@ -189,9 +187,7 @@ describe('github:repo:create', () => {
         hasIssues: false,
       },
     });
-    expect(
-      mockOctokit.rest.repos.createInOrg,
-    ).toHaveBeenCalledWith({
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith({
       description: 'description',
       name: 'repo',
       org: 'owner',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.ts
@@ -76,6 +76,9 @@ export function createGithubRepoCreateAction(options: {
           access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
         }
     >;
+    hasProjects?: boolean;
+    hasWiki?: boolean;
+    hasIssues?: boolean;
     token?: string;
     topics?: string[];
   }>({
@@ -103,6 +106,9 @@ export function createGithubRepoCreateAction(options: {
           allowRebaseMerge: inputProps.allowRebaseMerge,
           allowAutoMerge: inputProps.allowAutoMerge,
           collaborators: inputProps.collaborators,
+          hasProjects: inputProps.hasProjects,
+          hasWiki: inputProps.hasWiki,
+          hasIssues: inputProps.hasIssues,
           token: inputProps.token,
           topics: inputProps.topics,
         },
@@ -128,6 +134,9 @@ export function createGithubRepoCreateAction(options: {
         allowRebaseMerge = true,
         allowAutoMerge = false,
         collaborators,
+        hasProjects = undefined,
+        hasWiki = undefined,
+        hasIssues = undefined,
         topics,
         token: providedToken,
       } = ctx.input;
@@ -160,6 +169,9 @@ export function createGithubRepoCreateAction(options: {
         allowAutoMerge,
         access,
         collaborators,
+        hasProjects,
+        hasWiki,
+        hasIssues,
         topics,
         ctx.logger,
       );

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -122,6 +122,9 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           }
       )[]
     | undefined,
+  hasProjects: boolean | undefined,
+  hasWiki: boolean | undefined,
+  hasIssues: boolean | undefined,
   topics: string[] | undefined,
   logger: Logger,
 ) {
@@ -144,6 +147,9 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           allow_rebase_merge: allowRebaseMerge,
           allow_auto_merge: allowAutoMerge,
           homepage: homepage,
+          has_projects: hasProjects,
+          has_wiki: hasWiki,
+          has_issues: hasIssues,
         })
       : client.rest.repos.createForAuthenticatedUser({
           name: repo,
@@ -155,6 +161,9 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           allow_rebase_merge: allowRebaseMerge,
           allow_auto_merge: allowAutoMerge,
           homepage: homepage,
+          has_projects: hasProjects,
+          has_wiki: hasWiki,
+          has_issues: hasIssues,
         });
 
   let newRepo;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/inputProperties.ts
@@ -132,6 +132,21 @@ const collaborators = {
     oneOf: [{ required: ['user'] }, { required: ['team'] }],
   },
 };
+const hasProjects = {
+  title: 'Enable projects',
+  type: 'boolean',
+  description: `Enable projects for the repository. The default value is 'true' unless the organization has disabled repository projects`,
+};
+const hasWiki = {
+  title: 'Enable the wiki',
+  type: 'boolean',
+  description: `Enable the wiki for the repository. The default value is 'true'`,
+};
+const hasIssues = {
+  title: 'Enable issues',
+  type: 'boolean',
+  description: `Enable issues for the repository. The default value is 'true'`,
+};
 const token = {
   title: 'Authentication Token',
   type: 'string',
@@ -223,6 +238,9 @@ export { dismissStaleReviews };
 export { requiredStatusCheckContexts };
 export { requireBranchesToBeUpToDate };
 export { requiredConversationResolution };
+export { hasProjects };
+export { hasIssues };
+export { hasWiki };
 export { sourcePath };
 export { token };
 export { topics };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -157,6 +157,60 @@ describe('publish:github', () => {
       allow_auto_merge: false,
       visibility: 'private',
     });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: true,
+        hasProjects: true,
+        hasIssues: true,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createInOrg,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      org: 'owner',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      visibility: 'private',
+      has_wiki: true,
+      has_projects: true,
+      has_issues: true,
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: false,
+        hasProjects: false,
+        hasIssues: false,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createInOrg,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      org: 'owner',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      visibility: 'private',
+      has_wiki: false,
+      has_projects: false,
+      has_issues: false,
+    });
   });
 
   it('should call the githubApis with the correct values for createForAuthenticatedUser', async () => {
@@ -221,6 +275,56 @@ describe('publish:github', () => {
       allow_merge_commit: true,
       allow_rebase_merge: true,
       allow_auto_merge: false,
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: true,
+        hasProjects: true,
+        hasIssues: true,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      has_wiki: true,
+      has_projects: true,
+      has_issues: true,
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        hasWiki: false,
+        hasProjects: false,
+        hasIssues: false,
+      },
+    });
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      has_wiki: false,
+      has_projects: false,
+      has_issues: false,
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -167,9 +167,7 @@ describe('publish:github', () => {
         hasIssues: true,
       },
     });
-    expect(
-      mockOctokit.rest.repos.createInOrg,
-    ).toHaveBeenCalledWith({
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith({
       description: 'description',
       name: 'repo',
       org: 'owner',
@@ -194,9 +192,7 @@ describe('publish:github', () => {
         hasIssues: false,
       },
     });
-    expect(
-      mockOctokit.rest.repos.createInOrg,
-    ).toHaveBeenCalledWith({
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith({
       description: 'description',
       name: 'repo',
       org: 'owner',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -88,6 +88,9 @@ export function createPublishGithubAction(options: {
           access: 'pull' | 'push' | 'admin' | 'maintain' | 'triage';
         }
     >;
+    hasProjects?: boolean | undefined;
+    hasWiki?: boolean | undefined;
+    hasIssues?: boolean | undefined;
     token?: string;
     topics?: string[];
   }>({
@@ -124,6 +127,9 @@ export function createPublishGithubAction(options: {
           allowAutoMerge: inputProps.allowAutoMerge,
           sourcePath: inputProps.sourcePath,
           collaborators: inputProps.collaborators,
+          hasProjects: inputProps.hasProjects,
+          hasWiki: inputProps.hasWiki,
+          hasIssues: inputProps.hasIssues,
           token: inputProps.token,
           topics: inputProps.topics,
         },
@@ -161,6 +167,9 @@ export function createPublishGithubAction(options: {
         allowRebaseMerge = true,
         allowAutoMerge = false,
         collaborators,
+        hasProjects = undefined,
+        hasWiki = undefined,
+        hasIssues = undefined,
         topics,
         token: providedToken,
       } = ctx.input;
@@ -193,6 +202,9 @@ export function createPublishGithubAction(options: {
         allowAutoMerge,
         access,
         collaborators,
+        hasProjects,
+        hasWiki,
+        hasIssues,
         topics,
         ctx.logger,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds three new Github repo options: hasWiki, hasIssues, hasProjects.

The default value for these options remains as is, unset, to avoid any behavior change. API reference: https://octokit.github.io/rest.js/v19

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
