### PR TITLE
Embeds admin web app into CLI with a yarn command for development

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
-    "start": "nodemon --"
+    "start": "nodemon --",
+    "start-admin-web": "ts-node --transpile-only --project ../../tsconfig.json --compiler-options '{\"module\": \"CommonJS\"}' src/commands/admin-web/local-dev.ts"
   },
   "bin": {
     "backstage-cli": "bin/backstage-cli"

--- a/packages/cli/src/commands/admin-web/embedded/index.ts
+++ b/packages/cli/src/commands/admin-web/embedded/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+document.querySelector('button').onclick = event => {
+  event.target.innerHTML = 'clicked';
+};

--- a/packages/cli/src/commands/admin-web/embedded/package.json
+++ b/packages/cli/src/commands/admin-web/embedded/package.json
@@ -1,0 +1,3 @@
+{
+  "_comment": "Needed because serveBundle() wants a package.json to parse a 'proxy' property from"
+}

--- a/packages/cli/src/commands/admin-web/embedded/public/index.html
+++ b/packages/cli/src/commands/admin-web/embedded/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin page</title>
+    <link rel="stylesheet" href="style.css" type="text/css">
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <h1>Admin page 🎉</h1>
+    <button>Click here :)</button>
+  </body>
+</html>

--- a/packages/cli/src/commands/admin-web/embedded/public/style.css
+++ b/packages/cli/src/commands/admin-web/embedded/public/style.css
@@ -1,0 +1,5 @@
+h1 {
+  background-color: #f00;
+  padding: 5px;
+  border-radius: 3px;
+}

--- a/packages/cli/src/commands/admin-web/index.ts
+++ b/packages/cli/src/commands/admin-web/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default async () => {
+  console.log('🏗 This command is still under-construction :/');
+  console.log("You can develop it locally with 'yarn start-admin-web' though");
+};

--- a/packages/cli/src/commands/admin-web/local-dev.ts
+++ b/packages/cli/src/commands/admin-web/local-dev.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { serveBundle } from '../../lib/bundler';
+import path from 'path';
+import { ConfigReader } from '@backstage/config';
+
+console.log('CLI spoolin');
+
+async function main() {
+  /* eslint-disable-next-line no-restricted-syntax */
+  const targetDir = path.resolve(__dirname, 'embedded/');
+  const waitForExit = await serveBundle({
+    entry: path.resolve(targetDir, 'index'),
+    targetDir,
+    checksEnabled: false,
+    frontendAppConfigs: [],
+    frontendConfig: new ConfigReader(
+      {
+        app: {
+          baseUrl: 'http://127.0.0.1:7008',
+        },
+      },
+      '',
+    ),
+    fullConfig: new ConfigReader({}, ''),
+  });
+
+  await waitForExit();
+}
+
+main().then(() => {});

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -392,6 +392,11 @@ export function registerCommands(program: Command) {
     .action(lazy(() => import('./create-github-app').then(m => m.default)));
 
   program
+    .command('admin-web')
+    .description('Open web-based administration tool')
+    .action(lazy(() => import('./admin-web').then(m => m.default)));
+
+  program
     .command('info')
     .description('Show helpful information for debugging and reporting bugs')
     .action(lazy(() => import('./info').then(m => m.default)));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "plugins/*/dev",
     "plugins/*/migrations"
   ],
+  "exclude": ["packages/cli/src/commands/admin-web/embedded"],
   "compilerOptions": {
     "outDir": "dist-types",
     "rootDir": ".",


### PR DESCRIPTION
* Added an `admin-web` command to the CLI, but the web app isn't currently bundled properly for distribution so it's a no-op.
* `yarn start-admin-web` allows local development of this very simple admin web app
  * There's some hackery in `local-dev.ts` to make `serveBundle()` work in this new use case - I tried to make the minimal config that would satisfy the type system and work.
* Adds some example HTML, CSS and JS as demonstration for how to use each

![image](https://user-images.githubusercontent.com/110673802/217788791-4c98f021-8711-4935-8d6b-53404bb95492.png)
