### PR TITLE
backend-plugin-api: align opaque type markers

### DIFF
--- a/.changeset/itchy-chairs-punch.md
+++ b/.changeset/itchy-chairs-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Aligned opaque type markers to all use a `$$type` property with namespacing.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -275,7 +275,7 @@ export type ExtensionPoint<T> = {
   id: string;
   T: T;
   toString(): string;
-  $$ref: 'extension-point';
+  $$type: '@backstage/ExtensionPoint';
 };
 
 // @public
@@ -490,7 +490,7 @@ export type ServiceRef<
   scope: TScope;
   T: TService;
   toString(): string;
-  $$ref: 'service';
+  $$type: '@backstage/ServiceRef';
 };
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -508,7 +508,7 @@ export interface ServiceRefConfig<TService, TScope extends 'root' | 'plugin'> {
 // @public
 export interface SharedBackendEnvironment {
   // (undocumented)
-  $$type: 'SharedBackendEnvironment';
+  $$type: '@backstage/SharedBackendEnvironment';
 }
 
 // @public

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -44,7 +44,7 @@ export type ServiceRef<
 
   toString(): string;
 
-  $$ref: 'service';
+  $$type: '@backstage/ServiceRef';
 };
 
 /** @public */
@@ -119,7 +119,7 @@ export function createServiceRef<TService>(
     toString() {
       return `serviceRef{${config.id}}`;
     },
-    $$ref: 'service', // TODO: declare
+    $$type: '@backstage/ServiceRef',
     __defaultFactory: defaultFactory,
   } as ServiceRef<TService, typeof scope> & {
     __defaultFactory?: (

--- a/packages/backend-plugin-api/src/wiring/createSharedEnvironment.test.ts
+++ b/packages/backend-plugin-api/src/wiring/createSharedEnvironment.test.ts
@@ -48,7 +48,7 @@ describe('createSharedEnvironment', () => {
     expect(env).toBeDefined();
     const internalEnv = env() as unknown as InternalSharedBackendEnvironment;
     expect(internalEnv).toEqual({
-      $$type: 'SharedBackendEnvironment',
+      $$type: '@backstage/SharedBackendEnvironment',
       version: 'v1',
       services: undefined,
     });

--- a/packages/backend-plugin-api/src/wiring/createSharedEnvironment.ts
+++ b/packages/backend-plugin-api/src/wiring/createSharedEnvironment.ts
@@ -31,7 +31,7 @@ export interface SharedBackendEnvironmentConfig {
  * @public
  */
 export interface SharedBackendEnvironment {
-  $$type: 'SharedBackendEnvironment';
+  $$type: '@backstage/SharedBackendEnvironment';
 
   // NOTE: This type is opaque in order to allow for future API evolution without
   // cluttering the external API. For example we might want to add support
@@ -93,7 +93,7 @@ export function createSharedEnvironment<
 
     // Here to ensure type safety in this internal implementation.
     const env: SharedBackendEnvironment & InternalSharedBackendEnvironment = {
-      $$type: 'SharedBackendEnvironment',
+      $$type: '@backstage/SharedBackendEnvironment',
       version: 'v1',
       services,
     };

--- a/packages/backend-plugin-api/src/wiring/factories.ts
+++ b/packages/backend-plugin-api/src/wiring/factories.ts
@@ -55,7 +55,7 @@ export function createExtensionPoint<T>(
     toString() {
       return `extensionPoint{${config.id}}`;
     },
-    $$ref: 'extension-point', // TODO: declare
+    $$type: '@backstage/ExtensionPoint',
   };
 }
 

--- a/packages/backend-plugin-api/src/wiring/types.ts
+++ b/packages/backend-plugin-api/src/wiring/types.ts
@@ -32,7 +32,7 @@ export type ExtensionPoint<T> = {
 
   toString(): string;
 
-  $$ref: 'extension-point';
+  $$type: '@backstage/ExtensionPoint';
 };
 
 /**


### PR DESCRIPTION
🧹 

Adding a bit of namespacing with `@backstage/` too, figured it's worth it for the extra context during debugging etc.