### PR TITLE
Update org.md

### DIFF
--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -37,7 +37,6 @@ schedule it:
 
 ```diff
  // packages/backend/src/plugins/catalog.ts
-+import { Duration } from 'luxon';
 +import { LdapOrgEntityProvider } from '@backstage/plugin-catalog-backend-module-ldap';
 
  export default async function createPlugin(


### PR DESCRIPTION
`luxon` dependency is not used

Signed-off-by: Giorgos Papaefthimiou <georgeyord@users.noreply.github.com>

## Hey, I just made a Pull Request!

I just changed the documentation taking out `luxon` dependency since is not used in the following code

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [] Tests for new functionality and regression tests for bug fixes
- [] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
