### PR TITLE
cli: switch to inline source maps for jest setup

### DIFF
--- a/.changeset/two-melons-lie.md
+++ b/.changeset/two-melons-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switch to inline source maps for test transpilation, simplifying editor setups.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -22,7 +22,6 @@ const { version } = require('../package.json');
 
 const envOptions = {
   oldTests: Boolean(process.env.BACKSTAGE_OLD_TESTS),
-  enableSourceMaps: Boolean(process.env.ENABLE_SOURCE_MAPS),
 };
 
 const transformIgnorePattern = [
@@ -130,7 +129,6 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.(mjs|cjs|js)$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'ecmascript',
@@ -141,7 +139,6 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.jsx$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'ecmascript',
@@ -158,7 +155,6 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.ts$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -169,7 +165,6 @@ async function getProjectConfig(targetPath, extraConfig) {
       '\\.tsx$': [
         require.resolve('./jestSwcTransform'),
         {
-          sourceMaps: envOptions.enableSourceMaps || !envOptions.oldTests,
           jsc: {
             parser: {
               syntax: 'typescript',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related to #16031. Turns out that the default behavior of the SWC transform is to use inline source maps. We then instead set it to generate the source maps separately, which makes editor setup more complicated.

Will want to keep an eye on the test execution speed of this one, but unless there's a significant impact I feel it's best to use inline maps.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
