### PR TITLE
Bug fix: Allow Kubernetes Proxy endpoint to support write operations

### DIFF
--- a/.changeset/neat-schools-raise.md
+++ b/.changeset/neat-schools-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Kubernetes proxy endpoint now accepts content types that are not json

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -31,6 +31,10 @@ import {
 import { KubernetesBuilder } from './KubernetesBuilder';
 import { KubernetesFanOutHandler } from './KubernetesFanOutHandler';
 import { CatalogApi } from '@backstage/catalog-client';
+import { HEADER_KUBERNETES_CLUSTER } from './KubernetesProxy';
+import { setupServer } from 'msw/node';
+import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
+import { rest } from 'msw';
 
 describe('KubernetesBuilder', () => {
   let app: express.Express;
@@ -265,6 +269,80 @@ describe('KubernetesBuilder', () => {
 
       expect(response.body).toEqual(result);
       expect(response.status).toEqual(200);
+    });
+  });
+
+  describe('post /proxy', () => {
+    const worker = setupServer();
+    setupRequestMockHandlers(worker);
+
+    it('returns the given request body', async () => {
+      const requestBody = {
+        kind: 'Namespace',
+        apiVersion: 'v1',
+        metadata: {
+          name: 'new-ns',
+        },
+      };
+
+      const proxyEndpointRequest = request(app)
+        .post('/proxy/api/v1/namespaces')
+        .set(HEADER_KUBERNETES_CLUSTER, 'some-cluster')
+        .send(requestBody);
+
+      worker.use(
+        rest.post('https://localhost:1234/api/v1/namespaces', (req, res, ctx) =>
+          req
+            .arrayBuffer()
+            .then(body =>
+              res(
+                ctx.set('content-type', `${req.headers.get('content-type')}`),
+                ctx.body(body),
+              ),
+            ),
+        ),
+        rest.all(proxyEndpointRequest.url, (req, _res, _ctx) =>
+          req.passthrough(),
+        ),
+      );
+
+      const response = await proxyEndpointRequest;
+
+      expect(response.body).toStrictEqual(requestBody);
+    });
+
+    it('supports yaml content type', async () => {
+      const requestBody = `---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: new-ns
+`;
+
+      const proxyEndpointRequest = request(app)
+        .post('/proxy/api/v1/namespaces')
+        .set(HEADER_KUBERNETES_CLUSTER, 'some-cluster')
+        .set('content-type', 'application/yaml')
+        .send(requestBody);
+
+      worker.use(
+        rest.post('https://localhost:1234/api/v1/namespaces', (req, res, ctx) =>
+          req
+            .arrayBuffer()
+            .then(body =>
+              res(
+                ctx.set('content-type', `${req.headers.get('content-type')}`),
+                ctx.body(body),
+              ),
+            ),
+        ),
+        rest.all(proxyEndpointRequest.url, (req, _res, _ctx) =>
+          req.passthrough(),
+        ),
+      );
+
+      const response = await proxyEndpointRequest;
+      expect(response.text).toEqual(requestBody);
     });
   });
 });

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -276,6 +276,21 @@ describe('KubernetesBuilder', () => {
     const worker = setupServer();
     setupRequestMockHandlers(worker);
 
+    beforeEach(() => {
+      worker.use(
+        rest.post('https://localhost:1234/api/v1/namespaces', (req, res, ctx) =>
+          req
+            .arrayBuffer()
+            .then(body =>
+              res(
+                ctx.set('content-type', `${req.headers.get('content-type')}`),
+                ctx.body(body),
+              ),
+            ),
+        ),
+      );
+    });
+
     it('returns the given request body', async () => {
       const requestBody = {
         kind: 'Namespace',
@@ -290,21 +305,7 @@ describe('KubernetesBuilder', () => {
         .set(HEADER_KUBERNETES_CLUSTER, 'some-cluster')
         .send(requestBody);
 
-      worker.use(
-        rest.post('https://localhost:1234/api/v1/namespaces', (req, res, ctx) =>
-          req
-            .arrayBuffer()
-            .then(body =>
-              res(
-                ctx.set('content-type', `${req.headers.get('content-type')}`),
-                ctx.body(body),
-              ),
-            ),
-        ),
-        rest.all(proxyEndpointRequest.url, (req, _res, _ctx) =>
-          req.passthrough(),
-        ),
-      );
+      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
 
       const response = await proxyEndpointRequest;
 
@@ -325,21 +326,7 @@ metadata:
         .set('content-type', 'application/yaml')
         .send(requestBody);
 
-      worker.use(
-        rest.post('https://localhost:1234/api/v1/namespaces', (req, res, ctx) =>
-          req
-            .arrayBuffer()
-            .then(body =>
-              res(
-                ctx.set('content-type', `${req.headers.get('content-type')}`),
-                ctx.body(body),
-              ),
-            ),
-        ),
-        rest.all(proxyEndpointRequest.url, (req, _res, _ctx) =>
-          req.passthrough(),
-        ),
-      );
+      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
 
       const response = await proxyEndpointRequest;
       expect(response.text).toEqual(requestBody);

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -265,6 +265,7 @@ export class KubernetesBuilder {
   ): express.Router {
     const logger = this.env.logger;
     const router = Router();
+    router.use('/proxy', proxy.createRequestHandler());
     router.use(express.json());
 
     // @deprecated
@@ -296,8 +297,6 @@ export class KubernetesBuilder {
         })),
       });
     });
-
-    router.use('/proxy', proxy.createRequestHandler());
 
     addResourceRoutesToRouter(router, catalogApi, objectsProvider);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bug Fix that allows Kubernetes Proxy endpoint to support write operations. Fix resolves #16018. Details on the bug were described in [bug-report](https://github.com/backstage/backstage/issues/16018)

Changes also allow the proxy to accept content type other than json now. Unit test was added for this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
