### PR TITLE
feat(Vault plugin improvement): Improve error messaging

### DIFF
--- a/.changeset/mean-squids-kneel.md
+++ b/.changeset/mean-squids-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-vault': patch
+---
+
+Surface additional context and details to the Backstage UI when the Vault plugin encounters non-successful HTTP responses from the Vault API.

--- a/plugins/vault/src/api.ts
+++ b/plugins/vault/src/api.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { DiscoveryApi, createApiRef } from '@backstage/core-plugin-api';
-import { NotFoundError } from '@backstage/errors';
+import { NotFoundError, ResponseError } from '@backstage/errors';
 
 /**
  * @public
@@ -75,9 +75,7 @@ export class VaultClient implements VaultApi {
     } else if (response.status === 404) {
       throw new NotFoundError(`No secrets found in path '${path}'`);
     }
-    throw new Error(
-      `Unexpected error while fetching secrets from path '${path}'`,
-    );
+    throw await ResponseError.fromResponse(response);
   }
 
   async listSecrets(secretPath: string): Promise<VaultSecret[]> {

--- a/plugins/vault/src/components/EntityVaultTable/EntityVaultTable.test.tsx
+++ b/plugins/vault/src/components/EntityVaultTable/EntityVaultTable.test.tsx
@@ -33,40 +33,28 @@ describe('EntityVaultTable', () => {
   let apis: TestApiRegistry;
   const mockBaseUrl = 'https://api-vault.com/api/vault';
   const discoveryApi = UrlPatternDiscovery.compile(mockBaseUrl);
-
-  const entityOk: ComponentEntity = {
-    apiVersion: 'backstage.io/v1alpha1',
-    kind: 'Component',
-    metadata: {
-      name: 'test',
-      description: 'This is the description',
-      annotations: {
-        'vault.io/secrets-path': 'test/success',
+  const entity = (secretPath: string) => {
+    return {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'test',
+        description: 'This is the description',
+        annotations: {
+          'vault.io/secrets-path': secretPath,
+        },
       },
-    },
-    spec: {
-      lifecycle: 'production',
-      owner: 'owner',
-      type: 'service',
-    },
+      spec: {
+        lifecycle: 'production',
+        owner: 'owner',
+        type: 'service',
+      },
+    } as ComponentEntity;
   };
 
-  const entityNotOk: ComponentEntity = {
-    apiVersion: 'backstage.io/v1alpha1',
-    kind: 'Component',
-    metadata: {
-      name: 'test',
-      description: 'This is the description',
-      annotations: {
-        'vault.io/secrets-path': 'test/error',
-      },
-    },
-    spec: {
-      lifecycle: 'production',
-      owner: 'owner',
-      type: 'service',
-    },
-  };
+  const entityOk = entity('test/success');
+  const entityEmpty = entity('test/empty');
+  const entityNotOk = entity('test/error');
 
   const mockSecretsResult: { items: VaultSecret[] } = {
     items: [
@@ -91,7 +79,7 @@ describe('EntityVaultTable', () => {
         const { path } = req.params;
         if (path === 'test/success') {
           return res(ctx.json(mockSecretsResult));
-        } else if (path === 'test/error') {
+        } else if (path === 'test/empty') {
           return res(ctx.json([]));
         }
         return res(ctx.status(400));
@@ -122,10 +110,25 @@ describe('EntityVaultTable', () => {
     setupHandlers();
     const rendered = await renderInTestApp(
       <ApiProvider apis={apis}>
-        <EntityVaultTable entity={entityNotOk} />
+        <EntityVaultTable entity={entityEmpty} />
       </ApiProvider>,
     );
 
     expect(rendered.getByText(/No secrets found/)).toBeInTheDocument();
+  });
+
+  it('should surface an appropriate error when the Vault API responds unsuccessfully', async () => {
+    setupHandlers();
+    const rendered = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <EntityVaultTable entity={entityNotOk} />
+      </ApiProvider>,
+    );
+
+    expect(
+      rendered.getByText(
+        /Unexpected error while fetching secrets from path \'test\/error\'\: Request failed with 400 Error/,
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/vault/src/components/EntityVaultTable/EntityVaultTable.tsx
+++ b/plugins/vault/src/components/EntityVaultTable/EntityVaultTable.tsx
@@ -81,7 +81,12 @@ export const EntityVaultTable = ({ entity }: { entity: Entity }) => {
   });
 
   if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return (
+      <Alert severity="error">
+        Unexpected error while fetching secrets from path '{secretPath}':{' '}
+        {error.message}
+      </Alert>
+    );
   }
 
   return (


### PR DESCRIPTION
👋 This seeks to address issue #16176 by improving the error messaging surfaced to the Backstage UI when the Vault plugin encounters non-successful HTTP responses from the Vault API.

Previously, the error messaging rendered to the UI was:

1. 404s: `No secrets found in path \'v1/secrets/PATH'`
2. other not-okay HTTP responses: `Unexpected error while fetching secrets from path 'PATH'`

As per this PR, the error messaging rendered to the UI now includes response details. For example:

```
Unexpected error while fetching secrets from path 'PATH': Request failed with 400 Error
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
