### PR TITLE
default commit msgs for bitbucketServer

### DIFF
--- a/.changeset/red-pens-tickle.md
+++ b/.changeset/red-pens-tickle.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Override default commit message and author details in BitbucketServer
+Added ability to override the commit message and author details for the `publish:bitbucketServer` action.

--- a/.changeset/red-pens-tickle.md
+++ b/.changeset/red-pens-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Override default commit message and author details in BitbucketServer

--- a/.changeset/red-pens-tickle.md
+++ b/.changeset/red-pens-tickle.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Added ability to override the commit message and author details for the `publish:bitbucketServer` action.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -341,6 +341,9 @@ export function createPublishBitbucketServerAction(options: {
   sourcePath?: string | undefined;
   enableLFS?: boolean | undefined;
   token?: string | undefined;
+  gitCommitMessage?: string | undefined;
+  gitAuthorName?: string | undefined;
+  gitAuthorEmail?: string | undefined;
 }>;
 
 // @public

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucketServer.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucketServer.test.ts
@@ -375,7 +375,11 @@ describe('publish:bitbucketServer', () => {
       defaultBranch: 'master',
       auth: { token: 'thing' },
       logger: mockContext.logger,
-      gitAuthorInfo: {},
+      commitMessage: 'initial commit',
+      gitAuthorInfo: {
+        email: undefined,
+        name: undefined,
+      },
     });
   });
 
@@ -429,7 +433,11 @@ describe('publish:bitbucketServer', () => {
       defaultBranch: 'master',
       auth: { username: 'test-user', password: 'test-password' },
       logger: mockContext.logger,
-      gitAuthorInfo: {},
+      commitMessage: 'initial commit',
+      gitAuthorInfo: {
+        email: undefined,
+        name: undefined,
+      },
     });
   });
 
@@ -481,7 +489,11 @@ describe('publish:bitbucketServer', () => {
       defaultBranch: 'main',
       auth: { token: 'thing' },
       logger: mockContext.logger,
-      gitAuthorInfo: {},
+      commitMessage: 'initial commit',
+      gitAuthorInfo: {
+        email: undefined,
+        name: undefined,
+      },
     });
   });
 
@@ -555,6 +567,7 @@ describe('publish:bitbucketServer', () => {
       auth: { token: 'thing' },
       logger: mockContext.logger,
       defaultBranch: 'master',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
     });
   });
@@ -574,7 +587,7 @@ describe('publish:bitbucketServer', () => {
         ],
       },
       scaffolder: {
-        defaultCommitMessage: 'Test commit message',
+        defaultCommitMessage: 'initial commit',
       },
     });
 
@@ -626,7 +639,7 @@ describe('publish:bitbucketServer', () => {
       auth: { token: 'thing' },
       logger: mockContext.logger,
       defaultBranch: 'master',
-      commitMessage: 'Test commit message',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { email: undefined, name: undefined },
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucketServer.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucketServer.ts
@@ -130,6 +130,9 @@ export function createPublishBitbucketServerAction(options: {
     sourcePath?: string;
     enableLFS?: boolean;
     token?: string;
+    gitCommitMessage?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
   }>({
     id: 'publish:bitbucketServer',
     description:
@@ -174,6 +177,21 @@ export function createPublishBitbucketServerAction(options: {
             description:
               'The token to use for authorization to BitBucket Server',
           },
+          gitCommitMessage: {
+            title: 'Git Commit Message',
+            type: 'string',
+            description: `Sets the commit message on the repository. The default value is 'initial commit'`,
+          },
+          gitAuthorName: {
+            title: 'Default Author Name',
+            type: 'string',
+            description: `Sets the default author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Default Author Email',
+            type: 'string',
+            description: `Sets the default author email for the commit.`,
+          },
         },
       },
       output: {
@@ -197,6 +215,9 @@ export function createPublishBitbucketServerAction(options: {
         defaultBranch = 'master',
         repoVisibility = 'private',
         enableLFS = false,
+        gitCommitMessage = 'initial commit',
+        gitAuthorName,
+        gitAuthorEmail,
       } = ctx.input;
 
       const { project, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -241,8 +262,12 @@ export function createPublishBitbucketServerAction(options: {
       });
 
       const gitAuthorInfo = {
-        name: config.getOptionalString('scaffolder.defaultAuthor.name'),
-        email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+        name: gitAuthorName
+          ? gitAuthorName
+          : config.getOptionalString('scaffolder.defaultAuthor.name'),
+        email: gitAuthorEmail
+          ? gitAuthorEmail
+          : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
 
       const auth = authConfig.token
@@ -260,9 +285,9 @@ export function createPublishBitbucketServerAction(options: {
         auth,
         defaultBranch,
         logger: ctx.logger,
-        commitMessage: config.getOptionalString(
-          'scaffolder.defaultCommitMessage',
-        ),
+        commitMessage: gitCommitMessage
+          ? gitCommitMessage
+          : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucketServer.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucketServer.ts
@@ -183,14 +183,14 @@ export function createPublishBitbucketServerAction(options: {
             description: `Sets the commit message on the repository. The default value is 'initial commit'`,
           },
           gitAuthorName: {
-            title: 'Default Author Name',
+            title: 'Author Name',
             type: 'string',
-            description: `Sets the default author name for the commit. The default value is 'Scaffolder'`,
+            description: `Sets the author name for the commit. The default value is 'Scaffolder'`,
           },
           gitAuthorEmail: {
-            title: 'Default Author Email',
+            title: 'Author Email',
             type: 'string',
-            description: `Sets the default author email for the commit.`,
+            description: `Sets the author email for the commit.`,
           },
         },
       },


### PR DESCRIPTION
Signed-off-by: Maurice Mohlek <maurice.mohlek@valtech.de>

## Hey, I just made a Pull Request!

Based on #9859 and #10968 I also added the functionality to BitbucketServer.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
