### PR TITLE
fix stepper hasErrors to not bottom out at first error

### DIFF
--- a/.changeset/chilled-rice-own.md
+++ b/.changeset/chilled-rice-own.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder-react': patch
----
-
-fix `stepper` `hasErrors` to not bottom out at first error

--- a/.changeset/chilled-rice-own.md
+++ b/.changeset/chilled-rice-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+fix `stepper` `hasErrors` to not bottom out at first error

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
@@ -181,6 +181,18 @@ describe('createAsyncValidators', () => {
                   title: 'General',
                   type: 'object',
                   properties: {
+                    address: {
+                      type: 'object',
+                      'ui:field': 'AddressField',
+                      properties: {
+                        street: {
+                          type: 'string',
+                        },
+                        postcode: {
+                          type: 'string',
+                        },
+                      },
+                    },
                     name: {
                       title: 'Name',
                       type: 'string',
@@ -207,6 +219,19 @@ describe('createAsyncValidators', () => {
       },
     };
 
+    const AddressField: NextCustomFieldValidator<{
+      street?: string;
+      postcode?: string;
+    }> = (value, { addError }) => {
+      if (!value.postcode) {
+        addError('postcode is missing!');
+      }
+
+      if (!value.street) {
+        addError('street is missing here!');
+      }
+    };
+
     const NameField: NextCustomFieldValidator<string> = (
       value,
       { addError },
@@ -217,6 +242,7 @@ describe('createAsyncValidators', () => {
     };
 
     const validators = {
+      AddressField: AddressField as NextCustomFieldValidator<unknown>,
       NameField: NameField as NextCustomFieldValidator<unknown>,
     };
 
@@ -228,11 +254,18 @@ describe('createAsyncValidators', () => {
       validate({
         actionType: 'newThing',
         general: {
+          address: {
+            street: 'street',
+            postcode: 'postcode',
+          },
           name: undefined,
         },
       }),
     ).resolves.toEqual({
       general: {
+        address: expect.objectContaining({
+          __errors: [],
+        }),
         name: expect.objectContaining({
           __errors: ['something is broken here!'],
         }),

--- a/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { hasErrors } from './utils';
+
+describe('hasErrors', () => {
+  it('should return false for empty _errors', () => {
+    expect(
+      hasErrors({
+        name: {
+          __errors: [],
+          addError: jest.fn(),
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true for a single error', () => {
+    expect(
+      hasErrors({
+        name: {
+          __errors: ['an error'],
+          addError: jest.fn(),
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true for more than one error', () => {
+    expect(
+      hasErrors({
+        name: {
+          __errors: [],
+          addError: jest.fn(),
+        },
+        general: {
+          address: {
+            __errors: [],
+            addError: jest.fn(),
+          },
+          name: {
+            __errors: ['something is broken here!'],
+            addError: jest.fn(),
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/plugins/scaffolder-react/src/next/components/Stepper/utils.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/utils.ts
@@ -28,7 +28,11 @@ export function hasErrors(errors?: FormValidation): boolean {
 
   for (const error of Object.values(errors)) {
     if (isFieldValidation(error)) {
-      return (error.__errors ?? []).length > 0;
+      if ((error.__errors ?? []).length > 0) {
+        return true;
+      }
+
+      continue;
     }
 
     return hasErrors(error);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I had realisation after #16196 was merged that there is a bug in the recursive `hasErrors` function that is used by the `Stepper` 🤦 .

It was bottoming out at the first check for an `__errors` array.

This PR fixes that and adds some testing around `hasErrors`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
