### PR TITLE
backend-plugin-api: switch createBackendPlugin id -> pluginId

### DIFF
--- a/.changeset/bright-teachers-compete.md
+++ b/.changeset/bright-teachers-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': minor
+---
+
+**BREAKING**: The plugin ID option passed to `createBackendPlugin` is now `pluginId`, rather than just `id`. This is to make it match `createBackendModule` more closely.

--- a/.changeset/little-jars-lay.md
+++ b/.changeset/little-jars-lay.md
@@ -1,0 +1,18 @@
+---
+'@internal/plugin-todo-list-backend': patch
+'@backstage/plugin-user-settings-backend': patch
+'@backstage/backend-test-utils': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/backend-defaults': patch
+'@backstage/backend-app-api': patch
+'@backstage/plugin-periskop-backend': patch
+'@backstage/backend-common': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-bazaar-backend': patch
+'@backstage/plugin-events-backend': patch
+'@backstage/plugin-kafka-backend': patch
+'@backstage/plugin-proxy-backend': patch
+'@backstage/plugin-app-backend': patch
+---
+
+Updated usage of `createBackendPlugin`.

--- a/.changeset/little-jars-lay.md
+++ b/.changeset/little-jars-lay.md
@@ -1,10 +1,6 @@
 ---
-'@internal/plugin-todo-list-backend': patch
 '@backstage/plugin-user-settings-backend': patch
-'@backstage/backend-test-utils': patch
 '@backstage/plugin-scaffolder-backend': patch
-'@backstage/backend-defaults': patch
-'@backstage/backend-app-api': patch
 '@backstage/plugin-periskop-backend': patch
 '@backstage/backend-common': patch
 '@backstage/plugin-catalog-backend': patch

