### PR TITLE
Add Markdown support in the About Card description section

### DIFF
--- a/.changeset/many-nails-joke.md
+++ b/.changeset/many-nails-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Added Markdown support in the About card description section

--- a/.changeset/many-nails-joke.md
+++ b/.changeset/many-nails-joke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog': minor
 ---
 
-Added Markdown support in the About card description section
+Added Markdown support in the `AboutCard` description section

--- a/packages/catalog-model/examples/components/petstore-component.yaml
+++ b/packages/catalog-model/examples/components/petstore-component.yaml
@@ -2,8 +2,11 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: petstore
-  # This is an extra long description
-  description: The Petstore is an example API used to show features of the OpenAPI spec.
+  # This is an extra long description with Markdown
+  description: |
+    [The Petstore](http://petstore.example.com) is an example API used to show features of the OpenAPI spec.
+    - First item
+    - Second item
   links:
     - url: https://github.com/swagger-api/swagger-petstore
       title: GitHub Repo

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -25,7 +25,8 @@ import {
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
 import { JsonArray } from '@backstage/types';
-import { Chip, Grid, makeStyles, Typography } from '@material-ui/core';
+import { Chip, Grid, makeStyles } from '@material-ui/core';
+import { MarkdownContent } from '@backstage/core-components';
 import React from 'react';
 import { AboutField } from './AboutField';
 import { LinksGridList } from '../EntityLinksCard/LinksGridList';
@@ -111,9 +112,10 @@ export function AboutContent(props: AboutContentProps) {
   return (
     <Grid container>
       <AboutField label="Description" gridSizes={{ xs: 12 }}>
-        <Typography variant="body2" paragraph className={classes.description}>
-          {entity?.metadata?.description || 'No description'}
-        </Typography>
+        <MarkdownContent
+          className={classes.description}
+          content={entity?.metadata?.description || 'No description'}
+        />
       </AboutField>
       <AboutField
         label="Owner"


### PR DESCRIPTION
To keep consistency with the Scaffolder template cards this commit introduces Markdown support in the Catalog components About Card

Signed-off-by: Konstantin Matyukhin <kmatyukhin@gmail.com>

## Hey, I just added Markdown support in the description on the About Card!

![image](https://user-images.githubusercontent.com/5629224/215105667-6a921bd9-99a3-4bb2-bcc2-465cbe64b9f2.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
