### PR TITLE
rename misspelled k8s type

### DIFF
--- a/.changeset/khaki-toes-care.md
+++ b/.changeset/khaki-toes-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-common': minor
+---
+
+**BREAKING**: Renamed misspelled `LimitRangeFetchReponse` to `LimitRangeFetchResponse`.

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -140,7 +140,7 @@ export type FetchResponse =
   | ServiceFetchResponse
   | ConfigMapFetchResponse
   | DeploymentFetchResponse
-  | LimitRangeFetchReponse
+  | LimitRangeFetchResponse
   | ReplicaSetsFetchResponse
   | HorizontalPodAutoscalersFetchResponse
   | JobsFetchResponse
@@ -205,7 +205,7 @@ export interface KubernetesRequestBody {
 }
 
 // @public (undocumented)
-export interface LimitRangeFetchReponse {
+export interface LimitRangeFetchResponse {
   // (undocumented)
   resources: Array<V1LimitRange>;
   // (undocumented)

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -127,7 +127,7 @@ export type FetchResponse =
   | ServiceFetchResponse
   | ConfigMapFetchResponse
   | DeploymentFetchResponse
-  | LimitRangeFetchReponse
+  | LimitRangeFetchResponse
   | ReplicaSetsFetchResponse
   | HorizontalPodAutoscalersFetchResponse
   | JobsFetchResponse
@@ -169,7 +169,7 @@ export interface ReplicaSetsFetchResponse {
 }
 
 /** @public */
-export interface LimitRangeFetchReponse {
+export interface LimitRangeFetchResponse {
   type: 'limitranges';
   resources: Array<V1LimitRange>;
 }


### PR DESCRIPTION
Opting to do this without a deprecation period and instead just breaking it since it's an obvious misspelling and at least has no internal use - let me know if you think this is overly lax, happy to go the whole deprecation route as well if you think it's warranted.