### PR TITLE
Expose all props available to underlying `EntityRelationsGraph` on the `CatalogGraphCard`.

### DIFF
--- a/.changeset/slow-sloths-do.md
+++ b/.changeset/slow-sloths-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': minor
+---
+
+Expose additional props on the CatalogGraphCard to allow for custom node & label rendering or kind/relation filtering.

--- a/.changeset/slow-sloths-do.md
+++ b/.changeset/slow-sloths-do.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-graph': minor
+'@backstage/plugin-catalog-graph': patch
 ---
 
-Expose additional props on the CatalogGraphCard to allow for custom node & label rendering or kind/relation filtering.
+Expose additional props on the `CatalogGraphCard` to allow for custom node & label rendering or kind/relation filtering.

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -65,19 +65,16 @@ export enum Direction {
 }
 
 // @public
-export const EntityCatalogGraphCard: (props: {
-  variant?: InfoCardVariants | undefined;
-  relationPairs?: RelationPairs | undefined;
-  maxDepth?: number | undefined;
-  unidirectional?: boolean | undefined;
-  mergeRelations?: boolean | undefined;
-  kinds?: string[] | undefined;
-  relations?: string[] | undefined;
-  direction?: Direction | undefined;
-  height?: number | undefined;
-  title?: string | undefined;
-  zoom?: 'disabled' | 'enabled' | 'enable-on-click' | undefined;
-}) => JSX.Element;
+export const EntityCatalogGraphCard: (
+  props: Omit<
+    EntityRelationsGraphProps,
+    'className' | 'onNodeClick' | 'rootEntityNames'
+  > & {
+    variant?: InfoCardVariants | undefined;
+    height?: number | undefined;
+    title?: string | undefined;
+  },
+) => JSX.Element;
 
 // @public
 export type EntityEdge = DependencyGraphTypes.DependencyEdge<EntityEdgeData>;
@@ -103,26 +100,27 @@ export type EntityNodeData = {
 };
 
 // @public
