### PR TITLE
Swagger plugins annotations

### DIFF
--- a/.changeset/olive-onions-unite.md
+++ b/.changeset/olive-onions-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Added annotation functionality to disable the try-it and / or the authroize buttons on the Swagger page of an API (OAS)

--- a/.changeset/olive-onions-unite.md
+++ b/.changeset/olive-onions-unite.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-Added annotation functionality to disable the try-it and / or the authroize buttons on the Swagger page of an API (OAS)
+Added annotation functionality to disable the try-it and / or the authorize buttons on the Swagger page of an API (OAS)

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -131,6 +131,25 @@ repository itself. If the URL points to a folder, it is important that it is
 suffixed with a `'/'` in order for relative path resolution to work
 consistently.
 
+### backstage.io/disableTryItOut, backstage.io/disableAuthorizeButton
+
+```yaml
+# Example:
+metadata:
+  annotations:
+    backstage.io/disableTryItOut: 'true'
+    backstage.io/disableAuthorizeButton: 'true'
+```
+
+These annotations allow customizing some of the Swagger options from an API Entity.
+Certain API's have the need to disable some of the options that the Swagger page offers,
+and these annotations provide the API the full flexibility of having the choice of whether
+or not to disable the try-it button (which normally allows predefined calls to the API
+from the Swagger page) and disabling the Authorize button (which provides the authorization
+needed to call the API). This can be especially useful for API's that hold production data.
+
+These annotations are only needed when their values should be true, as the default is false.
+
 ### jenkins.io/job-full-name
 
 ```yaml

--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -35,9 +35,15 @@ $ yarn install  # fetch dependency packages - may take a while
 $ yarn tsc      # does a first run of type generation and checks
 ```
 
-If yarn install does not complete, you might need to download some of the dependencies.
-The best way to find out which dependencies are missing is by looking through the logs
-of the yarn install, and finding which dependency is missing.
+If yarn install does not complete, you might need to download some the following dependencies
+(list is of common missing dependencies, it is not exhaustive):
+
+```
+pixman
+cairo
+pango
+canvas (npm dependency)
+```
 
 ## Serving the Example App
 

--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -36,7 +36,7 @@ $ yarn tsc      # does a first run of type generation and checks
 ```
 
 If yarn install does not complete, you might need to download some of the dependencies.
-The best way to find out which depenencies are missing is by looking through the logs
+The best way to find out which dependencies are missing is by looking through the logs
 of the yarn install, and finding which dependency is missing.
 
 ## Serving the Example App

--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -35,12 +35,9 @@ $ yarn install  # fetch dependency packages - may take a while
 $ yarn tsc      # does a first run of type generation and checks
 ```
 
-If yarn install does not complete, you might need to download the following dependencies
-(list is of common missing dependencies, it is not exhaustive)
-pixman
-cairo
-pango
-canvas (npm dependency)
+If yarn install does not complete, you might need to download some of the dependencies.
+The best way to find out which depenencies are missing is by looking through the logs
+of the yarn install, and finding which dependency is missing.
 
 ## Serving the Example App
 

