### PR TITLE
[TechDocs] Support older versions of react router

### DIFF
--- a/.changeset/tidy-hats-begin.md
+++ b/.changeset/tidy-hats-begin.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-react': minor
+'@backstage/plugin-techdocs': patch
+---
+
+Support older versions of react-router

--- a/plugins/techdocs-react/api-report.md
+++ b/plugins/techdocs-react/api-report.md
@@ -33,6 +33,9 @@ export const SHADOW_DOM_STYLE_LOAD_EVENT = 'TECH_DOCS_SHADOW_DOM_STYLE_LOAD';
 export type SyncResult = 'cached' | 'updated';
 
 // @public
+export const TECHDOCS_ADDONS_KEY = 'techdocs.addons.addon.v1';
+
+// @public
 export const TECHDOCS_ADDONS_WRAPPER_KEY = 'techdocs.addons.wrapper.v1';
 
 // @public

--- a/plugins/techdocs-react/src/addons.tsx
+++ b/plugins/techdocs-react/src/addons.tsx
@@ -27,6 +27,10 @@ import {
 
 import { TechDocsAddonLocations, TechDocsAddonOptions } from './types';
 
+/**
+ * Key for each addon.
+ * @public
+ */
 export const TECHDOCS_ADDONS_KEY = 'techdocs.addons.addon.v1';
 
 /**

--- a/plugins/techdocs-react/src/index.ts
+++ b/plugins/techdocs-react/src/index.ts
@@ -25,6 +25,7 @@ export {
   createTechDocsAddonExtension,
   TechDocsAddons,
   TECHDOCS_ADDONS_WRAPPER_KEY,
+  TECHDOCS_ADDONS_KEY,
 } from './addons';
 export { techdocsApiRef, techdocsStorageApiRef } from './api';
 export type { SyncResult, TechDocsApi, TechDocsStorageApi } from './api';

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -67,6 +67,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
     "@backstage/dev-utils": "workspace:^",
+    "@backstage/plugin-techdocs-module-addons-contrib": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
@@ -200,4 +200,31 @@ describe('<TechDocsReaderPage />', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('should render techdocs reader page with addons and page', async () => {
+    (Page as jest.Mock).mockImplementation(PageMock);
+    await act(async () => {
+      const rendered = await renderInTestApp(
+        <Wrapper>
+          <FlatRoutes>
+            <Route
+              path="/docs/:namespace/:kind/:name/*"
+              element={<TechDocsReaderPage />}
+            >
+              <p>the page</p>
+              <TechDocsAddons>
+                <ReportIssue />
+              </TechDocsAddons>
+            </Route>
+          </FlatRoutes>
+        </Wrapper>,
+        {
+          mountedRoutes,
+          routeEntries: ['/docs/test-namespace/test/test-name'],
+        },
+      );
+
+      expect(rendered.getByText('the page')).toBeInTheDocument();
+    });
+  });
 });

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
@@ -73,7 +73,7 @@ const techdocsStorageApiMock: jest.Mocked<typeof techdocsStorageApiRef.T> = {
 
 const PageMock = () => {
   const { namespace, kind, name } = useParams();
-  return <>{`LayoutMock: ${namespace}#${kind}#${name}`}</>;
+  return <>{`PageMock: ${namespace}#${kind}#${name}`}</>;
 };
 
 jest.mock('@backstage/core-components', () => ({
@@ -189,7 +189,7 @@ describe('<TechDocsReaderPage />', () => {
       );
 
       expect(
-        rendered.getByText(`LayoutMock: ${namespace}#${kind}#${name}`),
+        rendered.getByText(`PageMock: ${namespace}#${kind}#${name}`),
       ).toBeInTheDocument();
     });
   });

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
@@ -30,8 +30,9 @@ import { TechDocsReaderPage } from './TechDocsReaderPage';
 import { Route, useParams } from 'react-router-dom';
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
-import { Page } from '@backstage/core-components';
 import { FlatRoutes } from '@backstage/core-app-api';
+
+import { Page } from '@backstage/core-components';
 
 const mockEntityMetadata = {
   locationMetadata: {
@@ -112,6 +113,12 @@ describe('<TechDocsReaderPage />', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
+
+  beforeEach(() => {
+    const realPage = jest.requireActual('@backstage/core-components').Page;
+    (Page as jest.Mock).mockImplementation(realPage);
+  });
+
   it('should render a techdocs reader page without children', async () => {
     const rendered = await renderInTestApp(
       <Wrapper>

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
@@ -21,6 +21,7 @@ import { Page } from '@backstage/core-components';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import {
   TECHDOCS_ADDONS_WRAPPER_KEY,
+  TECHDOCS_ADDONS_KEY,
   TechDocsReaderPageProvider,
 } from '@backstage/plugin-techdocs-react';
 
@@ -165,11 +166,14 @@ export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
   if (!children) {
     const childrenList = outlet ? Children.toArray(outlet.props.children) : [];
 
-    const grandChildren = childrenList.flatMap(
+    const grandChildren = childrenList.flatMap<ReactElement>(
       child => (child as ReactElement)?.props?.children ?? [],
     );
+
     const page: React.ReactNode = grandChildren.find(
-      grandChild => !getComponentData(grandChild, TECHDOCS_ADDONS_WRAPPER_KEY),
+      grandChild =>
+        !getComponentData(grandChild, TECHDOCS_ADDONS_WRAPPER_KEY) &&
+        !getComponentData(grandChild, TECHDOCS_ADDONS_KEY),
     );
 
     // As explained above, "page" is configuration 4 and <TechDocsReaderLayout> is 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -8263,6 +8263,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"
+    "@backstage/plugin-techdocs-module-addons-contrib": "workspace:^"
     "@backstage/plugin-techdocs-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Background:** This issue https://github.com/backstage/backstage/issues/15126 made clear that older (but technically supported) versions of `react-router` are not compatible with newer versions of `@backstage/plugin-techdocs`. We don't want to force users to upgrade `react-router`, so this PR adds backwards compatibility.

I've tested using `yarn dev` with the following versions
* `6.0.0-beta.0`
* `6.1.1` techdocs pages work, but there seems to be bigger problems. e.g. /catalog does not work.
* `6.2.0`
* `6.3.0`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
