### PR TITLE
Explicitly declaring children as optional props for react 18 upgrade

### DIFF
--- a/.changeset/sharp-icons-obey.md
+++ b/.changeset/sharp-icons-obey.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Explicitly declaring children as optional props to facilitate react 18 changes

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -552,7 +552,9 @@ export interface ScaffolderDryRunResponse {
 }
 
 // @public
-export const ScaffolderFieldExtensions: React_2.ComponentType;
+export const ScaffolderFieldExtensions: React_2.ComponentType<
+  React_2.PropsWithChildren<{}>
+>;
 
 // @public
 export interface ScaffolderGetIntegrationsListOptions {

--- a/plugins/scaffolder/src/extensions/index.tsx
+++ b/plugins/scaffolder/src/extensions/index.tsx
@@ -94,8 +94,9 @@ export function createNextScaffolderFieldExtension<
  *
  * @public
  */
-export const ScaffolderFieldExtensions: React.ComponentType =
-  (): JSX.Element | null => null;
+export const ScaffolderFieldExtensions: React.ComponentType<
+  React.PropsWithChildren<{}>
+> = (): JSX.Element | null => null;
 
 attachComponentData(
   ScaffolderFieldExtensions,

--- a/plugins/techdocs-react/api-report.md
+++ b/plugins/techdocs-react/api-report.md
@@ -56,7 +56,9 @@ export type TechDocsAddonOptions<TAddonProps = {}> = {
 };
 
 // @public
-export const TechDocsAddons: React_2.ComponentType;
+export const TechDocsAddons: React_2.ComponentType<
+  React_2.PropsWithChildren<{}>
+>;
 
 // @public
 export interface TechDocsApi {

--- a/plugins/techdocs-react/src/addons.tsx
+++ b/plugins/techdocs-react/src/addons.tsx
@@ -43,7 +43,9 @@ export const TECHDOCS_ADDONS_WRAPPER_KEY = 'techdocs.addons.wrapper.v1';
  * TechDocs Addon registry.
  * @public
  */
-export const TechDocsAddons: React.ComponentType = () => null;
+export const TechDocsAddons: React.ComponentType<
+  React.PropsWithChildren<{}>
+> = () => null;
 
 attachComponentData(TechDocsAddons, TECHDOCS_ADDONS_WRAPPER_KEY, true);
 
@@ -71,7 +73,9 @@ export function createTechDocsAddonExtension<TComponentProps>(
  * Create a TechDocs addon implementation.
  * @public
  */
-export function createTechDocsAddonExtension<TComponentProps>(
+export function createTechDocsAddonExtension<
+  TComponentProps extends React.PropsWithChildren<{}>,
+>(
   options: TechDocsAddonOptions<TComponentProps>,
 ): Extension<(props: TComponentProps) => JSX.Element | null> {
   const { name, component: TechDocsAddon } = options;


### PR DESCRIPTION
Helps to address #12252

## Hey, I just made a Pull Request!

Added in "children" as optional props for components which use children. This is a change in react 18 https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
