### PR TITLE
fixed: current user team ids fetch issue in azure-devops plugin

### DIFF
--- a/.changeset/brown-islands-own.md
+++ b/.changeset/brown-islands-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops': patch
+---
+
+Fixed `AssignedToCurrentUsersTeams` & `CreatedByCurrentUsersTeams` filter in `AzurePullRequestsPage` component.

--- a/plugins/azure-devops/src/hooks/useUserTeamIds.ts
+++ b/plugins/azure-devops/src/hooks/useUserTeamIds.ts
@@ -31,7 +31,7 @@ export function useUserTeamIds(userId: string | undefined): {
     error,
   } = useAsync(() => {
     return userId ? api.getUserTeamIds(userId) : Promise.resolve(undefined);
-  }, [api]);
+  }, [userId, api]);
 
   return {
     teamIds,


### PR DESCRIPTION
Signed-off-by: Deepankumar Loganathan <deepan0433@gmail.com>

## Hey, I just made a Pull Request!

This PullRequest will fix issue #15760.

Now the filters  AssignedToCurrentUsersTeams & CreatedByCurrentUsersTeams are working as excepted.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
