### PR TITLE
docs/backend-system: add plugin creation section

### DIFF
--- a/docs/backend-system/building-plugins-and-modules/01-index.md
+++ b/docs/backend-system/building-plugins-and-modules/01-index.md
@@ -18,7 +18,7 @@ backend _features_, are the building blocks that adopters add to their
 
 ## Creating a new Plugin
 
-This guide assumes that you already have a Backend project set up. Even if you only want to develop a single plugin for publishing, we still recommend that you do so in a standard Backstage monorepo project, as you often end up needing multiple package. For instructions on how to set up a new project, see our [getting started](../../getting-started/index.md#prerequisites) documentation.
+This guide assumes that you already have a Backend project set up. Even if you only want to develop a single plugin for publishing, we still recommend that you do so in a standard Backstage monorepo project, as you often end up needing multiple packages. For instructions on how to set up a new project, see our [getting started](../../getting-started/index.md#prerequisites) documentation.
 
 To create a Backend plugin, run `yarn new`, select `backend-plugin`, and fill out the rest of the prompts. This will create a new package at `plugins/<pluginId>-backend`, which will be the main entrypoint for your plugin.
 

--- a/docs/backend-system/building-plugins-and-modules/01-index.md
+++ b/docs/backend-system/building-plugins-and-modules/01-index.md
@@ -16,6 +16,12 @@ Backend [plugins](../architecture/04-plugins.md) and
 backend _features_, are the building blocks that adopters add to their
 [backends](../architecture/02-backends.md).
 
+## Creating a new Plugin
+
+This guide assumes that you already have a Backend project set up. Even if you only want to develop a single plugin for publishing, we still recommend that you do so in a standard Backstage monorepo project, as you often end up needing multiple package. For instructions on how to set up a new project, see our [getting started](../../getting-started/index.md#prerequisites) documentation.
+
+To create a Backend plugin, run `yarn new`, select `backend-plugin`, and fill out the rest of the prompts. This will create a new package at `plugins/<pluginId>-backend`, which will be the main entrypoint for your plugin.
+
 ## Plugins
 
 A basic backend plugin might look as follows:


### PR DESCRIPTION
Had written this up earlier and figured it still fits into the existing docs.