### PR TITLE
Add tRPC API Definition Widget

### DIFF
--- a/.changeset/great-goats-talk.md
+++ b/.changeset/great-goats-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': minor
+---
+
+Adds a new tRPC API definition widget which users can utilize to integrate their tRPC API definitions into Backstage.

--- a/.changeset/many-pans-unite.md
+++ b/.changeset/many-pans-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Adds the tRPC API type to the catalog.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "create-plugin": "echo \"use 'yarn new' instead\"",
     "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",
     "prettier:check": "prettier --check .",
+    "prettier:fix": "prettier --write .",
     "storybook": "yarn ./storybook run start",
     "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
     "snyk:test:package": "yarn snyk:test --include",

--- a/packages/catalog-model/examples/all-apis.yaml
+++ b/packages/catalog-model/examples/all-apis.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   targets:
     - ./apis/hello-world-api.yaml
+    - ./apis/hello-world-trpc-api.yaml
     - ./apis/petstore-api.yaml
     - ./apis/spotify-api.yaml
     - ./apis/streetlights-api.yaml

--- a/packages/catalog-model/examples/apis/hello-world-trpc-api.yaml
+++ b/packages/catalog-model/examples/apis/hello-world-trpc-api.yaml
@@ -10,7 +10,7 @@ spec:
   definition: |
     import { z } from 'zod';
     import { publicProcedure, router } from '../trpc';
