### PR TITLE
backend-app-api: switch plugin log label pluginId->plugin

### DIFF
--- a/.changeset/polite-books-suffer.md
+++ b/.changeset/polite-books-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Tweaked the plugin logger to use `plugin` as the label for the plugin ID, rather than `pluginId`.

--- a/packages/backend-app-api/src/services/implementations/loggerService.ts
+++ b/packages/backend-app-api/src/services/implementations/loggerService.ts
@@ -28,7 +28,7 @@ export const loggerFactory = createServiceFactory({
   },
   async factory({ rootLogger }) {
     return async ({ plugin }) => {
-      return rootLogger.child({ pluginId: plugin.getId() });
+      return rootLogger.child({ plugin: plugin.getId() });
     };
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We currently use `plugin` in existing backends, and our default log formatter has special treatment of that label.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
