### PR TITLE
Improve MS Graph Onboarding

### DIFF
--- a/.changeset/modern-horses-poke.md
+++ b/.changeset/modern-horses-poke.md
@@ -1,0 +1,24 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': minor
+---
+
+Improved performance by reducing the number of calls being made to the Microsoft Graph API.
+
+- Increased the number of rows returned at a time from 100 to 999.
+- Load user data in batches when getting users by group membership, rather than making individual calls per user.
+
+Improved logging to provide more information as the task progresses.
+
+Added support for loading only users and only groups
+If you don't add any configuration for groups or users, then they won't be ingested.
+You can restore the previous behavior by providing empty (do you want to include disabled accounts and guest users?)
+
+```yaml
+microsoftGraphOrg:
+  default:
+  # ...
+  userGroupMember:
+    filter: ' '
+  group:
+    filter: ' '
+```

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -70,7 +70,11 @@ export const MICROSOFT_GRAPH_USER_ID_ANNOTATION = 'graph.microsoft.com/user-id';
 export class MicrosoftGraphClient {
   constructor(baseUrl: string, tokenCredential: TokenCredential);
   static create(config: MicrosoftGraphProviderConfig): MicrosoftGraphClient;
-  getGroupMembers(groupId: string): AsyncIterable<GroupMember>;
+  getGroupMembers(
+    groupId: string,
+    query?: ODataQuery,
+    queryMode?: QueryMode,
+  ): AsyncIterable<GroupMember>;
   // (undocumented)
   getGroupPhoto(groupId: string, sizeId?: string): Promise<string | undefined>;
   getGroupPhotoWithSizeLimit(
@@ -79,8 +83,13 @@ export class MicrosoftGraphClient {
   ): Promise<string | undefined>;
   getGroups(
     query?: ODataQuery,
-    queryMode?: 'basic' | 'advanced',
+    queryMode?: QueryMode,
   ): AsyncIterable<MicrosoftGraph.Group>;
+  getGroupUserMembers(
+    groupId: string,
+    query?: ODataQuery,
+    queryMode?: QueryMode,
+  ): AsyncIterable<MicrosoftGraph.User>;
   getOrganization(tenantId: string): Promise<MicrosoftGraph.Organization>;
   // (undocumented)
   getUserPhoto(userId: string, sizeId?: string): Promise<string | undefined>;
@@ -88,13 +97,9 @@ export class MicrosoftGraphClient {
     userId: string,
     maxSize: number,
   ): Promise<string | undefined>;
-  getUserProfile(
-    userId: string,
-    query?: ODataQuery,
-  ): Promise<MicrosoftGraph.User>;
   getUsers(
     query?: ODataQuery,
-    queryMode?: 'basic' | 'advanced',
+    queryMode?: QueryMode,
   ): AsyncIterable<MicrosoftGraph.User>;
   requestApi(
     path: string,
@@ -104,7 +109,7 @@ export class MicrosoftGraphClient {
   requestCollection<T>(
     path: string,
     query?: ODataQuery,
-    queryMode?: 'basic' | 'advanced',
+    queryMode?: QueryMode,
   ): AsyncIterable<T>;
   requestRaw(
     url: string,
@@ -233,12 +238,16 @@ export type ODataQuery = {
   expand?: string;
   select?: string[];
   count?: boolean;
+  top?: number;
 };
 
 // @public
 export type OrganizationTransformer = (
   organization: MicrosoftGraph.Organization,
 ) => Promise<GroupEntity | undefined>;
+
+// @public
+export type QueryMode = 'basic' | 'advanced';
 
 // @public @deprecated
 export function readMicrosoftGraphConfig(
@@ -259,11 +268,11 @@ export function readMicrosoftGraphOrg(
     groupSearch?: string;
     groupFilter?: string;
     groupSelect?: string[];
-    queryMode?: 'basic' | 'advanced';
+    queryMode?: QueryMode;
     userTransformer?: UserTransformer;
     groupTransformer?: GroupTransformer;
     organizationTransformer?: OrganizationTransformer;
-    logger: Logger;
+    logger?: Logger;
   },
 ): Promise<{
   users: UserEntity[];

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
@@ -70,7 +70,7 @@ describe('MicrosoftGraphClient', () => {
     expect(await response.json()).toEqual({ value: 'example' });
   });
 
-  it('should perform api request with filter, select and expand', async () => {
+  it('should perform api request with filter, select, expand and top', async () => {
     worker.use(
       rest.get('https://example.com/users', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ queryString: req.url.search })),
@@ -81,12 +81,13 @@ describe('MicrosoftGraphClient', () => {
       filter: 'test eq true',
       expand: 'children',
       select: ['id', 'children'],
+      top: 471,
     });
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       queryString:
-        '?$filter=test%20eq%20true&$select=id,children&$expand=children',
+        '?$filter=test%20eq%20true&$select=id,children&$expand=children&$top=471',
     });
   });
 
@@ -132,33 +133,6 @@ describe('MicrosoftGraphClient', () => {
     );
 
     expect(values).toEqual(['first', 'second']);
-  });
-
-  it('should load user profile', async () => {
-    worker.use(
-      rest.get('https://example.com/users/user-id', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            surname: 'Example',
-          }),
-        ),
-      ),
-    );
-
-    const userProfile = await client.getUserProfile('user-id');
-
-    expect(userProfile).toEqual({ surname: 'Example' });
-  });
-
-  it('should throw exception if load user profile fails', async () => {
-    worker.use(
-      rest.get('https://example.com/users/user-id', (_, res, ctx) =>
-        res(ctx.status(404)),
-      ),
-    );
-
-    await expect(() => client.getUserProfile('user-id')).rejects.toThrow();
   });
 
   it('should load user profile photo with max size of 120', async () => {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/defaultTransformers.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MICROSOFT_EMAIL_ANNOTATION,
+  MICROSOFT_GRAPH_GROUP_ID_ANNOTATION,
+  MICROSOFT_GRAPH_TENANT_ID_ANNOTATION,
+  MICROSOFT_GRAPH_USER_ID_ANNOTATION,
+} from './constants';
+import { normalizeEntityName } from './helper';
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
+
+/**
+ * The default implementation of the transformation from a graph organization
+ * entry to a Group entity.
+ *
+ * @public
+ */
+export async function defaultOrganizationTransformer(
+  organization: MicrosoftGraph.Organization,
+): Promise<GroupEntity | undefined> {
+  if (!organization.id || !organization.displayName) {
+    return undefined;
+  }
+
+  const name = normalizeEntityName(organization.displayName!);
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: name,
+      description: organization.displayName!,
+      annotations: {
+        [MICROSOFT_GRAPH_TENANT_ID_ANNOTATION]: organization.id!,
+      },
+    },
+    spec: {
+      type: 'root',
+      profile: {
+        displayName: organization.displayName!,
+      },
+      children: [],
+    },
+  };
+}
+
+function extractGroupName(group: MicrosoftGraph.Group): string {
+  if (group.securityEnabled) {
+    return group.displayName as string;
+  }
+  return (group.mailNickname || group.displayName) as string;
+}
+
+/**
+ * The default implementation of the transformation from a graph group entry to
+ * a Group entity.
+ *
+ * @public
+ */
+export async function defaultGroupTransformer(
+  group: MicrosoftGraph.Group,
+  groupPhoto?: string,
+): Promise<GroupEntity | undefined> {
+  if (!group.id || !group.displayName) {
+    return undefined;
+  }
+
+  const name = normalizeEntityName(extractGroupName(group));
+  const entity: GroupEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: name,
+      annotations: {
+        [MICROSOFT_GRAPH_GROUP_ID_ANNOTATION]: group.id,
+      },
+    },
+    spec: {
+      type: 'team',
+      profile: {},
+      children: [],
+    },
+  };
+
+  if (group.description) {
+    entity.metadata.description = group.description;
+  }
+  if (group.displayName) {
+    entity.spec.profile!.displayName = group.displayName;
+  }
+  if (group.mail) {
+    entity.spec.profile!.email = group.mail;
+  }
+  if (groupPhoto) {
+    entity.spec.profile!.picture = groupPhoto;
+  }
+
+  return entity;
+}
+
+/**
+ * The default implementation of the transformation from a graph user entry to
+ * a User entity.
+ *
+ * @public
+ */
+export async function defaultUserTransformer(
+  user: MicrosoftGraph.User,
+  userPhoto?: string,
+): Promise<UserEntity | undefined> {
+  if (!user.id || !user.displayName || !user.mail) {
+    return undefined;
+  }
+
+  const name = normalizeEntityName(user.mail);
+  const entity: UserEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'User',
+    metadata: {
+      name,
+      annotations: {
+        [MICROSOFT_EMAIL_ANNOTATION]: user.mail!,
+        [MICROSOFT_GRAPH_USER_ID_ANNOTATION]: user.id!,
+      },
+    },
+    spec: {
+      profile: {
+        displayName: user.displayName!,
+        email: user.mail!,
+
+        // TODO: Additional fields?
+        // jobTitle: user.jobTitle || undefined,
+        // officeLocation: user.officeLocation || undefined,
+        // mobilePhone: user.mobilePhone || undefined,
+      },
+      memberOf: [],
+    },
+  };
+
+  if (userPhoto) {
+    entity.spec.profile!.picture = userPhoto;
+  }
+
+  return entity;
+}

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/index.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/index.ts
@@ -25,14 +25,15 @@ export {
   MICROSOFT_GRAPH_USER_ID_ANNOTATION,
 } from './constants';
 export { normalizeEntityName } from './helper';
