### PR TITLE
cli: set a default jest worker memory limit

### DIFF
--- a/.changeset/chatty-owls-care.md
+++ b/.changeset/chatty-owls-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `backstage-cli repo test` command now sets a default Jest `--workerIdleMemoryLimit` of 1GB. This is the recommended workaround for dealing with Jest workers leaking memory and eventually hitting the heap limit.

--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -84,6 +84,13 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
     }
   }
 
+  // When running tests from the repo root in large repos you can easily hit the heap limit.
+  // This is because Jest workers leak a lot of memory, and the workaround is to limit worker memory.
+  // We set a default memory limit, but if an explicit one is supplied it will be used instead
+  if (!args.some(arg => arg.match(/^--workerIdleMemoryLimit/))) {
+    args.push('--workerIdleMemoryLimit=1000M');
+  }
+
   if (opts.since) {
     removeOptionArg(args, '--since');
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Right now you need to know to add this flag if you want to run `repo test` in a large repo. Let's ship it by default instead. If you want to remove the limit it's possible to set a really high one instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
