### PR TITLE
feat(PagerDuty plugin): dev environment now utilizes mock PagerDuty API

### DIFF
--- a/plugins/pagerduty/dev/index.tsx
+++ b/plugins/pagerduty/dev/index.tsx
@@ -13,7 +13,153 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createDevApp } from '@backstage/dev-utils';
-import { pagerDutyPlugin } from '../src/plugin';
 
-createDevApp().registerPlugin(pagerDutyPlugin).render();
+import React from 'react';
+import { Entity } from '@backstage/catalog-model';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { createDevApp } from '@backstage/dev-utils';
+import { pagerDutyPlugin, EntityPagerDutyCard } from '../src/plugin';
+import { pagerDutyApiRef } from '../src/api';
+import { PagerDutyApi, PagerDutyTriggerAlarmRequest } from '../src/api/types';
+import {
+  PagerDutyIncident,
+  PagerDutyChangeEvent,
+} from '../src/components/types';
+
+const mockEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'backstage',
+    description: 'backstage.io',
+    annotations: {
+      'github.com/project-slug': 'backstage/backstage',
+      'pagerduty.com/service-id': 'foo',
+      'pagerduty.com/integration-key': 'foo',
+    },
+  },
+  spec: {
+    lifecycle: 'production',
+    type: 'website',
+    owner: 'user:guest',
+  },
+};
+
+const mockPagerDutyApi: PagerDutyApi = {
+  async getServiceByEntity(entity: Entity) {
+    return {
+      service: {
+        name: entity.metadata.name,
+        integrationKey: 'key',
+        id: '123',
+        html_url: 'http://service',
+        escalation_policy: {
+          id: '123',
+          html_url: 'http://escalationpolicy',
+          user: {
+            id: '123',
+            summary: 'summary',
+            email: 'email@email.com',
+            html_url: 'http://user',
+            name: 'some-user',
+          },
+        },
+      },
+    };
+  },
+
+  async getIncidentsByServiceId(serviceId: string) {
+    const incident = (title: string) => {
+      return {
+        id: '123',
+        title: title,
+        status: 'acknowledged',
+        html_url: 'http://incident',
+        assignments: [
+          {
+            assignee: {
+              id: '123',
+              summary: 'Jane Doe',
+              html_url: 'http://assignee',
+            },
+          },
+        ],
+        serviceId: serviceId,
+        created_at: '2015-10-06T21:30:42Z',
+      } as PagerDutyIncident;
+    };
+
+    return {
+      incidents: [
+        incident('Some Alerting Incident'),
+        incident('Another Alerting Incident'),
+      ],
+    };
+  },
+
+  async getChangeEventsByServiceId(serviceId: string) {
+    const changeEvent = (description: string) => {
+      return {
+        id: serviceId,
+        source: 'some-source',
+        html_url: 'http://changeevent',
+        links: [
+          {
+            href: 'http://link',
+            text: 'link text',
+          },
+        ],
+        summary: description,
+        timestamp: '2018-10-06T21:30:42Z',
+      } as PagerDutyChangeEvent;
+    };
+
+    return {
+      change_events: [
+        changeEvent('us-east-1 deployment'),
+        changeEvent('us-west-2 deployment'),
+      ],
+    };
+  },
+
+  async getOnCallByPolicyId() {
+    const oncall = (name: string, escalation: number) => {
+      return {
+        user: {
+          id: '123',
+          name: name,
+          html_url: 'http://assignee',
+          summary: 'summary',
+          email: 'email@email.com',
+        },
+        escalation_level: escalation,
+      };
+    };
+
+    return {
+      oncalls: [oncall('Jane Doe', 1), oncall('John Doe', 2)],
+    };
+  },
+
+  async triggerAlarm(request: PagerDutyTriggerAlarmRequest) {
+    return new Response(request.description);
+  },
+};
+
+createDevApp()
+  .registerApi({
+    api: pagerDutyApiRef,
+    deps: {},
+    factory: () => mockPagerDutyApi,
+  })
+  .registerPlugin(pagerDutyPlugin)
+  .addPage({
+    path: '/pagerduty',
+    title: 'PagerDuty',
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <EntityPagerDutyCard />
+      </EntityProvider>
+    ),
+  })
+  .render();


### PR DESCRIPTION
This seeks to address issue #16291 

By making use of a mock PagerDuty API to render the `EntityPagerDuty` component via a `yarn start`-created dev environment, this unblocks development for contributors who don't otherwise have access to the PagerDuty API.

## Before

<img width="831" alt="Screen Shot 2023-02-10 at 8 03 58 AM" src="https://user-images.githubusercontent.com/184109/218099105-e65a200a-eb8e-46f1-a129-d3257c1945aa.png">

## After

<img width="1126" alt="Screen Shot 2023-02-10 at 7 57 23 AM" src="https://user-images.githubusercontent.com/184109/218098116-616905c6-4fcd-44b0-82d8-cdb8797745c8.png">

<img width="1132" alt="Screen Shot 2023-02-10 at 7 57 35 AM" src="https://user-images.githubusercontent.com/184109/218098135-9d95b877-bb40-42e5-8156-4ad7f44be23c.png">

<img width="1120" alt="Screen Shot 2023-02-10 at 7 57 45 AM" src="https://user-images.githubusercontent.com/184109/218098151-0b20bbd0-7aeb-41e9-bbc2-7308b6b0a295.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
