### PR TITLE
feat(backend-common): service name override

### DIFF
--- a/.changeset/loud-plums-begin.md
+++ b/.changeset/loud-plums-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+You can now specify a custom service name for the root Backstage logger by passing it in to `createRootLogger`.

--- a/packages/backend-common/src/logging/createRootLogger.ts
+++ b/packages/backend-common/src/logging/createRootLogger.ts
@@ -56,7 +56,8 @@ export const coloredFormat = WinstonLogger.colorFormat();
  */
 export function createRootLogger(
   options: winston.LoggerOptions = {},
-  env = process.env,
+  env: NodeJS.ProcessEnv = process.env,
+  service: string = 'backstage',
 ): winston.Logger {
   const logger = winston
     .createLogger(
@@ -78,7 +79,7 @@ export function createRootLogger(
         options,
       ),
     )
-    .child({ service: 'backstage' });
+    .child({ service: service });
 
   setRootLogger(logger);
 


### PR DESCRIPTION
A service name can now be passed in as an override to `createRootLogger`. By default, `createRootLogger` will use 'Backstage' as the service name when not provided.

Signed-off-by: Dan Hoizner <dan.hoizner@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
