### PR TITLE
s3ForcePathStyle no longer the correct name for techdocs S3 publisher

### DIFF
--- a/.changeset/cyan-deers-walk.md
+++ b/.changeset/cyan-deers-walk.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs-node': minor
+'@backstage/plugin-techdocs-node': patch
 ---
 
 Fixed bug caused by recent migration to AWS SDK V3 for techdocs-node. Instead of s3ForcePathStyle, forcePathStyle should be passed.

--- a/.changeset/cyan-deers-walk.md
+++ b/.changeset/cyan-deers-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': minor
+---
+
+Fixed bug caused by recent migration to AWS SDK V3 for techdocs-node. Instead of s3ForcePathStyle, forcePathStyle should be passed.

--- a/plugins/techdocs-node/src/stages/publish/awsS3.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.ts
@@ -152,7 +152,7 @@ export class AwsS3Publish implements PublisherBase {
 
     // AWS forcePathStyle is an optional config. If missing, it defaults to false. Needs to be enabled for cases
     // where endpoint url points to locally hosted S3 compatible storage like Localstack
-    const s3ForcePathStyle = config.getOptionalBoolean(
+    const forcePathStyle = config.getOptionalBoolean(
       'techdocs.publisher.awsS3.s3ForcePathStyle',
     );
 
@@ -161,7 +161,7 @@ export class AwsS3Publish implements PublisherBase {
       credentialDefaultProvider: () => sdkCredentialProvider,
       ...(region && { region }),
       ...(endpoint && { endpoint }),
-      ...(s3ForcePathStyle && { s3ForcePathStyle }),
+      ...(forcePathStyle && { forcePathStyle }),
     });
 
     const legacyPathCasing =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

techdocs-node [was recently bumped to use AWS SDK v3 ](https://github.com/backstage/backstage/commit/37931c33ce#), however, this appears to have broken use of `s3ForcePathStyle`, meaning that people who use s3 and reference their buckets path-style have broken techdoc usage. This was recently changed in AWS SDK v3 to be `forcePathStyle` instead, [as detailed in this issue](https://github.com/backstage/backstage/issues/15605).

The simplest fix would be to correct this to `forcePathStyle` in the awsS3 publishing step for techdocs-node. I would prefer to change the config definition as well, but it seems that there are parts of backstage that are still using v2 (backend-common, catalog-backend-module-aws), as documented in this issue:

https://github.com/backstage/backstage/issues/15516

Changing the config definition from `s3ForcePathStyle` to `forcePathStyle` seems like it'd necessitate an upgrade of all instances of the v2 SDK to v3, which is probably larger in scope. Feel free to let me know if it's preferable to look at that first, or if we'd like to get this short-term fix in first. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
