### PR TITLE
Fixed techdocs-cli package publish CLI command missing awsBucketRootPath option + having the gcsBucketRootPath option misconfigured

### DIFF
--- a/.changeset/quick-ladybugs-reply.md
+++ b/.changeset/quick-ladybugs-reply.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Fixed publish command missing awsBucketRootPath option.

--- a/.changeset/quick-ladybugs-reply.md
+++ b/.changeset/quick-ladybugs-reply.md
@@ -3,3 +3,4 @@
 ---
 
 Fixed publish command missing awsBucketRootPath option.
+Fixed publish command having the gcsBucketRootPath option misconfigured, previously returning a boolean vs a string.

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -52,7 +52,6 @@ Options:
   --awsRoleArn <AWS ROLE ARN>
   --awsEndpoint <AWS ENDPOINT>
   --awsS3ForcePathStyle
-  --awsBucketRootPath
   --osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>
   --osSecret <OPENSTACK SWIFT APPLICATION CREDENTIAL SECRET>
   --osAuthUrl <OPENSTACK SWIFT AUTHURL>
@@ -79,6 +78,7 @@ Options:
   --awsEndpoint <AWS ENDPOINT>
   --awsS3sse <AWS SSE>
   --awsS3ForcePathStyle
+  --awsBucketRootPath <AWS BUCKET ROOT PATH>
   --osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>
   --osSecret <OPENSTACK SWIFT APPLICATION CREDENTIAL SECRET>
   --osAuthUrl <OPENSTACK SWIFT AUTHURL>

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -83,7 +83,7 @@ Options:
   --osSecret <OPENSTACK SWIFT APPLICATION CREDENTIAL SECRET>
   --osAuthUrl <OPENSTACK SWIFT AUTHURL>
   --osSwiftUrl <OPENSTACK SWIFT SWIFTURL>
-  --gcsBucketRootPath
+  --gcsBucketRootPath <GCS BUCKET ROOT PATH>
   --directory <PATH>
   -h, --help
 ```

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -194,7 +194,7 @@ export function registerCommands(program: Command) {
       '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
     .option(
-      '--gcsBucketRootPath',
+      '--gcsBucketRootPath <GCS BUCKET ROOT PATH>',
       'Optional sub-directory to store files in Google cloud storage',
     )
     .option(

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -102,10 +102,6 @@ export function registerCommands(program: Command) {
       'Optional AWS S3 option to force path style.',
     )
     .option(
-      '--awsBucketRootPath',
-      'Optional sub-directory to store files in Amazon S3',
-    )
-    .option(
       '--osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>',
       '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
@@ -176,6 +172,10 @@ export function registerCommands(program: Command) {
     .option(
       '--awsS3ForcePathStyle',
       'Optional AWS S3 option to force path style.',
+    )
+    .option(
+      '--awsBucketRootPath <AWS BUCKET ROOT PATH>',
+      'Optional sub-directory to store files in Amazon S3',
     )
     .option(
       '--osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>',


### PR DESCRIPTION
Signed-off-by: Albin Halinen Wilén <git@alphahw.eu>

## Hey, I just made a Pull Request!

Fixed techdocs-cli package publish CLI command:
- previously missing awsBucketRootPath option (#15635)
- having the gcsBucketRootPath option misconfigured, previously returning a boolean vs a string

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
