### PR TITLE
feat: add last-modified support to UrlReader

### DIFF
--- a/.changeset/sharp-rings-cry.md
+++ b/.changeset/sharp-rings-cry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': minor
+'@backstage/backend-plugin-api': minor
+---
+
+Added `lastModifiedAt` field on `UrlReaderService` responses and a `lastModifiedAfter` option to `UrlReaderService.readUrl`.

--- a/.changeset/sharp-rings-cry.md
+++ b/.changeset/sharp-rings-cry.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-common': minor
+'@backstage/backend-common': patch
 '@backstage/backend-plugin-api': minor
 ---
 

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -301,6 +301,7 @@ export class FetchUrlReader implements UrlReader {
 export type FromReadableArrayOptions = Array<{
   data: Readable;
   path: string;
+  lastModifiedAt?: Date;
 }>;
 
 // @public
@@ -635,6 +636,7 @@ export class ReadUrlResponseFactory {
 // @public
 export type ReadUrlResponseFactoryFromStreamOptions = {
   etag?: string;
+  lastModifiedAt?: Date;
 };
 
 // @public

--- a/packages/backend-common/src/reading/AzureUrlReader.ts
+++ b/packages/backend-common/src/reading/AzureUrlReader.ts
@@ -192,6 +192,7 @@ export class AzureUrlReader implements UrlReader {
           base: url,
         }),
         content: file.content,
+        lastModifiedAt: file.lastModifiedAt,
       })),
     };
   }

--- a/packages/backend-common/src/reading/BitbucketCloudUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketCloudUrlReader.test.ts
@@ -156,6 +156,83 @@ describe('BitbucketCloudUrlReader', () => {
       expect(buffer.toString()).toBe('foo');
       expect(result.etag).toBe('new-etag-value');
     });
