### PR TITLE
backend-common: added compatibility wrapper for legacy plugins

### DIFF
--- a/.changeset/famous-books-matter.md
+++ b/.changeset/famous-books-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added `legacyPlugin` and the lower level `makeLegacyPlugin` wrappers that convert legacy plugins to the new backend system. This will be used to ease the future migration to the new backend system, but we discourage use of it for now.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -9,6 +9,7 @@
 import aws from 'aws-sdk';
 import { AwsS3Integration } from '@backstage/integration';
 import { AzureIntegration } from '@backstage/integration';
+import { BackendFeature } from '@backstage/backend-plugin-api';
 import { BitbucketCloudIntegration } from '@backstage/integration';
 import { BitbucketIntegration } from '@backstage/integration';
 import { BitbucketServerIntegration } from '@backstage/integration';
@@ -16,6 +17,7 @@ import { CacheClient } from '@backstage/backend-plugin-api';
 import { CacheClientOptions } from '@backstage/backend-plugin-api';
 import { CacheClientSetOptions } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
+import { ConfigService } from '@backstage/backend-plugin-api';
 import cors from 'cors';
 import Docker from 'dockerode';
 import { Duration } from 'luxon';
@@ -26,6 +28,7 @@ import { GiteaIntegration } from '@backstage/integration';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { GithubIntegration } from '@backstage/integration';
 import { GitLabIntegration } from '@backstage/integration';
+import { IdentityService } from '@backstage/backend-plugin-api';
 import { isChildPath } from '@backstage/cli-common';
 import { Knex } from 'knex';
 import { KubeConfig } from '@kubernetes/client-node';
@@ -33,6 +36,7 @@ import { LoadConfigOptionsRemote } from '@backstage/config-loader';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { MergeResult } from 'isomorphic-git';
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { CacheService as PluginCacheManager } from '@backstage/backend-plugin-api';
 import { DatabaseService as PluginDatabaseManager } from '@backstage/backend-plugin-api';
 import { DiscoveryService as PluginEndpointDiscovery } from '@backstage/backend-plugin-api';
@@ -47,10 +51,12 @@ import { ReadUrlOptions } from '@backstage/backend-plugin-api';
 import { ReadUrlResponse } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { Router } from 'express';
+import { SchedulerService } from '@backstage/backend-plugin-api';
 import { SearchOptions } from '@backstage/backend-plugin-api';
 import { SearchResponse } from '@backstage/backend-plugin-api';
 import { SearchResponseFile } from '@backstage/backend-plugin-api';
 import { Server } from 'http';
+import { ServiceRef } from '@backstage/backend-plugin-api';
 import { TokenManagerService as TokenManager } from '@backstage/backend-plugin-api';
 import { TransportStreamOptions } from 'winston-transport';
 import { UrlReaderService as UrlReader } from '@backstage/backend-plugin-api';
@@ -227,6 +233,32 @@ export function createDatabaseClient(
   dbConfig: Config,
   overrides?: Partial<Knex.Config>,
 ): Knex<any, any[]>;
