### PR TITLE
backend-plugin-api: add new root lifecycle service + impl

### DIFF
--- a/.changeset/beige-rats-cheer.md
+++ b/.changeset/beige-rats-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Added `RootLifecycleService` and `rootLifecycleServiceRef`, as well as added a `labels` option to the existing `LifecycleServiceShutdownHook`.

--- a/.changeset/clever-years-hang.md
+++ b/.changeset/clever-years-hang.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-test-utils': patch
+'@backstage/backend-defaults': patch
+---
+
+Include implementations for the new `rootLifecycleServiceRef`.

--- a/.changeset/twenty-nails-camp.md
+++ b/.changeset/twenty-nails-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Updated implementations for the new `RootLifecycleService`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -83,6 +83,11 @@ export const permissionsFactory: (
   options?: undefined,
 ) => ServiceFactory<PermissionsService>;
 
+// @public
+export const rootLifecycleFactory: (
+  options?: undefined,
+) => ServiceFactory<LifecycleService>;
+
 // @public (undocumented)
 export const rootLoggerFactory: (
   options?: undefined,

--- a/packages/backend-app-api/src/services/implementations/index.ts
+++ b/packages/backend-app-api/src/services/implementations/index.ts
@@ -26,4 +26,5 @@ export { tokenManagerFactory } from './tokenManagerService';
 export { urlReaderFactory } from './urlReaderService';
 export { httpRouterFactory } from './httpRouterService';
 export { lifecycleFactory } from './lifecycleService';
+export { rootLifecycleFactory } from './rootLifecycleService';
 export type { HttpRouterFactoryOptions } from './httpRouterService';

--- a/packages/backend-app-api/src/services/implementations/rootLifecycleService.test.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLifecycleService.test.ts
@@ -15,14 +15,14 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import { BackendLifecycleImpl } from './lifecycleService';
+import { BackendLifecycleImpl } from './rootLifecycleService';
 
 describe('lifecycleService', () => {
   it('should execute registered shutdown hook', async () => {
     const service = new BackendLifecycleImpl(getVoidLogger());
     const hook = jest.fn();
     service.addShutdownHook({
-      pluginId: 'test',
+      labels: { plugin: 'test' },
       fn: async () => {
         hook();
       },
@@ -37,7 +37,7 @@ describe('lifecycleService', () => {
   it('should not throw errors', async () => {
     const service = new BackendLifecycleImpl(getVoidLogger());
     service.addShutdownHook({
-      pluginId: 'test',
+      labels: { plugin: 'test' },
       fn: async () => {
         throw new Error('oh no');
       },

--- a/packages/backend-app-api/src/services/implementations/rootLifecycleService.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLifecycleService.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  createServiceFactory,
+  coreServices,
+  loggerToWinstonLogger,
+  LifecycleServiceShutdownHook,
+  RootLifecycleService,
+} from '@backstage/backend-plugin-api';
+import { Logger } from 'winston';
+
+const CALLBACKS = ['SIGTERM', 'SIGINT', 'beforeExit'];
+export class BackendLifecycleImpl implements RootLifecycleService {
+  constructor(private readonly logger: Logger) {
+    CALLBACKS.map(signal => process.on(signal, () => this.shutdown()));
+  }
+
+  #isCalled = false;
+  #shutdownTasks: Array<LifecycleServiceShutdownHook> = [];
+
+  addShutdownHook(options: LifecycleServiceShutdownHook): void {
+    this.#shutdownTasks.push(options);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.#isCalled) {
+      return;
+    }
+    this.#isCalled = true;
+
+    this.logger.info(`Running ${this.#shutdownTasks.length} shutdown tasks...`);
+    await Promise.all(
+      this.#shutdownTasks.map(async hook => {
+        try {
+          await hook.fn();
+          this.logger.info(`Shutdown hook succeeded`, hook.labels);
+        } catch (error) {
+          this.logger.error(`Shutdown hook failed, ${error}`, hook.labels);
+        }
+      }),
+    );
+  }
+}
+
+/**
+ * Allows plugins to register shutdown hooks that are run when the process is about to exit.
+ * @public */
+export const rootLifecycleFactory = createServiceFactory({
+  service: coreServices.rootLifecycle,
+  deps: {
+    logger: coreServices.rootLogger,
+  },
+  async factory({ logger }) {
+    return new BackendLifecycleImpl(loggerToWinstonLogger(logger));
+  },
+});

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -20,7 +20,7 @@ import {
   coreServices,
   ServiceRef,
 } from '@backstage/backend-plugin-api';
-import { BackendLifecycleImpl } from '../services/implementations/lifecycleService';
+import { BackendLifecycleImpl } from '../services/implementations/rootLifecycleService';
 import {
   BackendRegisterInit,
   EnumerableServiceHolder,
@@ -182,14 +182,13 @@ export class BackendInitializer {
     }
 
     const lifecycleService = await this.#serviceHolder.get(
-      coreServices.lifecycle,
+      coreServices.rootLifecycle,
       'root',
     );
 
     // TODO(Rugvip): Find a better way to do this
-    const lifecycle = (lifecycleService as any)?.lifecycle;
-    if (lifecycle instanceof BackendLifecycleImpl) {
-      await lifecycle.shutdown();
+    if (lifecycleService instanceof BackendLifecycleImpl) {
+      await lifecycleService.shutdown();
     } else {
       throw new Error('Unexpected lifecycle service implementation');
     }

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -23,6 +23,7 @@ import {
   discoveryFactory,
   httpRouterFactory,
   lifecycleFactory,
+  rootLifecycleFactory,
   loggerFactory,
   permissionsFactory,
   rootLoggerFactory,
@@ -45,6 +46,7 @@ export const defaultServiceFactories = [
   urlReaderFactory,
   httpRouterFactory,
   lifecycleFactory,
+  rootLifecycleFactory,
 ];
 
 /**

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -89,6 +89,7 @@ declare namespace coreServices {
     tokenManagerServiceRef as tokenManager,
     permissionsServiceRef as permissions,
     schedulerServiceRef as scheduler,
+    rootLifecycleServiceRef as rootLifecycle,
     rootLoggerServiceRef as rootLogger,
     pluginMetadataServiceRef as pluginMetadata,
     lifecycleServiceRef as lifecycle,
@@ -200,6 +201,7 @@ const lifecycleServiceRef: ServiceRef<LifecycleService, 'plugin'>;
 // @public (undocumented)
 export type LifecycleServiceShutdownHook = {
   fn: () => void | Promise<void>;
+  labels?: Record<string, string>;
 };
 
 // @public (undocumented)
@@ -244,6 +246,12 @@ export interface PluginMetadataService {
 
 // @public (undocumented)
 const pluginMetadataServiceRef: ServiceRef<PluginMetadataService, 'plugin'>;
+
+// @public (undocumented)
+export type RootLifecycleService = LifecycleService;
+
+// @public (undocumented)
+const rootLifecycleServiceRef: ServiceRef<LifecycleService, 'root'>;
 
 // @public (undocumented)
 export type RootLoggerService = LoggerService;

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -24,6 +24,7 @@ export { discoveryServiceRef as discovery } from './discoveryServiceRef';
 export { tokenManagerServiceRef as tokenManager } from './tokenManagerServiceRef';
 export { permissionsServiceRef as permissions } from './permissionsServiceRef';
 export { schedulerServiceRef as scheduler } from './schedulerServiceRef';
+export { rootLifecycleServiceRef as rootLifecycle } from './rootLifecycleServiceRef';
 export { rootLoggerServiceRef as rootLogger } from './rootLoggerServiceRef';
 export { pluginMetadataServiceRef as pluginMetadata } from './pluginMetadataServiceRef';
 export { lifecycleServiceRef as lifecycle } from './lifecycleServiceRef';

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -29,6 +29,7 @@ export type {
 export type { LoggerService, LogMeta } from './loggerServiceRef';
 export type { PermissionsService } from './permissionsServiceRef';
 export type { PluginMetadataService } from './pluginMetadataServiceRef';
+export type { RootLifecycleService } from './rootLifecycleServiceRef';
 export type { RootLoggerService } from './rootLoggerServiceRef';
 export type { SchedulerService } from './schedulerServiceRef';
 export type { TokenManagerService } from './tokenManagerServiceRef';

--- a/packages/backend-plugin-api/src/services/definitions/rootLifecycleServiceRef.ts
+++ b/packages/backend-plugin-api/src/services/definitions/rootLifecycleServiceRef.ts
@@ -15,31 +15,15 @@
  */
 
 import { createServiceRef } from '../system/types';
+import { LifecycleService } from './lifecycleServiceRef';
 
-/**
- * @public
- **/
-export type LifecycleServiceShutdownHook = {
-  fn: () => void | Promise<void>;
-
-  /** Labels to help identify the shutdown hook */
-  labels?: Record<string, string>;
-};
-
-/**
- * @public
- **/
-export interface LifecycleService {
-  /**
-   * Register a function to be called when the backend is shutting down.
-   */
-  addShutdownHook(options: LifecycleServiceShutdownHook): void;
-}
+/** @public */
+export type RootLifecycleService = LifecycleService;
 
 /**
  * @public
  */
-export const lifecycleServiceRef = createServiceRef<LifecycleService>({
-  id: 'core.lifecycle',
-  scope: 'plugin',
+export const rootLifecycleServiceRef = createServiceRef<RootLifecycleService>({
+  id: 'core.rootLifecycle',
+  scope: 'root',
 });

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -18,6 +18,7 @@ import {
   Backend,
   createSpecializedBackend,
   lifecycleFactory,
+  rootLifecycleFactory,
   loggerFactory,
   rootLoggerFactory,
 } from '@backstage/backend-app-api';
@@ -57,6 +58,7 @@ const defaultServiceFactories = [
   rootLoggerFactory(),
   loggerFactory(),
   lifecycleFactory(),
+  rootLifecycleFactory(),
 ];
 
 const backendInstancesToCleanUp = new Array<Backend>();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding a root lifecycle service so that other root services are able to register lifecycle hooks. It also adds a label option to the hooks, which we then use to forward the plugin ID, and also lets us give a bit more context for root services.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
