### PR TITLE
perform 10 concurrent publish steps

### DIFF
--- a/.github/workflows/deploy_nightly.yml
+++ b/.github/workflows/deploy_nightly.yml
@@ -57,7 +57,7 @@ jobs:
       - name: publish nightly release
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag nightly
+          yarn workspaces foreach -p -j 10 -v --no-private npm publish --access public --tolerate-republish --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -166,7 +166,7 @@ jobs:
           if [ -f ".changeset/pre.json" ]; then
               yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag next
           else
-              yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+              yarn workspaces foreach -p -j 10 -v --no-private npm publish --access public --tolerate-republish
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This might be a bit of a high number? The full flow takes almost 20 minutes now, so something needed to change :) Hopefully this does not run into rate limits with NPM or similar. I originally intended to only start with nightly, but this way we'll have an entire week to find problems anyway in the nightly. Deeming it less likely that this hits problems in nightly, than it is to forget to add these to the main deploy flow :)