### PR TITLE
Revert "ci: skip publishing upgrade-helper diff for next releases"

### DIFF
--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -53,10 +53,6 @@ jobs:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           # TODO(Rugvip): Remove the create-app dispatch once we've been on the release version for a while
           script: |
-            const releaseVersion = require('./backstage/package.json').version;
-            if(releaseVersion.includes('next')) {
-              return;
-            }
             console.log('Dispatching upgrade helper sync');
             await github.rest.actions.createWorkflowDispatch({
               owner: 'backstage',
@@ -65,6 +61,6 @@ jobs:
               ref: 'master',
               inputs: {
                 version: require('./backstage/packages/create-app/package.json').version,
-                releaseVersion
+                releaseVersion: require('./backstage/package.json').version
               },
             });


### PR DESCRIPTION


## Hey, I just made a Pull Request!

This reverts commit a948b6af07d45b304eb39af6e81582a5f965e848 in order to start creating diffs for the `next` versions of Backstage.
The `next` versions are currently filtered out by the upgrade helper https://github.com/backstage/upgrade-helper/pull/10
We will remove the filter once proper support for the next version is introduced in the upgrade helper.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
