### PR TITLE
await expect instead of expect await

### DIFF
--- a/plugins/catalog/src/apis/StarredEntitiesApi/migration.test.ts
+++ b/plugins/catalog/src/apis/StarredEntitiesApi/migration.test.ts
@@ -46,7 +46,7 @@ describe('performMigrationToTheNewBucket', () => {
     await performMigrationToTheNewBucket({ storageApi: mockStorage });
 
     // read NEW bucket
-    expect(await newBucket.snapshot('entityRefs').value).toEqual([
+    await expect(newBucket.snapshot('entityRefs').value).resolves.toEqual([
       'component:default/c',
       'component:default/a',
       'template:custom/b',
@@ -72,7 +72,7 @@ describe('performMigrationToTheNewBucket', () => {
     await performMigrationToTheNewBucket({ storageApi: mockStorage });
 
     // read NEW bucket
-    expect(await newBucket.snapshot('entityRefs').value).toEqual([
+    await expect(newBucket.snapshot('entityRefs').value).resolves.toEqual([
       'component:default/a',
     ]);
 

--- a/plugins/catalog/src/apis/StarredEntitiesApi/migration.test.ts
+++ b/plugins/catalog/src/apis/StarredEntitiesApi/migration.test.ts
@@ -46,7 +46,7 @@ describe('performMigrationToTheNewBucket', () => {
     await performMigrationToTheNewBucket({ storageApi: mockStorage });
 
     // read NEW bucket
-    await expect(newBucket.snapshot('entityRefs').value).resolves.toEqual([
+    expect(newBucket.snapshot('entityRefs').value).toEqual([
       'component:default/c',
       'component:default/a',
       'template:custom/b',
@@ -72,7 +72,7 @@ describe('performMigrationToTheNewBucket', () => {
     await performMigrationToTheNewBucket({ storageApi: mockStorage });
 
     // read NEW bucket
-    await expect(newBucket.snapshot('entityRefs').value).resolves.toEqual([
+    expect(newBucket.snapshot('entityRefs').value).toEqual([
       'component:default/a',
     ]);
 

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -198,10 +198,12 @@ describe('DefaultCatalogPage', () => {
   it('should render the default actions of an item in the grid', async () => {
     await renderWrapped(<DefaultCatalogPage />);
     fireEvent.click(screen.getByTestId('user-picker-owned'));
-    expect(await screen.findByText(/Owned \(1\)/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/View/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Edit/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Add to favorites/)).toBeInTheDocument();
+    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(/View/)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(/Edit/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByTitle(/Add to favorites/),
+    ).resolves.toBeInTheDocument();
   }, 20_000);
 
   it('should render the custom actions of an item passed as prop', async () => {
@@ -226,10 +228,12 @@ describe('DefaultCatalogPage', () => {
 
     await renderWrapped(<DefaultCatalogPage actions={actions} />);
     fireEvent.click(screen.getByTestId('user-picker-owned'));
-    expect(await screen.findByText(/Owned \(1\)/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Foo Action/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Bar Action/)).toBeInTheDocument();
-    expect((await screen.findByTitle(/Bar Action/)).firstChild).toBeDisabled();
+    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(/Foo Action/)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(/Bar Action/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByTitle(/Bar Action/).then(e => e.firstChild),
+    ).resolves.toBeDisabled();
   }, 20_000);
 
   // this test right now causes some red lines in the log output when running tests
@@ -256,7 +260,7 @@ describe('DefaultCatalogPage', () => {
     await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
     // The "Starred" menu option should initially be disabled, since there
     // aren't any starred entities.
-    await expect(screen.getByTestId('user-picker-starred')).toHaveAttribute(
+    expect(screen.getByTestId('user-picker-starred')).toHaveAttribute(
       'aria-disabled',
       'true',
     );
@@ -269,7 +273,7 @@ describe('DefaultCatalogPage', () => {
 
     // Now that we've starred an entity, the "Starred" menu option should be
     // enabled.
-    await expect(screen.getByTestId('user-picker-starred')).not.toHaveAttribute(
+    expect(screen.getByTestId('user-picker-starred')).not.toHaveAttribute(
       'aria-disabled',
       'true',
     );

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -78,10 +78,9 @@ describe('CatalogTable component', () => {
         },
       },
     );
-    const errorMessage = await screen.findByText(
-      /Could not fetch catalog entities./,
-    );
-    expect(errorMessage).toBeInTheDocument();
+    await expect(
+      screen.findByText(/Could not fetch catalog entities./),
+    ).resolves.toBeInTheDocument();
   });
 
   it('should display entity names when loading has finished and no error occurred', async () => {
@@ -306,6 +305,7 @@ describe('CatalogTable component', () => {
     },
     20_000,
   );
+
   it('should render the subtitle when it is specified', async () => {
     const entity = {
       apiVersion: 'backstage.io/v1alpha1',


### PR DESCRIPTION
Not expecting this to _fix_ any of the end-to-end timeout errors ... but maybe they will start happening in a different way, making them easier to diagnose.