### PR TITLE
[Search] Improve router query errors

### DIFF
--- a/.changeset/hip-onions-tan.md
+++ b/.changeset/hip-onions-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Change the router's response to include the error message instead of its object type in case it fails during a search query because the messages have more info.

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -74,6 +74,23 @@ describe('createRouter', () => {
   });
 
   describe('GET /query', () => {
+    it('throws meaningful query errors', async () => {
+      const error = new Error('Query error message');
+      mockSearchEngine.query.mockRejectedValueOnce(error);
+
+      const response = await request(app).get('/query');
+
+      expect(response.status).toEqual(500);
+      expect(response.body).toMatchObject(
+        expect.objectContaining({
+          error: {
+            name: 'Error',
+            message: `There was a problem performing the search query: ${error.message}`,
+          },
+        }),
+      );
+    });
+
     it('returns empty results array', async () => {
       const response = await request(app).get('/query');
 

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -184,7 +184,7 @@ export async function createRouter(
         }
 
         throw new Error(
-          `There was a problem performing the search query. ${error}`,
+          `There was a problem performing the search query: ${error.message}`,
         );
       }
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As shown in the example below, query errors do not provide details on the problem that occurred:
```
Error: There was a problem performing the search query. [object Object]
```

This pull request changes the router's response to contain the error message instead of its object type in case it fails during a search query.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
