### PR TITLE
Migrate Cache and Database types into backend-plugin-api

### DIFF
--- a/.changeset/nasty-pumas-kneel.md
+++ b/.changeset/nasty-pumas-kneel.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-common': patch
+---
+
+Migrated types related to `CacheService` and `DatabaseService` into backend-plugin-api.

--- a/.changeset/nasty-pumas-kneel.md
+++ b/.changeset/nasty-pumas-kneel.md
@@ -3,4 +3,4 @@
 '@backstage/backend-common': patch
 ---
 
-Migrated types related to `CacheService` and `DatabaseService` into backend-plugin-api.
+Migrated types related to `TokenManagerService`, `CacheService` and `DatabaseService` into backend-plugin-api.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -4,14 +4,14 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { CacheService } from '@backstage/backend-plugin-api';
 import { ConfigService } from '@backstage/backend-plugin-api';
-import { DatabaseService } from '@backstage/backend-plugin-api';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { PermissionsService } from '@backstage/backend-plugin-api';
+import { PluginCacheManager } from '@backstage/backend-common';
+import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { RootLoggerService } from '@backstage/backend-plugin-api';
@@ -34,7 +34,7 @@ export interface Backend {
 // @public (undocumented)
 export const cacheFactory: (
   options?: undefined,
-) => ServiceFactory<CacheService>;
+) => ServiceFactory<PluginCacheManager>;
 
 // @public (undocumented)
 export const configFactory: (
@@ -55,7 +55,7 @@ export interface CreateSpecializedBackendOptions {
 // @public (undocumented)
 export const databaseFactory: (
   options?: undefined,
-) => ServiceFactory<DatabaseService>;
+) => ServiceFactory<PluginDatabaseManager>;
 
 // @public (undocumented)
 export const discoveryFactory: (

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -51,11 +51,8 @@ import { SearchOptions } from '@backstage/backend-plugin-api';
 import { SearchResponse } from '@backstage/backend-plugin-api';
 import { SearchResponseFile } from '@backstage/backend-plugin-api';
 import { Server } from 'http';
-<<<<<<< HEAD
-import { TransportStreamOptions } from 'winston-transport';
-=======
 import { TokenManagerService as TokenManager } from '@backstage/backend-plugin-api';
->>>>>>> 24636656b5 (Migrate TokenManager types)
+import { TransportStreamOptions } from 'winston-transport';
 import { UrlReaderService as UrlReader } from '@backstage/backend-plugin-api';
 import { V1PodTemplateSpec } from '@kubernetes/client-node';
 import * as winston from 'winston';

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -12,6 +12,9 @@ import { AzureIntegration } from '@backstage/integration';
 import { BitbucketCloudIntegration } from '@backstage/integration';
 import { BitbucketIntegration } from '@backstage/integration';
 import { BitbucketServerIntegration } from '@backstage/integration';
+import { CacheClient } from '@backstage/backend-plugin-api';
+import { CacheClientOptions } from '@backstage/backend-plugin-api';
+import { CacheClientSetOptions } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import cors from 'cors';
 import Docker from 'dockerode';
@@ -24,13 +27,14 @@ import { GithubCredentialsProvider } from '@backstage/integration';
 import { GithubIntegration } from '@backstage/integration';
 import { GitLabIntegration } from '@backstage/integration';
 import { isChildPath } from '@backstage/cli-common';
-import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
 import { KubeConfig } from '@kubernetes/client-node';
 import { LoadConfigOptionsRemote } from '@backstage/config-loader';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { MergeResult } from 'isomorphic-git';
+import { CacheService as PluginCacheManager } from '@backstage/backend-plugin-api';
+import { DatabaseService as PluginDatabaseManager } from '@backstage/backend-plugin-api';
 import { DiscoveryService as PluginEndpointDiscovery } from '@backstage/backend-plugin-api';
 import { PushResult } from 'isomorphic-git';
 import { Readable } from 'stream';
@@ -165,26 +169,11 @@ export class BitbucketUrlReader implements UrlReader {
   toString(): string;
 }
 
-// @public
-export interface CacheClient {
-  delete(key: string): Promise<void>;
-  get(key: string): Promise<JsonValue | undefined>;
-  set(
-    key: string,
-    value: JsonValue,
-    options?: CacheClientSetOptions,
-  ): Promise<void>;
-}
+export { CacheClient };
 
-// @public
-export type CacheClientOptions = {
-  defaultTtl?: number;
-};
+export { CacheClientOptions };
 
-// @public
-export type CacheClientSetOptions = {
-  ttl?: number;
-};
+export { CacheClientSetOptions };
 
 // @public
 export class CacheManager {
@@ -526,18 +515,9 @@ export function loggerToWinstonLogger(
 // @public
 export function notFoundHandler(): RequestHandler;
 
-// @public
-export type PluginCacheManager = {
-  getClient: (options?: CacheClientOptions) => CacheClient;
-};
+export { PluginCacheManager };
 
-// @public
-export interface PluginDatabaseManager {
-  getClient(): Promise<Knex>;
-  migrations?: {
-    skip?: boolean;
-  };
-}
+export { PluginDatabaseManager };
 
 export { PluginEndpointDiscovery };
 

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -51,7 +51,11 @@ import { SearchOptions } from '@backstage/backend-plugin-api';
 import { SearchResponse } from '@backstage/backend-plugin-api';
 import { SearchResponseFile } from '@backstage/backend-plugin-api';
 import { Server } from 'http';
+<<<<<<< HEAD
 import { TransportStreamOptions } from 'winston-transport';
+=======
+import { TokenManagerService as TokenManager } from '@backstage/backend-plugin-api';
+>>>>>>> 24636656b5 (Migrate TokenManager types)
 import { UrlReaderService as UrlReader } from '@backstage/backend-plugin-api';
 import { V1PodTemplateSpec } from '@kubernetes/client-node';
 import * as winston from 'winston';
@@ -698,13 +702,7 @@ export interface StatusCheckHandlerOptions {
   statusCheck?: StatusCheck;
 }
 
-// @public
-export interface TokenManager {
-  authenticate(token: string): Promise<void>;
-  getToken(): Promise<{
-    token: string;
-  }>;
-}
+export { TokenManager };
 
 export { UrlReader };
 

--- a/packages/backend-common/src/cache/CacheClient.ts
+++ b/packages/backend-common/src/cache/CacheClient.ts
@@ -14,56 +14,22 @@
  * limitations under the License.
  */
 
+import {
+  CacheClient,
+  CacheClientSetOptions,
+} from '@backstage/backend-plugin-api';
 import { JsonValue } from '@backstage/types';
 import { createHash } from 'crypto';
 import Keyv from 'keyv';
 
+export type {
+  CacheClient,
+  CacheClientSetOptions,
+} from '@backstage/backend-plugin-api';
+
 type CacheClientArgs = {
   client: Keyv;
 };
-
-/**
- * Options passed to {@link CacheClient.set}.
- *
- * @public
- */
-export type CacheClientSetOptions = {
-  /**
-   * Optional TTL in milliseconds. Defaults to the TTL provided when the client
-   * was set up (or no TTL if none are provided).
-   */
-  ttl?: number;
-};
-
-/**
- * A pre-configured, storage agnostic cache client suitable for use by
- * Backstage plugins.
- *
- * @public
- */
-export interface CacheClient {
-  /**
-   * Reads data from a cache store for the given key. If no data was found,
-   * returns undefined.
-   */
-  get(key: string): Promise<JsonValue | undefined>;
-
-  /**
-   * Writes the given data to a cache store, associated with the given key. An
-   * optional TTL may also be provided, otherwise it defaults to the TTL that
-   * was provided when the client was instantiated.
-   */
-  set(
-    key: string,
-    value: JsonValue,
-    options?: CacheClientSetOptions,
-  ): Promise<void>;
-
-  /**
-   * Removes the given key from the cache store.
-   */
-  delete(key: string): Promise<void>;
-}
 
 /**
  * A basic, concrete implementation of the CacheClient, suitable for almost

--- a/packages/backend-common/src/cache/types.ts
+++ b/packages/backend-common/src/cache/types.ts
@@ -15,21 +15,11 @@
  */
 
 import { Logger } from 'winston';
-import { CacheClient } from './CacheClient';
 
-/**
- * Options given when constructing a {@link CacheClient}.
- *
- * @public
- */
-export type CacheClientOptions = {
-  /**
-   * An optional default TTL (in milliseconds) to be set when getting a client
-   * instance. If not provided, data will persist indefinitely by default (or
-   * can be configured per entry at set-time).
-   */
-  defaultTtl?: number;
-};
+export type {
+  CacheService as PluginCacheManager,
+  CacheClientOptions,
+} from '@backstage/backend-plugin-api';
 
 /**
  * Options given when constructing a {@link CacheManager}.
@@ -47,22 +37,4 @@ export type CacheManagerOptions = {
    * store.
    */
   onError?: (err: Error) => void;
-};
-
-/**
- * Manages access to cache stores that plugins get.
- *
- * @public
- */
-export type PluginCacheManager = {
-  /**
-   * Provides backend plugins cache connections for themselves.
-   *
-   * @remarks
-   *
-   * The purpose of this method is to allow plugins to get isolated data stores
-   * so that plugins are discouraged from cache-level integration and/or cache
-   * key collisions.
-   */
-  getClient: (options?: CacheClientOptions) => CacheClient;
 };

--- a/packages/backend-common/src/database/types.ts
+++ b/packages/backend-common/src/database/types.ts
@@ -17,32 +17,7 @@
 import { Config } from '@backstage/config';
 import { Knex } from 'knex';
 
-/**
- * The PluginDatabaseManager manages access to databases that Plugins get.
- *
- * @public
- */
-export interface PluginDatabaseManager {
-  /**
-   * getClient provides backend plugins database connections for itself.
-   *
-   * The purpose of this method is to allow plugins to get isolated data
-   * stores so that plugins are discouraged from database integration.
-   */
-  getClient(): Promise<Knex>;
-
-  /**
-   * This property is used to control the behavior of database migrations.
-   */
-  migrations?: {
-    /**
-     * skip database migrations. Useful if connecting to a read-only database.
-     *
-     * @defaultValue false
-     */
-    skip?: boolean;
-  };
-}
+export type { DatabaseService as PluginDatabaseManager } from '@backstage/backend-plugin-api';
 
 /**
  * DatabaseConnector manages an underlying Knex database driver.

--- a/packages/backend-common/src/tokens/types.ts
+++ b/packages/backend-common/src/tokens/types.ts
@@ -14,26 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * Interface for creating and validating tokens.
- *
- * @public
- */
-export interface TokenManager {
-  /**
-   * Fetches a valid token.
-   *
-   * @remarks
-   *
-   * Tokens are valid for roughly one hour; the actual deadline is set in the
-   * payload `exp` claim. Never hold on to tokens for reuse; always ask for a
-   * new one for each outgoing request. This ensures that you always get a
-   * valid, fresh one.
-   */
-  getToken(): Promise<{ token: string }>;
-
-  /**
-   * Validates a given token.
-   */
-  authenticate(token: string): Promise<void>;
-}
+export type { TokenManagerService as TokenManager } from '@backstage/backend-plugin-api';

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -12,7 +12,11 @@ import { PluginCacheManager } from '@backstage/backend-common';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Readable } from 'stream';
+<<<<<<< HEAD
 import { TokenManager } from '@backstage/backend-common';
+=======
+import { TransportStreamOptions } from 'winston-transport';
+>>>>>>> 24636656b5 (Migrate TokenManager types)
 
 // @public (undocumented)
 export interface BackendFeature {
@@ -323,8 +327,13 @@ export type ServiceRef<
   $$ref: 'service';
 };
 
-// @public (undocumented)
-export interface TokenManagerService extends TokenManager {}
+// @public
+export interface TokenManagerService {
+  authenticate(token: string): Promise<void>;
+  getToken(): Promise<{
+    token: string;
+  }>;
+}
 
 // @public (undocumented)
 export type TypesToServiceRef<T> = {

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -7,16 +7,11 @@
 
 import { Config } from '@backstage/config';
 import { Handler } from 'express';
+import { JsonValue } from '@backstage/types';
+import { Knex } from 'knex';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
-import { PluginCacheManager } from '@backstage/backend-common';
-import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Readable } from 'stream';
-<<<<<<< HEAD
-import { TokenManager } from '@backstage/backend-common';
-=======
-import { TransportStreamOptions } from 'winston-transport';
->>>>>>> 24636656b5 (Migrate TokenManager types)
 
 // @public (undocumented)
 export interface BackendFeature {
@@ -67,8 +62,31 @@ export interface BackendRegistrationPoints {
   }): void;
 }
 
-// @public (undocumented)
-export interface CacheService extends PluginCacheManager {}
+// @public
+export interface CacheClient {
+  delete(key: string): Promise<void>;
+  get(key: string): Promise<JsonValue | undefined>;
+  set(
+    key: string,
+    value: JsonValue,
+    options?: CacheClientSetOptions,
+  ): Promise<void>;
+}
+
+// @public
+export type CacheClientOptions = {
+  defaultTtl?: number;
+};
+
+// @public
+export type CacheClientSetOptions = {
+  ttl?: number;
+};
+
+// @public
+export interface CacheService {
+  getClient: (options?: CacheClientOptions) => CacheClient;
+}
 
 // @public (undocumented)
 export interface ConfigService extends Config {}
@@ -155,8 +173,13 @@ export function createServiceRef<T>(options: {
   ) => Promise<ServiceFactory<T> | (() => ServiceFactory<T>)>;
 }): ServiceRef<T, 'root'>;
 
