### PR TITLE
[TechRadar] Deprecate RadarEntry.url

### DIFF
--- a/.changeset/hip-chairs-double.md
+++ b/.changeset/hip-chairs-double.md
@@ -6,7 +6,6 @@ Deprecate `RadarEntry.url` - use `RadarEntry.links` instead
 
 ```diff
 - url: 'https://www.javascript.com/',
-+ url: '#',
   key: 'javascript',
   id: 'javascript',
   title: 'JavaScript',

--- a/.changeset/hip-chairs-double.md
+++ b/.changeset/hip-chairs-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': minor
+---
+
+Deprecate `RadarEntry.url` - use `RadarEntry.links` instead

--- a/.changeset/hip-chairs-double.md
+++ b/.changeset/hip-chairs-double.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-tech-radar': minor
+'@backstage/plugin-tech-radar': patch
 ---
 
 Deprecate `RadarEntry.url` - use `RadarEntry.links` instead

--- a/.changeset/hip-chairs-double.md
+++ b/.changeset/hip-chairs-double.md
@@ -3,3 +3,18 @@
 ---
 
 Deprecate `RadarEntry.url` - use `RadarEntry.links` instead
+
+```diff
+- url: 'https://www.javascript.com/',
++ url: '#',
+  key: 'javascript',
+  id: 'javascript',
+  title: 'JavaScript',
+  quadrant: 'languages',
+  links: [
++    {
++      url: 'https://www.javascript.com/',
++      title: 'Learn more',
++    },
+  ],
+```

--- a/.changeset/slow-moles-sin.md
+++ b/.changeset/slow-moles-sin.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-circleci': patch
 ---
 
-Making workflow a link 
+Making workflow a link

--- a/plugins/tech-radar/api-report.md
+++ b/plugins/tech-radar/api-report.md
@@ -25,6 +25,7 @@ export interface RadarEntry {
   quadrant: string;
   timeline: Array<RadarEntrySnapshot>;
   title: string;
+  // @deprecated
   url: string;
 }
 

--- a/plugins/tech-radar/api-report.md
+++ b/plugins/tech-radar/api-report.md
@@ -26,7 +26,7 @@ export interface RadarEntry {
   timeline: Array<RadarEntrySnapshot>;
   title: string;
   // @deprecated
-  url: string;
+  url?: string;
 }
 
 // @public

--- a/plugins/tech-radar/src/api.ts
+++ b/plugins/tech-radar/src/api.ts
@@ -133,6 +133,8 @@ export interface RadarEntry {
    * @remarks
    *
    * You can use `#` if you don't want to provide any other url
+   *
+   * @deprecated Use {@link RadarEntry.links} instead
    */
   url: string;
   /**

--- a/plugins/tech-radar/src/api.ts
+++ b/plugins/tech-radar/src/api.ts
@@ -136,7 +136,7 @@ export interface RadarEntry {
    *
    * @deprecated Use {@link RadarEntry.links} instead
    */
-  url: string;
+  url?: string;
   /**
    * History of the Entry moving through {@link RadarRing}
    */

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -45,7 +45,6 @@ entries.push({
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
     },
   ],
-  url: '#',
   key: 'javascript',
   id: 'javascript',
   title: 'JavaScript',
@@ -73,7 +72,6 @@ entries.push({
         'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat',
     },
   ],
-  url: '#',
   key: 'typescript',
   id: 'typescript',
   title: 'TypeScript',
@@ -91,7 +89,6 @@ entries.push({
         'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
     },
   ],
-  url: '#',
   links: [
     {
       url: 'https://webpack.js.org/',
@@ -111,7 +108,6 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: '#',
   links: [
     {
       url: 'https://reactjs.org/',
@@ -131,7 +127,6 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: '#',
   key: 'code-reviews',
   id: 'code-reviews',
   title: 'Code Reviews',
@@ -145,7 +140,6 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: '#',
   key: 'mob-programming',
   id: 'mob-programming',
   title: 'Mob Programming',
@@ -159,7 +153,6 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: '#',
   key: 'docs-like-code',
   id: 'docs-like-code',
   title: 'Docs-like-code',
@@ -172,7 +165,6 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: '#',
   key: 'force-push',
   id: 'force-push',
   title: 'Force push to master',
@@ -186,7 +178,6 @@ entries.push({
       description: 'long description',
     },
   ],
-  url: '#',
   links: [
     {
       url: 'https://reactjs.org/',

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -180,7 +180,7 @@ entries.push({
   ],
   links: [
     {
-      url: 'https://reactjs.org/',
+      url: 'https://github.com',
       title: 'Learn more',
     },
   ],

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -45,12 +45,16 @@ entries.push({
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
     },
   ],
-  url: 'https://www.javascript.com/',
+  url: '#',
   key: 'javascript',
   id: 'javascript',
   title: 'JavaScript',
   quadrant: 'languages',
   links: [
+    {
+      url: 'https://www.javascript.com/',
+      title: 'Learn more',
+    },
     {
       url: 'https://www.typescriptlang.org/',
       title: 'TypeScript',
@@ -87,7 +91,13 @@ entries.push({
         'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
     },
   ],
-  url: 'https://webpack.js.org/',
+  url: '#',
+  links: [
+    {
+      url: 'https://webpack.js.org/',
+      title: 'Learn more',
+    },
+  ],
   key: 'webpack',
   id: 'webpack',
   title: 'Webpack',
@@ -101,7 +111,13 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: 'https://reactjs.org/',
+  url: '#',
+  links: [
+    {
+      url: 'https://reactjs.org/',
+      title: 'Learn more',
+    },
+  ],
   key: 'react',
   id: 'react',
   title: 'React',
@@ -170,7 +186,13 @@ entries.push({
       description: 'long description',
     },
   ],
-  url: 'https://github.com',
+  url: '#',
+  links: [
+    {
+      url: 'https://reactjs.org/',
+      title: 'Learn more',
+    },
+  ],
   key: 'github-actions',
   id: 'github-actions',
   title: 'GitHub Actions',


### PR DESCRIPTION
## Hey, I just made a Pull Request! 👋

In the pull request https://github.com/backstage/backstage/pull/15802 i've introduced `links` attribute, so you can add more links to the tech radar's entry description (documentation, external tools...). But i forget to deprecate `url` attribute.

In some next major version, we can remove `RadarEntry.url` and just use more robust `RadarEntry.links`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
