### PR TITLE
fix(techdocs): Fixes anchor bug in Techdocs reader 

### DIFF
--- a/.changeset/gold-masks-sleep.md
+++ b/.changeset/gold-masks-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bug in Techdocs reader where a techdocs page with a hash in the URL did not always jump to the document anchor.

--- a/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.ts
+++ b/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.ts
@@ -24,7 +24,6 @@ export const scrollIntoAnchor = (): Transformer => {
       function handleShadowDomStyleLoad() {
         if (window.location.hash) {
           const hash = window.location.hash.slice(1);
-          // fix invalid selector error for anchor starting with number
           dom?.querySelector(`[id="${hash}"]`)?.scrollIntoView();
         }
         dom.removeEventListener(

--- a/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.ts
+++ b/plugins/techdocs/src/reader/transformers/scrollIntoAnchor.ts
@@ -15,17 +15,24 @@
  */
 
 import type { Transformer } from './transformer';
+import { SHADOW_DOM_STYLE_LOAD_EVENT } from '@backstage/plugin-techdocs-react';
 
 export const scrollIntoAnchor = (): Transformer => {
   return dom => {
-    setTimeout(() => {
-      // Scroll to the desired anchor on initial navigation
-      if (window.location.hash) {
-        const hash = window.location.hash.slice(1);
-        // fix invalid selector error for anchor starting with number
-        dom?.querySelector(`[id="${hash}"]`)?.scrollIntoView();
-      }
-    }, 200);
+    dom.addEventListener(
+      SHADOW_DOM_STYLE_LOAD_EVENT,
+      function handleShadowDomStyleLoad() {
+        if (window.location.hash) {
+          const hash = window.location.hash.slice(1);
+          // fix invalid selector error for anchor starting with number
+          dom?.querySelector(`[id="${hash}"]`)?.scrollIntoView();
+        }
+        dom.removeEventListener(
+          SHADOW_DOM_STYLE_LOAD_EVENT,
+          handleShadowDomStyleLoad,
+        );
+      },
+    );
     return dom;
   };
 };


### PR DESCRIPTION
Fixed a bug in techdocs reader where loading a techdocs page with a hash did not always result in a jump to the right anchor location of the document.

fixes #15597

Signed-off-by: Gabriel Testault <gabriel.testault@goto.com>

## Hey, I just made a Pull Request!

- The scrollIntoAnchor transformer now jumps to the anchor only after css was loaded instead of jumping after 200ms. Implemenation similar to onCssLoaded
- added tests for new behavior
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
