### PR TITLE
style: update footer width in tablet viewports

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -1210,7 +1210,8 @@ code {
 }
 
 .nav-footer .copyright {
-  width: 600px;
+  width: 100%;
+  padding: 0 8px;
   color: #fff;
   margin: 0 auto;
   font-size: 10pt;


### PR DESCRIPTION
Closes #15700

## Hey, I just made a Pull Request!

The footer, with this change, looks like the way we can see in the image below:

<img width="600" alt="CleanShot 2023-01-11 at 12 54 46@2x" src="https://user-images.githubusercontent.com/5417662/211811738-ae2b2c78-8d74-4d99-8981-ac90fb72b556.png">

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
