### PR TITLE
fixed issue where scroll position was not reset

### DIFF
--- a/.changeset/spotty-wombats-relax.md
+++ b/.changeset/spotty-wombats-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bug in useTechDocsReaderDom that was causing the scroll position to not be reset when navigating to a new page within TechDocs

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -247,7 +247,7 @@ export const useTechDocsReaderDom = (
       }
 
       // Scroll to top after render
-      window.scroll({ top: 0 });
+      document.querySelector('[class^=BackstageHeader]')?.scrollIntoView();
 
       // Post-render
       const postTransformedDomElement = await postRender(

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -247,7 +247,10 @@ export const useTechDocsReaderDom = (
       }
 
       // Scroll to top after render
-      document.querySelector('[class^=BackstageHeader]')?.scrollIntoView();
+      const mainElement = document.querySelector('main');
+      if (mainElement?.scroll) {
+        mainElement.scroll({ top: 0 });
+      }
 
       // Post-render
       const postTransformedDomElement = await postRender(


### PR DESCRIPTION
Signed-off-by: Patrick Knight <pknight@redhat.com>

## Hey, I just made a Pull Request!
Fixes: #15356 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR fixes the issue of when navigating to another page in techdocs via link, the new page will retain the vertical position of the old page instead of going to the top. In this PR, I updated the window.scroll({ top: 0}) to document.querySelector('[class^=BackstageHeader]')?.scrollIntoView(). My reasoning was to grab the header and scroll it into view since the window is already classified as at the top of the screen.

Before:
![before-scroll-fix](https://user-images.githubusercontent.com/82788581/213201618-a0ae31a4-bcec-40c5-bf34-f31f9f5770dc.gif)

After:
![after-scroll-fix](https://user-images.githubusercontent.com/82788581/213201568-85910dd2-9e73-432e-8275-68797f5e552c.gif)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
