### PR TITLE
Inconsistent display of list of entities

### DIFF
--- a/.changeset/brown-kings-wait.md
+++ b/.changeset/brown-kings-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+The list of entities takes into account the title when its different from the name to sort the entities.

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -20,6 +20,7 @@ import {
   parseEntityRef,
   stringifyEntityRef,
   stringifyLocationRef,
+  DEFAULT_NAMESPACE,
 } from '@backstage/catalog-model';
 import { ResponseError } from '@backstage/errors';
 import crossFetch from 'cross-fetch';
@@ -176,8 +177,8 @@ export class CatalogClient implements CatalogApi {
         return 0;
       }
 
-      const aRef = stringifyEntityRef(a);
-      const bRef = stringifyEntityRef(b);
+      const aRef = this.stringifySortingEntityRef(a);
+      const bRef = this.stringifySortingEntityRef(b);
       if (aRef < bRef) {
         return -1;
       }
@@ -503,5 +504,15 @@ export class CatalogClient implements CatalogApi {
     }
 
     return await response.json();
+  }
+
+  private stringifySortingEntityRef(ref: Entity): string {
+    const kind = ref.kind;
+    const namespace = ref.metadata.namespace ?? DEFAULT_NAMESPACE;
+    const name = ref.metadata.title || ref.metadata.name;
+
+    return `${kind.toLocaleLowerCase('en-US')}:${namespace.toLocaleLowerCase(
+      'en-US',
+    )}/${name.toLocaleLowerCase('en-US')}`;
   }
 }


### PR DESCRIPTION
## Hey, trying to fix this one https://github.com/backstage/backstage/issues/16138

The Catalog Entities are returned ordered by the stringify ref, but in the way, the listings are shown, it makes sense to use the Title instead of the Name for the default sorting when possible.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
