### PR TITLE
fix: add missing googleServiceAccount auth provider in config schema

### DIFF
--- a/.changeset/thick-tomatoes-bow.md
+++ b/.changeset/thick-tomatoes-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Added the missing auth provider googleServiceAccount in config schema.

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -47,7 +47,8 @@ export interface Config {
               | 'google'
               | 'serviceAccount'
               | 'azure'
-              | 'oidc';
+              | 'oidc'
+              | 'googleServiceAccount';
             /** @visibility frontend */
             oidcTokenProvider?: string;
             /** @visibility frontend */


### PR DESCRIPTION
Signed-off-by: Shardul Srivastava <shardul.srivastava007@gmail.com>

## Hey, I just made a Pull Request!

Fixed the missing authProvider `googleServiceAccount` in config schema. This PR fixes https://github.com/backstage/backstage/issues/15349.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
