### PR TITLE
Read msgraph user.select from configuration

### DIFF
--- a/.changeset/silly-buckets-joke.md
+++ b/.changeset/silly-buckets-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Fixed bug in readProviderConfig as it wasn't reading the user.select field expected from the app-config.yaml configuration

--- a/.changeset/silly-buckets-joke.md
+++ b/.changeset/silly-buckets-joke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-msgraph': patch
 ---
 
-Fixed bug in readProviderConfig as it wasn't reading the user.select field expected from the app-config.yaml configuration
+Fixed a bug reading the `user.select` field expected from the `app-config.yaml` configuration

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
@@ -52,6 +52,7 @@ describe('readMicrosoftGraphConfig', () => {
           authority: 'https://login.example.com/',
           userExpand: 'manager',
           userFilter: 'accountEnabled eq true',
+          userSelect: ['id', 'displayName', 'department'],
           groupExpand: 'member',
           groupSelect: ['id', 'displayName', 'description'],
           groupFilter: 'securityEnabled eq false',
@@ -69,6 +70,7 @@ describe('readMicrosoftGraphConfig', () => {
         authority: 'https://login.example.com/',
         userExpand: 'manager',
         userFilter: 'accountEnabled eq true',
+        userSelect: ['id', 'displayName', 'department'],
         groupExpand: 'member',
         groupSelect: ['id', 'displayName', 'description'],
         groupFilter: 'securityEnabled eq false',
@@ -167,6 +169,7 @@ describe('readProviderConfigs', () => {
               user: {
                 expand: 'manager',
                 filter: 'accountEnabled eq true',
+                select: ['id', 'displayName', 'department'],
               },
               group: {
                 expand: 'member',
@@ -196,6 +199,7 @@ describe('readProviderConfigs', () => {
         queryMode: 'advanced',
         userExpand: 'manager',
         userFilter: 'accountEnabled eq true',
+        userSelect: ['id', 'displayName', 'department'],
         groupExpand: 'member',
         groupSelect: ['id', 'displayName', 'description'],
         groupFilter: 'securityEnabled eq false',

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -264,6 +264,7 @@ export function readProviderConfig(
 
   const userExpand = config.getOptionalString('user.expand');
   const userFilter = config.getOptionalString('user.filter');
+  const userSelect = config.getOptionalStringArray('user.select');
 
   const groupExpand = config.getOptionalString('group.expand');
   const groupFilter = config.getOptionalString('group.filter');
@@ -318,6 +319,7 @@ export function readProviderConfig(
     tenantId,
     userExpand,
     userFilter,
+    userSelect,
     groupExpand,
     groupFilter,
     groupSearch,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

**Description**
Read `user.select` field from the configuration (app-config.yml) as it is currently not loaded.

**Context**
The current documentation suggests that users' msgraph fields can be selected using the `user.select` field: 
<img width="700" alt="image" src="https://user-images.githubusercontent.com/18457531/216991208-7e8a37fa-e795-4462-bdf8-d59f6b188c6e.png">

However, `user.select` was never loaded in `readProviderConfig()` - though it was expected in [read.ts](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts#L51).


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
