### PR TITLE
Align GitHub App permissions with documentation

### DIFF
--- a/.changeset/orange-windows-melt.md
+++ b/.changeset/orange-windows-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix permissions in GitHub App created through CLI for publishing software templates

--- a/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
+++ b/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
@@ -117,8 +117,11 @@ export class GithubCreateAppServer {
         ...(this.permissions.includes('members') && { members: 'read' }),
         ...(this.permissions.includes('read') && { contents: 'read' }),
         ...(this.permissions.includes('write') && {
+          administration: 'write',
           contents: 'write',
-          actions: 'write',
+          pull_requests: 'write',
+          issues: 'write',
+          workflows: 'write',
         }),
       },
       name: 'Backstage-<changeme>',


### PR DESCRIPTION
**Problem:**
- Current permission granted to the Org GHA through the Manifest workflow are insufficient for publishing software templates to the Org
- The documentation mentions the correct permissions - the Manifest is just not aligned to the documentation

**Solution:**
- Align default permission to the required permission for either step - espacially the "write"/"publishing software templates" step
----

Documentation: https://backstage.io/docs/integrations/github/github-apps#app-permissions
Context on GHA Manifest-Flow parameters: https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app-from-a-manifest#github-app-manifest-parameters

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
