### PR TITLE
feat(PagerDuty plugin improvement): expose 'readOnly' configuration option to PagerDuty plugin

### DIFF
--- a/.changeset/rich-bags-sleep.md
+++ b/.changeset/rich-bags-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-pagerduty': patch
+---
+
+The PagerDutyCard now supports an optional `readOnly` property (`<PagerDutyCard readOnly />`) for the suppressing the rendering of the "Create Incident" button from the Backstage UI.

--- a/.changeset/rich-bags-sleep.md
+++ b/.changeset/rich-bags-sleep.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-pagerduty': patch
 ---
 
-The PagerDutyCard now supports an optional `readOnly` property (`<PagerDutyCard readOnly />`) for the suppressing the rendering of the "Create Incident" button from the Backstage UI.
+The PagerDutyCard now supports an optional `readOnly` property (`<PagerDutyCard readOnly />`) for suppressing the rendering of the "Create Incident" button from the Backstage UI.

--- a/plugins/pagerduty/README.md
+++ b/plugins/pagerduty/README.md
@@ -6,7 +6,7 @@
 # How it Works
 
 - The Backstage PagerDuty plugin allows PagerDuty information about a Backstage entity to be displayed within Backstage. This includes active incidents, recent change events, as well as the current on-call responders' names, email addresses, and links to their profiles in PagerDuty.
-- Incidents can be manually triggered via the plugin with a user-provided description, which will in turn notify the current on-call responders.
+- Incidents can be manually triggered via the plugin with a user-provided description, which will in turn notify the current on-call responders (Alternatively, the plugin can be configured with an optional `readOnly` property to suppress the ability to trigger incidents from the plugin).
   - _Note: This feature is only available when providing the `pagerduty.com/integration-key` annotation_
 - Change events will be displayed in a separate tab. If the change event payload has additional links the first link only will be rendered.
 
@@ -143,6 +143,24 @@ If you want to override the default URL used for events, you can add it to `app-
 ```yaml
 pagerduty:
   eventsBaseUrl: 'https://events.pagerduty.com/v2'
