### PR TITLE
events-backend: await subscribers and log errors

### DIFF
--- a/.changeset/nasty-planets-end.md
+++ b/.changeset/nasty-planets-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend': patch
+---
+
+The default event broker will now catch and log errors thrown by the `onEvent` method of subscribers. The returned promise from `publish` method will also not resolve until all subscribers have handled the event.

--- a/plugins/events-backend/src/service/InMemoryEventBroker.ts
+++ b/plugins/events-backend/src/service/InMemoryEventBroker.ts
@@ -42,7 +42,18 @@ export class InMemoryEventBroker implements EventBroker {
     );
 
     const subscribed = this.subscribers[params.topic] ?? [];
-    subscribed.forEach(subscriber => subscriber.onEvent(params));
+    await Promise.all(
+      subscribed.map(async subscriber => {
+        try {
+          await subscriber.onEvent(params);
+        } catch (error) {
+          this.logger.error(
+            `Subscriber "${subscriber.constructor.name}" failed to process event`,
+            error,
+          );
+        }
+      }),
+    );
   }
 
   subscribe(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a fix for the issue seen in #15406 where errors thrown by `onEvent` end up crashing the backend and don't provide a lot of context. The built-in broker will now instead await the event handlers and log any errors with more context.

I also threw in a `Promise.all` so that publishers have the option to wait for all events to be handled, as right now that's not possible.

CC @pjungermann 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
