### PR TITLE
Bump `better-sqlite3` to v8.0.0

### DIFF
--- a/.changeset/wicked-socks-build.md
+++ b/.changeset/wicked-socks-build.md
@@ -1,0 +1,10 @@
+---
+'@backstage/create-app': patch
+---
+
+Bumped the minimum version of `better-sqlite3`. You can make the following change to your `packages/backend/package.json` to keep your instance of Backstage updated.
+
+```diff
+- "better-sqlite3": "^7.5.0",
++ "better-sqlite3": "^8.0.0",
+```

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -34,7 +34,7 @@
     "@backstage/plugin-search-backend-node": "^{{version '@backstage/plugin-search-backend-node'}}",
     "@backstage/plugin-techdocs-backend": "^{{version '@backstage/plugin-techdocs-backend'}}",
     "app": "link:../app",
-    "better-sqlite3": "^7.5.0",
+    "better-sqlite3": "^8.0.0",
     "dockerode": "^3.3.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",


### PR DESCRIPTION
On the back of #15555, let's roll this change out to new `create-app`'s too.