### PR TITLE
backend-app-api: throw errors on conflicting service implementations

### DIFF
--- a/.changeset/eleven-fans-love.md
+++ b/.changeset/eleven-fans-love.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-test-utils': patch
+'@backstage/backend-defaults': patch
+---
+
+Updated to make sure that service implementations replace default service implementations.

--- a/.changeset/great-forks-lay.md
+++ b/.changeset/great-forks-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+An error will now be thrown if attempting to override the plugin metadata service.

--- a/.changeset/nine-falcons-appear.md
+++ b/.changeset/nine-falcons-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+The `createSpecializedBackend` function will now throw an error if duplicate service implementations are provided.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -40,12 +40,12 @@ describe('BackendInitializer', () => {
         service: rootRef,
         deps: {},
         factory: rootFactory,
-      }),
+      })(),
       createServiceFactory({
         service: pluginRef,
         deps: {},
         factory: pluginFactory,
-      }),
+      })(),
     ]);
 
     const init = new BackendInitializer(registry);

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
@@ -33,7 +33,7 @@ const sf1 = createServiceFactory({
       return { x: 1 };
     };
   },
-});
+})();
 
 const ref2 = createServiceRef<{ x: number }>({
   scope: 'root',
@@ -45,7 +45,7 @@ const sf2 = createServiceFactory({
   async factory() {
     return { x: 2 };
   },
-});
+})();
 const sf2b = createServiceFactory({
   service: ref2,
   deps: {},
@@ -133,7 +133,7 @@ describe('ServiceRegistry', () => {
         return { x: 2 };
       },
     });
-    const registry = new ServiceRegistry([factory, sf1]);
+    const registry = new ServiceRegistry([factory(), sf1]);
     await expect(registry.get(ref2, 'catalog')).rejects.toThrow(
       "Failed to instantiate 'root' scoped service '2' because it depends on 'plugin' scoped service '1'.",
     );
@@ -147,7 +147,7 @@ describe('ServiceRegistry', () => {
         return async () => ({ x: rootDep.x });
       },
     });
-    const registry = new ServiceRegistry([factory, sf2]);
+    const registry = new ServiceRegistry([factory(), sf2]);
     await expect(registry.get(ref1, 'catalog')).resolves.toEqual({
       x: 2,
     });
@@ -162,7 +162,7 @@ describe('ServiceRegistry', () => {
         return { x: rootDep.x };
       },
     });
-    const registry = new ServiceRegistry([factory, sf2]);
+    const registry = new ServiceRegistry([factory(), sf2]);
     await expect(registry.get(ref, 'catalog')).resolves.toEqual({
       x: 2,
     });
@@ -177,7 +177,7 @@ describe('ServiceRegistry', () => {
         return async ({ meta }) => ({ pluginId: meta.getId() });
       },
     });
-    const registry = new ServiceRegistry([factory]);
+    const registry = new ServiceRegistry([factory()]);
     await expect(registry.get(ref, 'catalog')).resolves.toEqual({
       pluginId: 'catalog',
     });
@@ -257,7 +257,7 @@ describe('ServiceRegistry', () => {
       factory,
     });
 
-    const registry = new ServiceRegistry([myFactory]);
+    const registry = new ServiceRegistry([myFactory()]);
 
     await Promise.all([
       registry.get(ref1, 'catalog')!,
@@ -280,7 +280,7 @@ describe('ServiceRegistry', () => {
       },
     });
 
-    const registry = new ServiceRegistry([myFactory]);
+    const registry = new ServiceRegistry([myFactory()]);
 
     await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' for 'catalog' because the following dependent services are missing: '2'",
@@ -309,7 +309,7 @@ describe('ServiceRegistry', () => {
       },
     });
 
-    const registry = new ServiceRegistry([factoryA, factoryB]);
+    const registry = new ServiceRegistry([factoryA(), factoryB()]);
 
     await expect(registry.get(refA, 'catalog')).rejects.toThrow(
       "Failed to instantiate service 'a' for 'catalog' because the factory function threw an error, Error: Failed to instantiate service 'b' for 'catalog' because the following dependent services are missing: 'c', 'd'",
@@ -325,7 +325,7 @@ describe('ServiceRegistry', () => {
       },
     });
 
