### PR TITLE
Refactor Selec core component, make it more re-usable

### DIFF
--- a/.changeset/curvy-rules-fetch.md
+++ b/.changeset/curvy-rules-fetch.md
@@ -2,7 +2,7 @@
 '@backstage/core-components': minor
 ---
 
-Updated Select core component to be more customizable and general so more re-use cases will appear.
+Updated Select core component to be more customizable and general so more re-use cases will appear
 
 **BREAKING CHANGES**
 

--- a/.changeset/curvy-rules-fetch.md
+++ b/.changeset/curvy-rules-fetch.md
@@ -1,0 +1,14 @@
+---
+'@backstage/core-components': minor
+---
+
+Updated Select core component to be more customizable and general so more re-use cases will appear.
+
+**BREAKING CHANGES**
+
+- Property `placeholder` which was used as empty option label and placeholder for input
+  will no longer used as empty option label. For this use-case `emptyItemLabel` is added.
+- Wrapper `Box` with class `BackstageSelect-root` was removed,
+  so now it's possible to have select input width dependent on content
+- `native` option will change icon to default browser one
+- empty value was changed from `[]` to `''`

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -29,7 +29,6 @@ import {
 } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import React, { useEffect, useState } from 'react';
-import _ from 'lodash';
 
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
@@ -169,10 +168,10 @@ export function SelectComponent(props: SelectProps) {
   }, [triggerReset, multiple]);
 
   useEffect(() => {
-    if (selected !== undefined && selected !== value) {
+    if (selected !== undefined) {
       setValue(selected);
     }
-  }, [value, selected]);
+  }, [selected]);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     setValue(event.target.value as SelectedItems);
@@ -199,7 +198,7 @@ export function SelectComponent(props: SelectProps) {
   };
 
   const renderValueDefault = (selectedValues: unknown): React.ReactNode => {
-    if (multiple && !_.isEmpty(value)) {
+    if (multiple && (value as any[]).length !== 0) {
       return (
         <Box className={classes.chips}>
           {(selectedValues as string[]).map(selectedValue => (
@@ -217,7 +216,7 @@ export function SelectComponent(props: SelectProps) {
 
     return (
       <Typography>
-        {_.isEmpty(value)
+        {(value as any[]).length === 0
           ? placeholder || ''
           : items.find(el => el.value === selectedValues)?.label}
       </Typography>
@@ -262,7 +261,7 @@ export function SelectComponent(props: SelectProps) {
       )}
       <Select
         className={classnames({
-          selected: !_.isEmpty(value),
+          selected: (value as any[]).length !== 0,
         })}
         aria-label={label}
         value={value}

--- a/plugins/xcmetrics/src/components/OverviewTrends/OverviewTrends.test.tsx
+++ b/plugins/xcmetrics/src/components/OverviewTrends/OverviewTrends.test.tsx
@@ -53,8 +53,9 @@ describe('OverviewTrends', () => {
       </TestApiProvider>,
     );
 
-    await userEvent.click(rendered.getByText('14 days'));
-    await userEvent.click(await rendered.findByText('30 days'));
+    await userEvent.click(rendered.getByTestId('select'));
+    await userEvent.click(rendered.getByText('30 days'));
+
     expect(await rendered.findByText('30 days')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Signed-off-by: Ilya Savich <isavich@box.com>

Refactored `Select` component from `core-components` to make it a bit more customizable.

**What's changed**:

- added `className` prop to add to `FormControl`
- added `showLabel` prop to have ability not to show label (need guys you suggestion here as it's a hack cause I see you use `label` as kinda key, so I can't make it optional without some breaking refactoring)
- added `renderValue` prop to have ability to change value rendering in button
- added `renderOption` prop to have ability to change how options are rendering in the list
- `selected` class is adding to `FormControl` when some value is selected in the field 

**BREAKING CHANGES**

- Property `placeholder` which was used as empty option label and placeholder for input
  will no longer used as empty option label. For this use-case `emptyItemLabel` is added.
- Wrapper `Box` with class `BackstageSelect-root` was removed,
  so now it's possible to have select input width dependent on content
- `native` option will change icon to default browser one
- empty value was changed from `[]` to `''`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
