### PR TITLE
switch the order of the reprocessing statements in migrations

### DIFF
--- a/.changeset/modern-cats-worry.md
+++ b/.changeset/modern-cats-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Switched the order of reprocessing statements retroactively in migrations. This only improves the experience for those who at a later time perform a large upgrade of an old Backstage installation.

--- a/plugins/catalog-backend/migrations/20220222164811_reprocess_for_relation_refs.js
+++ b/plugins/catalog-backend/migrations/20220222164811_reprocess_for_relation_refs.js
@@ -21,11 +21,11 @@
  */
 exports.up = async function up(knex) {
   // Make sure to reprocess everything, to make sure that relations have a targetRef produced
+  await knex('final_entities').update({ hash: '' });
   await knex('refresh_state').update({
     result_hash: '',
     next_update_at: knex.fn.now(),
   });
-  await knex('final_entities').update({ hash: '' });
 };
 
 exports.down = async function down() {};

--- a/plugins/catalog-backend/migrations/20221109192547_search_add_original_value_column.js
+++ b/plugins/catalog-backend/migrations/20221109192547_search_add_original_value_column.js
@@ -34,11 +34,11 @@ exports.up = async function up(knex) {
   // not enough to just reset the final_entities hash, since stitching is driven
   // only by processing resulting in data that isn't matching the refresh_state
   // hash.
+  await knex('final_entities').update({ hash: '' });
   await knex('refresh_state').update({
     result_hash: '',
     next_update_at: knex.fn.now(),
   });
-  await knex('final_entities').update({ hash: '' });
 };
 
 /**


### PR DESCRIPTION
Mimicking the fix in #15944

I know that this seems a bit odd. It'd only have a PRACTICAL effect if doing a partial migration. But these also serve as copy-paste fodder, so I wanted to have it changed elsewhere anyway.