### PR TITLE
backend-plugin-api: doc cleanup for create methods

### DIFF
--- a/.changeset/wicked-bottles-itch.md
+++ b/.changeset/wicked-bottles-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Updates all `create*` methods to simplify their type definitions and ensure they all have configuration interfaces.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -111,28 +111,19 @@ export namespace coreServices {
 }
 
 // @public
-export function createBackendModule<
-  TOptions extends object | undefined = undefined,
->(
+export function createBackendModule<TOptions extends MaybeOptions = undefined>(
   config: BackendModuleConfig<TOptions>,
-): undefined extends TOptions
-  ? (options?: TOptions) => BackendFeature
-  : (options: TOptions) => BackendFeature;
+): FactoryFunctionWithOptions<BackendFeature, TOptions>;
 
 // @public (undocumented)
-export function createBackendPlugin<
-  TOptions extends object | undefined = undefined,
->(config: {
-  id: string;
-  register(reg: BackendRegistrationPoints, options: TOptions): void;
-}): undefined extends TOptions
-  ? (options?: TOptions) => BackendFeature
-  : (options: TOptions) => BackendFeature;
+export function createBackendPlugin<TOptions extends MaybeOptions = undefined>(
+  config: BackendPluginConfig<TOptions>,
+): FactoryFunctionWithOptions<BackendFeature, TOptions>;
 
 // @public (undocumented)
-export function createExtensionPoint<T>(options: {
-  id: string;
-}): ExtensionPoint<T>;
+export function createExtensionPoint<T>(
+  config: ExtensionPointConfig,
+): ExtensionPoint<T>;
 
 // @public (undocumented)
 export function createServiceFactory<
@@ -142,37 +133,20 @@ export function createServiceFactory<
   TDeps extends {
     [name in string]: ServiceRef<unknown>;
   },
-  TOpts extends object | undefined = undefined,
->(config: {
-  service: ServiceRef<TService, TScope>;
-  deps: TDeps;
-  factory(
-    deps: ServiceRefsToInstances<TDeps, 'root'>,
-    options: TOpts,
-  ): TScope extends 'root'
-    ? Promise<TImpl>
-    : Promise<(deps: ServiceRefsToInstances<TDeps>) => Promise<TImpl>>;
-}): undefined extends TOpts
-  ? (options?: TOpts) => ServiceFactory<TService>
-  : (options: TOpts) => ServiceFactory<TService>;
+  TOpts extends MaybeOptions = undefined,
+>(
+  config: ServiceFactoryConfig<TService, TScope, TImpl, TDeps, TOpts>,
+): FactoryFunctionWithOptions<ServiceFactory<TService>, TOpts>;
 
