### PR TITLE
[Docs] Gitlab Auth needs read_api 

### DIFF
--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -18,7 +18,7 @@ Settings for local development:
 
 - Name: Backstage (or your custom app name)
 - Redirect URI: `http://localhost:7007/api/auth/gitlab/handler/frame`
-- Scopes: `read_user`
+- Scopes: `read_api` and `read_user`
 
 ## Configuration
 


### PR DESCRIPTION
otherwise it gives a weird error with The requested scope is invalid, unknown, or malformed.
