### PR TITLE
Added /api/ to the example as its missing and wont work without it

### DIFF
--- a/docs/plugins/call-existing-api.md
+++ b/docs/plugins/call-existing-api.md
@@ -79,7 +79,7 @@ proxy:
 ```ts
 // Inside your component
 const backendUrl = config.getString('backend.baseUrl');
-fetch(`${backendUrl}/proxy/frobs/list`)
+fetch(`${backendUrl}/api/proxy/frobs/list`)
   .then(response => response.json())
   .then(payload => setFrobs(payload as Frob[]));
 ```


### PR DESCRIPTION
Hey Team :wave: !

Based on a quick chat with @freben, I've updated the docs page (https://backstage.io/docs/plugins/call-existing-api#using-the-backstage-proxy) as it seemed to be missing the */api/* part of the URL which got me stuck the other day :sweat_smile: 

Let me know if I missed anything!

Thanks Team!


Signed-off-by: Peter Macdonald <macdonald.peter90@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
