### PR TITLE
docs: fix permissions tutorial setup script

### DIFF
--- a/docs/permissions/plugin-authors/01-setup.md
+++ b/docs/permissions/plugin-authors/01-setup.md
@@ -26,6 +26,9 @@ The source code is available here:
       git checkout master -- plugins/example-todo-list/
       git checkout master -- plugins/example-todo-list-backend/
       git checkout master -- plugins/example-todo-list-common/
+      sed -i '' 's/workspace:\^/\*/g' plugins/example-todo-list/package.json
+      sed -i '' 's/workspace:\^/\*/g' plugins/example-todo-list-backend/package.json
+      sed -i '' 's/workspace:\^/\*/g' plugins/example-todo-list-common/package.json
       for file in plugins/*; do mv "$file" "$OLDPWD/${file/example-todo/todo}"; done
       cd -
     ```
@@ -37,8 +40,8 @@ The source code is available here:
 2.  Add these packages as dependencies for your Backstage app:
 
     ```
-    $ yarn workspace backend add @internal/plugin-todo-list-backend@^1.0.0 @internal/plugin-todo-list-common@^1.0.0
-    $ yarn workspace app add @internal/plugin-todo-list@^1.0.0
+    $ yarn workspace backend add @internal/plugin-todo-list-backend @internal/plugin-todo-list-common
+    $ yarn workspace app add @internal/plugin-todo-list
     ```
 
 3.  Include the backend and frontend plugin in your application:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue reported on [Discord](https://discord.com/channels/687207715902193673/935836080563966042/1070094106543542355) where it isn't possible reference any of the `example-todo-list` plugins in a Backstage app.

- Removed the outdated hardcoded versions from the docs
- Modified the script to replace any occurrence of `workspace:^` to `*`, within the `package.json` of the 3 plugins (this is needed since the plugins are going to be used outside of the main Backstage repository).

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
