### PR TITLE
fix(techdocs-cli): Fix proxying to mkdocs

### DIFF
--- a/.changeset/flat-lizards-poke.md
+++ b/.changeset/flat-lizards-poke.md
@@ -1,0 +1,10 @@
+---
+'@techdocs/cli': patch
+---
+
+Fix proxying to mkdocs
+
+The domain localhost may point to both 127.0.0.1 and ::1, ipv4 and ipv6
+and when node tries to lookup localhost it might prefer ipv6 while mkdocs
+is only listening on ipv4. This tells node-proxy to target the ipv4 address
+instead of relying on localhost hostname lookup.

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -127,7 +127,7 @@ export default async function serve(opts: OptionValues) {
   const httpServer = new HTTPServer(
     previewAppPath,
     port,
-    opts.mkdocsPort,
+    mkdocsExpectedDevAddr,
     opts.verbose,
   );
 

--- a/packages/techdocs-cli/src/lib/httpServer.ts
+++ b/packages/techdocs-cli/src/lib/httpServer.ts
@@ -23,26 +23,26 @@ export default class HTTPServer {
   private readonly proxyEndpoint: string;
   private readonly backstageBundleDir: string;
   private readonly backstagePort: number;
-  private readonly mkdocsPort: number;
+  private readonly mkdocsTargetAddress: string;
   private readonly verbose: boolean;
 
   constructor(
     backstageBundleDir: string,
     backstagePort: number,
-    mkdocsPort: number,
+    mkdocsTargetAddress: string,
     verbose: boolean,
   ) {
     this.proxyEndpoint = '/api/techdocs/';
     this.backstageBundleDir = backstageBundleDir;
     this.backstagePort = backstagePort;
-    this.mkdocsPort = mkdocsPort;
+    this.mkdocsTargetAddress = mkdocsTargetAddress;
     this.verbose = verbose;
   }
 
   // Create a Proxy for mkdocs server
   private createProxy() {
     const proxy = httpProxy.createProxyServer({
-      target: `http://localhost:${this.mkdocsPort}`,
+      target: this.mkdocsTargetAddress,
     });
 
     return (request: http.IncomingMessage): [httpProxy, string] => {


### PR DESCRIPTION
The domain localhost may point to both 127.0.0.1 and ::1 - ipv4 and ipv6,
and when node tries to lookup localhost it might prefer ipv6 while mkdocs
is only listening on ipv4. This tells node-proxy to target the ipv4 address
instead of relying on localhost hostname lookup.

Might be related to #15903 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
