### PR TITLE
fix: move backend-test-utils to devDependencies

### DIFF
--- a/.changeset/red-toes-suffer.md
+++ b/.changeset/red-toes-suffer.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-playlist-backend': patch
+'@backstage/plugin-bazaar-backend': patch
+'@backstage/plugin-vault-backend': patch
+---
+
+Moving the backend-test-utils to devDependencies.

--- a/plugins/bazaar-backend/package.json
+++ b/plugins/bazaar-backend/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
-    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
@@ -37,6 +36,7 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^"
   },
   "files": [

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -36,7 +36,6 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
-    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
@@ -56,6 +55,7 @@
   },
   "devDependencies": {
     "@backstage/backend-app-api": "workspace:^",
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-catalog-backend": "workspace:^"
   },

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@azure/identity": "^2.0.4",
     "@backstage/backend-common": "workspace:^",
-    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
@@ -66,6 +65,7 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/aws4": "^1.5.1",
     "@types/http-proxy-middleware": "^0.19.3",

--- a/plugins/playlist-backend/package.json
+++ b/plugins/playlist-backend/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
-    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
@@ -43,6 +42,7 @@
     "zod": "~3.18.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/supertest": "^2.0.8",
     "msw": "^0.49.0",

--- a/plugins/vault-backend/package.json
+++ b/plugins/vault-backend/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
-    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@types/express": "*",
@@ -50,6 +49,7 @@
     "yn": "^5.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/compression": "^1.7.2",
     "@types/supertest": "^2.0.8",


### PR DESCRIPTION
The backend-test-utils should only be used as devDependencies. Otherwise they might cause trouble while installing related plugins in docker images.

Signed-off-by: Dominik Schwank <dominik.schwank@sda.se>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
