### PR TITLE
backend-common: work around missing logform dependency

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -53,6 +53,7 @@
     "@types/dockerode": "^3.3.0",
     "@types/express": "^4.17.6",
     "@types/luxon": "^3.0.0",
+    "@types/triple-beam": "^1.3.2",
     "@types/webpack-env": "^1.15.2",
     "archiver": "^5.0.2",
     "aws-sdk": "^2.840.0",

--- a/packages/repo-tools/src/commands/type-deps/type-deps.ts
+++ b/packages/repo-tools/src/commands/type-deps/type-deps.ts
@@ -196,6 +196,14 @@ function findTypeDepErrors(typeDeps: string[], pkg: Package) {
   }
 
   for (const dep of deps) {
+    // Remove this once the logform issue has been fixed.
+    // https://github.com/winstonjs/logform/issues/242
+    if (
+      pkg.packageJson.name === '@backstage/backend-common' &&
+      dep === '@types/triple-beam'
+    ) {
+      continue;
+    }
     errors.push(
       mkErr('WrongDepError', `Should be dev dep ${dep}`, {
         dep,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3457,6 +3457,7 @@ __metadata:
     "@types/stoppable": ^1.1.0
     "@types/supertest": ^2.0.8
     "@types/tar": ^6.1.1
+    "@types/triple-beam": ^1.3.2
     "@types/webpack-env": ^1.15.2
     "@types/yauzl": ^2.10.0
     archiver: ^5.0.2
@@ -15440,6 +15441,13 @@ __metadata:
   version: 4.0.0
   resolution: "@types/tough-cookie@npm:4.0.0"
   checksum: 454fa8d4d64532992274ebf2ff5ea0061b0dd32a2282255a3e793f04a8b64a9c4c1f9e0f4ed83c514c852b7b604d69336c66c80de4a857cb41a81e9572981e7f
+  languageName: node
+  linkType: hard
+
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@types/triple-beam@npm:1.3.2"
+  checksum: dd7b4a563fb710abc992e5d59eac481bed9e303fada2e276e37b00be31c392e03300ee468e57761e616512872e77935f92472877d0704a19688d15a726cee17b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Temporary fix for https://github.com/winstonjs/logform/issues/242 to get our builds going. Once it's fixed we can remove this dependency.