### PR TITLE
Use both variables in cli's "base url conflict" error message

### DIFF
--- a/.changeset/forty-mangos-fail.md
+++ b/.changeset/forty-mangos-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Slightly improve readability of "base URL conflict" error handling code

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -80,7 +80,7 @@ export async function startFrontend(options: StartAppOptions) {
         `⚠️   Conflict between app baseUrl and backend baseUrl:
 
     app.baseUrl:     ${appBaseUrl}
-    backend.baseUrl: ${appBaseUrl}
+    backend.baseUrl: ${backendBaseUrl}
 
     Must have unique hostname and/or ports.
 


### PR DESCRIPTION
`appBaseUrl` was specified twice - which _is_ fine, because the two
values were already proven equal - but it took me until writing this
commit message to realize that it isn't a bug.

So, I'd advocate for this change as "ease of understanding" improvement :)
