### PR TITLE
[PRFC] Catalog table record streaming by page

### DIFF
--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -210,7 +210,7 @@ function removeDefaultValues(state: any, defaultState: any): any {
 const defaultInitialState = {
   search: '',
   filtersOpen: false,
-  filters: {},
+  filters: {} as SelectedFilters,
 };
 
 export interface TableColumn<T extends object = {}> extends Column<T> {
@@ -375,7 +375,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
       const newData = (data as any[]).filter(
         el =>
           !!Object.entries(selectedFilters)
-            .filter(([, value]) => !!(value as { length?: number }).length)
+            .filter(([, value]) => !!value.length)
             .every(([key, filterValue]) => {
               const fieldValue = extractValueByField(
                 el,

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
@@ -28,13 +28,14 @@ import { CatalogTable, CatalogTableRow } from '@backstage/plugin-catalog';
 import {
   EntityKindPicker,
   EntityLifecyclePicker,
-  EntityListProvider,
   EntityOwnerPicker,
   EntityTagPicker,
   EntityTypePicker,
   UserListFilterKind,
   UserListPicker,
   CatalogFilterLayout,
+  EntityFilterProvider,
+  EntityStreamProvider,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { registerComponentRouteRef } from '../../routes';
@@ -88,24 +89,26 @@ export const DefaultApiExplorerPage = (props: DefaultApiExplorerPageProps) => {
           />
           <SupportButton>All your APIs</SupportButton>
         </ContentHeader>
-        <EntityListProvider>
-          <CatalogFilterLayout>
-            <CatalogFilterLayout.Filters>
-              <EntityKindPicker initialFilter="api" hidden />
-              <EntityTypePicker />
-              <UserListPicker initialFilter={initiallySelectedFilter} />
-              <EntityOwnerPicker />
-              <EntityLifecyclePicker />
-              <EntityTagPicker />
-            </CatalogFilterLayout.Filters>
-            <CatalogFilterLayout.Content>
-              <CatalogTable
-                columns={columns || defaultColumns}
-                actions={actions}
-              />
-            </CatalogFilterLayout.Content>
-          </CatalogFilterLayout>
-        </EntityListProvider>
+        <EntityFilterProvider>
+          <EntityStreamProvider>
+            <CatalogFilterLayout>
+              <CatalogFilterLayout.Filters>
+                <EntityKindPicker initialFilter="api" hidden />
+                <EntityTypePicker />
+                <UserListPicker initialFilter={initiallySelectedFilter} />
+                <EntityOwnerPicker />
+                <EntityLifecyclePicker />
+                <EntityTagPicker />
+              </CatalogFilterLayout.Filters>
+              <CatalogFilterLayout.Content>
+                <CatalogTable
+                  columns={columns || defaultColumns}
+                  actions={actions}
+                />
+              </CatalogFilterLayout.Content>
+            </CatalogFilterLayout>
+          </EntityStreamProvider>
+        </EntityFilterProvider>
       </Content>
     </PageWithHeader>
   );

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -12,6 +12,7 @@ import { ComponentEntity } from '@backstage/catalog-model';
 import { ComponentProps } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
+import { EntityOrderQuery } from '@backstage/catalog-client';
 import { IconButton } from '@material-ui/core';
 import { InfoCardVariants } from '@backstage/core-components';
 import { LinkProps } from '@backstage/core-components';
@@ -156,6 +157,28 @@ export type EntityFilter = {
   toQueryValue?: () => string | string[];
 };
 
+// @public (undocumented)
+export type EntityFilterContextProps<
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+> = {
+  filters: EntityFilters;
+  updateFilters: (
+    filters:
+      | Partial<EntityFilters>
+      | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
+  ) => void;
+  queryParameters: Partial<Record<keyof EntityFilters, string | string[]>>;
+  entityFilter: (entity: Entity) => boolean;
+  backendEntityFilter: (entity: Entity) => boolean;
+};
+
+// @public
+export const EntityFilterProvider: <
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+>({
+  children,
+}: PropsWithChildren<{}>) => JSX.Element;
+
 // @public
 export class EntityKindFilter implements EntityFilter {
   constructor(value: string);
@@ -207,22 +230,24 @@ export type EntityListContextProps<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
 > = {
   filters: EntityFilters;
-  entities: Entity[];
-  backendEntities: Entity[];
   updateFilters: (
     filters:
       | Partial<EntityFilters>
       | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
   ) => void;
   queryParameters: Partial<Record<keyof EntityFilters, string | string[]>>;
+  entities: Entity[];
+  backendEntities: Entity[];
   loading: boolean;
   error?: Error;
 };
 
 // @public
-export const EntityListProvider: <EntityFilters extends DefaultEntityFilters>(
-  props: PropsWithChildren<{}>,
-) => JSX.Element;
+export const EntityListProvider: <
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+>({
+  children,
+}: PropsWithChildren<{}>) => JSX.Element;
 
 // @public (undocumented)
 export type EntityLoadingStatus<TEntity extends Entity = Entity> = {
@@ -267,6 +292,21 @@ export class EntityOwnerFilter implements EntityFilter {
 
 // @public (undocumented)
 export const EntityOwnerPicker: () => JSX.Element | null;
+
+// @public (undocumented)
+export interface EntityPageOptions {
+  // (undocumented)
+  from: number;
+  // (undocumented)
+  search: {
+    term: string;
+    fields: string[];
+  };
+  // (undocumented)
+  sortBy?: EntityOrderQuery;
+  // (undocumented)
+  to: number;
+}
 
 // @public
 export const EntityPeekAheadPopover: (
@@ -350,6 +390,33 @@ export type EntitySourceLocation = {
   locationTargetUrl: string;
   integrationType?: string;
 };
+
+// @public
+export const EntityStreamContext: React_2.Context<
+  EntityStreamContextProps | undefined
+>;
+
+// @public (undocumented)
+export type EntityStreamContextProps = {
+  entities: Entity[];
+  backendEntities: Entity[];
+  loading: boolean;
+  error?: Error;
+  hasMoreData: boolean;
+  getEntities: (pageConfig: EntityPageOptions) => Promise<{
+    data: Entity[];
+    hasMoreData: boolean;
+    count: number;
+  } | null>;
+  count: number;
+};
+
+// @public
+export const EntityStreamProvider: <
+  EntityFilters extends DefaultEntityFilters,
+>({
+  children,
+}: PropsWithChildren<{}>) => JSX.Element;
 
 // @public
 export const EntityTable: {
@@ -495,6 +562,16 @@ export function MockEntityListContextProvider<
   }>,
 ): JSX.Element;
 
+// @public (undocumented)
+export function MockEntityStreamContextProvider<
+  T extends DefaultEntityFilters = DefaultEntityFilters,
+>(
+  props: PropsWithChildren<{
+    value?: Partial<EntityStreamContextProps> &
+      Partial<EntityFilterContextProps<T>>;
+  }>,
+): JSX.Element;
+
 // @public
 export class MockStarredEntitiesApi implements StarredEntitiesApi {
   // (undocumented)
@@ -531,9 +608,19 @@ export function useAsyncEntity<
 >(): EntityLoadingStatus<TEntity>;
 
 // @public
+export function useEntities():
+  | EntityListContextProps
+  | EntityStreamContextProps;
+
+// @public
 export function useEntity<TEntity extends Entity = Entity>(): {
   entity: TEntity;
 };
+
+// @public
+export function useEntityFilter<
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+>(): EntityFilterContextProps<EntityFilters>;
 
 // @public
 export function useEntityList<
@@ -545,6 +632,9 @@ export function useEntityOwnership(): {
   loading: boolean;
   isOwnedEntity: (entity: Entity) => boolean;
 };
+
+// @public
+export function useEntityStream(): EntityStreamContextProps;
 
 // @public
 export function useEntityTypeFilter(): {

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -23,11 +23,12 @@ import useAsync from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../../api';
 import { EntityAutocompletePickerOption } from './EntityAutocompletePickerOption';
 import { EntityAutocompletePickerInput } from './EntityAutocompletePickerInput';
-import {
-  DefaultEntityFilters,
-  useEntityList,
-} from '../../hooks/useEntityListProvider';
 import { EntityFilter } from '../../types';
+import _ from 'lodash';
+import {
+  useEntityFilter,
+  DefaultEntityFilters,
+} from '../../hooks/useEntityFilter';
 
 type KeysMatchingCondition<T, V, K> = T extends V ? K : never;
 type KeysMatching<T, V> = {
@@ -67,7 +68,7 @@ export function EntityAutocompletePicker<
     updateFilters,
     filters,
     queryParameters: { [name]: queryParameter },
-  } = useEntityList<T>();
+  } = useEntityFilter<T>();
 
   const catalogApi = useApi(catalogApiRef);
   const { value: availableValues } = useAsync(async () => {

--- a/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
@@ -19,7 +19,7 @@ import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import { Box } from '@material-ui/core';
 import React, { useEffect, useMemo, useState } from 'react';
 import { EntityKindFilter } from '../../filters';
-import { useEntityList } from '../../hooks';
+import { useEntityFilter } from '../../hooks';
 import { filterKinds, useAllKinds } from './kindFilterUtils';
 
 function useEntityKindFilter(opts: { initialFilter: string }): {
@@ -33,7 +33,7 @@ function useEntityKindFilter(opts: { initialFilter: string }): {
     filters,
     queryParameters: { kind: kindParameter },
     updateFilters,
-  } = useEntityList();
+  } = useEntityFilter();
 
   const queryParamKind = useMemo(
     () => [kindParameter].flat()[0],

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -28,8 +28,10 @@ import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Autocomplete } from '@material-ui/lab';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useEntityList } from '../../hooks/useEntityListProvider';
+import useDeepCompareEffect from 'react-use/lib/useDeepCompareEffect';
 import { EntityLifecycleFilter } from '../../filters';
+import { useEntityFilter } from '../../hooks';
+import { useEntities } from '../../hooks/useEntities';
 
 /** @public */
 export type CatalogReactEntityLifecyclePickerClassKey = 'input';
@@ -50,12 +52,12 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 export const EntityLifecyclePicker = (props: { initialFilter?: string[] }) => {
   const { initialFilter = [] } = props;
   const classes = useStyles();
+  const { backendEntities } = useEntities();
   const {
     updateFilters,
-    backendEntities,
     filters,
     queryParameters: { lifecycles: lifecyclesParameter },
-  } = useEntityList();
+  } = useEntityFilter();
 
   const queryParamLifecycles = useMemo(
     () => [lifecyclesParameter].flat().filter(Boolean) as string[],
@@ -88,7 +90,7 @@ export const EntityLifecyclePicker = (props: { initialFilter?: string[] }) => {
     [backendEntities],
   );
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     updateFilters({
       lifecycles:
         selectedLifecycles.length && availableLifecycles.length

--- a/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.tsx
@@ -27,7 +27,7 @@ import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import React, { useState } from 'react';
-import { useEntityList } from '../../hooks';
+import { useEntityFilter } from '../../hooks';
 import { Autocomplete } from '@material-ui/lab';
 
 /** @public */
@@ -48,7 +48,7 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 /** @public */
 export const EntityProcessingStatusPicker = () => {
   const classes = useStyles();
-  const { updateFilters } = useEntityList();
+  const { updateFilters } = useEntityFilter();
 
   const [selectedAdvancedItems, setSelectedAdvancedItems] = useState<string[]>(
     [],

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
@@ -17,9 +17,9 @@
 import React from 'react';
 import { fireEvent, render, waitFor, screen } from '@testing-library/react';
 import { EntitySearchBar } from './EntitySearchBar';
-import { DefaultEntityFilters } from '../../hooks/useEntityListProvider';
 import { EntityTextFilter } from '../../filters';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
+import { DefaultEntityFilters } from '../../hooks';
 
 describe('EntitySearchBar', () => {
   it('should display search value and execute set callback', async () => {

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
@@ -26,8 +26,8 @@ import Clear from '@material-ui/icons/Clear';
 import Search from '@material-ui/icons/Search';
 import React, { useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
-import { useEntityList } from '../../hooks/useEntityListProvider';
 import { EntityTextFilter } from '../../filters';
+import { useEntityFilter } from '../../hooks';
 
 /** @public */
 export type CatalogReactEntitySearchBarClassKey = 'searchToolbar' | 'input';
@@ -52,7 +52,7 @@ const useStyles = makeStyles(
 export const EntitySearchBar = () => {
   const classes = useStyles();
 
-  const { filters, updateFilters } = useEntityList();
+  const { filters, updateFilters } = useEntityFilter();
   const [search, setSearch] = useState(filters.text?.value ?? '');
 
   useDebounce(

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -36,10 +36,11 @@ import { compact } from 'lodash';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { UserListFilter } from '../../filters';
 import {
-  useEntityList,
   useStarredEntities,
   useEntityOwnership,
+  useEntityFilter,
 } from '../../hooks';
+import { useEntities } from '../../hooks/useEntities';
 import { UserListFilterKind } from '../../types';
 import { reduceEntityFilters } from '../../utils';
 
@@ -130,13 +131,12 @@ export const UserListPicker = (props: UserListPickerProps) => {
   const classes = useStyles();
   const configApi = useApi(configApiRef);
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
+  const { backendEntities, loading: loadingBackendEntities } = useEntities();
   const {
     filters,
     updateFilters,
-    backendEntities,
     queryParameters: { kind: kindParameter, user: userParameter },
-    loading: loadingBackendEntities,
-  } = useEntityList();
+  } = useEntityFilter();
 
   // Remove group items that aren't in availableFilters and exclude
   // any now-empty groups.

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -29,10 +29,22 @@ export {
   EntityListProvider,
   useEntityList,
 } from './useEntityListProvider';
+export type { EntityListContextProps } from './useEntityListProvider';
+export {
+  useEntityStream,
+  EntityStreamContext,
+  EntityStreamProvider,
+} from './useEntityStreamProvider';
+export type {
+  EntityStreamContextProps,
+  EntityPageOptions,
+} from './useEntityStreamProvider';
+export { EntityFilterProvider, useEntityFilter } from './useEntityFilter';
 export type {
   DefaultEntityFilters,
-  EntityListContextProps,
-} from './useEntityListProvider';
+  EntityFilterContextProps,
+} from './useEntityFilter';
+export { useEntities } from './useEntities';
 export { useEntityTypeFilter } from './useEntityTypeFilter';
 export { useRelatedEntities } from './useRelatedEntities';
 export { useStarredEntities } from './useStarredEntities';

--- a/plugins/catalog-react/src/hooks/useEntities.tsx
+++ b/plugins/catalog-react/src/hooks/useEntities.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from 'react';
+import { EntityFilterContext } from './useEntityFilter';
+import {
+  EntityListContext,
+  EntityListContextProps,
+} from './useEntityListProvider';
+import {
+  EntityStreamContext,
+  EntityStreamContextProps,
+} from './useEntityStreamProvider';
+
+/**
+ * Use a list of entities, either loaded all at once or by a stream. For interoperability between both
+ *  contexts.
+ *
+ * @public
+ * @returns Hook for interacting with context provided by either {@link EntityListProvider} or {@link EntityStreamProvider}.
+ */
+export function useEntities():
+  | EntityListContextProps
+  | EntityStreamContextProps {
+  const filterContext = useContext(EntityFilterContext);
+  if (!filterContext) {
+    throw new Error('useEntities must be used within EntityFilterProvider');
+  }
+  const listContext = useContext(EntityListContext);
+  const streamContext = useContext(EntityStreamContext);
+  if (!listContext && !streamContext)
+    throw new Error(
+      'useEntities must be used within EntityListProvider or EntityStreamProvider',
+    );
+  if (listContext && streamContext) {
+    throw new Error(
+      'useEntities must have only one of EntityListProvider or EntityStreamProvider',
+    );
+  }
+  return listContext || streamContext!;
+}

--- a/plugins/catalog-react/src/hooks/useEntityFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityFilter.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { compact, isEqual } from 'lodash';
+import qs from 'qs';
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+import useMountedState from 'react-use/lib/useMountedState';
+import {
+  EntityErrorFilter,
+  EntityKindFilter,
+  EntityLifecycleFilter,
+  EntityNamespaceFilter,
+  EntityOrphanFilter,
+  EntityOwnerFilter,
+  EntityTagFilter,
+  EntityTextFilter,
+  EntityTypeFilter,
+  UserListFilter,
+} from '../filters';
+import { EntityFilter } from '../types';
+import { reduceEntityFilters } from '../utils';
+
+/** @public */
+export type DefaultEntityFilters = {
+  kind?: EntityKindFilter;
+  type?: EntityTypeFilter;
+  user?: UserListFilter;
+  owners?: EntityOwnerFilter;
+  lifecycles?: EntityLifecycleFilter;
+  tags?: EntityTagFilter;
+  text?: EntityTextFilter;
+  orphan?: EntityOrphanFilter;
+  error?: EntityErrorFilter;
+  namespace?: EntityNamespaceFilter;
+};
+
+/** @public */
+export type EntityFilterContextProps<
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+> = {
+  /**
+   * The currently registered filters, adhering to the shape of DefaultEntityFilters or an extension
+   * of that default (to add custom filter types).
+   */
+  filters: EntityFilters;
+
+  /**
+   * Update one or more of the registered filters. Optional filters can be set to `undefined` to
+   * reset the filter.
+   */
+  updateFilters: (
+    filters:
+      | Partial<EntityFilters>
+      | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
+  ) => void;
+
+  /**
+   * Filter values from query parameters.
+   */
+  queryParameters: Partial<Record<keyof EntityFilters, string | string[]>>;
+
+  entityFilter: (entity: Entity) => boolean;
+
+  backendEntityFilter: (entity: Entity) => boolean;
+};
+
+/**
+ * Creates new context for entity listing and filtering.
+ * @public
+ */
+export const EntityFilterContext = createContext<
+  EntityFilterContextProps<any> | undefined
+>(undefined);
+
+/**
+ * Provides entities and filters for a catalog listing.
+ * @public
+ */
+export const EntityFilterProvider = <
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+>({
+  children,
+}: PropsWithChildren<{}>) => {
+  const isMounted = useMountedState();
+  const [requestedFilters, setRequestedFilters] = useState<EntityFilters>(
+    {} as EntityFilters,
+  );
+
+  // We use react-router's useLocation hook so updates from external sources trigger an update to
+  // the queryParameters in outputState. Updates from this hook use replaceState below and won't
+  // trigger a useLocation change; this would instead come from an external source, such as a manual
+  // update of the URL or two catalog sidebar links with different catalog filters.
+  const location = useLocation();
+  const queryParameters = useMemo(
+    () =>
+      (qs.parse(location.search, {
+        ignoreQueryPrefix: true,
+      }).filters ?? {}) as Record<string, string | string[]>,
+    [location],
+  );
+
+  const entityFilter = useMemo(() => {
+    const compacted = compact(Object.values(requestedFilters));
+    return reduceEntityFilters(compacted);
+  }, [requestedFilters]);
+
+  const backendEntityFilter = useMemo(() => {
+    const compacted = compact(
+      Object.values(requestedFilters).filter(
+        (value: EntityFilter) => !!value?.getCatalogFilters,
+      ),
+    );
+    return reduceEntityFilters(compacted);
+  }, [requestedFilters]);
+
+  useEffect(() => {
+    if (isMounted()) {
+      const queryParams = Object.keys(requestedFilters).reduce(
+        (params, key) => {
+          const filter = requestedFilters[key as keyof EntityFilters] as
+            | EntityFilter
+            | undefined;
+          if (filter?.toQueryValue) {
+            params[key] = filter.toQueryValue();
+          }
+          return params;
+        },
+        {} as Record<string, string | string[]>,
+      );
+      const newParams = qs.stringify(
+        { ...queryParameters, filters: queryParams },
+        { addQueryPrefix: true, arrayFormat: 'repeat' },
+      );
+      const newUrl = `${window.location.pathname}${newParams}`;
+      // We use direct history manipulation since useSearchParams and
+      // useNavigate in react-router-dom cause unnecessary extra rerenders.
+      // Also make sure to replace the state rather than pushing, since we
+      // don't want there to be back/forward slots for every single filter
+      // change.
+      window.history?.replaceState(null, document.title, newUrl);
+    }
+  }, [isMounted, queryParameters, requestedFilters]);
+
+  const updateFilters = useCallback(
+    (
+      update:
+        | Partial<EntityFilter>
+        | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
+    ) => {
+      setRequestedFilters(prevFilters => {
+        const newFilters =
+          typeof update === 'function' ? update(prevFilters) : update;
+        if (!isEqual({ ...prevFilters, ...newFilters }, prevFilters)) {
+          return { ...prevFilters, ...newFilters };
+        }
+        return prevFilters;
+      });
+    },
+    [],
+  );
+
+  const value = useMemo(() => {
+    return {
+      filters: requestedFilters,
+      updateFilters,
+      entityFilter,
+      backendEntityFilter,
+      queryParameters,
+    };
+  }, [
+    updateFilters,
+    queryParameters,
+    requestedFilters,
+    entityFilter,
+    backendEntityFilter,
+  ]);
+
+  return (
+    <EntityFilterContext.Provider value={value}>
+      {children}
+    </EntityFilterContext.Provider>
+  );
+};
+
+/**
+ * Hook for interacting with the entity list context provided by the {@link EntityFilterProvider}.
+ * @public
+ */
+export function useEntityFilter<
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+>(): EntityFilterContextProps<EntityFilters> {
+  const context = useContext(EntityFilterContext);
+  if (!context)
+    throw new Error('useEntityFilter must be used within EntityFilterProvider');
+  return context;
+}

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -16,49 +16,24 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { compact, isEqual } from 'lodash';
-import qs from 'qs';
 import React, {
   createContext,
   PropsWithChildren,
-  useCallback,
   useContext,
   useMemo,
   useState,
 } from 'react';
-import { useLocation } from 'react-router-dom';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import useDebounce from 'react-use/lib/useDebounce';
-import useMountedState from 'react-use/lib/useMountedState';
 import { catalogApiRef } from '../api';
-import {
-  EntityErrorFilter,
-  EntityKindFilter,
-  EntityLifecycleFilter,
-  EntityOrphanFilter,
-  EntityOwnerFilter,
-  EntityTagFilter,
-  EntityTextFilter,
-  EntityTypeFilter,
-  UserListFilter,
-  EntityNamespaceFilter,
-} from '../filters';
-import { EntityFilter } from '../types';
-import { reduceCatalogFilters, reduceEntityFilters } from '../utils';
+import { reduceCatalogFilters } from '../utils';
 import { useApi } from '@backstage/core-plugin-api';
-
-/** @public */
-export type DefaultEntityFilters = {
-  kind?: EntityKindFilter;
-  type?: EntityTypeFilter;
-  user?: UserListFilter;
-  owners?: EntityOwnerFilter;
-  lifecycles?: EntityLifecycleFilter;
-  tags?: EntityTagFilter;
-  text?: EntityTextFilter;
-  orphan?: EntityOrphanFilter;
-  error?: EntityErrorFilter;
-  namespace?: EntityNamespaceFilter;
-};
+import {
+  DefaultEntityFilters,
+  EntityFilterContext,
+  EntityFilterProvider,
+  useEntityFilter,
+} from './useEntityFilter';
 
 /** @public */
 export type EntityListContextProps<
@@ -69,16 +44,6 @@ export type EntityListContextProps<
    * of that default (to add custom filter types).
    */
   filters: EntityFilters;
-
-  /**
-   * The resolved list of catalog entities, after all filters are applied.
-   */
-  entities: Entity[];
-
-  /**
-   * The resolved list of catalog entities, after _only catalog-backend_ filters are applied.
-   */
-  backendEntities: Entity[];
 
   /**
    * Update one or more of the registered filters. Optional filters can be set to `undefined` to
@@ -94,6 +59,16 @@ export type EntityListContextProps<
    * Filter values from query parameters.
    */
   queryParameters: Partial<Record<keyof EntityFilters, string | string[]>>;
+
+  /**
+   * The resolved list of catalog entities, after all filters are applied.
+   */
+  entities: Entity[];
+
+  /**
+   * The resolved list of catalog entities, after _only catalog-backend_ filters are applied.
+   */
+  backendEntities: Entity[];
 
   loading: boolean;
   error?: Error;
@@ -117,27 +92,18 @@ type OutputState<EntityFilters extends DefaultEntityFilters> = {
  * Provides entities and filters for a catalog listing.
  * @public
  */
-export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
-  props: PropsWithChildren<{}>,
-) => {
-  const isMounted = useMountedState();
+export const EntityListProvider = <
+  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
+>({
+  children,
+}: PropsWithChildren<{}>) => {
+  const {
+    entityFilter,
+    filters: requestedFilters,
+    updateFilters,
+    queryParameters,
+  } = useEntityFilter<EntityFilters>();
   const catalogApi = useApi(catalogApiRef);
-  const [requestedFilters, setRequestedFilters] = useState<EntityFilters>(
-    {} as EntityFilters,
-  );
-
-  // We use react-router's useLocation hook so updates from external sources trigger an update to
-  // the queryParameters in outputState. Updates from this hook use replaceState below and won't
-  // trigger a useLocation change; this would instead come from an external source, such as a manual
-  // update of the URL or two catalog sidebar links with different catalog filters.
-  const location = useLocation();
-  const queryParameters = useMemo(
-    () =>
-      (qs.parse(location.search, {
-        ignoreQueryPrefix: true,
-      }).filters ?? {}) as Record<string, string | string[]>,
-    [location],
-  );
 
   const [outputState, setOutputState] = useState<OutputState<EntityFilters>>(
     () => {
@@ -155,23 +121,9 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   const [{ loading, error }, refresh] = useAsyncFn(
     async () => {
       const compacted = compact(Object.values(requestedFilters));
-      const entityFilter = reduceEntityFilters(compacted);
       const backendFilter = reduceCatalogFilters(compacted);
       const previousBackendFilter = reduceCatalogFilters(
         compact(Object.values(outputState.appliedFilters)),
-      );
-
-      const queryParams = Object.keys(requestedFilters).reduce(
-        (params, key) => {
-          const filter = requestedFilters[key as keyof EntityFilters] as
-            | EntityFilter
-            | undefined;
-          if (filter?.toQueryValue) {
-            params[key] = filter.toQueryValue();
-          }
-          return params;
-        },
-        {} as Record<string, string | string[]>,
       );
 
       // TODO(mtlewis): currently entities will never be requested unless
@@ -195,23 +147,6 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
           entities: outputState.backendEntities.filter(entityFilter),
         });
       }
-
-      if (isMounted()) {
-        const oldParams = qs.parse(location.search, {
-          ignoreQueryPrefix: true,
-        });
-        const newParams = qs.stringify(
-          { ...oldParams, filters: queryParams },
-          { addQueryPrefix: true, arrayFormat: 'repeat' },
-        );
-        const newUrl = `${window.location.pathname}${newParams}`;
-        // We use direct history manipulation since useSearchParams and
-        // useNavigate in react-router-dom cause unnecessary extra rerenders.
-        // Also make sure to replace the state rather than pushing, since we
-        // don't want there to be back/forward slots for every single filter
-        // change.
-        window.history?.replaceState(null, document.title, newUrl);
-      }
     },
     [catalogApi, queryParameters, requestedFilters, outputState],
     { loading: true },
@@ -220,21 +155,6 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   // Slight debounce on the refresh, since (especially on page load) several
   // filters will be calling this in rapid succession.
   useDebounce(refresh, 10, [requestedFilters]);
-
-  const updateFilters = useCallback(
-    (
-      update:
-        | Partial<EntityFilter>
-        | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
-    ) => {
-      setRequestedFilters(prevFilters => {
-        const newFilters =
-          typeof update === 'function' ? update(prevFilters) : update;
-        return { ...prevFilters, ...newFilters };
-      });
-    },
-    [],
-  );
 
   const value = useMemo(
     () => ({
@@ -250,9 +170,11 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   );
 
   return (
-    <EntityListContext.Provider value={value}>
-      {props.children}
-    </EntityListContext.Provider>
+    <EntityFilterProvider>
+      <EntityListContext.Provider value={value}>
+        {children}
+      </EntityListContext.Provider>
+    </EntityFilterProvider>
   );
 };
 
@@ -264,7 +186,10 @@ export function useEntityList<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
 >(): EntityListContextProps<EntityFilters> {
   const context = useContext(EntityListContext);
-  if (!context)
-    throw new Error('useEntityList must be used within EntityListProvider');
+  const filterContext = useContext(EntityFilterContext);
+  if (!context || !filterContext)
+    throw new Error(
+      'useEntityList must be used within EntityListProvider and EntityFilterProvider',
+    );
   return context;
 }

--- a/plugins/catalog-react/src/hooks/useEntityStreamProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityStreamProvider.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { compact, isEqual } from 'lodash';
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { catalogApiRef } from '../api';
+import { useApi } from '@backstage/core-plugin-api';
+import { DefaultEntityFilters, useEntityFilter } from './useEntityFilter';
+import { reduceCatalogFilters } from '../utils';
+import { EntityOrderQuery } from '@backstage/catalog-client';
+
+/**
+ * @public
+ */
+export interface EntityPageOptions {
+  to: number;
+  from: number;
+  search: {
+    term: string;
+    fields: string[];
+  };
+  sortBy?: EntityOrderQuery;
+}
+
+interface PageableEntityFilters {
+  search: EntityPageOptions['search'];
+  sortBy?: EntityPageOptions['sortBy'];
+}
+
+/** @public */
+export type EntityStreamContextProps = {
+  /**
+   * The resolved list of catalog entities, after all filters are applied.
+   */
+  entities: Entity[];
+
+  /**
+   * Corollary to `useEntityListProvider`'s `backendEntities`.
+   * Contains the resolved list of catalog entities as you would expect from the backend
+   *  request that we're not making.
+   */
+  backendEntities: Entity[];
+
+  loading: boolean;
+  error?: Error;
+
+  hasMoreData: boolean;
+
+  getEntities: (pageConfig: EntityPageOptions) => Promise<{
+    data: Entity[];
+    hasMoreData: boolean;
+    count: number;
+  } | null>;
+
+  count: number;
+};
+
+/**
+ * Creates new context for entity listing and filtering.
+ * @public
+ */
+export const EntityStreamContext = createContext<
+  EntityStreamContextProps | undefined
+>(undefined);
+
+/**
+ * Provides entities and filters for a catalog listing.
+ * @public
+ */
+export const EntityStreamProvider = <
+  EntityFilters extends DefaultEntityFilters,
+>({
+  children,
+}: PropsWithChildren<{}>) => {
+  const catalogApi = useApi(catalogApiRef);
+  const { entityFilter, filters } = useEntityFilter<EntityFilters>();
+  const [limit] = useState(2);
+  const [entities, setEntities] = useState<Entity[]>([]);
+  const [after, setAfter] = useState<string | undefined>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error>();
+  const [appliedFilters, setAppliedFilters] = useState<EntityFilters>(
+    {} as EntityFilters,
+  );
+  const [appliedPageFilters, setAppliedPageFilters] =
+    useState<PageableEntityFilters>({} as PageableEntityFilters);
+
+  const getEntities = useCallback(
+    async ({ to, from, search, sortBy }: EntityPageOptions) => {
+      try {
+        setLoading(true);
+
+        const countToRetrieve = to - from;
+
+        let _after = after;
+        let internalEntities = entities;
+
+        const compacted = compact(Object.values(filters));
+        const backendFilter = reduceCatalogFilters(compacted);
+        const previousBackendFilter = reduceCatalogFilters(
+          compact(Object.values(appliedFilters)),
+        );
+        if (
+          !isEqual(backendFilter, previousBackendFilter) ||
+          !isEqual(appliedPageFilters, { search, sortBy })
+        ) {
+          _after = '';
+          internalEntities = [];
+        }
+        const rows = internalEntities.filter(entityFilter).slice(from, to);
+
+        while (rows.length < countToRetrieve && _after !== undefined) {
+          const cursorObj = _after
+            ? {
+                cursor: _after,
+              }
+            : {
+                fullTextFilter: search,
+                orderFields: sortBy ?? undefined,
+              };
+          const response = await catalogApi.queryEntities({
+            filter: backendFilter,
+            limit,
+            ...cursorObj,
+          });
+          internalEntities = internalEntities.concat(response.items);
+          _after = response.pageInfo.nextCursor;
+
+          const newRows = internalEntities
+            .filter(entityFilter)
+            .slice(rows.length + from, to);
+          rows.push(...newRows);
+        }
+        setAfter(_after);
+        setEntities(internalEntities);
+
+        setLoading(false);
+        setAppliedFilters(filters);
+        setAppliedPageFilters({ search, sortBy });
+
+        return {
+          data: rows,
+          hasMoreData: !!_after,
+          count: internalEntities.filter(entityFilter).length,
+        };
+      } catch (err) {
+        setError(err);
+        return null;
+      }
+    },
+    [
+      catalogApi,
+      entities,
+      entityFilter,
+      limit,
+      after,
+      filters,
+      appliedFilters,
+      appliedPageFilters,
+    ],
+  );
+
+  const value = useMemo(() => {
+    const filteredEntities = entities.filter(entityFilter);
+    return {
+      entities: filteredEntities,
+      backendEntities: entities,
+      loading,
+      error,
+      getEntities,
+      hasMoreData: !!after,
+      count: filteredEntities.length,
+    };
+  }, [loading, error, after, getEntities, entities, entityFilter]);
+
+  return (
+    <EntityStreamContext.Provider value={value}>
+      {children}
+    </EntityStreamContext.Provider>
+  );
+};
+
+/**
+ * Hook for interacting with the entity list context provided by the {@link EntityStreamProvider}.
+ * @public
+ */
+export function useEntityStream(): EntityStreamContextProps {
+  const context = useContext(EntityStreamContext);
+  if (!context)
+    throw new Error('useEntityStream must be used within EntityStreamProvider');
+  return context;
+}

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -20,8 +20,8 @@ import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '../api';
-import { useEntityList } from './useEntityListProvider';
 import { EntityTypeFilter } from '../filters';
+import { useEntityFilter } from './useEntityFilter';
 
 /**
  * A hook built on top of `useEntityList` for enabling selection of valid `spec.type` values
@@ -40,7 +40,7 @@ export function useEntityTypeFilter(): {
     filters: { kind: kindFilter, type: typeFilter },
     queryParameters: { type: typeParameter },
     updateFilters,
-  } = useEntityList();
+  } = useEntityFilter();
 
   const flattenedQueryTypes = useMemo(
     () => [typeParameter].flat().filter(Boolean) as string[],

--- a/plugins/catalog-react/src/testUtils/index.ts
+++ b/plugins/catalog-react/src/testUtils/index.ts
@@ -13,4 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { MockEntityListContextProvider } from './providers';
+export {
+  MockEntityListContextProvider,
+  MockEntityStreamContextProvider,
+} from './providers';

--- a/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.tsx
+++ b/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.tsx
@@ -25,7 +25,7 @@ import {
 } from '@material-ui/core';
 import {
   EntityKindFilter,
-  useEntityList,
+  useEntityFilter,
 } from '@backstage/plugin-catalog-react';
 import pluralize from 'pluralize';
 import { filterKinds, useAllKinds } from './kindFilterUtils';
@@ -68,7 +68,7 @@ export function CatalogKindHeader(props: CatalogKindHeaderProps) {
     filters,
     updateFilters,
     queryParameters: { kind: kindParameter },
-  } = useEntityList();
+  } = useEntityFilter();
 
   const queryParamKind = useMemo(
     () => [kindParameter].flat()[0],

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -59,14 +59,31 @@ describe('DefaultCatalogPage', () => {
   });
 
   const catalogApi: Partial<CatalogApi> = {
-    getEntities: () =>
-      Promise.resolve({
+    getLocationByRef: () =>
+      Promise.resolve({ id: 'id', type: 'url', target: 'url' }),
+    getEntityByRef: async entityRef => {
+      return {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: { name: parseEntityRef(entityRef).name },
+        relations: [
+          {
+            type: RELATION_MEMBER_OF,
+            targetRef: 'group:default/tools',
+            target: { namespace: 'default', kind: 'Group', name: 'tools' },
+          },
+        ],
+      };
+    },
+    queryEntities: async () => {
+      return {
         items: [
           {
             apiVersion: 'backstage.io/v1alpha1',
             kind: 'Component',
             metadata: {
               name: 'Entity1',
+              uid: '2',
             },
             spec: {
               owner: 'tools',
@@ -84,6 +101,7 @@ describe('DefaultCatalogPage', () => {
             kind: 'Component',
             metadata: {
               name: 'Entity2',
+              uid: '1',
             },
             spec: {
               owner: 'not-tools',
@@ -102,21 +120,8 @@ describe('DefaultCatalogPage', () => {
             ],
           },
         ] as Entity[],
-      }),
-    getLocationByRef: () =>
-      Promise.resolve({ id: 'id', type: 'url', target: 'url' }),
-    getEntityByRef: async entityRef => {
-      return {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'User',
-        metadata: { name: parseEntityRef(entityRef).name },
-        relations: [
-          {
-            type: RELATION_MEMBER_OF,
-            targetRef: 'group:default/tools',
-            target: { namespace: 'default', kind: 'Group', name: 'tools' },
-          },
-        ],
+        totalItems: 2,
+        pageInfo: {},
       };
     },
     /**

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -27,7 +27,6 @@ import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
   CatalogFilterLayout,
   EntityLifecyclePicker,
-  EntityListProvider,
   EntityProcessingStatusPicker,
   EntityOwnerPicker,
   EntityTagPicker,
@@ -36,6 +35,8 @@ import {
   UserListPicker,
   EntityKindPicker,
   EntityNamespacePicker,
+  EntityStreamProvider,
+  EntityFilterProvider,
 } from '@backstage/plugin-catalog-react';
 import React, { ReactNode } from 'react';
 import { createComponentRouteRef } from '../../routes';
@@ -81,28 +82,30 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
           />
           <SupportButton>All your software catalog entities</SupportButton>
         </ContentHeader>
-        <EntityListProvider>
-          <CatalogFilterLayout>
-            <CatalogFilterLayout.Filters>
-              <EntityKindPicker initialFilter={initialKind} />
-              <EntityTypePicker />
-              <UserListPicker initialFilter={initiallySelectedFilter} />
-              <EntityOwnerPicker />
-              <EntityLifecyclePicker />
-              <EntityTagPicker />
-              <EntityProcessingStatusPicker />
-              <EntityNamespacePicker />
-            </CatalogFilterLayout.Filters>
-            <CatalogFilterLayout.Content>
-              <CatalogTable
-                columns={columns}
-                actions={actions}
-                tableOptions={tableOptions}
-                emptyContent={emptyContent}
-              />
-            </CatalogFilterLayout.Content>
-          </CatalogFilterLayout>
-        </EntityListProvider>
+        <EntityFilterProvider>
+          <EntityStreamProvider>
+            <CatalogFilterLayout>
+              <CatalogFilterLayout.Filters>
+                <EntityKindPicker initialFilter={initialKind} />
+                <EntityTypePicker />
+                <UserListPicker initialFilter={initiallySelectedFilter} />
+                <EntityOwnerPicker />
+                <EntityLifecyclePicker />
+                <EntityTagPicker />
+                <EntityProcessingStatusPicker />
+                <EntityNamespacePicker />
+              </CatalogFilterLayout.Filters>
+              <CatalogFilterLayout.Content>
+                <CatalogTable
+                  columns={columns}
+                  actions={actions}
+                  tableOptions={tableOptions}
+                  emptyContent={emptyContent}
+                />
+              </CatalogFilterLayout.Content>
+            </CatalogFilterLayout>
+          </EntityStreamProvider>
+        </EntityFilterProvider>
       </Content>
     </PageWithHeader>
   );

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -23,7 +23,7 @@ import { ApiProvider } from '@backstage/core-app-api';
 import {
   EntityKindFilter,
   entityRouteRef,
-  MockEntityListContextProvider,
+  MockEntityStreamContextProvider,
   MockStarredEntitiesApi,
   starredEntitiesApiRef,
   UserListFilter,
@@ -68,9 +68,9 @@ describe('CatalogTable component', () => {
   it('should render error message', async () => {
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider value={{ error: new Error('error') }}>
+        <MockEntityStreamContextProvider value={{ error: new Error('error') }}>
           <CatalogTable />
-        </MockEntityListContextProvider>
+        </MockEntityStreamContextProvider>
       </ApiProvider>,
       {
         mountedRoutes: {
@@ -86,7 +86,7 @@ describe('CatalogTable component', () => {
   it('should display entity names when loading has finished and no error occurred', async () => {
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider
+        <MockEntityStreamContextProvider
           value={{
             entities,
             filters: {
@@ -99,7 +99,7 @@ describe('CatalogTable component', () => {
           }}
         >
           <CatalogTable />
-        </MockEntityListContextProvider>
+        </MockEntityStreamContextProvider>
       </ApiProvider>,
       {
         mountedRoutes: {
@@ -125,9 +125,9 @@ describe('CatalogTable component', () => {
 
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider value={{ entities: [entity] }}>
+        <MockEntityStreamContextProvider value={{ entities: [entity] }}>
           <CatalogTable />
-        </MockEntityListContextProvider>
+        </MockEntityStreamContextProvider>
       </ApiProvider>,
       {
         mountedRoutes: {
@@ -157,9 +157,9 @@ describe('CatalogTable component', () => {
 
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider value={{ entities: [entity] }}>
+        <MockEntityStreamContextProvider value={{ entities: [entity] }}>
           <CatalogTable />
-        </MockEntityListContextProvider>
+        </MockEntityStreamContextProvider>
       </ApiProvider>,
       {
         mountedRoutes: {
@@ -284,7 +284,7 @@ describe('CatalogTable component', () => {
     async ({ kind, expectedColumns }) => {
       await renderInTestApp(
         <ApiProvider apis={mockApis}>
-          <MockEntityListContextProvider
+          <MockEntityStreamContextProvider
             value={{
               entities,
               filters: {
@@ -293,7 +293,7 @@ describe('CatalogTable component', () => {
             }}
           >
             <CatalogTable />
-          </MockEntityListContextProvider>
+          </MockEntityStreamContextProvider>
         </ApiProvider>,
         {
           mountedRoutes: {
@@ -323,9 +323,9 @@ describe('CatalogTable component', () => {
 
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider value={{ entities: [entity] }}>
+        <MockEntityStreamContextProvider value={{ entities: [entity] }}>
           <CatalogTable subtitle="Should be rendered" />
-        </MockEntityListContextProvider>
+        </MockEntityStreamContextProvider>
       </ApiProvider>,
       {
         mountedRoutes: {
@@ -354,9 +354,9 @@ describe('CatalogTable component', () => {
 
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider value={{ entities: [entity] }}>
+        <MockEntityStreamContextProvider value={{ entities: [entity] }}>
           <CatalogTable columns={columns} />
-        </MockEntityListContextProvider>
+        </MockEntityStreamContextProvider>
       </ApiProvider>,
       {
         mountedRoutes: {

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -20,6 +20,7 @@ import {
   RELATION_OWNED_BY,
   RELATION_PART_OF,
 } from '@backstage/catalog-model';
+import { useState } from 'react';
 import {
   CodeSnippet,
   Table,
@@ -30,7 +31,8 @@ import {
 import {
   getEntityRelations,
   humanizeEntityRef,
-  useEntityList,
+  useEntityFilter,
+  useEntityStream,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
 import { Typography } from '@material-ui/core';
@@ -40,9 +42,68 @@ import OpenInNew from '@material-ui/icons/OpenInNew';
 import Star from '@material-ui/icons/Star';
 import StarBorder from '@material-ui/icons/StarBorder';
 import { capitalize } from 'lodash';
-import React, { ReactNode, useMemo } from 'react';
+import React, { ReactNode, useCallback, useMemo, useRef } from 'react';
+import useDebounce from 'react-use/lib/useDebounce';
 import { columnFactories } from './columns';
 import { CatalogTableRow } from './types';
+
+const DEFAULT_PAGE_SIZE = 3;
+
+// From material table. https://github.com/mbrn/material-table/blob/master/src/utils/index.js
+export const selectFromObject = (o: object, s: string | undefined) => {
+  if (!s) {
+    return null;
+  }
+  let a;
+  let _s;
+  let _o = o;
+  if (!Array.isArray(s)) {
+    _s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
+    _s = _s.replace(/^\./, ''); // strip a leading dot
+    a = _s.split('.');
+  } else {
+    a = s;
+  }
+  for (let i = 0, n = a.length; i < n; ++i) {
+    const x = a[i] as any;
+    if (_o && x in _o) {
+      _o = (_o as any)[x];
+    } else {
+      return null;
+    }
+  }
+  return _o as unknown;
+};
+
+// Pulled from material table, https://github.com/mbrn/material-table/blob/master/src/utils/data-manager.js#L548.
+const _sort = (a: any, b: any, type: string) => {
+  if (type === 'numeric') {
+    return a - b;
+  }
+  if (a !== b) {
+    // to find nulls
+    if (!a) return -1;
+    if (!b) return 1;
+  }
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+};
+const getFieldValue = (
+  rowData: Record<string, any>,
+  columnDef: TableColumn<CatalogTableRow>,
+  lookup = true,
+) => {
+  let value =
+    typeof rowData[columnDef.field!] !== 'undefined'
+      ? rowData[columnDef.field!]
+      : selectFromObject(rowData, columnDef.field);
+  if (columnDef.lookup && lookup) {
+    value = (columnDef.lookup as any)[value];
+  }
+
+  return value;
+};
 
 /**
  * Props for {@link CatalogTable}.
@@ -63,21 +124,21 @@ const YellowStar = withStyles({
   },
 })(Star);
 
-const refCompare = (a: Entity, b: Entity) => {
-  const toRef = (entity: Entity) =>
-    entity.metadata.title ||
-    humanizeEntityRef(entity, {
-      defaultKind: 'Component',
-    });
-
-  return toRef(a).localeCompare(toRef(b));
-};
+export interface MTable {
+  onQueryChange: (query: { page: number }) => void;
+}
 
 /** @public */
 export const CatalogTable = (props: CatalogTableProps) => {
   const { columns, actions, tableOptions, subtitle, emptyContent } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
-  const { loading, error, entities, filters } = useEntityList();
+  const { error, loading, hasMoreData, getEntities, count } = useEntityStream();
+
+  const { filters } = useEntityFilter();
+
+  const [hasLoadedFilters, setHasLoadedFilters] = useState(false);
+
+  const ref = useRef<MTable>();
 
   const defaultColumns: TableColumn<CatalogTableRow>[] = useMemo(() => {
     return [
@@ -94,6 +155,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         columnFactories.createOwnerColumn(),
         columnFactories.createSpecTypeColumn(),
         columnFactories.createSpecLifecycleColumn(),
+        columnFactories.createNamespaceColumn(),
       ];
       switch (filters.kind?.value) {
         case 'user':
@@ -110,14 +172,168 @@ export const CatalogTable = (props: CatalogTableProps) => {
             columnFactories.createSpecTargetsColumn(),
           ];
         default:
-          return entities.every(
-            entity => entity.metadata.namespace === 'default',
-          )
-            ? baseColumns
-            : [...baseColumns, columnFactories.createNamespaceColumn()];
+          return baseColumns;
       }
     }
-  }, [filters.kind?.value, entities]);
+  }, [filters.kind?.value]);
+
+  // Trigger a reload of loadData function to get the correct rows.
+  useDebounce(
+    () => {
+      /**
+       * TODO (@sennyeya): This is currently triggering when the favorite button is pressed,
+       *  can't think of an easy solution here as we may need to retrigger render logic when
+       *  you unfavorite an entity on the last page with the entity filter active. We could subscribe
+       *  to the list of favorited entities?
+       */
+
+      setHasLoadedFilters(true);
+      ref?.current?.onQueryChange({ page: 0 });
+    },
+    10,
+    [filters],
+  );
+
+  /**
+   * Convert a given entity to its MaterialTable row equivalent.
+   * @param entity Entity to convert.
+   * @returns A table row.
+   */
+  const toRow = (entity: Entity) => {
+    const partOfSystemRelations = getEntityRelations(entity, RELATION_PART_OF, {
+      kind: 'system',
+    });
+    const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+
+    return {
+      entity,
+      resolved: {
+        name: humanizeEntityRef(entity, {
+          defaultKind: 'Component',
+        }),
+        ownedByRelationsTitle: ownedByRelations
+          .map(r => humanizeEntityRef(r, { defaultKind: 'group' }))
+          .join(', '),
+        ownedByRelations,
+        partOfSystemRelationTitle: partOfSystemRelations
+          .map(r =>
+            humanizeEntityRef(r, {
+              defaultKind: 'system',
+            }),
+          )
+          .join(', '),
+        partOfSystemRelations,
+      },
+    };
+  };
+
+  /**
+   * Sort the entities in a given direction by a given orderBy column.
+   * @param entities List of returned entities.
+   * @param orderBy Column to order by, from MaterialTable.
+   * @param orderDirection Which way to sort said column.
+   */
+  const sort = useCallback((orderBy: any, orderDirection: 'asc' | 'desc') => {
+    type Row = ReturnType<typeof toRow>;
+    return (a: Row, b: Row) => {
+      if (orderBy.customSort) {
+        if (orderDirection === 'desc') {
+          return orderBy.customSort(b, a, 'row', 'desc');
+        }
+        return orderBy.customSort(a, b, 'row');
+      }
+      if (orderDirection === 'desc') {
+        return _sort(
+          getFieldValue(b, orderBy),
+          getFieldValue(a, orderBy),
+          orderBy.type,
+        );
+      }
+      return _sort(
+        getFieldValue(a, orderBy),
+        getFieldValue(b, orderBy),
+        orderBy.type,
+      );
+    };
+  }, []);
+
+  const getFieldFromColumn = (columnField: string) => {
+    if (columnField.startsWith('resolved.')) return undefined;
+    // Remove the `entity.` part of the string.
+    return columnField.replace(/^entity./, '');
+  };
+
+  const loadData = useCallback(
+    async query => {
+      /**
+       * Query is passed in as undefined on first load, if so just return nothing.
+       */
+      if (!query || !hasLoadedFilters)
+        return {
+          data: [],
+          totalCount: 0,
+          page: 0,
+        };
+      const { page, pageSize, search, orderBy, orderDirection } = query;
+      const entities = [];
+      let shouldLoadMore = false;
+      const shouldOrderClientSide =
+        orderBy && !getFieldFromColumn(orderBy.field);
+
+      let _count = 0;
+      const tableColumns = columns || defaultColumns;
+      do {
+        const from = page * pageSize;
+        /**
+         * We grab an additional item here to prevent issues where there are 20 items in the catalog
+         *  but we think there may be more so we go to the next page and there were actually only 20 items.
+         * The +1 forces a full search if we're on the last page.
+         */
+        const to = shouldOrderClientSide
+          ? Number.MAX_SAFE_INTEGER
+          : (page + 1) * pageSize + 1;
+        const response = await getEntities({
+          search: {
+            term: search,
+            fields: tableColumns
+              .map(e => e.field && getFieldFromColumn(e.field))
+              .filter((e): boolean => !!e) as string[],
+          },
+          sortBy:
+            orderBy && !shouldOrderClientSide
+              ? {
+                  field: orderBy.field,
+                  order: orderDirection,
+                }
+              : undefined,
+          to,
+          from,
+        });
+
+        if (response) {
+          // Do search filtering here.
+          _count = response.count;
+          entities.push(...response.data.map(toRow));
+          shouldLoadMore = shouldOrderClientSide
+            ? response.hasMoreData
+            : entities.length < pageSize && response.hasMoreData;
+        }
+      } while (shouldLoadMore);
+
+      if (orderBy) {
+        entities.sort(sort(orderBy, orderDirection));
+      }
+
+      return {
+        data: entities,
+        page,
+        totalCount: shouldLoadMore
+          ? Math.ceil((_count + 1) / pageSize) * pageSize
+          : _count,
+      };
+    },
+    [getEntities, columns, defaultColumns, hasLoadedFilters, sort],
+  );
 
   const showTypeColumn = filters.type === undefined;
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar
@@ -193,59 +409,31 @@ export const CatalogTable = (props: CatalogTableProps) => {
     },
   ];
 
-  const rows = entities.sort(refCompare).map(entity => {
-    const partOfSystemRelations = getEntityRelations(entity, RELATION_PART_OF, {
-      kind: 'system',
-    });
-    const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
-
-    return {
-      entity,
-      resolved: {
-        name: humanizeEntityRef(entity, {
-          defaultKind: 'Component',
-        }),
-        ownedByRelationsTitle: ownedByRelations
-          .map(r => humanizeEntityRef(r, { defaultKind: 'group' }))
-          .join(', '),
-        ownedByRelations,
-        partOfSystemRelationTitle: partOfSystemRelations
-          .map(r =>
-            humanizeEntityRef(r, {
-              defaultKind: 'system',
-            }),
-          )
-          .join(', '),
-        partOfSystemRelations,
-      },
-    };
-  });
-
   const typeColumn = (columns || defaultColumns).find(c => c.title === 'Type');
   if (typeColumn) {
     typeColumn.hidden = !showTypeColumn;
   }
-  const showPagination = rows.length > 20;
+  const showPagination = hasMoreData || count > DEFAULT_PAGE_SIZE;
 
   return (
     <Table<CatalogTableRow>
-      isLoading={loading}
       columns={columns || defaultColumns}
       options={{
         paging: showPagination,
-        pageSize: 20,
+        pageSize: DEFAULT_PAGE_SIZE,
         actionsColumnIndex: -1,
         loadingType: 'linear',
-        showEmptyDataSourceMessage: !loading,
         padding: 'dense',
-        pageSizeOptions: [20, 50, 100],
+        pageSizeOptions: [DEFAULT_PAGE_SIZE, 50, 100],
         ...tableOptions,
       }}
-      title={`${titlePreamble} (${entities.length})`}
-      data={rows}
+      isLoading={loading}
+      title={`${titlePreamble} (${hasMoreData ? `about ` : ''}${count})`}
+      data={loadData}
       actions={actions || defaultActions}
       subtitle={subtitle}
       emptyContent={emptyContent}
+      tableRef={ref}
     />
   );
 };

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -47,7 +47,7 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { columnFactories } from './columns';
 import { CatalogTableRow } from './types';
 
-const DEFAULT_PAGE_SIZE = 3;
+const DEFAULT_PAGE_SIZE = 20;
 
 // From material table. https://github.com/mbrn/material-table/blob/master/src/utils/index.js
 export const selectFromObject = (o: object, s: string | undefined) => {

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 export { CatalogTable } from './CatalogTable';
 export type { CatalogTableProps } from './CatalogTable';
 export type { CatalogTableRow } from './types';

--- a/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.test.tsx
@@ -15,7 +15,7 @@
  */
 
 jest.mock('@backstage/plugin-catalog-react', () => ({
-  useEntityList: jest.fn(),
+  useEntities: jest.fn(),
 }));
 
 jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
@@ -23,17 +23,17 @@ jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
 }));
 
 import React from 'react';
-import { useEntityList } from '@backstage/plugin-catalog-react';
 import { TemplateGroups } from './TemplateGroups';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { errorApiRef } from '@backstage/core-plugin-api';
 import { TemplateGroup } from '@backstage/plugin-scaffolder-react/alpha';
+import { useEntities } from '@backstage/plugin-catalog-react';
 
 describe('TemplateGroups', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('should return progress if the hook is loading', async () => {
-    (useEntityList as jest.Mock).mockReturnValue({ loading: true });
+    (useEntities as jest.Mock).mockReturnValue({ loading: true });
 
     const { findByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[errorApiRef, {}]]}>
@@ -46,7 +46,7 @@ describe('TemplateGroups', () => {
 
   it('should use the error api if there is an error with the retrieval of entitylist', async () => {
     const mockError = new Error('tings went poop');
-    (useEntityList as jest.Mock).mockReturnValue({
+    (useEntities as jest.Mock).mockReturnValue({
       error: mockError,
     });
     const errorApi = {
@@ -62,7 +62,7 @@ describe('TemplateGroups', () => {
   });
 
   it('should return a no templates message if entities is unset', async () => {
-    (useEntityList as jest.Mock).mockReturnValue({
+    (useEntities as jest.Mock).mockReturnValue({
       entities: null,
       loading: false,
       error: null,
@@ -78,7 +78,7 @@ describe('TemplateGroups', () => {
   });
 
   it('should return a no templates message if entities has no values in it', async () => {
-    (useEntityList as jest.Mock).mockReturnValue({
+    (useEntities as jest.Mock).mockReturnValue({
       entities: [],
       loading: false,
       error: null,
@@ -113,7 +113,7 @@ describe('TemplateGroups', () => {
       },
     ];
 
-    (useEntityList as jest.Mock).mockReturnValue({
+    (useEntities as jest.Mock).mockReturnValue({
       entities: mockEntities,
       loading: false,
       error: null,
@@ -155,7 +155,7 @@ describe('TemplateGroups', () => {
       },
     ];
 
-    (useEntityList as jest.Mock).mockReturnValue({
+    (useEntities as jest.Mock).mockReturnValue({
       entities: mockEntities,
       loading: false,
       error: null,
@@ -197,7 +197,7 @@ describe('TemplateGroups', () => {
       },
     ];
 
-    (useEntityList as jest.Mock).mockReturnValue({
+    (useEntities as jest.Mock).mockReturnValue({
       entities: mockEntities,
       loading: false,
       error: null,

--- a/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 import React, { useCallback } from 'react';
-
-import { useEntityList } from '@backstage/plugin-catalog-react';
 import {
   isTemplateEntityV1beta3,
   TemplateEntityV1beta3,
@@ -24,6 +22,7 @@ import { Progress, Link } from '@backstage/core-components';
 import { Typography } from '@material-ui/core';
 import { errorApiRef, IconComponent, useApi } from '@backstage/core-plugin-api';
 import { TemplateGroup } from '@backstage/plugin-scaffolder-react/alpha';
+import { useEntities } from '@backstage/plugin-catalog-react';
 
 /**
  * @alpha
@@ -54,7 +53,7 @@ export interface TemplateGroupsProps {
  * @alpha
  */
 export const TemplateGroups = (props: TemplateGroupsProps) => {
-  const { loading, error, entities } = useEntityList();
+  const { loading, error, entities } = useEntities();
   const { groups, templateFilter, TemplateCardComponent, onTemplateSelected } =
     props;
   const errorApi = useApi(errorApiRef);

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -26,6 +26,7 @@ import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import {
   CatalogFilterLayout,
+  EntityFilterProvider,
   EntityKindPicker,
   EntityListProvider,
   EntitySearchBar,
@@ -147,13 +148,17 @@ export const ScaffolderPage = ({
   contextMenu,
   headerOptions,
 }: ScaffolderPageProps) => (
-  <EntityListProvider>
-    <ScaffolderPageContents
-      TemplateCardComponent={TemplateCardComponent}
-      groups={groups}
-      templateFilter={templateFilter}
-      contextMenu={contextMenu}
-      headerOptions={headerOptions}
-    />
-  </EntityListProvider>
+  <EntityFilterProvider>
+    <EntityFilterProvider>
+      <EntityListProvider>
+        <ScaffolderPageContents
+          TemplateCardComponent={TemplateCardComponent}
+          groups={groups}
+          templateFilter={templateFilter}
+          contextMenu={contextMenu}
+          headerOptions={headerOptions}
+        />
+      </EntityListProvider>
+    </EntityFilterProvider>
+  </EntityFilterProvider>
 );

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -149,16 +149,14 @@ export const ScaffolderPage = ({
   headerOptions,
 }: ScaffolderPageProps) => (
   <EntityFilterProvider>
-    <EntityFilterProvider>
-      <EntityListProvider>
-        <ScaffolderPageContents
-          TemplateCardComponent={TemplateCardComponent}
-          groups={groups}
-          templateFilter={templateFilter}
-          contextMenu={contextMenu}
-          headerOptions={headerOptions}
-        />
-      </EntityListProvider>
-    </EntityFilterProvider>
+    <EntityListProvider>
+      <ScaffolderPageContents
+        TemplateCardComponent={TemplateCardComponent}
+        groups={groups}
+        templateFilter={templateFilter}
+        contextMenu={contextMenu}
+        headerOptions={headerOptions}
+      />
+    </EntityListProvider>
   </EntityFilterProvider>
 );

--- a/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
+++ b/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
@@ -28,7 +28,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core-components';
-import { useEntityList } from '@backstage/plugin-catalog-react';
+import { useEntities } from '@backstage/plugin-catalog-react';
 import { Typography } from '@material-ui/core';
 import { TemplateCard } from '../TemplateCard';
 
@@ -54,7 +54,7 @@ export const TemplateList = ({
   group,
   templateFilter,
 }: TemplateListProps) => {
-  const { loading, error, entities } = useEntityList();
+  const { loading, error, entities } = useEntities();
   const Card = TemplateCardComponent || TemplateCard;
   const templateEntities = entities.filter(isTemplateEntityV1beta3);
   const maybeFilteredEntities = (

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -34,6 +34,7 @@ import {
   EntityTagPicker,
   CatalogFilterLayout,
   UserListPicker,
+  EntityFilterProvider,
 } from '@backstage/plugin-catalog-react';
 import {
   ScaffolderPageContextMenu,
@@ -41,7 +42,6 @@ import {
   TemplateGroupFilter,
   TemplateGroups,
 } from '@backstage/plugin-scaffolder-react/alpha';
-
 import { RegisterExistingButton } from './RegisterExistingButton';
 import {
   actionsRouteRef,
@@ -150,51 +150,52 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
   );
 
   return (
-    <EntityListProvider>
-      <Page themeId="website">
-        <Header
-          pageTitleOverride="Create a new component"
-          title="Create a new component"
-          subtitle="Create new software components using standard templates in your organization"
-        >
-          <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
-        </Header>
-        <Content>
-          <ContentHeader title="Available Templates">
-            <RegisterExistingButton
-              title="Register Existing Component"
-              to={registerComponentLink && registerComponentLink()}
-            />
-            <SupportButton>
-              Create new software components using standard templates. Different
-              templates create different kinds of components (services,
-              websites, documentation, ...).
-            </SupportButton>
-          </ContentHeader>
-
-          <CatalogFilterLayout>
-            <CatalogFilterLayout.Filters>
-              <EntitySearchBar />
-              <EntityKindPicker initialFilter="template" hidden />
-              <UserListPicker
-                initialFilter="all"
-                availableFilters={['all', 'starred']}
+    <EntityFilterProvider>
+      <EntityListProvider>
+        <Page themeId="website">
+          <Header
+            pageTitleOverride="Create a new component"
+            title="Create a new component"
+            subtitle="Create new software components using standard templates in your organization"
+          >
+            <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
+          </Header>
+          <Content>
+            <ContentHeader title="Available Templates">
+              <RegisterExistingButton
+                title="Register Existing Component"
+                to={registerComponentLink && registerComponentLink()}
               />
-              <TemplateCategoryPicker />
-              <EntityTagPicker />
-            </CatalogFilterLayout.Filters>
-            <CatalogFilterLayout.Content>
-              <TemplateGroups
-                groups={groups}
-                templateFilter={templateFilter}
-                TemplateCardComponent={TemplateCardComponent}
-                onTemplateSelected={onTemplateSelected}
-                additionalLinksForEntity={additionalLinksForEntity}
-              />
-            </CatalogFilterLayout.Content>
-          </CatalogFilterLayout>
-        </Content>
-      </Page>
-    </EntityListProvider>
+              <SupportButton>
+                Create new software components using standard templates.
+                Different templates create different kinds of components
+                (services, websites, documentation, ...).
+              </SupportButton>
+            </ContentHeader>
+            <CatalogFilterLayout>
+              <CatalogFilterLayout.Filters>
+                <EntitySearchBar />
+                <EntityKindPicker initialFilter="template" hidden />
+                <UserListPicker
+                  initialFilter="all"
+                  availableFilters={['all', 'starred']}
+                />
+                <TemplateCategoryPicker />
+                <EntityTagPicker />
+              </CatalogFilterLayout.Filters>
+              <CatalogFilterLayout.Content>
+                <TemplateGroups
+                  groups={groups}
+                  templateFilter={templateFilter}
+                  TemplateCardComponent={TemplateCardComponent}
+                  onTemplateSelected={onTemplateSelected}
+                  additionalLinksForEntity={additionalLinksForEntity}
+                />
+              </CatalogFilterLayout.Content>
+            </CatalogFilterLayout>
+          </Content>
+        </Page>
+      </EntityListProvider>
+    </EntityFilterProvider>
   );
 };

--- a/plugins/techdocs/src/home/components/DefaultTechDocsHome.tsx
+++ b/plugins/techdocs/src/home/components/DefaultTechDocsHome.tsx
@@ -22,6 +22,7 @@ import {
 } from '@backstage/core-components';
 import {
   CatalogFilterLayout,
+  EntityFilterProvider,
   EntityListProvider,
   EntityOwnerPicker,
   EntityTagPicker,
@@ -55,19 +56,21 @@ export const DefaultTechDocsHome = (props: TechDocsIndexPageProps) => {
             Discover documentation in your ecosystem.
           </SupportButton>
         </ContentHeader>
-        <EntityListProvider>
-          <CatalogFilterLayout>
-            <CatalogFilterLayout.Filters>
-              <TechDocsPicker />
-              <UserListPicker initialFilter={initialFilter} />
-              <EntityOwnerPicker />
-              <EntityTagPicker />
-            </CatalogFilterLayout.Filters>
-            <CatalogFilterLayout.Content>
-              <EntityListDocsTable actions={actions} columns={columns} />
-            </CatalogFilterLayout.Content>
-          </CatalogFilterLayout>
-        </EntityListProvider>
+        <EntityFilterProvider>
+          <EntityListProvider>
+            <CatalogFilterLayout>
+              <CatalogFilterLayout.Filters>
+                <TechDocsPicker />
+                <UserListPicker initialFilter={initialFilter} />
+                <EntityOwnerPicker />
+                <EntityTagPicker />
+              </CatalogFilterLayout.Filters>
+              <CatalogFilterLayout.Content>
+                <EntityListDocsTable actions={actions} columns={columns} />
+              </CatalogFilterLayout.Content>
+            </CatalogFilterLayout>
+          </EntityListProvider>
+        </EntityFilterProvider>
       </Content>
     </TechDocsPageWrapper>
   );

--- a/plugins/techdocs/src/home/components/TechDocsPicker.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsPicker.tsx
@@ -19,7 +19,7 @@ import {
   CATALOG_FILTER_EXISTS,
   DefaultEntityFilters,
   EntityFilter,
-  useEntityList,
+  useEntityFilter,
 } from '@backstage/plugin-catalog-react';
 
 class TechDocsFilter implements EntityFilter {
@@ -40,7 +40,7 @@ type CustomFilters = DefaultEntityFilters & {
  * @public
  */
 export const TechDocsPicker = () => {
-  const { updateFilters } = useEntityList<CustomFilters>();
+  const { updateFilters } = useEntityFilter<CustomFilters>();
 
   useEffect(() => {
     updateFilters({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Will move from draft once I've added test cases, but wanted to get initial feedback on this iteration.

Created a new CatalogTable clone that streams catalog records from the backend instead of loading everything at once. Implementation of freben's comment, https://github.com/backstage/backstage/issues/12247#issuecomment-1167444741, for movement towards full pagination support. 
 Uses the by-query endpoint.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


https://user-images.githubusercontent.com/34432188/215232639-f6e1ac8f-7f04-4a91-b7cc-b4ff34cd5973.mov