### PR TITLE
feat(search): Don't close dialog on ctrl+click at quick search [Option 1]

### DIFF
--- a/.changeset/neat-buses-type.md
+++ b/.changeset/neat-buses-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Improved usability of quick search when opening items in new tab

--- a/packages/app/src/components/search/SearchModal.tsx
+++ b/packages/app/src/components/search/SearchModal.tsx
@@ -91,15 +91,29 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
     searchBarRef?.current?.focus();
   });
 
-  const handleSearchResultClick = useCallback(() => {
-    toggleModal();
+  const isOpenNewTabOrWindow = (
+    event: React.MouseEvent | React.KeyboardEvent,
+  ): boolean =>
+    // open new tab (linux or windows)
+    event.ctrlKey === true ||
+    // open new wab (macos)
+    event.metaKey === true ||
+    // open new window
+    event.shiftKey === true ||
+    // open new tab (middle/wheel click)
+    ('button' in event ? event.button === 1 : false);
+
+  const handleSearchResultClick = useCallback((event) => {
+    if (!isOpenNewTabOrWindow(event)) {
+      toggleModal();
+    }
     setTimeout(focusContent, transitions.duration.leavingScreen);
   }, [toggleModal, focusContent, transitions]);
 
   const handleSearchBarKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (e.key === 'Enter') {
-        handleSearchResultClick();
+        handleSearchResultClick(e);
         navigate(searchPagePath);
       }
     },

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -39,6 +39,7 @@ import {
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { Link, useContent } from '@backstage/core-components';
 import { rootRouteRef } from '../../plugin';
+import { isOpenNewTabOrWindow } from '../util';
 
 /**
  * @public
@@ -106,8 +107,10 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
     searchBarRef?.current?.focus();
   });
 
-  const handleSearchResultClick = useCallback(() => {
-    toggleModal();
+  const handleSearchResultClick = useCallback((event) => {
+    if (!isOpenNewTabOrWindow(event)) {
+      toggleModal();
+    }
     setTimeout(focusContent, transitions.duration.leavingScreen);
   }, [toggleModal, focusContent, transitions]);
 
@@ -115,7 +118,7 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
     (e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (e.key === 'Enter') {
         navigate(searchPagePath);
-        handleSearchResultClick();
+        handleSearchResultClick(e);
       }
     },
     [navigate, handleSearchResultClick, searchPagePath],

--- a/plugins/search/src/components/util.ts
+++ b/plugins/search/src/components/util.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import qs from 'qs';
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { rootRouteRef } from '../plugin';
 
@@ -32,3 +32,15 @@ export const useNavigateToQuery = () => {
     [navigate, searchRoute],
   );
 };
+
+export const isOpenNewTabOrWindow = (
+  event: React.MouseEvent | React.KeyboardEvent,
+): boolean =>
+  // open new tab (linux or windows)
+  event.ctrlKey === true ||
+  // open new wab (macos)
+  event.metaKey === true ||
+  // open new window
+  event.shiftKey === true ||
+  // open new tab (middle/wheel click)
+  ('button' in event ? event.button === 1 : false);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This draft is a proposal for https://github.com/backstage/backstage/issues/14903. A suggestion to improve user experience while using quick search. The other option is [here](https://github.com/backstage/backstage/pull/16137).

After opening quick search, if you need to go though multiple results by clicking <kbd>ctrl</kbd>/<kbd>cmd</kbd> + click to open new tabs, the quick search dialogs closes.

With this it is kept open, so you can go through the other results without having to open the quick search again:
![204536959-f3009750-0dc4-48d0-9f0c-da2d1d3ee9c3](https://user-images.githubusercontent.com/187639/216306554-66337d46-fe62-4879-ad09-b813a6698c54.gif)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
