### PR TITLE
chore: use the maintainers group for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,14 +8,14 @@
 yarn.lock                                           @backstage/maintainers @backstage-service
 */yarn.lock                                         @backstage/maintainers @backstage-service
 /.changeset/cost-insights-*                         @backstage/maintainers @backstage/silver-lining
-/.changeset                                         @backstage/maintainers @backstage/techdocs-core
-/cypress/src/integration/plugins/techdocs.spec.ts   @backstage/maintainers @backstage/techdocs-core
-/docs/assets/search                                 @backstage/maintainers @backstage/techdocs-core
-/docs/features/search                               @backstage/maintainers @backstage/techdocs-core
-/docs/features/techdocs                             @backstage/maintainers @backstage/techdocs-core
-/docs/plugins/integrating-search-into-plugins.md    @backstage/maintainers @backstage/techdocs-core
-/packages/techdocs-cli                              @backstage/maintainers @backstage/techdocs-core
-/packages/techdocs-cli-embedded-app                 @backstage/maintainers @backstage/techdocs-core
+/.changeset                                         @backstage/owners
+/cypress/src/integration/plugins/techdocs.spec.ts   @backstage/techdocs-core
+/docs/assets/search                                 @backstage/techdocs-core
+/docs/features/search                               @backstage/techdocs-core
+/docs/features/techdocs                             @backstage/techdocs-core
+/docs/plugins/integrating-search-into-plugins.md    @backstage/techdocs-core
+/packages/techdocs-cli                              @backstage/techdocs-core
+/packages/techdocs-cli-embedded-app                 @backstage/techdocs-core
 /plugins/adr                                        @backstage/maintainers @kuangp
 /plugins/adr-*                                      @backstage/maintainers @kuangp
 /plugins/allure                                     @backstage/maintainers @deepak-bhardwaj-ps
@@ -52,7 +52,7 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/fossa                                      @backstage/maintainers @backstage/sda-se-reviewers
 /plugins/gcalendar                                  @backstage/maintainers @szubster @ptychu @kielosz @alexrybch
 /plugins/git-release-manager                        @backstage/maintainers @erikengervall
-/plugins/home                                       @backstage/maintainers @backstage/techdocs-core
+/plugins/home                                       @backstage/techdocs-core
 /plugins/ilert                                      @backstage/maintainers @yacut
 /plugins/jenkins                                    @backstage/maintainers @timja
 /plugins/jenkins-backend                            @backstage/maintainers @timja
@@ -67,13 +67,13 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/rollbar-backend                            @backstage/maintainers @andrewthauer
 /plugins/scaffolder-backend-module-rails            @backstage/maintainers @angeliski
 /plugins/scaffolder-backend-module-yeoman           @backstage/maintainers @pawelmitka
-/plugins/search                                     @backstage/maintainers @backstage/techdocs-core
-/plugins/search-*                                   @backstage/maintainers @backstage/techdocs-core
+/plugins/search                                     @backstage/techdocs-core
+/plugins/search-*                                   @backstage/techdocs-core
 /plugins/sonarqube                                  @backstage/maintainers @backstage/sda-se-reviewers
-/plugins/stack-overflow                             @backstage/maintainers @backstage/techdocs-core
-/plugins/stack-overflow-backend                     @backstage/maintainers @backstage/techdocs-core
-/plugins/techdocs                                   @backstage/maintainers @backstage/techdocs-core
-/plugins/techdocs-*                                 @backstage/maintainers @backstage/techdocs-core
+/plugins/stack-overflow                             @backstage/techdocs-core
+/plugins/stack-overflow-backend                     @backstage/techdocs-core
+/plugins/techdocs                                   @backstage/techdocs-core
+/plugins/techdocs-*                                 @backstage/techdocs-core
 /plugins/user-settings-backend                      @backstage/maintainers @backstage/sda-se-reviewers
 /tech-insights-backend                              @backstage/maintainers @xantier @iain-b
 /tech-insights-backend-module-jsonfc                @backstage/maintainers @xantier @iain-b

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,8 +35,8 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/cloudbuild                                 @backstage/maintainers @trivago/ebarrios
 /plugins/code-coverage                              @backstage/maintainers @alde @nissayeva
 /plugins/code-coverage-backend                      @backstage/maintainers @alde @nissayeva