-    const registry = new ServiceRegistry([myFactory]);
+    const registry = new ServiceRegistry([myFactory()]);
 
     await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' because the top-level factory function threw an error, Error: top-level error",
@@ -343,7 +343,7 @@ describe('ServiceRegistry', () => {
       },
     });
 
-    const registry = new ServiceRegistry([myFactory]);
+    const registry = new ServiceRegistry([myFactory()]);
 
     await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' for 'catalog' because the factory function threw an error, Error: error in plugin",

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -44,18 +44,8 @@ export class ServiceRegistry implements EnumerableServiceHolder {
     }
   >;
 
-  constructor(
-    factories: Array<ServiceFactory<unknown> | (() => ServiceFactory<unknown>)>,
-  ) {
-    this.#providedFactories = new Map(
-      factories.map(f => {
-        if (typeof f === 'function') {
-          const cf = f();
-          return [cf.service.id, cf];
-        }
-        return [f.service.id, f];
-      }),
-    );
+  constructor(factories: Array<ServiceFactory<unknown>>) {
+    this.#providedFactories = new Map(factories.map(f => [f.service.id, f]));
     this.#loadedDefaultFactories = new Map();
     this.#implementations = new Map();
   }

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { createSpecializedBackend } from './createSpecializedBackend';
+
+describe('createSpecializedBackend', () => {
+  it('should create a backend without services', () => {
+    expect(() => createSpecializedBackend({ services: [] })).not.toThrow();
+  });
+
+  it('should throw on duplicate service implementations', () => {
+    expect(() =>
+      createSpecializedBackend({
+        services: [
+          createServiceFactory({
+            service: coreServices.rootLifecycle,
+            deps: {},
+            factory: async () => ({ addShutdownHook: () => {} }),
+          }),
+          createServiceFactory({
+            service: coreServices.rootLifecycle,
+            deps: {},
+            factory: async () => ({ addShutdownHook: () => {} }),
+          }),
+        ],
+      }),
+    ).toThrow(
+      'Duplicate service implementations provided for core.rootLifecycle',
+    );
+  });
+
+  it('should throw when providing a plugin metadata service implementation', () => {
+    expect(() =>
+      createSpecializedBackend({
+        services: [
+          createServiceFactory({
+            service: coreServices.pluginMetadata,
+            deps: {},
+            factory: async () => async () => ({ getId: () => 'test' }),
+          }),
+        ],
+      }),
+    ).toThrow('The core.plugin-metadata service cannot be overridden');
+  });
+});

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
@@ -57,6 +57,6 @@ describe('createSpecializedBackend', () => {
           }),
         ],
       }),
-    ).toThrow('The core.plugin-metadata service cannot be overridden');
+    ).toThrow('The core.pluginMetadata service cannot be overridden');
   });
 });

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { coreServices } from '@backstage/backend-plugin-api';
+import { BackstageBackend } from './BackstageBackend';
+import { Backend, CreateSpecializedBackendOptions } from './types';
+
+/**
+ * @public
+ */
+export function createSpecializedBackend(
+  options: CreateSpecializedBackendOptions,
+): Backend {
+  const services = options.services.map(sf =>
+    typeof sf === 'function' ? sf() : sf,
+  );
+
+  const exists = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const { service } of services) {
+    if (exists.has(service.id)) {
+      duplicates.add(service.id);
+    } else {
+      exists.add(service.id);
+    }
+  }
+  if (duplicates.size > 0) {
+    const ids = Array.from(duplicates).join(', ');
+    throw new Error(`Duplicate service implementations provided for ${ids}`);
+  }
+  if (exists.has(coreServices.pluginMetadata.id)) {
+    throw new Error(
+      `The ${coreServices.pluginMetadata.id} service cannot be overridden`,
+    );
+  }
+
+  return new BackstageBackend(services);
+}

--- a/packages/backend-app-api/src/wiring/index.ts
+++ b/packages/backend-app-api/src/wiring/index.ts
@@ -19,4 +19,4 @@ export type {
   CreateSpecializedBackendOptions,
   ServiceOrExtensionPoint,
 } from './types';
-export { createSpecializedBackend } from './types';
+export { createSpecializedBackend } from './createSpecializedBackend';

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -15,13 +15,11 @@
  */
 
 import {
-  ServiceFactory,
   BackendFeature,
   ExtensionPoint,
+  ServiceFactory,
   ServiceRef,
-  coreServices,
 } from '@backstage/backend-plugin-api';
