### PR TITLE
Add a migration script to trigger a reprocessing of the entities

### DIFF
--- a/.changeset/dull-gorillas-sing.md
+++ b/.changeset/dull-gorillas-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The previous migration that adds the `search.original_value` column may leave some of the entities not updated. Add a migration script to trigger a reprocessing of the entities.

--- a/plugins/catalog-backend/migrations/20230125085746_trigger_reprocessing.js
+++ b/plugins/catalog-backend/migrations/20230125085746_trigger_reprocessing.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async function up(knex) {
+  await knex('final_entities').update({ hash: '' });
+  await knex('refresh_state').update({
+    result_hash: '',
+    next_update_at: knex.fn.now(),
+  });
+};
+
+/**
+ * @param { import("knex").Knex } _knex
+ */
+exports.down = async function down(_knex) {};


### PR DESCRIPTION
Signed-off-by: Mengnan Gong <namco1992@gmail.com>

## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/15939. More details see https://github.com/backstage/backstage/issues/15939#issuecomment-1403267692.

The problem is introduced back in version v1.9.0 (https://github.com/backstage/backstage/pull/14230), and we need to fix the data for the users who have upgraded to v1.9.0 and v1.10.0. I'm not quite sure if this is an ideal approach, but that's what I can think of for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
