### PR TITLE
Allow all symlinks to be added in the publish action

### DIFF
--- a/.changeset/weak-gifts-destroy.md
+++ b/.changeset/weak-gifts-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix issue where only symlinks pointing the non-valid path would be serialized and add to a Pull Request

--- a/plugins/scaffolder-backend/src/lib/files/serializeDirectoryContents.test.ts
+++ b/plugins/scaffolder-backend/src/lib/files/serializeDirectoryContents.test.ts
@@ -106,7 +106,7 @@ describe('serializeDirectoryContents', () => {
     ]);
   });
 
-  it('should ignore symlinked files', async () => {
+  it('should not ignore symlinked files', async () => {
     mockFs({
       root: {
         'a.txt': 'some text',
@@ -122,6 +122,12 @@ describe('serializeDirectoryContents', () => {
         executable: false,
         symlink: false,
         content: Buffer.from('some text', 'utf8'),
+      },
+      {
+        path: 'sym',
+        executable: false,
+        symlink: true,
+        content: Buffer.from('./a.txt', 'utf8'),
       },
     ]);
   });
@@ -145,7 +151,32 @@ describe('serializeDirectoryContents', () => {
     ]);
   });
 
-  it('should ignore symlinked folder files', async () => {
+  it('should add symlinks', async () => {
+    mockFs({
+      root: {
+        'a.txt': 'a',
+        'b.txt': mockFs.symlink({
+          path: './a.txt',
+        }),
+      },
+    });
+
+    await expect(serializeDirectoryContents('root')).resolves.toEqual([
+      {
+        path: 'a.txt',
+        executable: false,
+        symlink: false,
+        content: Buffer.from('a', 'utf8'),
+      },
+      {
+        path: 'b.txt',
+        executable: false,
+        symlink: true,
+        content: Buffer.from('./a.txt', 'utf8'),
+      },
+    ]);
+  });
+  it('should not ignore symlinked folder files', async () => {
     mockFs({
       root: {
         'a.txt': 'some text',
@@ -164,6 +195,12 @@ describe('serializeDirectoryContents', () => {
         executable: false,
         symlink: false,
         content: Buffer.from('some text', 'utf8'),
+      },
+      {
+        path: 'sym',
+        executable: false,
+        symlink: true,
+        content: Buffer.from('./linkme', 'utf8'),
       },
       {
         path: 'linkme/b.txt',

--- a/plugins/scaffolder-backend/src/lib/files/serializeDirectoryContents.ts
+++ b/plugins/scaffolder-backend/src/lib/files/serializeDirectoryContents.ts
@@ -66,15 +66,7 @@ export async function serializeDirectoryContents(
     if (dirent.isDirectory()) return false;
     if (!dirent.isSymbolicLink()) return true;
 
-    const safePath = resolveSafeChildPath(sourcePath, path);
-
-    // we only want files that don't exist
-    try {
-      await fs.stat(safePath);
-      return false;
-    } catch (e) {
-      return isError(e) && e.code === 'ENOENT';
-    }
+    return true;
   });
 
   return Promise.all(

--- a/plugins/scaffolder-backend/src/lib/files/serializeDirectoryContents.ts
+++ b/plugins/scaffolder-backend/src/lib/files/serializeDirectoryContents.ts
@@ -19,7 +19,6 @@ import globby from 'globby';
 import limiterFactory from 'p-limit';
 import { resolveSafeChildPath } from '@backstage/backend-common';
 import { SerializedFile } from './types';
-import { isError } from '@backstage/errors';
 
 const DEFAULT_GLOB_PATTERNS = ['./**', '!.git'];
 
@@ -62,7 +61,7 @@ export async function serializeDirectoryContents(
 
   const limiter = limiterFactory(10);
 
-  const valid = await asyncFilter(paths, async ({ dirent, path }) => {
+  const valid = await asyncFilter(paths, async ({ dirent }) => {
     if (dirent.isDirectory()) return false;
     if (!dirent.isSymbolicLink()) return true;
 


### PR DESCRIPTION
Previously only symlinks linking to a non-existing target would be added using the publish:github:pull-request action

We were confused as why the symlinks that we created were not included in the resulting Pull Request using the action
It seems that this change  #13169 did make it sure only non-valid symlinks (in the context of a changeset) would be included  and I not sure this was the original intent of not 

This is my first PR on the backstage project and I didn't open an issue but let me know if you want me to do so :) 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