+export { readMicrosoftGraphOrg } from './read';
 export {
   defaultGroupTransformer,
   defaultOrganizationTransformer,
   defaultUserTransformer,
-  readMicrosoftGraphOrg,
-} from './read';
+} from './defaultTransformers';
 export type {
   GroupTransformer,
   OrganizationTransformer,
   UserTransformer,
+  QueryMode,
 } from './types';

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
@@ -57,13 +57,12 @@ function group(data: Partial<GroupEntity>): GroupEntity {
     data,
   );
 }
-
 describe('read microsoft graph', () => {
   const client: jest.Mocked<MicrosoftGraphClient> = {
     getUsers: jest.fn(),
-    getUserProfile: jest.fn(),
     getGroups: jest.fn(),
     getGroupMembers: jest.fn(),
+    getGroupUserMembers: jest.fn(),
     getUserPhotoWithSizeLimit: jest.fn(),
     getGroupPhotoWithSizeLimit: jest.fn(),
     getOrganization: jest.fn(),
@@ -71,16 +70,35 @@ describe('read microsoft graph', () => {
 
   afterEach(() => jest.resetAllMocks());
 
+  async function* getExampleUsers() {
+    yield {
+      id: 'userid',
+      displayName: 'User Name',
+      mail: 'user.name@example.com',
+    };
+  }
+
+  async function* getExampleGroups() {
+    yield {
+      id: 'groupid',
+      displayName: 'Group Name',
+      description: 'Group Description',
+      mail: 'group@example.com',
+    };
+  }
+  async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
+    yield {
+      '@odata.type': '#microsoft.graph.group',
+      id: 'childgroupid',
+    };
+    yield {
+      '@odata.type': '#microsoft.graph.user',
+      id: 'userid',
+    };
+  }
+
   describe('readMicrosoftGraphUsers', () => {
     it('should read users', async () => {
-      async function* getExampleUsers() {
-        yield {
-          id: 'userid',
-          displayName: 'User Name',
-          mail: 'user.name@example.com',
-        };
-      }
-
       client.getUsers.mockImplementation(getExampleUsers);
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
@@ -115,6 +133,7 @@ describe('read microsoft graph', () => {
       expect(client.getUsers).toHaveBeenCalledWith(
         {
           filter: 'accountEnabled eq true',
+          top: 999,
         },
         undefined,
       );
@@ -126,14 +145,6 @@ describe('read microsoft graph', () => {
     });
 
     it('should read users with advanced query mode', async () => {
-      async function* getExampleUsers() {
-        yield {
-          id: 'userid',
-          displayName: 'User Name',
-          mail: 'user.name@example.com',
-        };
-      }
-
       client.getUsers.mockImplementation(getExampleUsers);
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
@@ -169,6 +180,7 @@ describe('read microsoft graph', () => {
       expect(client.getUsers).toHaveBeenCalledWith(
         {
           filter: 'accountEnabled eq true',
+          top: 999,
         },
         'advanced',
       );
@@ -180,14 +192,6 @@ describe('read microsoft graph', () => {
     });
 
     it('should read users with userExpand and custom transformer', async () => {
-      async function* getExampleUsers() {
-        yield {
-          id: 'userid',
-          displayName: 'User Name',
-          mail: 'user.name@example.com',
-        };
-      }
-
       client.getUsers.mockImplementation(getExampleUsers);
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
@@ -219,6 +223,7 @@ describe('read microsoft graph', () => {
         {
           expand: 'manager',
           filter: 'accountEnabled eq true',
+          top: 999,
         },
         undefined,
       );
@@ -232,34 +237,9 @@ describe('read microsoft graph', () => {
 
   describe('readMicrosoftGraphUsersInGroups', () => {
     it('should read users from Groups', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
-      client.getGroupMembers.mockImplementation(getExampleGroupMembers);
+      client.getGroupUserMembers.mockImplementation(getExampleUsers);
 
-      client.getUserProfile.mockResolvedValue({
-        id: 'userid',
-        displayName: 'User Name',
-        mail: 'user.name@example.com',
-      });
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
       );
@@ -292,17 +272,19 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledTimes(1);
       expect(client.getGroups).toHaveBeenCalledWith(
         {
+          select: ['id', 'displayName'],
           filter: 'securityEnabled eq true',
+          top: 999,
         },
         undefined,
       );
-      expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupUserMembers).toHaveBeenCalledTimes(1);
+      expect(client.getGroupUserMembers).toHaveBeenCalledWith(
+        'groupid',
+        { top: 999 },
+        undefined,
+      );
 
-      expect(client.getUserProfile).toHaveBeenCalledTimes(1);
-      expect(client.getUserProfile).toHaveBeenCalledWith('userid', {
-        expand: undefined,
-      });
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledTimes(1);
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledWith(
         'userid',
@@ -311,34 +293,9 @@ describe('read microsoft graph', () => {
     });
 
     it('should read users from Groups with advanced query mode', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
-      client.getGroupMembers.mockImplementation(getExampleGroupMembers);
+      client.getGroupUserMembers.mockImplementation(getExampleUsers);
 
-      client.getUserProfile.mockResolvedValue({
-        id: 'userid',
-        displayName: 'User Name',
-        mail: 'user.name@example.com',
-      });
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
       );
@@ -373,16 +330,18 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq true',
+          select: ['id', 'displayName'],
+          top: 999,
         },
         'advanced',
       );
-      expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupUserMembers).toHaveBeenCalledTimes(1);
+      expect(client.getGroupUserMembers).toHaveBeenCalledWith(
+        'groupid',
+        { top: 999 },
+        'advanced',
+      );
 
-      expect(client.getUserProfile).toHaveBeenCalledTimes(1);
-      expect(client.getUserProfile).toHaveBeenCalledWith('userid', {
-        expand: undefined,
-      });
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledTimes(1);
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledWith(
         'userid',
@@ -391,34 +350,8 @@ describe('read microsoft graph', () => {
     });
 
     it('should read users with userExpand, groupExpand and custom transformer', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
-      client.getGroupMembers.mockImplementation(getExampleGroupMembers);
-
-      client.getUserProfile.mockResolvedValue({
-        id: 'userid',
-        displayName: 'User Name',
-        mail: 'user.name@example.com',
-      });
+      client.getGroupUserMembers.mockImplementation(getExampleUsers);
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
       );
@@ -450,16 +383,21 @@ describe('read microsoft graph', () => {
         {
           expand: 'member',
           filter: 'securityEnabled eq true',
+          select: ['id', 'displayName'],
+          top: 999,
         },
         undefined,
       );
-      expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupUserMembers).toHaveBeenCalledTimes(1);
+      expect(client.getGroupUserMembers).toHaveBeenCalledWith(
+        'groupid',
+        {
+          expand: 'manager',
+          top: 999,
+        },
+        undefined,
+      );
 
-      expect(client.getUserProfile).toHaveBeenCalledTimes(1);
-      expect(client.getUserProfile).toHaveBeenCalledWith('userid', {
-        expand: 'manager',
-      });
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledTimes(1);
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledWith(
         'userid',
@@ -524,26 +462,6 @@ describe('read microsoft graph', () => {
 
   describe('readMicrosoftGraphGroups', () => {
     it('should read groups', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
       client.getGroupMembers.mockImplementation(getExampleGroupMembers);
       client.getOrganization.mockResolvedValue({
@@ -607,11 +525,15 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq false',
+          top: 999,
         },
         undefined,
       );
       expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid', {
+        select: ['id'],
+        top: 999,
+      });
       // TODO: Loading groups photos doesn't work right now as Microsoft Graph
       // doesn't allows this yet
       // expect(client.getGroupPhotoWithSizeLimit).toBeCalledTimes(1);
@@ -619,26 +541,6 @@ describe('read microsoft graph', () => {
     });
 
     it('should read groups with advanced query mode', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
       client.getGroupMembers.mockImplementation(getExampleGroupMembers);
       client.getOrganization.mockResolvedValue({
@@ -703,11 +605,15 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq false',
+          top: 999,
         },
         'advanced',
       );
       expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid', {
+        select: ['id'],
+        top: 999,
+      });
       // TODO: Loading groups photos doesn't work right now as Microsoft Graph
       // doesn't allows this yet
       // expect(client.getGroupPhotoWithSizeLimit).toBeCalledTimes(1);
@@ -715,26 +621,6 @@ describe('read microsoft graph', () => {
     });
 
     it('should read groups with groupExpand', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
       client.getGroupMembers.mockImplementation(getExampleGroupMembers);
       client.getOrganization.mockResolvedValue({
@@ -800,11 +686,15 @@ describe('read microsoft graph', () => {
         {
           expand: 'member',
           filter: 'securityEnabled eq false',
+          top: 999,
         },
         undefined,
       );
       expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid', {
+        select: ['id'],
+        top: 999,
+      });
       // TODO: Loading groups photos doesn't work right now as Microsoft Graph
       // doesn't allows this yet
       // expect(client.getGroupPhotoWithSizeLimit).toBeCalledTimes(1);
@@ -812,29 +702,6 @@ describe('read microsoft graph', () => {
     });
 
     it('should read security groups', async () => {
-      async function* getExampleGroups() {
-        yield {
-          id: 'groupid',
-          displayName: 'Group Name',
-          description: 'Group Description',
-          mail: 'group@example.com',
-          mailNickname: 'df546d53-4f5f-4462-b371-d4a855787047',
-          mailEnabled: false,
-          securityEnabled: true,
-        };
-      }
-
-      async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-        yield {
-          '@odata.type': '#microsoft.graph.group',
-          id: 'childgroupid',
-        };
-        yield {
-          '@odata.type': '#microsoft.graph.user',
-          id: 'userid',
-        };
-      }
-
       client.getGroups.mockImplementation(getExampleGroups);
       client.getGroupMembers.mockImplementation(getExampleGroupMembers);
       client.getOrganization.mockResolvedValue({
@@ -893,11 +760,15 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq true',
+          top: 999,
         },
         undefined,
       );
       expect(client.getGroupMembers).toHaveBeenCalledTimes(1);
-      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid');
+      expect(client.getGroupMembers).toHaveBeenCalledWith('groupid', {
+        select: ['id'],
+        top: 999,
+      });
     });
   });
 
@@ -994,84 +865,25 @@ describe('read microsoft graph', () => {
   });
 
   describe('readMicrosoftGraphOrg', () => {
-    async function* getExampleUsers() {
-      yield {
-        id: 'userid',
-        displayName: 'User Name',
-        mail: 'user.name@example.com',
-      };
-    }
-
     async function* getExampleUsersEmail() {
       yield {
         mail: 'user.name@example.com',
       };
     }
 
-    async function getExampleUserProfile(userId: string) {
-      return {
-        id: userId,
-        displayName: 'User Name',
-        mail: 'user.name@example.com',
-      };
-    }
-
-    async function* getExampleGroups() {
-      yield {
-        id: 'groupid',
-        displayName: 'Group Name',
-        description: 'Group Description',
-        mail: 'group@example.com',
-      };
-    }
-
-    async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
-      yield {
-        '@odata.type': '#microsoft.graph.group',
-        id: 'childgroupid',
-      };
-      yield {
-        '@odata.type': '#microsoft.graph.user',
-        id: 'userid',
-      };
-    }
-
-    it('should read all users if no filter provided', async () => {
-      client.getOrganization.mockResolvedValue({
-        id: 'tenantid',
-        displayName: 'Organization Name',
-      });
-
-      client.getUsers.mockImplementation(getExampleUsers);
-      client.getUserPhotoWithSizeLimit.mockResolvedValue(
-        'data:image/jpeg;base64,...',
-      );
-
-      client.getGroups.mockImplementation(getExampleGroups);
-      client.getGroupMembers.mockImplementation(getExampleGroupMembers);
-      client.getGroupPhotoWithSizeLimit.mockResolvedValue(
-        'data:image/jpeg;base64,...',
-      );
-
-      await readMicrosoftGraphOrg(client, 'tenantid', {
-        logger: getVoidLogger(),
-        groupFilter: 'securityEnabled eq false',
-      });
-
-      expect(client.getUsers).toHaveBeenCalledTimes(1);
-      expect(client.getUsers).toHaveBeenCalledWith(
+    it('should read no users or groups if no search or filters provided', async () => {
+      const { users, groups } = await readMicrosoftGraphOrg(
+        client,
+        'tenantid',
         {
-          filter: undefined,
+          logger: getVoidLogger(),
         },
-        undefined,
       );
-      expect(client.getGroups).toHaveBeenCalledTimes(1);
-      expect(client.getGroups).toHaveBeenCalledWith(
-        {
-          filter: 'securityEnabled eq false',
-        },
-        undefined,
-      );
+
+      expect(users.length).toBe(0);
+      expect(groups.length).toBe(0);
+      expect(client.getUsers).toHaveBeenCalledTimes(0);
+      expect(client.getGroups).toHaveBeenCalledTimes(0);
     });
 
     it('should read users using userExpand and userFilter', async () => {
@@ -1103,6 +915,7 @@ describe('read microsoft graph', () => {
         {
           expand: 'manager',
           filter: 'accountEnabled eq true',
+          top: 999,
         },
         undefined,
       );
@@ -1110,6 +923,7 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq false',
+          top: 999,
         },
         undefined,
       );
@@ -1132,12 +946,15 @@ describe('read microsoft graph', () => {
       await readMicrosoftGraphOrg(client, 'tenantid', {
         logger: getVoidLogger(),
         userSelect: ['mail'],
+        userFilter: 'filter',
       });
 
       expect(client.getUsers).toHaveBeenCalledTimes(1);
       expect(client.getUsers).toHaveBeenCalledWith(
         {
           select: ['mail'],
+          filter: 'filter',
+          top: 999,
         },
         undefined,
       );
@@ -1150,13 +967,13 @@ describe('read microsoft graph', () => {
       });
 
       client.getUsers.mockImplementation(getExampleUsers);
-      client.getUserProfile.mockImplementation(getExampleUserProfile);
       client.getUserPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
       );
 
       client.getGroups.mockImplementation(getExampleGroups);
       client.getGroupMembers.mockImplementation(getExampleGroupMembers);
+      client.getGroupUserMembers.mockImplementation(getExampleUsers);
       client.getGroupPhotoWithSizeLimit.mockResolvedValue(
         'data:image/jpeg;base64,...',
       );
@@ -1172,16 +989,18 @@ describe('read microsoft graph', () => {
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'name eq backstage-group',
+          select: ['id', 'displayName'],
+          top: 999,
         },
         undefined,
       );
       expect(client.getGroups).toHaveBeenCalledWith(
         {
           filter: 'securityEnabled eq false',
+          top: 999,
         },
         undefined,
       );
-      expect(client.getUserProfile).toHaveBeenCalledTimes(1);
       expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledTimes(1);
     });
   });

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/types.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/types.ts
@@ -18,6 +18,13 @@ import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 
 /**
+ * Type of query to execute
+ *
+ * @public
+ */
+export type QueryMode = 'basic' | 'advanced';
+
+/**
  * Customize the ingested User entity
  *
  * @public

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
@@ -364,10 +364,10 @@ function trackProgress(logger: Logger) {
   let timestamp = Date.now();
   let summary: string;
 
-  logger.info('Reading msgraph users and groups');
+  logger.info('Reading Microsoft Graph users and groups');
 
   function markReadComplete(read: { users: unknown[]; groups: unknown[] }) {
-    summary = `${read.users.length} msgraph users and ${read.groups.length} msgraph groups`;
+    summary = `${read.users.length} users and ${read.groups.length} groups from Microsoft graph`;
     const readDuration = ((Date.now() - timestamp) / 1000).toFixed(1);
     timestamp = Date.now();
     logger.info(`Read ${summary} in ${readDuration} seconds. Committing...`);


### PR DESCRIPTION
Fixes #14757

## Hey, I just made a Pull Request!

Improved performance by reducing the number of calls being made to the Microsoft Graph API.
* Increased the number of rows returned at a time from 100 to 999.
* Load user data in batches when getting users by group membership, rather than making individual calls per user.

In my local environment, this improved the time for ingesting 42 users and 28 groups from 173 seconds to 113 (a roughly 33% improvement). This will show biggest improvements in local environments where the latency of extra calls is more expensive, but should show some benefits in production environments.

Added support for natively loading only users or only groups, without having hack it in (e.g. by using queries that always return false). If you don't add any configuration for groups or users, then they won't be ingested.

Improved Logging to provide more indications that something is happening throughout the ingestion process.  This should hopefully help with the questions we get around the Microsoft Graph plugin not loading users, when the issue is not waiting long enough.  As an example of hte new logging:

Before

```plain
[1] 2023-01-09T20:07:44.063Z catalog info Reading msgraph users and groups type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=4bd2db5e-943c-440d-932a-b3cddf770e5e
[1] 2023-01-09T20:08:13.857Z catalog info groupMemberUsers 43 type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=4bd2db5e-943c-440d-932a-b3cddf770e5e
[0] webpack compiled successfully
[1] 2023-01-09T20:10:37.077Z catalog info Read 42 msgraph users and 28 msgraph groups in 173.0 seconds. Committing... type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=4bd2db5e-943c-440d-932a-b3cddf770e5e
[1] 2023-01-09T20:10:37.139Z catalog info Committed 42 msgraph users and 28 msgraph groups in 0.1 seconds. type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=4bd2db5e-943c-440d-932a-b3cddf770e5e
```

After

```plain
[1] 2023-01-09T20:33:32.844Z catalog info Reading Microsoft graph users and groups type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[1] 2023-01-09T20:33:32.852Z catalog info Loading users by group membership type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[1] 2023-01-09T20:33:46.318Z catalog info Read users from group type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7 groupId=REDACTED groupName=REDACTED memberCount=5
[1] 2023-01-09T20:33:46.354Z catalog info Read users from group type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7 groupId=REDACTED groupName=REDACTED memberCount=0
...
[1] 2023-01-09T20:34:02.150Z catalog info Read users from group membership type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7 groupCount=27 userCount=43
[1] 2023-01-09T20:34:02.151Z catalog info Transforming users type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[1] 2023-01-09T20:34:59.023Z catalog info Finished transforming users type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7 microsoftUserCount=43 backstageUserCount=42
[1] 2023-01-09T20:34:59.024Z catalog info Loading Organization type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[1] 2023-01-09T20:35:03.086Z catalog info Loading Groups type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[0] webpack compiled successfully
[1] 2023-01-09T20:35:26.670Z catalog info Loaded Groups type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7 count=28
[1] 2023-01-09T20:35:26.671Z catalog info Resolving relations type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[1] 2023-01-09T20:35:26.680Z catalog info Read 42 users and 28 groups from Microsoft graph in 113.8 seconds. Committing... type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
[1] 2023-01-09T20:35:26.712Z catalog info Committed 42 users and 28 groups from Microsoft graph in 0.0 seconds. type=plugin class=MicrosoftGraphOrgEntityProvider taskId=MicrosoftGraphOrgEntityProvider:default:refresh taskInstanceId=94390bd8-dd4d-4ecc-8cc6-0822aaa8b9c7
```

Other misc changes

* Moved default transformers out to their own file
* Reduced duplication in tests by reusing examples, rather than duplicate the same sample data in multiple tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
