### PR TITLE
fix: hide support button if there are no links

### DIFF
--- a/.changeset/perfect-pans-flash.md
+++ b/.changeset/perfect-pans-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Hide support button if there is no support in configuration

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1264,7 +1264,7 @@ export type SubvalueCellClassKey = 'value' | 'subvalue';
 // Warning: (ae-missing-release-tag) "SupportButton" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function SupportButton(props: SupportButtonProps): JSX.Element;
+export function SupportButton(props: SupportButtonProps): JSX.Element | null;
 
 // Warning: (ae-missing-release-tag) "SupportButtonClassKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1505,7 +1505,7 @@ export const useSidebarPinState: () => SidebarPinState;
 // Warning: (ae-missing-release-tag) "useSupportConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function useSupportConfig(): SupportConfig;
+export function useSupportConfig(): SupportConfig | undefined;
 
 // @public (undocumented)
 export function WarningIcon(props: IconComponentProps): JSX.Element;

--- a/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
@@ -44,14 +44,22 @@ const POPOVER_ID = 'support-button-popover';
 
 describe('<SupportButton />', () => {
   it('renders without exploding', async () => {
-    await renderInTestApp(<SupportButton />);
+    await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
+        <SupportButton />
+      </TestApiProvider>,
+    );
     await expect(
       screen.findByTestId(SUPPORT_BUTTON_ID),
     ).resolves.toBeInTheDocument();
   });
 
   it('supports passing a title', async () => {
-    await renderInTestApp(<SupportButton title="Custom title" />);
+    await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
+        <SupportButton title="Custom title" />
+      </TestApiProvider>,
+    );
     fireEvent.click(screen.getByTestId(SUPPORT_BUTTON_ID));
     expect(screen.getByText('Custom title')).toBeInTheDocument();
   });
@@ -95,7 +103,11 @@ describe('<SupportButton />', () => {
   });
 
   it('shows popover on click', async () => {
-    await renderInTestApp(<SupportButton />);
+    await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
+        <SupportButton />
+      </TestApiProvider>,
+    );
 
     await expect(
       screen.findByTestId(SUPPORT_BUTTON_ID),
@@ -105,5 +117,15 @@ describe('<SupportButton />', () => {
     });
 
     await expect(screen.findByTestId(POPOVER_ID)).resolves.toBeInTheDocument();
+  });
+
+  it('hide button if config is missing', async () => {
+    const emptyConfig = new MockConfigApi({});
+    await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, emptyConfig]]}>
+        <SupportButton />
+      </TestApiProvider>,
+    );
+    await expect(screen.findByTestId(SUPPORT_BUTTON_ID)).rejects.toThrow();
   });
 });

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -84,7 +84,8 @@ const SupportListItem = ({ item }: { item: SupportItem }) => {
 
 export function SupportButton(props: SupportButtonProps) {
   const { title, items, children } = props;
-  const { items: configItems } = useSupportConfig();
+  const config = useSupportConfig();
+  const supportItems = items ?? config?.items;
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
@@ -101,6 +102,10 @@ export function SupportButton(props: SupportButtonProps) {
   const popoverCloseHandler = () => {
     setPopoverOpen(false);
   };
+
+  if (!supportItems || supportItems.length === 0) {
+    return null;
+  }
 
   return (
     <>
@@ -151,7 +156,7 @@ export function SupportButton(props: SupportButtonProps) {
               {child}
             </ListItem>
           ))}
-          {(items ?? configItems).map((item, i) => (
+          {supportItems.map((item, i) => (
             <SupportListItem item={item} key={`item-${i}`} />
           ))}
         </List>

--- a/packages/core-components/src/hooks/useSupportConfig.ts
+++ b/packages/core-components/src/hooks/useSupportConfig.ts
@@ -32,30 +32,13 @@ export type SupportConfig = {
   items: SupportItem[];
 };
 
-const DEFAULT_SUPPORT_CONFIG: SupportConfig = {
-  url: 'https://github.com/backstage/backstage/issues',
-  items: [
-    {
-      title: 'Support Not Configured',
-      icon: 'warning',
-      links: [
-        {
-          // TODO: Update to dedicated support page on backstage.io/docs
-          title: 'Add `app.support` config key',
-          url: 'https://github.com/backstage/backstage/blob/master/app-config.yaml',
-        },
-      ],
-    },
-  ],
-};
-
-export function useSupportConfig(): SupportConfig {
+export function useSupportConfig(): SupportConfig | undefined {
   const apiHolder = useApiHolder();
   const config = apiHolder.get(configApiRef);
   const supportConfig = config?.getOptionalConfig('app.support');
 
   if (!supportConfig) {
-    return DEFAULT_SUPPORT_CONFIG;
+    return undefined;
   }
 
   return {

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -17,7 +17,27 @@
 import React from 'react';
 import { ErrorPage } from './ErrorPage';
 import { Link } from '../../components/Link';
-import { renderInTestApp } from '@backstage/test-utils';
+import {
+  MockConfigApi,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
+import { configApiRef } from '@backstage/core-plugin-api';
+
+const configApi = new MockConfigApi({
+  app: {
+    support: {
+      url: 'https://github.com',
+      items: [
+        {
+          title: 'Github',
+          icon: 'github',
+          links: [{ title: 'Github Issues', url: '/issues' }],
+        },
+      ],
+    },
+  },
+});
 
 describe('<ErrorPage/>', () => {
   it('should render with status code, status message and go back link', async () => {
@@ -68,9 +88,11 @@ describe('<ErrorPage/>', () => {
     expect(getByText(/a link/i)).toHaveAttribute('href', '/test');
   });
 
-  it('should render with default support url if supportUrl is not provided', async () => {
+  it('should render with config support url if supportUrl is not provided', async () => {
     const { getByText } = await renderInTestApp(
-      <ErrorPage status="404" statusMessage="PAGE NOT FOUND" />,
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
+        <ErrorPage status="404" statusMessage="PAGE NOT FOUND" />
+      </TestApiProvider>,
     );
     expect(
       getByText(/looks like someone dropped the mic!/i),
@@ -78,7 +100,7 @@ describe('<ErrorPage/>', () => {
     expect(getByText(/contact support/i)).toBeInTheDocument();
     expect(getByText(/contact support/i)).toHaveAttribute(
       'href',
-      'https://github.com/backstage/backstage/issues',
+      'https://github.com',
     );
   });
 

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -67,6 +67,7 @@ export function ErrorPage(props: IErrorPageProps) {
   const classes = useStyles();
   const navigate = useNavigate();
   const support = useSupportConfig();
+  const supportLink = supportUrl || support?.url;
 
   return (
     <Grid container spacing={0} className={classes.container}>
@@ -88,9 +89,12 @@ export function ErrorPage(props: IErrorPageProps) {
           <Link to="#" data-testid="go-back-link" onClick={() => navigate(-1)}>
             Go back
           </Link>
-          ... or please{' '}
-          <Link to={supportUrl || support.url}>contact support</Link> if you
-          think this is a bug.
+          {supportLink && (
+            <>
+              ... or please <Link to={supportLink}>contact support</Link> if you
+              think this is a bug.
+            </>
+          )}
         </Typography>
       </Grid>
       <MicDrop />


### PR DESCRIPTION
Fixes #15821

Signed-off-by: Heikki Hellgren <heikki.hellgren@op.fi>

## Hey, I just made a Pull Request!

Hide Support button if there are no links to show in Popover

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
