### PR TITLE
feat: allow users to add their own header component

### DIFF
--- a/.changeset/slow-mirrors-work.md
+++ b/.changeset/slow-mirrors-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphiql': patch
+---
+
+Add a GraphiQLPageProp that allows users to add their custom header

--- a/.changeset/slow-moles-sin.md
+++ b/.changeset/slow-moles-sin.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-circleci': patch
 ---
 
-Making workflow a link 
+Making workflow a link

--- a/plugins/graphiql/api-report.md
+++ b/plugins/graphiql/api-report.md
@@ -36,7 +36,12 @@ export type GithubEndpointConfig = {
 export const GraphiQLIcon: IconComponent;
 
 // @public (undocumented)
-export const GraphiQLPage: () => JSX.Element;
+export const GraphiQLPage: (props: GraphiQLPageProps) => JSX.Element;
+
+// @public (undocumented)
+export type GraphiQLPageProps = {
+  header?: JSX.Element;
+};
 
 // @public (undocumented)
 const graphiqlPlugin: BackstagePlugin<{}, {}, {}>;
@@ -73,7 +78,7 @@ export class GraphQLEndpoints implements GraphQLBrowseApi {
 }
 
 // @public (undocumented)
-export const Router: () => JSX.Element;
+export const Router: (props: GraphiQLPageProps) => JSX.Element;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.test.tsx
+++ b/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.test.tsx
@@ -19,6 +19,7 @@ import { GraphiQLPage } from './GraphiQLPage';
 import { act } from '@testing-library/react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { GraphQLBrowseApi, graphQlBrowseApiRef } from '../../lib/api';
+import { Header } from '@backstage/core-components';
 
 jest.mock('../GraphiQLBrowser', () => ({
   GraphiQLBrowser: () => '<GraphiQLBrowser />',
@@ -79,5 +80,26 @@ describe('GraphiQLPage', () => {
 
     rendered.getByText('GraphiQL');
     rendered.getByText('<GraphiQLBrowser />');
+  });
+
+  it('should render a different header when one is given', async () => {
+    const loadingApi: GraphQLBrowseApi = {
+      async getEndpoints() {
+        return [];
+      },
+    };
+
+    const CustomHeader = () => {
+      return <Header title="my custom header" />;
+    };
+
+    const rendered = await renderInTestApp(
+      <TestApiProvider apis={[[graphQlBrowseApiRef, loadingApi]]}>
+        <GraphiQLPage header={<CustomHeader />} />
+      </TestApiProvider>,
+    );
+
+    expect(rendered.getByText('my custom header')).toBeInTheDocument();
+    expect(rendered.getByText('<GraphiQLBrowser />')).toBeInTheDocument();
   });
 });

--- a/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.tsx
+++ b/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.tsx
@@ -29,7 +29,21 @@ import {
 } from '@backstage/core-components';
 
 /** @public */
-export const GraphiQLPage = () => {
+export type GraphiQLPageProps = {
+  header?: JSX.Element;
+};
+
+const DefaultHeader = () => {
+  return (
+    <Header title="GraphiQL">
+      <HeaderLabel label="Owner" value="Spotify" />
+      <HeaderLabel label="Lifecycle" value="Alpha" />
+    </Header>
+  );
+};
+
+/** @public */
+export const GraphiQLPage = (props: GraphiQLPageProps) => {
   const graphQlBrowseApi = useApi(graphQlBrowseApiRef);
   const endpoints = useAsync(() => graphQlBrowseApi.getEndpoints());
 
@@ -60,10 +74,7 @@ export const GraphiQLPage = () => {
 
   return (
     <Page themeId="tool">
-      <Header title="GraphiQL">
-        <HeaderLabel label="Owner" value="Spotify" />
-        <HeaderLabel label="Lifecycle" value="Alpha" />
-      </Header>
+      {props.header ? props.header : <DefaultHeader />}
       {content}
     </Page>
   );

--- a/plugins/graphiql/src/index.ts
+++ b/plugins/graphiql/src/index.ts
@@ -29,6 +29,7 @@ export {
   GraphiQLPage,
 } from './plugin';
 export { GraphiQLPage as Router } from './components';
+export type { GraphiQLPageProps } from './components';
 export * from './lib/api';
 export * from './route-refs';
 


### PR DESCRIPTION
Signed-off-by: MitchWijt <mitchel@wijt.net>

## Hey, I just made a Pull Request!

Added custom props to the headers of the GraphiQLPage so people can add their custom header

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
