### PR TITLE
Export reader state hook

### DIFF
--- a/.changeset/twenty-yaks-learn.md
+++ b/.changeset/twenty-yaks-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Export useReaderState from techdocs so that addons can use the hook in packages/app.

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -473,4 +473,12 @@ export class TechDocsStorageClient implements TechDocsStorageApi {
     logHandler?: (line: string) => void,
   ): Promise<SyncResult>;
 }
+
+// @public
+export function useReaderState(
+  kind: string,
+  namespace: string,
+  name: string,
+  path: string,
+): ReaderState;
 ```

--- a/plugins/techdocs/src/reader/components/index.ts
+++ b/plugins/techdocs/src/reader/components/index.ts
@@ -27,4 +27,5 @@ export { TechDocsReaderLayout } from './TechDocsReaderPage';
 export * from './TechDocsReaderPageHeader';
 export * from './TechDocsReaderPageContent';
 export * from './TechDocsReaderPageSubheader';
+export { useReaderState } from './useReaderState';
 export type { ReaderState, ContentStateTypes } from './useReaderState';

--- a/plugins/techdocs/src/reader/components/useReaderState.ts
+++ b/plugins/techdocs/src/reader/components/useReaderState.ts
@@ -238,6 +238,14 @@ export type ReaderState = {
   buildLog: string[];
 };
 
+/**
+ * @public get shared reader state for current entity and article
+ *
+ * @param kind - The entity kind
+ * @param namespace - The entity namespace
+ * @param name - The entity name
+ * @param path - The document path
+ */
 export function useReaderState(
   kind: string,
   namespace: string,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Exports `useReaderState` from techdocs so we can use the hook in our TechDocs addons. I would also be open to exporting `TechDocsReaderContext` if that is the preferred solution from the maintainers. 

I was also unclear on best practices for the `api-reports` docs, so any feedback is appreciated!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
