### PR TITLE
support customization of ApiDefinitionWidgets

### DIFF
--- a/.changeset/smooth-moles-reply.md
+++ b/.changeset/smooth-moles-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Added the ability to provide custom props to ApiDefinitionWidgets with default support for disabling try-it and authorize buttons for Swagger UI.

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -384,6 +384,25 @@ This annotation allowed to load the API definition from another location. Use
 [substitution](./descriptor-format.md#substitutions-in-the-descriptor-format)
 instead.
 
+### backstage.io/disableTryItOut, backstage.io/disableAuthorizeButton
+
+```yaml
+# Example:
+metadata:
+  annotations:
+    backstage.io/disableTryItOut: 'true'
+    backstage.io/disableAuthorizeButton: 'true'
+```
+
+These annotations allow customizing some of the Swagger options from an API Entity.
+Certain API's have the need to disable some of the options that the Swagger page offers,
+and these annotations provide the API the full flexibility of having the choice of whether
+or not to disable the try-it button (which normally allows predefined calls to the API
+from the Swagger page) and disabling the Authorize button (which provides the authorization
+needed to call the API). This can be especially useful for API's that hold production data.
+
+These annotations are only needed when their values should be true, as the default is false.
+
 ### jenkins.io/github-folder
 
 Use the `jenkins.io/job-full-name` instead.

--- a/plugins/api-docs/README.md
+++ b/plugins/api-docs/README.md
@@ -99,6 +99,90 @@ There are other components to discover in [`./src/components`](./src/components)
 
 ## Customizations
 
+### Customizing Standard API Rendering
+
+The components used to render OpenAPI ([Swagger UI](https://github.com/swagger-api/swagger-ui)) and GraphQL ([GraphiQL](https://github.com/graphql/graphiql)) support additional configuration options. This plugin supports providing those additional configuration options by registering functions in the `customizers` prop of `EntityApiDefinitionCard`.
+
+Each customization function needs to accept two arguments:
+
+1. The current entity.
+2. An object representing the current customizations, in the form of a `props` entry.
+
+And must return an object representing the _new_ customizations.
+
+For example, adding a [Swagger UI plugin](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/plugin-api.md) would be done like this:
+
+```tsx
+// packages/app/src/components/apidocs/SwaggerInfoCustomizer.tsx
+
+import { ApiDefinitionWidgetCustomizer } from '@backstage/plugin-api-docs';
+
+export const SwaggerInfoCustomizer: ApiDefinitionWidgetCustomizer = (
+  entity,
+  current,
+) => {
+  if (entity.spec.type === 'openapi') {
+    if (!current.props.plugins) {
+      current.props.plugins = [];
+    }
+    current.props.plugins.push({
+      wrapComponents: {
+        info: (Original, system) => props => {
+          return (
+            <div>
+              <h3>Hello world! I am above the Info component.</h3>
+              <Original {...props} />
+            </div>
+          );
+        },
+      },
+    });
+  }
+
+  return current;
+};
+
+// packages/app/src/components/catalog/EntityPage.tsx
+
+import {
+  EntityAboutCard,
+  EntityApiDefinitionCard,
+  EntityConsumingComponentsCard,
+  EntityProvidingComponentsCard,
+} from '@backstage/plugin-api-docs';
+import { SwaggerInfoCustomizer } from '../../apidocs/SwaggerInfoCustomizer';
+
+const apiPage = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <EntityAboutCard />
+        </Grid>
+        <Grid container>
+          <Grid item md={12}>
+            <Grid item xs={12} md={6}>
+              <EntityProvidingComponentsCard />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <EntityConsumingComponentsCard />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/definition" title="Definition">
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <EntityApiDefinitionCard customizers={[SwaggerInfoCustomizer]} />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+```
+
 ### Custom API Renderings
 
 You can add support for additional API types by providing a custom implementation for the `apiDocsConfigRef`.

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -18,15 +18,33 @@ import { TableProps } from '@backstage/core-components';
 import { UserListFilterKind } from '@backstage/plugin-catalog-react';
 
 // @public (undocumented)
-export const ApiDefinitionCard: () => JSX.Element;
+export const ApiDefinitionCard: ({
+  customizers,
+}: ApiDefinitionCardProps) => JSX.Element;
+
+// @public (undocumented)
+export type ApiDefinitionCardProps = {
+  customizers?: ApiDefinitionWidgetCustomizer[];
+};
 
 // @public (undocumented)
 export type ApiDefinitionWidget = {
   type: string;
   title: string;
-  component: (definition: string) => React_2.ReactElement;
+  component: (definition: string, customProps?: any) => React_2.ReactElement;
   rawLanguage?: string;
 };
+
+// @public (undocumented)
+export type ApiDefinitionWidgetCustomization = {
+  props: Record<string, any>;
+};
+
+// @public (undocumented)
+export type ApiDefinitionWidgetCustomizer = (
+  entity: ApiEntity,
+  current: ApiDefinitionWidgetCustomization,
+) => ApiDefinitionWidgetCustomization;
 
 // @public (undocumented)
 export interface ApiDocsConfig {
@@ -101,7 +119,9 @@ export type DefaultApiExplorerPageProps = {
 export function defaultDefinitionWidgets(): ApiDefinitionWidget[];
 
 // @public (undocumented)
-export const EntityApiDefinitionCard: () => JSX.Element;
+export const EntityApiDefinitionCard: ({
+  customizers,
+}: ApiDefinitionCardProps) => JSX.Element;
 
 // @public (undocumented)
 export const EntityConsumedApisCard: (props: {
@@ -136,6 +156,7 @@ export const GraphQlDefinitionWidget: (
 // @public (undocumented)
 export type GraphQlDefinitionWidgetProps = {
   definition: string;
+  customProps?: any;
 };
 
 // @public (undocumented)
@@ -151,6 +172,7 @@ export const OpenApiDefinitionWidget: (
 // @public (undocumented)
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
+  customProps?: any;
 };
 
 // @public (undocumented)

--- a/plugins/api-docs/dev/index.tsx
+++ b/plugins/api-docs/dev/index.tsx
@@ -21,6 +21,7 @@ import { CatalogEntityPage } from '@backstage/plugin-catalog';
 import { catalogApiRef, EntityProvider } from '@backstage/plugin-catalog-react';
 import React from 'react';
 import {
+  ApiDefinitionWidgetCustomizer,
   apiDocsConfigRef,
   apiDocsPlugin,
   ApiExplorerPage,
@@ -31,17 +32,44 @@ import asyncapiApiEntity from './asyncapi-example-api.yaml';
 import graphqlApiEntity from './graphql-example-api.yaml';
 import invalidLanguageApiEntity from './invalid-language-example-api.yaml';
 import openapiApiEntity from './openapi-example-api.yaml';
+import openapiApiEntityDisabledTryItOut from './openapi-example-api-disabled-try-it-out.yaml';
 import otherApiEntity from './other-example-api.yaml';
 import trpcApiEntity from './trpc-example-api.yaml';
 
 const mockEntities = [
   openapiApiEntity,
+  openapiApiEntityDisabledTryItOut,
   asyncapiApiEntity,
   graphqlApiEntity,
   invalidLanguageApiEntity,
   otherApiEntity,
   trpcApiEntity,
 ] as unknown as Entity[];
+
+const SwaggerInfoCustomizer: ApiDefinitionWidgetCustomizer = (
+  entity,
+  current,
+) => {
+  if (entity.spec.type === 'openapi') {
+    if (!current.props.plugins) {
+      current.props.plugins = [];
+    }
+    current.props.plugins.push({
+      wrapComponents: {
+        info: (Original: any) => (props: any) => {
+          return (
+            <div>
+              <h3>Hello world! I am above the Info component.</h3>
+              <Original {...props} />
+            </div>
+          );
+        },
+      },
+    });
+  }
+
+  return current;
+};
 
 createDevApp()
   .registerPlugin(apiDocsPlugin)
@@ -81,6 +109,21 @@ createDevApp()
         <Header title="OpenAPI" />
         <Content>
           <EntityProvider entity={openapiApiEntity as any as Entity}>
+            <EntityApiDefinitionCard customizers={[SwaggerInfoCustomizer]} />
+          </EntityProvider>
+        </Content>
+      </Page>
+    ),
+  })
+  .addPage({
+    title: 'OpenAPI -- Disabled Try It Out',
+    element: (
+      <Page themeId="home">
+        <Header title="OpenAPI" />
+        <Content>
+          <EntityProvider
+            entity={openapiApiEntityDisabledTryItOut as any as Entity}
+          >
             <EntityApiDefinitionCard />
           </EntityProvider>
         </Content>

--- a/plugins/api-docs/dev/openapi-example-api-disabled-try-it-out.yaml
+++ b/plugins/api-docs/dev/openapi-example-api-disabled-try-it-out.yaml
@@ -3,10 +3,12 @@ kind: API
 metadata:
   name: petstore
   description: The petstore API
-  uid: '1'
+  uid: '2'
   tags:
     - store
     - rest
+  annotations:
+    backstage.io/disableTryItOut: 'true'
 spec:
   type: openapi
   lifecycle: experimental

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
@@ -24,7 +24,7 @@ import { TrpcApiDefinitionWidget } from '../TrpcDefinitionWidget';
 export type ApiDefinitionWidget = {
   type: string;
   title: string;
-  component: (definition: string) => React.ReactElement;
+  component: (definition: string, customProps?: any) => React.ReactElement;
   rawLanguage?: string;
 };
 
@@ -35,8 +35,11 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       type: 'openapi',
       title: 'OpenAPI',
       rawLanguage: 'yaml',
-      component: definition => (
-        <OpenApiDefinitionWidget definition={definition} />
+      component: (definition, customProps = {}) => (
+        <OpenApiDefinitionWidget
+          definition={definition}
+          customProps={customProps}
+        />
       ),
     },
     {
@@ -51,8 +54,11 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       type: 'graphql',
       title: 'GraphQL',
       rawLanguage: 'graphql',
-      component: definition => (
-        <GraphQlDefinitionWidget definition={definition} />
+      component: (definition, customProps = {}) => (
+        <GraphQlDefinitionWidget
+          definition={definition}
+          customProps={customProps}
+        />
       ),
     },
     {

--- a/plugins/api-docs/src/components/ApiDefinitionCard/DefaultApiEntityWidgetCustomizer.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/DefaultApiEntityWidgetCustomizer.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApiDefinitionWidgetCustomizer } from './ApiDefinitionCard';
+
+export const DefaultApiEntityWidgetCustomizer: ApiDefinitionWidgetCustomizer = (
+  entity,
+  current,
+) => {
+  if (entity.spec.type === 'openapi') {
+    if (
+      entity.metadata?.annotations?.['backstage.io/disableTryItOut'] === 'true'
+    ) {
+      if (!current.props.plugins) {
+        current.props.plugins = [];
+      }
+      current.props.plugins.push({
+        statePlugins: {
+          spec: {
+            wrapSelectors: {
+              allowTryItOutFor: () => () => false,
+            },
+          },
+        },
+      });
+    }
+    if (
+      entity.metadata?.annotations?.['backstage.io/disableAuthorizeButton'] ===
+      'true'
+    ) {
+      if (!current.props.plugins) {
+        current.props.plugins = [];
+      }
+      current.props.plugins.push({
+        wrapComponents: {
+          authorizeBtn: () => () => false,
+        },
+      });
+    }
+  }
+
+  return current;
+};

--- a/plugins/api-docs/src/components/ApiDefinitionCard/index.ts
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/index.ts
@@ -15,6 +15,11 @@
  */
 
 export { ApiDefinitionCard } from './ApiDefinitionCard';
+export type {
+  ApiDefinitionCardProps,
+  ApiDefinitionWidgetCustomizer,
+  ApiDefinitionWidgetCustomization,
+} from './ApiDefinitionCard';
 export { defaultDefinitionWidgets } from './ApiDefinitionWidget';
 export type { ApiDefinitionWidget } from './ApiDefinitionWidget';
 export { ApiTypeTitle } from './ApiTypeTitle';

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinition.tsx
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinition.tsx
@@ -42,9 +42,10 @@ const useStyles = makeStyles<BackstageTheme>(() => ({
 
 type Props = {
   definition: string;
+  customProps?: any;
 };
 
-export const GraphQlDefinition = ({ definition }: Props) => {
+export const GraphQlDefinition = ({ definition, customProps = {} }: Props) => {
   const classes = useStyles();
   const schema = buildSchema(definition);
 
@@ -56,6 +57,7 @@ export const GraphQlDefinition = ({ definition }: Props) => {
           schema={schema}
           docExplorerOpen
           defaultSecondaryEditorOpen={false}
+          {...customProps}
         />
       </div>
     </div>

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinitionWidget.tsx
@@ -28,6 +28,7 @@ const LazyGraphQlDefinition = React.lazy(() =>
 /** @public */
 export type GraphQlDefinitionWidgetProps = {
   definition: string;
+  customProps?: any;
 };
 
 /** @public */

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -133,9 +133,13 @@ const useStyles = makeStyles(theme => ({
 
 export type OpenApiDefinitionProps = {
   definition: string;
+  customProps?: any;
 };
 
-export const OpenApiDefinition = ({ definition }: OpenApiDefinitionProps) => {
+export const OpenApiDefinition = ({
+  definition,
+  customProps = {},
+}: OpenApiDefinitionProps) => {
   const classes = useStyles();
 
   // Due to a bug in the swagger-ui-react component, the component needs
@@ -149,7 +153,7 @@ export const OpenApiDefinition = ({ definition }: OpenApiDefinitionProps) => {
 
   return (
     <div className={classes.root}>
-      <SwaggerUI spec={def} url="" deepLinking />
+      <SwaggerUI spec={def} url="" deepLinking {...customProps} />
     </div>
   );
 };

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -28,6 +28,7 @@ const LazyOpenApiDefinition = React.lazy(() =>
 /** @public */
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
+  customProps?: any;
 };
 
 /** @public */


### PR DESCRIPTION
Signed-off-by: Justin Edelson <jedelson@pagerduty.com>

## Hey, I just made a Pull Request!

This is essentially a replacement for #15531 which enables the props passed to `ApiDefinitionWidget` components to be augmented on a per-application basis, generally by using entity annotations. The syntax to do so is:

```
<EntityApiDefinitionCard
    customizers={[(entity, currentCustomizations): newCustomizations]}
 />
```

A default implementation of a customizer function is provided to address the two annotations defined in #15531. 

I have a use case which is similar to the one described in #14824 but is very application specific and would *not* belong in the plugin proper. Such a customization model was _hinted_ at by @Rugvip in https://github.com/backstage/backstage/issues/14824#issuecomment-1343189045

Here's a example, following along with the changes in the README:

![image](https://user-images.githubusercontent.com/103767938/216699416-c284d631-d089-47a6-a179-2b73643f9ad6.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