+
+    it('should be able to readUrl via buffer without If-Modified-Since', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('If-None-Match')).toBeNull();
+            return res(
+              ctx.status(200),
+              ctx.body('foo'),
+              ctx.set('ETag', 'etag-value'),
+              ctx.set(
+                'Last-Modified',
+                new Date('2020-01-01T00:00:00Z').toUTCString(),
+              ),
+            );
+          },
+        ),
+      );
+
+      const result = await reader.readUrl(
+        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+      );
+      const buffer = await result.buffer();
+      expect(result.lastModifiedAt).toEqual(new Date('2020-01-01T00:00:00Z'));
+      expect(buffer.toString()).toBe('foo');
+    });
+
+    it('should be throw not modified when If-Modified-Since returns a 304', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('If-Modified-Since')).toBe(
+              new Date('1999 12 31 23:59:59 GMT').toUTCString(),
+            );
+            return res(ctx.status(304));
+          },
+        ),
+      );
+
+      await expect(
+        reader.readUrl(
+          'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+          { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
+        ),
+      ).rejects.toThrow(NotModifiedError);
+    });
+
+    it('should be able to readUrl when If-Modified-Since is before Last-Modified', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('If-Modified-Since')).toBe(
+              new Date('1999 12 31 23:59:59 GMT').toUTCString(),
+            );
+            return res(
+              ctx.status(200),
+              ctx.set(
+                'Last-Modified',
+                new Date('2020-01-01T00:00:00Z').toUTCString(),
+              ),
+              ctx.body('foo'),
+            );
+          },
+        ),
+      );
+
+      const result = await reader.readUrl(
+        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
+      );
+      const buffer = await result.buffer();
+      expect(buffer.toString()).toBe('foo');
+      expect(result.lastModifiedAt).toEqual(new Date('2020-01-01T00:00:00Z'));
+    });
   });
 
   describe('read', () => {

--- a/packages/backend-common/src/reading/BitbucketCloudUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketCloudUrlReader.ts
@@ -40,6 +40,7 @@ import {
   UrlReader,
 } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
+import { parseLastModified } from './util';
 
 /**
  * Implements a {@link @backstage/backend-plugin-api#UrlReaderService} for files from Bitbucket Cloud.
@@ -80,7 +81,7 @@ export class BitbucketCloudUrlReader implements UrlReader {
     url: string,
     options?: ReadUrlOptions,
   ): Promise<ReadUrlResponse> {
-    const { etag, signal } = options ?? {};
+    const { etag, lastModifiedAfter, signal } = options ?? {};
     const bitbucketUrl = getBitbucketCloudFileFetchUrl(
       url,
       this.integration.config,
@@ -95,6 +96,9 @@ export class BitbucketCloudUrlReader implements UrlReader {
         headers: {
           ...requestOptions.headers,
           ...(etag && { 'If-None-Match': etag }),
+          ...(lastModifiedAfter && {
+            'If-Modified-Since': lastModifiedAfter.toUTCString(),
+          }),
         },
         // TODO(freben): The signal cast is there because pre-3.x versions of
         // node-fetch have a very slightly deviating AbortSignal type signature.
@@ -115,6 +119,9 @@ export class BitbucketCloudUrlReader implements UrlReader {
     if (response.ok) {
       return ReadUrlResponseFactory.fromNodeJSReadable(response.body, {
         etag: response.headers.get('ETag') ?? undefined,
+        lastModifiedAt: parseLastModified(
+          response.headers.get('Last-Modified'),
+        ),
       });
     }
 
@@ -184,6 +191,7 @@ export class BitbucketCloudUrlReader implements UrlReader {
           base: url,
         }),
         content: file.content,
+        lastModifiedAt: file.lastModifiedAt,
       })),
     };
   }

--- a/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
@@ -204,6 +204,83 @@ describe('BitbucketUrlReader', () => {
       expect(buffer.toString()).toBe('foo');
       expect(result.etag).toBe('new-etag-value');
     });
+
+    it('should be able to readUrl via buffer without If-Modified-Since', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('If-None-Match')).toBeNull();
+            return res(
+              ctx.status(200),
+              ctx.body('foo'),
+              ctx.set('ETag', 'etag-value'),
+              ctx.set(
+                'Last-Modified',
+                new Date('2020-01-01T00:00:00Z').toUTCString(),
+              ),
+            );
+          },
+        ),
+      );
+
+      const result = await bitbucketProcessor.readUrl(
+        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+      );
+      const buffer = await result.buffer();
+      expect(result.lastModifiedAt).toEqual(new Date('2020-01-01T00:00:00Z'));
+      expect(buffer.toString()).toBe('foo');
+    });
+
+    it('should be throw not modified when If-Modified-Since returns a 304', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('If-Modified-Since')).toBe(
+              new Date('1999 12 31 23:59:59 GMT').toUTCString(),
+            );
+            return res(ctx.status(304));
+          },
+        ),
+      );
+
+      await expect(
+        bitbucketProcessor.readUrl(
+          'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+          { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
+        ),
+      ).rejects.toThrow(NotModifiedError);
+    });
+
+    it('should be able to readUrl when If-Modified-Since is before Last-Modified', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('If-Modified-Since')).toBe(
+              new Date('1999 12 31 23:59:59 GMT').toUTCString(),
+            );
+            return res(
+              ctx.status(200),
+              ctx.set(
+                'Last-Modified',
+                new Date('2020-01-01T00:00:00Z').toUTCString(),
+              ),
+              ctx.body('foo'),
+            );
+          },
+        ),
+      );
+
+      const result = await bitbucketProcessor.readUrl(
+        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
+      );
+      const buffer = await result.buffer();
+      expect(buffer.toString()).toBe('foo');
+      expect(result.lastModifiedAt).toEqual(new Date('2020-01-01T00:00:00Z'));
+    });
   });
 
   describe('read', () => {

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -41,6 +41,7 @@ import {
   UrlReader,
 } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
+import { parseLastModified } from './util';
 
 /**
  * Implements a {@link @backstage/backend-plugin-api#UrlReaderService} for files from Bitbucket v1 and v2 APIs, such
@@ -96,7 +97,7 @@ export class BitbucketUrlReader implements UrlReader {
     url: string,
     options?: ReadUrlOptions,
   ): Promise<ReadUrlResponse> {
-    const { etag, signal } = options ?? {};
+    const { etag, lastModifiedAfter, signal } = options ?? {};
     const bitbucketUrl = getBitbucketFileFetchUrl(url, this.integration.config);
     const requestOptions = getBitbucketRequestOptions(this.integration.config);
 
@@ -106,6 +107,9 @@ export class BitbucketUrlReader implements UrlReader {
         headers: {
           ...requestOptions.headers,
           ...(etag && { 'If-None-Match': etag }),
+          ...(lastModifiedAfter && {
+            'If-Modified-Since': lastModifiedAfter.toUTCString(),
+          }),
         },
         // TODO(freben): The signal cast is there because pre-3.x versions of
         // node-fetch have a very slightly deviating AbortSignal type signature.
@@ -126,6 +130,9 @@ export class BitbucketUrlReader implements UrlReader {
     if (response.ok) {
       return ReadUrlResponseFactory.fromNodeJSReadable(response.body, {
         etag: response.headers.get('ETag') ?? undefined,
+        lastModifiedAt: parseLastModified(
+          response.headers.get('Last-Modified'),
+        ),
       });
     }
 
@@ -195,6 +202,7 @@ export class BitbucketUrlReader implements UrlReader {
           base: url,
         }),
         content: file.content,
+        lastModifiedAt: file.lastModifiedAt,
       })),
     };
   }

--- a/packages/backend-common/src/reading/FetchUrlReader.ts
+++ b/packages/backend-common/src/reading/FetchUrlReader.ts
@@ -26,6 +26,7 @@ import {
 } from './types';
 import path from 'path';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
+import { parseLastModified } from './util';
 
 const isInRange = (num: number, [start, end]: [number, number]) => {
   return num >= start && num <= end;
@@ -127,6 +128,9 @@ export class FetchUrlReader implements UrlReader {
       response = await fetch(url, {
         headers: {
           ...(options?.etag && { 'If-None-Match': options.etag }),
+          ...(options?.lastModifiedAfter && {
+            'If-Modified-Since': options.lastModifiedAfter.toUTCString(),
+          }),
         },
         // TODO(freben): The signal cast is there because pre-3.x versions of
         // node-fetch have a very slightly deviating AbortSignal type signature.
@@ -147,6 +151,9 @@ export class FetchUrlReader implements UrlReader {
     if (response.ok) {
       return ReadUrlResponseFactory.fromNodeJSReadable(response.body, {
         etag: response.headers.get('ETag') ?? undefined,
+        lastModifiedAt: parseLastModified(
+          response.headers.get('Last-Modified'),
+        ),
       });
     }
 

--- a/packages/backend-common/src/reading/GiteaUrlReader.ts
+++ b/packages/backend-common/src/reading/GiteaUrlReader.ts
@@ -34,6 +34,7 @@ import {
   NotModifiedError,
 } from '@backstage/errors';
 import { Readable } from 'stream';
+import { parseLastModified } from './util';
 
 /**
  * Implements a {@link @backstage/backend-plugin-api#UrlReaderService} for the Gitea v1 api.
@@ -86,6 +87,9 @@ export class GiteaUrlReader implements UrlReader {
           Readable.from(Buffer.from(content, 'base64')),
           {
             etag: response.headers.get('ETag') ?? undefined,
+            lastModifiedAt: parseLastModified(
+              response.headers.get('Last-Modified'),
+            ),
           },
         );
       }

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -247,7 +247,7 @@ describe('GithubUrlReader', () => {
       ).rejects.toThrow(/rate limit exceeded/);
     });
 
-    it('should return etag from the response', async () => {
+    it('should return etag and last-modified from the response', async () => {
       (mockCredentialsProvider.getCredentials as jest.Mock).mockResolvedValue({
         headers: {
           Authorization: 'bearer blah',
@@ -261,6 +261,11 @@ describe('GithubUrlReader', () => {
             return res(
               ctx.status(200),
               ctx.set('Etag', 'foo'),
+              ctx.set(
+                'Last-Modified',
+                new Date('2021-01-01T00:00:00Z').toUTCString(),
+              ),
+
               ctx.body('bar'),
             );
           },
@@ -271,6 +276,7 @@ describe('GithubUrlReader', () => {
         'https://github.com/backstage/mock/tree/blob/main',
       );
       expect(response.etag).toBe('foo');
+      expect(response.lastModifiedAt).toEqual(new Date('2021-01-01T00:00:00Z'));
     });
   });
 

--- a/packages/backend-common/src/reading/ReadUrlResponseFactory.ts
+++ b/packages/backend-common/src/reading/ReadUrlResponseFactory.ts
@@ -61,6 +61,7 @@ export class ReadUrlResponseFactory {
         return stream;
       },
       etag: options?.etag,
+      lastModifiedAt: options?.lastModifiedAt,
     };
   }
 

--- a/packages/backend-common/src/reading/tree/ReadableArrayResponse.ts
+++ b/packages/backend-common/src/reading/tree/ReadableArrayResponse.ts
@@ -63,6 +63,7 @@ export class ReadableArrayResponse implements ReadTreeResponse {
         files.push({
           path: this.stream[i].path,
           content: () => getRawBody(this.stream[i].data),
+          lastModifiedAt: this.stream[i]?.lastModifiedAt,
         });
       }
     }

--- a/packages/backend-common/src/reading/tree/TarArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/TarArchiveResponse.test.ts
@@ -45,10 +45,12 @@ describe('TarArchiveResponse', () => {
       {
         path: 'mkdocs.yml',
         content: expect.any(Function),
+        lastModifiedAt: undefined,
       },
       {
         path: 'docs/index.md',
         content: expect.any(Function),
+        lastModifiedAt: undefined,
       },
     ]);
     const contents = await Promise.all(files.map(f => f.content()));
@@ -70,6 +72,7 @@ describe('TarArchiveResponse', () => {
       {
         path: 'mkdocs.yml',
         content: expect.any(Function),
+        lastModifiedAt: undefined,
       },
     ]);
     const content = await files[0].content();
@@ -93,10 +96,12 @@ describe('TarArchiveResponse', () => {
       {
         path: 'mkdocs.yml',
         content: expect.any(Function),
+        lastModifiedAt: undefined,
       },
       {
         path: 'docs/index.md',
         content: expect.any(Function),
+        lastModifiedAt: undefined,
       },
     ]);
     const contents = await Promise.all(files.map(f => f.content()));

--- a/packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
@@ -59,10 +59,12 @@ describe('ZipArchiveResponse', () => {
       {
         path: 'mkdocs.yml',
         content: expect.any(Function),
+        lastModifiedAt: expect.any(Date),
       },
       {
         path: 'docs/index.md',
         content: expect.any(Function),
+        lastModifiedAt: expect.any(Date),
       },
     ]);
 
@@ -85,6 +87,7 @@ describe('ZipArchiveResponse', () => {
       {
         path: 'mkdocs.yml',
         content: expect.any(Function),
+        lastModifiedAt: expect.any(Date),
       },
     ]);
     const content = await files[0].content();
@@ -108,10 +111,12 @@ describe('ZipArchiveResponse', () => {
       {
         path: 'mkdocs.yml',
         content: expect.any(Function),
+        lastModifiedAt: expect.any(Date),
       },
       {
         path: 'docs/index.md',
         content: expect.any(Function),
+        lastModifiedAt: expect.any(Date),
       },
     ]);
     const contents = await Promise.all(files.map(f => f.content()));

--- a/packages/backend-common/src/reading/tree/ZipArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/ZipArchiveResponse.ts
@@ -146,6 +146,9 @@ export class ZipArchiveResponse implements ReadTreeResponse {
       files.push({
         path: this.getInnerPath(entry.fileName),
         content: async () => await streamToBuffer(content),
+        lastModifiedAt: entry.lastModFileTime
+          ? new Date(entry.lastModFileTime)
+          : undefined,
       });
     });
 

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -65,6 +65,7 @@ export type ReaderFactory = (options: {
  */
 export type ReadUrlResponseFactoryFromStreamOptions = {
   etag?: string;
+  lastModifiedAt?: Date;
 };
 
 /**
@@ -95,10 +96,16 @@ export type FromReadableArrayOptions = Array<{
    * The raw data itself.
    */
   data: Readable;
+
   /**
    * The filepath of the data.
    */
   path: string;
+
+  /**
+   * Last modified date of the file contents.
+   */
+  lastModifiedAt?: Date;
 }>;
 
 /**

--- a/packages/backend-common/src/reading/util.ts
+++ b/packages/backend-common/src/reading/util.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function parseLastModified(value: string | null | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  return new Date(value);
+}

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -359,11 +359,13 @@ export type ReadTreeResponseDirOptions = {
 export type ReadTreeResponseFile = {
   path: string;
   content(): Promise<Buffer>;
+  lastModifiedAt?: Date;
 };
 
 // @public
 export type ReadUrlOptions = {
   etag?: string;
+  lastModifiedAfter?: Date;
   signal?: AbortSignal;
 };
 
@@ -372,6 +374,7 @@ export type ReadUrlResponse = {
   buffer(): Promise<Buffer>;
   stream?(): Readable;
   etag?: string;
+  lastModifiedAt?: Date;
 };
 
 // @public (undocumented)
@@ -420,6 +423,7 @@ export type SearchResponse = {
 export type SearchResponseFile = {
   url: string;
   content(): Promise<Buffer>;
+  lastModifiedAt?: Date;
 };
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
@@ -65,6 +65,26 @@ export type ReadUrlOptions = {
   etag?: string;
 
   /**
+   * A date which can be provided to check whether a
+   * {@link UrlReaderService.readUrl} response has changed since the lastModifiedAt.
+   *
+   * @remarks
+   *
+   * In the {@link UrlReaderService.readUrl} response, an lastModifiedAt is returned
+   * along with data. The lastModifiedAt date represents the last time the data
+   * was modified.
+   *
+   * When an lastModifiedAfter is given in ReadUrlOptions, {@link UrlReaderService.readUrl}
+   * will compare the lastModifiedAfter against the lastModifiedAt of the target. If
+   * the data has not been modified since this date, the {@link UrlReaderService.readUrl}
+   * will throw a {@link @backstage/errors#NotModifiedError} indicating that the
+   * response does not contain any new data. If they do not match,
+   * {@link UrlReaderService.readUrl} will return the rest of the response along with new
+   * lastModifiedAt date.
+   */
+  lastModifiedAfter?: Date;
+
+  /**
    * An abort signal to pass down to the underlying request.
    *
    * @remarks
@@ -102,6 +122,11 @@ export type ReadUrlResponse = {
    * Can be used to compare and cache responses when doing subsequent calls.
    */
   etag?: string;
+
+  /**
+   * Last modified date of the file contents.
+   */
+  lastModifiedAt?: Date;
 };
 
 /**
@@ -213,8 +238,20 @@ export type ReadTreeResponse = {
  * @public
  */
 export type ReadTreeResponseFile = {
+  /**
+   * The filepath of the data.
+   */
   path: string;
+
+  /**
+   * The binary contents of the file.
+   */
   content(): Promise<Buffer>;
+
+  /**
+   * The last modified timestamp of the data.
+   */
+  lastModifiedAt?: Date;
 };
 
 /**
@@ -278,4 +315,9 @@ export type SearchResponseFile = {
    * The binary contents of the file.
    */
   content(): Promise<Buffer>;
+
+  /**
+   * The last modified timestamp of the data.
+   */
+  lastModifiedAt?: Date;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #15160

- Adds a new optional `lastModifiedAt` field to the types `ReadUrlResponse`, `ReadTreeResponseFile`, & `SearchResponseFile`. These are implemented on almost all of the current providers where it seems like it makes sense. For `fetch` based ones I made the assumption that most providers will adhere to the standard `Last-Modified` HTTP response header. If it doesn't exist it will fall back to `undefined`. 
- Adds a new optional `ifModifiedSince` option on `ReadUrlOptions`. If provided it will be passed along to the underlying request (typically as the standard HTTP request `If-Modified-Since` header). Providers should return a `304` similar to `etag` in this case.

**TODO** - I'll write tests once I can confirm I'm headed in the right direction.

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
