### PR TITLE
Fix/ilert services uptimepercentage

### DIFF
--- a/.changeset/strong-eyes-march.md
+++ b/.changeset/strong-eyes-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-ilert': patch
+---
+
+fixed error on service page not showing if historical uptime was disabled on a service

--- a/plugins/ilert/src/components/ServicesPage/ServicesTable.tsx
+++ b/plugins/ilert/src/components/ServicesPage/ServicesTable.tsx
@@ -86,7 +86,7 @@ export const ServicesTable = ({
     cellStyle: smColumnStyle,
     headerStyle: smColumnStyle,
     render: rowData => (
-      <Typography>{rowData.uptime.uptimePercentage.p90}</Typography>
+      <Typography>{rowData.uptime?.uptimePercentage?.p90 || ''}</Typography>
     ),
   };
   const actionsColumn: TableColumn<Service> = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a patch update for our plugin, which adresses an issue in the services tab causing some users to experience a crash of the services page when historical uptime is not enabled on a service.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