-// @public (undocumented)
-export function createServiceRef<T>(options: {
-  id: string;
-  scope?: 'plugin';
-  defaultFactory?: (
-    service: ServiceRef<T, 'plugin'>,
-  ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>;
-}): ServiceRef<T, 'plugin'>;
+// @public
+export function createServiceRef<TService>(
+  config: ServiceRefConfig<TService, 'plugin'>,
+): ServiceRef<TService, 'plugin'>;
 
-// @public (undocumented)
-export function createServiceRef<T>(options: {
-  id: string;
-  scope: 'root';
-  defaultFactory?: (
-    service: ServiceRef<T, 'root'>,
-  ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>;
-}): ServiceRef<T, 'root'>;
+// @public
+export function createServiceRef<TService>(
+  config: ServiceRefConfig<TService, 'root'>,
+): ServiceRef<TService, 'root'>;
 
 // @public
 export interface DatabaseService {
@@ -195,6 +169,12 @@ export type ExtensionPoint<T> = {
   toString(): string;
   $$ref: 'extension-point';
 };
+
+// @public (undocumented)
+export interface ExtensionPointConfig {
+  // (undocumented)
+  id: string;
+}
 
 // @public (undocumented)
 export interface HttpRouterService {
@@ -344,6 +324,29 @@ export type ServiceFactory<TService = unknown> =
       >;
     };
 
+// @public (undocumented)
+export interface ServiceFactoryConfig<
+  TService,
+  TScope extends 'root' | 'plugin',
+  TImpl extends TService,
+  TDeps extends {
+    [name in string]: ServiceRef<unknown>;
+  },
+  TOpts extends MaybeOptions = undefined,
+> {
+  // (undocumented)
+  deps: TDeps;
+  // (undocumented)
+  factory(
+    deps: ServiceRefsToInstances<TDeps, 'root'>,
+    options: TOpts,
+  ): TScope extends 'root'
+    ? Promise<TImpl>
+    : Promise<(deps: ServiceRefsToInstances<TDeps>) => Promise<TImpl>>;
+  // (undocumented)
+  service: ServiceRef<TService, TScope>;
+}
+
 // @public
 export type ServiceRef<
   TService,
@@ -355,6 +358,18 @@ export type ServiceRef<
   toString(): string;
   $$ref: 'service';
 };
+
+// @public (undocumented)
+export interface ServiceRefConfig<TService, TScope extends 'root' | 'plugin'> {
+  // (undocumented)
+  defaultFactory?: (
+    service: ServiceRef<TService, TScope>,
+  ) => Promise<ServiceFactory<TService> | (() => ServiceFactory<TService>)>;
+  // (undocumented)
+  id: string;
+  // (undocumented)
+  scope?: TScope;
+}
 
 // @public
 export interface TokenManagerService {

--- a/packages/backend-plugin-api/src/services/system/index.ts
+++ b/packages/backend-plugin-api/src/services/system/index.ts
@@ -14,5 +14,10 @@
  * limitations under the License.
  */
 
-export type { ServiceRef, TypesToServiceRef, ServiceFactory } from './types';
+export type {
+  ServiceRef,
+  TypesToServiceRef,
+  ServiceFactory,
+  ServiceFactoryConfig,
+} from './types';
 export { createServiceRef, createServiceFactory } from './types';

--- a/packages/backend-plugin-api/src/services/system/index.ts
+++ b/packages/backend-plugin-api/src/services/system/index.ts
@@ -16,6 +16,7 @@
 
 export type {
   ServiceRef,
+  ServiceRefConfig,
   TypesToServiceRef,
   ServiceFactory,
   ServiceFactoryConfig,

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -72,48 +72,50 @@ export type ServiceFactory<TService = unknown> =
     };
 
 /** @public */
-export function createServiceRef<T>(options: {
+export interface ServiceRefConfig<TService, TScope extends 'root' | 'plugin'> {
   id: string;
-  scope?: 'plugin';
+  scope?: TScope;
   defaultFactory?: (
-    service: ServiceRef<T, 'plugin'>,
-  ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>;
-}): ServiceRef<T, 'plugin'>;
-/** @public */
-export function createServiceRef<T>(options: {
-  id: string;
-  scope: 'root';
-  defaultFactory?: (
-    service: ServiceRef<T, 'root'>,
-  ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>;
-}): ServiceRef<T, 'root'>;
-export function createServiceRef<T>(options: {
-  id: string;
-  scope?: 'plugin' | 'root';
-  defaultFactory?:
-    | ((
-        service: ServiceRef<T, 'plugin'>,
-      ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>)
-    | ((
-        service: ServiceRef<T, 'root'>,
-      ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>);
-}): ServiceRef<T> {
-  const { id, scope = 'plugin', defaultFactory } = options;
+    service: ServiceRef<TService, TScope>,
+  ) => Promise<ServiceFactory<TService> | (() => ServiceFactory<TService>)>;
+}
+
+/**
+ * Creates a new service definition. This overload is used to create plugin scoped services.
+ *
+ * @public
+ */
+export function createServiceRef<TService>(
+  config: ServiceRefConfig<TService, 'plugin'>,
+): ServiceRef<TService, 'plugin'>;
+
+/**
+ * Creates a new service definition. This overload is used to create root scoped services.
+ *
+ * @public
+ */
+export function createServiceRef<TService>(
+  config: ServiceRefConfig<TService, 'root'>,
+): ServiceRef<TService, 'root'>;
+export function createServiceRef<TService>(
+  config: ServiceRefConfig<TService, any>,
+): ServiceRef<TService, any> {
+  const { id, scope = 'plugin', defaultFactory } = config;
   return {
     id,
     scope,
-    get T(): T {
+    get T(): TService {
       throw new Error(`tried to read ServiceRef.T of ${this}`);
     },
     toString() {
-      return `serviceRef{${options.id}}`;
+      return `serviceRef{${config.id}}`;
     },
     $$ref: 'service', // TODO: declare
     __defaultFactory: defaultFactory,
-  } as ServiceRef<T, typeof scope> & {
+  } as ServiceRef<TService, typeof scope> & {
     __defaultFactory?: (
-      service: ServiceRef<T>,
-    ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>;
+      service: ServiceRef<TService>,
+    ) => Promise<ServiceFactory<TService> | (() => ServiceFactory<TService>)>;
   };
 }
 

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { FactoryFunctionWithOptions, MaybeOptions } from '../../types';
+
 /**
  * TODO
  *
@@ -125,16 +127,14 @@ type ServiceRefsToInstances<
   }[keyof T]]: T[name] extends ServiceRef<infer TImpl> ? TImpl : never;
 };
 
-/**
- * @public
- */
-export function createServiceFactory<
+/** @public */
+export interface ServiceFactoryConfig<
   TService,
   TScope extends 'root' | 'plugin',
   TImpl extends TService,
   TDeps extends { [name in string]: ServiceRef<unknown> },
-  TOpts extends object | undefined = undefined,
->(config: {
+  TOpts extends MaybeOptions = undefined,
+> {
   service: ServiceRef<TService, TScope>;
   deps: TDeps;
   factory(
@@ -143,9 +143,20 @@ export function createServiceFactory<
   ): TScope extends 'root'
     ? Promise<TImpl>
     : Promise<(deps: ServiceRefsToInstances<TDeps>) => Promise<TImpl>>;
-}): undefined extends TOpts
-  ? (options?: TOpts) => ServiceFactory<TService>
-  : (options: TOpts) => ServiceFactory<TService> {
+}
+
+/**
+ * @public
+ */
+export function createServiceFactory<
+  TService,
+  TScope extends 'root' | 'plugin',
+  TImpl extends TService,
+  TDeps extends { [name in string]: ServiceRef<unknown> },
+  TOpts extends MaybeOptions = undefined,
+>(
+  config: ServiceFactoryConfig<TService, TScope, TImpl, TDeps, TOpts>,
+): FactoryFunctionWithOptions<ServiceFactory<TService>, TOpts> {
   return (options?: TOpts) =>
     ({
       scope: config.service.scope,

--- a/packages/backend-plugin-api/src/types.ts
+++ b/packages/backend-plugin-api/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-export type {
-  BackendModuleConfig,
-  BackendPluginConfig,
-  ExtensionPointConfig,
-} from './factories';
-export {
-  createBackendModule,
-  createBackendPlugin,
-  createExtensionPoint,
-} from './factories';
-export type {
-  BackendRegistrationPoints,
-  BackendFeature,
-  ExtensionPoint,
-} from './types';
+/**
+ * Base type for options objects that aren't required.
+ *
+ * @internal
+ * @ignore
+ */
+export type MaybeOptions = object | undefined;
+
+/**
+ * Helper type that makes the options argument optional if options are not required.
+ *
+ * @internal
+ * @ignore
+ */
+export type FactoryFunctionWithOptions<TResult, TOptions> =
+  undefined extends TOptions
+    ? (options?: TOptions) => TResult
+    : (options: TOptions) => TResult;

--- a/packages/backend-plugin-api/src/types.ts
+++ b/packages/backend-plugin-api/src/types.ts
@@ -17,7 +17,6 @@
 /**
  * Base type for options objects that aren't required.
  *
- * @internal
  * @ignore
  */
 export type MaybeOptions = object | undefined;
@@ -25,7 +24,6 @@ export type MaybeOptions = object | undefined;
 /**
  * Helper type that makes the options argument optional if options are not required.
  *
- * @internal
  * @ignore
  */
 export type FactoryFunctionWithOptions<TResult, TOptions> =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #13082, cleaning up the type definitions to make them show up nicer in the docs.

This part makes sure there are config interfaces for all `create*` methods and simplifies their return type with the new `FactoryFunctionWithOptions` helper.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
