### PR TITLE
Improve fact lifecycle performance

### DIFF
--- a/.changeset/unlucky-zebras-scream.md
+++ b/.changeset/unlucky-zebras-scream.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+---
+
+Modifies database cleanup to remove all facts for entities instead of hand-picked ones only. Improves query execution a lot in large datasets.
+Changes semantics of the lifecycle deletion logic slightly for cases were historical entities/facts, that are , not present in the application anymore, were kept forever instead of being cleaned up. The new implementation is more along the expected lines.

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts
@@ -212,43 +212,45 @@ export class TechInsightsDatabase implements TechInsightsStore {
     factRetrieverId: string,
     maxItems: number,
   ) {
-    const deletables = await tx<RawDbFactRow>('facts')
-      .where({ id: factRetrieverId })
-      .and.whereIn('entity', db =>
-        db.distinct('entity').where({ id: factRetrieverId }),
-      )
-      .and.leftJoin(
-        joinTable =>
-          joinTable
-            .select('*')
-            .from(
-              this.db('facts')
-                .column(
-                  { fid: 'id' },
-                  { fentity: 'entity' },
-                  { ftimestamp: 'timestamp' },
-                )
-                .column(
-                  this.db.raw(
-                    'row_number() over (partition by id, entity order by timestamp desc) as fact_rank',
-                  ),
-                )
-                .as('ranks'),
-            )
-            .where('fact_rank', '<=', maxItems)
-            .as('filterjoin'),
-        joinClause => {
-          joinClause
-            .on('filterjoin.fid', 'facts.id')
-            .on('filterjoin.fentity', 'facts.entity')
-            .on('filterjoin.ftimestamp', 'facts.timestamp');
-        },
-      )
-      .whereNull('filterjoin.fid');
+    const deletionFilterQuery = (subTx: Knex.QueryBuilder<any, unknown[]>) =>
+      subTx
+        .select(['id', 'entity', 'timestamp'])
+        .from('facts')
+        .where({ id: factRetrieverId })
+        .and.whereIn('entity', db =>
+          db.distinct('entity').where({ id: factRetrieverId }),
+        )
+        .and.leftJoin(
+          joinTable =>
+            joinTable
+              .select('*')
+              .from(
+                this.db('facts')
+                  .column(
+                    { fid: 'id' },
+                    { fentity: 'entity' },
+                    { ftimestamp: 'timestamp' },
+                  )
+                  .column(
+                    this.db.raw(
+                      'row_number() over (partition by id, entity order by timestamp desc) as fact_rank',
+                    ),
+                  )
+                  .as('ranks'),
+              )
+              .where('fact_rank', '<=', maxItems)
+              .as('filterjoin'),
+          joinClause => {
+            joinClause
+              .on('filterjoin.fid', 'facts.id')
+              .on('filterjoin.fentity', 'facts.entity')
+              .on('filterjoin.ftimestamp', 'facts.timestamp');
+          },
+        )
+        .whereNull('filterjoin.fid');
     await tx('facts')
-      .whereIn(
-        ['id', 'entity', 'timestamp'],
-        deletables.map(it => [it.id, it.entity, it.timestamp]),
+      .whereIn(['id', 'entity', 'timestamp'], database =>
+        deletionFilterQuery(database),
       )
       .delete();
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Modifies database cleanup to remove all facts for entities instead of hand-picked ones only. Improves query execution a lot in large datasets.

Changes semantics of the lifecycle deletion logic slightly for cases were historical entities/facts, that are not present in the application anymore, were kept forever instead of being cleaned up. The new implementation is more along the expected lines.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
