### PR TITLE
[Search] Improve stability in the ES search indexer

### DIFF
--- a/.changeset/search-mele-kalikimaka.md
+++ b/.changeset/search-mele-kalikimaka.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Fixed a bug that could cause the backstage backend to unexpectedly terminate when client errors were encountered during the indexing process.


### PR DESCRIPTION
## What / Why

Three small improvements to the ES indexer that should improve stability and performance in the ES search indexer:

- [x] **Handle ES Client Errors**: We've found in some exceptional circumstances that the ES client will throw errors that get handled differently from HTTP-level response errors. The indexer handles the latter type of error gracefully (catching, logging, cleaning up, and passing back to the scheduler task)...  But client-level errors (such as an HTTP timeout when communicating with ES) are not being caught, which causes the node process terminate.  This PR adds handling for this case.
- [ ] **Indexing becomes unresponsive**
- [ ] **Batch optimizations**

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
