### PR TITLE
'techdocs-cli' awsS3 'forcePathStyle'- Compatibility with new AWS SDK

### DIFF
--- a/packages/techdocs-cli/src/lib/PublisherConfig.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.ts
@@ -92,7 +92,7 @@ export class PublisherConfig {
         }),
         ...(opts.awsRoleArn && { credentials: { roleArn: opts.awsRoleArn } }),
         ...(opts.awsEndpoint && { endpoint: opts.awsEndpoint }),
-        ...(opts.awsS3ForcePathStyle && { s3ForcePathStyle: true }),
+        ...(opts.awsS3ForcePathStyle && { forcePathStyle: true }),
         ...(opts.awsS3sse && { sse: opts.awsS3sse }),
       },
     };


### PR DESCRIPTION
Changed from s3ForcePathStyle to forcePathStyle

https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/bucketendpointinputconfig.html#forcepathstyle

---

Running `techdocs-cli publish --publisher-type awsS3 --awsEndpoint https://s3.example.com --storage-name my-bucket-name --awsS3ForcePathStyle --entity default/System/example` on techdocs-cli@1.3.1, leads to something similar to:

info: Creating AWS S3 Bucket publisher for TechDocs
error: Could not retrieve metadata about the AWS S3 bucket my-bucket-name. Make sure the bucket exists. Also make sure that authentication is setup either by explicitly defining credentials and region in techdocs.publisher.awsS3 in app config or by using environment variables. Refer to https://backstage.io/docs/features/techdocs/using-cloud-storage
**_error: from AWS client library getaddrinfo ENOTFOUND my-bucket-name.s3.powerhrg.com_**

Seems that the --awsS3ForcePathStyle flag no longer works.

Similar change to https://github.com/backstage/backstage/pull/15613
---

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