--- a/docs/backend-system/architecture/04-plugins.md
+++ b/docs/backend-system/architecture/04-plugins.md
@@ -22,7 +22,7 @@ import {
 } from '@backstage/backend-plugin-api';
 
 export const examplePlugin = createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -53,7 +53,7 @@ export interface ExamplePluginOptions {
 
 export const examplePlugin = createBackendPlugin(
   (options?: ExamplePluginOptions) => ({
-    id: 'example',
+    pluginId: 'example',
     register(env) {
       env.registerInit({
         deps: {

--- a/docs/backend-system/architecture/05-extension-points.md
+++ b/docs/backend-system/architecture/05-extension-points.md
@@ -44,7 +44,7 @@ class ActionsExtension implements ScaffolderActionsExtensionPoint {
 
 export const scaffolderPlugin = createBackendPlugin(
   {
-    id: 'scaffolder',
+    pluginId: 'scaffolder',
     register(env) {
       const actionsExtensions = new ActionsExtension();
       env.registerExtensionPoint(

--- a/docs/backend-system/architecture/07-naming-patterns.md
+++ b/docs/backend-system/architecture/07-naming-patterns.md
@@ -21,7 +21,7 @@ Example:
 
 ```ts
 export const catalogPlugin = createBackendPlugin({
-  id: 'catalog',
+  pluginId: 'catalog',
   ...
 })
 ```
@@ -36,7 +36,7 @@ export const catalogPlugin = createBackendPlugin({
 Example:
 
 ```ts
-export const catalogModuleGithubEntityProvider = createBackendPlugin({
+export const catalogModuleGithubEntityProvider = createBackendModule({
   pluginId: 'catalog',
   moduleId: 'githubEntityProvider',
   ...

--- a/docs/backend-system/building-plugins-and-modules/01-index.md
+++ b/docs/backend-system/building-plugins-and-modules/01-index.md
@@ -36,7 +36,7 @@ import {
 import { createExampleRouter } from './router';
 
 export const examplePlugin = createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -183,7 +183,7 @@ that needs to be different across environments.
 import { coreServices } from '@backstage/backend-plugin-api';
 
 export const examplePlugin = createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: { config: coreServices.config },
@@ -216,7 +216,7 @@ export interface ExampleOptions {
 
 export const examplePlugin = createBackendPlugin(
   (options?: ExampleOptions) => ({
-    id: 'example',
+    pluginId: 'example',
     register(env) {
       env.registerInit({
         deps: {

--- a/docs/backend-system/building-plugins-and-modules/08-migrating.md
+++ b/docs/backend-system/building-plugins-and-modules/08-migrating.md
@@ -46,7 +46,7 @@ import { Router } from 'express';
 import { KubernetesBuilder } from './KubernetesBuilder';
 
 export const kubernetesPlugin = createBackendPlugin({
-  id: 'kubernetes',
+  pluginId: 'kubernetes',
   register(env) {
     env.registerInit({
       deps: {
@@ -95,7 +95,7 @@ export interface KubernetesOptions {
 }
 
 const kubernetesPlugin = createBackendPlugin((options: KubernetesOptions) => ({
-  id: 'kubernetes',
+  pluginId: 'kubernetes',
   register(env) {
     env.registerInit({
       deps: {
@@ -182,7 +182,7 @@ class ClusterSupplier implements KubernetesClusterSupplierExtensionPoint {
 }
 
 export const kubernetesPlugin = createBackendPlugin({
-  id: 'kubernetes',
+  pluginId: 'kubernetes',
   register(env) {
     const extensionPoint = new ClusterSupplier();
     // We register the extension point with the backend, which allows modules to

--- a/docs/backend-system/core-services/01-index.md
+++ b/docs/backend-system/core-services/01-index.md
@@ -33,7 +33,7 @@ import {
 import { Router } from 'express';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: { http: coreServices.httpRouter },
@@ -86,7 +86,7 @@ import {
 import { Router } from 'express';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -157,7 +157,7 @@ import {
 } from '@backstage/backend-plugin-api';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -215,7 +215,7 @@ import {
 } from '@backstage/backend-plugin-api';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -288,7 +288,7 @@ import {
 } from '@backstage/backend-plugin-api';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -327,7 +327,7 @@ import {
 import { resolvePackagePath } from '@backstage/backend-common';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -366,7 +366,7 @@ import {
 import { fetch } from 'node-fetch';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -397,7 +397,7 @@ import {
 import { Router } from 'express';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -465,7 +465,7 @@ import {
 } from '@backstage/backend-plugin-api';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -564,7 +564,7 @@ import {
 import { Router } from 'express';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -613,7 +613,7 @@ import {
 import { fetch } from 'node-fetch';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -652,7 +652,7 @@ import {
 import os from 'os';
 
 createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {

--- a/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
@@ -301,7 +301,7 @@ Finally, we need to update `plugins/todo-list-backend/src/plugin.ts`:
   * @alpha
   */
   export const exampleTodoListPlugin = createBackendPlugin({
-    id: 'exampleTodoList',
+    pluginId: 'exampleTodoList',
     register(env) {
       env.registerInit({
         deps: {

--- a/docs/plugins/new-backend-system.md
+++ b/docs/plugins/new-backend-system.md
@@ -84,7 +84,7 @@ import {
 // export type ExamplePluginOptions = { exampleOption: boolean };
 export const examplePlugin = createBackendPlugin({
   // unique id for the plugin
-  id: 'example',
+  pluginId: 'example',
   // It's possible to provide options to the plugin
   // register(env, options: ExamplePluginOptions) {
   register(env) {
@@ -111,7 +111,7 @@ If we wanted our plugin to accept options as well, we'd accept the options as th
 
 ```ts
 export const examplePlugin = createBackendPlugin({
-  id: 'example',
+  pluginId: 'example',
   register(env, options?: { silent?: boolean }) {
     env.registerInit({
       deps: { logger: coreServices.logger },

--- a/packages/backend-app-api/src/services/implementations/scheduler/schedulerFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/scheduler/schedulerFactory.test.ts
@@ -28,7 +28,7 @@ describe('schedulerFactory', () => {
     const subject = schedulerFactory();
 
     const plugin = createBackendPlugin({
-      id: 'example',
+      pluginId: 'example',
       register(reg) {
         reg.registerInit({
           deps: {

--- a/packages/backend-common/src/legacy.ts
+++ b/packages/backend-common/src/legacy.ts
@@ -60,7 +60,7 @@ export function makeLegacyPlugin<
     }>,
   ) => {
     const compatPlugin = createBackendPlugin({
-      id: name,
+      pluginId: name,
       register(env) {
         env.registerInit({
           deps: { ...envMapping, _router: coreServices.httpRouter },

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -143,7 +143,7 @@ describe('createBackend', () => {
     expect.assertions(3);
     backend.add(
       createBackendPlugin({
-        id: 'test',
+        pluginId: 'test',
         register(reg) {
           reg.registerInit({
             deps: {

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -47,7 +47,7 @@ export interface BackendModuleRegistrationPoints {
 
 // @public
 export interface BackendPluginConfig {
-  id: string;
+  pluginId: string;
   // (undocumented)
   register(reg: BackendPluginRegistrationPoints): void;
 }

--- a/packages/backend-plugin-api/src/wiring/factories.test.ts
+++ b/packages/backend-plugin-api/src/wiring/factories.test.ts
@@ -33,7 +33,7 @@ describe('createExtensionPoint', () => {
 describe('createBackendPlugin', () => {
   it('should create a BackendPlugin', () => {
     const plugin = createBackendPlugin((_options: { a: string }) => ({
-      id: 'x',
+      pluginId: 'x',
       register() {},
     }));
     expect(plugin).toBeDefined();
@@ -47,7 +47,7 @@ describe('createBackendPlugin', () => {
 
   it('should create plugins with optional options', () => {
     const plugin = createBackendPlugin((_options?: { a: string }) => ({
-      id: 'x',
+      pluginId: 'x',
       register() {},
     }));
     expect(plugin).toBeDefined();
@@ -59,7 +59,7 @@ describe('createBackendPlugin', () => {
 
   it('should create plugins without options', () => {
     const plugin = createBackendPlugin({
-      id: 'x',
+      pluginId: 'x',
       register() {},
     });
     expect(plugin).toBeDefined();
@@ -74,7 +74,7 @@ describe('createBackendPlugin', () => {
       a: string;
     }
     const plugin = createBackendPlugin((_options: TestOptions) => ({
-      id: 'x',
+      pluginId: 'x',
       register() {},
     }));
     expect(plugin).toBeDefined();
@@ -91,7 +91,7 @@ describe('createBackendPlugin', () => {
       a: string;
     }
     const plugin = createBackendPlugin((_options?: TestOptions) => ({
-      id: 'x',
+      pluginId: 'x',
       register() {},
     }));
     expect(plugin).toBeDefined();

--- a/packages/backend-plugin-api/src/wiring/factories.ts
+++ b/packages/backend-plugin-api/src/wiring/factories.ts
@@ -72,7 +72,7 @@ export interface BackendPluginConfig {
    *
    * @see {@link https://backstage.io/docs/backend-system/architecture/naming-patterns | Recommended naming patterns}
    */
-  id: string;
+  pluginId: string;
   register(reg: BackendPluginRegistrationPoints): void;
 }
 
@@ -87,10 +87,18 @@ export function createBackendPlugin<TOptions extends [options?: object] = []>(
   config: BackendPluginConfig | ((...params: TOptions) => BackendPluginConfig),
 ): (...params: TOptions) => BackendFeature {
   if (typeof config === 'function') {
-    return config;
+    return (...options: TOptions) => {
+      const c = config(...options);
+      return {
+        ...c,
+        id: c.pluginId,
+      };
+    };
   }
-
-  return () => config;
+  return () => ({
+    ...config,
+    id: config.pluginId,
+  });
 }
 
 /**

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
@@ -165,7 +165,7 @@ describe('TestBackend', () => {
     expect.assertions(2);
 
     const testPlugin = createBackendPlugin({
-      id: 'test',
+      pluginId: 'test',
       register(env) {
         env.registerInit({
           deps: {
@@ -201,7 +201,7 @@ describe('TestBackend', () => {
 
   it('should allow making requests via supertest', async () => {
     const testPlugin = createBackendPlugin({
-      id: 'test',
+      pluginId: 'test',
       register(env) {
         env.registerInit({
           deps: {

--- a/plugins/app-backend/src/service/appPlugin.ts
+++ b/plugins/app-backend/src/service/appPlugin.ts
@@ -71,7 +71,7 @@ export type AppPluginOptions = {
  * @alpha
  */
 export const appPlugin = createBackendPlugin((options: AppPluginOptions) => ({
-  id: 'app',
+  pluginId: 'app',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/bazaar-backend/src/plugin.ts
+++ b/plugins/bazaar-backend/src/plugin.ts
@@ -27,7 +27,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export const bazaarPlugin = createBackendPlugin({
-  id: 'bazaar',
+  pluginId: 'bazaar',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -56,7 +56,7 @@ class CatalogExtensionPointImpl implements CatalogProcessingExtensionPoint {
  * @alpha
  */
 export const catalogPlugin = createBackendPlugin({
-  id: 'catalog',
+  pluginId: 'catalog',
   register(env) {
     const processingExtensions = new CatalogExtensionPointImpl();
     // plugins depending on this API will be initialized before this plugins init method is executed.

--- a/plugins/events-backend/src/service/EventsPlugin.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.ts
@@ -80,7 +80,7 @@ class EventsExtensionPointImpl implements EventsExtensionPoint {
  * @alpha
  */
 export const eventsPlugin = createBackendPlugin({
-  id: 'events',
+  pluginId: 'events',
   register(env) {
     const extensionPoint = new EventsExtensionPointImpl();
     env.registerExtensionPoint(eventsExtensionPoint, extensionPoint);

--- a/plugins/example-todo-list-backend/src/plugin.ts
+++ b/plugins/example-todo-list-backend/src/plugin.ts
@@ -27,7 +27,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export const exampleTodoListPlugin = createBackendPlugin({
-  id: 'exampleTodoList',
+  pluginId: 'exampleTodoList',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/kafka-backend/src/plugin.ts
+++ b/plugins/kafka-backend/src/plugin.ts
@@ -27,7 +27,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export const kafkaPlugin = createBackendPlugin({
-  id: 'kafka',
+  pluginId: 'kafka',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/periskop-backend/src/plugin.ts
+++ b/plugins/periskop-backend/src/plugin.ts
@@ -27,7 +27,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export const periskopPlugin = createBackendPlugin({
-  id: 'periskop',
+  pluginId: 'periskop',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/proxy-backend/src/plugin.ts
+++ b/plugins/proxy-backend/src/plugin.ts
@@ -28,7 +28,7 @@ import { createRouter } from './service/router';
  */
 export const proxyPlugin = createBackendPlugin(
   (options?: { skipInvalidProxies?: boolean }) => ({
-    id: 'proxy',
+    pluginId: 'proxy',
     register(env) {
       env.registerInit({
         deps: {

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -64,7 +64,7 @@ class ScaffolderActionsExtensionPointImpl
  */
 export const scaffolderPlugin = createBackendPlugin(
   (options: ScaffolderPluginOptions) => ({
-    id: 'scaffolder',
+    pluginId: 'scaffolder',
     register(env) {
       const actionsExtensions = new ScaffolderActionsExtensionPointImpl();
 

--- a/plugins/user-settings-backend/src/plugin.ts
+++ b/plugins/user-settings-backend/src/plugin.ts
@@ -26,7 +26,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export const userSettingsPlugin = createBackendPlugin({
-  id: 'userSettings',
+  pluginId: 'userSettings',
   register(env) {
     env.registerInit({
       deps: {


### PR DESCRIPTION
More outcomes of backend system API review. This one is a bit larger, but we figured it's worth it to have the options match across `createBackendPlugin` and `createBackendModule`.