### PR TITLE
feat(search): Don't close dialog on ctrl+click at quick search [Option 2]

### DIFF
--- a/.changeset/unlucky-snakes-smile.md
+++ b/.changeset/unlucky-snakes-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': minor
+---
+
+Search modal auto closes on location change

--- a/packages/app/src/components/search/SearchModal.tsx
+++ b/packages/app/src/components/search/SearchModal.tsx
@@ -186,7 +186,7 @@ export const SearchModal = ({ toggleModal }: { toggleModal: () => void }) => {
             </Grid>
           </Grid>
           <Grid item xs>
-            <SearchResult onClick={toggleModal}>
+            <SearchResult>
               <CatalogSearchResultListItem icon={<CatalogIcon />} />
               <TechDocsSearchResultListItem icon={<DocsIcon />} />
               <ToolSearchResultListItem icon={<BuildIcon />} />

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -67,6 +67,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "^16.11.26",
     "cross-fetch": "^3.1.5",
+    "history": "^5.0.0",
     "msw": "^1.0.0"
   },
   "files": [

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -92,7 +92,7 @@ const useStyles = makeStyles(theme => ({
   viewResultsLink: { verticalAlign: '0.5em' },
 }));
 
-export const Modal = ({ toggleModal }: SearchModalProps) => {
+export const Modal = () => {
   const classes = useStyles();
   const navigate = useNavigate();
   const { transitions } = useTheme();
@@ -107,9 +107,8 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
   });
 
   const handleSearchResultClick = useCallback(() => {
-    toggleModal();
     setTimeout(focusContent, transitions.duration.leavingScreen);
-  }, [toggleModal, focusContent, transitions]);
+  }, [focusContent, transitions]);
 
   const handleSearchBarKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -188,7 +187,7 @@ export const SearchModal = (props: SearchModalProps) => {
       {open && (
         <SearchContextProvider inheritParentContextIfAvailable>
           {(children && children({ toggleModal })) ?? (
-            <Modal toggleModal={toggleModal} />
+            <Modal />
           )}
         </SearchContextProvider>
       )}

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -186,9 +186,7 @@ export const SearchModal = (props: SearchModalProps) => {
     >
       {open && (
         <SearchContextProvider inheritParentContextIfAvailable>
-          {(children && children({ toggleModal })) ?? (
-            <Modal />
-          )}
+          {(children && children({ toggleModal })) ?? <Modal />}
         </SearchContextProvider>
       )}
     </Dialog>

--- a/plugins/search/src/components/SearchModal/useSearchModal.test.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.test.tsx
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import React from 'react';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { useSearchModal } from './useSearchModal';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 describe('useSearchModal', () => {
   it.each([
@@ -78,5 +79,22 @@ describe('useSearchModal', () => {
       open: true,
       hidden: true,
     });
+  });
+
+  it('should hide when location changes', () => {
+    const history = createMemoryHistory({ initialEntries: ['/'] });
+
+    const rendered = renderHook(() => useSearchModal(true), {
+      wrapper: ({ children }) => (
+        <Router location={history.location} navigator={history}>
+          {children}
+        </Router>
+      ),
+    });
+
+    expect(rendered.result.current.state.hidden).toBe(false);
+    act(() => history.push('/new/path'));
+    rendered.rerender();
+    expect(rendered.result.current.state.hidden).toBe(true);
   });
 });

--- a/plugins/search/src/components/SearchModal/useSearchModal.test.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.test.tsx
@@ -16,6 +16,7 @@
 
 import { act, renderHook } from '@testing-library/react-hooks';
 import { useSearchModal } from './useSearchModal';
+import { BrowserRouter } from 'react-router-dom';
 
 describe('useSearchModal', () => {
   it.each([
@@ -24,14 +25,18 @@ describe('useSearchModal', () => {
   ])(
     'should return the correct state when initial state is %s',
     (initialState, result) => {
-      const rendered = renderHook(() => useSearchModal(initialState));
+      const rendered = renderHook(() => useSearchModal(initialState), {
+        wrapper: BrowserRouter,
+      });
 
       expect(rendered.result.current.state).toEqual(result);
     },
   );
 
   it('should keep open forever to true once modal is toggled', () => {
-    const rendered = renderHook(() => useSearchModal());
+    const rendered = renderHook(() => useSearchModal(), {
+      wrapper: BrowserRouter,
+    });
     act(() => rendered.result.current.toggleModal());
 
     expect(rendered.result.current.state).toEqual({
@@ -47,7 +52,9 @@ describe('useSearchModal', () => {
   });
 
   it('should keep open to false if setOpen(false) is invoked on an initially closed modal', () => {
-    const rendered = renderHook(() => useSearchModal());
+    const rendered = renderHook(() => useSearchModal(), {
+      wrapper: BrowserRouter,
+    });
     act(() => rendered.result.current.setOpen(false));
     expect(rendered.result.current.state).toEqual({
       open: false,
@@ -56,7 +63,9 @@ describe('useSearchModal', () => {
   });
 
   it('should keep open forever to true even when the modal transition from opened to closed', () => {
-    const rendered = renderHook(() => useSearchModal());
+    const rendered = renderHook(() => useSearchModal(), {
+      wrapper: BrowserRouter,
+    });
 
     act(() => rendered.result.current.setOpen(true));
     expect(rendered.result.current.state).toEqual({

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import React, {
-  ReactNode,
-  useCallback,
-  useContext,
-  useState,
-  useEffect,
-} from 'react';
+import React, { ReactNode, useCallback, useContext, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   createVersionedContext,

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -26,6 +26,7 @@ import {
   createVersionedContext,
   createVersionedValueMap,
 } from '@backstage/version-bridge';
+import { useUpdateEffect } from 'react-use';
 
 /**
  * The state of the search modal, as well as functions for changing the modal's
@@ -143,22 +144,12 @@ export function useSearchModal(initialState = false) {
 
   // Monitor route pathname changes to automatically hide the modal.
   const { pathname } = useLocation();
-  const [openedPathname, setOpenedPathname] = useState<string | null>(null);
-  const { open, hidden } = state;
-  const isModalOpened = !isParentContextPresent && open && !hidden;
-  useEffect(() => {
-    if (isModalOpened) {
-      setOpenedPathname(pathname);
-    }
-  }, [isModalOpened, pathname]);
-  useEffect(() => {
-    if (isModalOpened && openedPathname && openedPathname !== pathname) {
-      setState(prevState => ({
-        open: prevState.open,
-        hidden: true,
-      }));
-    }
-  }, [isModalOpened, openedPathname, pathname]);
+  useUpdateEffect(() => {
+    setState(prevState => ({
+      open: prevState.open,
+      hidden: true,
+    }));
+  }, [pathname]);
 
   // Inherit from parent context, if set.
   return isParentContextPresent

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -20,7 +20,7 @@ import {
   createVersionedContext,
   createVersionedValueMap,
 } from '@backstage/version-bridge';
-import { useUpdateEffect } from 'react-use';
+import useUpdateEffect from 'react-use/lib/useUpdateEffect';
 
 /**
  * The state of the search modal, as well as functions for changing the modal's
@@ -136,14 +136,15 @@ export function useSearchModal(initialState = false) {
   const parentContextValue = parentContext?.atVersion(1);
   const isParentContextPresent = !!parentContextValue?.state;
 
-  // Monitor route pathname changes to automatically hide the modal.
-  const { pathname } = useLocation();
+  // Monitor route changes to automatically hide the modal.
+  const location = useLocation();
+  const locationKey = `${location.pathname}${location.search}${location.hash}`;
   useUpdateEffect(() => {
     setState(prevState => ({
       open: prevState.open,
       hidden: true,
     }));
-  }, [pathname]);
+  }, [locationKey]);
 
   // Inherit from parent context, if set.
   return isParentContextPresent

--- a/yarn.lock
+++ b/yarn.lock
@@ -8450,6 +8450,7 @@ __metadata:
     "@types/node": ^16.11.26
     "@types/react": ^16.13.1 || ^17.0.0
     cross-fetch: ^3.1.5
+    history: ^5.0.0
     msw: ^1.0.0
     qs: ^6.9.4
     react-use: ^17.2.4


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This draft is a proposal for https://github.com/backstage/backstage/issues/14903. A suggestion to improve user experience while using quick search. The other option is [here](https://github.com/backstage/backstage/pull/16136).


After opening quick search, if you need to go though multiple results by clicking <kbd>ctrl</kbd>/<kbd>cmd</kbd> + click to open new tabs, the quick search dialogs closes.

With this it is kept open, so you can go through the other results without having to open the quick search again:
![204536959-f3009750-0dc4-48d0-9f0c-da2d1d3ee9c3](https://user-images.githubusercontent.com/187639/216306554-66337d46-fe62-4879-ad09-b813a6698c54.gif)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