-import { BackstageBackend } from './BackstageBackend';
 
 /**
  * @public
@@ -56,38 +54,6 @@ export interface ServiceHolder {
  */
 export interface EnumerableServiceHolder extends ServiceHolder {
   getServiceRefs(): ServiceRef<unknown>[];
-}
-
-/**
- * @public
- */
-export function createSpecializedBackend(
-  options: CreateSpecializedBackendOptions,
-): Backend {
-  const services = options.services.map(sf =>
-    typeof sf === 'function' ? sf() : sf,
-  );
-
-  const exists = new Set<string>();
-  const duplicates = new Set<string>();
-  for (const { service } of services) {
-    if (exists.has(service.id)) {
-      duplicates.add(service.id);
-    } else {
-      exists.add(service.id);
-    }
-  }
-  if (duplicates.size > 0) {
-    const ids = Array.from(duplicates).join(', ');
-    throw new Error(`Duplicate service implementations provided for ${ids}`);
-  }
-  if (exists.has(coreServices.pluginMetadata.id)) {
-    throw new Error(
-      `The ${coreServices.pluginMetadata.id} service cannot be overridden`,
-    );
-  }
-
-  return new BackstageBackend(services);
 }
 
 /**

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -19,6 +19,7 @@ import {
   BackendFeature,
   ExtensionPoint,
   ServiceRef,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { BackstageBackend } from './BackstageBackend';
 
@@ -79,6 +80,11 @@ export function createSpecializedBackend(
   if (duplicates.size > 0) {
     const ids = Array.from(duplicates).join(', ');
     throw new Error(`Duplicate service implementations provided for ${ids}`);
+  }
+  if (exists.has(coreServices.pluginMetadata.id)) {
+    throw new Error(
+      `The ${coreServices.pluginMetadata.id} service cannot be overridden`,
+    );
   }
 
   return new BackstageBackend(services);

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -67,6 +67,6 @@ describe('createBackend', () => {
           }),
         ],
       }),
-    ).toThrow('The core.plugin-metadata service cannot be overridden');
+    ).toThrow('The core.pluginMetadata service cannot be overridden');
   });
 });

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -55,4 +55,18 @@ describe('createBackend', () => {
       'Duplicate service implementations provided for core.rootLifecycle',
     );
   });
+
+  it('should throw when providing a plugin metadata service implementation', () => {
+    expect(() =>
+      createBackend({
+        services: [
+          createServiceFactory({
+            service: coreServices.pluginMetadata,
+            deps: {},
+            factory: async () => async () => ({ getId: () => 'test' }),
+          }),
+        ],
+      }),
+    ).toThrow('The core.plugin-metadata service cannot be overridden');
+  });
 });

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { createBackend } from './CreateBackend';
+
+describe('createBackend', () => {
+  it('should not throw when overriding a default service implementation', () => {
+    expect(() =>
+      createBackend({
+        services: [
+          createServiceFactory({
+            service: coreServices.rootLifecycle,
+            deps: {},
+            factory: async () => ({ addShutdownHook: () => {} }),
+          }),
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it('should throw on duplicate service implementations', () => {
+    expect(() =>
+      createBackend({
+        services: [
+          createServiceFactory({
+            service: coreServices.rootLifecycle,
+            deps: {},
+            factory: async () => ({ addShutdownHook: () => {} }),
+          }),
+          createServiceFactory({
+            service: coreServices.rootLifecycle,
+            deps: {},
+            factory: async () => ({ addShutdownHook: () => {} }),
+          }),
+        ],
+      }),
+    ).toThrow(
+      'Duplicate service implementations provided for core.rootLifecycle',
+    );
+  });
+});

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -35,20 +35,20 @@ import {
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 
 export const defaultServiceFactories = [
-  cacheFactory,
-  configFactory,
-  databaseFactory,
-  discoveryFactory,
-  loggerFactory,
-  rootLoggerFactory,
-  permissionsFactory,
-  schedulerFactory,
-  tokenManagerFactory,
-  urlReaderFactory,
-  httpRouterFactory,
-  rootHttpRouterFactory,
-  lifecycleFactory,
-  rootLifecycleFactory,
+  cacheFactory(),
+  configFactory(),
+  databaseFactory(),
+  discoveryFactory(),
+  loggerFactory(),
+  rootLoggerFactory(),
+  permissionsFactory(),
+  schedulerFactory(),
+  tokenManagerFactory(),
+  urlReaderFactory(),
+  httpRouterFactory(),
+  rootHttpRouterFactory(),
+  lifecycleFactory(),
+  rootLifecycleFactory(),
 ];
 
 /**
@@ -62,7 +62,15 @@ export interface CreateBackendOptions {
  * @public
  */
 export function createBackend(options?: CreateBackendOptions): Backend {
+  const providedServices = (options?.services ?? []).map(sf =>
+    typeof sf === 'function' ? sf() : sf,
+  );
+  const providedIds = new Set(providedServices.map(sf => sf.service.id));
+  const neededDefaultFactories = defaultServiceFactories.filter(
+    sf => !providedIds.has(sf.service.id),
+  );
+
   return createSpecializedBackend({
-    services: [...defaultServiceFactories, ...(options?.services ?? [])],
+    services: [...neededDefaultFactories, ...providedServices],
   });
 }

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
@@ -64,33 +64,34 @@ describe('TestBackend', () => {
     const extensionPoint3 = createExtensionPoint<Obj>({ id: 'b3' });
     const extensionPoint4 = createExtensionPoint<Obj>({ id: 'b4' });
     const extensionPoint5 = createExtensionPoint<Obj>({ id: 'b5' });
-    await startTestBackend({
-      services: [
-        // @ts-expect-error
-        [extensionPoint1, { a: 'a' }],
-        [serviceRef, { a: 'a' }],
-        [serviceRef, { a: 'a', b: 'b' }],
-        // @ts-expect-error
-        [serviceRef, { c: 'c' }],
-        // @ts-expect-error
-        [serviceRef, { a: 'a', c: 'c' }],
-        // @ts-expect-error
-        [serviceRef, { a: 'a', b: 'b', c: 'c' }],
-      ],
-      extensionPoints: [
-        // @ts-expect-error
-        [serviceRef, { a: 'a' }],
-        [extensionPoint1, { a: 'a' }],
-        [extensionPoint2, { a: 'a', b: 'b' }],
-        // @ts-expect-error
-        [extensionPoint3, { c: 'c' }],
-        // @ts-expect-error
-        [extensionPoint4, { a: 'a', c: 'c' }],
-        // @ts-expect-error
-        [extensionPoint5, { a: 'a', b: 'b', c: 'c' }],
-      ],
-    });
-    expect(1).toBe(1);
+    await expect(
+      startTestBackend({
+        services: [
+          // @ts-expect-error
+          [extensionPoint1, { a: 'a' }],
+          [serviceRef, { a: 'a' }],
+          [serviceRef, { a: 'a', b: 'b' }],
+          // @ts-expect-error
+          [serviceRef, { c: 'c' }],
+          // @ts-expect-error
+          [serviceRef, { a: 'a', c: 'c' }],
+          // @ts-expect-error
+          [serviceRef, { a: 'a', b: 'b', c: 'c' }],
+        ],
+        extensionPoints: [
+          // @ts-expect-error
+          [serviceRef, { a: 'a' }],
+          [extensionPoint1, { a: 'a' }],
+          [extensionPoint2, { a: 'a', b: 'b' }],
+          // @ts-expect-error
+          [extensionPoint3, { c: 'c' }],
+          // @ts-expect-error
+          [extensionPoint4, { a: 'a', c: 'c' }],
+          // @ts-expect-error
+          [extensionPoint5, { a: 'a', b: 'b', c: 'c' }],
+        ],
+      }),
+    ).rejects.toThrow();
   });
 
   it('should start the test backend', async () => {

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -93,11 +93,14 @@ export async function startTestBackend<
         factory: async () => impl,
       })();
     }
+    if (typeof serviceDef === 'function') {
+      return serviceDef();
+    }
     return serviceDef as ServiceFactory;
   });
 
   for (const factory of defaultServiceFactories) {
-    if (!factories.some(f => f.service === factory.service)) {
+    if (!factories.some(f => f.service.id === factory.service.id)) {
       factories.push(factory);
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #13082, this adds errors for duplicate service implementations and trying to override the plugin metadata service.

I also switched the `ServiceRegistry` input to be plain factories, since that's how all the code was set up anyway

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