-/plugins/cost-insights                              @backstage/silver-lining
-/plugins/cost-insights-*                            @backstage/silver-lining
+/plugins/cost-insights                              @backstage/maintainers @backstage/silver-lining
+/plugins/cost-insights-*                            @backstage/maintainers @backstage/silver-lining
 /plugins/events-backend                             @backstage/maintainers @pjungermann
 /plugins/events-backend-module-aws-sqs              @backstage/maintainers @pjungermann
 /plugins/events-backend-module-azure                @backstage/maintainers @pjungermann

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,8 +35,8 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/cloudbuild                                 @backstage/maintainers @trivago/ebarrios
 /plugins/code-coverage                              @backstage/maintainers @alde @nissayeva
 /plugins/code-coverage-backend                      @backstage/maintainers @alde @nissayeva
-/plugins/cost-insights                              @backstage/maintainers @backstage/silver-lining
-/plugins/cost-insights-*                            @backstage/maintainers @backstage/silver-lining
+/plugins/cost-insights                              @backstage/silver-lining
+/plugins/cost-insights-*                            @backstage/silver-lining
 /plugins/events-backend                             @backstage/maintainers @pjungermann
 /plugins/events-backend-module-aws-sqs              @backstage/maintainers @pjungermann
 /plugins/events-backend-module-azure                @backstage/maintainers @pjungermann

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 *                                                   @backstage/maintainers
 yarn.lock                                           @backstage/maintainers @backstage-service
 */yarn.lock                                         @backstage/maintainers @backstage-service
