### PR TITLE
docs: standardize term 'gitlab instance'

### DIFF
--- a/.changeset/breezy-ears-rule.md
+++ b/.changeset/breezy-ears-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+The config now consistently uses the term 'instance' to refer to a single GitLab API host.

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -22,7 +22,7 @@ catalog:
       yourProviderId:
         host: gitlab-host # Identifies one of the hosts set up in the integrations
         branch: main # Optional. Uses `master` as default
-        group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole project will be scanned
+        group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
         projectPattern: /[\s\S]*/ # Optional. Filters found projects based on provided patter. Defaults to `/[\s\S]*/`, what means to not filter anything
         schedule: # optional; same options as in TaskScheduleDefinition

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -31,7 +31,7 @@ export interface Config {
           host: string;
           /**
            * (Optional) Gitlab's group[/subgroup] where the discovery is done.
-           * If not defined the whole project will be scanned.
+           * If not defined the whole instance will be scanned.
            */
           group?: string;
           /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Basic docs tweak to avoid confusion about the term 'project'.

#### :heavy_check_mark: Checklist

- [x] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~ docs only
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
