### PR TITLE
fix(techdocs): remove footer overlay on large screen

### DIFF
--- a/.changeset/nervous-apricots-whisper.md
+++ b/.changeset/nervous-apricots-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Improve view: remove footer overlay on large screen

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -105,7 +105,13 @@ export default ({ theme, sidebar }: RuleOptions) => `
 .md-footer {
   position: fixed;
   bottom: 0px;
+  pointer-events: none;
 }
+
+.md-footer-nav__link {
+  pointer-events: all;
+}
+
 .md-footer__title {
   background-color: unset;
 }


### PR DESCRIPTION
Uses static positions on the child links instead of the container 
Resolves #15653

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
