### PR TITLE
feat: add entity context menu tooltip

### DIFF
--- a/.changeset/silver-papayas-cough.md
+++ b/.changeset/silver-papayas-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+There is now tooltip in the entity context menu

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -22,6 +22,7 @@ import {
   MenuItem,
   MenuList,
   Popover,
+  Tooltip,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import BugReportIcon from '@material-ui/icons/BugReport';
@@ -114,19 +115,21 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
 
   return (
     <>
-      <IconButton
-        aria-label="more"
-        aria-controls="long-menu"
-        aria-haspopup="true"
-        aria-expanded={!!anchorEl}
-        role="button"
-        onClick={onOpen}
-        data-testid="menu-button"
-        className={classes.button}
-        id="long-menu"
-      >
-        <MoreVert />
-      </IconButton>
+      <Tooltip title="More" arrow>
+        <IconButton
+          aria-label="more"
+          aria-controls="long-menu"
+          aria-haspopup="true"
+          aria-expanded={!!anchorEl}
+          role="button"
+          onClick={onOpen}
+          data-testid="menu-button"
+          className={classes.button}
+          id="long-menu"
+        >
+          <MoreVert />
+        </IconButton>
+      </Tooltip>
       <Popover
         open={Boolean(anchorEl)}
         onClose={onClose}


### PR DESCRIPTION
closes #15609

Signed-off-by: Heikki Hellgren <heikki.hellgren@op.fi>

## Hey, I just made a Pull Request!

Added "More" tooltip to entity context menu.

![image](https://user-images.githubusercontent.com/1178319/211075314-4ebd5fc2-e0fe-4b9f-8106-e1e0dd2bc726.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
