### PR TITLE
fix: use graph API target url for access token

### DIFF
--- a/.changeset/four-rivers-enjoy.md
+++ b/.changeset/four-rivers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Fix MS Graph provider to use target URL for fetching access token

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
@@ -53,7 +53,7 @@ describe('MicrosoftGraphClient', () => {
     expect(await response.json()).toEqual({ value: 'example' });
     expect(tokenCredential.getToken).toHaveBeenCalledTimes(1);
     expect(tokenCredential.getToken).toHaveBeenCalledWith(
-      'https://graph.microsoft.com/.default',
+      'https://example.com/.default',
     );
   });
 

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
@@ -214,7 +214,7 @@ export class MicrosoftGraphClient {
   ): Promise<Response> {
     // Make sure that we always have a valid access token (might be cached)
     const token = await this.tokenCredential.getToken(
-      'https://graph.microsoft.com/.default',
+      `${this.baseUrl}/.default`,
     );
 
     if (!token) {


### PR DESCRIPTION
this fixes #15998

Signed-off-by: Heikki Hellgren <heikki.hellgren@op.fi>

## Hey, I just made a Pull Request!

Use the graph api target url for fetching the access token instead using the hardcoded URL.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
