### PR TITLE
fix(incremental): do not try to commit empty array of entity records

### DIFF
--- a/.changeset/six-crabs-sell.md
+++ b/.changeset/six-crabs-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Fixed issue with sometimes trying to commit an empty array of references

--- a/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.ts
@@ -577,13 +577,15 @@ export class IncrementalIngestionDatabaseManager {
         .update('ingestion_mark_id', markId)
         .whereIn('ref', existingRefsArray);
 
-      await tx('ingestion_mark_entities').insert(
-        newRefs.map(ref => ({
-          id: v4(),
-          ingestion_mark_id: markId,
-          ref,
-        })),
-      );
+      if (newRefs.length > 0) {
+        await tx('ingestion_mark_entities').insert(
+          newRefs.map(ref => ({
+            id: v4(),
+            ingestion_mark_id: markId,
+            ref,
+          })),
+        );
+      }
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Damon Kaswell <damon.kaswell1@hp.com>

## Hey, I just made a Pull Request!

This resolves a bug identified internally by HP Inc. Under some circumstances, the incremental entity provider will try to commit an empty array of entity references to the `ingestion_mark_entities` table.

This PR resolves the issue by ensuring that if the array is empty, no attempt will be made to commit it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
