### PR TITLE
add onChange handler to next/Stepper

### DIFF
--- a/.changeset/metal-hotels-deliver.md
+++ b/.changeset/metal-hotels-deliver.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-'add onChange handler`to`Stepper` component
+add `onChange` handler to`Stepper` component

--- a/.changeset/metal-hotels-deliver.md
+++ b/.changeset/metal-hotels-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+'add onChange handler`to`Stepper` component

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
@@ -20,6 +20,7 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { act, fireEvent } from '@testing-library/react';
 import type { RJSFValidationError } from '@rjsf/utils';
 import { JsonValue } from '@backstage/types';
+import { NextFieldExtensionComponentProps } from '../../../extensions/types';
 
 describe('Stepper', () => {
   it('should render the step titles for each step of the manifest', async () => {
@@ -108,6 +109,96 @@ describe('Stepper', () => {
     expect(getByRole('textbox', { name: 'name' })).toHaveValue(
       'im a test value',
     );
+  });
+
+  it('should merge nested formData correctly in multiple steps', async () => {
+    const Repo = ({
+      onChange,
+    }: NextFieldExtensionComponentProps<{ repository: string }, any>) => (
+      <input
+        aria-label="repo"
+        type="text"
+        onChange={e => onChange({ repository: e.target.value })}
+        defaultValue=""
+      />
+    );
+
+    const Owner = ({
+      onChange,
+    }: NextFieldExtensionComponentProps<{ owner: string }, any>) => (
+      <input
+        aria-label="owner"
+        type="text"
+        onChange={e => onChange({ owner: e.target.value })}
+        defaultValue=""
+      />
+    );
+
+    const manifest: TemplateParameterSchema = {
+      steps: [
+        {
+          title: 'Step 1',
+          schema: {
+            properties: {
+              first: {
+                type: 'object',
+                'ui:field': 'Repo',
+              },
+            },
+          },
+        },
+        {
+          title: 'Step 2',
+          schema: {
+            properties: {
+              second: {
+                type: 'object',
+                'ui:field': 'Owner',
+              },
+            },
+          },
+        },
+      ],
+      title: 'React JSON Schema Form Test',
+    };
+
+    const onComplete = jest.fn(async (values: Record<string, JsonValue>) => {
+      expect(values).toEqual({
+        first: { repository: 'Repo' },
+        second: { owner: 'Owner' },
+      });
+    });
+
+    const { getByRole } = await renderInTestApp(
+      <Stepper
+        manifest={manifest}
+        onComplete={onComplete}
+        extensions={[
+          { name: 'Repo', component: Repo },
+          { name: 'Owner', component: Owner },
+        ]}
+      />,
+    );
+
+    await fireEvent.change(getByRole('textbox', { name: 'repo' }), {
+      target: { value: 'Repo' },
+    });
+
+    await act(async () => {
+      await fireEvent.click(getByRole('button', { name: 'Next' }));
+    });
+
+    await fireEvent.change(getByRole('textbox', { name: 'owner' }), {
+      target: { value: 'Owner' },
+    });
+
+    await act(async () => {
+      await fireEvent.click(getByRole('button', { name: 'Review' }));
+    });
+
+    await act(async () => {
+      await fireEvent.click(getByRole('button', { name: 'Create' }));
+    });
   });
 
   it('should render custom field extensions properly', async () => {

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.test.tsx
@@ -199,6 +199,8 @@ describe('Stepper', () => {
     await act(async () => {
       await fireEvent.click(getByRole('button', { name: 'Create' }));
     });
+
+    expect(onComplete).toHaveBeenCalled();
   });
 
   it('should render custom field extensions properly', async () => {

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -102,7 +102,8 @@ export const Stepper = (props: StepperProps) => {
   };
 
   const handleChange = useCallback(
-    (e: IChangeEvent) => setFormState(e.formData),
+    (e: IChangeEvent) =>
+      setFormState(current => ({ ...current, ...e.formData })),
     [setFormState],
   );
 

--- a/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/Stepper/Stepper.tsx
@@ -26,9 +26,9 @@ import {
   Button,
   makeStyles,
 } from '@material-ui/core';
-import { withTheme } from '@rjsf/core-v5';
+import { type IChangeEvent, withTheme } from '@rjsf/core-v5';
 import { ErrorSchema, FieldValidation } from '@rjsf/utils';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { NextFieldExtensionOptions } from '../../../extensions';
 import { TemplateParameterSchema } from '../../../types';
 import { createAsyncValidators } from './createAsyncValidators';
@@ -36,7 +36,6 @@ import { useTemplateSchema } from './useTemplateSchema';
 import { ReviewState } from './ReviewState';
 import validator from '@rjsf/validator-ajv6';
 import { selectedTemplateRouteRef } from '../../../routes';
-import { getDefaultFormState } from '@rjsf/utils';
 import { useFormData } from './useFormData';
 import { FormProps } from '../../types';
 
@@ -102,6 +101,11 @@ export const Stepper = (props: StepperProps) => {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   };
 
+  const handleChange = useCallback(
+    (e: IChangeEvent) => setFormState(e.formData),
+    [setFormState],
+  );
+
   const handleNext = async ({
     formData,
   }: {
@@ -111,18 +115,7 @@ export const Stepper = (props: StepperProps) => {
     // to display it's own loading? Or should we grey out the entire form.
     setErrors(undefined);
 
-    const schema = steps[activeStep]?.schema;
-    const rootSchema = steps[activeStep]?.mergedSchema;
-
-    const newFormData = getDefaultFormState(
-      validator,
-      schema,
-      formData,
-      rootSchema,
-      true,
-    );
-
-    const returnedValidation = await validation(newFormData);
+    const returnedValidation = await validation(formData);
 
     const hasErrors = Object.values(returnedValidation).some(
       i => i.__errors?.length,
@@ -138,7 +131,7 @@ export const Stepper = (props: StepperProps) => {
         return stepNum;
       });
     }
-    setFormState(current => ({ ...current, ...newFormData }));
+    setFormState(current => ({ ...current, ...formData }));
   };
 
   return (
@@ -165,6 +158,7 @@ export const Stepper = (props: StepperProps) => {
             onSubmit={handleNext}
             fields={extensions}
             showErrorList={false}
+            onChange={handleChange}
             {...(props.FormProps ?? {})}
           >
             <div className={styles.footer}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We have some templates that contain lots of placeholders and `ui:field` extensions and they were not initialised correctly.

The `formData`  that is passed to all the extensions and placeholders is not in sync with the `@rjsf` `<Form />` component.

The current `MultistepJson` form component uses an `onChange` handler to keep the `formData` in sync with the `<Form />` component.

This PR adds an `onChange` handler to the `<Stepper/>` component and seems to do an excellent job of keeping the `formData` in sync.  The `getDefaultFormState` that I added in #14660 is no longer needed with this approach, and I have removed it.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
