### PR TITLE
[Search] Fix modal input focus

### DIFF
--- a/.changeset/breezy-carpets-tie.md
+++ b/.changeset/breezy-carpets-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+When the search modal is opened, the focus is placed on the search bar input field.

--- a/packages/app/src/components/search/SearchModal.tsx
+++ b/packages/app/src/components/search/SearchModal.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { KeyboardEvent, useRef, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   DialogActions,
   DialogContent,
@@ -74,29 +75,48 @@ const useStyles = makeStyles(theme => ({
   viewResultsLink: { verticalAlign: '0.5em' },
 }));
 
+const rootRouteRef = searchPlugin.routes.root;
+
 export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
-  const getSearchLink = useRouteRef(searchPlugin.routes.root);
   const classes = useStyles();
+  const navigate = useNavigate();
+  const { transitions } = useTheme();
+  const { focusContent } = useContent();
 
   const catalogApi = useApi(catalogApiRef);
-  const { term, types } = useSearch();
-  const { focusContent } = useContent();
-  const { transitions } = useTheme();
 
-  const handleResultClick = () => {
+  const { term, types } = useSearch();
+  const searchBarRef = useRef<HTMLInputElement | null>(null);
+  const searchPagePath = `${useRouteRef(rootRouteRef)()}?query=${term}`;
+
+  useEffect(() => {
+    searchBarRef?.current?.focus();
+  });
+
+  const handleSearchResulClick = useCallback(() => {
     toggleModal();
     setTimeout(focusContent, transitions.duration.leavingScreen);
-  };
+  }, [toggleModal, focusContent, transitions]);
 
-  const handleKeyPress = () => {
-    handleResultClick();
-  };
+  const handleSearchBarKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (e.key === 'Enter') {
+        navigate(searchPagePath);
+        toggleModal();
+      }
+    },
+    [navigate, toggleModal, searchPagePath],
+  );
 
   return (
     <>
       <DialogTitle>
         <Paper className={classes.container}>
-          <SearchBar className={classes.input} />
+          <SearchBar
+            className={classes.input}
+            inputProps={{ ref: searchBarRef }}
+            onKeyDown={handleSearchBarKeyDown}
+          />
         </Paper>
       </DialogTitle>
       <DialogContent>
@@ -169,16 +189,7 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
               alignItems="center"
             >
               <Grid item>
-                <Link
-                  onClick={() => {
-                    toggleModal();
-                    setTimeout(
-                      focusContent,
-                      transitions.duration.leavingScreen,
-                    );
-                  }}
-                  to={`${getSearchLink()}?query=${term}`}
-                >
+                <Link to={searchPagePath} onClick={handleSearchResulClick}>
                   <Typography
                     component="span"
                     className={classes.viewResultsLink}
@@ -245,8 +256,8 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
                         role="button"
                         tabIndex={0}
                         key={`${document.location}-btn`}
-                        onClick={handleResultClick}
-                        onKeyPress={handleKeyPress}
+                        onClick={handleSearchResulClick}
+                        onKeyDown={handleSearchResulClick}
                       >
                         {resultItem}
                       </div>

--- a/plugins/search/src/components/SearchModal/SearchModal.test.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.test.tsx
@@ -153,4 +153,19 @@ describe('SearchModal', () => {
     expect(getByTestId('search-bar-next')).toBeInTheDocument();
     expect(getByTestId('search-bar-next')).not.toBeVisible();
   });
+
+  it('should focus on its search bar when opened', async () => {
+    await renderInTestApp(
+      <ApiProvider apis={apiRegistry}>
+        <SearchModal open hidden={false} toggleModal={toggleModal} />
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/search': rootRouteRef,
+        },
+      },
+    );
+
+    expect(screen.getByLabelText('Search')).toHaveFocus();
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As first attempted in [this](https://github.com/backstage/backstage/pull/8382#issuecomment-1003426871) pull request and also reported again in [this](https://discord.com/channels/687207715902193673/1063134709498007672/1063135152483614920) Discord message, the search modal would be more accessible if:

- The modal's search field received focus when the modal was opened;
- The enter key press event on the search bar redirects the user to the advanced search page.

This pull request fixes the search modal implementing those accessibility improvements.

Default search modal:

https://user-images.githubusercontent.com/6290749/212565950-871bce86-9510-40b5-a830-86483242c7f1.mov

Example app search modal:

https://user-images.githubusercontent.com/6290749/212565346-78c39088-4ae1-4348-a91f-75bd9e8881d1.mp4

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
