### PR TITLE
refactor(backend-common): export DefaultTreeResponseFactory

### DIFF
--- a/.changeset/empty-avocados-repair.md
+++ b/.changeset/empty-avocados-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+`DefaultReadTreeResponseFactory` is exported from the package

--- a/packages/backend-common/src/reading/index.ts
+++ b/packages/backend-common/src/reading/index.ts
@@ -43,5 +43,6 @@ export type {
   UrlReader,
   UrlReaderPredicateTuple,
 } from './types';
+export { DefaultReadTreeResponseFactory } from './tree';
 export { UrlReaders } from './UrlReaders';
 export type { UrlReadersOptions } from './UrlReaders';


### PR DESCRIPTION
Signed-off-by: Gabriel Testault <gabriel.testault@goto.com>

## Hey, I just made a Pull Request!
Hi, could you please export the `DefaultReadTreeResponseFactory` from the backend-common package? I wanted to use the `BitbucketServerUrlReader` in our company's backstage project, but it has a dependency on this utility. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
