### PR TITLE
STYLE.md: document method for testing with private constructors

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -94,6 +94,13 @@ This section describes guidelines for designing public APIs. It can also be appl
        /* ... */
      }
 
+     // In order to make a private constructor available for testing you can use a
+     // static factory marked as `@internal`, which will not show up in the public API.
+     /** @internal */
+     static forTesting(internalOptions?: { ... }) {
+       return new DefaultImageLoader(internalOptions);
+     }
+
      private constructor(/* ... */) {
        /* ... */
      }


### PR DESCRIPTION
Figured it's best to document this trick