+
+// @public
+export const createPluginCompat: (
+  name: string,
+  createRouterImport: Promise<{
+    default: LegacyCreateRouter<
+      TransformedEnv<
+        {
+          cache: PluginCacheManager;
+          config: ConfigService;
+          database: PluginDatabaseManager;
+          discovery: PluginEndpointDiscovery;
+          logger: LoggerService;
+          permissions: PermissionsService;
+          scheduler: SchedulerService;
+          tokenManager: TokenManager;
+          reader: UrlReader;
+          identity: IdentityService;
+        },
+        {
+          logger: (log: LoggerService) => Logger;
+        }
+      >
+    >;
+  }>,
+) => BackendFeature;
 
 // @public
 export function createRootLogger(
@@ -500,6 +532,9 @@ export type KubernetesContainerRunnerOptions = {
   timeoutMs?: number;
 };
 
+// @public (undocumented)
+export type LegacyCreateRouter<TEnv> = (deps: TEnv) => Promise<RequestHandler>;
+
 // @public
 export function loadBackendConfig(options: {
   logger: LoggerService;
@@ -512,6 +547,24 @@ export function loggerToWinstonLogger(
   logger: LoggerService,
   opts?: TransportStreamOptions,
 ): Logger;
+
+// @public
+export function makePluginCompat<
+  TEnv extends Record<string, unknown>,
+  TEnvTransforms extends {
+    [key in keyof TEnv]?: (dep: TEnv[key]) => unknown;
+  },
+>(
+  envMapping: {
+    [key in keyof TEnv]: ServiceRef<TEnv[key]>;
+  },
+  envTransforms: TEnvTransforms,
+): (
+  name: string,
+  createRouterImport: Promise<{
+    default: LegacyCreateRouter<TransformedEnv<TEnv, TEnvTransforms>>;
+  }>,
+) => BackendFeature;
 
 // @public
 export function notFoundHandler(): RequestHandler;

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -235,32 +235,6 @@ export function createDatabaseClient(
 ): Knex<any, any[]>;
 
 // @public
-export const createPluginCompat: (
-  name: string,
-  createRouterImport: Promise<{
-    default: LegacyCreateRouter<
-      TransformedEnv<
-        {
-          cache: PluginCacheManager;
-          config: ConfigService;
-          database: PluginDatabaseManager;
-          discovery: PluginEndpointDiscovery;
-          logger: LoggerService;
-          permissions: PermissionsService;
-          scheduler: SchedulerService;
-          tokenManager: TokenManager;
-          reader: UrlReader;
-          identity: IdentityService;
-        },
-        {
-          logger: (log: LoggerService) => Logger;
-        }
-      >
-    >;
-  }>,
-) => BackendFeature;
-
-// @public
 export function createRootLogger(
   options?: winston.LoggerOptions,
   env?: NodeJS.ProcessEnv,
@@ -536,6 +510,32 @@ export type KubernetesContainerRunnerOptions = {
 export type LegacyCreateRouter<TEnv> = (deps: TEnv) => Promise<RequestHandler>;
 
 // @public
+export const legacyPlugin: (
+  name: string,
+  createRouterImport: Promise<{
+    default: LegacyCreateRouter<
+      TransformedEnv<
+        {
+          cache: PluginCacheManager;
+          config: ConfigService;
+          database: PluginDatabaseManager;
+          discovery: PluginEndpointDiscovery;
+          logger: LoggerService;
+          permissions: PermissionsService;
+          scheduler: SchedulerService;
+          tokenManager: TokenManager;
+          reader: UrlReader;
+          identity: IdentityService;
+        },
+        {
+          logger: (log: LoggerService) => Logger;
+        }
+      >
+    >;
+  }>,
+) => BackendFeature;
+
+// @public
 export function loadBackendConfig(options: {
   logger: LoggerService;
   remote?: LoadConfigOptionsRemote;
@@ -549,7 +549,7 @@ export function loggerToWinstonLogger(
 ): Logger;
 
 // @public
-export function makePluginCompat<
+export function makeLegacyPlugin<
   TEnv extends Record<string, unknown>,
   TEnvTransforms extends {
     [key in keyof TEnv]?: (dep: TEnv[key]) => unknown;

--- a/packages/backend-common/src/compat.ts
+++ b/packages/backend-common/src/compat.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendPlugin,
+  ServiceRef,
+} from '@backstage/backend-plugin-api';
+import { RequestHandler } from 'express';
+import { loggerToWinstonLogger } from './logging';
+
+/**
+ * @public
+ */
+export type LegacyCreateRouter<TEnv> = (deps: TEnv) => Promise<RequestHandler>;
+
+/** @ignore */
+type TransformedEnv<
+  TEnv extends Record<string, unknown>,
+  TEnvTransforms extends { [key in keyof TEnv]?: (dep: TEnv[key]) => unknown },
+> = {
+  [key in keyof TEnv]: TEnvTransforms[key] extends (dep: TEnv[key]) => infer R
+    ? R
+    : TEnv[key];
+};
+
+/**
+ * Creates a new custom plugin compatibility wrapper.
+ *
+ * @public
+ * @remarks
+ *
+ * Usually you can use {@link createPluginCompat} directly instead, but you might
+ * need to use this if you have customized the plugin environment in your backend.
+ */
+export function makePluginCompat<
+  TEnv extends Record<string, unknown>,
+  TEnvTransforms extends { [key in keyof TEnv]?: (dep: TEnv[key]) => unknown },
+>(
+  envMapping: { [key in keyof TEnv]: ServiceRef<TEnv[key]> },
+  envTransforms: TEnvTransforms,
+) {
+  return (
+    name: string,
+    createRouterImport: Promise<{
+      default: LegacyCreateRouter<TransformedEnv<TEnv, TEnvTransforms>>;
+    }>,
+  ) => {
+    const compatPlugin = createBackendPlugin({
+      id: name,
+      register(env) {
+        env.registerInit({
+          deps: { ...envMapping, _router: coreServices.httpRouter },
+          async init({ _router, ...envDeps }) {
+            const { default: createRouter } = await createRouterImport;
+            const pluginEnv = Object.fromEntries(
+              Object.entries(envDeps).map(([key, dep]) => {
+                const transform = envTransforms[key];
+                if (transform) {
+                  return [key, transform(dep)];
+                }
+                return [key, dep];
+              }),
+            );
+            const router = await createRouter(
+              pluginEnv as TransformedEnv<TEnv, TEnvTransforms>,
+            );
+            _router.use(router);
+          },
+        });
+      },
+    });
+
+    return compatPlugin();
+  };
+}
+
+/**
+ * Helper function to create a plugin from a legacy createRouter function and
+ * register it with the http router based on the plugin id.
+ *
+ * @public
+ * @remarks
+ *
+ * This is intended to be used by plugin authors to ease the transition to the
+ * new backend system.
+ *
+ * @example
+ *
+ *```ts
+ *backend.add(createPluginCompat('kafka', import('./plugins/kafka')));
+ *```
+ */
+export const createPluginCompat = makePluginCompat(
+  {
+    cache: coreServices.cache,
+    config: coreServices.config,
+    database: coreServices.database,
+    discovery: coreServices.discovery,
+    logger: coreServices.logger,
+    permissions: coreServices.permissions,
+    scheduler: coreServices.scheduler,
+    tokenManager: coreServices.tokenManager,
+    reader: coreServices.urlReader,
+    identity: coreServices.identity,
+  },
+  {
+    logger: log => loggerToWinstonLogger(log),
+  },
+);

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -20,8 +20,8 @@
  * @packageDocumentation
  */
 
-export { makePluginCompat, createPluginCompat } from './compat';
-export type { LegacyCreateRouter } from './compat';
+export { legacyPlugin, makeLegacyPlugin } from './legacy';
+export type { LegacyCreateRouter } from './legacy';
 export * from './cache';
 export { loadBackendConfig } from './config';
 export * from './context';

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -20,6 +20,8 @@
  * @packageDocumentation
  */
 
+export { makePluginCompat, createPluginCompat } from './compat';
+export type { LegacyCreateRouter } from './compat';
 export * from './cache';
 export { loadBackendConfig } from './config';
 export * from './context';

--- a/packages/backend-common/src/legacy.ts
+++ b/packages/backend-common/src/legacy.ts
@@ -43,10 +43,10 @@ type TransformedEnv<
  * @public
  * @remarks
  *
- * Usually you can use {@link createPluginCompat} directly instead, but you might
+ * Usually you can use {@link legacyPlugin} directly instead, but you might
  * need to use this if you have customized the plugin environment in your backend.
  */
-export function makePluginCompat<
+export function makeLegacyPlugin<
   TEnv extends Record<string, unknown>,
   TEnvTransforms extends { [key in keyof TEnv]?: (dep: TEnv[key]) => unknown },
 >(
@@ -101,10 +101,10 @@ export function makePluginCompat<
  * @example
  *
  *```ts
- *backend.add(createPluginCompat('kafka', import('./plugins/kafka')));
+ *backend.add(legacyPlugin('kafka', import('./plugins/kafka')));
  *```
  */
-export const createPluginCompat = makePluginCompat(
+export const legacyPlugin = makeLegacyPlugin(
   {
     cache: coreServices.cache,
     config: coreServices.config,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a new compatibility wrapper that allows plugin setup files that export a `createRouter` to be used and installed as a plugin in the new backend system.

It works by creating a legacy plugin environment using the new service dependencies, first by listing all dependencies to be included in the environment, and then by applying optional transforms to each of the dependencies.

Applying this to the create-app template, the `packages/backend/src/index.ts` looks like this:

```ts
import { legacyPlugin } from '@backstage/backend-common';
import { createBackend } from '@backstage/backend-defaults';

const backend = createBackend();

backend.add(legacyPlugin('app', import('./plugins/app')));
backend.add(legacyPlugin('auth', import('./plugins/auth')));
backend.add(legacyPlugin('catalog', import('./plugins/catalog')));
backend.add(legacyPlugin('scaffolder', import('./plugins/scaffolder')));
backend.add(legacyPlugin('proxy', import('./plugins/proxy')));
backend.add(legacyPlugin('techdocs', import('./plugins/techdocs')));
backend.add(legacyPlugin('search', import('./plugins/search')));

backend.start();
```

We of course don't want this to be the permanent state of backends, but rather a helper to be able to quickly move entire backends over to the new system, and then be able to migrate individual plugins separately.

There's also an option to define a custom `createPluginCompat` wrapper in case the plugin environment has been customized, which you do using `makePluginCompat`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
