### PR TITLE
Client-side Kubernetes Auth solution for AAD-enabled AKS clusters

### DIFF
--- a/.changeset/good-mails-sleep.md
+++ b/.changeset/good-mails-sleep.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+'@backstage/plugin-kubernetes': patch
+---
+
+Introduced new Auth Provider and Auth Translator that uses the following scope 6dae42f8-4368-4678-94ff-3960e28e3630/user.read

--- a/.changeset/mighty-tips-flow.md
+++ b/.changeset/mighty-tips-flow.md
@@ -9,3 +9,8 @@ authorization code for a non-Microsoft Graph scope, the user profile will not be
 fetched. Similarly no user profile or photo data will be fetched by the backend
 if the `/refresh` endpoint is called with the `scope` query parameter strictly
 containing scopes for resources besides Microsoft Graph.
+
+Furthermore, the `offline_access` scope will be requested by default, even when
+it is not mentioned in the argument to `getAccessToken`. This means that any
+Azure access token can be automatically refreshed, even if the user has not
+signed in via Azure.

--- a/.changeset/mighty-tips-flow.md
+++ b/.changeset/mighty-tips-flow.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+The `microsoft` (i.e. Azure) auth provider now supports negotiating tokens for
+Azure resources besides Microsoft Graph (e.g. AKS, Virtual Machines, Machine
+Learning Services, etc.). When the `/frame/handler` endpoint is called with an
+authorization code for a non-Microsoft Graph scope, the user profile will not be
+fetched. Similarly no user profile or photo data will be fetched by the backend
+if the `/refresh` endpoint is called with the `scope` query parameter strictly
+containing scopes for resources besides Microsoft Graph.

--- a/.changeset/sixty-insects-visit.md
+++ b/.changeset/sixty-insects-visit.md
@@ -1,0 +1,9 @@
+---
+'@backstage/core-app-api': minor
+---
+
+The `AuthConnector` interface now supports specifying a set of scopes when
+refreshing a session. The `DefaultAuthConnector` implementation passes the
+`scope` query parameter to the auth-backend plugin appropriately. The
+`RefreshingAuthSessionManager` passes any scopes in its `GetSessionRequest`
+appropriately.

--- a/docs/features/kubernetes/authentication.md
+++ b/docs/features/kubernetes/authentication.md
@@ -68,6 +68,29 @@ The providers available as client side are:
 
 - `google`
 - `oidc`
