### PR TITLE
Make Search Select filter more re-customizable. Add Multiselect filter

### DIFF
--- a/.changeset/silly-goats-enjoy.md
+++ b/.changeset/silly-goats-enjoy.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-react': minor
 ---
 
-Make Search Select filter more re-customizable. Add `MultiSelect` filter.
+Make Search Select filter more re-customizable.

--- a/.changeset/silly-goats-enjoy.md
+++ b/.changeset/silly-goats-enjoy.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-react': minor
 ---
 
-Make Search Select filter more re-customizable. Add `Multiselect` filter
+Make Search Select filter more re-customizable. Add `MultiSelect` filter

--- a/.changeset/silly-goats-enjoy.md
+++ b/.changeset/silly-goats-enjoy.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-react': minor
 ---
 
-Make Search Select filter more re-customizable. Add `MultiSelect` filter
+Make Search Select filter more re-customizable. Add `MultiSelect` filter.

--- a/.changeset/silly-goats-enjoy.md
+++ b/.changeset/silly-goats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': minor
+---
+
+Make Search Select filter more re-customizable. Add `Multiselect` filter

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -83,15 +83,6 @@ export class MockSearchApi implements SearchApi {
 }
 
 // @public (undocumented)
-export const MultiSelectFilter: (props: MultiselectFilterProps) => JSX.Element;
-
-// @public (undocumented)
-export type MultiselectFilterProps<T extends SearchFilterValue = string> = Omit<
-  SelectFilterProps<T>,
-  'multiple' | 'renderValue' | 'allOptionLabel'
->;
-
-// @public (undocumented)
 export interface SearchApi {
   // (undocumented)
   query(query: SearchQuery): Promise<SearchResultSet>;
@@ -207,11 +198,8 @@ export const SearchFilter: {
     props: Omit<SearchFilterWrapperProps, 'component'> &
       SearchFilterComponentProps,
   ): JSX.Element;
-  Select(
-    props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps,
-  ): JSX.Element;
-  MultiSelect(
-    props: Omit<SearchFilterWrapperProps, 'component'> & MultiselectFilterProps,
+  Select<T extends SearchFilterValue = string>(
+    props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps<T>,
   ): JSX.Element;
   Autocomplete(props: SearchAutocompleteFilterProps): JSX.Element;
 };

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -83,9 +83,13 @@ export class MockSearchApi implements SearchApi {
 }
 
 // @public (undocumented)
-export const MultiSelectFilter: (
-  props: SearchFilterComponentProps,
-) => JSX.Element;
+export const MultiSelectFilter: (props: MultiselectFilterProps) => JSX.Element;
+
+// @public (undocumented)
+export type MultiselectFilterProps<T extends SearchFilterValue = string> = Omit<
+  SelectFilterProps<T>,
+  'multiple' | 'renderValue' | 'allOptionLabel'
+>;
 
 // @public (undocumented)
 export interface SearchApi {
@@ -207,8 +211,7 @@ export const SearchFilter: {
     props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps,
   ): JSX.Element;
   MultiSelect(
-    props: Omit<SearchFilterWrapperProps, 'component'> &
-      SearchFilterComponentProps,
+    props: Omit<SearchFilterWrapperProps, 'component'> & MultiselectFilterProps,
   ): JSX.Element;
   Autocomplete(props: SearchAutocompleteFilterProps): JSX.Element;
 };
@@ -219,9 +222,12 @@ export type SearchFilterComponentProps = {
   name: string;
   label?: string;
   values?: string[] | ((partial: string) => Promise<string[]>);
-  defaultValue?: string[] | string | null;
+  defaultValue?: SearchFilterValue | null;
   valuesDebounceMs?: number;
 };
+
+// @public (undocumented)
+export type SearchFilterValue = string | string[];
 
 // @public (undocumented)
 export type SearchFilterWrapperProps = SearchFilterComponentProps & {
@@ -462,23 +468,23 @@ export type SearchResultStateProps = SearchResultContextProps &
   Partial<SearchResultApiProps>;
 
 // @public (undocumented)
-export function SelectFilter<T extends JsonValue = string>(
+export function SelectFilter<T extends SearchFilterValue = string>(
   props: SelectFilterProps<T>,
 ): JSX.Element;
 
 // @public (undocumented)
-export interface SelectFilterProps<T extends JsonValue = string>
+export interface SelectFilterProps<T extends SearchFilterValue = string>
   extends SearchFilterComponentProps {
   // (undocumented)
-  emptyItemLabel?: string;
+  allOptionLabel?: React_2.ReactNode;
   // (undocumented)
   fullWidth?: boolean;
   // (undocumented)
   multiple?: boolean;
   // (undocumented)
-  placeholder?: string;
+  placeholder?: React_2.ReactNode;
   // (undocumented)
-  renderValue?: (selected: T) => string;
+  renderValue?: (selected: T) => React_2.ReactNode;
 }
 
 // @public

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -83,7 +83,7 @@ export class MockSearchApi implements SearchApi {
 }
 
 // @public (undocumented)
-export const MultiselectFilter: (
+export const MultiSelectFilter: (
   props: SearchFilterComponentProps,
 ) => JSX.Element;
 
@@ -206,7 +206,7 @@ export const SearchFilter: {
   Select(
     props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps,
   ): JSX.Element;
-  Multiselect(
+  MultiSelect(
     props: Omit<SearchFilterWrapperProps, 'component'> &
       SearchFilterComponentProps,
   ): JSX.Element;

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -83,6 +83,11 @@ export class MockSearchApi implements SearchApi {
 }
 
 // @public (undocumented)
+export const MultiselectFilter: (
+  props: SearchFilterComponentProps,
+) => JSX.Element;
+
+// @public (undocumented)
 export interface SearchApi {
   // (undocumented)
   query(query: SearchQuery): Promise<SearchResultSet>;
@@ -199,6 +204,9 @@ export const SearchFilter: {
       SearchFilterComponentProps,
   ): JSX.Element;
   Select(
+    props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps,
+  ): JSX.Element;
+  Multiselect(
     props: Omit<SearchFilterWrapperProps, 'component'> &
       SearchFilterComponentProps,
   ): JSX.Element;
@@ -454,7 +462,24 @@ export type SearchResultStateProps = SearchResultContextProps &
   Partial<SearchResultApiProps>;
 
 // @public (undocumented)
-export const SelectFilter: (props: SearchFilterComponentProps) => JSX.Element;
+export function SelectFilter<T extends JsonValue = string>(
+  props: SelectFilterProps<T>,
+): JSX.Element;
+
+// @public (undocumented)
+export interface SelectFilterProps<T extends JsonValue = string>
+  extends SearchFilterComponentProps {
+  // (undocumented)
+  emptyItemLabel?: string;
+  // (undocumented)
+  fullWidth?: boolean;
+  // (undocumented)
+  multiple?: boolean;
+  // (undocumented)
+  placeholder?: string;
+  // (undocumented)
+  renderValue?: (selected: T) => string;
+}
 
 // @public
 export const useSearch: () => SearchContextValue;

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -40,6 +40,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
+    "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "qs": "^6.9.4",
     "react-use": "^17.3.2"

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
@@ -52,14 +52,10 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
   } = props;
   const [inputValue, setInputValue] = useState<string>('');
   useDefaultFilterValue(name, defaultValue);
-  const asyncValues =
-    typeof givenValues === 'function' ? givenValues : undefined;
-  const defaultValues =
-    typeof givenValues === 'function' ? undefined : givenValues;
+
   const { value: values, loading } = useAsyncFilterValues(
-    asyncValues,
+    givenValues,
     inputValue,
-    defaultValues,
     valuesDebounceMs,
   );
   const { filters, setFilters } = useSearch();

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
@@ -97,7 +97,6 @@ export const AllOptionSelectFilter = () => {
         label="Search Select Filter"
         name="select_filter"
         values={['value1', 'value2']}
-        renderValue={value => <i>{value}</i>}
       />
     </Paper>
   );
@@ -106,7 +105,8 @@ export const AllOptionSelectFilter = () => {
 export const MultiSelectFilter = () => {
   return (
     <Paper style={{ padding: 10 }}>
-      <SearchFilter.MultiSelect
+      <SearchFilter.Select<string[]>
+        multiple
         label="Search Select Filter"
         name="select_filter"
         values={['value1', 'value2']}

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
@@ -64,6 +64,45 @@ export const SelectFilter = () => {
   );
 };
 
+export const PlaceholderSelectFilter = () => {
+  return (
+    <Paper style={{ padding: 10 }}>
+      <SearchFilter.Select
+        placeholder="Search Select Filter"
+        name="select_filter"
+        values={['value1', 'value2']}
+      />
+    </Paper>
+  );
+};
+
+export const RenderValueSelectFilter = () => {
+  return (
+    <Paper style={{ padding: 10 }}>
+      <SearchFilter.Select
+        label="Search Select Filter"
+        name="select_filter"
+        values={['value1', 'value2']}
+        renderValue={value => <i>{value}</i>}
+      />
+    </Paper>
+  );
+};
+
+export const AllOptionSelectFilter = () => {
+  return (
+    <Paper style={{ padding: 10 }}>
+      <SearchFilter.Select
+        allOptionLabel="Any value"
+        label="Search Select Filter"
+        name="select_filter"
+        values={['value1', 'value2']}
+        renderValue={value => <i>{value}</i>}
+      />
+    </Paper>
+  );
+};
+
 export const MultiSelectFilter = () => {
   return (
     <Paper style={{ padding: 10 }}>

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
@@ -64,10 +64,10 @@ export const SelectFilter = () => {
   );
 };
 
-export const MultiselectFilter = () => {
+export const MultiSelectFilter = () => {
   return (
     <Paper style={{ padding: 10 }}>
-      <SearchFilter.Multiselect
+      <SearchFilter.MultiSelect
         label="Search Select Filter"
         name="select_filter"
         values={['value1', 'value2']}

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.stories.tsx
@@ -64,6 +64,18 @@ export const SelectFilter = () => {
   );
 };
 
+export const MultiselectFilter = () => {
+  return (
+    <Paper style={{ padding: 10 }}>
+      <SearchFilter.Multiselect
+        label="Search Select Filter"
+        name="select_filter"
+        values={['value1', 'value2']}
+      />
+    </Paper>
+  );
+};
+
 export const AsyncSelectFilter = () => {
   return (
     <Paper style={{ padding: 10 }}>

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
@@ -422,7 +422,12 @@ describe('SearchFilter', () => {
     it('Selecting multiple values sets filter state', async () => {
       render(
         <SearchContextProvider initialState={initialState}>
-          <SearchFilter.MultiSelect label={label} name={name} values={values} />
+          <SearchFilter.Select
+            multiple
+            label={label}
+            name={name}
+            values={values}
+          />
         </SearchContextProvider>,
       );
 

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
@@ -37,7 +37,7 @@ describe('SearchFilter', () => {
 
   const label = 'Field';
   const name = 'field';
-  const values = ['value1', 'value2'];
+  const values = ['value1', 'value2', 'value3'];
   const filters = { unrelated: 'unrelated' };
 
   const query = jest.fn().mockResolvedValue({});
@@ -208,6 +208,18 @@ describe('SearchFilter', () => {
       expect(
         screen.getByRole('option', { name: values[1] }),
       ).toBeInTheDocument();
+    });
+
+    it('Renders placeholder', async () => {
+      render(
+        <SearchContextProvider initialState={initialState}>
+          <SearchFilter.Select placeholder="Hey" name={name} values={values} />
+        </SearchContextProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Hey')).toBeInTheDocument();
+      });
     });
 
     it('Renders values when provided asynchronously', async () => {
@@ -403,6 +415,53 @@ describe('SearchFilter', () => {
       await waitFor(() => {
         expect(query).toHaveBeenLastCalledWith(
           expect.objectContaining({ filters }),
+        );
+      });
+    });
+
+    it('Selecting multiple values sets filter state', async () => {
+      render(
+        <SearchContextProvider initialState={initialState}>
+          <SearchFilter.Multiselect label={label} name={name} values={values} />
+        </SearchContextProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole('option', { name: values[0] }));
+      await userEvent.click(screen.getByRole('option', { name: values[2] }));
+
+      await waitFor(() => {
+        expect(query).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            filters: { [name]: [values[0], values[2]] },
+          }),
+        );
+      });
+
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole('option', { name: values[0] }));
+
+      await waitFor(() => {
+        expect(query).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            filters: { [name]: [values[2]] },
+          }),
         );
       });
     });

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
@@ -422,7 +422,7 @@ describe('SearchFilter', () => {
     it('Selecting multiple values sets filter state', async () => {
       render(
         <SearchContextProvider initialState={initialState}>
-          <SearchFilter.Multiselect label={label} name={name} values={values} />
+          <SearchFilter.MultiSelect label={label} name={name} values={values} />
         </SearchContextProvider>,
       );
 

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
@@ -94,14 +94,6 @@ export interface SelectFilterProps<T extends SearchFilterValue = string>
 /**
  * @public
  */
-export type MultiselectFilterProps<T extends SearchFilterValue = string> = Omit<
-  SelectFilterProps<T>,
-  'multiple' | 'renderValue' | 'allOptionLabel'
->;
-
-/**
- * @public
- */
 export const CheckboxFilter = (props: SearchFilterComponentProps) => {
   const {
     className,
@@ -241,6 +233,10 @@ export function SelectFilter<T extends SearchFilterValue = string>(
             return renderValue(selected as T);
           }
 
+          if (multiple) {
+            return (selected as any[]).join(', ');
+          }
+
           return selected as T;
         }}
         MenuProps={{
@@ -268,19 +264,6 @@ export function SelectFilter<T extends SearchFilterValue = string>(
 /**
  * @public
  */
-export const MultiSelectFilter = (props: MultiselectFilterProps) => {
-  return (
-    <SelectFilter<string[]>
-      {...props}
-      multiple
-      renderValue={selected => selected.join(', ')}
-    />
-  );
-};
-
-/**
- * @public
- */
 const SearchFilter = ({
   component: Element,
   ...props
@@ -291,13 +274,9 @@ SearchFilter.Checkbox = (
     SearchFilterComponentProps,
 ) => <SearchFilter {...props} component={CheckboxFilter} />;
 
-SearchFilter.Select = (
-  props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps,
+SearchFilter.Select = <T extends SearchFilterValue = string>(
+  props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps<T>,
 ) => <SearchFilter {...props} component={SelectFilter} />;
-
-SearchFilter.MultiSelect = (
-  props: Omit<SearchFilterWrapperProps, 'component'> & MultiselectFilterProps,
-) => <SearchFilter {...props} component={MultiSelectFilter} />;
 
 /**
  * A control surface for a given filter field name, rendered as an autocomplete

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { ReactElement, ChangeEvent } from 'react';
-import isEmpty from 'lodash/isEmpty';
 import classnames from 'classnames';
 import {
   makeStyles,
@@ -192,7 +191,9 @@ export function SelectFilter<T extends JsonValue = string>(
     setFilters(prevFilters => {
       const { [props.name]: filter, ...others } = prevFilters;
 
-      return isEmpty(value) ? others : { ...others, [props.name]: value as T };
+      return (value as any[]).length === 0
+        ? others
+        : { ...others, [props.name]: value as T };
     });
   };
 
@@ -221,7 +222,7 @@ export function SelectFilter<T extends JsonValue = string>(
         multiple={multiple}
         displayEmpty={displayEmpty}
         renderValue={selected => {
-          if (displayEmpty && isEmpty(selected as T)) {
+          if (displayEmpty && (selected as any[]).length === 0) {
             return placeholder;
           }
 

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { ReactElement, ChangeEvent } from 'react';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import classnames from 'classnames';
 import {
   makeStyles,
@@ -192,9 +192,7 @@ export function SelectFilter<T extends JsonValue = string>(
     setFilters(prevFilters => {
       const { [props.name]: filter, ...others } = prevFilters;
 
-      return _.isEmpty(value)
-        ? others
-        : { ...others, [props.name]: value as T };
+      return isEmpty(value) ? others : { ...others, [props.name]: value as T };
     });
   };
 
@@ -223,7 +221,7 @@ export function SelectFilter<T extends JsonValue = string>(
         multiple={multiple}
         displayEmpty={displayEmpty}
         renderValue={selected => {
-          if (displayEmpty && _.isEmpty(selected as T)) {
+          if (displayEmpty && isEmpty(selected as T)) {
             return placeholder;
           }
 
@@ -258,7 +256,7 @@ export function SelectFilter<T extends JsonValue = string>(
 /**
  * @public
  */
-export const MultiselectFilter = (props: SearchFilterComponentProps) => {
+export const MultiSelectFilter = (props: SearchFilterComponentProps) => {
   return (
     <SelectFilter<string[]>
       {...props}
@@ -285,10 +283,10 @@ SearchFilter.Select = (
   props: Omit<SearchFilterWrapperProps, 'component'> & SelectFilterProps,
 ) => <SearchFilter {...props} component={SelectFilter} />;
 
-SearchFilter.Multiselect = (
+SearchFilter.MultiSelect = (
   props: Omit<SearchFilterWrapperProps, 'component'> &
     SearchFilterComponentProps,
-) => <SearchFilter {...props} component={MultiselectFilter} />;
+) => <SearchFilter {...props} component={MultiSelectFilter} />;
 
 /**
  * A control surface for a given filter field name, rendered as an autocomplete

--- a/plugins/search-react/src/components/SearchFilter/hooks.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/hooks.test.tsx
@@ -217,7 +217,7 @@ describe('SearchFilter.hooks', () => {
     it('should immediately return given values when provided', () => {
       const givenValues = ['value1', 'value2'];
       const { result } = renderHook(() =>
-        useAsyncFilterValues(undefined, '', givenValues),
+        useAsyncFilterValues(givenValues, ''),
       );
 
       expect(result.current.loading).toEqual(false);
@@ -228,7 +228,7 @@ describe('SearchFilter.hooks', () => {
       const expectedValues = ['value1', 'value2'];
       const asyncFn = () => Promise.resolve(expectedValues);
       const { result, waitForNextUpdate } = renderHook(() =>
-        useAsyncFilterValues(asyncFn, '', undefined, 1000),
+        useAsyncFilterValues(asyncFn, '', 1000),
       );
 
       expect(result.current.loading).toEqual(true);
@@ -243,7 +243,7 @@ describe('SearchFilter.hooks', () => {
     it('should debounce method invocation', async () => {
       const expectedValues = ['value1', 'value2'];
       const asyncFn = jest.fn().mockResolvedValue(expectedValues);
-      renderHook(() => useAsyncFilterValues(asyncFn, '', undefined, 1000));
+      renderHook(() => useAsyncFilterValues(asyncFn, '', 1000));
 
       expect(asyncFn).not.toHaveBeenCalled();
 
@@ -262,7 +262,7 @@ describe('SearchFilter.hooks', () => {
         .mockImplementation((x: string) => Promise.resolve([x]));
       const { rerender, waitForNextUpdate } = renderHook(
         (props: { inputValue: string } = { inputValue: '' }) =>
-          useAsyncFilterValues(asyncFn, props.inputValue, undefined, 1000),
+          useAsyncFilterValues(asyncFn, props.inputValue, 1000),
       );
 
       expect(asyncFn).not.toHaveBeenCalled();
@@ -284,7 +284,7 @@ describe('SearchFilter.hooks', () => {
       const asyncFn = jest.fn().mockResolvedValue(expectedValues);
       const { rerender, waitForNextUpdate } = renderHook(
         (props: { inputValue: string } = { inputValue: '' }) =>
-          useAsyncFilterValues(asyncFn, props.inputValue, undefined, 1000),
+          useAsyncFilterValues(asyncFn, props.inputValue, 1000),
       );
 
       expect(asyncFn).not.toHaveBeenCalled();

--- a/plugins/search-react/src/components/SearchFilter/hooks.ts
+++ b/plugins/search-react/src/components/SearchFilter/hooks.ts
@@ -27,14 +27,19 @@ import { useSearch } from '../../context';
  * @public
  */
 export const useAsyncFilterValues = (
-  fn: ((partial: string) => Promise<string[]>) | undefined,
+  givenValues: string[] | ((partial: string) => Promise<string[]>) | undefined,
   inputValue: string,
-  defaultValues: string[] = [],
   debounce: number = 250,
 ) => {
+  const fn = typeof givenValues === 'function' ? givenValues : undefined;
+
+  const defaultValues =
+    (typeof givenValues === 'function' ? undefined : givenValues) ?? [];
+
   const valuesMemo = useRef<Record<string, string[] | Promise<string[]>>>({});
   const definiteFn = fn || (() => Promise.resolve([]));
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const [state, callback] = useAsyncFn(definiteFn, [inputValue], {
     loading: true,
   });

--- a/plugins/search-react/src/components/SearchFilter/hooks.ts
+++ b/plugins/search-react/src/components/SearchFilter/hooks.ts
@@ -39,7 +39,6 @@ export const useAsyncFilterValues = (
   const valuesMemo = useRef<Record<string, string[] | Promise<string[]>>>({});
   const definiteFn = fn || (() => Promise.resolve([]));
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const [state, callback] = useAsyncFn(definiteFn, [inputValue], {
     loading: true,
   });

--- a/plugins/search-react/src/components/SearchFilter/index.ts
+++ b/plugins/search-react/src/components/SearchFilter/index.ts
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-export {
-  CheckboxFilter,
-  SearchFilter,
-  SelectFilter,
-  MultiSelectFilter,
-} from './SearchFilter';
+export { CheckboxFilter, SearchFilter, SelectFilter } from './SearchFilter';
 export { AutocompleteFilter } from './SearchFilter.Autocomplete';
 export type {
   SearchFilterComponentProps,
   SearchFilterWrapperProps,
   SelectFilterProps,
-  MultiselectFilterProps,
   SearchFilterValue,
 } from './SearchFilter';
 export type { SearchAutocompleteFilterProps } from './SearchFilter.Autocomplete';

--- a/plugins/search-react/src/components/SearchFilter/index.ts
+++ b/plugins/search-react/src/components/SearchFilter/index.ts
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-export { CheckboxFilter, SearchFilter, SelectFilter } from './SearchFilter';
+export {
+  CheckboxFilter,
+  SearchFilter,
+  SelectFilter,
+  MultiselectFilter,
+} from './SearchFilter';
 export { AutocompleteFilter } from './SearchFilter.Autocomplete';
 export type {
   SearchFilterComponentProps,
   SearchFilterWrapperProps,
+  SelectFilterProps,
 } from './SearchFilter';
 export type { SearchAutocompleteFilterProps } from './SearchFilter.Autocomplete';

--- a/plugins/search-react/src/components/SearchFilter/index.ts
+++ b/plugins/search-react/src/components/SearchFilter/index.ts
@@ -18,7 +18,7 @@ export {
   CheckboxFilter,
   SearchFilter,
   SelectFilter,
-  MultiselectFilter,
+  MultiSelectFilter,
 } from './SearchFilter';
 export { AutocompleteFilter } from './SearchFilter.Autocomplete';
 export type {

--- a/plugins/search-react/src/components/SearchFilter/index.ts
+++ b/plugins/search-react/src/components/SearchFilter/index.ts
@@ -25,5 +25,7 @@ export type {
   SearchFilterComponentProps,
   SearchFilterWrapperProps,
   SelectFilterProps,
+  MultiselectFilterProps,
+  SearchFilterValue,
 } from './SearchFilter';
 export type { SearchAutocompleteFilterProps } from './SearchFilter.Autocomplete';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7796,6 +7796,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@testing-library/react-hooks": ^8.0.0
     "@testing-library/user-event": ^14.0.0
+    classnames: ^2.3.1
     lodash: ^4.17.21
     qs: ^6.9.4
     react-use: ^17.3.2


### PR DESCRIPTION
Signed-off-by: Ilya Savich <isavich@box.com>

Hi, I refactored a little bit Search Select filter to make it more customizable and re-used to create multiselect input
#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
