### PR TITLE
cli: additional fix for worker memory limits to make sure it's always applied by default

### DIFF
--- a/.changeset/chatty-owls-care.md
+++ b/.changeset/chatty-owls-care.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-The `backstage-cli repo test` command now sets a default Jest `--workerIdleMemoryLimit` of 1GB. This is the recommended workaround for dealing with Jest workers leaking memory and eventually hitting the heap limit.
+The `backstage-cli repo test` command now sets a default Jest `--workerIdleMemoryLimit` of 1GB. If needed to ensure that tests are not run in band, `--maxWorkers=2` is set as well. This is the recommended workaround for dealing with Jest workers leaking memory and eventually hitting the heap limit.

--- a/packages/cli/src/commands/repo/test.test.ts
+++ b/packages/cli/src/commands/repo/test.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createFlagFinder } from './test';
+
+describe('createFlagFinder', () => {
+  it('finds flags', () => {
+    const find = createFlagFinder([
+      '--foo',
+      '--no-bar',
+      '-b',
+      '-c',
+      '--baz=1',
+      '--qux',
+      '2',
+      '-de',
+    ]);
+
+    expect(
+      find('--foo', '--bar', '-b', '-c', '--baz', '--qux', '-d', '-e'),
+    ).toBe(true);
+    expect(find('--foo')).toBe(true);
+    expect(find('--bar')).toBe(true);
+    expect(find('--no-bar')).toBe(false);
+    expect(find('-a')).toBe(false);
+    expect(find('-b')).toBe(true);
+    expect(find('-c')).toBe(true);
+    expect(find('-d')).toBe(true);
+    expect(find('-e')).toBe(true);
+    expect(find('--baz')).toBe(true);
+    expect(find('--qux')).toBe(true);
+    expect(find('--qux')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Additional fix for #15985. Without ensuring a worker count of at least two it's very easy to run into issues in CI. For example Jest in GitHub actions will default to one worker.

Threw in a refactor as well

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
