### PR TITLE
MemberListCard UI Fix

### DIFF
--- a/.changeset/polite-falcons-jump.md
+++ b/.changeset/polite-falcons-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fix small UI-glitch in MemberListCard

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -64,6 +64,7 @@ const useStyles = makeStyles((theme: Theme) =>
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
       display: 'inline-block',
+      verticalAlign: 'middle',
       maxWidth: '100%',
       '&:hover': {
         overflow: 'visible',


### PR DESCRIPTION
When a description is provided and the user hovers over the email link, the description jumps a bit in the UI.

Signed-off-by: Gustaf Lundh <gustaf.lundh@axis.com>

https://user-images.githubusercontent.com/300900/217842034-d8fb4f94-2be3-4403-b8a1-fc5c2aed39fe.mp4


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