-/.changeset                                        
+/.changeset/*.md                                        
 /cypress/src/integration/plugins/techdocs.spec.ts   @backstage/techdocs-core
 /docs/assets/search                                 @backstage/techdocs-core
 /docs/features/search                               @backstage/techdocs-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,78 +4,78 @@
 # The last matching pattern takes precedence.
 # https://help.github.com/articles/about-codeowners/
 
-*                                                   @backstage/reviewers
-yarn.lock                                           @backstage/reviewers @backstage-service
-*/yarn.lock                                         @backstage/reviewers @backstage-service
-/.changeset/cost-insights-*                         @backstage/reviewers @backstage/silver-lining
-/.changeset                                         @backstage/reviewers @backstage/techdocs-core
-/cypress/src/integration/plugins/techdocs.spec.ts   @backstage/reviewers @backstage/techdocs-core
-/docs/assets/search                                 @backstage/reviewers @backstage/techdocs-core
-/docs/features/search                               @backstage/reviewers @backstage/techdocs-core
-/docs/features/techdocs                             @backstage/reviewers @backstage/techdocs-core
-/docs/plugins/integrating-search-into-plugins.md    @backstage/reviewers @backstage/techdocs-core
-/packages/techdocs-cli                              @backstage/reviewers @backstage/techdocs-core
-/packages/techdocs-cli-embedded-app                 @backstage/reviewers @backstage/techdocs-core
-/plugins/adr                                        @backstage/reviewers @kuangp
-/plugins/adr-*                                      @backstage/reviewers @kuangp
-/plugins/allure                                     @backstage/reviewers @deepak-bhardwaj-ps
-/plugins/apache-airflow                             @backstage/reviewers @cmpadden
-/plugins/api-docs                                   @backstage/reviewers @backstage/sda-se-reviewers
-/plugins/azure-devops                               @backstage/reviewers @marleypowell @awanlin
-/plugins/azure-devops-backend                       @backstage/reviewers @marleypowell @awanlin
-/plugins/azure-devops-common                        @backstage/reviewers @marleypowell @awanlin
-/plugins/bitbucket-cloud-common                     @backstage/reviewers @pjungermann
-/plugins/bitrise                                    @backstage/reviewers @backstage/sda-se-reviewers
-/plugins/catalog                                    @backstage/reviewers @backstage/catalog-core
-/plugins/catalog-*                                  @backstage/reviewers @backstage/catalog-core
-/plugins/catalog-backend-module-aws                 @backstage/reviewers @backstage/catalog-core @pjungermann
-/plugins/catalog-backend-module-bitbucket-cloud     @backstage/reviewers @backstage/catalog-core @pjungermann
-/plugins/catalog-backend-module-msgraph             @backstage/reviewers @backstage/catalog-core @pjungermann
-/plugins/catalog-graph                              @backstage/reviewers @backstage/catalog-core @backstage/sda-se-reviewers
-/plugins/circleci                                   @backstage/reviewers @adamdmharvey
-/plugins/cloudbuild                                 @backstage/reviewers @trivago/ebarrios
-/plugins/code-coverage                              @backstage/reviewers @alde @nissayeva
-/plugins/code-coverage-backend                      @backstage/reviewers @alde @nissayeva
-/plugins/cost-insights                              @backstage/reviewers @backstage/silver-lining
-/plugins/cost-insights-*                            @backstage/reviewers @backstage/silver-lining
-/plugins/events-backend                             @backstage/reviewers @pjungermann
-/plugins/events-backend-module-aws-sqs              @backstage/reviewers @pjungermann
-/plugins/events-backend-module-azure                @backstage/reviewers @pjungermann
-/plugins/events-backend-module-bitbucket-cloud      @backstage/reviewers @pjungermann
-/plugins/events-backend-module-gerrit               @backstage/reviewers @pjungermann
-/plugins/events-backend-module-github               @backstage/reviewers @pjungermann
-/plugins/events-backend-module-gitlab               @backstage/reviewers @pjungermann
-/plugins/events-backend-test-utils                  @backstage/reviewers @pjungermann
-/plugins/events-node                                @backstage/reviewers @pjungermann
-/plugins/explore                                    @backstage/reviewers @backstage/sda-se-reviewers
-/plugins/explore-react                              @backstage/reviewers @backstage/sda-se-reviewers
-/plugins/fossa                                      @backstage/reviewers @backstage/sda-se-reviewers
-/plugins/gcalendar                                  @backstage/reviewers @szubster @ptychu @kielosz @alexrybch
-/plugins/git-release-manager                        @backstage/reviewers @erikengervall
-/plugins/home                                       @backstage/reviewers @backstage/techdocs-core
-/plugins/ilert                                      @backstage/reviewers @yacut
-/plugins/jenkins                                    @backstage/reviewers @timja
-/plugins/jenkins-backend                            @backstage/reviewers @timja
-/plugins/kafka                                      @backstage/reviewers @nirga @andrewthauer
-/plugins/kafka-backend                              @backstage/reviewers @nirga @andrewthauer
-/plugins/kubernetes                                 @backstage/reviewers @backstage/warpspeed
-/plugins/kubernetes-*                               @backstage/reviewers @backstage/warpspeed
-/plugins/newrelic-dashboard                         @backstage/reviewers @mufaddal7
-/plugins/playlist                                   @backstage/reviewers @kuangp
-/plugins/playlist-*                                 @backstage/reviewers @kuangp
-/plugins/rollbar                                    @backstage/reviewers @andrewthauer
-/plugins/rollbar-backend                            @backstage/reviewers @andrewthauer
-/plugins/scaffolder-backend-module-rails            @backstage/reviewers @angeliski
-/plugins/scaffolder-backend-module-yeoman           @backstage/reviewers @pawelmitka
-/plugins/search                                     @backstage/reviewers @backstage/techdocs-core
-/plugins/search-*                                   @backstage/reviewers @backstage/techdocs-core
-/plugins/sonarqube                                  @backstage/reviewers @backstage/sda-se-reviewers
-/plugins/stack-overflow                             @backstage/reviewers @backstage/techdocs-core
-/plugins/stack-overflow-backend                     @backstage/reviewers @backstage/techdocs-core
-/plugins/techdocs                                   @backstage/reviewers @backstage/techdocs-core
-/plugins/techdocs-*                                 @backstage/reviewers @backstage/techdocs-core
-/plugins/user-settings-backend                      @backstage/reviewers @backstage/sda-se-reviewers
-/tech-insights-backend                              @backstage/reviewers @xantier @iain-b
-/tech-insights-backend-module-jsonfc                @backstage/reviewers @xantier @iain-b
-/tech-insights-tech-insights-common                 @backstage/reviewers @xantier @iain-b
-/tech-insights-tech-insights-node                   @backstage/reviewers @xantier @iain-b
+*                                                   @backstage/maintainers
+yarn.lock                                           @backstage/maintainers @backstage-service
+*/yarn.lock                                         @backstage/maintainers @backstage-service
+/.changeset/cost-insights-*                         @backstage/maintainers @backstage/silver-lining
+/.changeset                                         @backstage/maintainers @backstage/techdocs-core
+/cypress/src/integration/plugins/techdocs.spec.ts   @backstage/maintainers @backstage/techdocs-core
+/docs/assets/search                                 @backstage/maintainers @backstage/techdocs-core
+/docs/features/search                               @backstage/maintainers @backstage/techdocs-core
+/docs/features/techdocs                             @backstage/maintainers @backstage/techdocs-core
+/docs/plugins/integrating-search-into-plugins.md    @backstage/maintainers @backstage/techdocs-core
+/packages/techdocs-cli                              @backstage/maintainers @backstage/techdocs-core
+/packages/techdocs-cli-embedded-app                 @backstage/maintainers @backstage/techdocs-core
+/plugins/adr                                        @backstage/maintainers @kuangp
+/plugins/adr-*                                      @backstage/maintainers @kuangp
+/plugins/allure                                     @backstage/maintainers @deepak-bhardwaj-ps
+/plugins/apache-airflow                             @backstage/maintainers @cmpadden
+/plugins/api-docs                                   @backstage/maintainers @backstage/sda-se-reviewers
+/plugins/azure-devops                               @backstage/maintainers @marleypowell @awanlin
+/plugins/azure-devops-backend                       @backstage/maintainers @marleypowell @awanlin
+/plugins/azure-devops-common                        @backstage/maintainers @marleypowell @awanlin
+/plugins/bitbucket-cloud-common                     @backstage/maintainers @pjungermann
+/plugins/bitrise                                    @backstage/maintainers @backstage/sda-se-reviewers
+/plugins/catalog                                    @backstage/maintainers @backstage/catalog-core
+/plugins/catalog-*                                  @backstage/maintainers @backstage/catalog-core
+/plugins/catalog-backend-module-aws                 @backstage/maintainers @backstage/catalog-core @pjungermann
+/plugins/catalog-backend-module-bitbucket-cloud     @backstage/maintainers @backstage/catalog-core @pjungermann
+/plugins/catalog-backend-module-msgraph             @backstage/maintainers @backstage/catalog-core @pjungermann
+/plugins/catalog-graph                              @backstage/maintainers @backstage/catalog-core @backstage/sda-se-reviewers
+/plugins/circleci                                   @backstage/maintainers @adamdmharvey
+/plugins/cloudbuild                                 @backstage/maintainers @trivago/ebarrios
+/plugins/code-coverage                              @backstage/maintainers @alde @nissayeva
+/plugins/code-coverage-backend                      @backstage/maintainers @alde @nissayeva
+/plugins/cost-insights                              @backstage/maintainers @backstage/silver-lining
+/plugins/cost-insights-*                            @backstage/maintainers @backstage/silver-lining
+/plugins/events-backend                             @backstage/maintainers @pjungermann
+/plugins/events-backend-module-aws-sqs              @backstage/maintainers @pjungermann
+/plugins/events-backend-module-azure                @backstage/maintainers @pjungermann
+/plugins/events-backend-module-bitbucket-cloud      @backstage/maintainers @pjungermann
+/plugins/events-backend-module-gerrit               @backstage/maintainers @pjungermann
+/plugins/events-backend-module-github               @backstage/maintainers @pjungermann
+/plugins/events-backend-module-gitlab               @backstage/maintainers @pjungermann
+/plugins/events-backend-test-utils                  @backstage/maintainers @pjungermann
+/plugins/events-node                                @backstage/maintainers @pjungermann
+/plugins/explore                                    @backstage/maintainers @backstage/sda-se-reviewers
+/plugins/explore-react                              @backstage/maintainers @backstage/sda-se-reviewers
+/plugins/fossa                                      @backstage/maintainers @backstage/sda-se-reviewers
+/plugins/gcalendar                                  @backstage/maintainers @szubster @ptychu @kielosz @alexrybch
+/plugins/git-release-manager                        @backstage/maintainers @erikengervall
+/plugins/home                                       @backstage/maintainers @backstage/techdocs-core
+/plugins/ilert                                      @backstage/maintainers @yacut
+/plugins/jenkins                                    @backstage/maintainers @timja
+/plugins/jenkins-backend                            @backstage/maintainers @timja
+/plugins/kafka                                      @backstage/maintainers @nirga @andrewthauer
+/plugins/kafka-backend                              @backstage/maintainers @nirga @andrewthauer
+/plugins/kubernetes                                 @backstage/maintainers @backstage/warpspeed
+/plugins/kubernetes-*                               @backstage/maintainers @backstage/warpspeed
+/plugins/newrelic-dashboard                         @backstage/maintainers @mufaddal7
+/plugins/playlist                                   @backstage/maintainers @kuangp
+/plugins/playlist-*                                 @backstage/maintainers @kuangp
+/plugins/rollbar                                    @backstage/maintainers @andrewthauer
+/plugins/rollbar-backend                            @backstage/maintainers @andrewthauer
+/plugins/scaffolder-backend-module-rails            @backstage/maintainers @angeliski
+/plugins/scaffolder-backend-module-yeoman           @backstage/maintainers @pawelmitka
+/plugins/search                                     @backstage/maintainers @backstage/techdocs-core
+/plugins/search-*                                   @backstage/maintainers @backstage/techdocs-core
+/plugins/sonarqube                                  @backstage/maintainers @backstage/sda-se-reviewers
+/plugins/stack-overflow                             @backstage/maintainers @backstage/techdocs-core
+/plugins/stack-overflow-backend                     @backstage/maintainers @backstage/techdocs-core
+/plugins/techdocs                                   @backstage/maintainers @backstage/techdocs-core
+/plugins/techdocs-*                                 @backstage/maintainers @backstage/techdocs-core
+/plugins/user-settings-backend                      @backstage/maintainers @backstage/sda-se-reviewers
+/tech-insights-backend                              @backstage/maintainers @xantier @iain-b
+/tech-insights-backend-module-jsonfc                @backstage/maintainers @xantier @iain-b
+/tech-insights-tech-insights-common                 @backstage/maintainers @xantier @iain-b
+/tech-insights-tech-insights-node                   @backstage/maintainers @xantier @iain-b

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 *                                                   @backstage/maintainers
 yarn.lock                                           @backstage/maintainers @backstage-service
 */yarn.lock                                         @backstage/maintainers @backstage-service
-/.changeset                                         @backstage/owners
+/.changeset                                        
 /cypress/src/integration/plugins/techdocs.spec.ts   @backstage/techdocs-core
 /docs/assets/search                                 @backstage/techdocs-core
 /docs/features/search                               @backstage/techdocs-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,6 @@
 *                                                   @backstage/maintainers
 yarn.lock                                           @backstage/maintainers @backstage-service
 */yarn.lock                                         @backstage/maintainers @backstage-service
-/.changeset/cost-insights-*                         @backstage/maintainers @backstage/silver-lining
 /.changeset                                         @backstage/owners
 /cypress/src/integration/plugins/techdocs.spec.ts   @backstage/techdocs-core
 /docs/assets/search                                 @backstage/techdocs-core


### PR DESCRIPTION
I left the change for `@backstage/everyone` as if I was to make that change, it would notify everyone as opposed to just `@backstage/maintainers` and `@backstage/techdocs-core`