### PR TITLE
create `taskSchedulerServiceRef` for `backend-tasks`

### DIFF
--- a/.changeset/curvy-donkeys-pay.md
+++ b/.changeset/curvy-donkeys-pay.md
@@ -2,4 +2,4 @@
 '@backstage/backend-tasks': patch
 ---
 
-Added a `tasksServiceRef` export that implements a plugin scoped task scheduler service for the new backend system.
+Added a `taskSchedulerServiceRef` export that implements a plugin scoped task scheduler service for the new backend system.

--- a/.changeset/curvy-donkeys-pay.md
+++ b/.changeset/curvy-donkeys-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Added a `tasksServiceRef` export that implements a plugin scoped task scheduler service for the new backend system.

--- a/packages/backend-tasks/api-report.md
+++ b/packages/backend-tasks/api-report.md
@@ -9,6 +9,7 @@ import { Duration } from 'luxon';
 import { HumanDuration as HumanDuration_2 } from '@backstage/types';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
+import { ServiceRef } from '@backstage/backend-plugin-api';
 
 // @public @deprecated
 export type HumanDuration = HumanDuration_2;
@@ -89,4 +90,7 @@ export class TaskScheduler {
     },
   ): TaskScheduler;
 }
+
+// @public
+export const tasksServiceRef: ServiceRef<PluginTaskScheduler, 'plugin'>;
 ```

--- a/packages/backend-tasks/api-report.md
+++ b/packages/backend-tasks/api-report.md
@@ -91,6 +91,6 @@ export class TaskScheduler {
   ): TaskScheduler;
 }
 
-// @public
-export const tasksServiceRef: ServiceRef<PluginTaskScheduler, 'plugin'>;
+// @alpha
+export const taskSchedulerServiceRef: ServiceRef<PluginTaskScheduler, 'plugin'>;
 ```

--- a/packages/backend-tasks/package.json
+++ b/packages/backend-tasks/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
+    "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",

--- a/packages/backend-tasks/package.json
+++ b/packages/backend-tasks/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "alphaTypes": "dist/index.alpha.d.ts"
   },
   "backstage": {
     "role": "node-library"
@@ -23,7 +24,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
-    "build": "backstage-cli package build",
+    "build": "backstage-cli package build --experimental-type-build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
@@ -54,6 +55,7 @@
   },
   "files": [
     "dist",
+    "alpha",
     "migrations/**/*.{js,d.ts}"
   ]
 }

--- a/packages/backend-tasks/src/index.ts
+++ b/packages/backend-tasks/src/index.ts
@@ -21,4 +21,5 @@
  */
 
 export * from './tasks';
+export { tasksServiceRef } from './service';
 export * from './deprecated';

--- a/packages/backend-tasks/src/index.ts
+++ b/packages/backend-tasks/src/index.ts
@@ -21,5 +21,5 @@
  */
 
 export * from './tasks';
-export { tasksServiceRef } from './service';
+export { taskSchedulerServiceRef } from './service';
 export * from './deprecated';

--- a/packages/backend-tasks/src/service.test.ts
+++ b/packages/backend-tasks/src/service.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { startTestBackend } from '@backstage/backend-test-utils';
+import { tasksServiceRef } from './service';
+
+describe('tasksServiceRef', () => {
+  it('creates sidecar database features', async () => {
+    expect.assertions(3);
+
+    const plugin = createBackendPlugin({
+      id: 'example',
+      register(reg) {
+        reg.registerInit({
+          deps: { tasks: tasksServiceRef, database: coreServices.database },
+          init: async ({ tasks, database }) => {
+            await tasks.scheduleTask({
+              id: 'task1',
+              timeout: { seconds: 1 },
+              frequency: { seconds: 1 },
+              fn: async () => {},
+            });
+
+            const client = await database.getClient();
+            await expect(
+              client.from('backstage_backend_tasks__tasks').count(),
+            ).resolves.toEqual([{ 'count(*)': 1 }]);
+            await expect(
+              client.from('backstage_backend_tasks__knex_migrations').count(),
+            ).resolves.toEqual([{ 'count(*)': expect.any(Number) }]);
+            await expect(
+              client
+                .from('backstage_backend_tasks__knex_migrations_lock')
+                .count(),
+            ).resolves.toEqual([{ 'count(*)': expect.any(Number) }]);
+          },
+        });
+      },
+    });
+
+    await startTestBackend({
+      features: [plugin()],
+    });
+  });
+});

--- a/packages/backend-tasks/src/service.test.ts
+++ b/packages/backend-tasks/src/service.test.ts
@@ -19,9 +19,9 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
-import { tasksServiceRef } from './service';
+import { taskSchedulerServiceRef } from './service';
 
-describe('tasksServiceRef', () => {
+describe('taskSchedulerServiceRef', () => {
   it('creates sidecar database features', async () => {
     expect.assertions(3);
 
@@ -29,7 +29,10 @@ describe('tasksServiceRef', () => {
       id: 'example',
       register(reg) {
         reg.registerInit({
-          deps: { tasks: tasksServiceRef, database: coreServices.database },
+          deps: {
+            tasks: taskSchedulerServiceRef,
+            database: coreServices.database,
+          },
           init: async ({ tasks, database }) => {
             await tasks.scheduleTask({
               id: 'task1',

--- a/packages/backend-tasks/src/service.ts
+++ b/packages/backend-tasks/src/service.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { loggerToWinstonLogger } from '@backstage/backend-common';
+import {
+  coreServices,
+  createServiceFactory,
+  createServiceRef,
+} from '@backstage/backend-plugin-api';
+import { PluginTaskScheduler, TaskScheduler } from './tasks';
+
+/**
+ * Deals with the scheduling of distributed tasks, for a given plugin.
+ *
+ * @public
+ */
+export const tasksServiceRef = createServiceRef<PluginTaskScheduler>({
+  id: 'plugin.tasks.service',
+  scope: 'plugin',
+  defaultFactory: async service =>
+    createServiceFactory({
+      service,
+      deps: {
+        database: coreServices.database,
+        logger: coreServices.logger,
+        pluginMetadata: coreServices.pluginMetadata,
+      },
+      factory: ({ database, logger, pluginMetadata }) => {
+        return TaskScheduler.forPlugin({
+          pluginId: pluginMetadata.getId(),
+          databaseManager: database,
+          logger: loggerToWinstonLogger(logger).child({
+            type: 'taskManager',
+          }),
+        });
+      },
+    }),
+});

--- a/packages/backend-tasks/src/service.ts
+++ b/packages/backend-tasks/src/service.ts
@@ -25,10 +25,10 @@ import { PluginTaskScheduler, TaskScheduler } from './tasks';
 /**
  * Deals with the scheduling of distributed tasks, for a given plugin.
  *
- * @public
+ * @alpha
  */
-export const tasksServiceRef = createServiceRef<PluginTaskScheduler>({
-  id: 'plugin.tasks.service',
+export const taskSchedulerServiceRef = createServiceRef<PluginTaskScheduler>({
+  id: 'plugin.tasks.scheduler-service',
   scope: 'plugin',
   defaultFactory: async service =>
     createServiceFactory({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,6 +3548,7 @@ __metadata:
   resolution: "@backstage/backend-tasks@workspace:packages/backend-tasks"
   dependencies:
     "@backstage/backend-common": "workspace:^"
+    "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"


### PR DESCRIPTION
Considerations:

- Is it sufficient to export from here or should it be baked into `coreServices` (can still be in both, and re-exported from there if we want of course)
