### PR TITLE
Align buttons to the same line on "Unregister entity" modal dialog

### DIFF
--- a/.changeset/twenty-islands-wonder.md
+++ b/.changeset/twenty-islands-wonder.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': minor
 ---
 
-Aligined buttons on "Unregister entity" dialog to keep them on the same line
+Aligned buttons on "Unregister entity" dialog to keep them on the same line

--- a/.changeset/twenty-islands-wonder.md
+++ b/.changeset/twenty-islands-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Aligined buttons on "Unregister entity" dialog to keep them on the same line

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
@@ -80,7 +80,11 @@ describe('UnregisterEntityDialog', () => {
 
   it('can cancel', async () => {
     const onClose = jest.fn();
-    stateSpy.mockImplementation(() => ({ type: 'loading' }));
+    stateSpy.mockImplementation(() => ({
+      type: 'bootstrap',
+      location: '',
+      deleteEntity: jest.fn(),
+    }));
 
     await renderInTestApp(
       <Wrapper>

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -39,14 +39,19 @@ const useStyles = makeStyles({
   advancedButton: {
     fontSize: '0.7em',
   },
+  dialogActions: {
+    display: 'inline-block',
+  },
 });
 
 const Contents = ({
   entity,
   onConfirm,
+  onClose,
 }: {
   entity: Entity;
   onConfirm: () => any;
+  onClose: () => any;
 }) => {
   const alertApi = useApi(alertApiRef);
   const configApi = useApi(configApiRef);
@@ -92,6 +97,14 @@ const Contents = ({
     [alertApi, onConfirm, state],
   );
 
+  const DialogActionsPanel = () => (
+    <DialogActions className={classes.dialogActions}>
+      <Button onClick={onClose} color="primary">
+        Cancel
+      </Button>
+    </DialogActions>
+  );
+
   if (state.type === 'loading') {
     return <Progress />;
   }
@@ -112,15 +125,18 @@ const Contents = ({
 
         <Box marginTop={2}>
           {!showDelete && (
-            <Button
-              variant="text"
-              size="small"
-              color="primary"
-              className={classes.advancedButton}
-              onClick={() => setShowDelete(true)}
-            >
-              Advanced Options
-            </Button>
+            <>
+              <Button
+                variant="text"
+                size="small"
+                color="primary"
+                className={classes.advancedButton}
+                onClick={() => setShowDelete(true)}
+              >
+                Advanced Options
+              </Button>
+              <DialogActionsPanel />
+            </>
           )}
 
           {showDelete && (
@@ -140,6 +156,7 @@ const Contents = ({
               >
                 Delete Entity
               </Button>
+              <DialogActionsPanel />
             </>
           )}
         </Box>
@@ -162,6 +179,7 @@ const Contents = ({
         >
           Delete Entity
         </Button>
+        <DialogActionsPanel />
       </>
     );
   }
@@ -258,13 +276,8 @@ export const UnregisterEntityDialog = (props: UnregisterEntityDialogProps) => {
         Are you sure you want to unregister this entity?
       </DialogTitle>
       <DialogContent>
-        <Contents entity={entity} onConfirm={onConfirm} />
+        <Contents entity={entity} onConfirm={onConfirm} onClose={onClose} />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} color="primary">
-          Cancel
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

What do you think about aligning buttons to keep them on the same line?

Now it looks like this

<img width="643" alt="Screenshot 2023-01-30 at 19 04 46" src="https://user-images.githubusercontent.com/2265094/215558258-8b2a493d-6851-4f1a-b219-5ee18575274a.png">

This change will make it look like this

<img width="644" alt="Screenshot 2023-01-30 at 19 04 28" src="https://user-images.githubusercontent.com/2265094/215558323-60ef196f-6a02-44e1-b923-8c5e32c7aee9.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
