### PR TITLE
feat: add option to override material table options for DocsTable

### DIFF
--- a/.changeset/cuddly-boxes-agree.md
+++ b/.changeset/cuddly-boxes-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Update DocsTable and EntityListDocsTable to accept overrides for Material Table options.

--- a/.changeset/pretty-ladybugs-taste.md
+++ b/.changeset/pretty-ladybugs-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Adds new type, TableOptions, extending Material Table Options.

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -240,6 +240,8 @@ export interface TableProps<T extends object = {}>
   onStateChange?: (state: TableState) => any;
 }
 
+export interface TableOptions<T extends object = {}> extends Options<T> {}
+
 export function TableToolbar(toolbarProps: {
   toolbarRef: MutableRefObject<any>;
   setSearch: (value: string) => void;

--- a/packages/core-components/src/components/Table/index.ts
+++ b/packages/core-components/src/components/Table/index.ts
@@ -22,6 +22,7 @@ export type {
   TableColumn,
   TableFilter,
   TableProps,
+  TableOptions,
   TableState,
   TableClassKey,
   FiltersContainerClassKey,

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -29,6 +29,7 @@ import {
   EmptyState,
   Table,
   TableColumn,
+  TableOptions,
   TableProps,
 } from '@backstage/core-components';
 import { actionFactories } from './actions';
@@ -47,6 +48,7 @@ export type DocsTableProps = {
   loading?: boolean | undefined;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
+  options?: TableOptions<DocsTableRow>;
 };
 
 /**
@@ -55,7 +57,7 @@ export type DocsTableProps = {
  * @public
  */
 export const DocsTable = (props: DocsTableProps) => {
-  const { entities, title, loading, columns, actions } = props;
+  const { entities, title, loading, columns, actions, options } = props;
   const [, copyToClipboard] = useCopyToClipboard();
   const getRouteToReaderPageFor = useRouteRef(rootDocsRouteRef);
   const config = useApi(configApiRef);
@@ -102,6 +104,7 @@ export const DocsTable = (props: DocsTableProps) => {
             pageSize: 20,
             search: true,
             actionsColumnIndex: -1,
+            ...options,
           }}
           data={documents}
           columns={columns || defaultColumns}

--- a/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
@@ -20,6 +20,7 @@ import { capitalize } from 'lodash';
 import {
   CodeSnippet,
   TableColumn,
+  TableOptions,
   TableProps,
   WarningPanel,
 } from '@backstage/core-components';
@@ -40,6 +41,7 @@ import { DocsTableRow } from './types';
 export type EntityListDocsTableProps = {
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
+  options?: TableOptions<DocsTableRow>;
 };
 
 /**
@@ -48,7 +50,7 @@ export type EntityListDocsTableProps = {
  * @public
  */
 export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
-  const { columns, actions } = props;
+  const { columns, actions, options } = props;
   const { loading, error, entities, filters } = useEntityList();
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const [, copyToClipboard] = useCopyToClipboard();
@@ -81,6 +83,7 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
       loading={loading}
       actions={actions || defaultActions}
       columns={columns}
+      options={options}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Adds new optional prop to `<EntityListDocsTable/>` and `<DocsTable/>`, `options` which extends the [Options type from Material Table](https://github.com/mbrn/material-table/blob/master/types/index.d.ts#L294). Continues to use [current defaults](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/home/components/Tables/DocsTable.tsx#L101-L104) unless overridden. 

Closes #15673 

![docs table with configured pageSize of 5](https://user-images.githubusercontent.com/61716964/213029041-0a4566e8-82d9-410a-abc7-0657c932792e.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
