### PR TITLE
fix: Keep custom root Jest config

### DIFF
--- a/.changeset/gorgeous-flies-explode.md
+++ b/.changeset/gorgeous-flies-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix support for global and project Jest configuration

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -262,6 +262,8 @@ async function getRootConfig() {
         testScript?.includes('backstage-cli test') ||
         testScript?.includes('backstage-cli package test');
       if (testScript && isSupportedTestScript) {
+        // Some global Jest config might be invalid for a 'project' level config and output warnings
+        // See: https://github.com/facebook/jest/blob/main/packages/jest-types/src/Config.ts
         return await getProjectConfig(projectPath, {
           displayName: packageData.name,
         });
@@ -271,10 +273,13 @@ async function getRootConfig() {
     }),
   ).then(cs => cs.filter(Boolean));
 
+  const rootBaseConfig = await getProjectConfig(targetPath, coverageConfig);
   return {
-    rootDir: targetPath,
-    projects: configs,
-    ...coverageConfig,
+    ...rootBaseConfig,
+    ...{
+      rootDir: targetPath,
+      projects: configs,
+    },
   };
 }
 


### PR DESCRIPTION
Signed-off-by: Sergio-Mira <sergio.mira@zendesk.com>

## Hey, I just made a Pull Request!

Looking to fix this issue with Jest config https://github.com/backstage/backstage/issues/15311

The main problem is that the root Jest config is not returned for the root project folder and thus 'reporters' and other config currently does not work.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
