### PR TITLE
Feature: Plugin templates sourced from git URL

### DIFF
--- a/packages/cli/src/lib/new/factories/common/prompts.ts
+++ b/packages/cli/src/lib/new/factories/common/prompts.ts
@@ -56,3 +56,19 @@ export function ownerPrompt(): Prompt<{
     },
   };
 }
+
+export function templatePrompt(): Prompt<{ template: string }> {
+  return {
+    type: 'input',
+    name: 'template',
+    message: 'Enter the URL of the git template repository [required]',
+    validate: (value: string) => {
+      if (!value) {
+        return 'Please enter the URL of the template';
+      } else if (value === '') {
+        return 'Template URLs must be valid .git repositories';
+      }
+      return true;
+    },
+  };
+}

--- a/packages/cli/src/lib/new/factories/common/tasks.ts
+++ b/packages/cli/src/lib/new/factories/common/tasks.ts
@@ -23,6 +23,13 @@ import { Lockfile } from '../../../versioning';
 import { createPackageVersionProvider } from '../../../version';
 import { CreateContext } from '../../types';
 
+// Inspired by https://github.com/xxorax/node-shell-escape/blob/master/shell-escape.js
+function escapeShellArg(s: string) {
+  let res = `'${s.replace(/'/g, "'\\''")}'`;
+  res = res.replace(/^(?:'')+/g, '').replace(/\\'''/g, "\\'");
+  return res;
+}
+
 export async function executePluginPackageTemplate(
   ctx: CreateContext,
   options: {
@@ -80,6 +87,80 @@ export async function executePluginPackageTemplate(
       );
     });
   });
+
+  ctx.markAsModified();
+}
+
+export async function executePluginTemplateFromGitURL(
+  ctx: CreateContext,
+  options: {
+    templateGitURL: string;
+    targetDir: string;
+    values: Record<string, unknown>;
+  },
+) {
+  const { targetDir, templateGitURL } = options;
+
+  let lockfile: Lockfile | undefined;
+  try {
+    lockfile = await Lockfile.load(paths.resolveTargetRoot('yarn.lock'));
+  } catch {
+    /* ignored */
+  }
+
+  Task.section('Checking Prerequisites');
+  const shortPluginDir = relativePath(paths.targetRoot, targetDir);
+  await Task.forItem('availability', shortPluginDir, async () => {
+    if (await fs.pathExists(targetDir)) {
+      throw new Error(
+        `A package with the same plugin ID already exists at ${chalk.cyan(
+          shortPluginDir,
+        )}. Please try again with a different ID.`,
+      );
+    }
+  });
+
+  const tempDir = await Task.forItem('creating', 'temp dir', async () => {
+    return await ctx.createTemporaryDirectory('backstage-create');
+  });
+
+  // construct clone command of passed url
+  Task.section(`Cloning Template - ${templateGitURL}`);
+  const gitCloneCommand = `git clone ${escapeShellArg(
+    templateGitURL,
+  )} ${tempDir}`;
+
+  //
+  await Task.forCommand(gitCloneCommand);
+
+  await Task.forCommand('rm -rf .git', { cwd: tempDir });
+
+  Task.section('Executing Template');
+  await templatingTask(
+    paths.resolveOwn(tempDir),
+    tempDir,
+    options.values,
+    createPackageVersionProvider(lockfile),
+    ctx.isMonoRepo,
+  );
+
+  // Format package.json if it exists
+  const pkgJsonPath = resolvePath(tempDir, 'package.json');
+  if (await fs.pathExists(pkgJsonPath)) {
+    const pkgJson = await fs.readJson(pkgJsonPath);
+    await fs.writeJson(pkgJsonPath, pkgJson, { spaces: 2 });
+  }
+
+  Task.section('Installing');
+  await Task.forItem('moving', shortPluginDir, async () => {
+    await fs.move(tempDir, targetDir).catch(error => {
+      throw new Error(
+        `Failed to move package from ${tempDir} to ${targetDir}, ${error.message}`,
+      );
+    });
+  });
+
+  Task.forCommand('yarn install', { cwd: paths.ownRoot });
 
   ctx.markAsModified();
 }

--- a/packages/cli/src/lib/new/factories/gitTemplatePlugin.ts
+++ b/packages/cli/src/lib/new/factories/gitTemplatePlugin.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import camelCase from 'lodash/camelCase';
+import upperFirst from 'lodash/upperFirst';
+import { paths } from '../../paths';
+import { addCodeownersEntry, getCodeownersFilePath } from '../../codeowners';
+import { createFactory, CreateContext } from '../types';
+import { addPackageDependency, Task } from '../../tasks';
+import { ownerPrompt, pluginIdPrompt, templatePrompt } from './common/prompts';
+import { executePluginTemplateFromGitURL } from './common/tasks';
+
+type Options = {
+  id: string;
+  template: string;
+  owner?: string;
+  codeOwnersPath?: string;
+};
+
+export const gitTemplatePlugin = createFactory<Options>({
+  name: 'git-template',
+  description: 'A new plugin created from a git source',
+  optionsDiscovery: async () => ({
+    codeOwnersPath: await getCodeownersFilePath(paths.targetRoot),
+  }),
+  optionsPrompts: [pluginIdPrompt(), templatePrompt(), ownerPrompt()],
+  async create(options: Options, ctx: CreateContext) {
+    const { id } = options;
+
+    const name = ctx.scope
+      ? `@${ctx.scope}/plugin-${id}`
+      : `backstage-plugin-${id}`;
+    const extensionName = `${upperFirst(camelCase(id))}Page`;
+
+    Task.log();
+    Task.log(`Creating plugin ${chalk.cyan(name)} from TEMPLATE NAME`);
+
+    const targetDir = ctx.isMonoRepo
+      ? paths.resolveTargetRoot('plugins', id)
+      : paths.resolveTargetRoot(`backstage-plugin-${id}`);
+
+    await executePluginTemplateFromGitURL(ctx, {
+      targetDir,
+      templateGitURL: options.template,
+      values: {
+        id,
+        name,
+        extensionName,
+        pluginVar: `${camelCase(id)}Plugin`,
+        pluginVersion: ctx.defaultVersion,
+        privatePackage: ctx.private,
+        npmRegistry: ctx.npmRegistry,
+      },
+    });
+
+    if (await fs.pathExists(paths.resolveTargetRoot('packages/app'))) {
+      await Task.forItem('app', 'adding dependency', async () => {
+        await addPackageDependency(
+          paths.resolveTargetRoot('packages/app/package.json'),
+          {
+            dependencies: {
+              [name]: `^${ctx.defaultVersion}`,
+            },
+          },
+        );
+      });
+
+      await Task.forItem('app', 'adding import', async () => {
+        const pluginsFilePath = paths.resolveTargetRoot(
+          'packages/app/src/App.tsx',
+        );
+        if (!(await fs.pathExists(pluginsFilePath))) {
+          return;
+        }
+
+        const content = await fs.readFile(pluginsFilePath, 'utf8');
+        const revLines = content.split('\n').reverse();
+
+        const lastImportIndex = revLines.findIndex(line =>
+          line.match(/ from ("|').*("|')/),
+        );
+        const lastRouteIndex = revLines.findIndex(line =>
+          line.match(/<\/FlatRoutes/),
+        );
+
+        if (lastImportIndex !== -1 && lastRouteIndex !== -1) {
+          const importLine = `import { ${extensionName} } from '${name}';`;
+          if (!content.includes(importLine)) {
+            revLines.splice(lastImportIndex, 0, importLine);
+          }
+
+          const componentLine = `<Route path="/${id}" element={<${extensionName} />} />`;
+          if (!content.includes(componentLine)) {
+            const [indentation] =
+              revLines[lastRouteIndex + 1].match(/^\s*/) ?? [];
+            revLines.splice(lastRouteIndex + 1, 0, indentation + componentLine);
+          }
+
+          const newContent = revLines.reverse().join('\n');
+          await fs.writeFile(pluginsFilePath, newContent, 'utf8');
+        }
+      });
+    }
+
+    if (options.owner) {
+      await addCodeownersEntry(`/plugins/${id}`, options.owner);
+    }
+
+    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+    await Task.forCommand('yarn lint --fix', {
+      cwd: targetDir,
+      optional: true,
+    });
+  },
+});

--- a/packages/cli/src/lib/new/factories/index.ts
+++ b/packages/cli/src/lib/new/factories/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { frontendPlugin } from './frontendPlugin';
+export { gitTemplatePlugin } from './gitTemplatePlugin';
 export { backendPlugin } from './backendPlugin';
 export { webLibraryPackage } from './webLibraryPackage';
 export { pluginCommon } from './pluginCommon';


### PR DESCRIPTION
Draft of PR for #15818 

I wound up creating a gitTemplateFactory to keep it out of the flow of the default frontend plugin. I did this because teams might want to host templates for many different plugin types. I also cloned the default plugin with copy changes and hosted it in [hsbacot/backstage-template](https://github.com/hsbacot/backstage-template). The resulting interface would be

```.shell
bin/backstage-cli new --select git-template --option id=test-cli-args --option template=https://github.com/hsbacot/backstage-template.git
```

Please let me know your thoughts on this approach @Rugvip. If it sounds good to you I'll clean it up, add tests, and update the docs. Thanks

This is a recreation #16211 after the history from master was accidentally kept

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