-// @public (undocumented)
-export interface DatabaseService extends PluginDatabaseManager {}
+// @public
+export interface DatabaseService {
+  getClient(): Promise<Knex>;
+  migrations?: {
+    skip?: boolean;
+  };
+}
 
 // @public
 export interface DiscoveryService {

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -33,7 +33,6 @@
     "start": "backstage-cli package start"
   },
   "dependencies": {
-    "@backstage/backend-common": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -36,9 +36,11 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@types/express": "^4.17.6",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "knex": "^2.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^"

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -36,8 +36,8 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
     "@backstage/config": "workspace:^",
-    "@backstage/types": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "knex": "^2.0.0"

--- a/packages/backend-plugin-api/src/services/definitions/CacheService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/CacheService.ts
@@ -14,7 +14,79 @@
  * limitations under the License.
  */
 
-import { PluginCacheManager } from '@backstage/backend-common';
+import { JsonValue } from '@backstage/types';
 
-/** @public */
-export interface CacheService extends PluginCacheManager {}
+/**
+ * Manages access to cache stores that plugins get.
+ *
+ * @public
+ */
+export interface CacheService {
+  /**
+   * Provides backend plugins cache connections for themselves.
+   *
+   * @remarks
+   *
+   * The purpose of this method is to allow plugins to get isolated data stores
+   * so that plugins are discouraged from cache-level integration and/or cache
+   * key collisions.
+   */
+  getClient: (options?: CacheClientOptions) => CacheClient;
+}
+
+/**
+ * Options passed to {@link CacheClient.set}.
+ *
+ * @public
+ */
+export type CacheClientSetOptions = {
+  /**
+   * Optional TTL in milliseconds. Defaults to the TTL provided when the client
+   * was set up (or no TTL if none are provided).
+   */
+  ttl?: number;
+};
+
+/**
+ * A pre-configured, storage agnostic cache client suitable for use by
+ * Backstage plugins.
+ *
+ * @public
+ */
+export interface CacheClient {
+  /**
+   * Reads data from a cache store for the given key. If no data was found,
+   * returns undefined.
+   */
+  get(key: string): Promise<JsonValue | undefined>;
+
+  /**
+   * Writes the given data to a cache store, associated with the given key. An
+   * optional TTL may also be provided, otherwise it defaults to the TTL that
+   * was provided when the client was instantiated.
+   */
+  set(
+    key: string,
+    value: JsonValue,
+    options?: CacheClientSetOptions,
+  ): Promise<void>;
+
+  /**
+   * Removes the given key from the cache store.
+   */
+  delete(key: string): Promise<void>;
+}
+
+/**
+ * Options given when constructing a {@link CacheClient}.
+ *
+ * @public
+ */
+export type CacheClientOptions = {
+  /**
+   * An optional default TTL (in milliseconds) to be set when getting a client
+   * instance. If not provided, data will persist indefinitely by default (or
+   * can be configured per entry at set-time).
+   */
+  defaultTtl?: number;
+};

--- a/packages/backend-plugin-api/src/services/definitions/DatabaseService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/DatabaseService.ts
@@ -14,7 +14,31 @@
  * limitations under the License.
  */
 
-import { PluginDatabaseManager } from '@backstage/backend-common';
+import { Knex } from 'knex';
 
-/** @public */
-export interface DatabaseService extends PluginDatabaseManager {}
+/**
+ * The DatabaseService manages access to databases that Plugins get.
+ *gs
+ * @public
+ */
+export interface DatabaseService {
+  /**
+   * getClient provides backend plugins database connections for itself.
+   *
+   * The purpose of this method is to allow plugins to get isolated data
+   * stores so that plugins are discouraged from database integration.
+   */
+  getClient(): Promise<Knex>;
+
+  /**
+   * This property is used to control the behavior of database migrations.
+   */
+  migrations?: {
+    /**
+     * skip database migrations. Useful if connecting to a read-only database.
+     *
+     * @defaultValue false
+     */
+    skip?: boolean;
+  };
+}

--- a/packages/backend-plugin-api/src/services/definitions/TokenManagerService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/TokenManagerService.ts
@@ -14,7 +14,26 @@
  * limitations under the License.
  */
 
-import { TokenManager } from '@backstage/backend-common';
+/**
+ * Interface for creating and validating tokens.
+ *
+ * @public
+ */
+export interface TokenManagerService {
+  /**
+   * Fetches a valid token.
+   *
+   * @remarks
+   *
+   * Tokens are valid for roughly one hour; the actual deadline is set in the
+   * payload `exp` claim. Never hold on to tokens for reuse; always ask for a
+   * new one for each outgoing request. This ensures that you always get a
+   * valid, fresh one.
+   */
+  getToken(): Promise<{ token: string }>;
 
-/** @public */
-export interface TokenManagerService extends TokenManager {}
+  /**
+   * Validates a given token.
+   */
+  authenticate(token: string): Promise<void>;
+}

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -15,7 +15,12 @@
  */
 
 export { coreServices } from './coreServices';
-export type { CacheService } from './CacheService';
+export type {
+  CacheService,
+  CacheClient,
+  CacheClientOptions,
+  CacheClientSetOptions,
+} from './CacheService';
 export type { ConfigService } from './ConfigService';
 export type { DatabaseService } from './DatabaseService';
 export type { DiscoveryService } from './DiscoveryService';

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -7,7 +7,7 @@
 
 import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
 import { BackstageSignInResult } from '@backstage/plugin-auth-node';
-import { CacheClient } from '@backstage/backend-common';
+import { CacheClient } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3491,7 +3491,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/backend-plugin-api@workspace:packages/backend-plugin-api"
   dependencies:
-    "@backstage/backend-common": "workspace:^"
     "@backstage/backend-tasks": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,8 +3496,10 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@types/express": ^4.17.6
     express: ^4.17.1
+    knex: ^2.0.0
   languageName: unknown
   linkType: soft
 
@@ -3566,7 +3568,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/catalog-model@npm:^1.1.2, @backstage/catalog-model@npm:^1.1.3, @backstage/catalog-model@npm:^1.1.4":
+"@backstage/catalog-model@npm:^1.1.2, @backstage/catalog-model@npm:^1.1.4":
   version: 1.1.4
   resolution: "@backstage/catalog-model@npm:1.1.4"
   dependencies:
@@ -3901,7 +3903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:^0.12.0, @backstage/core-components@npm:^0.12.2":
+"@backstage/core-components@npm:^0.12.2":
   version: 0.12.2
   resolution: "@backstage/core-components@npm:0.12.2"
   dependencies:
@@ -4022,7 +4024,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/core-plugin-api@npm:^1.0.7, @backstage/core-plugin-api@npm:^1.1.0, @backstage/core-plugin-api@npm:^1.2.0":
+"@backstage/core-plugin-api@npm:^1.0.7, @backstage/core-plugin-api@npm:^1.2.0":
   version: 1.2.0
   resolution: "@backstage/core-plugin-api@npm:1.2.0"
   dependencies:
@@ -5409,7 +5411,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-catalog-react@npm:^1.2.0, @backstage/plugin-catalog-react@npm:^1.2.1, @backstage/plugin-catalog-react@npm:^1.2.3":
+"@backstage/plugin-catalog-react@npm:^1.2.0, @backstage/plugin-catalog-react@npm:^1.2.3":
   version: 1.2.3
   resolution: "@backstage/plugin-catalog-react@npm:1.2.3"
   dependencies:


### PR DESCRIPTION
Migrated types related to `CacheService` and `DatabaseService` into backend-plugin-api.
