### PR TITLE
chore: turn off the auto assign functionality of our workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,12 +18,12 @@ jobs:
     if: github.repository == 'backstage/backstage' && ( github.event.pull_request || github.event.issue.pull_request )
     steps:
       - name: PR sync
-        uses: backstage/actions/pr-sync@v0.6.0
+        uses: backstage/actions/pr-sync@v0.6.1
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN  }}
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
           project-id: PVT_kwDOBFKqdc02LQ
-          excluded-users: ${{ secrets.OOO_USERS }}
+          auto-assign: false
           owning-teams: '@backstage/techdocs-core'


### PR DESCRIPTION
requires: https://github.com/backstage/actions/pull/115

For context - we're opting out of our homegrown solution in favour of Github Auto assignment from the teams that are codeowners for the files.

