### PR TITLE
[repo-tools] moved to peerDeps to match version w/api-extractor

### DIFF
--- a/.changeset/good-geckos-reflect.md
+++ b/.changeset/good-geckos-reflect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Move some dependencies as `peerDependencies` because we need to always use same version as in `api-extractor`

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -35,9 +35,6 @@
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.17.11",
     "@microsoft/api-extractor": "^7.23.0",
-    "@microsoft/api-extractor-model": "^7.17.2",
-    "@microsoft/tsdoc": "0.14.1",
-    "@microsoft/tsdoc-config": "0.16.2",
     "chalk": "^4.0.0",
     "commander": "^9.1.0",
     "fs-extra": "10.1.0",
@@ -53,6 +50,9 @@
     "mock-fs": "^5.1.0"
   },
   "peerDependencies": {
+    "@microsoft/api-extractor-model": "*",
+    "@microsoft/tsdoc": "*",
+    "@microsoft/tsdoc-config": "*",
     "@rushstack/node-core-library": "*",
     "prettier": "^2.8.1",
     "typescript": "> 3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8225,9 +8225,6 @@ __metadata:
     "@manypkg/get-packages": ^1.1.3
     "@microsoft/api-documenter": ^7.17.11
     "@microsoft/api-extractor": ^7.23.0
-    "@microsoft/api-extractor-model": ^7.17.2
-    "@microsoft/tsdoc": 0.14.1
-    "@microsoft/tsdoc-config": 0.16.2
     "@types/is-glob": ^4.0.2
     "@types/mock-fs": ^4.13.0
     chalk: ^4.0.0
@@ -8239,6 +8236,9 @@ __metadata:
     mock-fs: ^5.1.0
     ts-node: ^10.0.0
   peerDependencies:
+    "@microsoft/api-extractor-model": "*"
+    "@microsoft/tsdoc": "*"
+    "@microsoft/tsdoc-config": "*"
     "@rushstack/node-core-library": "*"
     prettier: ^2.8.1
     typescript: "> 3.0.0"
@@ -11229,7 +11229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor-model@npm:7.17.2, @microsoft/api-extractor-model@npm:^7.17.2":
+"@microsoft/api-extractor-model@npm:7.17.2":
   version: 7.17.2
   resolution: "@microsoft/api-extractor-model@npm:7.17.2"
   dependencies:
@@ -11269,7 +11269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/tsdoc-config@npm:0.16.2, @microsoft/tsdoc-config@npm:~0.16.1":
+"@microsoft/tsdoc-config@npm:~0.16.1":
   version: 0.16.2
   resolution: "@microsoft/tsdoc-config@npm:0.16.2"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!
For this packages we need the same version used on api-extractor and api-documenter
when we update uno of those version as in https://github.com/backstage/backstage/pull/15346, bring errors because `api-exporter` use fixed version.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
