### PR TITLE
Add more cluster details to the software catalog

### DIFF
--- a/.changeset/calm-avocados-exercise.md
+++ b/.changeset/calm-avocados-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-common': patch
+---
+
+New K8s catalog entity annotations added that will replace now deprecated k8s annotations in the catalog-model package. K8s annotation imports should now be made from plugin-kubernetes-common.

--- a/.changeset/cold-cycles-switch.md
+++ b/.changeset/cold-cycles-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Adding new Cluster detail fields to catalogClusterLocator. Replace deprecated imports with k8s annotations from plugin-kubernetes-common.

--- a/.changeset/stale-dots-smile.md
+++ b/.changeset/stale-dots-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Add deprecation tag to kubernetes constants in catalog, constants are now defined in plugin-kubernetes-common

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -14,14 +14,14 @@ export interface AlphaEntity extends Entity {
 // @public
 export const ANNOTATION_EDIT_URL = 'backstage.io/edit-url';
 
-// @public
+// @public @deprecated
 export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';
 
-// @public
+// @public @deprecated
 export const ANNOTATION_KUBERNETES_API_SERVER_CA =
   'kubernetes.io/api-server-certificate-authority';
 
-// @public
+// @public @deprecated
 export const ANNOTATION_KUBERNETES_AUTH_PROVIDER =
   'kubernetes.io/auth-provider';
 

--- a/packages/catalog-model/src/entity/constants.ts
+++ b/packages/catalog-model/src/entity/constants.ts
@@ -38,6 +38,7 @@ export const ANNOTATION_EDIT_URL = 'backstage.io/edit-url';
 /**
  * Annotation for specifying the API server of a Kubernetes cluster
  *
+ * @deprecated Import this constant from `@backstage/plugin-kubernetes-common` instead
  * @public
  */
 export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';
@@ -45,6 +46,7 @@ export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';
 /**
  * Annotation for specifying the Certificate Authority of an API server for a Kubernetes cluster
  *
+ * @deprecated Import this constant from `@backstage/plugin-kubernetes-common` instead
  * @public
  */
 export const ANNOTATION_KUBERNETES_API_SERVER_CA =
@@ -53,6 +55,7 @@ export const ANNOTATION_KUBERNETES_API_SERVER_CA =
 /**
  * Annotation for specifying the auth provider for a Kubernetes cluster
  *
+ * @deprecated Import this constant from `@backstage/plugin-kubernetes-common` instead
  * @public
  */
 export const ANNOTATION_KUBERNETES_AUTH_PROVIDER =

--- a/packages/catalog-model/src/entity/index.ts
+++ b/packages/catalog-model/src/entity/index.ts
@@ -15,14 +15,7 @@
  */
 
 export * from './conditions';
-export {
-  DEFAULT_NAMESPACE,
-  ANNOTATION_EDIT_URL,
-  ANNOTATION_VIEW_URL,
-  ANNOTATION_KUBERNETES_API_SERVER,
-  ANNOTATION_KUBERNETES_API_SERVER_CA,
-  ANNOTATION_KUBERNETES_AUTH_PROVIDER,
-} from './constants';
+export * from './constants';
 export type {
   AlphaEntity,
   Entity,

--- a/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.test.ts
@@ -18,39 +18,66 @@ import '@backstage/backend-common';
 import { CatalogClusterLocator } from './CatalogClusterLocator';
 import { CatalogApi } from '@backstage/catalog-client';
 
+const mockCatalogApi = {
+  getEntityByRef: jest.fn(),
+  getEntities: async () => ({
+    items: [
+      {
+        apiVersion: 'version',
+        kind: 'User',
+        metadata: {
+          annotations: {
+            'kubernetes.io/api-server': 'https://apiserver.com',
+            'kubernetes.io/api-server-certificate-authority': 'caData',
+            'kubernetes.io/auth-provider': 'aws',
+            'kubernetes.io/oidc-token-provider': 'google',
+            'kubernetes.io/skip-metrics-lookup': 'true',
+            'kubernetes.io/skip-tls-verify': 'true',
+            'kubernetes.io/dashboard-url': 'my-url',
+            'kubernetes.io/dashboard-app': 'my-app',
+          },
+          name: 'owned',
+          namespace: 'default',
+        },
+      },
+    ],
+  }),
+} as unknown as CatalogApi;
+
 describe('CatalogClusterLocator', () => {
-  it('empty clusters returns empty cluster details', async () => {
-    const mockCatalogApi = {
+  it('returns empty cluster details when the cluster is empty', async () => {
+    const emptyMockCatalogApi = {
       getEntityByRef: jest.fn(),
       getEntities: async () => ({
-        items: [
-          {
-            apiVersion: 'version',
-            kind: 'User',
-            metadata: {
-              annotations: {
-                'kubernetes.io/api-server': 'https://apiserver.com',
-                'kubernetes.io/api-server-certificate-authority': 'caData',
-                'kubernetes.io/auth-provider': 'aws',
-              },
-              name: 'owned',
-              namespace: 'default',
-            },
-          },
-        ],
+        items: [],
       }),
     } as Partial<CatalogApi> as CatalogApi;
 
-    const sut = CatalogClusterLocator.fromConfig(mockCatalogApi);
+    const clusterSupplier =
+      CatalogClusterLocator.fromConfig(emptyMockCatalogApi);
 
-    const result = await sut.getClusters();
+    const result = await clusterSupplier.getClusters();
+
+    expect(result).toHaveLength(0);
+    expect(result).toStrictEqual([]);
+  });
+
+  it('returns the cluster details provided by annotations', async () => {
+    const clusterSupplier = CatalogClusterLocator.fromConfig(mockCatalogApi);
+
+    const result = await clusterSupplier.getClusters();
 
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
+    expect(result[0]).toStrictEqual({
       name: 'owned',
       url: 'https://apiserver.com',
       caData: 'caData',
       authProvider: 'aws',
+      oidcTokenProvider: 'google',
+      skipMetricsLookup: true,
+      skipTLSVerify: true,
+      dashboardUrl: 'my-url',
+      dashboardApp: 'my-app',
     });
   });
 });

--- a/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts
@@ -20,7 +20,12 @@ import {
   ANNOTATION_KUBERNETES_API_SERVER,
   ANNOTATION_KUBERNETES_API_SERVER_CA,
   ANNOTATION_KUBERNETES_AUTH_PROVIDER,
-} from '@backstage/catalog-model';
+  ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER,
+  ANNOTATION_KUBERNETES_SKIP_METRICS_LOOKUP,
+  ANNOTATION_KUBERNETES_SKIP_TLS_VERIFY,
+  ANNOTATION_KUBERNETES_DASHBOARD_URL,
+  ANNOTATION_KUBERNETES_DASHBOARD_APP,
+} from '@backstage/plugin-kubernetes-common';
 
 export class CatalogClusterLocator implements KubernetesClustersSupplier {
   private catalogClient: CatalogApi;
@@ -57,6 +62,26 @@ export class CatalogClusterLocator implements KubernetesClustersSupplier {
           entity.metadata.annotations![ANNOTATION_KUBERNETES_API_SERVER_CA]!,
         authProvider:
           entity.metadata.annotations![ANNOTATION_KUBERNETES_AUTH_PROVIDER]!,
+        oidcTokenProvider:
+          entity.metadata.annotations![
+            ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER
+          ]!,
+        skipMetricsLookup:
+          entity.metadata.annotations![
+            ANNOTATION_KUBERNETES_SKIP_METRICS_LOOKUP
+          ]! === 'true'
+            ? true
+            : false,
+        skipTLSVerify:
+          entity.metadata.annotations![
+            ANNOTATION_KUBERNETES_SKIP_TLS_VERIFY
+          ]! === 'true'
+            ? true
+            : false,
+        dashboardUrl:
+          entity.metadata.annotations![ANNOTATION_KUBERNETES_DASHBOARD_URL]!,
+        dashboardApp:
+          entity.metadata.annotations![ANNOTATION_KUBERNETES_DASHBOARD_APP]!,
       };
 
       return clusterDetails;

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -19,6 +19,37 @@ import { V1ReplicaSet } from '@kubernetes/client-node';
 import { V1Service } from '@kubernetes/client-node';
 import { V1StatefulSet } from '@kubernetes/client-node';
 
+// @public
+export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';
+
+// @public
+export const ANNOTATION_KUBERNETES_API_SERVER_CA =
+  'kubernetes.io/api-server-certificate-authority';
+
+// @public
+export const ANNOTATION_KUBERNETES_AUTH_PROVIDER =
+  'kubernetes.io/auth-provider';
+
+// @public
+export const ANNOTATION_KUBERNETES_DASHBOARD_APP =
+  'kubernetes.io/dashboard-app';
+
+// @public
+export const ANNOTATION_KUBERNETES_DASHBOARD_URL =
+  'kubernetes.io/dashboard-url';
+
+// @public
+export const ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER =
+  'kubernetes.io/oidc-token-provider';
+
+// @public
+export const ANNOTATION_KUBERNETES_SKIP_METRICS_LOOKUP =
+  'kubernetes.io/skip-metrics-lookup';
+
+// @public
+export const ANNOTATION_KUBERNETES_SKIP_TLS_VERIFY =
+  'kubernetes.io/skip-tls-verify';
+
 // @public (undocumented)
 export type AuthProviderType = 'google' | 'serviceAccount' | 'aws' | 'azure';
 

--- a/plugins/kubernetes-common/src/catalog-entity-constants.ts
+++ b/plugins/kubernetes-common/src/catalog-entity-constants.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Annotation for specifying the API server of a Kubernetes cluster
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';
+
+/**
+ * Annotation for specifying the Certificate Authority of an API server for a Kubernetes cluster
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_API_SERVER_CA =
+  'kubernetes.io/api-server-certificate-authority';
+
+/**
+ * Annotation for specifying the auth provider for a Kubernetes cluster
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_AUTH_PROVIDER =
+  'kubernetes.io/auth-provider';
+
+/**
+ * Annotation for specifying the oidc provider used to get id tokens for a Kubernetes cluster
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER =
+  'kubernetes.io/oidc-token-provider';
+
+/**
+ * Annotation for specifying boolean value for skip metric lookup.
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_SKIP_METRICS_LOOKUP =
+  'kubernetes.io/skip-metrics-lookup';
+
+/**
+ * Annotation for specifying boolean value for skip tls verify.
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_SKIP_TLS_VERIFY =
+  'kubernetes.io/skip-tls-verify';
+
+/**
+ * Annotation for specifying the dashboard url for a Kubernetes cluster.
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_DASHBOARD_URL =
+  'kubernetes.io/dashboard-url';
+
+/**
+ * Annotation for specifying the dashboard app for a Kubernetes cluster.
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_DASHBOARD_APP =
+  'kubernetes.io/dashboard-app';

--- a/plugins/kubernetes-common/src/index.ts
+++ b/plugins/kubernetes-common/src/index.ts
@@ -21,3 +21,4 @@
  */
 
 export * from './types';
+export * from './catalog-entity-constants';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding additional fields to catalog cluster details so that its catalog cluster locator method better matches the config cluster locator method. This resolves #15088. Details on how to test this feature were provided in the issue. 

This was implemented by adding new annotations to @backstage/catalog-model and then having the [CatalogClusterLocator](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts) read them in its getClusters method and surface them in the clusterDetails appropriately. With this current implementation we can now specify cluster details in our catalog and still successfully see our kubernetes resources under the kubernetes tab.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
