### PR TITLE
Make create button more accurate

### DIFF
--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -82,7 +82,7 @@ export const catalogPlugin = createPlugin({
     options?: CatalogInputPluginOptions,
   ): CatalogPluginOptions {
     const defaultOptions = {
-      createButtonTitle: 'Create',
+      createButtonTitle: 'Create component',
     };
     return { ...defaultOptions, ...options };
   },


### PR DESCRIPTION
The create button on the catalog page also shows when filtering for users and groups. It's not possible to create users or groups, so the button can be misleading.

| Before | After | 
| --- | --- |
| <img width="1675" alt="Screenshot 2023-02-02 at 11 29 22" src="https://user-images.githubusercontent.com/11618797/216315050-0d157a14-e98d-48d9-b2b4-435cd6beb419.png"> | <img width="1685" alt="Screenshot 2023-02-02 at 11 29 43" src="https://user-images.githubusercontent.com/11618797/216315065-149560ae-d5a2-4dfc-8099-4046d7b8aa20.png"> |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
