### PR TITLE
fix: better error around github teams not found

### DIFF
--- a/.changeset/olive-ads-peel.md
+++ b/.changeset/olive-ads-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Provide better error messaging when GitHub fails due to missing team definitions

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
@@ -42,6 +42,7 @@ const mockOctokit = {
     },
     teams: {
       addOrUpdateRepoPermissionsInOrg: jest.fn(),
+      getByName: jest.fn(),
     },
   },
 };
@@ -94,6 +95,13 @@ describe('github:repo:create', () => {
   it('should call the githubApis with the correct values for createInOrg', async () => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({
       data: { type: 'Organization' },
+    });
+
+    mockOctokit.rest.teams.getByName.mockResolvedValue({
+      data: {
+        name: 'blam',
+        id: 42,
+      },
     });
 
     mockOctokit.rest.repos.createInOrg.mockResolvedValue({ data: {} });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { assertError, InputError } from '@backstage/errors';
+import { assertError, InputError, NotFoundError } from '@backstage/errors';
 import {
   DefaultGithubCredentialsProvider,
   GithubCredentialsProvider,
@@ -370,7 +370,7 @@ async function validateAccessTeam(client: Octokit, access: string) {
     if (e.response.data.message === 'Not Found') {
       const message = `Received 'Not Found' from the API; one of org:
         ${org} or team: ${team_slug} was not found within GitHub.`;
-      throw new Error(message, { cause: e });
+      throw new NotFoundError(message);
     }
   }
 }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -45,6 +45,7 @@ const mockOctokit = {
       replaceAllTopics: jest.fn(),
     },
     teams: {
+      getByName: jest.fn(),
       addOrUpdateRepoPermissionsInOrg: jest.fn(),
     },
   },
@@ -96,9 +97,39 @@ describe('publish:github', () => {
     });
   });
 
+  it('should fail to create if the team is not found in the org', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'Organization' },
+    });
+
+    mockOctokit.rest.teams.getByName.mockRejectedValue({
+      response: {
+        status: 404,
+        data: {
+          message: 'Not Found',
+          documentation_url:
+            'https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions',
+        },
+      },
+    });
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      "Received 'Not Found' from the API;",
+    );
+
+    expect(mockOctokit.rest.repos.createInOrg).not.toHaveBeenCalled();
+  });
+
   it('should call the githubApis with the correct values for createInOrg', async () => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({
       data: { type: 'Organization' },
+    });
+
+    mockOctokit.rest.teams.getByName.mockResolvedValue({
+      data: {
+        name: 'blam',
+        id: 42,
+      },
     });
 
     mockOctokit.rest.repos.createInOrg.mockResolvedValue({ data: {} });
@@ -523,24 +554,23 @@ describe('publish:github', () => {
       data: { type: 'User' },
     });
 
-    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
-      data: {
-        clone_url: 'https://github.com/clone/url.git',
-        html_url: 'https://github.com/html/url',
-      },
-    });
-
-    mockOctokit.rest.teams.addOrUpdateRepoPermissionsInOrg.mockRejectedValue({
-      status: 404,
-      data: {
-        message: 'Not Found',
-        documentation_url:
-          'https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions',
+    mockOctokit.rest.teams.getByName.mockRejectedValue({
+      response: {
+        status: 404,
+        data: {
+          message: 'Not Found',
+          documentation_url:
+            'https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions',
+        },
       },
     });
     await expect(action.handler(mockContext)).rejects.toThrow(
       "Received 'Not Found' from the API;",
     );
+
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).not.toHaveBeenCalled();
   });
 
   it('should add outside collaborators when provided', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -518,6 +518,31 @@ describe('publish:github', () => {
     });
   });
 
+  it('should provide an adequate failure message when adding access', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    mockOctokit.rest.teams.addOrUpdateRepoPermissionsInOrg.mockRejectedValue({
+      status: 404,
+      data: {
+        message: 'Not Found',
+        documentation_url:
+          'https://docs.github.com/en/rest/teams/teams#add-or-update-team-repository-permissions',
+      },
+    });
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      "Received 'Not Found' from the API;",
+    );
+  });
+
   it('should add outside collaborators when provided', async () => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({
       data: { type: 'User' },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a literate error around the
`createGithubRepoWithCollaboratorsAndTopics` function in order to provide that error in the scaffolder logs. Prior to this, the only thing returned was "Not Found," which didn't provide much information for someone trying to determine what failed in the background.

Fixes #10160

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
