### PR TITLE
Make catalog search result list a bit more customizable

### DIFF
--- a/.changeset/spotty-spiders-love.md
+++ b/.changeset/spotty-spiders-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Make catalog search result list a bit more customizable

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -29,16 +29,20 @@ import {
 } from '@backstage/plugin-search-common';
 import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
 
-const useStyles = makeStyles({
-  flexContainer: {
-    flexWrap: 'wrap',
+const useStyles = makeStyles(
+  {
+    item: {},
+    flexContainer: {
+      flexWrap: 'wrap',
+    },
+    itemText: {
+      width: '100%',
+      wordBreak: 'break-all',
+      marginBottom: '1rem',
+    },
   },
-  itemText: {
-    width: '100%',
-    wordBreak: 'break-all',
-    marginBottom: '1rem',
-  },
-});
+  { name: 'CatalogSearchResultListItem' },
+);
 
 /**
  * Props for {@link CatalogSearchResultListItem}.
@@ -64,7 +68,7 @@ export function CatalogSearchResultListItem(
   if (!result) return null;
 
   return (
-    <>
+    <div className={classes.item}>
       {props.icon && <ListItemIcon>{props.icon}</ListItemIcon>}
       <div className={classes.flexContainer}>
         <ListItemText
@@ -102,6 +106,6 @@ export function CatalogSearchResultListItem(
           )}
         </Box>
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Signed-off-by: Ilya Savich <isavich@box.com>

Hi, noticed that in recent versions something slightly changed in `CatalogSearchResultListItem` so there is no ability to customize some styles on parent element (which I need in particular), so fixed that

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
