### PR TITLE
Do not fail fast on run checks endpoint 

### DIFF
--- a/.changeset/proud-birds-worry.md
+++ b/.changeset/proud-birds-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+---
+
+Complete check results run when a single check errors so that we don't block other checks from working due to an error in a single check

--- a/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/plugins/tech-insights-backend/src/service/router.test.ts
@@ -101,18 +101,6 @@ describe('Tech Insights router tests', () => {
     });
   });
 
-  describe('/checks/run', () => {
-    it('should continue to run all checks if a single one fails', async () => {
-      await request(app)
-        .post('/checks/run')
-        .query({
-          entity: 'a:a/a',
-          ids: ['check1', 'check2'],
-        })
-        .expect(500);
-    });
-  });
-
   describe('/facts/latest', () => {
     it('should be able to parse id request params for fact retrieval', async () => {
       await request(app)

--- a/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/plugins/tech-insights-backend/src/service/router.test.ts
@@ -101,6 +101,18 @@ describe('Tech Insights router tests', () => {
     });
   });
 
+  describe('/checks/run', () => {
+    it('should continue to run all checks if a single one fails', async () => {
+      await request(app)
+        .post('/checks/run')
+        .query({
+          entity: 'a:a/a',
+          ids: ['check1', 'check2'],
+        })
+        .expect(500);
+    });
+  });
+
   describe('/facts/latest', () => {
     it('should be able to parse id request params for fact retrieval', async () => {
       await request(app)

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -124,8 +124,13 @@ export async function createRouter<
         }
       });
       const results = await Promise.all(tasks);
-      if (errors.length > 0) {
+      const noResults =
+        results.length === 0 || results.flatMap(r => r.results).length === 0;
+      if (errors.length > 0 && noResults) {
         return res.status(500).send({ errors, results });
+      }
+      if (errors.length > 0) {
+        return res.json({ errors, results });
       }
       return res.json(results);
     });

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -124,8 +124,7 @@ export async function createRouter<
         }
       });
       const results = await Promise.all(tasks);
-      const noResults =
-        results.length === 0 || results.flatMap(r => r.results).length === 0;
+      const noResults = results.flatMap(r => r.results).length === 0;
       if (errors.length > 0 && noResults) {
         return res.status(500).send({ errors, results });
       }

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -103,7 +103,7 @@ export async function createRouter<
         checks,
         entities,
       }: { checks: string[]; entities: CompoundEntityRef[] } = req.body;
-      let error = undefined;
+      const errors: string[] = [];
       const tasks = entities.map(async entity => {
         const entityTriplet =
           typeof entity === 'string' ? entity : stringifyEntityRef(entity);
@@ -116,7 +116,7 @@ export async function createRouter<
         } catch (e: any) {
           const errorMessage = `Failed to run check for entity ${entityTriplet} due to error: ${e.message}`;
           logger.error(errorMessage);
-          error = errorMessage;
+          errors.push(errorMessage);
           return {
             entity: entityTriplet,
             results: [],
@@ -124,8 +124,8 @@ export async function createRouter<
         }
       });
       const results = await Promise.all(tasks);
-      if (error) {
-        return res.status(500).send({ error, results });
+      if (errors.length > 0) {
+        return res.status(500).send({ errors, results });
       }
       return res.json(results);
     });

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -124,10 +124,6 @@ export async function createRouter<
         }
       });
       const results = await Promise.all(tasks);
-      const noResults = results.flatMap(r => r.results).length === 0;
-      if (errors.length > 0 && noResults) {
-        return res.status(500).send({ errors, results });
-      }
       if (errors.length > 0) {
         return res.json({ errors, results });
       }

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -32,7 +32,7 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { errorHandler } from '@backstage/backend-common';
-import { serializeError } from '@backstage/errors/dist';
+import { serializeError } from '@backstage/errors';
 
 /**
  * @public


### PR DESCRIPTION
Signed-off-by: sblausten <sam@roadie.io>

## Hey, I just made a Pull Request!

When some checks fail to run but others run successfully, this PR allows us to return a 200 with the errors message alongside any results that completed. 

Currently this endpoint fails to run any checks if a single one errors which does not seem desirable as it breaks the whole of tech insights if for instance you delete a single fact that is depended on by one of your checks. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
