### PR TITLE
feat: enable jenkins sort upon fetch from jenkins api

### DIFF
--- a/.changeset/nasty-grapes-matter.md
+++ b/.changeset/nasty-grapes-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+Adding isLatestCICDBuildsEnabled config, which allows the backend to fetch all builds and sort them by the timestamp of the build

--- a/plugins/jenkins-backend/README.md
+++ b/plugins/jenkins-backend/README.md
@@ -93,6 +93,8 @@ jenkins:
   # optionally add extra headers
   # extraRequestHeaders:
   #   extra-header: my-value
+  # optinally specify backed to fetch all jobs and sort them by latest build according to timestamp
+  # isLatestCICDBuildsEnabled: true
 ```
 
 Catalog

--- a/plugins/jenkins-backend/config.d.ts
+++ b/plugins/jenkins-backend/config.d.ts
@@ -44,5 +44,11 @@ export interface Config {
       /** @visibility secret */
       apiKey: string;
     }[];
+
+    /**
+     * Enabling this functionality, will force the backed to retrieve all builds, sort them by build time and
+     * whether the latest builds exist. Latest builds are returned first.
+     */
+    isLatestCICDBuildsEnabled?: boolean;
   };
 }

--- a/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
@@ -230,6 +230,7 @@ describe('DefaultJenkinsInfoProvider', () => {
         'extra-header': 'extra-value',
       },
       jobFullName: 'teamA/artistLookup-build',
+      isLatestCICDBuildsEnabled: undefined,
     });
   });
 

--- a/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -42,6 +42,7 @@ export interface JenkinsInfoProvider {
 export interface JenkinsInfo {
   baseUrl: string;
   headers?: Record<string, string | string[]>;
+  isLatestCICDBuildsEnabled?: boolean;
   jobFullName: string; // TODO: make this an array
   crumbIssuer?: boolean;
 }
@@ -53,6 +54,7 @@ export interface JenkinsInstanceConfig {
   username: string;
   apiKey: string;
   crumbIssuer?: boolean;
+  isLatestCICDBuildsEnabled?: boolean;
   /**
    * Extra headers to send to Jenkins instance
    */
@@ -98,6 +100,9 @@ export class JenkinsConfig {
     const username = jenkinsConfig.getOptionalString('username');
     const apiKey = jenkinsConfig.getOptionalString('apiKey');
     const crumbIssuer = jenkinsConfig.getOptionalBoolean('crumbIssuer');
+    const isLatestCICDBuildsEnabled = jenkinsConfig.getOptionalBoolean(
+      'isLatestCICDBuildsEnabled',
+    );
     const extraRequestHeaders = jenkinsConfig.getOptional<
       JenkinsInstanceConfig['extraRequestHeaders']
     >('extraRequestHeaders');
@@ -126,6 +131,7 @@ export class JenkinsConfig {
           apiKey,
           extraRequestHeaders,
           crumbIssuer,
+          isLatestCICDBuildsEnabled,
         },
       ]);
     }
@@ -252,6 +258,7 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
       },
       jobFullName,
       crumbIssuer: instanceConfig.crumbIssuer,
+      isLatestCICDBuildsEnabled: instanceConfig.isLatestCICDBuildsEnabled,
     };
   }
 


### PR DESCRIPTION
Signed-off-by: dimcho <dimcho.karakashev@ssense.com>

## Hey, I just made a Pull Request!
I have been testing the jenkins plugin, and we have noticed that the ci/cd page is not very useful for us. The default behavior includes some old prs(following screenshots are for the same repo):
![DefaultBehavior](https://user-images.githubusercontent.com/77258232/210608999-83e3be43-cf01-44c5-be12-02c8e9135d0c.png)

I see previously that there has been similar issue: https://github.com/backstage/backstage/pull/7594, however the PR fixes the issue only on the frontend. We have more than 50 jobs(the default query only gets 50: https://github.com/backstage/backstage/blob/master/plugins/jenkins-backend/src/service/jenkinsApi.ts#L65), so the api does not return very useful information based on my test. I tried exploring the api endpoint on jenkins, but I could not find any way to filter/query things on the query to jenkins.

Therefore, I thought it might be useful to fetch all jobs and sort them by the timestamp of the build(+ put all job with no build at the end):
![AfterSorting](https://user-images.githubusercontent.com/77258232/210609816-11c4fbad-4883-4615-b834-d454c65b7316.png)

So finally it appears like so:
![FinalBehavior](https://user-images.githubusercontent.com/77258232/210609859-f858fc54-1352-4470-bac9-86a5a82d7128.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
