### PR TITLE
Tweak CLI admin page example to be compatible with TS linting

### DIFF
--- a/packages/cli/src/commands/admin-web/embedded/index.ts
+++ b/packages/cli/src/commands/admin-web/embedded/index.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
-document.querySelector('button').onclick = event => {
-  event.target.innerHTML = 'clicked';
-};
+const button = document.querySelector('button');
+
+if (button) {
+  button.addEventListener('clicked', () => {
+    button.innerHTML = 'clicked';
+  });
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "plugins/*/dev",
     "plugins/*/migrations"
   ],
-  "exclude": ["packages/cli/src/commands/admin-web/embedded"],
   "compilerOptions": {
     "outDir": "dist-types",
     "rootDir": ".",


### PR DESCRIPTION
Earlier, I assumed that the TS errors were due to Typescript not understanding that the code was to be run from a "browser" context rather than "node module" context.

However, simply adding an `export {}` was enough to resolve the "isolated module"-related warning, and the other type errors were due to real typing issues which had to be maneuvered around.
