### PR TITLE
Export airbrake plugin helper function

### DIFF
--- a/.changeset/tall-years-relate.md
+++ b/.changeset/tall-years-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-airbrake': patch
+---
+
+Adds a boolean helper function to airbrake plugin for use on the EntityPage to show/hide airbrake tab depending on whether the entity's catalog-info.yml has an airbrake id set in the metadata

--- a/plugins/airbrake/README.md
+++ b/plugins/airbrake/README.md
@@ -18,14 +18,21 @@ The Airbrake plugin provides connectivity between Backstage and Airbrake (https:
    yarn add --cwd packages/backend @backstage/plugin-airbrake-backend
    ```
 
-3. Add the `EntityAirbrakeContent` to `packages/app/src/components/catalog/EntityPage.tsx` for all the entity pages you want Airbrake to be in:
+3. Add the `EntityAirbrakeContent` and `isAirbrakeAvailable` to `packages/app/src/components/catalog/EntityPage.tsx` for all the entity pages you want Airbrake to be in:
 
    ```typescript jsx
-   import { EntityAirbrakeContent } from '@backstage/plugin-airbrake';
+   import {
+     EntityAirbrakeContent,
+     isAirbrakeAvailable,
+   } from '@backstage/plugin-airbrake';
 
    const serviceEntityPage = (
      <EntityLayoutWrapper>
-       <EntityLayout.Route path="/airbrake" title="Airbrake">
+       <EntityLayout.Route
+         if={isAirbrakeAvailable}
+         path="/airbrake"
+         title="Airbrake"
+       >
          <EntityAirbrakeContent />
        </EntityLayout.Route>
      </EntityLayoutWrapper>
@@ -33,7 +40,11 @@ The Airbrake plugin provides connectivity between Backstage and Airbrake (https:
 
    const websiteEntityPage = (
      <EntityLayoutWrapper>
-       <EntityLayout.Route path="/airbrake" title="Airbrake">
+       <EntityLayout.Route
+         if={isAirbrakeAvailable}
+         path="/airbrake"
+         title="Airbrake"
+       >
          <EntityAirbrakeContent />
        </EntityLayout.Route>
      </EntityLayoutWrapper>
@@ -41,7 +52,11 @@ The Airbrake plugin provides connectivity between Backstage and Airbrake (https:
 
    const defaultEntityPage = (
      <EntityLayoutWrapper>
-       <EntityLayout.Route path="/airbrake" title="Airbrake">
+       <EntityLayout.Route
+         if={isAirbrakeAvailable}
+         path="/airbrake"
+         title="Airbrake"
+       >
          <EntityAirbrakeContent />
        </EntityLayout.Route>
      </EntityLayoutWrapper>

--- a/plugins/airbrake/api-report.md
+++ b/plugins/airbrake/api-report.md
@@ -6,6 +6,7 @@
 /// <reference types="react" />
 
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public
@@ -19,4 +20,7 @@ export const airbrakePlugin: BackstagePlugin<
 
 // @public
 export const EntityAirbrakeContent: () => JSX.Element;
+
+// @public
+export const isAirbrakeAvailable: (entity: Entity) => boolean;
 ```

--- a/plugins/airbrake/src/components/isAirbrakeAvailable.ts
+++ b/plugins/airbrake/src/components/isAirbrakeAvailable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2020 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-/**
- * The Airbrake plugin provides connectivity between Backstage and Airbrake (https://airbrake.io/).
- *
- * @packageDocumentation
- */
+import { Entity } from '@backstage/catalog-model';
+import { AIRBRAKE_PROJECT_ID_ANNOTATION } from './useProjectId';
 
-export { airbrakePlugin } from './plugin';
-export { EntityAirbrakeContent } from './extensions';
-export { isAirbrakeAvailable } from './components/isAirbrakeAvailable';
+export const isAirbrakeAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[AIRBRAKE_PROJECT_ID_ANNOTATION]);

--- a/plugins/airbrake/src/components/isAirbrakeAvailable.ts
+++ b/plugins/airbrake/src/components/isAirbrakeAvailable.ts
@@ -17,5 +17,9 @@
 import { Entity } from '@backstage/catalog-model';
 import { AIRBRAKE_PROJECT_ID_ANNOTATION } from './useProjectId';
 
+/**
+ * Utility function to determine if the given entity has an Airbrake ID set in the repos catalog-info.yml .
+ * @public
+ */
 export const isAirbrakeAvailable = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[AIRBRAKE_PROJECT_ID_ANNOTATION]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a `isAirbrakeAvailable` helper function to the Airbrake plugin, much like the helper functions that exist in other plugins (see [isAdrAvailable](https://github.com/backstage/backstage/blob/76b838a85493d210d51817f3776117989f1dced5/plugins/adr-common/src/index.ts#L47-L48) and [isGithubActionsAvailable](https://github.com/backstage/backstage/blob/76b838a85493d210d51817f3776117989f1dced5/plugins/github-actions/src/components/Router.tsx#L27-L29) for examples of near identical help functions that exist in other plugins). It is for use in the `EntityPage` so that if you are using the airbrake plugin you can opt to not show the airbrake tab on your entitie's page if the entity's airbrake id is not set in the catalog-info.yml. 

Add it to the `packages/app/src/components/catalog/EntityPage.tsx` like so: 

```
import { EntityAirbrakeContent, isAirbrakeAvailable } from "@backstage/plugin-airbrake"
.
.
.

const websiteEntityPage = (
  <EntityLayout>
    <EntityLayout.Route path="/" title="Overview">
      {overviewContent}
    </EntityLayout.Route>
        <EntityLayout.Route if={isAirbrakeAvailable} path="/airbrake" title="Airbrake">
              <EntityAirbrakeContent />
         </EntityLayout.Route>
```


**The airbrake tab will appear on the entity pages that have the airbrake id set in the catalog-info.yml and appear like so:** 
<img width="1587" alt="Screen Shot 2023-01-26 at 1 44 17 PM" src="https://user-images.githubusercontent.com/12126866/214929068-172c7185-2dcb-4bf3-84a5-aa2e6c95a13f.png">

**And if the id is not set it will not appear:** 
<img width="1305" alt="Screen Shot 2023-01-26 at 1 44 40 PM" src="https://user-images.githubusercontent.com/12126866/214929077-fdc4e5c6-887f-4a32-b14f-79bd99336529.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


### Issue
https://github.com/simplybusiness/backstage/issues/1796
