### PR TITLE
`backstage-cli new` duplicated `-backend` in `standaloneServer.ts` stubs

### DIFF
--- a/.changeset/few-mails-help.md
+++ b/.changeset/few-mails-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated backend plugin ID during creation to match user-entered input.

--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -48,7 +48,7 @@ This will think for a bit, and then say `Listening on :7007`. In a different
 terminal window, now run
 
 ```sh
-curl localhost:7007/carmen/health
+curl localhost:7007/carmen-backend/health
 ```
 
 This should return `{"status":"ok"}`. Success! Press `Ctrl + c` to stop it

--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -48,7 +48,7 @@ This will think for a bit, and then say `Listening on :7007`. In a different
 terminal window, now run
 
 ```sh
-curl localhost:7007/carmen-backend/health
+curl localhost:7007/carmen/health
 ```
 
 This should return `{"status":"ok"}`. Success! Press `Ctrl + c` to stop it

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -100,6 +100,15 @@ describe('backendPlugin factory', () => {
         'backstage-plugin-test-backend': '^1.0.0',
       },
     });
+    const standaloneServerFile = await fs.readFile(
+      '/root/plugins/test-backend/src/service/standaloneServer.ts',
+      'utf-8',
+    );
+
+    expect(standaloneServerFile).toContain(
+      `const logger = options.logger.child({ service: 'test-backend' });`,
+    );
+    expect(standaloneServerFile).toContain(`.addRouter('/test', router);`);
 
     expect(Task.forCommand).toHaveBeenCalledTimes(2);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -38,17 +38,18 @@ export const backendPlugin = createFactory<Options>({
   }),
   optionsPrompts: [pluginIdPrompt(), ownerPrompt()],
   async create(options: Options, ctx: CreateContext) {
-    const id = `${options.id}-backend`;
+    const { id } = options;
+    const pluginId = `${id}-backend`;
     const name = ctx.scope
-      ? `@${ctx.scope}/plugin-${id}`
-      : `backstage-plugin-${id}`;
+      ? `@${ctx.scope}/plugin-${pluginId}`
+      : `backstage-plugin-${pluginId}`;
 
     Task.log();
     Task.log(`Creating backend plugin ${chalk.cyan(name)}`);
 
     const targetDir = ctx.isMonoRepo
-      ? paths.resolveTargetRoot('plugins', id)
-      : paths.resolveTargetRoot(`backstage-plugin-${id}`);
+      ? paths.resolveTargetRoot('plugins', pluginId)
+      : paths.resolveTargetRoot(`backstage-plugin-${pluginId}`);
 
     await executePluginPackageTemplate(ctx, {
       targetDir,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/15714 by passing the original user-entered ID to the Handlebars template.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
