### PR TITLE
[core-plugin-api] Only re-resolve useRouteRef on pathname changes

### DIFF
--- a/.changeset/long-beds-accept.md
+++ b/.changeset/long-beds-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+useRouteRef - Limit re-resolving to location pathname changes only

--- a/packages/core-plugin-api/src/routing/useRouteRef.tsx
+++ b/packages/core-plugin-api/src/routing/useRouteRef.tsx
@@ -85,7 +85,7 @@ export function useRouteRef<Params extends AnyParams>(
     | SubRouteRef<Params>
     | ExternalRouteRef<Params, any>,
 ): RouteFunc<Params> | undefined {
-  const sourceLocation = useLocation();
+  const { pathname } = useLocation();
   const versionedContext = useVersionedContext<{ 1: RouteResolver }>(
     'routing-context',
   );
@@ -95,8 +95,8 @@ export function useRouteRef<Params extends AnyParams>(
 
   const resolver = versionedContext.atVersion(1);
   const routeFunc = useMemo(
-    () => resolver && resolver.resolve(routeRef, sourceLocation),
-    [resolver, routeRef, sourceLocation],
+    () => resolver && resolver.resolve(routeRef, { pathname }),
+    [resolver, routeRef, pathname],
   );
 
   if (!versionedContext) {


### PR DESCRIPTION
## Description
Resolving `routeFunc` is an expensive call. The `routeFunc` memo is currently being recalculated for search parameter changes, hash parameter changes and same pathname history pushes. None of these parts of location are required for resolving the `routeFunc`. This PR changes `useRouteRef` to only re-resolve when the `location.pathname` changes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
