### PR TITLE
Skip STS calls for AWS account credentials when not needed

### DIFF
--- a/.changeset/empty-glasses-pump.md
+++ b/.changeset/empty-glasses-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration-aws-node': patch
+---
+
+Skip STS API calls where not needed, to support Minio use cases

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -252,8 +252,12 @@ describe('DefaultAwsCredentialsManager', () => {
         },
       });
       const provider = DefaultAwsCredentialsManager.fromConfig(minConfig);
-      const awsCredentialProvider1 = await provider.getCredentialProvider({});
-      const awsCredentialProvider2 = await provider.getCredentialProvider({});
+      const awsCredentialProvider1 = await provider.getCredentialProvider({
+        accountId: '123456789012',
+      });
+      const awsCredentialProvider2 = await provider.getCredentialProvider({
+        accountId: '123456789012',
+      });
 
       expect(awsCredentialProvider1).toBe(awsCredentialProvider2);
       expect(stsMock).toHaveReceivedCommandTimes(GetCallerIdentityCommand, 1);
@@ -374,7 +378,7 @@ describe('DefaultAwsCredentialsManager', () => {
         arn: 'arn:aws:s3:::bucket_name',
       });
 
-      expect(awsCredentialProvider.accountId).toEqual('123456789012');
+      expect(awsCredentialProvider.accountId).toBeUndefined();
 
       const creds = await awsCredentialProvider.sdkCredentialProvider();
       expect(creds).toEqual({
@@ -387,7 +391,7 @@ describe('DefaultAwsCredentialsManager', () => {
       const provider = DefaultAwsCredentialsManager.fromConfig(config);
       const awsCredentialProvider = await provider.getCredentialProvider({});
 
-      expect(awsCredentialProvider.accountId).toEqual('123456789012');
+      expect(awsCredentialProvider.accountId).toBeUndefined();
 
       const creds = await awsCredentialProvider.sdkCredentialProvider();
       expect(creds).toEqual({
@@ -400,7 +404,7 @@ describe('DefaultAwsCredentialsManager', () => {
       const provider = DefaultAwsCredentialsManager.fromConfig(config);
       const awsCredentialProvider = await provider.getCredentialProvider();
 
-      expect(awsCredentialProvider.accountId).toEqual('123456789012');
+      expect(awsCredentialProvider.accountId).toBeUndefined();
 
       const creds = await awsCredentialProvider.sdkCredentialProvider();
       expect(creds).toEqual({
@@ -421,10 +425,11 @@ describe('DefaultAwsCredentialsManager', () => {
 
     it('rejects main account that has invalid credentials', async () => {
       stsMock.on(GetCallerIdentityCommand).rejects('No credentials found');
-      const provider = DefaultAwsCredentialsManager.fromConfig(config);
-      await expect(provider.getCredentialProvider({})).rejects.toThrow(
-        /No credentials found/,
-      );
+      const minConfig = new ConfigReader({});
+      const provider = DefaultAwsCredentialsManager.fromConfig(minConfig);
+      await expect(
+        provider.getCredentialProvider({ accountId: '123456789012' }),
+      ).rejects.toThrow(/No credentials found/);
     });
   });
 });

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
@@ -221,7 +221,6 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
   ): Promise<AwsCredentialProvider> {
     // If no options provided, fall back to the main account
     if (!opts) {
-      await fillInAccountId(this.mainAccountCredentialProvider);
       return this.mainAccountCredentialProvider;
     }
 
@@ -235,7 +234,6 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
     // If the account ID was not provided (explicitly or in the ARN),
     // fall back to the main account
     if (!accountId) {
-      await fillInAccountId(this.mainAccountCredentialProvider);
       return this.mainAccountCredentialProvider;
     }
 


### PR DESCRIPTION
Skipping STS calls enables using the credential provider utility for calls to Minio Fixes #15669

Signed-off-by: Clare Liguori <liguori@amazon.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
