### PR TITLE
Check cost insights array length

### DIFF
--- a/.changeset/sweet-yaks-taste.md
+++ b/.changeset/sweet-yaks-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fix bug in EntityCostsCard if cost aggregation array is empty. Allow title override on the Cost Insights Page

--- a/plugins/cost-insights/src/components/CostInsightsLayout/CostInsightsLayout.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsLayout/CostInsightsLayout.tsx
@@ -37,6 +37,7 @@ type CostInsightsLayoutProps = {
 };
 
 export const CostInsightsLayout = ({
+  title = 'Cost Insights',
   groups,
   children,
 }: PropsWithChildren<CostInsightsLayoutProps>) => {
@@ -46,7 +47,7 @@ export const CostInsightsLayout = ({
       <Header
         style={{ boxShadow: 'none' }}
         title="Cost Insights"
-        pageTitleOverride="Cost Insights"
+        pageTitleOverride={title}
         type="Tool"
       />
       <div className={classes.root}>

--- a/plugins/cost-insights/src/components/EntityCosts/EntityCosts.tsx
+++ b/plugins/cost-insights/src/components/EntityCosts/EntityCosts.tsx
@@ -120,7 +120,7 @@ export const EntityCostsCard = () => {
     return <MaterialAlert severity="error">{error.message}</MaterialAlert>;
   }
 
-  if (!dailyCost) {
+  if (!dailyCost || !dailyCost.aggregation.length) {
     return <MaterialAlert severity="error">No daily costs</MaterialAlert>;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fix bug in EntityCostsCard if cost aggregation array is empty. Allow title override on the Cost Insights Page


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
