### PR TITLE
Clean up deprecated use ofScaffolderFieldExtensions

### DIFF
--- a/.changeset/afraid-lies-join.md
+++ b/.changeset/afraid-lies-join.md
@@ -1,5 +1,0 @@
----
-'example-app': patch
----
-
-Internal refactor to replace deprecated 'ScaffolderFieldExtensions'.

--- a/.changeset/afraid-lies-join.md
+++ b/.changeset/afraid-lies-join.md
@@ -1,0 +1,5 @@
+---
+'example-app': patch
+---
+
+Internal refactor to replace deprecated 'ScaffolderFieldExtensions'.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -60,12 +60,12 @@ import { HomepageCompositionRoot } from '@backstage/plugin-home';
 import { LighthousePage } from '@backstage/plugin-lighthouse';
 import { NewRelicPage } from '@backstage/plugin-newrelic';
 import {
-  ScaffolderFieldExtensions,
   ScaffolderPage,
   NextScaffolderPage,
   scaffolderPlugin,
   ScaffolderLayouts,
 } from '@backstage/plugin-scaffolder';
+import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
 import {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR is related to https://github.com/backstage/backstage/issues/14602

Clean up deprecated use of`ScaffolderFieldExtensions` in packages/app/src/App.tsx. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
