### PR TITLE
create-app: avoid conflicting tmp dir for reading git config

### DIFF
--- a/.changeset/sweet-tomatoes-cheer.md
+++ b/.changeset/sweet-tomatoes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Avoid potential temporary directory conflict.

--- a/packages/create-app/src/lib/tasks.test.ts
+++ b/packages/create-app/src/lib/tasks.test.ts
@@ -284,7 +284,7 @@ describe('tasks', () => {
   });
 
   describe('readGitConfig', () => {
-    const tmpDir = resolvePath(os.tmpdir(), 'git-temp-dir');
+    const tmpDirPrefix = resolvePath(os.tmpdir(), 'git-temp-dir-');
 
     it('should return git config if git package is installed and git credentials are set', async () => {
       mockExec.mockImplementation((_command, _options, callback) => {
@@ -299,17 +299,17 @@ describe('tasks', () => {
       expect(mockExec).toHaveBeenCalledTimes(3);
       expect(mockExec).toHaveBeenCalledWith(
         'git init',
-        { cwd: tmpDir },
+        { cwd: expect.stringContaining(tmpDirPrefix) },
         expect.any(Function),
       );
       expect(mockExec).toHaveBeenCalledWith(
         'git commit --allow-empty -m "Initial commit"',
-        { cwd: tmpDir },
+        { cwd: expect.stringContaining(tmpDirPrefix) },
         expect.any(Function),
       );
       expect(mockExec).toHaveBeenCalledWith(
         'git branch --format="%(refname:short)"',
-        { cwd: tmpDir },
+        { cwd: expect.stringContaining(tmpDirPrefix) },
         expect.any(Function),
       );
     });

--- a/packages/create-app/src/lib/tasks.ts
+++ b/packages/create-app/src/lib/tasks.ts
@@ -248,11 +248,9 @@ export async function moveAppTask(
  * @throws if `exec` fails
  */
 export async function readGitConfig(): Promise<GitConfig | undefined> {
-  const tempDir = resolvePath(os.tmpdir(), 'git-temp-dir');
+  const tempDir = await fs.mkdtemp(resolvePath(os.tmpdir(), 'git-temp-dir-'));
 
   try {
-    await fs.mkdir(tempDir);
-
     await exec('git init', { cwd: tempDir });
     await exec('git commit --allow-empty -m "Initial commit"', {
       cwd: tempDir,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the issue seen in #14327

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
