### PR TITLE
create-app: added yarn version check

### DIFF
--- a/.changeset/dry-donkeys-cheer.md
+++ b/.changeset/dry-donkeys-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Added a check to ensure that Yarn v1 is used when creating new projects.

--- a/packages/create-app/src/lib/tasks.ts
+++ b/packages/create-app/src/lib/tasks.ts
@@ -199,9 +199,21 @@ export async function createTemporaryAppFolderTask(tempDir: string) {
  * @param appDir - location of application to build
  */
 export async function buildAppTask(appDir: string) {
+  process.chdir(appDir);
+
+  await Task.forItem('determining', 'yarn version', async () => {
+    const result = await exec('yarn --version');
+    const yarnVersion = result.stdout?.trim();
+
+    if (yarnVersion && !yarnVersion.startsWith('1.')) {
+      throw new Error(
+        `@backstage/create-app requires Yarn v1, found '${yarnVersion}'. You can migrate the project to Yarn 3 after creation using https://backstage.io/docs/tutorials/yarn-migration`,
+      );
+    }
+  });
+
   const runCmd = async (cmd: string) => {
     await Task.forItem('executing', cmd, async () => {
-      process.chdir(appDir);
       await exec(cmd).catch(error => {
         process.stdout.write(error.stderr);
         process.stdout.write(error.stdout);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We currently only support Yarn classic in `@backstage/create-app`, this ensures a more clear error message for the user rather than the more cryptic errors that will follow.

We're not quite ready to encourage migration to Yarn 3 yet, we're still stuck with a couple of problems in this repo because of lacking or spotty Yarn 3 support from external tools.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
