### PR TITLE
Add initial filter prop for lifecycle picker

### DIFF
--- a/.changeset/rare-melons-battle.md
+++ b/.changeset/rare-melons-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Add initialFilter prop to EntityLifecyclePicker. This allows you to set an initial lifecycle for the catalog.

--- a/.changeset/rare-melons-battle.md
+++ b/.changeset/rare-melons-battle.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Add initialFilter prop to EntityLifecyclePicker. This allows you to set an initial lifecycle for the catalog.
+Add `initialFilter` prop to EntityLifecyclePicker. This allows you to set an initial lifecycle for the catalog.

--- a/.changeset/rare-melons-battle.md
+++ b/.changeset/rare-melons-battle.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog-react': minor
 ---
 
 Add `initialFilter` prop to EntityLifecyclePicker. This allows you to set an initial lifecycle for the catalog.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -194,14 +194,9 @@ export class EntityLifecycleFilter implements EntityFilter {
 }
 
 // @public (undocumented)
-export const EntityLifecyclePicker: (
-  props: EntityLifecyclePickerProps,
-) => JSX.Element | null;
-
-// @public (undocumented)
-export type EntityLifecyclePickerProps = {
+export const EntityLifecyclePicker: (props: {
   initialFilter?: string[];
-};
+}) => JSX.Element | null;
 
 // @public
 export const EntityListContext: React_2.Context<

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -194,7 +194,14 @@ export class EntityLifecycleFilter implements EntityFilter {
 }
 
 // @public (undocumented)
-export const EntityLifecyclePicker: () => JSX.Element | null;
+export const EntityLifecyclePicker: (
+  props: EntityLifecyclePickerProps,
+) => JSX.Element | null;
+
+// @public (undocumented)
+export type EntityLifecyclePickerProps = {
+  initialFilter?: string[];
+};
 
 // @public
 export const EntityListContext: React_2.Context<

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
@@ -210,4 +210,21 @@ describe('<EntityLifecyclePicker/>', () => {
       lifecycles: undefined,
     });
   });
+  it('responds to initialFilter prop', () => {
+    const updateFilters = jest.fn();
+    render(
+      <MockEntityListContextProvider
+        value={{
+          entities: sampleEntities,
+          backendEntities: sampleEntities,
+          updateFilters,
+        }}
+      >
+        <EntityLifecyclePicker initialFilter={['production']} />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      lifecycles: new EntityLifecycleFilter(['production']),
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -47,12 +47,7 @@ const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 /** @public */
-export type EntityLifecyclePickerProps = {
-  initialFilter?: string[];
-};
-
-/** @public */
-export const EntityLifecyclePicker = (props: EntityLifecyclePickerProps) => {
+export const EntityLifecyclePicker = (props: { initialFilter?: string[] }) => {
   const { initialFilter = [] } = props;
   const classes = useStyles();
   const {

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -53,7 +53,7 @@ export type EntityLifecyclePickerProps = {
 
 /** @public */
 export const EntityLifecyclePicker = (props: EntityLifecyclePickerProps) => {
-  const { initialFilter } = props;
+  const { initialFilter = [] } = props;
   const classes = useStyles();
   const {
     updateFilters,
@@ -70,7 +70,7 @@ export const EntityLifecyclePicker = (props: EntityLifecyclePickerProps) => {
   const [selectedLifecycles, setSelectedLifecycles] = useState(
     queryParamLifecycles.length
       ? queryParamLifecycles
-      : filters.lifecycles?.values ?? (initialFilter || []),
+      : filters.lifecycles?.values ?? initialFilter,
   );
 
   // Set selected lifecycles on query parameter updates; this happens at initial page load and from

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -47,7 +47,13 @@ const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 /** @public */
-export const EntityLifecyclePicker = () => {
+export type EntityLifecyclePickerProps = {
+  initialFilter?: string[];
+};
+
+/** @public */
+export const EntityLifecyclePicker = (props: EntityLifecyclePickerProps) => {
+  const { initialFilter } = props;
   const classes = useStyles();
   const {
     updateFilters,
@@ -64,7 +70,7 @@ export const EntityLifecyclePicker = () => {
   const [selectedLifecycles, setSelectedLifecycles] = useState(
     queryParamLifecycles.length
       ? queryParamLifecycles
-      : filters.lifecycles?.values ?? [],
+      : filters.lifecycles?.values ?? (initialFilter || []),
   );
 
   // Set selected lifecycles on query parameter updates; this happens at initial page load and from

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EntityLifecyclePicker } from './EntityLifecyclePicker';
-export type { CatalogReactEntityLifecyclePickerClassKey } from './EntityLifecyclePicker';
+export type {
+  CatalogReactEntityLifecyclePickerClassKey,
+  EntityLifecyclePickerProps,
+} from './EntityLifecyclePicker';

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
@@ -15,7 +15,4 @@
  */
 
 export { EntityLifecyclePicker } from './EntityLifecyclePicker';
-export type {
-  CatalogReactEntityLifecyclePickerClassKey,
-  EntityLifecyclePickerProps,
-} from './EntityLifecyclePicker';
+export type { CatalogReactEntityLifecyclePickerClassKey } from './EntityLifecyclePicker';


### PR DESCRIPTION
Signed-off-by: Sarah Medeiros <smedeiros@wayfair.com>

## Hey, I just made a Pull Request!
Update the EntityLifecyclePicker to accept an initialFIlter prop. This way you can set the initial lifecycle for the catalog to filter on.
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
![Screen Shot 2023-01-13 at 12 00 15 PM](https://user-images.githubusercontent.com/14253893/212383349-5204dd23-1c45-467e-82d9-0ecc47ac37db.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
