### PR TITLE
Fix context missing for `yarn build` errors

### DIFF
--- a/.changeset/eight-hotels-sparkle.md
+++ b/.changeset/eight-hotels-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Show module name causing error during build

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -122,15 +122,9 @@ async function build(config: webpack.Configuration, isCi: boolean) {
     warnings: true,
     errors: true,
   });
-  // NOTE(freben): The code below that extracts the message part of the errors,
-  // is due to react-dev-utils not yet being compatible with webpack 5. This
-  // may be possible to remove (just passing the serialized stats object
-  // directly into the format function) after a new release of react-dev-utils
-  // has been made available.
-  // See https://github.com/facebook/create-react-app/issues/9880
   const { errors, warnings } = formatWebpackMessages({
-    errors: serializedStats.errors?.map(e => (e.message ? e.message : e)),
-    warnings: serializedStats.warnings?.map(e => (e.message ? e.message : e)),
+    errors: serializedStats.errors,
+    warnings: serializedStats.warnings,
   });
 
   if (errors.length) {

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -133,7 +133,7 @@ async function build(config: webpack.Configuration, isCi: boolean) {
     // of the same problem, but confuse the reader with noise.
     const errorWithContext = applyContextToError(
       errors[0],
-      serializedStats.errors?.[0].moduleName || '',
+      serializedStats.errors?.[0]?.moduleName ?? '',
     );
     throw new Error(errorWithContext);
   }
@@ -141,7 +141,7 @@ async function build(config: webpack.Configuration, isCi: boolean) {
     const warningsWithContext = warnings.map((warning, i) => {
       return applyContextToError(
         warning,
-        serializedStats.warnings?.[i].moduleName || '',
+        serializedStats.warnings?.[i]?.moduleName ?? '',
       );
     });
     console.log(

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -63,10 +63,7 @@ export async function buildBundle(options: BuildOptions) {
     );
   }
 
-  const { stats } = await build(config, isCi).catch(error => {
-    console.log(chalk.red('Failed to compile.\n'));
-    throw new Error(`Failed to compile.\n${error.message || error}`);
-  });
+  const { stats } = await build(config, isCi);
 
   if (!stats) {
     throw new Error('No stats returned');
@@ -114,7 +111,7 @@ async function build(config: webpack.Configuration, isCi: boolean) {
   );
 
   if (!stats) {
-    throw new Error('No stats provided');
+    throw new Error('Failed to compile: No stats provided');
   }
 
   const serializedStats = stats.toJson({
@@ -130,7 +127,7 @@ async function build(config: webpack.Configuration, isCi: boolean) {
   if (errors.length) {
     // Only keep the first error. Others are often indicative
     // of the same problem, but confuse the reader with noise.
-    throw new Error(errors[0]);
+    throw new Error(`Failed to compile.\n${errors[0]}`);
   }
   if (isCi && warnings.length) {
     console.log(
@@ -138,7 +135,7 @@ async function build(config: webpack.Configuration, isCi: boolean) {
         '\nTreating warnings as errors because process.env.CI = true.\n',
       ),
     );
-    throw new Error(warnings.join('\n\n'));
+    throw new Error(`Failed to compile.\n${warnings.join('\n\n')}`);
   }
 
   return { stats };


### PR DESCRIPTION
Make build error cause more clear by prepending with module name

Simplify the diagnosis of build failures by showing the module name
encountering the issue right before the error itself is printed.

Also apply the fix to warnings.

Finally, while in the area, remove a `react-dev-utils` workaround which should no longer be needed.

-----

Before:
```
Error: Failed to compile.
Attempted import error: 'smile' is not exported from '@backstage/plugin-catalog-common/alpha' (imported as 'smile').
```
After:
```
Error: Failed to compile.
./src/App.tsx:
  Attempted import error: 'smile' is not exported from '@backstage/plugin-catalog-common/alpha' (imported as 'smile').
```

-----

See [the webpack docs here](https://webpack.js.org/api/stats/#errors-and-warnings) for the structure of error and warnings objects. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
