### PR TITLE
Added support for externalId when assuming role in AwsS3EntityProvider

### DIFF
--- a/.changeset/lemon-tables-train.md
+++ b/.changeset/lemon-tables-train.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-aws': patch
 ---
 
-Added support for externalId when assuming role in AwsS3EntityProvider
+Added support for `externalId` when assuming role in `AwsS3EntityProvider`

--- a/.changeset/lemon-tables-train.md
+++ b/.changeset/lemon-tables-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Added support for externalId when assuming role in AwsS3EntityProvider

--- a/plugins/catalog-backend-module-aws/src/credentials/AwsCredentials.ts
+++ b/plugins/catalog-backend-module-aws/src/credentials/AwsCredentials.ts
@@ -27,6 +27,7 @@ export class AwsCredentials {
       accessKeyId?: string;
       secretAccessKey?: string;
       roleArn?: string;
+      externalId?: string;
     },
     roleSessionName: string,
   ): Credentials | CredentialsOptions | undefined {
@@ -52,6 +53,7 @@ export class AwsCredentials {
         params: {
           RoleArn: roleArn,
           RoleSessionName: roleSessionName,
+          ExternalId: config.externalId,
         },
       });
     }


### PR DESCRIPTION
Signed-off-by: Diego Bardari <diego.bardari@klarna.com>

## Hey, I just made a Pull Request!

Added support for externalId when assuming role in AwsS3EntityProvider

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
