### PR TITLE
Resolve locations via github annotations rather than entity name

### DIFF
--- a/.changeset/serious-grapes-brush.md
+++ b/.changeset/serious-grapes-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Use github team slug and login annotations rather than entity name to infer location annotations

--- a/plugins/catalog-backend-module-github/src/lib/annotation.ts
+++ b/plugins/catalog-backend-module-github/src/lib/annotation.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The value of this annotation is the so-called login that identifies a user on
+[GitHub](https://github.com)
+ *
+ * @public
+ */
+export const ANNOTATION_GITHUB_USER_LOGIN = 'github.com/user-login';

--- a/plugins/catalog-backend-module-github/src/lib/annotation.ts
+++ b/plugins/catalog-backend-module-github/src/lib/annotation.ts
@@ -21,3 +21,14 @@
  * @public
  */
 export const ANNOTATION_GITHUB_USER_LOGIN = 'github.com/user-login';
+
+/**
+ * The value of this annotation is the so-called slug that identifies a team on
+[GitHub](https://github.com) (either the public one, or a private GitHub
+Enterprise installation) that is related to this entity. It is on the format
+`<organization>/<team>`, and is the same as can be seen in the URL location bar
+of the browser when viewing that team.
+ *
+ * @public
+ */
+export const ANNOTATION_GITHUB_TEAM_SLUG = 'github.com/team-slug';

--- a/plugins/catalog-backend-module-github/src/lib/annotation.ts
+++ b/plugins/catalog-backend-module-github/src/lib/annotation.ts
@@ -16,7 +16,10 @@
 
 /**
  * The value of this annotation is the so-called login that identifies a user on
-[GitHub](https://github.com)
+[GitHub](https://github.com) (either the public one, or a private GitHub
+Enterprise installation) that is related to this entity. It is on the format
+`<username>`, and is the same as can be seen in the URL location bar of the
+browser when viewing that user.
  *
  * @public
  */

--- a/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts
@@ -16,7 +16,10 @@
 
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import { graphql } from '@octokit/graphql';
-import { ANNOTATION_GITHUB_USER_LOGIN } from './annotation';
+import {
+  ANNOTATION_GITHUB_TEAM_SLUG,
+  ANNOTATION_GITHUB_USER_LOGIN,
+} from './annotation';
 import { GithubTeam, GithubUser } from './github';
 
 /**
@@ -88,7 +91,7 @@ export const defaultUserTransformer: UserTransformer = async (
 export const defaultOrganizationTeamTransformer: TeamTransformer =
   async team => {
     const annotations: { [annotationName: string]: string } = {
-      'github.com/team-slug': team.combinedSlug,
+      [ANNOTATION_GITHUB_TEAM_SLUG]: team.combinedSlug,
     };
 
     if (team.editTeamUrl) {

--- a/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts
@@ -16,6 +16,7 @@
 
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import { graphql } from '@octokit/graphql';
+import { ANNOTATION_GITHUB_USER_LOGIN } from './annotation';
 import { GithubTeam, GithubUser } from './github';
 
 /**
@@ -63,7 +64,7 @@ export const defaultUserTransformer: UserTransformer = async (
     metadata: {
       name: item.login,
       annotations: {
-        'github.com/user-login': item.login,
+        [ANNOTATION_GITHUB_USER_LOGIN]: item.login,
       },
     },
     spec: {

--- a/plugins/catalog-backend-module-github/src/lib/util.ts
+++ b/plugins/catalog-backend-module-github/src/lib/util.ts
@@ -88,3 +88,14 @@ export function satisfiesForkFilter(
   // if forks are allowed, allow all repos through
   return true;
 }
+
+// Given the github organisation team slug, returns a tuple containing [organisation, team]
+export function splitTeamSlug(slug: string): [string, string] {
+  const parts = slug.split('/');
+  if (parts.length !== 2) {
+    throw new Error(
+      `Github team slug '${slug}' was not in the expected format <organisation>/<team>`,
+    );
+  }
+  return [parts[0], parts[1]];
+}

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -181,7 +181,10 @@ describe('GithubOrgEntityProvider', () => {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'User',
         metadata: {
-          name: 'githubuser',
+          name: 'user-name',
+          annotations: {
+            'github.com/user-login': 'githubuser',
+          },
         },
         spec: {
           memberOf: [],
@@ -192,12 +195,13 @@ describe('GithubOrgEntityProvider', () => {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'User',
         metadata: {
-          name: 'githubuser',
+          name: 'user-name',
           annotations: {
             'backstage.io/managed-by-location':
               'url:https://github.com/githubuser',
             'backstage.io/managed-by-origin-location':
               'url:https://github.com/githubuser',
+            'github.com/user-login': 'githubuser',
           },
         },
         spec: {
@@ -211,7 +215,10 @@ describe('GithubOrgEntityProvider', () => {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Group',
         metadata: {
-          name: 'mygroup',
+          name: 'group-name',
+          annotations: {
+            'github.com/team-slug': 'backstage/mygroup',
+          },
         },
         spec: {
           type: 'team',
@@ -223,12 +230,13 @@ describe('GithubOrgEntityProvider', () => {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Group',
         metadata: {
-          name: 'mygroup',
+          name: 'group-name',
           annotations: {
             'backstage.io/managed-by-location':
               'url:https://github.com/orgs/backstage/teams/mygroup',
             'backstage.io/managed-by-origin-location':
               'url:https://github.com/orgs/backstage/teams/mygroup',
+            'github.com/team-slug': 'backstage/mygroup',
           },
         },
         spec: {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -65,7 +65,11 @@ import {
   getOrganizationTeam,
   getOrganizationTeamsFromUsers,
 } from '../lib/github';
-import { ANNOTATION_GITHUB_USER_LOGIN } from '../lib/annotation';
+import {
+  ANNOTATION_GITHUB_TEAM_SLUG,
+  ANNOTATION_GITHUB_USER_LOGIN,
+} from '../lib/annotation';
+import { splitTeamSlug } from '../lib/util';
 
 /**
  * Options for {@link GithubOrgEntityProvider}.
@@ -604,11 +608,19 @@ export function withLocations(
   entity: Entity,
 ): Entity {
   const login =
-    entity.metadata.annotations[ANNOTATION_GITHUB_USER_LOGIN] ||
+    entity.metadata.annotations?.[ANNOTATION_GITHUB_USER_LOGIN] ||
     entity.metadata.name;
+
+  let team = entity.metadata.name;
+  const slug = entity.metadata.annotations?.[ANNOTATION_GITHUB_TEAM_SLUG];
+  if (slug) {
+    const [_, slugTeam] = splitTeamSlug(slug);
+    team = slugTeam;
+  }
+
   const location =
     entity.kind === 'Group'
-      ? `url:${baseUrl}/orgs/${org}/teams/${login}`
+      ? `url:${baseUrl}/orgs/${org}/teams/${team}`
       : `url:${baseUrl}/${login}`;
   return merge(
     {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -65,6 +65,7 @@ import {
   getOrganizationTeam,
   getOrganizationTeamsFromUsers,
 } from '../lib/github';
+import { ANNOTATION_GITHUB_USER_LOGIN } from '../lib/annotation';
 
 /**
  * Options for {@link GithubOrgEntityProvider}.
@@ -602,10 +603,13 @@ export function withLocations(
   org: string,
   entity: Entity,
 ): Entity {
+  const login =
+    entity.metadata.annotations[ANNOTATION_GITHUB_USER_LOGIN] ||
+    entity.metadata.name;
   const location =
     entity.kind === 'Group'
-      ? `url:${baseUrl}/orgs/${org}/teams/${entity.metadata.name}`
-      : `url:${baseUrl}/${entity.metadata.name}`;
+      ? `url:${baseUrl}/orgs/${org}/teams/${login}`
+      : `url:${baseUrl}/${login}`;
   return merge(
     {
       metadata: {


### PR DESCRIPTION
Location annotations  (`backstage.io/managed-by-location`, `backstage.io/managed-by-origin-location`) for groups and users ingested from github are currently derived from the `metadata.name` field. This is fine in the case that field equates to github logins and teams for users and groups respectively. However in the case of custom user and group transformers it is possible for `metadata.name` to diverge from those values.

The approach I've used here is to instead rely on the annotations `github.com/user-login` and `github.com/team-slug` which appear to be more reliable as they have well defined semantics as described in [well-known-annotations](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/well-known-annotations.md)

Of course it's entirely possible that the transformers mutate those annotations too but I don't know why they would and it should probably be discouraged.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
