### PR TITLE
feat(catalog): add detailPanel prop to CatalogTable

### DIFF
--- a/.changeset/catalog-table-detail-panel.md
+++ b/.changeset/catalog-table-detail-panel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added the `detailPanel` prop in the `CatalogTable` that is forwarded to the `Table` component.

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -168,6 +168,8 @@ export interface CatalogTableProps {
   // (undocumented)
   columns?: TableColumn<CatalogTableRow>[];
   // (undocumented)
+  detailPanel?: TableProps<CatalogTableRow>['detailPanel'];
+  // (undocumented)
   emptyContent?: ReactNode;
   // (undocumented)
   subtitle?: string;

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -52,6 +52,7 @@ export interface CatalogTableProps {
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
   tableOptions?: TableProps<CatalogTableRow>['options'];
+  detailPanel?: TableProps<CatalogTableRow>['detailPanel'];
   emptyContent?: ReactNode;
   subtitle?: string;
 }
@@ -64,7 +65,14 @@ const YellowStar = withStyles({
 
 /** @public */
 export const CatalogTable = (props: CatalogTableProps) => {
-  const { columns, actions, tableOptions, subtitle, emptyContent } = props;
+  const {
+    columns,
+    actions,
+    tableOptions,
+    detailPanel,
+    subtitle,
+    emptyContent,
+  } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const { loading, error, entities, filters } = useEntityList();
 
@@ -230,6 +238,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
       actions={actions || defaultActions}
       subtitle={subtitle}
       emptyContent={emptyContent}
+      detailPanel={detailPanel}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the `detailPanel` prop to the `CatalogTable` forwarding it to the underlying `Table`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
