### PR TITLE
Added a mock template for testing to Uffizzi preview deployments

### DIFF
--- a/.github/uffizzi/uffizzi.production.app-config.yaml
+++ b/.github/uffizzi/uffizzi.production.app-config.yaml
@@ -36,6 +36,9 @@ catalog:
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
 
+    - type: url
+      target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
+
 proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1

--- a/.github/uffizzi/uffizzi.production.app-config.yaml
+++ b/.github/uffizzi/uffizzi.production.app-config.yaml
@@ -37,7 +37,14 @@ catalog:
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
 
     - type: url
-      target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
+      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
+      rules:
+        - allow: [User, Group]
+
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/all-templates.yaml
+      rules:
+        - allow: [Template]
 
 proxy:
   '/circleci/api':


### PR DESCRIPTION
Signed-off-by: blam <ben@blam.sh>

Eventually will convert this template so that it can use the users credentials to scaffold things for real, but for now this is just to test the UI as there is no `GITHUB_TOKEN` or anything set in the preview deployment.