-export const EntityRelationsGraph: (props: {
+export const EntityRelationsGraph: (
+  props: EntityRelationsGraphProps,
+) => JSX.Element;
+
+// @public (undocumented)
+export type EntityRelationsGraphProps = {
   rootEntityNames: CompoundEntityRef | CompoundEntityRef[];
-  maxDepth?: number | undefined;
-  unidirectional?: boolean | undefined;
-  mergeRelations?: boolean | undefined;
-  kinds?: string[] | undefined;
-  relations?: string[] | undefined;
-  direction?: Direction | undefined;
-  onNodeClick?:
-    | ((value: EntityNode, event: MouseEvent_2<unknown>) => void)
-    | undefined;
-  relationPairs?: RelationPairs | undefined;
-  className?: string | undefined;
-  zoom?: 'disabled' | 'enabled' | 'enable-on-click' | undefined;
-  renderNode?: DependencyGraphTypes.RenderNodeFunction<EntityNode> | undefined;
-  renderLabel?:
-    | DependencyGraphTypes.RenderLabelFunction<EntityEdge>
-    | undefined;
-  curve?: 'curveStepBefore' | 'curveMonotoneX' | undefined;
-}) => JSX.Element;
+  maxDepth?: number;
+  unidirectional?: boolean;
+  mergeRelations?: boolean;
+  kinds?: string[];
+  relations?: string[];
+  direction?: Direction;
+  onNodeClick?: (value: EntityNode, event: MouseEvent_2<unknown>) => void;
+  relationPairs?: RelationPairs;
+  className?: string;
+  zoom?: 'enabled' | 'disabled' | 'enable-on-click';
+  renderNode?: DependencyGraphTypes.RenderNodeFunction<EntityNode>;
+  renderLabel?: DependencyGraphTypes.RenderLabelFunction<EntityEdge>;
+  curve?: 'curveStepBefore' | 'curveMonotoneX';
+};
 
 // @public
 export type RelationPairs = [string, string][];

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -66,10 +66,7 @@ export enum Direction {
 
 // @public
 export const EntityCatalogGraphCard: (
-  props: Omit<
-    EntityRelationsGraphProps,
-    'className' | 'onNodeClick' | 'rootEntityNames'
-  > & {
+  props: Partial<EntityRelationsGraphProps> & {
     variant?: InfoCardVariants | undefined;
     height?: number | undefined;
     title?: string | undefined;

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -72,6 +72,8 @@ export const CatalogGraphCard = (
     unidirectional = true,
     mergeRelations = true,
     direction = Direction.LEFT_RIGHT,
+    kinds,
+    relations,
     height,
     title = 'Relations',
     zoom = 'enable-on-click',

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -36,8 +36,8 @@ import {
   Direction,
   EntityNode,
   EntityRelationsGraph,
-  RelationPairs,
 } from '../EntityRelationsGraph';
+import { EntityRelationsGraphProps } from '../EntityRelationsGraph/EntityRelationsGraph';
 
 const useStyles = makeStyles<Theme, { height: number | undefined }>(
   {
@@ -55,27 +55,19 @@ const useStyles = makeStyles<Theme, { height: number | undefined }>(
   { name: 'PluginCatalogGraphCatalogGraphCard' },
 );
 
-export const CatalogGraphCard = (props: {
-  variant?: InfoCardVariants;
-  relationPairs?: RelationPairs;
-  maxDepth?: number;
-  unidirectional?: boolean;
-  mergeRelations?: boolean;
-  kinds?: string[];
-  relations?: string[];
-  direction?: Direction;
-  height?: number;
-  title?: string;
-  zoom?: 'enabled' | 'disabled' | 'enable-on-click';
-}) => {
+export const CatalogGraphCard = (
+  props: Omit<EntityRelationsGraphProps, 'rootEntityNames'> & {
+    variant?: InfoCardVariants;
+    height?: number;
+    title?: string;
+  },
+) => {
   const {
     variant = 'gridItem',
     relationPairs = ALL_RELATION_PAIRS,
     maxDepth = 1,
     unidirectional = true,
     mergeRelations = true,
-    kinds,
-    relations,
     direction = Direction.LEFT_RIGHT,
     height,
     title = 'Relations',
@@ -133,12 +125,11 @@ export const CatalogGraphCard = (props: {
       }}
     >
       <EntityRelationsGraph
+        {...props}
         rootEntityNames={entityName}
         maxDepth={maxDepth}
         unidirectional={unidirectional}
         mergeRelations={mergeRelations}
-        kinds={kinds}
-        relations={relations}
         direction={direction}
         onNodeClick={onNodeClick}
         className={classes.graph}

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -132,12 +132,12 @@ export const CatalogGraphCard = (
       <EntityRelationsGraph
         {...props}
         rootEntityNames={entityName}
+        onNodeClick={onNodeClick}
+        className={classes.graph}
         maxDepth={maxDepth}
         unidirectional={unidirectional}
         mergeRelations={mergeRelations}
         direction={direction}
-        onNodeClick={onNodeClick}
-        className={classes.graph}
         relationPairs={relationPairs}
         zoom={zoom}
       />

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -56,7 +56,10 @@ const useStyles = makeStyles<Theme, { height: number | undefined }>(
 );
 
 export const CatalogGraphCard = (
-  props: Omit<EntityRelationsGraphProps, 'rootEntityNames'> & {
+  props: Omit<
+    EntityRelationsGraphProps,
+    'rootEntityNames' | 'onNodeClick' | 'className'
+  > & {
     variant?: InfoCardVariants;
     height?: number;
     title?: string;

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -56,10 +56,7 @@ const useStyles = makeStyles<Theme, { height: number | undefined }>(
 );
 
 export const CatalogGraphCard = (
-  props: Omit<
-    EntityRelationsGraphProps,
-    'rootEntityNames' | 'onNodeClick' | 'className'
-  > & {
+  props: Partial<EntityRelationsGraphProps> & {
     variant?: InfoCardVariants;
     height?: number;
     title?: string;
@@ -75,6 +72,9 @@ export const CatalogGraphCard = (
     kinds,
     relations,
     height,
+    className,
+    rootEntityNames,
+    onNodeClick,
     title = 'Relations',
     zoom = 'enable-on-click',
   } = props;
@@ -87,7 +87,7 @@ export const CatalogGraphCard = (
   const classes = useStyles({ height });
   const analytics = useAnalytics();
 
-  const onNodeClick = useCallback(
+  const defaultOnNodeClick = useCallback(
     (node: EntityNode, _: MouseEvent<unknown>) => {
       const nodeEntityName = parseEntityRef(node.id);
       const path = catalogEntityRoute({
@@ -131,9 +131,9 @@ export const CatalogGraphCard = (
     >
       <EntityRelationsGraph
         {...props}
-        rootEntityNames={entityName}
-        onNodeClick={onNodeClick}
-        className={classes.graph}
+        rootEntityNames={rootEntityNames || entityName}
+        onNodeClick={onNodeClick || defaultOnNodeClick}
+        className={className || classes.graph}
         maxDepth={maxDepth}
         unidirectional={unidirectional}
         mergeRelations={mergeRelations}

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -66,12 +66,7 @@ const useStyles = makeStyles(
   { name: 'PluginCatalogGraphEntityRelationsGraph' },
 );
 
-/**
- * Core building block for custom entity relations diagrams.
- *
- * @public
- */
-export const EntityRelationsGraph = (props: {
+export interface EntityRelationsGraphProps {
   rootEntityNames: CompoundEntityRef | CompoundEntityRef[];
   maxDepth?: number;
   unidirectional?: boolean;
@@ -86,7 +81,14 @@ export const EntityRelationsGraph = (props: {
   renderNode?: DependencyGraphTypes.RenderNodeFunction<EntityNode>;
   renderLabel?: DependencyGraphTypes.RenderLabelFunction<EntityEdge>;
   curve?: 'curveStepBefore' | 'curveMonotoneX';
-}) => {
+}
+
+/**
+ * Core building block for custom entity relations diagrams.
+ *
+ * @public
+ */
+export const EntityRelationsGraph = (props: EntityRelationsGraphProps) => {
   const {
     rootEntityNames,
     maxDepth = 2,

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -66,7 +66,10 @@ const useStyles = makeStyles(
   { name: 'PluginCatalogGraphEntityRelationsGraph' },
 );
 
-export interface EntityRelationsGraphProps {
+/**
+ * @public
+ */
+export type EntityRelationsGraphProps = {
   rootEntityNames: CompoundEntityRef | CompoundEntityRef[];
   maxDepth?: number;
   unidirectional?: boolean;
@@ -81,7 +84,7 @@ export interface EntityRelationsGraphProps {
   renderNode?: DependencyGraphTypes.RenderNodeFunction<EntityNode>;
   renderLabel?: DependencyGraphTypes.RenderLabelFunction<EntityEdge>;
   curve?: 'curveStepBefore' | 'curveMonotoneX';
-}
+};
 
 /**
  * Core building block for custom entity relations diagrams.

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/index.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 export { EntityRelationsGraph } from './EntityRelationsGraph';
+export type { EntityRelationsGraphProps } from './EntityRelationsGraph';
 export { ALL_RELATION_PAIRS } from './relations';
 export type { RelationPairs } from './relations';
 export { Direction } from './types';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the props of the `CatalogGraphCard` to include all props (minus rootEntityNames) from `EntityRelationsGraph`. 
This allows for deeper overriding of the graph, especially with respect to node and label rendering.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
