### PR TITLE
Feature: Make workflow a link in CircleCI plugin

### DIFF
--- a/.changeset/slow-moles-sin.md
+++ b/.changeset/slow-moles-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-circleci': minor
+---
+
+Making workflow a link

--- a/.changeset/slow-moles-sin.md
+++ b/.changeset/slow-moles-sin.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-circleci': minor
+'@backstage/plugin-circleci': patch
 ---
 
-Making workflow a link
+Making workflow a link 

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -215,10 +215,7 @@ const generatedColumns: TableColumn[] = [
     highlight: true,
     render: (row: Partial<CITableBuildInfo>) => (
       <Link
-        to={
-          `https://app.circleci.com/pipelines/workflows/${row?.workflow?.id}` ??
-          ''
-        }
+        to={`https://app.circleci.com/pipelines/workflows/${row?.workflow?.id}`}
       >
         {row?.workflow?.name}
       </Link>

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -214,7 +214,14 @@ const generatedColumns: TableColumn[] = [
     field: 'workflow.name',
     highlight: true,
     render: (row: Partial<CITableBuildInfo>) => (
-      <Link to={row?.workflow?.url ?? ''}>{row?.workflow?.name}</Link>
+      <Link
+        to={
+          `https://app.circleci.com/pipelines/workflows/${row?.workflow?.id}` ??
+          ''
+        }
+      >
+        {row?.workflow?.name}
+      </Link>
     ),
   },
   {

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -212,6 +212,10 @@ const generatedColumns: TableColumn[] = [
   {
     title: 'Workflow',
     field: 'workflow.name',
+    highlight: true,
+    render: (row: Partial<CITableBuildInfo>) => (
+      <Link to={row?.workflow?.url ?? ''}>{row?.workflow?.name}</Link>
+    ),
   },
   {
     title: 'Actions',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Make Workflow in CircleCI plugin a clickable link

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
