### PR TITLE
plugin-azure-devops-backend encoded host breaks readme

### DIFF
--- a/.changeset/happy-cows-moo.md
+++ b/.changeset/happy-cows-moo.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-azure-devops-backend': patch
 ---
 
-Fixed a bug in buildEncodedUrl function where the colon between host name and port was being encoded and breaking the readme card
+Fixed a bug where the azure devops host in URLs on the readme card was being URL encoded, breaking hosts with ports.

--- a/.changeset/happy-cows-moo.md
+++ b/.changeset/happy-cows-moo.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-azure-devops-backend': patch
 ---
 
-Fixed a bug in buildEncodedUrl function where port was being encoded and breaking the readme card
+Fixed a bug in buildEncodedUrl function where the colon between host name and port was being encoded and breaking the readme card

--- a/.changeset/happy-cows-moo.md
+++ b/.changeset/happy-cows-moo.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Fixed a bug in buildEncodedUrl function where port was being encoded and breaking the readme card

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
@@ -27,6 +27,7 @@ import {
   getAvatarUrl,
   getPullRequestLink,
   replaceReadme,
+  buildEncodedUrl,
 } from './azure-devops-utils';
 import { GitPullRequest } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { UrlReader } from '@backstage/backend-common';

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
@@ -281,14 +281,16 @@ describe('replaceReadme', () => {
 
 describe('buildEncodedUrl', () => {
   it('should not encode the colon between host and port', async () => {
-	const result = await buildEncodedUrl(
+    const result = await buildEncodedUrl(
       'tfs.myorg.com:8443',
       'org',
       'project',
       'repo',
-      'path'
+      'path',
     );
-	
-    expect(result).toBe('https://tfs.myorg.com:8443/org/project/_git/repo?path=path');
+
+    expect(result).toBe(
+      'https://tfs.myorg.com:8443/org/project/_git/repo?path=path',
+    );
   });
 });

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
@@ -278,3 +278,17 @@ describe('replaceReadme', () => {
     expect(expected).toBe(result);
   });
 });
+
+describe('buildEncodedUrl', () => {
+  it('should not encode the colon between host and port', async () => {
+	const result = await buildEncodedUrl(
+      'tfs.myorg.com:8443',
+      'org',
+      'project',
+      'repo',
+      'path'
+    );
+	
+    expect(result).toBe('https://tfs.myorg.com:8443/org/project/_git/repo?path=path');
+  });
+});

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
@@ -242,12 +242,11 @@ export function buildEncodedUrl(
   repo: string,
   path: string,
 ): string {
-  const encodedHost = encodeURIComponent(host);
   const encodedOrg = encodeURIComponent(org);
   const encodedProject = encodeURIComponent(project);
   const encodedRepo = encodeURIComponent(repo);
   const encodedPath = encodeURIComponent(path);
-  return `https://${encodedHost}/${encodedOrg}/${encodedProject}/_git/${encodedRepo}?path=${encodedPath}`;
+  return `https://${host}/${encodedOrg}/${encodedProject}/_git/${encodedRepo}?path=${encodedPath}`;
 }
 
 function convertReviewer(


### PR DESCRIPTION
## plugin-azure-devops-backend encoded host breaks readme

Stop encoding the host so that ":" between host name and port stops turning into "%3A" and causing a malformed url.

Fixes https://github.com/backstage/backstage/issues/15874

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
