### PR TITLE
Attempt to show readable names in `EntityOwnerPicker` by loading from the `by-refs` endpoint.

### DIFF
--- a/.changeset/plenty-eels-listen.md
+++ b/.changeset/plenty-eels-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Attempt to load entity owner names in the EntityOwnerPicker through the `by-refs` endpoint. If `spec.profile.displayName` or `metadata.title` are populated, we now attempt to show those before showing the `humanizeEntityRef`'d version.

--- a/.changeset/plenty-eels-listen.md
+++ b/.changeset/plenty-eels-listen.md
@@ -7,19 +7,13 @@ Attempt to load entity owner names in the EntityOwnerPicker through the `by-refs
 **BREAKING**: `EntityOwnerFilter` now uses the full entity ref instead of the `humanizeEntityRef`. If you rely on `EntityOwnerFilter.values` or the `queryParameters.owners` of `useEntityList`, you will need to adjust your code like the following.
 
 ```tsx
-const {queryParameters: {owners}} = useEntityList();
+const { queryParameters: { owners } } = useEntityList();
 // or
-const {filter: {owners}} = useEntityList();
+const { filter: { owners } } = useEntityList();
 
 // Instead of,
-...
-if(owners.some(ref=>ref === humanizeEntityRef(myEntity))){
-    ...
-}
+if (owners.some(ref => ref === humanizeEntityRef(myEntity))) ...
 
 // You'll need to use,
-...
-if(owners.some(ref=>ref === stringifyEntityRef(myEntity))){
-    ...
-}
+if (owners.some(ref => ref === stringifyEntityRef(myEntity))) ...
 ```

--- a/.changeset/plenty-eels-listen.md
+++ b/.changeset/plenty-eels-listen.md
@@ -3,3 +3,23 @@
 ---
 
 Attempt to load entity owner names in the EntityOwnerPicker through the `by-refs` endpoint. If `spec.profile.displayName` or `metadata.title` are populated, we now attempt to show those before showing the `humanizeEntityRef`'d version.
+
+**BREAKING**: This updates the `EntityOwnerFilter` to use the full entity ref instead of the `humanizeEntityRef`. If you rely on `EntityOwnerFilter.values` or the `owners` query parameter of the catalog page, you will need to adjust your code to use
+
+```tsx
+const {queryParameters: {owners: oldEntityOwnerFilterRef}} = useEntityList();
+// or
+const {filter: {owners}} = useEntityList();
+
+// Instead of,
+...
+if(owners.some(ref=>ref === humanizeEntityRef(myEntity))){
+    ...
+}
+
+// You'll need to use,
+...
+if(owners.some(ref=>ref === stringifyEntityRef(myEntity))){
+    ...
+}
+```

--- a/.changeset/plenty-eels-listen.md
+++ b/.changeset/plenty-eels-listen.md
@@ -7,7 +7,7 @@ Attempt to load entity owner names in the EntityOwnerPicker through the `by-refs
 **BREAKING**: `EntityOwnerFilter` now uses the full entity ref instead of the `humanizeEntityRef`. If you rely on `EntityOwnerFilter.values` or the `queryParameters.owners` of `useEntityList`, you will need to adjust your code like the following.
 
 ```tsx
-const {queryParameters: {owners: oldEntityOwnerFilterRef}} = useEntityList();
+const {queryParameters: {owners}} = useEntityList();
 // or
 const {filter: {owners}} = useEntityList();
 

--- a/.changeset/plenty-eels-listen.md
+++ b/.changeset/plenty-eels-listen.md
@@ -4,7 +4,7 @@
 
 Attempt to load entity owner names in the EntityOwnerPicker through the `by-refs` endpoint. If `spec.profile.displayName` or `metadata.title` are populated, we now attempt to show those before showing the `humanizeEntityRef`'d version.
 
-**BREAKING**: This updates the `EntityOwnerFilter` to use the full entity ref instead of the `humanizeEntityRef`. If you rely on `EntityOwnerFilter.values` or the `owners` query parameter of the catalog page, you will need to adjust your code to use
+**BREAKING**: `EntityOwnerFilter` now uses the full entity ref instead of the `humanizeEntityRef`. If you rely on `EntityOwnerFilter.values` or the `queryParameters.owners` of `useEntityList`, you will need to adjust your code like the following.
 
 ```tsx
 const {queryParameters: {owners: oldEntityOwnerFilterRef}} = useEntityList();

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.test.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.test.tsx
@@ -64,6 +64,7 @@ describe('DefaultApiExplorerPage', () => {
       }),
     getLocationByRef: () =>
       Promise.resolve({ id: 'id', type: 'url', target: 'url' }),
