### PR TITLE
Bazaar: Added 'isBazaarAvailable' helper

### DIFF
--- a/.changeset/cool-kings-raise.md
+++ b/.changeset/cool-kings-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Added `isBazaarAvailable` helper to be used with the `EntitySwitch`.

--- a/plugins/bazaar/README.md
+++ b/plugins/bazaar/README.md
@@ -49,17 +49,20 @@ Add a **Bazaar icon** to the Sidebar to easily access the Bazaar. In `packages/a
 Add a **Bazaar card** to the overview tab on the `packages/app/src/components/catalog/EntityPage.tsx` add:
 
 ```diff
-+ import { EntityBazaarInfoCard } from '@backstage/plugin-bazaar';
++ import { EntityBazaarInfoCard, isBazaarAvailable } from '@backstage/plugin-bazaar';
 
 const overviewContent = (
 
     <Grid item md={8} xs={12}>
       <EntityAboutCard variant="gridItem" />
     </Grid>
-
-+   <Grid item sm={6}>
-+     <EntityBazaarInfoCard />
-+   </Grid>
++   <EntitySwitch>
++     <EntitySwitch.Case if={isBazaarAvailable}>
++       <Grid item sm={6}>
++         <EntityBazaarInfoCard />
++       </Grid>
++     </EntitySwitch.Case>
++    </EntitySwitch>
 
     {/* ...other entity-cards */}
 ```

--- a/plugins/bazaar/api-report.md
+++ b/plugins/bazaar/api-report.md
@@ -5,7 +5,9 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiHolder } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
@@ -35,6 +37,14 @@ export const bazaarPlugin: BackstagePlugin<
 
 // @public (undocumented)
 export const EntityBazaarInfoCard: () => JSX.Element | null;
+
+// @public (undocumented)
+export const isBazaarAvailable: (
+  entity: Entity,
+  context: {
+    apis: ApiHolder;
+  },
+) => Promise<boolean>;
 
 // @public (undocumented)
 export const SortView: () => JSX.Element;

--- a/plugins/bazaar/src/api.ts
+++ b/plugins/bazaar/src/api.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import {
+  ApiHolder,
   createApiRef,
   DiscoveryApi,
   FetchApi,
@@ -45,6 +47,25 @@ export interface BazaarApi {
 
   deleteProject(id: number): Promise<void>;
 }
+
+/** @public */
+export const isBazaarAvailable = async (
+  entity: Entity,
+  context: { apis: ApiHolder },
+): Promise<boolean> => {
+  const bazaarClient = context.apis.get(bazaarApiRef);
+  if (bazaarClient === undefined) {
+    return false;
+  }
+  const entityRef = stringifyEntityRef({
+    kind: entity.kind,
+    name: entity.metadata.name,
+    namespace: entity.metadata.namespace,
+  });
+  const response = await bazaarClient.getProjectByRef(entityRef);
+  const project = await response.json();
+  return project.data.length > 0;
+};
 
 export class BazaarClient implements BazaarApi {
   private readonly identityApi: IdentityApi;

--- a/plugins/bazaar/src/index.ts
+++ b/plugins/bazaar/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { bazaarPlugin, BazaarPage } from './plugin';
+export { isBazaarAvailable } from './api';
 export { BazaarOverviewCard } from './components/BazaarOverviewCard';
 export type { BazaarOverviewCardProps } from './components/BazaarOverviewCard';
 export { EntityBazaarInfoCard } from './components/EntityBazaarInfoCard';


### PR DESCRIPTION
The EntityBazaarInfoCard shows the bazaar data for components that have a bazaar item linked. The isBazaarAvailable helper makes it possible to only include the EntityBazaarInfoCard for components that actually have a bazaar project linked.

Closes #15013

Signed-off-by: Niklas Aronsson <niklasar@axis.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
