### PR TITLE
Add note about protected headers in JWT

### DIFF
--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -110,6 +110,9 @@ value of the configured key as the secret. It must also have the following paylo
 - `sub`: "backstage-server" (only this value supported currently)
 - `exp`: one hour from the time it was generated, in epoch seconds
 
+> NOTE: The JWT must encode the `alg` header as a protected header, such as with
+> [setProtectedHeader](https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md#setprotectedheader).
+
 ## Granular Access Control
 
 We plan to build out the service-to-service auth to be much more powerful in the


### PR DESCRIPTION
The [service-to-service auth docs](https://backstage.io/docs/auth/service-to-service-auth#usage-in-external-callers) talk about generating a JWT for use in external callers. If you naively generate a JWT from [jwt.io](https://jwt.io/), as one might do, you'll get a cryptic error:

```
"error": {
    "name": "AuthenticationError",
    "message": "\"alg\" (Algorithm) Header Parameter not allowed"
}
```

This is because Backstage expects `alg` to be sent in a [protected header](https://ordina-jworks.github.io/security/2016/03/12/Digitally-signing-your-JSON-documents.html#jws), as done in [ServerTokenManager](https://github.com/backstage/backstage/blob/ab43f12359eaeb4efa70cf719ac80624066afca5/packages/backend-common/src/tokens/ServerTokenManager.ts#L153).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
