### PR TITLE
Uffizzi Preview Workflow Improvements

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -89,16 +89,11 @@ jobs:
           name: preview-spec
           path: docker-compose.rendered.yml
           retention-days: 2
-      - name: Serialize PR Event to File
-        run: |
-          cat << EOF > event.json
-          ${{ toJSON(github.event) }}
-          EOF
       - name: Upload PR Event as Artifact
         uses: actions/upload-artifact@v3
         with:
           name: preview-spec
-          path: event.json
+          path: ${{ github.event_path }}
           retention-days: 2
 
   delete-preview:
@@ -107,14 +102,9 @@ jobs:
     if: ${{ github.event.action == 'closed' }}
     steps:
       # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
-      - name: Serialize PR Event to File
-        run: |
-          cat << EOF > event.json
-          ${{ toJSON(github.event) }}
-          EOF
       - name: Upload PR Event as Artifact
         uses: actions/upload-artifact@v3
         with:
           name: preview-spec
-          path: event.json
+          path: ${{ github.event_path }}
           retention-days: 2

--- a/.github/workflows/uffizzi-preview.yaml
+++ b/.github/workflows/uffizzi-preview.yaml
@@ -11,6 +11,7 @@ jobs:
   cache-compose-file:
     name: Cache Compose File
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       compose-file-cache-key: ${{ env.COMPOSE_FILE_HASH }}
       pr-number: ${{ env.PR_NUMBER }}
@@ -47,7 +48,7 @@ jobs:
         run: |
           echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
           cat event.json >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          echo -e '\nEOF' >> $GITHUB_ENV
 
       - name: Hash Rendered Compose File
         id: hash
@@ -77,6 +78,7 @@ jobs:
     name: Use Remote Workflow to Preview on Uffizzi
     needs:
       - cache-compose-file
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
     with:
       # If this workflow was triggered by a PR close event, cache-key will be an empty string


### PR DESCRIPTION
I noticed several Uffizzi image building and preview workflows were failing. Bots like `renovate` use a lot of special characters in their PR bodies and those should be handled better. These changes should reduce these failures.

I've also included conditions to skip the deployment workflow unless the build workflow completed successfully.