### PR TITLE
keep event stream alive even if its taking a while

### DIFF
--- a/.changeset/hungry-stingrays-type.md
+++ b/.changeset/hungry-stingrays-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Keep the tech docs sync event stream alive even if it is taking a while to build.

--- a/plugins/techdocs-backend/src/service/DocsSynchronizer.test.ts
+++ b/plugins/techdocs-backend/src/service/DocsSynchronizer.test.ts
@@ -32,6 +32,7 @@ import { DocsBuilder, shouldCheckForUpdate } from '../DocsBuilder';
 import { DocsSynchronizer, DocsSynchronizerSyncOpts } from './DocsSynchronizer';
 
 jest.mock('../DocsBuilder');
+jest.useFakeTimers();
 
 jest.mock('node-fetch', () => ({
   __esModule: true,
@@ -130,6 +131,8 @@ describe('DocsSynchronizer', () => {
 
         const logger = MockedDocsBuilder.mock.calls[0][0].logger;
 
+        jest.advanceTimersByTime(10001);
+
         logger.info('Some more log');
 
         return true;
@@ -144,11 +147,17 @@ describe('DocsSynchronizer', () => {
         generators,
       });
 
-      expect(mockResponseHandler.log).toHaveBeenCalledTimes(3);
+      expect(mockResponseHandler.log).toHaveBeenCalledTimes(4);
       expect(mockResponseHandler.log).toHaveBeenCalledWith('Some log');
       expect(mockResponseHandler.log).toHaveBeenCalledWith('Another log');
       expect(mockResponseHandler.log).toHaveBeenCalledWith(
         expect.stringMatching(/info.*Some more log/),
+      );
+
+      expect(mockResponseHandler.log).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /info.*The docs building process is taking a little bit longer to process this entity. Please bear with us/,
+        ),
       );
 
       expect(mockResponseHandler.finish).toHaveBeenCalledWith({

--- a/plugins/techdocs-backend/src/service/DocsSynchronizer.ts
+++ b/plugins/techdocs-backend/src/service/DocsSynchronizer.ts
@@ -128,7 +128,13 @@ export class DocsSynchronizer {
         cache: this.cache,
       });
 
+      const interval = setInterval(() => {
+        taskLogger.info(
+          'The docs building process is taking a little bit longer to process this entity. Please bear with us.',
+        );
+      }, 10000);
       const updated = await this.buildLimiter(() => docsBuilder.build());
+      clearInterval(interval);
 
       if (!updated) {
         finish({ updated: false });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The EventStream in the tech docs api client has a keep alive timeout of 45 seconds. If this is reached without a heartbeat it will cancel the http request. This happens regardless of how slow the tech docs build process might be. This change makes sure that something is sent over the event stream periodically while the build is taking place.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
