### PR TITLE
feat(search-react): customize <SearchResult/> no result state

### DIFF
--- a/.changeset/mean-moles-relate.md
+++ b/.changeset/mean-moles-relate.md
@@ -1,0 +1,31 @@
+---
+'@backstage/plugin-search-react': minor
+---
+
+Allow customizing empty state component through `noResultsComponent` property.
+
+Example:
+
+```jsx
+<SearchResult noResultsComponent={<>No results were found</>}>
+  {({ results }) => (
+    <List>
+      {results.map(({ type, document }) => {
+        switch (type) {
+          case 'custom-result-item':
+            return (
+              <CustomResultListItem key={document.location} result={document} />
+            );
+          default:
+            return (
+              <DefaultResultListItem
+                key={document.location}
+                result={document}
+              />
+            );
+        }
+      })}
+    </List>
+  )}
+</SearchResult>
+```

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -402,6 +402,7 @@ export const SearchResultPager: () => JSX.Element;
 // @public
 export type SearchResultProps = Pick<SearchResultStateProps, 'query'> & {
   children: (resultSet: SearchResultSet) => JSX.Element;
+  noResultsComponent?: JSX.Element;
 };
 
 // @public

--- a/plugins/search-react/src/components/SearchResult/SearchResult.stories.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.stories.tsx
@@ -218,3 +218,32 @@ export const GroupLayout = () => {
     </SearchResult>
   );
 };
+
+export const WithCustomNoResultsComponent = () => {
+  return (
+    <SearchResult noResultsComponent={<>No results were found</>}>
+      {({ results }) => (
+        <List>
+          {results.map(({ type, document }) => {
+            switch (type) {
+              case 'custom-result-item':
+                return (
+                  <CustomResultListItem
+                    key={document.location}
+                    result={document}
+                  />
+                );
+              default:
+                return (
+                  <DefaultResultListItem
+                    key={document.location}
+                    result={document}
+                  />
+                );
+            }
+          })}
+        </List>
+      )}
+    </SearchResult>
+  );
+};

--- a/plugins/search-react/src/components/SearchResult/SearchResult.test.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.test.tsx
@@ -93,6 +93,22 @@ describe('SearchResult', () => {
     });
   });
 
+  it('On empty result value state with custom component', async () => {
+    (useSearch as jest.Mock).mockReturnValueOnce({
+      result: { loading: false, error: '', value: { results: [] } },
+    });
+
+    const { getByText } = await renderInTestApp(
+      <SearchResult noResultsComponent={<>No results found</>}>
+        {() => <></>}
+      </SearchResult>,
+    );
+
+    await waitFor(() => {
+      expect(getByText('No results found')).toBeInTheDocument();
+    });
+  });
+
   it('Calls children with results set to result.value', async () => {
     (useSearch as jest.Mock).mockReturnValueOnce({
       result: {

--- a/plugins/search-react/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.tsx
@@ -167,6 +167,7 @@ export const SearchResultState = (props: SearchResultStateProps) => {
  */
 export type SearchResultProps = Pick<SearchResultStateProps, 'query'> & {
   children: (resultSet: SearchResultSet) => JSX.Element;
+  noResultsComponent?: JSX.Element;
 };
 
 /**
@@ -176,7 +177,13 @@ export type SearchResultProps = Pick<SearchResultStateProps, 'query'> & {
  * @public
  */
 export const SearchResultComponent = (props: SearchResultProps) => {
-  const { query, children } = props;
+  const {
+    query,
+    children,
+    noResultsComponent = (
+      <EmptyState missing="data" title="Sorry, no results were found" />
+    ),
+  } = props;
 
   return (
     <SearchResultState query={query}>
@@ -195,9 +202,7 @@ export const SearchResultComponent = (props: SearchResultProps) => {
         }
 
         if (!value?.results.length) {
-          return (
-            <EmptyState missing="data" title="Sorry, no results were found" />
-          );
+          return noResultsComponent;
         }
 
         return children(value);


### PR DESCRIPTION
Signed-off-by: Rutuja Marathe <rutujasudam.marathe@factset.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Similar to https://github.com/backstage/backstage/pull/13957, allow customizing empty state component through `noResultsComponent` property in `SearchResult`.

Example:
```JS
<SearchResult noResultsComponent={<>No results were found</>}>
  {({ results }) => (
    <List>
      {results.map(({ type, document }) => {
        switch (type) {
          case 'custom-result-item':
            return (
              <CustomResultListItem key={document.location} result={document} />
            );
          default:
            return (
              <DefaultResultListItem
                key={document.location}
                result={document}
              />
            );
        }
      })}
    </List>
  )}
</SearchResult>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
