### PR TITLE
docs(adrs): note default support for MADR 2.x

### DIFF
--- a/.changeset/long-owls-raise.md
+++ b/.changeset/long-owls-raise.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-adr-backend': patch
+'@backstage/plugin-adr': patch
+---
+
+Clarify that default ADR parsers support MADR specification v2.x

--- a/plugins/adr-backend/README.md
+++ b/plugins/adr-backend/README.md
@@ -35,7 +35,7 @@ indexBuilder.addCollator({
 
 ### Parsing custom ADR document formats
 
-By default, the `DefaultAdrCollatorFactory` will parse and index documents that follow the [MADR](https://adr.github.io/madr/) standard file name and template format. If you use a different ADR format and file name convention, you can configure `DefaultAdrCollatorFactory` with custom `adrFilePathFilterFn` and `parser` options (see type definitions for details):
+By default, the `DefaultAdrCollatorFactory` will parse and index documents that follow the [MADR v2.x standard file name and template format](https://github.com/adr/madr/tree/2.1.2). If you use a different ADR format and file name convention, you can configure `DefaultAdrCollatorFactory` with custom `adrFilePathFilterFn` and `parser` options (see type definitions for details):
 
 ```ts
 DefaultAdrCollatorFactory.fromConfig({

--- a/plugins/adr/README.md
+++ b/plugins/adr/README.md
@@ -79,7 +79,7 @@ case 'adr':
 
 ## Custom ADR formats
 
-By default, this plugin will parse ADRs according to the format specified by the [Markdown Architecture Decision Record (MADR)](https://adr.github.io/madr/) template. If your ADRs are written using a different format, you can apply the following customizations to correctly identify and parse your documents:
+By default, this plugin will parse ADRs according to the format specified by the [Markdown Architecture Decision Record (MADR) v2.x template](https://github.com/adr/madr/tree/2.1.2). If your ADRs are written using a different format, you can apply the following customizations to correctly identify and parse your documents:
 
 ### Custom Filename/Path Format
 


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

Updating READMEs to specify which version of the MADR spec this plugin supports (by default)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