+    getEntitiesByRefs: () => Promise.resolve({ items: [] }),
     getEntityByRef: async entityRef => {
       return {
         apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -453,6 +453,15 @@ export function getEntitySourceLocation(
   scmIntegrationsApi: ScmIntegrationRegistry,
 ): EntitySourceLocation | undefined;
 
+// @public
+export function humanizeEntity(
+  entity: Entity,
+  opts?: {
+    defaultKind?: string;
+    defaultNamespace?: string | false;
+  },
+): string;
+
 // @public (undocumented)
 export function humanizeEntityRef(
   entityRef: Entity | CompoundEntityRef,

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -242,7 +242,6 @@ export class EntityOwnerFilter implements EntityFilter {
   constructor(values: string[]);
   // (undocumented)
   filterEntity(entity: Entity): boolean;
-  // (undocumented)
   toQueryValue(): string[];
   // (undocumented)
   readonly values: string[];

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -452,15 +452,6 @@ export function getEntitySourceLocation(
   scmIntegrationsApi: ScmIntegrationRegistry,
 ): EntitySourceLocation | undefined;
 
-// @public
-export function humanizeEntity(
-  entity: Entity,
-  opts?: {
-    defaultKind?: string;
-    defaultNamespace?: string | false;
-  },
-): string;
-
 // @public (undocumented)
 export function humanizeEntityRef(
   entityRef: Entity | CompoundEntityRef,

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -57,6 +57,15 @@ const ownerEntities: Entity[] = [
       title: 'Another Owner',
     },
   },
+  {
+    apiVersion: '1',
+    kind: 'Group',
+    metadata: {
+      namespace: 'test-namespace',
+      name: 'another-owner-2',
+      title: 'Another Owner in Another Namespace',
+    },
+  },
 ];
 
 const sampleEntities: Entity[] = [
@@ -87,6 +96,10 @@ const sampleEntities: Entity[] = [
       {
         type: 'ownedBy',
         targetRef: 'group:default/another-owner',
+      },
+      {
+        type: 'ownedBy',
+        targetRef: 'group:test-namespace/another-owner-2',
       },
     ],
   },
@@ -134,7 +147,12 @@ describe('<EntityOwnerPicker/>', () => {
     expect(screen.getByText('Owner')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
-    ['Another Owner', 'some-owner', 'Some Owner 2'].forEach(owner => {
+    [
+      'Another Owner',
+      'some-owner',
+      'Some Owner 2',
+      'Another Owner in Another Namespace',
+    ].forEach(owner => {
       expect(screen.getByText(owner)).toBeInTheDocument();
     });
   });
@@ -155,6 +173,7 @@ describe('<EntityOwnerPicker/>', () => {
 
     expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
       'Another Owner',
+      'Another Owner in Another Namespace',
       'some-owner',
       'Some Owner 2',
     ]);

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -198,7 +198,7 @@ describe('<EntityOwnerPicker/>', () => {
     );
 
     expect(updateFilters).toHaveBeenLastCalledWith({
-      owners: new EntityOwnerFilter(['another-owner']),
+      owners: new EntityOwnerFilter(['group:default/another-owner']),
     });
   });
 
@@ -224,7 +224,7 @@ describe('<EntityOwnerPicker/>', () => {
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
     fireEvent.click(screen.getByText('some-owner'));
     expect(updateFilters).toHaveBeenLastCalledWith({
-      owners: new EntityOwnerFilter(['some-owner']),
+      owners: new EntityOwnerFilter(['group:default/some-owner']),
     });
   });
 
@@ -245,9 +245,10 @@ describe('<EntityOwnerPicker/>', () => {
       </ApiProvider>,
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
-      owners: new EntityOwnerFilter(['some-owner']),
+      owners: new EntityOwnerFilter(['group:default/some-owner']),
     });
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
+
     expect(screen.getByLabelText('some-owner')).toBeChecked();
 
     fireEvent.click(screen.getByLabelText('some-owner'));
@@ -272,7 +273,7 @@ describe('<EntityOwnerPicker/>', () => {
       </ApiProvider>,
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
-      owners: new EntityOwnerFilter(['team-a']),
+      owners: new EntityOwnerFilter(['group:default/team-a']),
     });
     rendered.rerender(
       <ApiProvider apis={mockApis}>
@@ -288,7 +289,7 @@ describe('<EntityOwnerPicker/>', () => {
       </ApiProvider>,
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
-      owners: new EntityOwnerFilter(['team-b']),
+      owners: new EntityOwnerFilter(['group:default/team-b']),
     });
   });
   it('removes owners from filters if there are none available', async () => {

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -93,7 +93,7 @@ export const EntityOwnerPicker = () => {
           .filter(Boolean) as string[],
       ),
     ];
-    const { items } = await catalogApi.getEntitiesByRefs({
+    const { items: ownerEntitiesOrNull } = await catalogApi.getEntitiesByRefs({
       entityRefs: ownerEntityRefs,
       fields: [
         'kind',
@@ -103,8 +103,7 @@ export const EntityOwnerPicker = () => {
         'spec.profile.displayName',
       ],
     });
-    const owners = ownerEntityRefs.map((ref, index) => {
-      const entity = items[index];
+    const owners = ownerEntitiesOrNull.map((entity, index) => {
       if (entity) {
         return {
           label: humanizeEntity(entity, { defaultKind: 'Group' }),
@@ -113,10 +112,10 @@ export const EntityOwnerPicker = () => {
       }
       return {
         label: humanizeEntityRef(
-          parseEntityRef(ref, { defaultKind: 'Group' }),
+          parseEntityRef(ownerEntityRefs[index], { defaultKind: 'Group' }),
           { defaultKind: 'group' },
         ),
-        entityRef: ref,
+        entityRef: ownerEntityRefs[index],
       };
     });
 

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -74,7 +74,9 @@ export const EntityOwnerPicker = () => {
   );
 
   const [selectedOwners, setSelectedOwners] = useState(
-    queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
+    queryParamOwners.length
+      ? new EntityOwnerFilter(queryParamOwners).values
+      : filters.owners?.values ?? [],
   );
 
   const {

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -104,7 +104,7 @@ export const EntityOwnerPicker = () => {
   const {
     loading,
     error,
-    value: owners,
+    value: ownerEntities,
   } = useAsync(async () => {
     const { items } = await catalogApi.getEntitiesByRefs({
       entityRefs: availableOwners.map(ref =>
@@ -143,9 +143,9 @@ export const EntityOwnerPicker = () => {
           multiple
           disableCloseOnSelect
           loading={loading}
-          options={owners || []}
+          options={ownerEntities || []}
           value={
-            owners?.filter(e =>
+            ownerEntities?.filter(e =>
               selectedOwners.some(
                 f => f === humanizeEntityRef(e, { defaultKind: 'Group' }),
               ),

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -40,6 +40,7 @@ import { humanizeEntityRef } from '../EntityRefLink';
 import useAsync from 'react-use/lib/useAsync';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '../../api';
+import { humanizeEntity } from '../EntityRefLink/humanize';
 
 /** @public */
 export type CatalogReactEntityOwnerPickerClassKey = 'input';
@@ -109,9 +110,16 @@ export const EntityOwnerPicker = () => {
       entityRefs: availableOwners.map(ref =>
         stringifyEntityRef(parseEntityRef(ref, { defaultKind: 'Group' })),
       ),
+      fields: [
+        'kind',
+        'metadata.name',
+        'metadata.title',
+        'spec.profile.displayName',
+      ],
     });
     return availableOwners.map(
-      (e, i) => items.at(i) || ({ metadata: { name: e } } as Entity),
+      (e, i) =>
+        items.at(i) || ({ metadata: { name: e }, kind: 'Group' } as Entity),
     );
   }, [availableOwners]);
 
@@ -136,14 +144,18 @@ export const EntityOwnerPicker = () => {
           disableCloseOnSelect
           loading={loading}
           options={owners || []}
-          getOptionLabel={option =>
-            option.metadata.title || option.metadata.name
+          value={
+            owners?.filter(e =>
+              selectedOwners.some(
+                f => f === humanizeEntityRef(e, { defaultKind: 'Group' }),
+              ),
+            ) ?? []
           }
-          value={owners?.filter(e =>
-            selectedOwners.some(f => f === e.metadata.name),
-          )}
           onChange={(_: object, value: Entity[]) =>
             setSelectedOwners(value.map(e => e.metadata.name))
+          }
+          getOptionLabel={option =>
+            humanizeEntity(option, { defaultKind: 'Group' })
           }
           renderOption={(option, { selected }) => (
             <FormControlLabel
@@ -155,7 +167,7 @@ export const EntityOwnerPicker = () => {
                 />
               }
               onClick={event => event.preventDefault()}
-              label={option.metadata.title || option.metadata.name}
+              label={humanizeEntity(option, { defaultKind: 'Group' })}
             />
           )}
           size="small"

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -107,14 +107,13 @@ export const EntityOwnerPicker = () => {
       if (entity) {
         return {
           label: humanizeEntity(entity, { defaultKind: 'Group' }),
-          entityRef: humanizeEntityRef(entity, { defaultKind: 'Group' }),
+          entityRef: stringifyEntityRef(entity),
         };
       }
       return {
-        label: humanizeEntityRef(
-          parseEntityRef(ownerEntityRefs[index], { defaultKind: 'Group' }),
-          { defaultKind: 'group' },
-        ),
+        label: humanizeEntityRef(parseEntityRef(ownerEntityRefs[index]), {
+          defaultKind: 'group',
+        }),
         entityRef: ownerEntityRefs[index],
       };
     });
@@ -143,7 +142,8 @@ export const EntityOwnerPicker = () => {
   // external updates to the page location.
   useEffect(() => {
     if (queryParamOwners.length) {
-      setSelectedOwners(queryParamOwners);
+      const filter = new EntityOwnerFilter(queryParamOwners);
+      setSelectedOwners(filter.values);
     }
   }, [queryParamOwners]);
 

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.test.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { humanizeEntityRef } from './humanize';
+import { Entity } from '@backstage/catalog-model';
+import { humanizeEntity, humanizeEntityRef } from './humanize';
 
 describe('humanizeEntityRef', () => {
   it('formats entity in default namespace', () => {
@@ -208,5 +209,61 @@ describe('humanizeEntityRef', () => {
       defaultNamespace: false,
     });
     expect(title).toEqual('component:default/software');
+  });
+});
+
+describe('humanizeEntity', () => {
+  it('gives a readable name when one is provided at metadata.title', () => {
+    expect(
+      humanizeEntity({
+        metadata: { name: 'my-entity', title: 'My Title' },
+      } as Entity),
+    ).toBe('My Title');
+  });
+
+  it.each([
+    [
+      'User',
+      {
+        apiVersion: '1',
+        kind: 'User',
+        metadata: {
+          name: 'user-name',
+        },
+        spec: {
+          profile: {
+            displayName: 'User Name',
+          },
+        },
+      },
+      'User Name',
+    ],
+    [
+      'Group',
+      {
+        apiVersion: '1',
+        kind: 'User',
+        metadata: {
+          name: 'team-name',
+        },
+        spec: {
+          profile: {
+            displayName: 'Team Name',
+          },
+        },
+      },
+      'Team Name',
+    ],
+  ])(
+    'gives a readable name for kind %s when one is provided at spec.profile.displayName',
+    (_, entity: Entity, expected) => {
+      expect(humanizeEntity(entity)).toBe(expected);
+    },
+  );
+
+  it('should pass through to humanizeEntityRef when nothing matches', () => {
+    expect(
+      humanizeEntity({ kind: 'Group', metadata: { name: 'test' } } as Entity),
+    ).toBe('group:test');
   });
 });

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -18,6 +18,7 @@ import {
   Entity,
   CompoundEntityRef,
   DEFAULT_NAMESPACE,
+  UserEntity,
 } from '@backstage/catalog-model';
 
 /**
@@ -64,4 +65,29 @@ export function humanizeEntityRef(
       ? undefined
       : kind;
   return `${kind ? `${kind}:` : ''}${namespace ? `${namespace}/` : ''}${name}`;
+}
+
+/**
+ * Convert an entity to its more common name.
+ *
+ * @param entity Entity to convert.
+ * @returns Readable name, defaults to unique identifier.
+ */
+export function humanizeEntity(
+  entity: Entity,
+  opts?: {
+    defaultKind?: string;
+    defaultNamespace?: string | false;
+  },
+) {
+  let title: string | undefined = undefined;
+  switch (entity.kind) {
+    case 'User':
+    case 'Group':
+      title = (entity as UserEntity).spec?.profile?.displayName;
+      break;
+    default:
+      title = entity.metadata.title;
+  }
+  return title || humanizeEntityRef(entity, opts);
 }

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -75,9 +75,11 @@ export function humanizeEntityRef(
  *
  * If neither of those are found or populated, fallback to `humanizeEntityRef`.
  *
- * @param entity Entity to convert.
- * @param opts If entity readable name is not available, opts will be used to specify humanizeEntityRef options.
+ * @param entity - Entity to convert.
+ * @param opts - If entity readable name is not available, opts will be used to specify humanizeEntityRef options.
  * @returns Readable name, defaults to unique identifier.
+ *
+ * @public
  */
 export function humanizeEntity(
   entity: Entity,

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -18,8 +18,8 @@ import {
   Entity,
   CompoundEntityRef,
   DEFAULT_NAMESPACE,
-  UserEntity,
 } from '@backstage/catalog-model';
+import get from 'lodash/get';
 
 /**
  * @param defaultNamespace - if set to false then namespace is never omitted,
@@ -88,14 +88,12 @@ export function humanizeEntity(
     defaultNamespace?: string | false;
   },
 ) {
-  let title: string | undefined = undefined;
-  switch (entity.kind) {
-    case 'User':
-    case 'Group':
-      title = (entity as UserEntity).spec?.profile?.displayName;
-      break;
-    default:
-      title = entity.metadata.title;
+  for (const path of ['spec.profile.displayName', 'metadata.title']) {
+    const value = get(entity, path);
+    if (value && typeof value === 'string') {
+      return value;
+    }
   }
-  return title || humanizeEntityRef(entity, opts);
+
+  return humanizeEntityRef(entity, opts);
 }

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -68,9 +68,15 @@ export function humanizeEntityRef(
 }
 
 /**
- * Convert an entity to its more common name.
+ * Convert an entity to its more readable name if available.
+ *
+ * If an entity is either User or Group, this will be its `spec.profile.displayName`.
+ * Otherwise, this is `metadata.title`.
+ *
+ * If neither of those are found or populated, fallback to `humanizeEntityRef`.
  *
  * @param entity Entity to convert.
+ * @param opts If entity readable name is not available, opts will be used to specify humanizeEntityRef options.
  * @returns Readable name, defaults to unique identifier.
  */
 export function humanizeEntity(

--- a/plugins/catalog-react/src/components/EntityRefLink/index.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/index.ts
@@ -18,4 +18,4 @@ export { EntityRefLink } from './EntityRefLink';
 export type { EntityRefLinkProps } from './EntityRefLink';
 export { EntityRefLinks } from './EntityRefLinks';
 export type { EntityRefLinksProps } from './EntityRefLinks';
-export { humanizeEntityRef } from './humanize';
+export { humanizeEntityRef, humanizeEntity } from './humanize';

--- a/plugins/catalog-react/src/components/EntityRefLink/index.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/index.ts
@@ -18,4 +18,4 @@ export { EntityRefLink } from './EntityRefLink';
 export type { EntityRefLinkProps } from './EntityRefLink';
 export { EntityRefLinks } from './EntityRefLinks';
 export type { EntityRefLinksProps } from './EntityRefLinks';
-export { humanizeEntityRef, humanizeEntity } from './humanize';
+export { humanizeEntityRef } from './humanize';

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -15,11 +15,12 @@
  */
 
 import { AlphaEntity } from '@backstage/catalog-model/alpha';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import {
   EntityErrorFilter,
   EntityOrphanFilter,
+  EntityOwnerFilter,
   EntityTextFilter,
 } from './filters';
 
@@ -141,5 +142,52 @@ describe('EntityErrorFilter', () => {
     const filter = new EntityErrorFilter(true);
     expect(filter.filterEntity(error)).toBeTruthy();
     expect(filter.filterEntity(entities[1])).toBeFalsy();
+  });
+});
+
+describe('EntityOwnerFilter', () => {
+  it('should handle humanizedEntityRefs', () => {
+    const filter = new EntityOwnerFilter(['my-user']);
+    expect(
+      filter.filterEntity({
+        relations: [
+          {
+            type: RELATION_OWNED_BY,
+            targetRef: 'group:default/my-user',
+          },
+        ],
+      } as Entity),
+    ).toBeTruthy();
+    expect(filter.values).toStrictEqual(['group:default/my-user']);
+  });
+
+  it('should also handle full entityRefs', () => {
+    const filter = new EntityOwnerFilter(['group:default/my-user']);
+    expect(
+      filter.filterEntity({
+        relations: [
+          {
+            type: RELATION_OWNED_BY,
+            targetRef: 'group:default/my-user',
+          },
+        ],
+      } as Entity),
+    ).toBeTruthy();
+    expect(filter.values).toStrictEqual(['group:default/my-user']);
+  });
+
+  it('should also gracefully reject non-entity refs', () => {
+    const filter = new EntityOwnerFilter(['group:default/my-user', '']);
+    expect(
+      filter.filterEntity({
+        relations: [
+          {
+            type: RELATION_OWNED_BY,
+            targetRef: 'group:default/my-user',
+          },
+        ],
+      } as Entity),
+    ).toBeTruthy();
+    expect(filter.values).toStrictEqual(['group:default/my-user']);
   });
 });

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -161,7 +161,7 @@ describe('EntityOwnerFilter', () => {
     expect(filter.values).toStrictEqual(['group:default/my-user']);
   });
 
-  it('should also handle full entityRefs', () => {
+  it('should handle full entityRefs', () => {
     const filter = new EntityOwnerFilter(['group:default/my-user']);
     expect(
       filter.filterEntity({
@@ -176,7 +176,7 @@ describe('EntityOwnerFilter', () => {
     expect(filter.values).toStrictEqual(['group:default/my-user']);
   });
 
-  it('should also gracefully reject non-entity refs', () => {
+  it('should gracefully reject non-entity refs', () => {
     const filter = new EntityOwnerFilter(['group:default/my-user', '']);
     expect(
       filter.filterEntity({
@@ -189,5 +189,20 @@ describe('EntityOwnerFilter', () => {
       } as Entity),
     ).toBeTruthy();
     expect(filter.values).toStrictEqual(['group:default/my-user']);
+  });
+
+  it('should handle non group full entity refs', () => {
+    const filter = new EntityOwnerFilter(['user:default/my-user', '']);
+    expect(
+      filter.filterEntity({
+        relations: [
+          {
+            type: RELATION_OWNED_BY,
+            targetRef: 'user:default/my-user',
+          },
+        ],
+      } as Entity),
+    ).toBeTruthy();
+    expect(filter.values).toStrictEqual(['user:default/my-user']);
   });
 });

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import {
+  Entity,
+  parseEntityRef,
+  RELATION_OWNED_BY,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import { AlphaEntity } from '@backstage/catalog-model/alpha';
-import { humanizeEntityRef } from './components/EntityRefLink';
 import { EntityFilter, UserListFilterKind } from './types';
 import { getEntityRelations } from './utils';
 
@@ -113,18 +117,37 @@ export class EntityTextFilter implements EntityFilter {
 /**
  * Filter matching entities that are owned by group.
  * @public
+ *
+ * CAUTION: This class may contain both full and partial entity refs.
  */
 export class EntityOwnerFilter implements EntityFilter {
-  constructor(readonly values: string[]) {}
+  readonly values: string[];
+  constructor(values: string[]) {
+    this.values = values.reduce((fullRefs, ref) => {
+      // Attempt to remove bad entity references here.
+      try {
+        fullRefs.push(
+          stringifyEntityRef(parseEntityRef(ref, { defaultKind: 'Group' })),
+        );
+        return fullRefs;
+      } catch (err) {
+        return fullRefs;
+      }
+    }, [] as string[]);
+  }
 
   filterEntity(entity: Entity): boolean {
     return this.values.some(v =>
       getEntityRelations(entity, RELATION_OWNED_BY).some(
-        o => humanizeEntityRef(o, { defaultKind: 'group' }) === v,
+        o => stringifyEntityRef(o) === v,
       ),
     );
   }
 
+  /**
+   * Get the URL query parameter value. May be a mix of full and humanized entity refs.
+   * @returns list of entity refs.
+   */
   toQueryValue(): string[] {
     return this.values;
   }

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -119,6 +119,13 @@ describe('DefaultCatalogPage', () => {
         ],
       };
     },
+    /**
+     * For the purposes of this test case, use existing functionality. The picker
+     *  isn't being tested, just needs this method to render correctly.
+     */
+    getEntitiesByRefs: async refs => {
+      return { items: refs.entityRefs.map(() => undefined) };
+    },
   };
   const testProfile: Partial<ProfileInfo> = {
     displayName: 'Display Name',

--- a/plugins/techdocs/src/home/components/DefaultTechDocsHome.test.tsx
+++ b/plugins/techdocs/src/home/components/DefaultTechDocsHome.test.tsx
@@ -38,6 +38,7 @@ import { DefaultTechDocsHome } from './DefaultTechDocsHome';
 
 const mockCatalogApi = {
   getEntityByRef: () => Promise.resolve(),
+  getEntitiesByRefs: () => Promise.resolve({ items: [] }),
   getEntities: async () => ({
     items: [
       {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `EntityOwnerPicker` to use `by-refs` endpoint and show readable names when possible. Also, forces the `EntityOwnerFilter` to use full entity refs instead of partial humanized ones.
Part of work for #15965.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

https://user-images.githubusercontent.com/34432188/218511230-58d89ddb-2d9e-4583-91ed-7322abfcae24.mov