+- `microsoftaks`
+
+### Microsoft AKS
+
+The Microsoft AKS client side authentication provider allows you to surface the status of deployed services in Backstage without granting high powered privileges to a service account. Please note that [Azure AD Authentication][1] is a requirement and has to be enabled in your AKS cluster, then follow these steps:
+
+- Go to your AKS cluster's resource page in the Azure Active Directory console and follow the steps in the
+  `Connect` tab to set the subscription and get your credentials for your providers auth definition.
+- Configure your cluster to use the `microsoftaks` auth provider like this:
+
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: config
+      clusters:
+        - name: My AKS cluster
+          url: ${AZURE_CLUSTER_API_SERVER_ADDRESS}
+          authProvider: microsoftaks
+          skipTLSVerify: true
+          skipMetricsLookup: true
+```
 
 [1]: https://docs.microsoft.com/en-us/azure/aks/managed-aad
 [2]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -439,7 +439,7 @@ export class LocalStorageFeatureFlags implements FeatureFlagsApi {
 // @public
 export class MicrosoftAuth {
   // (undocumented)
-  static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T;
+  static create(options: OAuth2CreateOptions): typeof microsoftAuthApiRef.T;
   // (undocumented)
   static expectedClaims(scope: string): {
     aud: string;

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -441,6 +441,11 @@ export class MicrosoftAuth {
   // (undocumented)
   static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T;
   // (undocumented)
+  static expectedClaims(scope: string): {
+    aud: string;
+    scp: string;
+  };
+  // (undocumented)
   getAccessToken(
     scope?: string | string[],
     options?: AuthRequestOptions,

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -440,6 +440,25 @@ export class LocalStorageFeatureFlags implements FeatureFlagsApi {
 export class MicrosoftAuth {
   // (undocumented)
   static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T;
+  // (undocumented)
+  getAccessToken(
+    scope?: string | string[],
+    options?: AuthRequestOptions,
+  ): Promise<string>;
+  // (undocumented)
+  getBackstageIdentity(
+    options?: AuthRequestOptions,
+  ): Promise<BackstageIdentityResponse | undefined>;
+  // (undocumented)
+  getIdToken(options?: AuthRequestOptions): Promise<string>;
+  // (undocumented)
+  getProfile(options?: AuthRequestOptions): Promise<ProfileInfo | undefined>;
+  // (undocumented)
+  sessionState$(): Observable<SessionState>;
+  // (undocumented)
+  signIn(): Promise<void>;
+  // (undocumented)
+  signOut(): Promise<void>;
 }
 
 // @public

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -110,6 +110,17 @@ describe('MicrosoftAuth', () => {
         scp: 'openid profile email User.Read',
       });
     });
+
+    it('gets access token for other azure resources', async () => {
+      const accessToken = await microsoftAuth.getAccessToken(
+        'azure-resource/scope',
+      );
+
+      expect(accessToken).toHaveJWTClaims({
+        aud: 'azure-resource',
+        scp: 'scope',
+      });
+    });
   });
 
   describe('without a refresh token', () => {

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MicrosoftAuth from './MicrosoftAuth';
+import MockOAuthApi from '../../OAuthRequestApi/MockOAuthApi';
+import { UrlPatternDiscovery } from '../../DiscoveryApi';
+import * as loginPopup from '../../../../lib/loginPopup';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+jest.mock('../../../../lib/loginPopup', () => {
+  return {
+    showLoginPopup: jest.fn(),
+  };
+});
+
+describe('MicrosoftAuth', () => {
+  const server = setupServer();
+  setupRequestMockHandlers(server);
+  const microsoftAuth = MicrosoftAuth.create({
+    oauthRequestApi: new MockOAuthApi(),
+    discoveryApi: UrlPatternDiscovery.compile(
+      'http://backstage.test/api/{{ pluginId }}',
+    ),
+  });
+  const showLoginPopup = jest.spyOn(loginPopup, 'showLoginPopup');
+
+  const toHaveJWTClaims = function toHaveJWTClaims(
+    this: jest.MatcherContext,
+    received: string,
+    expected: Record<string, any>,
+  ): jest.CustomMatcherResult {
+    let parsedClaims: Record<string, any>;
+    try {
+      parsedClaims = JSON.parse(
+        Buffer.from(received.split('.')[1], 'base64').toString(),
+      );
+    } catch (e) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected JWT with claims: ${this.utils.printExpected(
+            expected,
+          )}\nReceived invalid JWT ${this.utils.printReceived(
+            received,
+          )}\nError: ${e}`,
+      };
+    }
+    const expectedResult = expect.objectContaining(expected);
+    return {
+      pass: this.equals(parsedClaims, expectedResult),
+      message: () =>
+        `Expected JWT with claims: ${this.utils.printExpected(
+          expected,
+        )}\nReceived JWT with claims: ${this.utils.printReceived(
+          parsedClaims,
+        )}\n\n${this.utils.diff(expectedResult, parsedClaims)}`,
+    };
+  };
+  expect.extend({ toHaveJWTClaims });
+
+  describe('with a refresh token', () => {
+    beforeEach(() => {
+      server.use(
+        rest.get(
+          'http://backstage.test/api/auth/microsoft/refresh',
+          (req, res, ctx) => {
+            const scope =
+              req.url.searchParams.get('scope') ||
+              'openid profile email User.Read';
+            return res(
+              ctx.json({
+                providerInfo: {
+                  accessToken: `header.${Buffer.from(
+                    JSON.stringify(MicrosoftAuth.expectedClaims(scope)),
+                  ).toString('base64')}.signature`,
+                  scope,
+                },
+              }),
+            );
+          },
+        ),
+      );
+      showLoginPopup.mockRejectedValue(new Error('no popups should be shown'));
+    });
+
+    afterEach(() => {
+      showLoginPopup.mockRestore();
+    });
+
+    it('gets access token for Microsoft Graph', async () => {
+      const accessToken = await microsoftAuth.getAccessToken();
+
+      expect(accessToken).toHaveJWTClaims({
+        aud: '00000003-0000-0000-c000-000000000000',
+        scp: 'openid profile email User.Read',
+      });
+    });
+  });
+
+  describe('without a refresh token', () => {
+    const getAccessTokenWaitingForPopup = async (scope?: string) => {
+      const oauthRequestApi = new MockOAuthApi();
+
+      const accessToken = MicrosoftAuth.create({
+        oauthRequestApi,
+        discoveryApi: UrlPatternDiscovery.compile(
+          'http://backstage.test/api/{{ pluginId }}',
+        ),
+      }).getAccessToken(scope);
+
+      await new Promise<void>(resolve => {
+        const subscription = oauthRequestApi
+          .authRequest$()
+          .subscribe(requests => {
+            if (requests.length > 0) {
+              subscription.unsubscribe();
+              Promise.all(requests.map(request => request.trigger())).then(() =>
+                resolve(),
+              );
+            }
+          });
+      });
+
+      return accessToken;
+    };
+
+    beforeEach(() => {
+      server.use(
+        rest.get(
+          'http://backstage.test/api/auth/microsoft/refresh',
+          (_, res, ctx) => {
+            return res(
+              ctx.status(401),
+              ctx.json({
+                error: {
+                  name: 'AuthenticationError',
+                  message:
+                    'Refresh failed; caused by InputError: Missing session cookie',
+                  cause: {
+                    name: 'InputError',
+                    message: 'Missing session cookie',
+                  },
+                },
+                request: {
+                  method: 'GET',
+                  url: '/api/auth/microsoft/refresh?env=development',
+                },
+                response: {
+                  statusCode: 401,
+                },
+              }),
+            );
+          },
+        ),
+      );
+
+      showLoginPopup.mockImplementation(({ url }) => {
+        const scope = new URL(url).searchParams.get('scope')!;
+        return Promise.resolve({
+          providerInfo: {
+            accessToken: `header.${Buffer.from(
+              JSON.stringify(MicrosoftAuth.expectedClaims(scope)),
+            ).toString('base64')}.signature`,
+          },
+        });
+      });
+    });
+
+    afterEach(() => {
+      showLoginPopup.mockRestore();
+    });
+
+    it('gets access token for Microsoft Graph via a popup', async () => {
+      const accessToken = await getAccessTokenWaitingForPopup();
+
+      expect(accessToken).toHaveJWTClaims({
+        aud: '00000003-0000-0000-c000-000000000000',
+        scp: 'openid profile email User.Read',
+      });
+    });
+
+    it('gets access token for other azure resources via popup', async () => {
+      const accessToken = await getAccessTokenWaitingForPopup(
+        'azure-resource/scope',
+      );
+
+      expect(accessToken).toHaveJWTClaims({
+        aud: 'azure-resource',
+        scp: 'scope',
+      });
+    });
+
+    it('gets access token when scope contains a resource URI', async () => {
+      const accessToken = await getAccessTokenWaitingForPopup(
+        'api://customApiClientId/some.scope',
+      );
+
+      expect(accessToken).toHaveJWTClaims({
+        aud: 'customApiClientId',
+        scp: 'some.scope',
+      });
+    });
+  });
+});

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
@@ -52,22 +52,22 @@ describe('DefaultAuthConnector', () => {
     jest.resetAllMocks();
   });
 
