### PR TITLE
Change base theme to use table header color that meets a11y color contrast requirements

### DIFF
--- a/.changeset/nasty-kids-deny.md
+++ b/.changeset/nasty-kids-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Use same table header color as @backstage/core-components Table to meet accessibility color contrast requirements. This change affects material-ui tables.

--- a/packages/theme/src/baseTheme.ts
+++ b/packages/theme/src/baseTheme.ts
@@ -159,7 +159,7 @@ export function createThemeOverrides(theme: BackstageTheme): Overrides {
       head: {
         wordBreak: 'break-word',
         overflow: 'hidden',
-        color: 'rgb(179, 179, 179)',
+        color: theme.palette.textSubtle,
         fontWeight: 'normal',
         lineHeight: '1',
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The table headers color set by the base theme (light theme) does not meet a11y color contrast requirements. This affects any usage of material-ui tables.
[backstage/core-componentes Table already has a header color](https://github.com/backstage/backstage/blob/01488971c9c985b614cbd7e05ff087dde4986618/packages/core-components/src/components/Table/Table.tsx#L108) that meets a11y requirements and this PR is moving the base theme to use the same color.

Before:

<img width="404" alt="Screenshot 2023-02-09 at 14 31 45" src="https://user-images.githubusercontent.com/7041022/217845406-045ae4ba-5045-411a-a7a5-e39a5b4c4f27.png">
<img width="399" alt="Screenshot 2023-02-09 at 14 49 35" src="https://user-images.githubusercontent.com/7041022/217846275-2f374008-b435-406c-b669-d08b19a7f89d.png">


After:

<img width="405" alt="Screenshot 2023-02-09 at 14 44 26" src="https://user-images.githubusercontent.com/7041022/217845448-a7f90158-9ad7-433d-af57-5a7881611b15.png">
<img width="395" alt="Screenshot 2023-02-09 at 14 46 52" src="https://user-images.githubusercontent.com/7041022/217845726-324904b1-8d26-487a-bffd-8421146efee0.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