--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -35,6 +35,13 @@ $ yarn install  # fetch dependency packages - may take a while
 $ yarn tsc      # does a first run of type generation and checks
 ```
 
+If yarn install does not complete, you might need to download the following dependencies
+(list is of common missing dependencies, it is not exhaustive)
+pixman
+cairo
+pango
+canvas (npm dependency)
+
 ## Serving the Example App
 
 Open a terminal window and start the web app by using the following command from

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -41,12 +41,7 @@ export const ApiDefinitionCard = () => {
     return (
       <TabbedCard title={entityTitle}>
         <CardTab label={definitionWidget.title} key="widget">
-          {definitionWidget.component(
-            entity.spec.definition,
-            (
-              (entity.metadata?.annotations?.swaggerPlugins as string) ?? ''
-            )?.split(','),
-          )}
+          {definitionWidget.component(entity.spec.definition, entity)}
         </CardTab>
         <CardTab label="Raw" key="raw">
           <PlainApiDefinitionWidget

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -41,7 +41,12 @@ export const ApiDefinitionCard = () => {
     return (
       <TabbedCard title={entityTitle}>
         <CardTab label={definitionWidget.title} key="widget">
-          {definitionWidget.component(entity.spec.definition)}
+          {definitionWidget.component(
+            entity.spec.definition,
+            (
+              (entity.metadata?.annotations?.swaggerPlugins as string) ?? ''
+            )?.split(','),
+          )}
         </CardTab>
         <CardTab label="Raw" key="raw">
           <PlainApiDefinitionWidget

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
@@ -23,7 +23,10 @@ import { GrpcApiDefinitionWidget } from '../GrpcApiDefinitionWidget';
 export type ApiDefinitionWidget = {
   type: string;
   title: string;
-  component: (definition: string) => React.ReactElement;
+  component: (
+    definition: string,
+    swaggerPlugins?: string[] | undefined,
+  ) => React.ReactElement;
   rawLanguage?: string;
 };
 
@@ -34,8 +37,11 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       type: 'openapi',
       title: 'OpenAPI',
       rawLanguage: 'yaml',
-      component: definition => (
-        <OpenApiDefinitionWidget definition={definition} />
+      component: (definition, swaggerPlugins) => (
+        <OpenApiDefinitionWidget
+          definition={definition}
+          plugins={swaggerPlugins}
+        />
       ),
     },
     {

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
@@ -18,6 +18,7 @@ import { AsyncApiDefinitionWidget } from '../AsyncApiDefinitionWidget';
 import { GraphQlDefinitionWidget } from '../GraphQlDefinitionWidget';
 import { OpenApiDefinitionWidget } from '../OpenApiDefinitionWidget';
 import { GrpcApiDefinitionWidget } from '../GrpcApiDefinitionWidget';
+import { Entity } from '@backstage/catalog-model';
 
 /** @public */
 export type ApiDefinitionWidget = {
@@ -25,7 +26,7 @@ export type ApiDefinitionWidget = {
   title: string;
   component: (
     definition: string,
-    swaggerPlugins?: string[] | undefined,
+    entity?: Entity | undefined,
   ) => React.ReactElement;
   rawLanguage?: string;
 };
@@ -37,11 +38,8 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       type: 'openapi',
       title: 'OpenAPI',
       rawLanguage: 'yaml',
-      component: (definition, swaggerPlugins) => (
-        <OpenApiDefinitionWidget
-          definition={definition}
-          plugins={swaggerPlugins}
-        />
+      component: (definition, entity) => (
+        <OpenApiDefinitionWidget definition={definition} entity={entity} />
       ),
     },
     {

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -183,7 +183,7 @@ export const OpenApiDefinition = ({
   // isolate the entity annotations that are supportedSwaggerPlugins AND are set to true
   // then setup the values needed by the SwaggerUI
   const appliedSwaggerPlugins = Object.keys(supportedSwaggerPlugins)
-    ?.filter(key => entity?.metadata?.annotations?.[key] === 'true')
+    ?.filter(plugin => entity?.metadata?.annotations?.[plugin] === 'true')
     ?.map(plugin => supportedSwaggerPlugins[plugin]);
 
   return (

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -28,6 +28,7 @@ const LazyOpenApiDefinition = React.lazy(() =>
 /** @public */
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
+  plugins?: string[];
 };
 
 /** @public */

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Entity } from '@backstage/catalog-model';
 import { Progress } from '@backstage/core-components';
 import React, { Suspense } from 'react';
 
@@ -28,7 +29,7 @@ const LazyOpenApiDefinition = React.lazy(() =>
 /** @public */
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
-  plugins?: string[];
+  entity?: Entity;
 };
 
 /** @public */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PR associated with this https://github.com/backstage/backstage/issues/14824.

Originally was trying to allow the passing of a generic object containing any Swagger plugin to the UI for better customization. Due to the typing of the entity and the additions to the plugin, the approach was pivoted use the annotations instead. This PR leverages an annotation of API entities containing the names of the plugins for the Swagger UI. Specific plugin functionality can be implemented, however in this PR, the ability to disable the try it out and authorize buttons in the Swagger UI for an API (using the API plugin) were implemented.

Will loop back to add tests and changesets etc if the maintainers agree with this approach :).

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
