### PR TITLE
fix(docs): Errant dash in a sentence on keeping Backstage updated page

### DIFF
--- a/docs/getting-started/keeping-backstage-updated.md
+++ b/docs/getting-started/keeping-backstage-updated.md
@@ -47,7 +47,7 @@ For this reason, any changes made to the template are documented along with
 upgrade instructions in the
 [changelog](https://github.com/backstage/backstage/blob/master/packages/create-app/CHANGELOG.md)
 of the `@backstage/create-app` package. We recommend peeking at this changelog
--for any applicable updates when upgrading packages. As an alternative, the
+for any applicable updates when upgrading packages. As an alternative, the
 [Backstage Upgrade Helper](https://backstage.github.io/upgrade-helper/) provides
 a consolidated view of all the changes between two versions of Backstage. You
 can find the current version of your Backstage installation in `backstage.json`.


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
We were running through the upgrade docs and noticed a super trivial typo, some sort of dash that was left in the docs.  Minor fix!

<img width="795" alt="image" src="https://user-images.githubusercontent.com/33203301/210634538-44fd5272-4aeb-4913-b2a7-59944342ef2f.png">

https://backstage.io/docs/getting-started/keeping-backstage-updated#following-create-app-template-changes

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
