### PR TITLE
Fixes issue #15466: adjust properties on adopoters form, allow for sc…

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -1244,16 +1244,16 @@ h3.collapsible span.arrow {
   transform: translateY(-50%) translateX(500px);
 }
 
-@media only screen and (max-height: 675px){
- .Sidebar__Container {
-  top: 65%;
- }
+@media only screen and (max-height: 675px) {
+  .Sidebar__Container {
+    top: 65%;
+  }
 }
 
 @media only screen and (max-width: 650px) {
- .Sidebar__Container {
-  transform: translateY(-50%) translateX(300px);
- }
+  .Sidebar__Container {
+    transform: translateY(-50%) translateX(300px);
+  }
 }
 
 .Sidebar__Container--open {
@@ -1276,10 +1276,10 @@ h3.collapsible span.arrow {
 }
 
 @media only screen and (max-width: 650px) {
- .Sidebar__Button {
-  width: 175px;
-  font-size: 15px;
- }
+  .Sidebar__Button {
+    width: 175px;
+    font-size: 15px;
+  }
 }
 
 .Sidebar__Button:hover {
@@ -1294,15 +1294,15 @@ h3.collapsible span.arrow {
 }
 
 @media only screen and (max-width: 650px) {
- #Sidebar__HubSpotContainer {
-  width: 300px;
- }
+  #Sidebar__HubSpotContainer {
+    width: 300px;
+  }
 }
 
-#Sidebar__HubSpotContainer form{
- overflow-y: auto;
- height: 100%;
- padding: 25px 25px 0px 25px;
+#Sidebar__HubSpotContainer form {
+  overflow-y: auto;
+  height: 100%;
+  padding: 25px 25px 0px 25px;
 }
 
 #Sidebar__HubSpotContainer .hs-button {

--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -1244,12 +1244,24 @@ h3.collapsible span.arrow {
   transform: translateY(-50%) translateX(500px);
 }
 
+@media only screen and (max-height: 675px){
+ .Sidebar__Container {
+  top: 65%;
+ }
+}
+
+@media only screen and (max-width: 650px) {
+ .Sidebar__Container {
+  transform: translateY(-50%) translateX(300px);
+ }
+}
+
 .Sidebar__Container--open {
   transform: translateY(-50%);
 }
 
 .Sidebar__Button {
-  transform: rotate(-90deg) translateY(48px);
+  transform: rotate(-90deg) translateY(49px);
   padding: 12px 16px;
   border-radius: 8px 8px 0 0;
   background-color: rgb(92, 214, 200);
@@ -1263,18 +1275,34 @@ h3.collapsible span.arrow {
   cursor: pointer;
 }
 
+@media only screen and (max-width: 650px) {
+ .Sidebar__Button {
+  width: 175px;
+  font-size: 15px;
+ }
+}
+
 .Sidebar__Button:hover {
-  transform: rotate(-90deg) translateY(48px) scale(1.01);
+  transform: rotate(-90deg) translateY(49px) scale(1.01);
 }
 
 #Sidebar__HubSpotContainer {
   width: 500px;
   background-color: white;
   border-radius: 8px 0 0 8px;
-  padding: 16px;
-  padding-bottom: 0px;
-  z-index: 10001;
-  min-height: 260px;
+  height: 500px;
+}
+
+@media only screen and (max-width: 650px) {
+ #Sidebar__HubSpotContainer {
+  width: 300px;
+ }
+}
+
+#Sidebar__HubSpotContainer form{
+ overflow-y: auto;
+ height: 100%;
+ padding: 25px 25px 0px 25px;
 }
 
 #Sidebar__HubSpotContainer .hs-button {
@@ -1284,6 +1312,7 @@ h3.collapsible span.arrow {
   color: rgb(0, 0, 0);
   border: 0;
 }
+
 #Sidebar__HubSpotContainer.submitted-message {
   min-height: 260px;
   display: flex;


### PR DESCRIPTION
FIXES ISSUE #15466 

…roll, set feature to fixed height, add media queries for various breakpoints to keep integrity of the feature for smartphones and small devices

Signed-off-by: Michael Paglione <michael@michaelpaglione.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes behavior allowing users to now scroll through form:


<img width="1440" alt="Screen Shot 2023-01-17 at 9 08 48 PM" src="https://user-images.githubusercontent.com/91204918/213064516-0a722011-a034-4a93-8f0c-a07d1f915545.png">
<img width="1440" alt="Screen Shot 2023-01-17 at 9 08 59 PM" src="https://user-images.githubusercontent.com/91204918/213064533-dae3b322-bb04-4f0a-a598-2bfbb8ea07e9.png">

*Button was not visible on small viewports, and clicking the feature filled the viewport, forcing users to refresh the page to get out. *

Fix: shows button on smaller viewports and makes the form collapsable: 

<img width="1440" alt="Screen Shot 2023-01-17 at 9 10 09 PM" src="https://user-images.githubusercontent.com/91204918/213064544-b83668a1-38e2-4900-809b-fe1de347cf19.png">

<img width="1440" alt="Screen Shot 2023-01-17 at 9 17 29 PM" src="https://user-images.githubusercontent.com/91204918/213065426-93d2a9b3-79cf-4e63-bcd0-dc5401ecf1db.png">

<img width="1440" alt="Screen Shot 2023-01-17 at 9 17 35 PM" src="https://user-images.githubusercontent.com/91204918/213065437-793a2b51-17e8-46e8-b213-048bffad4fb3.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
