### PR TITLE
zcason/feature flag filter fix

### DIFF
--- a/.changeset/loud-beds-occur.md
+++ b/.changeset/loud-beds-occur.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-user-settings': major
+'@backstage/plugin-user-settings': patch
 ---
 
 Refactor for the feature flag filter functionality

--- a/.changeset/loud-beds-occur.md
+++ b/.changeset/loud-beds-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': major
+---
+
+Rafector for the feature flag filter functionality

--- a/.changeset/loud-beds-occur.md
+++ b/.changeset/loud-beds-occur.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-user-settings': major
 ---
 
-Rafector for the feature flag filter functionality
+Refactor for the feature flag filter functionality

--- a/.changeset/sixty-suits-battle.md
+++ b/.changeset/sixty-suits-battle.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-user-settings': major
----
-
-Feature flag filter functionality refactor

--- a/.changeset/sixty-suits-battle.md
+++ b/.changeset/sixty-suits-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': major
+---
+
+Feature flag filter functionality refactor

--- a/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
@@ -73,25 +73,17 @@ export const UserSettingsFeatureFlags = () => {
     inputRef?.current?.focus();
   };
 
-  let filteredFeatureFlags = Array.from(featureFlags);
-
-  const filterInputParts = filterInput
-    .split(/\s/)
-    .map(part => part.trim().toLocaleLowerCase('en-US'));
-
-  filterInputParts.forEach(
-    part =>
-      (filteredFeatureFlags = filteredFeatureFlags.filter(featureFlag =>
-        featureFlag.name.toLocaleLowerCase('en-US').includes(part),
-      )),
-  );
+  const filteredFeatureFlags = featureFlags.filter(featureFlag => {
+    const featureFlagName = featureFlag.name.toLocaleLowerCase('en-US');
+    return featureFlagName.includes(filterInput.toLocaleLowerCase('en-US'));
+  });
 
   const Header = () => (
     <Grid container style={{ justifyContent: 'space-between' }}>
       <Grid item xs={6} md={8}>
         <Typography variant="h5">Feature Flags</Typography>
       </Grid>
-      {featureFlags.length >= 10 && (
+      {10 && (
         <Grid item xs={6} md={4}>
           <TextField
             label="Filter"

--- a/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
@@ -83,7 +83,7 @@ export const UserSettingsFeatureFlags = () => {
       <Grid item xs={6} md={8}>
         <Typography variant="h5">Feature Flags</Typography>
       </Grid>
-      {10 && (
+      {featureFlags.length >= 10 && (
         <Grid item xs={6} md={4}>
           <TextField
             label="Filter"


### PR DESCRIPTION
Signed-off-by: zcason <a-zcason@expediagroup.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I rewrote the feature flag filter functionality, it was broken previously.

![feature-flag-fix](https://user-images.githubusercontent.com/62040057/209737553-e21da146-4edf-4f28-bdc9-17a3840b5d0b.png)

<img width="1502" alt="Screen Shot 2022-12-27 at 6 06 00 PM" src="https://user-images.githubusercontent.com/62040057/209738453-a86c42da-2c5c-40e8-8666-5d16b2797ef2.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