-    
+
     export const apiRouter = router({
       version: publicProcedure.query(() => {
         return { version: '0.42.0' };

--- a/packages/catalog-model/examples/apis/hello-world-trpc-api.yaml
+++ b/packages/catalog-model/examples/apis/hello-world-trpc-api.yaml
@@ -1,0 +1,25 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: hello-world-trpc
+  description: Hello World example for tRPC
+spec:
+  type: trpc
+  lifecycle: experimental
+  owner: team-c
+  definition: |
+    import { z } from 'zod';
+    import { publicProcedure, router } from '../trpc';
+    
+    export const apiRouter = router({
+      version: publicProcedure.query(() => {
+        return { version: '0.42.0' };
+      }),
+      hello: publicProcedure
+        .input(z.object({ username: z.string().nullish() }).nullish())
+        .query(({ input, ctx }) => {
+          return {
+            text: `hello ${input?.username ?? ctx.user?.name ?? 'world'}`,
+          };
+        }),
+    });

--- a/packages/catalog-model/src/schema/kinds/API.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/API.v1alpha1.schema.json
@@ -46,7 +46,7 @@
             "type": {
               "type": "string",
               "description": "The type of the API definition.",
-              "examples": ["openapi", "asyncapi", "graphql", "grpc"],
+              "examples": ["openapi", "asyncapi", "graphql", "grpc", "trpc"],
               "minLength": 1
             },
             "lifecycle": {

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -173,4 +173,12 @@ export const ProvidedApisCard: (props: {
 export const ProvidingComponentsCard: (props: {
   variant?: InfoCardVariants;
 }) => JSX.Element;
+
+// @public (undocumented)
+export const TrpcApiDefinitionWidget: React_2.FC<TrpcApiDefinitionWidgetProps>;
+
+// @public (undocumented)
+export type TrpcApiDefinitionWidgetProps = {
+  definition: string;
+};
 ```

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -175,7 +175,9 @@ export const ProvidingComponentsCard: (props: {
 }) => JSX.Element;
 
 // @public (undocumented)
-export const TrpcApiDefinitionWidget: React_2.FC<TrpcApiDefinitionWidgetProps>;
+export const TrpcApiDefinitionWidget: (
+  props: TrpcApiDefinitionWidgetProps,
+) => JSX.Element;
 
 // @public (undocumented)
 export type TrpcApiDefinitionWidgetProps = {

--- a/plugins/api-docs/dev/index.tsx
+++ b/plugins/api-docs/dev/index.tsx
@@ -32,6 +32,7 @@ import graphqlApiEntity from './graphql-example-api.yaml';
 import invalidLanguageApiEntity from './invalid-language-example-api.yaml';
 import openapiApiEntity from './openapi-example-api.yaml';
 import otherApiEntity from './other-example-api.yaml';
+import trpcApiEntity from './trpc-example-api.yaml';
 
 const mockEntities = [
   openapiApiEntity,
@@ -39,6 +40,7 @@ const mockEntities = [
   graphqlApiEntity,
   invalidLanguageApiEntity,
   otherApiEntity,
+  trpcApiEntity,
 ] as unknown as Entity[];
 
 createDevApp()
@@ -131,6 +133,19 @@ createDevApp()
         <Header title="Other" />
         <Content>
           <EntityProvider entity={otherApiEntity as any as Entity}>
+            <EntityApiDefinitionCard />
+          </EntityProvider>
+        </Content>
+      </Page>
+    ),
+  })
+  .addPage({
+    title: 'tRPC',
+    element: (
+      <Page themeId="home">
+        <Header title="tRPC" />
+        <Content>
+          <EntityProvider entity={trpcApiEntity as any as Entity}>
             <EntityApiDefinitionCard />
           </EntityProvider>
         </Content>

--- a/plugins/api-docs/dev/trpc-example-api.yaml
+++ b/plugins/api-docs/dev/trpc-example-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
-  name: hello-world
+  name: hello-world-trpc
   description: Hello World example for tRPC
 spec:
   type: trpc

--- a/plugins/api-docs/dev/trpc-example-api.yaml
+++ b/plugins/api-docs/dev/trpc-example-api.yaml
@@ -10,7 +10,7 @@ spec:
   definition: |
     import { z } from 'zod';
     import { publicProcedure, router } from '../trpc';
-    
+
     export const apiRouter = router({
       version: publicProcedure.query(() => {
         return { version: '0.42.0' };

--- a/plugins/api-docs/dev/trpc-example-api.yaml
+++ b/plugins/api-docs/dev/trpc-example-api.yaml
@@ -1,0 +1,25 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: hello-world
+  description: Hello World example for tRPC
+spec:
+  type: trpc
+  lifecycle: experimental
+  owner: team-c
+  definition: |
+    import { z } from 'zod';
+    import { publicProcedure, router } from '../trpc';
+    
+    export const apiRouter = router({
+      version: publicProcedure.query(() => {
+        return { version: '0.42.0' };
+      }),
+      hello: publicProcedure
+        .input(z.object({ username: z.string().nullish() }).nullish())
+        .query(({ input, ctx }) => {
+          return {
+            text: `hello ${input?.username ?? ctx.user?.name ?? 'world'}`,
+          };
+        }),
+    });

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
@@ -18,6 +18,7 @@ import { AsyncApiDefinitionWidget } from '../AsyncApiDefinitionWidget';
 import { GraphQlDefinitionWidget } from '../GraphQlDefinitionWidget';
 import { OpenApiDefinitionWidget } from '../OpenApiDefinitionWidget';
 import { GrpcApiDefinitionWidget } from '../GrpcApiDefinitionWidget';
+import { TrpcApiDefinitionWidget } from '../TrpcDefinitionWidget';
 
 /** @public */
 export type ApiDefinitionWidget = {
@@ -59,6 +60,13 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       title: 'gRPC',
       component: definition => (
         <GrpcApiDefinitionWidget definition={definition} />
+      ),
+    },
+    {
+      type: 'trpc',
+      title: 'tRPC',
+      component: definition => (
+        <TrpcApiDefinitionWidget definition={definition} />
       ),
     },
   ];

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinition.tsx
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinition.tsx
@@ -44,7 +44,7 @@ type Props = {
   definition: string;
 };
 
-export const GraphQlDefinition: React.FC<Props> = ({ definition }: Props) => {
+export const GraphQlDefinition = ({ definition }: Props) => {
   const classes = useStyles();
   const schema = buildSchema(definition);
 

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinition.tsx
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinition.tsx
@@ -44,7 +44,7 @@ type Props = {
   definition: string;
 };
 
-export const GraphQlDefinition = ({ definition }: Props) => {
+export const GraphQlDefinition: React.FC<Props> = ({ definition }: Props) => {
   const classes = useStyles();
   const schema = buildSchema(definition);
 

--- a/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.test.tsx
+++ b/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.test.tsx
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-export * from './ApiExplorerPage';
-export * from './ApiDefinitionCard';
-export * from './ApisCards';
-export * from './AsyncApiDefinitionWidget';
-export * from './ComponentsCards';
-export * from './GraphQlDefinitionWidget';
-export * from './OpenApiDefinitionWidget';
-export * from './PlainApiDefinitionWidget';
-export * from './TrpcDefinitionWidget';
+import { renderInTestApp } from '@backstage/test-utils';
+import React from 'react';
+import { TrpcApiDefinitionWidget } from './TrpcApiDefinitionWidget';
+
+describe('<TrpcApiDefinitionWidget />', () => {
+  it('renders plain text', async () => {
+    const { getAllByText } = await renderInTestApp(
+      <TrpcApiDefinitionWidget definition="Hello World" />,
+    );
+
+    expect(
+      getAllByText((_text, element) => element?.textContent === 'Hello World')
+        .length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { CodeSnippet } from '@backstage/core-components';
+import { useTheme } from '@material-ui/core/styles';
+import { BackstageTheme } from '@backstage/theme';
+
+/** @public */
+export type TrpcApiDefinitionWidgetProps = {
+  definition: string;
+};
+
+/** @public */
+export const TrpcApiDefinitionWidget: React.FC<TrpcApiDefinitionWidgetProps> = (
+  props: TrpcApiDefinitionWidgetProps,
+) => {
+  const { definition } = props;
+  const theme = useTheme<BackstageTheme>();
+  return (
+    <CodeSnippet
+      customStyle={{ backgroundColor: theme.palette.background.default }}
+      text={definition}
+      language="ts"
+      showCopyCodeButton
+    />
+  );
+};

--- a/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.tsx
@@ -33,7 +33,7 @@ export const TrpcApiDefinitionWidget: React.FC<TrpcApiDefinitionWidgetProps> = (
     <CodeSnippet
       customStyle={{ backgroundColor: theme.palette.background.default }}
       text={definition}
-      language="ts"
+      language="typescript"
       showCopyCodeButton
     />
   );

--- a/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/TrpcDefinitionWidget/TrpcApiDefinitionWidget.tsx
@@ -24,7 +24,7 @@ export type TrpcApiDefinitionWidgetProps = {
 };
 
 /** @public */
-export const TrpcApiDefinitionWidget: React.FC<TrpcApiDefinitionWidgetProps> = (
+export const TrpcApiDefinitionWidget = (
   props: TrpcApiDefinitionWidgetProps,
 ) => {
   const { definition } = props;

--- a/plugins/api-docs/src/components/TrpcDefinitionWidget/index.ts
+++ b/plugins/api-docs/src/components/TrpcDefinitionWidget/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from './ApiExplorerPage';
-export * from './ApiDefinitionCard';
-export * from './ApisCards';
-export * from './AsyncApiDefinitionWidget';
-export * from './ComponentsCards';
-export * from './GraphQlDefinitionWidget';
-export * from './OpenApiDefinitionWidget';
-export * from './PlainApiDefinitionWidget';
-export * from './TrpcDefinitionWidget';
+export {
+  TrpcApiDefinitionWidget,
+  type TrpcApiDefinitionWidgetProps,
+} from './TrpcApiDefinitionWidget';


### PR DESCRIPTION
Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Closes #15877 

![View of a tRPC-defined API within the Backstage API Catalog](https://user-images.githubusercontent.com/97077423/216350133-8f50b2c8-f190-4403-917d-d9c8533c5b4c.png "Backstage render of a tRPC API")

![tRPC as an API Option Within API Catalog](https://user-images.githubusercontent.com/97077423/216350354-4e3abfcb-1b79-4120-83aa-1df8443fbced.png "tRPC as an API Option Within API Catalog")



This pull request introduces a tRPC API definition widget, so that users may integrate their tRPC APIs into Backstage via the api-doc plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
