### PR TITLE
Review property order

### DIFF
--- a/.changeset/soft-snails-notice.md
+++ b/.changeset/soft-snails-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Prefer schema ordering of template properties during review content generation.

--- a/plugins/scaffolder/src/components/MultistepJsonForm/ReviewStep.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/ReviewStep.tsx
@@ -25,36 +25,38 @@ export function getReviewData(
   uiSchemas: UiSchema[],
 ) {
   const reviewData: Record<string, any> = {};
-  for (const key in formData) {
-    if (formData.hasOwnProperty(key)) {
-      const uiSchema = uiSchemas.find(us => us.name === key);
+  const orderedReviewProperties = new Set(
+    uiSchemas.map(us => us.name).concat(Object.getOwnPropertyNames(formData)),
+  );
 
-      if (!uiSchema) {
-        reviewData[key] = formData[key];
-        continue;
-      }
+  for (const key of orderedReviewProperties) {
+    const uiSchema = uiSchemas.find(us => us.name === key);
 
-      if (uiSchema['ui:widget'] === 'password') {
-        reviewData[key] = '******';
-        continue;
-      }
-
-      if (!uiSchema['ui:backstage'] || !uiSchema['ui:backstage'].review) {
-        reviewData[key] = formData[key];
-        continue;
-      }
-
-      const review = uiSchema['ui:backstage'].review as JsonObject;
-      if (review.mask) {
-        reviewData[key] = review.mask;
-        continue;
-      }
-
-      if (!review.show) {
-        continue;
-      }
+    if (!uiSchema) {
       reviewData[key] = formData[key];
+      continue;
     }
+
+    if (uiSchema['ui:widget'] === 'password') {
+      reviewData[key] = '******';
+      continue;
+    }
+
+    if (!uiSchema['ui:backstage'] || !uiSchema['ui:backstage'].review) {
+      reviewData[key] = formData[key];
+      continue;
+    }
+
+    const review = uiSchema['ui:backstage'].review as JsonObject;
+    if (review.mask) {
+      reviewData[key] = review.mask;
+      continue;
+    }
+
+    if (!review.show) {
+      continue;
+    }
+    reviewData[key] = formData[key];
   }
 
   return reviewData;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reimplemented review content generation function to prefer property order from UI Schema.
Addresses https://github.com/backstage/backstage/issues/16062 

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/487462/215610652-6212aa2c-3795-4402-b7e2-d2f78501ed5d.png">


#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
