### PR TITLE
Fix/plugin adr misisng annotation

### DIFF
--- a/.changeset/spotty-coats-clean.md
+++ b/.changeset/spotty-coats-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+Render the common `<MissingAnnotationEmptyState />` componenet when the `backstage.io/adr-location` annotation is missing from the component

--- a/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
+++ b/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
@@ -73,11 +73,10 @@ export const EntityAdrContent = (props: {
   const adrApi = useApi(adrApiRef);
   const entityHasAdrs = isAdrAvailable(entity);
 
-  const url = getAdrLocationUrl(entity, scmIntegrations);
-  const { value, loading, error } = useAsync(
-    async () => adrApi.listAdrs(url),
-    [url],
-  );
+  const { value, loading, error } = useAsync(async () => {
+    const url = getAdrLocationUrl(entity, scmIntegrations);
+    return adrApi.listAdrs(url);
+  }, [entity, scmIntegrations]);
 
   const selectedAdr =
     adrList.find(adr => adr === searchParams.get('record')) ?? '';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, the plugin throws an ugly error for components where the annotation is not present. This makes sure the common component will be rendered in these cases.

|before|after|
|-|-|
|<img width="1460" alt="image" src="https://user-images.githubusercontent.com/24729496/212789036-b6363789-5329-4b73-9d72-8cd79d893af5.png">|<img width="1499" alt="image" src="https://user-images.githubusercontent.com/24729496/212788969-d3668c36-4e8a-4d26-974f-4008f4082964.png">|


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