-  it('should refresh a session', async () => {
+  it('should refresh a session with scope', async () => {
     server.use(
-      rest.get('*', (_req, res, ctx) =>
+      rest.get('*', (req, res, ctx) =>
         res(
           ctx.json({
             idToken: 'mock-id-token',
             accessToken: 'mock-access-token',
-            scopes: 'a b c',
+            scopes: req.url.searchParams.get('scope') || 'default-scope',
             expiresInSeconds: '60',
           }),
         ),
       ),
     );
 
-    const helper = new DefaultAuthConnector<any>(defaultOptions);
-    const session = await helper.refreshSession();
+    const connector = new DefaultAuthConnector<any>(defaultOptions);
+    const session = await connector.refreshSession(new Set(['a', 'b', 'c']));
     expect(session.idToken).toBe('mock-id-token');
     expect(session.accessToken).toBe('mock-access-token');
     expect(session.scopes).toEqual(new Set(['a', 'b', 'c']));
@@ -82,8 +82,8 @@ describe('DefaultAuthConnector', () => {
       ),
     );
 
-    const helper = new DefaultAuthConnector(defaultOptions);
-    await expect(helper.refreshSession()).rejects.toThrow(
+    const connector = new DefaultAuthConnector(defaultOptions);
+    await expect(connector.refreshSession()).rejects.toThrow(
       'Auth refresh request failed, Error: Network NOPE',
     );
   });
@@ -91,19 +91,19 @@ describe('DefaultAuthConnector', () => {
   it('should handle failure response when refreshing session', async () => {
     server.use(rest.get('*', (_req, res, ctx) => res(ctx.status(401, 'NOPE'))));
 
-    const helper = new DefaultAuthConnector(defaultOptions);
-    await expect(helper.refreshSession()).rejects.toThrow(
+    const connector = new DefaultAuthConnector(defaultOptions);
+    await expect(connector.refreshSession()).rejects.toThrow(
       'Auth refresh request failed, NOPE',
     );
   });
 
   it('should fail if popup was rejected', async () => {
     const mockOauth = new MockOAuthApi();
-    const helper = new DefaultAuthConnector({
+    const connector = new DefaultAuthConnector({
       ...defaultOptions,
       oauthRequestApi: mockOauth,
     });
-    const promise = helper.createSession({ scopes: new Set(['a', 'b']) });
+    const promise = connector.createSession({ scopes: new Set(['a', 'b']) });
     await mockOauth.rejectAll();
     await expect(promise).rejects.toMatchObject({ name: 'RejectedError' });
   });
@@ -118,12 +118,12 @@ describe('DefaultAuthConnector', () => {
         scopes: 'a b',
         expiresInSeconds: 3600,
       });
-    const helper = new DefaultAuthConnector({
+    const connector = new DefaultAuthConnector({
       ...defaultOptions,
       oauthRequestApi: mockOauth,
     });
 
-    const sessionPromise = helper.createSession({
+    const sessionPromise = connector.createSession({
       scopes: new Set(['a', 'b']),
     });
 
@@ -146,13 +146,13 @@ describe('DefaultAuthConnector', () => {
     const popupSpy = jest
       .spyOn(loginPopup, 'showLoginPopup')
       .mockResolvedValue('my-session');
-    const helper = new DefaultAuthConnector({
+    const connector = new DefaultAuthConnector({
       ...defaultOptions,
       oauthRequestApi: new MockOAuthApi(),
       sessionTransform: str => str,
     });
 
-    const sessionPromise = helper.createSession({
+    const sessionPromise = connector.createSession({
       scopes: new Set(),
       instantPopup: true,
     });
@@ -167,13 +167,13 @@ describe('DefaultAuthConnector', () => {
     const popupSpy = jest
       .spyOn(loginPopup, 'showLoginPopup')
       .mockResolvedValue({ scopes: '' });
-    const helper = new DefaultAuthConnector({
+    const connector = new DefaultAuthConnector({
       ...defaultOptions,
       joinScopes: scopes => `-${[...scopes].join('')}-`,
       oauthRequestApi: mockOauth,
     });
 
-    helper.createSession({ scopes: new Set(['a', 'b']) });
+    connector.createSession({ scopes: new Set(['a', 'b']) });
 
     await mockOauth.triggerAll();
 

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
@@ -99,9 +99,12 @@ export class DefaultAuthConnector<AuthSession>
     return this.authRequester(options.scopes);
   }
 
-  async refreshSession(): Promise<any> {
+  async refreshSession(scopes?: Set<string>): Promise<any> {
     const res = await fetch(
-      await this.buildUrl('/refresh', { optional: true }),
+      await this.buildUrl('/refresh', {
+        optional: true,
+        ...(scopes && { scope: this.joinScopesFunc(scopes) }),
+      }),
       {
         headers: {
           'x-requested-with': 'XMLHttpRequest',

--- a/packages/core-app-api/src/lib/AuthConnector/types.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/types.ts
@@ -25,6 +25,6 @@ export type CreateSessionOptions = {
  */
 export type AuthConnector<AuthSession> = {
   createSession(options: CreateSessionOptions): Promise<AuthSession>;
-  refreshSession(): Promise<AuthSession>;
+  refreshSession(scopes?: Set<string>): Promise<AuthSession>;
   removeSession(): Promise<void>;
 };

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
@@ -47,7 +47,7 @@ describe('RefreshingAuthSessionManager', () => {
     await manager.getSession({});
     expect(createSession).toHaveBeenCalledTimes(1);
 
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledWith(undefined);
     expect(stateSubscriber.mock.calls).toEqual([
       [SessionState.SignedOut],
       [SessionState.SignedIn],
@@ -103,7 +103,7 @@ describe('RefreshingAuthSessionManager', () => {
 
     await manager.getSession({ scopes: new Set(['a']) });
     expect(createSession).toHaveBeenCalledTimes(1);
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledWith(new Set(['a']));
 
     await manager.getSession({ scopes: new Set(['a']) });
     expect(createSession).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe('RefreshingAuthSessionManager', () => {
 
     expect(await manager.getSession({ optional: true })).toBe(undefined);
     expect(createSession).toHaveBeenCalledTimes(0);
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledWith(undefined);
   });
 
   it('should forward option to instantly show auth popup and not attempt refresh', async () => {

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -73,7 +73,9 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
       }
 
       try {
-        const refreshedSession = await this.collapsedSessionRefresh();
+        const refreshedSession = await this.collapsedSessionRefresh(
+          options.scopes,
+        );
         const currentScopes = this.sessionScopesFunc(this.currentSession!);
         const refreshedScopes = this.sessionScopesFunc(refreshedSession);
         if (hasScopes(refreshedScopes, currentScopes)) {
@@ -97,7 +99,7 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
     // already had an existing session.
     if (!this.currentSession && !options.instantPopup) {
       try {
-        const newSession = await this.collapsedSessionRefresh();
+        const newSession = await this.collapsedSessionRefresh(options.scopes);
         this.currentSession = newSession;
         // The session might not have the scopes requested so go back and check again
         return this.getSession(options);
@@ -130,12 +132,12 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
     return this.stateTracker.sessionState$();
   }
 
-  private async collapsedSessionRefresh(): Promise<T> {
+  private async collapsedSessionRefresh(scopes?: Set<string>): Promise<T> {
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
 
-    this.refreshPromise = this.connector.refreshSession();
+    this.refreshPromise = this.connector.refreshSession(scopes);
 
     try {
       const session = await this.refreshPromise;

--- a/plugins/auth-backend/src/providers/microsoft/fake.test.ts
+++ b/plugins/auth-backend/src/providers/microsoft/fake.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FakeMicrosoftAPI } from './fake';
+
+describe('FakeMicrosoftAPI', () => {
+  const api = new FakeMicrosoftAPI();
+
+  describe('#token', () => {
+    it('exchanges auth codes', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('User.Read'),
+        }),
+      );
+
+      expect(api.tokenHasScope(access_token, 'User.Read')).toBe(true);
+    });
+
+    it('supports scopes for the first requested audience only', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('someaudience/somescope User.Read'),
+        }),
+      );
+
+      expect(api.tokenHasScope(access_token, 'User.Read')).toBe(false);
+    });
+
+    it('special openid scopes do not count towards the 1-audience limit', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('openid offline_access User.Read'),
+        }),
+      );
+
+      expect(api.tokenHasScope(access_token, 'User.Read')).toBe(true);
+    });
+
+    it('refreshes tokens', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: api.generateRefreshToken(
+            'email openid profile User.Read',
+          ),
+        }),
+      );
+
+      expect(
+        api.tokenHasScope(access_token, 'email openid profile User.Read'),
+      ).toBe(true);
+    });
+    it('requires `openid` scope for ID token', () => {
+      const { id_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('User.Read'),
+        }),
+      );
+
+      expect(id_token).toBeUndefined();
+    });
+    it('requires `offline_access` scope for refresh token', () => {
+      const { refresh_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('User.Read'),
+        }),
+      );
+
+      expect(refresh_token).toBeUndefined();
+    });
+  });
+});

--- a/plugins/auth-backend/src/providers/microsoft/fake.ts
+++ b/plugins/auth-backend/src/providers/microsoft/fake.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { decodeJwt } from 'jose';
+
+type Claims = { aud: string; scp: string };
+
+export class FakeMicrosoftAPI {
+  generateAccessToken(scope: string): string {
+    return this.tokenWithClaims(this.allClaimsForScope(scope)).access_token;
+  }
+  generateAuthCode(scope: string): string {
+    return this.encodeClaims(this.allClaimsForScope(scope));
+  }
+  generateRefreshToken(scope: string): string {
+    return this.encodeClaims(this.allClaimsForScope(scope));
+  }
+  token(formData: URLSearchParams): {
+    access_token: string;
+    scope: string;
+    refresh_token?: string;
+    id_token?: string;
+  } {
+    const scopeParameter = formData.get('scope');
+    const claims =
+      (scopeParameter && this.allClaimsForScope(scopeParameter)) ??
+      formData.get('grant_type') === 'refresh_token'
+        ? this.decodeClaims(formData.get('refresh_token')!)
+        : this.decodeClaims(formData.get('code')!);
+    return {
+      ...this.tokenWithClaims(claims),
+      ...(this.hasScope(claims, 'offline_access') && {
+        refresh_token: this.encodeClaims(claims),
+      }),
+      ...(this.hasScope(claims, 'openid') && {
+        id_token: 'header.e30K.microsoft',
+      }),
+    };
+  }
+  tokenHasScope(token: string, scope: string): boolean {
+    const { aud, scp } = decodeJwt(token);
+    return this.hasScope({ aud: aud as string, scp: scp as string }, scope);
+  }
+  private tokenWithClaims(claims: Claims): {
+    access_token: string;
+    scope: string;
+  } {
+    const filteredClaims = {
+      ...claims,
+      scp: claims.scp
+        .split(' ')
+        .filter(s => s !== 'offline_access')
+        .join(' '),
+    };
+    return {
+      access_token: `header.${Buffer.from(
+        JSON.stringify(filteredClaims),
+      ).toString('base64')}.signature`,
+      scope: this.scopeFromClaims(filteredClaims),
+    };
+  }
+  private allClaimsForScope(scope: string): Claims {
+    const scopes = scope.split(' ').map(this.parseScope);
+    const firstAudience = scopes
+      .map(({ aud }) => aud)
+      .find(aud => aud !== 'openid');
+    return {
+      aud: firstAudience ?? '00000003-0000-0000-c000-000000000000',
+      scp: scopes
+        .filter(({ aud }) => aud === 'openid' || aud === firstAudience)
+        .map(({ scp }) => scp)
+        .join(' '),
+    };
+  }
+  // auth codes and refresh tokens in this fake system are base64-encoded JSON
+  // strings of claims
+  private encodeClaims(claims: Claims): string {
+    return Buffer.from(JSON.stringify(claims)).toString('base64');
+  }
+  private decodeClaims(encoded: string): Claims {
+    return JSON.parse(Buffer.from(encoded, 'base64').toString());
+  }
+  private hasScope(claims: Claims, scope: string): boolean {
+    return this.scopeFromClaims(claims).includes(scope);
+  }
+  private parseScope(s: string): Claims {
+    if (s.includes('/')) {
+      const [aud, scp] = s.split('/');
+      return { aud, scp };
+    }
+    switch (s) {
+      case 'email':
+      case 'openid':
+      case 'offline_access':
+      case 'profile': {
+        return { aud: 'openid', scp: s };
+      }
+      default:
+        return { aud: '00000003-0000-0000-c000-000000000000', scp: s };
+    }
+  }
+  private scopeFromClaims(claims: Claims): string {
+    return claims.scp
+      .split(' ')
+      .map(this.parseScope)
+      .map(({ aud, scp }) =>
+        aud === 'openid' ||
+        claims.aud === '00000003-0000-0000-c000-000000000000'
+          ? scp
+          : `${claims.aud}/${scp}`,
+      )
+      .join(' ');
+  }
+}

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -22,6 +22,15 @@ import type { RequestHandler } from 'express';
 import { TokenCredential } from '@azure/identity';
 
 // @alpha (undocumented)
+export class AksKubernetesAuthTranslator implements KubernetesAuthTranslator {
+  // (undocumented)
+  decorateClusterDetailsWithAuth(
+    clusterDetails: AzureClusterDetails,
+    authConfig: KubernetesRequestAuth,
+  ): Promise<AzureClusterDetails>;
+}
+
+// @alpha (undocumented)
 export interface AWSClusterDetails extends ClusterDetails {
   // (undocumented)
   assumeRole?: string;

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -76,6 +76,9 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           case 'googleServiceAccount': {
             return clusterDetails;
           }
+          case 'microsoftaks': {
+            return clusterDetails;
+          }
           default: {
             throw new Error(
               `authProvider "${authProvider}" has no config associated with it`,

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AksKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AksKubernetesAuthTranslator.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthTranslator } from './types';
+import { AzureClusterDetails } from '../types/types';
+import { KubernetesRequestAuth } from '@backstage/plugin-kubernetes-common';
+
+/**
+ *
+ * @alpha
+ */
+export class AksKubernetesAuthTranslator implements KubernetesAuthTranslator {
+  async decorateClusterDetailsWithAuth(
+    clusterDetails: AzureClusterDetails,
+    authConfig: KubernetesRequestAuth,
+  ): Promise<AzureClusterDetails> {
+    const clusterDetailsWithAuthToken: AzureClusterDetails = Object.assign(
+      {},
+      clusterDetails,
+    );
+    const authToken: string | undefined = authConfig.aks;
+
+    if (authToken) {
+      clusterDetailsWithAuthToken.serviceAccountToken = authToken;
+    } else {
+      throw new Error('AKS token not found under auth.aks in request body');
+    }
+    return clusterDetailsWithAuthToken;
+  }
+}

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
@@ -22,6 +22,7 @@ import { AwsIamKubernetesAuthTranslator } from './AwsIamKubernetesAuthTranslator
 import { GoogleServiceAccountAuthTranslator } from './GoogleServiceAccountAuthProvider';
 import { AzureIdentityKubernetesAuthTranslator } from './AzureIdentityKubernetesAuthTranslator';
 import { OidcKubernetesAuthTranslator } from './OidcKubernetesAuthTranslator';
+import { AksKubernetesAuthTranslator } from './AksKubernetesAuthTranslator';
 
 /**
  *
@@ -55,6 +56,9 @@ export class KubernetesAuthTranslatorGenerator {
       }
       case 'localKubectlProxy': {
         return new NoopKubernetesAuthTranslator();
+      }
+      case 'microsoftaks': {
+        return new AksKubernetesAuthTranslator();
       }
       default: {
         throw new Error(

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/index.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/index.ts
@@ -22,3 +22,4 @@ export * from './KubernetesAuthTranslatorGenerator';
 export * from './NoopKubernetesAuthTranslator';
 export * from './OidcKubernetesAuthTranslator';
 export * from './types';
+export * from './AksKubernetesAuthTranslator';

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -220,6 +220,8 @@ export type KubernetesFetchError = StatusError | RawFetchError;
 // @public (undocumented)
 export interface KubernetesRequestAuth {
   // (undocumented)
+  aks?: string;
+  // (undocumented)
   google?: string;
   // (undocumented)
   oidc?: {

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -38,6 +38,7 @@ export interface KubernetesRequestAuth {
   oidc?: {
     [key: string]: string;
   };
+  aks?: string;
 }
 
 /** @public */

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -35,6 +35,19 @@ import { V1Service } from '@kubernetes/client-node';
 import { V1StatefulSet } from '@kubernetes/client-node';
 import { WorkloadsByEntityRequest } from '@backstage/plugin-kubernetes-common';
 
+// Warning: (ae-forgotten-export) The symbol "KubernetesAuthProvider" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export class AksKubernetesAuthProvider implements KubernetesAuthProvider {
+  constructor(authProvider: OAuthApi);
+  // (undocumented)
+  authProvider: OAuthApi;
+  // (undocumented)
+  decorateRequestBodyForAuth(
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody>;
+}
+
 // Warning: (ae-forgotten-export) The symbol "ClusterProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Cluster" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -172,7 +185,6 @@ export function formatClusterLink(
   options: FormatClusterLinkOptions,
 ): string | undefined;
 
-// Warning: (ae-forgotten-export) The symbol "KubernetesAuthProvider" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "GoogleKubernetesAuthProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -275,6 +287,7 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     oidcProviders?: {
       [key: string]: OpenIdConnectApi;
     };
+    microsoftAuthApi: OAuthApi;
   });
   // (undocumented)
   decorateRequestBodyForAuth(

--- a/plugins/kubernetes/src/kubernetes-auth-provider/AksKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/AksKubernetesAuthProvider.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthProvider } from './types';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+import { OAuthApi } from '@backstage/core-plugin-api';
+
+export class AksKubernetesAuthProvider implements KubernetesAuthProvider {
+  authProvider: OAuthApi;
+
+  constructor(authProvider: OAuthApi) {
+    this.authProvider = authProvider;
+  }
+
+  async decorateRequestBodyForAuth(
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody> {
+    const aksAuthToken: string = await this.authProvider.getAccessToken(
+      '6dae42f8-4368-4678-94ff-3960e28e3630/user.read',
+    );
+    if ('auth' in requestBody) {
+      requestBody.auth!.aks = aksAuthToken;
+    } else {
+      requestBody.auth = { aks: aksAuthToken };
+    }
+    return requestBody;
+  }
+}

--- a/plugins/kubernetes/src/kubernetes-auth-provider/AksKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/AksKubernetesAuthProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@
 import { KubernetesAuthProvider } from './types';
 import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { OAuthApi } from '@backstage/core-plugin-api';
+
+/**
+ *
+ * @public
+ */
 
 export class AksKubernetesAuthProvider implements KubernetesAuthProvider {
   authProvider: OAuthApi;

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
@@ -44,6 +44,7 @@ describe('KubernetesAuthProviders tests', () => {
     oidcProviders: {
       okta: new MockAuthApi('oktaToken'),
     },
+    microsoftAuthApi: new MockAuthApi('microsoftAksToken'),
   });
 
   it('adds token to request body for google authProvider', async () => {

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -20,6 +20,7 @@ import { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
 import { ServerSideKubernetesAuthProvider } from './ServerSideAuthProvider';
 import { OAuthApi, OpenIdConnectApi } from '@backstage/core-plugin-api';
 import { OidcKubernetesAuthProvider } from './OidcKubernetesAuthProvider';
+import { AksKubernetesAuthProvider } from './AksKubernetesAuthProvider';
 
 export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
   private readonly kubernetesAuthProviderMap: Map<
@@ -30,6 +31,7 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
   constructor(options: {
     googleAuthApi: OAuthApi;
     oidcProviders?: { [key: string]: OpenIdConnectApi };
+    microsoftAuthApi: OAuthApi;
   }) {
     this.kubernetesAuthProviderMap = new Map<string, KubernetesAuthProvider>();
     this.kubernetesAuthProviderMap.set(
@@ -55,6 +57,10 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     this.kubernetesAuthProviderMap.set(
       'localKubectlProxy',
       new ServerSideKubernetesAuthProvider(),
+    );
+    this.kubernetesAuthProviderMap.set(
+      'microsoftaks',
+      new AksKubernetesAuthProvider(options.microsoftAuthApi),
     );
 
     if (options.oidcProviders) {

--- a/plugins/kubernetes/src/kubernetes-auth-provider/index.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/index.ts
@@ -19,3 +19,4 @@ export type { KubernetesAuthProvidersApi } from './types';
 export { KubernetesAuthProviders } from './KubernetesAuthProviders';
 export { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
 export { ServerSideKubernetesAuthProvider } from './ServerSideAuthProvider';
+export { AksKubernetesAuthProvider } from './AksKubernetesAuthProvider';

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -67,7 +67,11 @@ export const kubernetesPlugin = createPlugin({
           onelogin: oneloginAuthApi,
         };
 
-        return new KubernetesAuthProviders({ googleAuthApi, oidcProviders });
+        return new KubernetesAuthProviders({
+          googleAuthApi,
+          oidcProviders,
+          microsoftAuthApi,
+        });
       },
     }),
   ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Need
The following PR addresses this user/integrator story:
As a Backstage integrator I want a client-side kubernetes auth solution for AKS clusters so that I can surface the status of AKS-deployed services in Backstage without granting high-powered privileges to a service account. This solution resolves [#13685](https://github.com/backstage/backstage/issues/13685). See issue for more information.

## Solution:
This is being done by:
- Creation of a new Auth Provider and ApiRef built from the oauth2 implementation using the 6dae42f8-4368-4678-94ff-3960e28e3630/user.read scope.
- Creation of a new KubernetesAuthProvider called AksKubernetesAuthProvider which consumes the above OAuthApi to get an access token and appends it to the kubernetes-backend request in a field like auth.microsoftaks
- Creation of a new KubernetesAuthTranslator called AksKubernetesrAuthTranslator which receives the token from the auth.microsoftaks field in the request body and uses it as a service account token in requests to k8s

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
