### PR TITLE
app-backend: avoid warning about missing app contents in development

### DIFF
--- a/.changeset/ninety-phones-tell.md
+++ b/.changeset/ninety-phones-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+The warning for missing app contents is now logged as an error instead, but only in production.

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -96,9 +96,11 @@ export async function createRouter(
   const staticDir = resolvePath(appDistDir, 'static');
 
   if (!(await fs.pathExists(staticDir))) {
-    logger.warn(
-      `Can't serve static app content from ${staticDir}, directory doesn't exist`,
-    );
+    if (process.env.NODE_ENV === 'production') {
+      logger.error(
+        `Can't serve static app content from ${staticDir}, directory doesn't exist`,
+      );
+    }
 
     return Router();
   }


### PR DESCRIPTION
🧹, partial fix for #15415