### PR TITLE
Updated LinksGroup to use Link over ListItem

### DIFF
--- a/.changeset/stale-houses-push.md
+++ b/.changeset/stale-houses-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Updated `LinksGroup` to use `Link` over `ListItem` as this makes the links more obvious and follows the pattern already used in the `GroupProfileCard`. Also updated the `GroupProfileCard` `ExtraDetails` story in Storybook to enable the `showLinks` feature whith this off there is no difference between it and the `default` story.

--- a/.changeset/stale-houses-push.md
+++ b/.changeset/stale-houses-push.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-org': patch
 ---
 
-Updated `LinksGroup` to use `Link` over `ListItem` as this makes the links more obvious and follows the pattern already used in the `GroupProfileCard`. Also updated the `GroupProfileCard` `ExtraDetails` story in Storybook to enable the `showLinks` feature whith this off there is no difference between it and the `default` story.
+Updated `LinksGroup` to use `Link` over `ListItem` as this makes the links more obvious and follows the pattern already used in the `GroupProfileCard`. Also updated the `GroupProfileCard` `ExtraDetails` story in Storybook to enable the `showLinks` feature with this off there is no difference between it and the `default` story.

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.stories.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.stories.tsx
@@ -123,7 +123,7 @@ export const ExtraDetails = () => (
   <EntityProvider entity={extraDetailsEntity}>
     <Grid container spacing={4}>
       <Grid item xs={12} md={4}>
-        <GroupProfileCard variant="gridItem" />
+        <GroupProfileCard variant="gridItem" showLinks />
       </Grid>
     </Grid>
   </EntityProvider>

--- a/plugins/org/src/components/Cards/Meta/LinksGroup.tsx
+++ b/plugins/org/src/components/Cards/Meta/LinksGroup.tsx
@@ -23,6 +23,7 @@ import {
   Divider,
 } from '@material-ui/core';
 import React from 'react';
+import { Link } from '@backstage/core-components';
 
 const WebLink = ({
   href,
@@ -33,9 +34,11 @@ const WebLink = ({
   text?: string;
   Icon?: IconComponent;
 }) => (
-  <ListItem button component="a" key={href} href={href}>
+  <ListItem key={href}>
     <ListItemIcon>{Icon ? <Icon /> : <LanguageIcon />}</ListItemIcon>
-    <ListItemText>{text}</ListItemText>
+    <ListItemText>
+      <Link to={href}>{text}</Link>
+    </ListItemText>
   </ListItem>
 );
 


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Updated `LinksGroup` to use `Link` over `ListItem` as this makes the links more obvious and follows the pattern already used in the `GroupProfileCard`. Also updated the `GroupProfileCard` `ExtraDetails` story in Storybook to enable the `showLinks` feature. With this off there is no difference between it and the `default` story.

Before:

![Screenshot 2023-02-09 at 1 10 14 PM](https://user-images.githubusercontent.com/67169551/217918154-aa76cb96-c3b8-4218-a5b2-a9fc039ba710.png)

After:

![Screenshot 2023-02-09 at 1 13 30 PM](https://user-images.githubusercontent.com/67169551/217918174-7969650b-7b46-492c-b720-2ef848636d35.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
