### PR TITLE
Fix: Unknown Return Status on CORS Request

### DIFF
--- a/packages/backend-app-api/src/http/readCorsOptions.ts
+++ b/packages/backend-app-api/src/http/readCorsOptions.ts
@@ -36,7 +36,7 @@ export function readCorsOptions(config?: Config): CorsOptions {
     return { origin: false }; // Disable CORS
   }
 
-  return {
+  return removeUnknown({
     origin: createCorsOriginMatcher(readStringArray(cc, 'origin')),
     methods: readStringArray(cc, 'methods'),
     allowedHeaders: readStringArray(cc, 'allowedHeaders'),
@@ -45,7 +45,13 @@ export function readCorsOptions(config?: Config): CorsOptions {
     maxAge: cc.getOptionalNumber('maxAge'),
     preflightContinue: cc.getOptionalBoolean('preflightContinue'),
     optionsSuccessStatus: cc.getOptionalNumber('optionsSuccessStatus'),
-  };
+  });
+}
+
+function removeUnknown<T extends object>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as T;
 }
 
 function readStringArray(config: Config, key: string): string[] | undefined {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was updating to the latest version and keep getting CORS Issues. Reason is that `optionsSuccessStatus` is undefined and therefore the preflight Request returns with unknown response code. Re-adding the removeUnknown to remove unset entries from CORS Options fixes it.

Signed-off-by: Dominik <dominik@pfaffenbauer.at>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
