### PR TITLE
docs: improve Vault plugin catalog entry language

### DIFF
--- a/microsite/data/plugins/vault.yaml
+++ b/microsite/data/plugins/vault.yaml
@@ -3,7 +3,7 @@ title: Vault
 author: Spread Group
 authorUrl: https://github.com/ivangonzalezacuna
 category: Vault
-description: Visualize a list secrets stored in your vault instance.
+description: Visualize a list of the secrets stored in your HashiCorp Vault instance.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/vault
 iconUrl: img/vault.png
 npmPackageName: '@backstage/plugin-vault'


### PR DESCRIPTION
👋 This seeks to fine-tune the language associated with the Vault plugin at https://backstage.io/plugins by...

1. correcting the grammar in the plugin description
2. clarifying that the plugin deals with HashiCorp Vault (and not another Vault, such as Ansible Vault)

<!--- Please include the following in your Pull Request when applicable: -->

- [X] Added or updated documentation
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
