### PR TITLE
Remove plugin-stack-overflow from packages.json in @plugin-home

### DIFF
--- a/.changeset/nine-guests-compete.md
+++ b/.changeset/nine-guests-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+remove unused plugin-stack-overflow dependency

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -38,7 +38,6 @@
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
-    "@backstage/plugin-stack-overflow": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6418,7 +6418,6 @@ __metadata:
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/dev-utils": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
-    "@backstage/plugin-stack-overflow": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@material-ui/core": ^4.12.2


### PR DESCRIPTION
Signed-off-by: Casper Thygesen <cth@trifork.com>

## Hey, I just made a Pull Request!

`plugin-stack-overflow` is not being used in this plugin, and I would like to remove it from my dependency tree

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
