### PR TITLE
fix: click out to close search modal

### DIFF
--- a/.changeset/sour-dancers-protect.md
+++ b/.changeset/sour-dancers-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': minor
+---
+
+Fix search modal closing functionality

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -120,7 +120,7 @@ export function useSearchModal(initialState = false) {
   const toggleModal = useCallback(
     () =>
       setState(prevState => ({
-        open: true,
+        open: !prevState.open,
         hidden: !prevState.hidden,
       })),
     [],


### PR DESCRIPTION
A quick fix to https://github.com/backstage/backstage/issues/16089 -- close the search modal when clicking outside of the modal.