### PR TITLE
Revert "chore(deps): update dependency puppeteer to v19"

### DIFF
--- a/packages/e2e-test/package.json
+++ b/packages/e2e-test/package.json
@@ -40,7 +40,7 @@
     "handlebars": "^4.7.3",
     "nodemon": "^2.0.2",
     "pgtools": "^0.3.0",
-    "puppeteer": "^19.0.0",
+    "puppeteer": "^17.0.0",
     "tree-kill": "^1.2.2",
     "ts-node": "^10.0.0"
   },

--- a/packages/e2e-test/src/lib/helpers.ts
+++ b/packages/e2e-test/src/lib/helpers.ts
@@ -22,7 +22,7 @@ import {
   ChildProcess,
 } from 'child_process';
 import { promisify } from 'util';
-import * as puppeteer from 'puppeteer';
+import puppeteer from 'puppeteer';
 
 const execFile = promisify(execFileCb);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19495,18 +19495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:8.0.0":
-  version: 8.0.0
-  resolution: "cosmiconfig@npm:8.0.0"
-  dependencies:
-    import-fresh: ^3.2.1
-    js-yaml: ^4.1.0
-    parse-json: ^5.0.0
-    path-type: ^4.0.0
-  checksum: ff4cdf89ac1ae52e7520816622c21a9e04380d04b82d653f5139ec581aa4f7f29e096d46770bc76c4a63c225367e88a1dfa233ea791669a35101f5f9b972c7d1
-  languageName: node
-  linkType: hard
-
 "cosmiconfig@npm:^6.0.0":
   version: 6.0.0
   resolution: "cosmiconfig@npm:6.0.0"
@@ -20689,10 +20677,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.1068969":
-  version: 0.0.1068969
-  resolution: "devtools-protocol@npm:0.0.1068969"
-  checksum: 53b9c8d661e4148eaf8e990f03902fb3a2cceb06044f661013b6c92dd48ece397ef49fd18401775823c9a33069b4b535502f2559d4f99c74a6bdcb71582b6c8a
+"devtools-protocol@npm:0.0.1036444":
+  version: 0.0.1036444
+  resolution: "devtools-protocol@npm:0.0.1036444"
+  checksum: 6975c8def95a5e1a4207d6deb05322e335d6a37bdaa3e589cbd5bde40fbbe3ab0df2cfedb1b3ad2785401f208c150fd489a6a065a4624b56e4c0c4c1bfd89172
   languageName: node
   linkType: hard
 
@@ -21072,7 +21060,7 @@ __metadata:
     handlebars: ^4.7.3
     nodemon: ^2.0.2
     pgtools: ^0.3.0
-    puppeteer: ^19.0.0
+    puppeteer: ^17.0.0
     tree-kill: ^1.2.2
     ts-node: ^10.0.0
   bin:
@@ -32804,34 +32792,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-core@npm:19.4.1":
-  version: 19.4.1
-  resolution: "puppeteer-core@npm:19.4.1"
+"puppeteer@npm:^17.0.0":
+  version: 17.1.3
+  resolution: "puppeteer@npm:17.1.3"
   dependencies:
     cross-fetch: 3.1.5
     debug: 4.3.4
-    devtools-protocol: 0.0.1068969
+    devtools-protocol: 0.0.1036444
     extract-zip: 2.0.1
     https-proxy-agent: 5.0.1
+    progress: 2.0.3
     proxy-from-env: 1.1.0
     rimraf: 3.0.2
     tar-fs: 2.1.1
     unbzip2-stream: 1.4.3
-    ws: 8.11.0
-  checksum: f4db1aa1d1e642356744bed2dc49ff7960a8b530d147ace1fe067937433ae40234ea973260b9b264d53a2f2297f53df796d008d4756f735b3f0a64a69724eaba
-  languageName: node
-  linkType: hard
-
-"puppeteer@npm:^19.0.0":
-  version: 19.4.1
-  resolution: "puppeteer@npm:19.4.1"
-  dependencies:
-    cosmiconfig: 8.0.0
-    https-proxy-agent: 5.0.1
-    progress: 2.0.3
-    proxy-from-env: 1.1.0
-    puppeteer-core: 19.4.1
-  checksum: 14b6bd8d5f73f389e5bf424df6a89c346b7a8a8d0326b6aa3670e447a98b638b9091f46b6980515d56152b916a4e7be49c21f25fe7bb5c66828e02466a891f57
+    ws: 8.8.1
+  checksum: b4518956c661df4c37690d46b9c6744d42d59d01fe3764938b4b3af8de4c94ef11a9dfa6bc261798f5e5490c6dce4d4f555f05d42c735249683da3017faf4585
   languageName: node
   linkType: hard
 
@@ -38813,6 +38789,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
+  languageName: node
+  linkType: hard
+
+"ws@npm:8.8.1":
+  version: 8.8.1
+  resolution: "ws@npm:8.8.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 2152cf862cae0693f3775bc688a6afb2e989d19d626d215e70f5fcd8eb55b1c3b0d3a6a4052905ec320e2d7734e20aeedbf9744496d62f15a26ad79cf4cf7dae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts backstage/backstage#15566

There's something going on with the cache directory where chromium is installed, whose [behaviour changed](https://pptr.dev/guides/configuration/#changing-the-default-cache-directory) in v19 so the e2e tests are broken. Let's revert this for now.