### PR TITLE
update fetcher to append resource to path instead of replace

### DIFF
--- a/.changeset/quick-ears-type.md
+++ b/.changeset/quick-ears-type.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-fixes a bug afecting clusers that have a base path in the url. The base path was being replaced with the resource path instead of being appended
+fixes a bug affecting clusters that have a base path in the URL. The base path was being replaced with the resource path instead of being appended

--- a/.changeset/quick-ears-type.md
+++ b/.changeset/quick-ears-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+fixes a bug afecting clusers that have a base path in the url. The base path was being replaced with the resource path instead of being appended

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -202,7 +202,12 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
         ),
       );
     }
-    url.pathname = (url.pathname + resourcePath).replace('//', '/');
+
+    if (url.pathname === '/') {
+      url.pathname = resourcePath;
+    } else {
+      url.pathname += resourcePath;
+    }
 
     if (labelSelector) {
       url.search = `labelSelector=${labelSelector}`;

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -202,8 +202,8 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
         ),
       );
     }
+    url.pathname = (url.pathname + resourcePath).replace('//', '/');
 
-    url.pathname += resourcePath;
     if (labelSelector) {
       url.search = `labelSelector=${labelSelector}`;
     }

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -203,7 +203,7 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
       );
     }
 
-    url.pathname = resourcePath;
+    url.pathname += resourcePath;
     if (labelSelector) {
       url.search = `labelSelector=${labelSelector}`;
     }


### PR DESCRIPTION
Signed-off-by: Lucas De Souza <lucas.desouza@aa.com>

## Hey, I just made a Pull Request!
This fixes a bug with the Kubernetes plugin which breaks clusters with a base path in the url

fixes #15733 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
