### PR TITLE
rename `RootHttpRouterConfigureOptions`, remove `ServiceOrExtensionPoint`

### DIFF
--- a/.changeset/afraid-planets-crash.md
+++ b/.changeset/afraid-planets-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+**BREAKING**: Renamed `RootHttpRouterConfigureOptions` to `RootHttpRouterConfigureContext`, and removed the unused type `ServiceOrExtensionPoint`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -11,7 +11,6 @@ import { ConfigService } from '@backstage/backend-plugin-api';
 import { CorsOptions } from 'cors';
 import { ErrorRequestHandler } from 'express';
 import { Express as Express_2 } from 'express';
-import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { Format } from 'logform';
 import { Handler } from 'express';
 import { HelmetOptions } from 'helmet';
@@ -34,7 +33,6 @@ import { RootLoggerService } from '@backstage/backend-plugin-api';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceFactoryOrFunction } from '@backstage/backend-plugin-api';
-import { ServiceRef } from '@backstage/backend-plugin-api';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { transport } from 'winston';
 import { UrlReader } from '@backstage/backend-common';
@@ -216,7 +214,7 @@ export function readHelmetOptions(config?: Config): HelmetOptions;
 export function readHttpServerOptions(config?: Config): HttpServerOptions;
 
 // @public (undocumented)
-export interface RootHttpRouterConfigureOptions {
+export interface RootHttpRouterConfigureContext {
   // (undocumented)
   app: Express_2;
   // (undocumented)
@@ -234,7 +232,7 @@ export interface RootHttpRouterConfigureOptions {
 // @public (undocumented)
 export type RootHttpRouterFactoryOptions = {
   indexPath?: string | false;
-  configure?(options: RootHttpRouterConfigureOptions): void;
+  configure?(context: RootHttpRouterConfigureContext): void;
 };
 
 // @public (undocumented)
@@ -250,11 +248,6 @@ export const rootLoggerServiceFactory: () => ServiceFactory<RootLoggerService>;
 
 // @public (undocumented)
 export const schedulerServiceFactory: () => ServiceFactory<SchedulerService>;
-
-// @public (undocumented)
-export type ServiceOrExtensionPoint<T = unknown> =
-  | ExtensionPoint<T>
-  | ServiceRef<T>;
 
 // @public (undocumented)
 export const tokenManagerServiceFactory: () => ServiceFactory<TokenManagerService>;

--- a/packages/backend-app-api/src/services/implementations/rootHttpRouter/index.ts
+++ b/packages/backend-app-api/src/services/implementations/rootHttpRouter/index.ts
@@ -17,7 +17,7 @@
 export {
   rootHttpRouterServiceFactory,
   type RootHttpRouterFactoryOptions,
-  type RootHttpRouterConfigureOptions,
+  type RootHttpRouterConfigureContext,
 } from './rootHttpRouterServiceFactory';
 export {
   DefaultRootHttpRouter,

--- a/packages/backend-app-api/src/services/implementations/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -32,7 +32,7 @@ import { DefaultRootHttpRouter } from './DefaultRootHttpRouter';
 /**
  * @public
  */
-export interface RootHttpRouterConfigureOptions {
+export interface RootHttpRouterConfigureContext {
   app: Express;
   middleware: MiddlewareFactory;
   routes: RequestHandler;
@@ -51,14 +51,11 @@ export type RootHttpRouterFactoryOptions = {
    */
   indexPath?: string | false;
 
-  configure?(options: RootHttpRouterConfigureOptions): void;
+  configure?(context: RootHttpRouterConfigureContext): void;
 };
 
-function defaultConfigure({
-  app,
-  routes,
-  middleware,
-}: RootHttpRouterConfigureOptions) {
+function defaultConfigure(context: RootHttpRouterConfigureContext) {
+  const { app, routes, middleware } = context;
   app.use(middleware.helmet());
   app.use(middleware.cors());
   app.use(middleware.compression());

--- a/packages/backend-app-api/src/wiring/index.ts
+++ b/packages/backend-app-api/src/wiring/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-export type {
-  Backend,
-  CreateSpecializedBackendOptions,
-  ServiceOrExtensionPoint,
-} from './types';
+export type { Backend, CreateSpecializedBackendOptions } from './types';
 export { createSpecializedBackend } from './createSpecializedBackend';


### PR DESCRIPTION
As part of the ongoing backend system API review before its release.