### PR TITLE
chore(deps): remove @backstage/test-utils form dependencies

### DIFF
--- a/.changeset/odd-kings-tell.md
+++ b/.changeset/odd-kings-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Removed @backstage/test-utils dependency, since it was already in the devDependencies where it belongs. The main benefit is that this will exclude better-sqlite3 from the production build.

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -38,7 +38,6 @@
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/plugin-cost-insights-common": "workspace:^",
-    "@backstage/test-utils": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
Signed-off-by: Dávid Kosztka <dkosztka@bol.com>

## Hey, I just made a Pull Request!

Removed @backstage/test-utils from the dependencies of the cost-insights plugin since it belongs to the devDependencies and it was already there.

This will exclude better-sqlite3 from production builds.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
