### PR TITLE
docs: fix wrong identifiers in software template

### DIFF
--- a/docs/features/software-templates/writing-custom-field-extensions.md
+++ b/docs/features/software-templates/writing-custom-field-extensions.md
@@ -94,14 +94,14 @@ import {
   createScaffolderFieldExtension,
 } from '@backstage/plugin-scaffolder';
 import {
-  ValidateKebabCase,
+  ValidateKebabCaseExtension,
   validateKebabCaseValidation,
 } from './ValidateKebabCase';
 
 export const ValidateKebabCaseFieldExtension = scaffolderPlugin.provide(
   createScaffolderFieldExtension({
     name: 'ValidateKebabCase',
-    component: ValidateKebabCase,
+    component: ValidateKebabCaseExtension,
     validation: validateKebabCaseValidation,
   }),
 );
@@ -173,7 +173,7 @@ spec:
           title: Name
           type: string
           description: My custom name for the component
-          ui:field: ValidateKebabCaseExtension
+          ui:field: ValidateKebabCase
   steps:
   [...]
 ```

--- a/docs/features/software-templates/writing-custom-field-extensions.md
+++ b/docs/features/software-templates/writing-custom-field-extensions.md
@@ -35,7 +35,7 @@ import FormControl from '@material-ui/core/FormControl';
 /*
  This is the actual component that will get rendered in the form
 */
-export const ValidateKebabCaseExtension = ({
+export const ValidateKebabCase = ({
   onChange,
   rawErrors,
   required,
@@ -94,14 +94,14 @@ import {
   createScaffolderFieldExtension,
 } from '@backstage/plugin-scaffolder';
 import {
-  ValidateKebabCaseExtension,
+  ValidateKebabCase,
   validateKebabCaseValidation,
-} from './ValidateKebabCase';
+} from './ValidateKebabCase/ValidateKebabCaseExtension';
 
 export const ValidateKebabCaseFieldExtension = scaffolderPlugin.provide(
   createScaffolderFieldExtension({
     name: 'ValidateKebabCase',
-    component: ValidateKebabCaseExtension,
+    component: ValidateKebabCase,
     validation: validateKebabCaseValidation,
   }),
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing docs at https://backstage.io/docs/features/software-templates/writing-custom-field-extensions. The docs there include code which import with incorrect module names. The second code block does the import as 
```ts
import {
  ValidateKebabCase,
  validateKebabCaseValidation,
} from './ValidateKebabCase';
```
whereas `ValidateKebabCase` doesn't exist. the first code block exports a const as `ValidateKebabCaseExtension`, which should have been the correct import.
The same has been fixed in the `component` call in the second code block.

Also, in the sixth code block under https://backstage.io/docs/features/software-templates/writing-custom-field-extensions#using-the-custom-field-extension, the name mentioned in `ui:field` is incorrect. the correct name is defined in the second code block as `ValidateKebabCase` and not `ValidateKebabCaseExtension`.

Ngl, these 2 left me head scratching for a while 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
