### PR TITLE
Fixed WelcomeTitle regression

### DIFF
--- a/.changeset/late-rice-crash.md
+++ b/.changeset/late-rice-crash.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-home': patch
 ---
 
-Fixed regresstion that caused the `WelcomeTitle` to not be the right size when passed to the `title` property of the `<Header>` component
+Fixed regression that caused the `WelcomeTitle` to not be the right size when passed to the `title` property of the `<Header>` component. A Storybook entry was also added for the `WelcomeTitle`

--- a/.changeset/late-rice-crash.md
+++ b/.changeset/late-rice-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fixed regresstion that caused the `WelcomeTitle` to not be the right size when passed to the `title` property of the `<Header>` component

--- a/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.stories.tsx
+++ b/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.stories.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Header } from '@backstage/core-components';
+import { wrapInTestApp } from '@backstage/test-utils';
+import React, { ComponentType } from 'react';
+import { WelcomeTitle } from './WelcomeTitle';
+
+export default {
+  title: 'Plugins/Home/Components/WelcomeTitle',
+  decorators: [(Story: ComponentType<{}>) => wrapInTestApp(<Story />)],
+};
+
+export const Default = () => {
+  return <Header title={<WelcomeTitle />} pageTitleOverride="Home" />;
+};

--- a/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
+++ b/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
@@ -43,7 +43,7 @@ export const WelcomeTitle = () => {
 
   return (
     <Tooltip title={greeting.language}>
-      <Typography variant="h3">{`${greeting.greeting}${
+      <Typography component="span" variant="inherit">{`${greeting.greeting}${
         profile?.displayName ? `, ${profile?.displayName}` : ''
       }!`}</Typography>
     </Tooltip>

--- a/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
+++ b/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
@@ -18,7 +18,7 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
-import { Tooltip } from '@material-ui/core';
+import { Tooltip, Typography } from '@material-ui/core';
 import React, { useEffect, useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { getTimeBasedGreeting } from './timeUtil';
@@ -43,9 +43,9 @@ export const WelcomeTitle = () => {
 
   return (
     <Tooltip title={greeting.language}>
-      <>{`${greeting.greeting}${
+      <Typography variant="h3">{`${greeting.greeting}${
         profile?.displayName ? `, ${profile?.displayName}` : ''
-      }!`}</>
+      }!`}</Typography>
     </Tooltip>
   );
 };

--- a/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
+++ b/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
@@ -19,7 +19,6 @@ import {
   useApi,
 } from '@backstage/core-plugin-api';
 import { Tooltip } from '@material-ui/core';
-import Typography from '@material-ui/core/Typography';
 import React, { useEffect, useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { getTimeBasedGreeting } from './timeUtil';
@@ -44,9 +43,9 @@ export const WelcomeTitle = () => {
 
   return (
     <Tooltip title={greeting.language}>
-      <Typography component="span">{`${greeting.greeting}${
+      <>{`${greeting.greeting}${
         profile?.displayName ? `, ${profile?.displayName}` : ''
-      }!`}</Typography>
+      }!`}</>
     </Tooltip>
   );
 };


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Fixed regression that caused the `WelcomeTitle` to not be the right size when passed to the `title` property of the `<Header>` component. Also added a Storybook entry. Closes #16040

Before:

![Screenshot 2023-01-25 at 12 30 38 PM](https://user-images.githubusercontent.com/67169551/214653902-bcb39143-0a2e-4613-a2f3-cf22e425fa5b.png)

After:

![Screenshot 2023-01-25 at 12 31 35 PM](https://user-images.githubusercontent.com/67169551/214654038-c392cbce-057e-4a12-8817-1b15bf708986.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
