### PR TITLE
fix: sets the method to POST in reRunWorkflow fetch request.

### DIFF
--- a/.changeset/poor-poems-allow.md
+++ b/.changeset/poor-poems-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cloudbuild': patch
+---
+
+Fixed bug in the CloudbuildClient reRunWorkflow fetch call. The method in the fetch request was not specified and defaulted to a GET. Method is now explicitly set to POST with this change.

--- a/plugins/cloudbuild/src/api/CloudbuildClient.ts
+++ b/plugins/cloudbuild/src/api/CloudbuildClient.ts
@@ -34,6 +34,7 @@ export class CloudbuildClient implements CloudbuildApi {
         options.projectId,
       )}/builds/${encodeURIComponent(options.runId)}:retry`,
       {
+        method: 'POST',
         headers: new Headers({
           Accept: '*/*',
           Authorization: `Bearer ${await this.getToken()}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
The cloudbuild plugin has a request to rerun workflow, but it did not have the method set.
The method defaulted to a GET, causing the request to fail CORS check.
The documentation from Google Cloud Build states that rerunning must be a POST [here](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds/retry).

Related issue: https://github.com/backstage/backstage/issues/15221


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [✔️  ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [✔️  ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
