### PR TITLE
ToC not rendering docs

### DIFF
--- a/docs/features/techdocs/troubleshooting.md
+++ b/docs/features/techdocs/troubleshooting.md
@@ -72,3 +72,23 @@ details.
 
 Instead use `svg_inline` which renders as an `<svg>` tag and provides the same
 benefits as `svg_object`.
+
+## Table of Contents doesn't render
+
+The [toc](https://python-markdown.github.io/extensions/toc/) extension is included
+in the standard Markdown library.
+
+But in order for it to render, you can't use single dash headers. (#)
+
+This header will not render in the Table of Contents:
+``` markdown
+# Some Header
+```
+
+This one will:
+``` markdown
+## Some Header
+```
+
+Avoid using single dash headers in your markdown-files to ensure that the
+Table of Contents will render.


### PR DESCRIPTION
Signed-off-by: Martin Eriksson <31728726+meriksson1991@users.noreply.github.com>

## Hey, I just made a Pull Request!

Added some useful information on avoiding the use of single dash headers (#) in your markdown files to ensure that the Table of Contents will render.

The information is added in the `troubleshooting.md` file under `techdocs`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
