### PR TITLE
fix: field extensions with correct CSS and HTML

### DIFF
--- a/.changeset/shaggy-rice-refuse.md
+++ b/.changeset/shaggy-rice-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed the HTML and CSS of field extensions in the scaffold so that their layout closely resembles inbuilt fields

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -40,6 +40,7 @@ import { ReviewStepProps } from '../types';
 import { ReviewStep } from './ReviewStep';
 import { extractSchemaFromStep } from '@backstage/plugin-scaffolder-react';
 import { selectedTemplateRouteRef } from '../../routes';
+import CustomFieldTemplate from '../fields/FieldTemplate/CustomFieldTemplate';
 
 const Form = withTheme(MuiTheme);
 
@@ -180,6 +181,7 @@ export const MultistepJsonForm = (props: MultistepJsonFormProps) => {
                 <Form
                   showErrorList={false}
                   fields={{ ...fieldOverrides, ...fields }}
+                  FieldTemplate={CustomFieldTemplate}
                   widgets={widgets}
                   noHtml5Validate
                   formData={formData}

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { EntityNamePickerProps } from './schema';
-import { FormControl, TextField, Typography } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 
 export { EntityNamePickerSchema } from './schema';
 
@@ -26,7 +26,7 @@ export const EntityNamePicker = (props: EntityNamePickerProps) => {
   const {
     onChange,
     required,
-    schema: { title = 'Name', description = 'Unique name of the component' },
+    schema: { title = 'Name' },
     rawErrors,
     formData,
     uiSchema: { 'ui:autofocus': autoFocus },
@@ -35,19 +35,15 @@ export const EntityNamePicker = (props: EntityNamePickerProps) => {
   } = props;
 
   return (
-    <FormControl required={required} error={rawErrors?.length > 0 && !formData}>
-      <TextField
-        id={idSchema?.$id}
-        label={title}
-        placeholder={placeholder}
-        required={required}
-        value={formData ?? ''}
-        onChange={({ target: { value } }) => onChange(value)}
-        inputProps={{ autoFocus }}
-      />
-      <Typography variant="caption" color="textSecondary">
-        {description}
-      </Typography>
-    </FormControl>
+    <TextField
+      id={idSchema?.$id}
+      label={title}
+      placeholder={placeholder}
+      required={required}
+      value={formData ?? ''}
+      onChange={({ target: { value } }) => onChange(value)}
+      error={rawErrors?.length > 0 && !formData}
+      inputProps={{ autoFocus }}
+    />
   );
 };

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { EntityNamePickerProps } from './schema';
-import { TextField } from '@material-ui/core';
+import { FormControl, TextField, Typography } from '@material-ui/core';
 
 export { EntityNamePickerSchema } from './schema';
 
@@ -35,17 +35,19 @@ export const EntityNamePicker = (props: EntityNamePickerProps) => {
   } = props;
 
   return (
-    <TextField
-      id={idSchema?.$id}
-      label={title}
-      placeholder={placeholder}
-      helperText={description}
-      required={required}
-      value={formData ?? ''}
-      onChange={({ target: { value } }) => onChange(value)}
-      margin="normal"
-      error={rawErrors?.length > 0 && !formData}
-      inputProps={{ autoFocus }}
-    />
+    <FormControl required={required} error={rawErrors?.length > 0 && !formData}>
+      <TextField
+        id={idSchema?.$id}
+        label={title}
+        placeholder={placeholder}
+        required={required}
+        value={formData ?? ''}
+        onChange={({ target: { value } }) => onChange(value)}
+        inputProps={{ autoFocus }}
+      />
+      <Typography variant="caption" color="textSecondary">
+        {description}
+      </Typography>
+    </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -19,7 +19,7 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { TextField, Typography } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React, { useCallback, useEffect } from 'react';
@@ -37,7 +37,7 @@ export { EntityPickerSchema } from './schema';
 export const EntityPicker = (props: EntityPickerProps) => {
   const {
     onChange,
-    schema: { title = 'Entity', description = 'An entity from the catalog' },
+    schema: { title = 'Entity' },
     required,
     uiSchema,
     rawErrors,
@@ -99,9 +99,6 @@ export const EntityPicker = (props: EntityPickerProps) => {
           />
         )}
       />
-      <Typography variant="caption" color="textSecondary">
-        {description}
-      </Typography>
     </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -19,7 +19,7 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { TextField } from '@material-ui/core';
+import { TextField, Typography } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React, { useCallback, useEffect } from 'react';
@@ -79,11 +79,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
   }, [entityRefs, onChange]);
 
   return (
-    <FormControl
-      margin="normal"
-      required={required}
-      error={rawErrors?.length > 0 && !formData}
-    >
+    <FormControl required={required} error={rawErrors?.length > 0 && !formData}>
       <Autocomplete
         disabled={entityRefs?.length === 1}
         id={idSchema?.$id}
@@ -97,15 +93,15 @@ export const EntityPicker = (props: EntityPickerProps) => {
           <TextField
             {...params}
             label={title}
-            margin="dense"
-            helperText={description}
-            FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
             variant="outlined"
             required={required}
             InputProps={params.InputProps}
           />
         )}
       />
+      <Typography variant="caption" color="textSecondary">
+        {description}
+      </Typography>
     </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/FieldTemplate/CustomFieldTemplate.tsx
+++ b/plugins/scaffolder/src/components/fields/FieldTemplate/CustomFieldTemplate.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+import { FieldTemplateProps } from '@rjsf/core';
+
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import Typography from '@material-ui/core/Typography';
+
+import WrapIfAdditional from './WrapIfAdditional';
+
+const CustomFieldTemplate = ({
+  id,
+  children,
+  classNames,
+  disabled,
+  hidden,
+  label,
+  onDropPropertyClick,
+  onKeyChange,
+  readonly,
+  required,
+  rawErrors = [],
+  rawHelp,
+  rawDescription,
+  schema,
+}: FieldTemplateProps) => {
+  if (hidden) {
+    return children;
+  }
+
+  return (
+    <WrapIfAdditional
+      classNames={classNames}
+      disabled={disabled}
+      id={id}
+      label={label}
+      onDropPropertyClick={onDropPropertyClick}
+      onKeyChange={onKeyChange}
+      readonly={readonly}
+      required={required}
+      schema={schema}
+    >
+      <FormControl
+        fullWidth
+        error={rawErrors.length ? true : false}
+        required={required}
+      >
+        {children}
+        {rawDescription ? (
+          <Typography variant="caption" color="textSecondary">
+            {rawDescription}
+          </Typography>
+        ) : null}
+        {rawErrors.length > 0 && (
+          <List dense disablePadding>
+            {rawErrors.map((error, i: number) => {
+              return (
+                <ListItem key={i} disableGutters>
+                  <FormHelperText id={id}>{error}</FormHelperText>
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+      </FormControl>
+    </WrapIfAdditional>
+  );
+};
+
+export default CustomFieldTemplate;

--- a/plugins/scaffolder/src/components/fields/FieldTemplate/IconButton.tsx
+++ b/plugins/scaffolder/src/components/fields/FieldTemplate/IconButton.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+import Button from '@material-ui/core/Button';
+import Add from '@material-ui/icons/Add';
+import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import ArrowDownward from '@material-ui/icons/ArrowDownward';
+import Remove from '@material-ui/icons/Remove';
+import { IconButtonProps as MuiIconButtonProps } from '@material-ui/core/IconButton';
+
+const mappings: any = {
+  remove: Remove,
+  plus: Add,
+  'arrow-up': ArrowUpward,
+  'arrow-down': ArrowDownward,
+};
+
+type IconButtonProps = MuiIconButtonProps & {
+  icon: string;
+  iconProps?: object;
+};
+
+const IconButton = (props: IconButtonProps) => {
+  const { icon, className, iconProps, ...otherProps } = props;
+  const IconComp = mappings[icon];
+  return (
+    <Button {...otherProps} size="small">
+      <IconComp {...iconProps} />
+    </Button>
+  );
+};
+
+export default IconButton;

--- a/plugins/scaffolder/src/components/fields/FieldTemplate/WrapIfAdditional.tsx
+++ b/plugins/scaffolder/src/components/fields/FieldTemplate/WrapIfAdditional.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+import { utils } from '@rjsf/core';
+import { JSONSchema7 } from 'json-schema';
+
+import Grid from '@material-ui/core/Grid';
+import FormControl from '@material-ui/core/FormControl';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
+
+import IconButton from './IconButton';
+
+const { ADDITIONAL_PROPERTY_FLAG } = utils;
+
+type WrapIfAdditionalProps = {
+  children: React.ReactElement;
+  classNames: string;
+  disabled: boolean;
+  id: string;
+  label: string;
+  onDropPropertyClick: (index: string) => (event?: any) => void;
+  onKeyChange: (index: string) => (event?: any) => void;
+  readonly: boolean;
+  required: boolean;
+  schema: JSONSchema7;
+};
+
+const WrapIfAdditional = ({
+  children,
+  disabled,
+  id,
+  label,
+  onDropPropertyClick,
+  onKeyChange,
+  readonly,
+  required,
+  schema,
+}: WrapIfAdditionalProps) => {
+  const keyLabel = `${label} Key`; // i18n ?
+  const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+  const btnStyle = {
+    flex: 1,
+    paddingLeft: 6,
+    paddingRight: 6,
+    fontWeight: 'bold',
+  };
+
+  if (!additional) {
+    return <>{children}</>;
+  }
+
+  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+    onKeyChange(target.value);
+
+  return (
+    <Grid container key={`${id}-key`} alignItems="center" spacing={2}>
+      <Grid item xs>
+        <FormControl fullWidth required={required}>
+          <InputLabel>{keyLabel}</InputLabel>
+          <Input
+            defaultValue={label}
+            disabled={disabled || readonly}
+            id={`${id}-key`}
+            name={`${id}-key`}
+            onBlur={!readonly ? handleBlur : undefined}
+            type="text"
+          />
+        </FormControl>
+      </Grid>
+      <Grid item xs>
+        {children}
+      </Grid>
+      <Grid item>
+        <IconButton
+          icon="remove"
+          tabIndex={-1}
+          style={btnStyle as any}
+          disabled={disabled || readonly}
+          onClick={onDropPropertyClick(label)}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default WrapIfAdditional;

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -20,7 +20,7 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { TextField } from '@material-ui/core';
+import { TextField, Typography } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React, { useMemo } from 'react';
@@ -63,11 +63,7 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
   };
 
   return (
-    <FormControl
-      margin="normal"
-      required={required}
-      error={rawErrors?.length > 0 && !formData}
-    >
+    <FormControl required={required} error={rawErrors?.length > 0 && !formData}>
       <Autocomplete
         id={idSchema?.$id}
         value={(formData as string) || ''}
@@ -80,14 +76,15 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
           <TextField
             {...params}
             label={title}
-            margin="normal"
-            helperText={description}
             variant="outlined"
             required={required}
             InputProps={params.InputProps}
           />
         )}
       />
+      <Typography variant="caption" color="textSecondary">
+        {description}
+      </Typography>
     </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -20,7 +20,7 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { TextField, Typography } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React, { useMemo } from 'react';
@@ -39,7 +39,7 @@ export { OwnedEntityPickerSchema } from './schema';
 export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
   const {
     onChange,
-    schema: { title = 'Entity', description = 'An entity from the catalog' },
+    schema: { title = 'Entity' },
     required,
     uiSchema,
     rawErrors,
@@ -82,9 +82,6 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
           />
         )}
       />
-      <Typography variant="caption" color="textSecondary">
-        {description}
-      </Typography>
     </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
@@ -15,10 +15,7 @@
  */
 
 import React from 'react';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import { FormControl, Grid, TextField, Typography } from '@material-ui/core';
 import { RepoUrlPickerState } from './types';
 import { Select, SelectItem } from '@backstage/core-components';
 
@@ -49,66 +46,62 @@ export const AzureRepoPicker = (props: {
 
   return (
     <>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !organization}
-      >
-        {allowedOrganizations?.length ? (
-          <Select
-            native
-            label="Organization"
-            onChange={s =>
-              onChange({ organization: String(Array.isArray(s) ? s[0] : s) })
-            }
-            disabled={allowedOrganizations.length === 1}
-            selected={organization}
-            items={organizationItems}
-          />
-        ) : (
-          <>
-            <InputLabel htmlFor="orgInput">Organization</InputLabel>
-            <Input
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl
+          required
+          error={rawErrors?.length > 0 && !organization}
+          fullWidth
+        >
+          {allowedOrganizations?.length ? (
+            <Select
+              native
+              label="Organization"
+              onChange={s =>
+                onChange({ organization: String(Array.isArray(s) ? s[0] : s) })
+              }
+              disabled={allowedOrganizations.length === 1}
+              selected={organization}
+              items={organizationItems}
+            />
+          ) : (
+            <TextField
               id="orgInput"
+              label="Organization"
               onChange={e => onChange({ organization: e.target.value })}
               value={organization}
             />
-          </>
-        )}
-        <FormHelperText>
-          The Organization that this repo will belong to
-        </FormHelperText>
-      </FormControl>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !owner}
-      >
-        {allowedOwners?.length ? (
-          <Select
-            native
-            label="Owner"
-            onChange={s =>
-              onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
-            }
-            disabled={allowedOwners.length === 1}
-            selected={owner}
-            items={ownerItems}
-          />
-        ) : (
-          <>
-            <InputLabel htmlFor="ownerInput">Project</InputLabel>
-            <Input
+          )}
+          <Typography variant="caption" color="textSecondary">
+            The Organization that this repo will belong to
+          </Typography>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
+          {allowedOwners?.length ? (
+            <Select
+              native
+              label="Owner"
+              onChange={s =>
+                onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
+              }
+              disabled={allowedOwners.length === 1}
+              selected={owner}
+              items={ownerItems}
+            />
+          ) : (
+            <TextField
               id="ownerInput"
+              label="Project"
               onChange={e => onChange({ owner: e.target.value })}
               value={owner}
             />
-          </>
-        )}
-        <FormHelperText>
-          The Project that this repo will belong to
-        </FormHelperText>
-      </FormControl>
+          )}
+          <Typography variant="caption" color="textSecondary">
+            The Project that this repo will belong to
+          </Typography>
+        </FormControl>
+      </Grid>
     </>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import React, { useEffect } from 'react';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import { FormControl, Grid, TextField, Typography } from '@material-ui/core';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
@@ -61,67 +58,67 @@ export const BitbucketRepoPicker = (props: {
   return (
     <>
       {host === 'bitbucket.org' && (
-        <FormControl
-          margin="normal"
-          required
-          error={rawErrors?.length > 0 && !workspace}
-        >
-          {allowedOwners?.length ? (
-            <Select
-              native
-              label="Allowed Workspaces"
-              onChange={s =>
-                onChange({ workspace: String(Array.isArray(s) ? s[0] : s) })
-              }
-              disabled={allowedOwners.length === 1}
-              selected={workspace}
-              items={ownerItems}
-            />
-          ) : (
-            <>
-              <InputLabel htmlFor="workspaceInput">Workspace</InputLabel>
-              <Input
+        <Grid item xs={12} style={{ marginBottom: '10px' }}>
+          <FormControl
+            required
+            error={rawErrors?.length > 0 && !workspace}
+            fullWidth
+          >
+            {allowedOwners?.length ? (
+              <Select
+                native
+                label="Allowed Workspaces"
+                onChange={s =>
+                  onChange({ workspace: String(Array.isArray(s) ? s[0] : s) })
+                }
+                disabled={allowedOwners.length === 1}
+                selected={workspace}
+                items={ownerItems}
+              />
+            ) : (
+              <TextField
                 id="workspaceInput"
+                label="Workspace"
                 onChange={e => onChange({ workspace: e.target.value })}
                 value={workspace}
               />
-            </>
-          )}
-          <FormHelperText>
-            The Workspace that this repo will belong to
-          </FormHelperText>
-        </FormControl>
+            )}
+            <Typography variant="caption" color="textSecondary">
+              The Workspace that this repo will belong to
+            </Typography>
+          </FormControl>
+        </Grid>
       )}
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !project}
-      >
-        {allowedProjects?.length ? (
-          <Select
-            native
-            label="Allowed Projects"
-            onChange={s =>
-              onChange({ project: String(Array.isArray(s) ? s[0] : s) })
-            }
-            disabled={allowedProjects.length === 1}
-            selected={project}
-            items={projectItems}
-          />
-        ) : (
-          <>
-            <InputLabel htmlFor="projectInput">Project</InputLabel>
-            <Input
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl
+          required
+          error={rawErrors?.length > 0 && !project}
+          fullWidth
+        >
+          {allowedProjects?.length ? (
+            <Select
+              native
+              label="Allowed Projects"
+              onChange={s =>
+                onChange({ project: String(Array.isArray(s) ? s[0] : s) })
+              }
+              disabled={allowedProjects.length === 1}
+              selected={project}
+              items={projectItems}
+            />
+          ) : (
+            <TextField
               id="projectInput"
+              label="Project"
               onChange={e => onChange({ project: e.target.value })}
               value={project}
             />
-          </>
-        )}
-        <FormHelperText>
-          The Project that this repo will belong to
-        </FormHelperText>
-      </FormControl>
+          )}
+          <Typography variant="caption" color="textSecondary">
+            The Project that this repo will belong to
+          </Typography>
+        </FormControl>
+      </Grid>
     </>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import { FormControl, Grid, TextField, Typography } from '@material-ui/core';
 import { RepoUrlPickerState } from './types';
 
 export const GerritRepoPicker = (props: {
@@ -29,30 +26,36 @@ export const GerritRepoPicker = (props: {
   const { workspace, owner } = state;
   return (
     <>
-      <FormControl margin="normal" error={rawErrors?.length > 0 && !workspace}>
-        <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-        <Input
-          id="ownerInput"
-          onChange={e => onChange({ owner: e.target.value })}
-          value={owner}
-        />
-        <FormHelperText>The owner of the project (optional)</FormHelperText>
-      </FormControl>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !workspace}
-      >
-        <InputLabel htmlFor="parentInput">Parent</InputLabel>
-        <Input
-          id="parentInput"
-          onChange={e => onChange({ workspace: e.target.value })}
-          value={workspace}
-        />
-        <FormHelperText>
-          The project parent that the repo will belong to
-        </FormHelperText>
-      </FormControl>
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl error={rawErrors?.length > 0 && !workspace} fullWidth>
+          <TextField
+            id="ownerInput"
+            label="Owner"
+            onChange={e => onChange({ owner: e.target.value })}
+            value={owner}
+          />
+          <Typography variant="caption" color="textSecondary">
+            The owner of the project (optional)
+          </Typography>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl
+          required
+          error={rawErrors?.length > 0 && !workspace}
+          fullWidth
+        >
+          <TextField
+            id="parentInput"
+            label="Parent"
+            onChange={e => onChange({ workspace: e.target.value })}
+            value={workspace}
+          />
+          <Typography variant="caption" color="textSecondary">
+            The project parent that the repo will belong to
+          </Typography>
+        </FormControl>
+      </Grid>
     </>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -32,33 +32,31 @@ export const GithubRepoPicker = (props: {
   const { owner } = state;
 
   return (
-    <>
-      <Grid item xs={12} style={{ marginBottom: '10px' }}>
-        <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
-          {allowedOwners?.length ? (
-            <Select
-              native
-              label="Owner Available"
-              onChange={s =>
-                onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
-              }
-              disabled={allowedOwners.length === 1}
-              selected={owner}
-              items={ownerItems}
-            />
-          ) : (
-            <TextField
-              id="ownerInput"
-              label="Owner"
-              onChange={e => onChange({ owner: e.target.value })}
-              value={owner}
-            />
-          )}
-          <Typography variant="caption" color="textSecondary">
-            The organization, user or project that this repo will belong to
-          </Typography>
-        </FormControl>
-      </Grid>
-    </>
+    <Grid item xs={12} style={{ marginBottom: '10px' }}>
+      <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
+        {allowedOwners?.length ? (
+          <Select
+            native
+            label="Owner Available"
+            onChange={s =>
+              onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
+            }
+            disabled={allowedOwners.length === 1}
+            selected={owner}
+            items={ownerItems}
+          />
+        ) : (
+          <TextField
+            id="ownerInput"
+            label="Owner"
+            onChange={e => onChange({ owner: e.target.value })}
+            value={owner}
+          />
+        )}
+        <Typography variant="caption" color="textSecondary">
+          The organization, user or project that this repo will belong to
+        </Typography>
+      </FormControl>
+    </Grid>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import { FormControl, Grid, TextField, Typography } from '@material-ui/core';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
@@ -36,36 +33,32 @@ export const GithubRepoPicker = (props: {
 
   return (
     <>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !owner}
-      >
-        {allowedOwners?.length ? (
-          <Select
-            native
-            label="Owner Available"
-            onChange={s =>
-              onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
-            }
-            disabled={allowedOwners.length === 1}
-            selected={owner}
-            items={ownerItems}
-          />
-        ) : (
-          <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-            <Input
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
+          {allowedOwners?.length ? (
+            <Select
+              native
+              label="Owner Available"
+              onChange={s =>
+                onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
+              }
+              disabled={allowedOwners.length === 1}
+              selected={owner}
+              items={ownerItems}
+            />
+          ) : (
+            <TextField
               id="ownerInput"
+              label="Owner"
               onChange={e => onChange({ owner: e.target.value })}
               value={owner}
             />
-          </>
-        )}
-        <FormHelperText>
-          The organization, user or project that this repo will belong to
-        </FormHelperText>
-      </FormControl>
+          )}
+          <Typography variant="caption" color="textSecondary">
+            The organization, user or project that this repo will belong to
+          </Typography>
+        </FormControl>
+      </Grid>
     </>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import { FormControl, Grid, TextField, Typography } from '@material-ui/core';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
@@ -37,39 +34,37 @@ export const GitlabRepoPicker = (props: {
 
   return (
     <>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !owner}
-      >
-        {allowedOwners?.length ? (
-          <Select
-            native
-            label="Owner Available"
-            onChange={selected =>
-              onChange({
-                owner: String(Array.isArray(selected) ? selected[0] : selected),
-              })
-            }
-            disabled={allowedOwners.length === 1}
-            selected={owner}
-            items={ownerItems}
-          />
-        ) : (
-          <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-            <Input
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
+          {allowedOwners?.length ? (
+            <Select
+              native
+              label="Owner Available"
+              onChange={selected =>
+                onChange({
+                  owner: String(
+                    Array.isArray(selected) ? selected[0] : selected,
+                  ),
+                })
+              }
+              disabled={allowedOwners.length === 1}
+              selected={owner}
+              items={ownerItems}
+            />
+          ) : (
+            <TextField
               id="ownerInput"
+              label="Owner"
               onChange={e => onChange({ owner: e.target.value })}
               value={owner}
             />
-          </>
-        )}
-        <FormHelperText>
-          GitLab namespace where this repository will belong to. It can be the
-          name of organization, group, subgroup, user, or the project.
-        </FormHelperText>
-      </FormControl>
+          )}
+          <Typography variant="caption" color="textSecondary">
+            GitLab namespace where this repository will belong to. It can be the
+            name of organization, group, subgroup, user, or the project.
+          </Typography>
+        </FormControl>
+      </Grid>
     </>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -33,38 +33,34 @@ export const GitlabRepoPicker = (props: {
   const { owner } = state;
 
   return (
-    <>
-      <Grid item xs={12} style={{ marginBottom: '10px' }}>
-        <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
-          {allowedOwners?.length ? (
-            <Select
-              native
-              label="Owner Available"
-              onChange={selected =>
-                onChange({
-                  owner: String(
-                    Array.isArray(selected) ? selected[0] : selected,
-                  ),
-                })
-              }
-              disabled={allowedOwners.length === 1}
-              selected={owner}
-              items={ownerItems}
-            />
-          ) : (
-            <TextField
-              id="ownerInput"
-              label="Owner"
-              onChange={e => onChange({ owner: e.target.value })}
-              value={owner}
-            />
-          )}
-          <Typography variant="caption" color="textSecondary">
-            GitLab namespace where this repository will belong to. It can be the
-            name of organization, group, subgroup, user, or the project.
-          </Typography>
-        </FormControl>
-      </Grid>
-    </>
+    <Grid item xs={12} style={{ marginBottom: '10px' }}>
+      <FormControl required error={rawErrors?.length > 0 && !owner} fullWidth>
+        {allowedOwners?.length ? (
+          <Select
+            native
+            label="Owner Available"
+            onChange={selected =>
+              onChange({
+                owner: String(Array.isArray(selected) ? selected[0] : selected),
+              })
+            }
+            disabled={allowedOwners.length === 1}
+            selected={owner}
+            items={ownerItems}
+          />
+        ) : (
+          <TextField
+            id="ownerInput"
+            label="Owner"
+            onChange={e => onChange({ owner: e.target.value })}
+            value={owner}
+          />
+        )}
+        <Typography variant="caption" color="textSecondary">
+          GitLab namespace where this repository will belong to. It can be the
+          name of organization, group, subgroup, user, or the project.
+        </Typography>
+      </FormControl>
+    </Grid>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -31,6 +31,7 @@ import { RepoUrlPickerProps } from './schema';
 import { RepoUrlPickerState } from './types';
 import useDebounce from 'react-use/lib/useDebounce';
 import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
+import { Grid } from '@material-ui/core';
 
 export { RepoUrlPickerSchema } from './schema';
 
@@ -75,7 +76,7 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
     onChange(serializeRepoPickerUrl(state));
   }, [state, onChange]);
 
-  /* we deal with calling the repo setting here instead of in each components for ease */
+  /* we deal with calling the repo setting here instead of in each component for ease */
   useEffect(() => {
     if (allowedOrganizations.length > 0 && !organization) {
       setState(prevState => ({
@@ -144,7 +145,7 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
         },
       });
 
-      // set the secret using the key provided in the the ui:options for use
+      // set the secret using the key provided in the ui:options for use
       // in the templating the manifest with ${{ secrets[secretsKey] }}
       setSecrets({ [requestUserCredentials.secretsKey]: token });
     },
@@ -157,61 +158,67 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
 
   return (
     <>
-      <RepoUrlPickerHost
-        host={state.host}
-        hosts={allowedHosts}
-        onChange={host => setState(prevState => ({ ...prevState, host }))}
-        rawErrors={rawErrors}
-      />
-      {hostType === 'github' && (
-        <GithubRepoPicker
-          allowedOwners={allowedOwners}
-          onChange={updateLocalState}
-          rawErrors={rawErrors}
-          state={state}
-        />
-      )}
-      {hostType === 'gitlab' && (
-        <GitlabRepoPicker
-          allowedOwners={allowedOwners}
-          rawErrors={rawErrors}
-          state={state}
-          onChange={updateLocalState}
-        />
-      )}
-      {hostType === 'bitbucket' && (
-        <BitbucketRepoPicker
-          allowedOwners={allowedOwners}
-          allowedProjects={allowedProjects}
-          rawErrors={rawErrors}
-          state={state}
-          onChange={updateLocalState}
-        />
-      )}
-      {hostType === 'azure' && (
-        <AzureRepoPicker
-          allowedOrganizations={allowedOrganizations}
-          allowedOwners={allowedOwners}
-          rawErrors={rawErrors}
-          state={state}
-          onChange={updateLocalState}
-        />
-      )}
-      {hostType === 'gerrit' && (
-        <GerritRepoPicker
-          rawErrors={rawErrors}
-          state={state}
-          onChange={updateLocalState}
-        />
-      )}
-      <RepoUrlPickerRepoName
-        repoName={state.repoName}
-        allowedRepos={allowedRepos}
-        onChange={repo =>
-          setState(prevState => ({ ...prevState, repoName: repo }))
-        }
-        rawErrors={rawErrors}
-      />
+      <Grid container spacing={2}>
+        <Grid item xs={12} style={{ marginBottom: '10px' }}>
+          <RepoUrlPickerHost
+            host={state.host}
+            hosts={allowedHosts}
+            onChange={host => setState(prevState => ({ ...prevState, host }))}
+            rawErrors={rawErrors}
+          />
+        </Grid>
+        {hostType === 'github' && (
+          <GithubRepoPicker
+            allowedOwners={allowedOwners}
+            onChange={updateLocalState}
+            rawErrors={rawErrors}
+            state={state}
+          />
+        )}
+        {hostType === 'gitlab' && (
+          <GitlabRepoPicker
+            allowedOwners={allowedOwners}
+            rawErrors={rawErrors}
+            state={state}
+            onChange={updateLocalState}
+          />
+        )}
+        {hostType === 'bitbucket' && (
+          <BitbucketRepoPicker
+            allowedOwners={allowedOwners}
+            allowedProjects={allowedProjects}
+            rawErrors={rawErrors}
+            state={state}
+            onChange={updateLocalState}
+          />
+        )}
+        {hostType === 'azure' && (
+          <AzureRepoPicker
+            allowedOrganizations={allowedOrganizations}
+            allowedOwners={allowedOwners}
+            rawErrors={rawErrors}
+            state={state}
+            onChange={updateLocalState}
+          />
+        )}
+        {hostType === 'gerrit' && (
+          <GerritRepoPicker
+            rawErrors={rawErrors}
+            state={state}
+            onChange={updateLocalState}
+          />
+        )}
+        <Grid item xs={12}>
+          <RepoUrlPickerRepoName
+            repoName={state.repoName}
+            allowedRepos={allowedRepos}
+            onChange={repo =>
+              setState(prevState => ({ ...prevState, repoName: repo }))
+            }
+            rawErrors={rawErrors}
+          />
+        </Grid>
+      </Grid>
     </>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -157,68 +157,66 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
     (state.host && integrationApi.byHost(state.host)?.type) ?? null;
 
   return (
-    <>
-      <Grid container spacing={2}>
-        <Grid item xs={12} style={{ marginBottom: '10px' }}>
-          <RepoUrlPickerHost
-            host={state.host}
-            hosts={allowedHosts}
-            onChange={host => setState(prevState => ({ ...prevState, host }))}
-            rawErrors={rawErrors}
-          />
-        </Grid>
-        {hostType === 'github' && (
-          <GithubRepoPicker
-            allowedOwners={allowedOwners}
-            onChange={updateLocalState}
-            rawErrors={rawErrors}
-            state={state}
-          />
-        )}
-        {hostType === 'gitlab' && (
-          <GitlabRepoPicker
-            allowedOwners={allowedOwners}
-            rawErrors={rawErrors}
-            state={state}
-            onChange={updateLocalState}
-          />
-        )}
-        {hostType === 'bitbucket' && (
-          <BitbucketRepoPicker
-            allowedOwners={allowedOwners}
-            allowedProjects={allowedProjects}
-            rawErrors={rawErrors}
-            state={state}
-            onChange={updateLocalState}
-          />
-        )}
-        {hostType === 'azure' && (
-          <AzureRepoPicker
-            allowedOrganizations={allowedOrganizations}
-            allowedOwners={allowedOwners}
-            rawErrors={rawErrors}
-            state={state}
-            onChange={updateLocalState}
-          />
-        )}
-        {hostType === 'gerrit' && (
-          <GerritRepoPicker
-            rawErrors={rawErrors}
-            state={state}
-            onChange={updateLocalState}
-          />
-        )}
-        <Grid item xs={12}>
-          <RepoUrlPickerRepoName
-            repoName={state.repoName}
-            allowedRepos={allowedRepos}
-            onChange={repo =>
-              setState(prevState => ({ ...prevState, repoName: repo }))
-            }
-            rawErrors={rawErrors}
-          />
-        </Grid>
+    <Grid container spacing={2}>
+      <Grid item xs={12} style={{ marginBottom: '10px' }}>
+        <RepoUrlPickerHost
+          host={state.host}
+          hosts={allowedHosts}
+          onChange={host => setState(prevState => ({ ...prevState, host }))}
+          rawErrors={rawErrors}
+        />
       </Grid>
-    </>
+      {hostType === 'github' && (
+        <GithubRepoPicker
+          allowedOwners={allowedOwners}
+          onChange={updateLocalState}
+          rawErrors={rawErrors}
+          state={state}
+        />
+      )}
+      {hostType === 'gitlab' && (
+        <GitlabRepoPicker
+          allowedOwners={allowedOwners}
+          rawErrors={rawErrors}
+          state={state}
+          onChange={updateLocalState}
+        />
+      )}
+      {hostType === 'bitbucket' && (
+        <BitbucketRepoPicker
+          allowedOwners={allowedOwners}
+          allowedProjects={allowedProjects}
+          rawErrors={rawErrors}
+          state={state}
+          onChange={updateLocalState}
+        />
+      )}
+      {hostType === 'azure' && (
+        <AzureRepoPicker
+          allowedOrganizations={allowedOrganizations}
+          allowedOwners={allowedOwners}
+          rawErrors={rawErrors}
+          state={state}
+          onChange={updateLocalState}
+        />
+      )}
+      {hostType === 'gerrit' && (
+        <GerritRepoPicker
+          rawErrors={rawErrors}
+          state={state}
+          onChange={updateLocalState}
+        />
+      )}
+      <Grid item xs={12}>
+        <RepoUrlPickerRepoName
+          repoName={state.repoName}
+          allowedRepos={allowedRepos}
+          onChange={repo =>
+            setState(prevState => ({ ...prevState, repoName: repo }))
+          }
+          rawErrors={rawErrors}
+        />
+      </Grid>
+    </Grid>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
@@ -63,22 +63,20 @@ export const RepoUrlPickerHost = (props: {
   }
 
   return (
-    <>
-      <FormControl required error={rawErrors?.length > 0 && !host} fullWidth>
-        <Select
-          native
-          disabled={hosts?.length === 1 ?? false}
-          label="Host"
-          onChange={s => onChange(String(Array.isArray(s) ? s[0] : s))}
-          selected={host}
-          items={hostsOptions}
-          data-testid="host-select"
-        />
+    <FormControl required error={rawErrors?.length > 0 && !host} fullWidth>
+      <Select
+        native
+        disabled={hosts?.length === 1 ?? false}
+        label="Host"
+        onChange={s => onChange(String(Array.isArray(s) ? s[0] : s))}
+        selected={host}
+        items={hostsOptions}
+        data-testid="host-select"
+      />
 
-        <Typography variant="caption" color="textSecondary">
-          The host where the repository will be created
-        </Typography>
-      </FormControl>
-    </>
+      <Typography variant="caption" color="textSecondary">
+        The host where the repository will be created
+      </Typography>
+    </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
@@ -15,8 +15,7 @@
  */
 import React, { useEffect } from 'react';
 import { Progress, Select, SelectItem } from '@backstage/core-components';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
+import { FormControl, Typography } from '@material-ui/core';
 import { useApi } from '@backstage/core-plugin-api';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import useAsync from 'react-use/lib/useAsync';
@@ -65,11 +64,7 @@ export const RepoUrlPickerHost = (props: {
 
   return (
     <>
-      <FormControl
-        margin="normal"
-        required
-        error={rawErrors?.length > 0 && !host}
-      >
+      <FormControl required error={rawErrors?.length > 0 && !host} fullWidth>
         <Select
           native
           disabled={hosts?.length === 1 ?? false}
@@ -80,9 +75,9 @@ export const RepoUrlPickerHost = (props: {
           data-testid="host-select"
         />
 
-        <FormHelperText>
+        <Typography variant="caption" color="textSecondary">
           The host where the repository will be created
-        </FormHelperText>
+        </Typography>
       </FormControl>
     </>
   );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -40,35 +40,29 @@ export const RepoUrlPickerRepoName = (props: {
     : [{ label: 'Loading...', value: 'loading' }];
 
   return (
-    <>
-      <FormControl
-        required
-        error={rawErrors?.length > 0 && !repoName}
-        fullWidth
-      >
-        {allowedRepos?.length ? (
-          <Select
-            native
-            label="Repositories Available"
-            onChange={selected =>
-              String(Array.isArray(selected) ? selected[0] : selected)
-            }
-            disabled={allowedRepos.length === 1}
-            selected={repoName}
-            items={repoItems}
-          />
-        ) : (
-          <TextField
-            id="repoNameInput"
-            label="Repository"
-            onChange={e => onChange(String(e.target.value))}
-            value={repoName}
-          />
-        )}
-        <Typography variant="caption" color="textSecondary">
-          The name of the repository
-        </Typography>
-      </FormControl>
-    </>
+    <FormControl required error={rawErrors?.length > 0 && !repoName} fullWidth>
+      {allowedRepos?.length ? (
+        <Select
+          native
+          label="Repositories Available"
+          onChange={selected =>
+            String(Array.isArray(selected) ? selected[0] : selected)
+          }
+          disabled={allowedRepos.length === 1}
+          selected={repoName}
+          items={repoItems}
+        />
+      ) : (
+        <TextField
+          id="repoNameInput"
+          label="Repository"
+          onChange={e => onChange(String(e.target.value))}
+          value={repoName}
+        />
+      )}
+      <Typography variant="caption" color="textSecondary">
+        The name of the repository
+      </Typography>
+    </FormControl>
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -15,10 +15,7 @@
  */
 import React, { useEffect } from 'react';
 import { Select, SelectItem } from '@backstage/core-components';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import { FormControl, Typography, TextField } from '@material-ui/core';
 
 export const RepoUrlPickerRepoName = (props: {
   repoName?: string;
@@ -45,9 +42,9 @@ export const RepoUrlPickerRepoName = (props: {
   return (
     <>
       <FormControl
-        margin="normal"
         required
         error={rawErrors?.length > 0 && !repoName}
+        fullWidth
       >
         {allowedRepos?.length ? (
           <Select
@@ -61,16 +58,16 @@ export const RepoUrlPickerRepoName = (props: {
             items={repoItems}
           />
         ) : (
-          <>
-            <InputLabel htmlFor="repoNameInput">Repository</InputLabel>
-            <Input
-              id="repoNameInput"
-              onChange={e => onChange(String(e.target.value))}
-              value={repoName}
-            />
-          </>
+          <TextField
+            id="repoNameInput"
+            label="Repository"
+            onChange={e => onChange(String(e.target.value))}
+            value={repoName}
+          />
         )}
-        <FormHelperText>The name of the repository</FormHelperText>
+        <Typography variant="caption" color="textSecondary">
+          The name of the repository
+        </Typography>
       </FormControl>
     </>
   );


### PR DESCRIPTION
Signed-off-by: Sayak Mukhopadhyay <mukhopadhyaysayak@gmail.com>

## Hey, I just made a Pull Request!
Closes #15870 

This PR fixes the 2 issues in the linked issue:

1. an inner div is having an extra css class with additional margin. The reason for this is the presence of `margin="normal"`  prop on all the custom fields. For eg. https://github.com/backstage/backstage/blob/2694cbba0591416bb38c1132e259d3ba85de6b75/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx#L46
You can check other custom fields, and all of them have that line. It adds an additional css class with margins that is not present when using the vanilla fields as shown in above screenshots. Removing this prop, renders the component exactly the same as the vanilla fields.

2. The second one is trickier. The vanilla fields have the helper text rendered in a `<span>` whereas the custom fields are getting rendered in `<p>`. That is because, rjfs is not using the `<FormHelperText>` that comes with the `<TextField>` in material ui 4. Instead rjfs is using a `<Typography>` element that sits within a `<FormControl>` (not within `<TextField>`) to render the helper.  Most of the custom fields by backstage have a `<FormControl>` except `EntityNamePicker`. Wrapping it with a `<FormControl>` and `<Typography>` renders the helper text exactly how rjfs itself renders.

~~The PR doesnt include the repo related field extensions yet as they are a bit tricker. I will be adding them shortly.~~ In the meantime, I need some feedback on this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
