### PR TITLE
docs: moving to docsearch for searching

### DIFF
--- a/microsite/siteConfig.js
+++ b/microsite/siteConfig.js
@@ -138,8 +138,9 @@ const siteConfig = {
   ],
 
   algolia: {
-    apiKey: '8d115c9875ba0f4feaee95bab55a1645',
-    indexName: 'backstage',
+    apiKey: '10b9e6c92a4513c1cf390f50e53aad1f',
+    indexName: 'backstage_io',
+    appId: 'JCMFNHCHI8',
     searchParameters: {}, // Optional (if provided by Algolia)
   },
 };


### PR DESCRIPTION
Moved to the new [docsearch](https://docsearch.algolia.com) service with the [crawler](https://crawler.algolia.com) ability.

**Before**
![Screenshot 2023-01-31 at 10 35 38](https://user-images.githubusercontent.com/3645856/215723377-e0b01385-aa8e-4537-8c94-5e2bd93c5fa7.png)
![Screenshot 2023-01-31 at 09 57 08](https://user-images.githubusercontent.com/3645856/215723428-4bb07f96-4d39-412b-b73d-69aaf15fe49d.png)
![Screenshot 2023-01-31 at 10 35 51](https://user-images.githubusercontent.com/3645856/215723468-85e3f813-c4e7-45cd-9aa6-04e8b5f721c9.png)

**After**
![Screenshot 2023-01-31 at 10 35 33](https://user-images.githubusercontent.com/3645856/215723639-f91d470d-397c-4e2c-94d7-b43e4d4e4e0d.png)
![Screenshot 2023-01-31 at 09 57 14](https://user-images.githubusercontent.com/3645856/215723680-a2caf3e3-01f0-40ee-aa37-b8fae14dd112.png)
![Screenshot 2023-01-31 at 10 35 45](https://user-images.githubusercontent.com/3645856/215723620-dbdd4542-7b92-4a50-b9d8-925c04535295.png)


The backend experimental docs are not in the search sidebar, so hence them not being indexed at all yet.