### PR TITLE
Don't erode webpack error message details

### DIFF
--- a/.changeset/odd-lions-fly.md
+++ b/.changeset/odd-lions-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Don't erode webpack error message details

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -122,15 +122,9 @@ async function build(config: webpack.Configuration, isCi: boolean) {
     warnings: true,
     errors: true,
   });
-  // NOTE(freben): The code below that extracts the message part of the errors,
-  // is due to react-dev-utils not yet being compatible with webpack 5. This
-  // may be possible to remove (just passing the serialized stats object
-  // directly into the format function) after a new release of react-dev-utils
-  // has been made available.
-  // See https://github.com/facebook/create-react-app/issues/9880
   const { errors, warnings } = formatWebpackMessages({
-    errors: serializedStats.errors?.map(e => (e.message ? e.message : e)),
-    warnings: serializedStats.warnings?.map(e => (e.message ? e.message : e)),
+    errors: serializedStats.errors,
+    warnings: serializedStats.warnings,
   });
 
   if (errors.length) {


### PR DESCRIPTION
To work around a `react-dev-utils` compatibility problem, errors and warnings had context stripped before being formatted.

This led to issues in internal Backstage where a build failure's cause was ambiguous and hard to diagnose.

Since this workaround was needed for `react-dev-utils` v5 (which was released over a year ago, nice! [1]), I think that it can be removed.

[1] https://github.com/facebook/create-react-app/releases/tag/v5.0.0
