### PR TITLE
backend-common: make it possible to override service log label

### DIFF
--- a/.changeset/orange-maps-roll.md
+++ b/.changeset/orange-maps-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Updated the logger created by `createRootLogger` to make it possible to override the default `service` log label.

--- a/packages/backend-common/src/logging/rootLogger.ts
+++ b/packages/backend-common/src/logging/rootLogger.ts
@@ -101,26 +101,27 @@ export function createRootLogger(
   options: winston.LoggerOptions = {},
   env = process.env,
 ): winston.Logger {
-  const logger = winston.createLogger(
-    merge<LoggerOptions, LoggerOptions>(
-      {
-        level: env.LOG_LEVEL || 'info',
-        format: winston.format.combine(
-          winston.format(redactWinstonLogLine)(),
-          env.NODE_ENV === 'production' ? winston.format.json() : coloredFormat,
-        ),
-        defaultMeta: {
-          service: 'backstage',
+  const logger = winston
+    .createLogger(
+      merge<LoggerOptions, LoggerOptions>(
+        {
+          level: env.LOG_LEVEL || 'info',
+          format: winston.format.combine(
+            winston.format(redactWinstonLogLine)(),
+            env.NODE_ENV === 'production'
+              ? winston.format.json()
+              : coloredFormat,
+          ),
+          transports: [
+            new winston.transports.Console({
+              silent: env.JEST_WORKER_ID !== undefined && !env.LOG_LEVEL,
+            }),
+          ],
         },
-        transports: [
-          new winston.transports.Console({
-            silent: env.JEST_WORKER_ID !== undefined && !env.LOG_LEVEL,
-          }),
-        ],
-      },
-      options,
-    ),
-  );
+        options,
+      ),
+    )
+    .child({ service: 'backstage' });
 
   setRootLogger(logger);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using the `defaultMeta` option it's not possible to override the label using `logger.child()`, so let's switch to just making it a child logger instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