+```
+
+To suppress the rendering of the actionable incident-creation button, the `PagerDutyCard` can also be instantiated in `readOnly` mode:
+
+```ts
+<PagerDuty readOnly />
+```
+
+**WARNING**: In current implementation, the PagerDuty plugin requires the `/pagerduty` proxy endpoint be exposed by the Backstage backend as an unprotected endpoint, in effect enabling PagerDuty API access using the configured `PAGERDUTY_TOKEN` for any user or process with access to the `/pagerduty` Backstage backend endpoint. If you regard this as problematic, consider using the plugin in `readOnly` mode (`<PagerDutyCard readOnly />`) using the following proxy configuration:
+
+```yaml
+proxy:
+  '/pagerduty':
+    target: https://api.pagerduty.com
+    headers:
+      Authorization: Token token=${PAGERDUTY_TOKEN}
+    # prohibit the `/pagerduty` proxy endpoint from servicing non-GET requests
+    allowedMethods: ['GET']
 ```
 
 # How to Uninstall

--- a/plugins/pagerduty/api-report.md
+++ b/plugins/pagerduty/api-report.md
@@ -13,8 +13,6 @@ import { Entity } from '@backstage/catalog-model';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { ReactNode } from 'react';
 
-// Warning: (ae-forgotten-export) The symbol "PagerDutyCardProps" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export const EntityPagerDutyCard: (props: PagerDutyCardProps) => JSX.Element;
 
@@ -48,6 +46,11 @@ export type PagerDutyAssignee = {
 
 // @public (undocumented)
 export const PagerDutyCard: (props: PagerDutyCardProps) => JSX.Element;
+
+// @public (undocumented)
+export type PagerDutyCardProps = {
+  readOnly?: boolean;
+};
 
 // @public (undocumented)
 export type PagerDutyChangeEvent = {

--- a/plugins/pagerduty/api-report.md
+++ b/plugins/pagerduty/api-report.md
@@ -13,8 +13,10 @@ import { Entity } from '@backstage/catalog-model';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { ReactNode } from 'react';
 
+// Warning: (ae-forgotten-export) The symbol "PagerDutyCardProps" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export const EntityPagerDutyCard: () => JSX.Element;
+export const EntityPagerDutyCard: (props: PagerDutyCardProps) => JSX.Element;
 
 // @public (undocumented)
 const isPluginApplicableToEntity: (entity: Entity) => boolean;
@@ -45,7 +47,7 @@ export type PagerDutyAssignee = {
 };
 
 // @public (undocumented)
-export const PagerDutyCard: () => JSX.Element;
+export const PagerDutyCard: (props: PagerDutyCardProps) => JSX.Element;
 
 // @public (undocumented)
 export type PagerDutyChangeEvent = {

--- a/plugins/pagerduty/src/components/PagerDutyCard/index.test.tsx
+++ b/plugins/pagerduty/src/components/PagerDutyCard/index.test.tsx
@@ -356,4 +356,27 @@ describe('PageDutyCard', () => {
       expect(getByText('Empty escalation policy')).toBeInTheDocument();
     });
   });
+
+  describe('when entity has all annotations but the plugin has been configured to be "read only"', () => {
+    it('queries by integration key but does not render the "Create Incident" button', async () => {
+      mockPagerDutyApi.getServiceByEntity = jest
+        .fn()
+        .mockImplementationOnce(async () => ({ service }));
+
+      const { getByText, queryByTestId } = render(
+        wrapInTestApp(
+          <ApiProvider apis={apis}>
+            <EntityProvider entity={entityWithAllAnnotations}>
+              <PagerDutyCard readOnly />
+            </EntityProvider>
+          </ApiProvider>,
+        ),
+      );
+      await waitFor(() => !queryByTestId('progress'));
+      expect(getByText('Service Directory')).toBeInTheDocument();
+      expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
+      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(() => getByText('Create Incident')).toThrow();
+    });
+  });
 });

--- a/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
+++ b/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
@@ -54,7 +54,13 @@ export const isPluginApplicableToEntity = (entity: Entity) =>
   );
 
 /** @public */
-export const PagerDutyCard = () => {
+export type PagerDutyCardProps = {
+  readOnly?: boolean;
+};
+
+/** @public */
+export const PagerDutyCard = (props: PagerDutyCardProps) => {
+  const { readOnly } = props;
   const { entity } = useEntity();
   const pagerDutyEntity = getPagerDutyEntity(entity);
   const api = useApi(pagerDutyApiRef);
@@ -156,7 +162,11 @@ export const PagerDutyCard = () => {
           title="PagerDuty"
           subheader={
             <HeaderIconLinkRow
-              links={[serviceLink, triggerLink, escalationPolicyLink]}
+              links={
+                !readOnly
+                  ? [serviceLink, triggerLink, escalationPolicyLink]
+                  : [serviceLink, escalationPolicyLink]
+              }
             />
           }
         />

--- a/plugins/pagerduty/src/components/index.ts
+++ b/plugins/pagerduty/src/components/index.ts
@@ -23,6 +23,8 @@ export type {
   PagerDutyUser,
 } from './types';
 
+export type { PagerDutyCardProps } from './PagerDutyCard';
+
 export {
   isPluginApplicableToEntity,
   isPluginApplicableToEntity as isPagerDutyAvailable,


### PR DESCRIPTION
This PR adds a `readOnly` property to the `PagerDutyCard` component to address issue #16147.

By default, the plugin continues to display a "Create Incident" link (assuming all the required entity annotations are in place): 

![pd1](https://user-images.githubusercontent.com/184109/216448067-b1890a98-14a5-4be9-874b-f3f1fe95a94b.png)

However, when `readOnly` is configured (`<PagerDutyCard readOnly />`), the plugin does not render the "Create Incident" link:

![pd1_readOnly](https://user-images.githubusercontent.com/184109/216447781-d753e913-0702-49d1-b0b3-549ca5288cc2.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
