### PR TITLE
use isAllPackages to generate tmp config

### DIFF
--- a/.changeset/curvy-ducks-explode.md
+++ b/.changeset/curvy-ducks-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Use the project tsconfig in case of selection all packages

--- a/packages/repo-tools/src/commands/api-reports/api-reports.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.ts
@@ -66,7 +66,7 @@ export const buildApiReports = async (paths: string[] = [], opts: Options) => {
   }
 
   let temporaryTsConfigPath: string | undefined;
-  if (selectedPackageDirs) {
+  if (!isAllPackages) {
     temporaryTsConfigPath = await createTemporaryTsConfig(selectedPackageDirs);
   }
   const tsconfigFilePath =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Selected packages now is always filled with user selection or package.json workspaces config

If we took all the workspaces packages, we should keep the original tsconfig as before

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
