### PR TITLE
Microsoft auth provider manages tokens for multiple resources

### DIFF
--- a/.changeset/mighty-tips-flow.md
+++ b/.changeset/mighty-tips-flow.md
@@ -9,3 +9,8 @@ authorization code for a non-Microsoft Graph scope, the user profile will not be
 fetched. Similarly no user profile or photo data will be fetched by the backend
 if the `/refresh` endpoint is called with the `scope` query parameter strictly
 containing scopes for resources besides Microsoft Graph.
+
+Furthermore, the `offline_access` scope will be requested by default, even when
+it is not mentioned in the argument to `getAccessToken`. This means that any
+Azure access token can be automatically refreshed, even if the user has not
+signed in via Azure.

--- a/.changeset/mighty-tips-flow.md
+++ b/.changeset/mighty-tips-flow.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+The `microsoft` (i.e. Azure) auth provider now supports negotiating tokens for
+Azure resources besides Microsoft Graph (e.g. AKS, Virtual Machines, Machine
+Learning Services, etc.). When the `/frame/handler` endpoint is called with an
+authorization code for a non-Microsoft Graph scope, the user profile will not be
+fetched. Similarly no user profile or photo data will be fetched by the backend
+if the `/refresh` endpoint is called with the `scope` query parameter strictly
+containing scopes for resources besides Microsoft Graph.

--- a/.changeset/sixty-insects-visit.md
+++ b/.changeset/sixty-insects-visit.md
@@ -1,0 +1,9 @@
+---
+'@backstage/core-app-api': minor
+---
+
+The `AuthConnector` interface now supports specifying a set of scopes when
+refreshing a session. The `DefaultAuthConnector` implementation passes the
+`scope` query parameter to the auth-backend plugin appropriately. The
+`RefreshingAuthSessionManager` passes any scopes in its `GetSessionRequest`
+appropriately.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -441,7 +441,7 @@ export class LocalStorageFeatureFlags implements FeatureFlagsApi {
 // @public
 export class MicrosoftAuth {
   // (undocumented)
-  static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T;
+  static create(options: OAuth2CreateOptions): typeof microsoftAuthApiRef.T;
   // (undocumented)
   getAccessToken(
     scope?: string | string[],

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -442,6 +442,25 @@ export class LocalStorageFeatureFlags implements FeatureFlagsApi {
 export class MicrosoftAuth {
   // (undocumented)
   static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T;
+  // (undocumented)
+  getAccessToken(
+    scope?: string | string[],
+    options?: AuthRequestOptions,
+  ): Promise<string>;
+  // (undocumented)
+  getBackstageIdentity(
+    options?: AuthRequestOptions,
+  ): Promise<BackstageIdentityResponse | undefined>;
+  // (undocumented)
+  getIdToken(options?: AuthRequestOptions): Promise<string>;
+  // (undocumented)
+  getProfile(options?: AuthRequestOptions): Promise<ProfileInfo | undefined>;
+  // (undocumented)
+  sessionState$(): Observable<SessionState>;
+  // (undocumented)
+  signIn(): Promise<void>;
+  // (undocumented)
+  signOut(): Promise<void>;
 }
 
 // @public

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MicrosoftAuth from './MicrosoftAuth';
+import MockOAuthApi from '../../OAuthRequestApi/MockOAuthApi';
+import { UrlPatternDiscovery } from '../../DiscoveryApi';
+import { ConfigReader } from '@backstage/config';
+import { microsoftAuthApiRef } from '@backstage/core-plugin-api';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+describe('MicrosoftAuth', () => {
+  const server = setupServer();
+  setupRequestMockHandlers(server);
+  const microsoftAuth = MicrosoftAuth.create({
+    configApi: new ConfigReader(undefined),
+    oauthRequestApi: new MockOAuthApi(),
+    discoveryApi: UrlPatternDiscovery.compile(
+      'http://backstage.test/api/{{ pluginId }}',
+    ),
+  });
+
+  const toHaveJWTClaims = function toHaveJWTClaims(
+    this: jest.MatcherContext,
+    received: string,
+    expected: Record<string, any>,
+  ): jest.CustomMatcherResult {
+    let parsedClaims: Record<string, any>;
+    try {
+      parsedClaims = JSON.parse(
+        Buffer.from(received.split('.')[1], 'base64').toString(),
+      );
+    } catch (e) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected JWT with claims: ${this.utils.printExpected(
+            expected,
+          )}\nReceived invalid JWT ${this.utils.printReceived(
+            received,
+          )}\nError: ${e}`,
+      };
+    }
+    const expectedResult = expect.objectContaining(expected);
+    return {
+      pass: this.equals(parsedClaims, expectedResult),
+      message: () =>
+        `Expected JWT with claims: ${this.utils.printExpected(
+          expected,
+        )}\nReceived JWT with claims: ${this.utils.printReceived(
+          parsedClaims,
+        )}\n\n${this.utils.diff(expectedResult, parsedClaims)}`,
+    };
+  };
+  expect.extend({ toHaveJWTClaims });
+
+  describe('with a refresh token', () => {
+    beforeEach(() => {
+      server.use(
+        rest.get(
+          'http://backstage.test/api/auth/microsoft/refresh',
+          (req, res, ctx) => {
+            const scope =
+              req.url.searchParams.get('scope') ||
+              'openid profile email User.Read';
+            return res(
+              ctx.json({
+                providerInfo: {
+                  accessToken: `header.${Buffer.from(
+                    JSON.stringify({
+                      aud: '00000003-0000-0000-c000-000000000000',
+                      scp: 'openid profile email User.Read',
+                    }),
+                  ).toString('base64')}.signature`,
+                  scope,
+                },
+              }),
+            );
+          },
+        ),
+      );
+    });
+
+    it('gets access token for Microsoft Graph', async () => {
+      const accessToken = await microsoftAuth.getAccessToken();
+
+      expect(accessToken).toHaveJWTClaims({
+        aud: '00000003-0000-0000-c000-000000000000',
+        scp: 'openid profile email User.Read',
+      });
+    });
+  });
+
+  describe('without a refresh token', () => {
+    let mockRequester: jest.Mock;
+    let sut: typeof microsoftAuthApiRef.T;
+
+    beforeEach(() => {
+      mockRequester = jest.fn();
+      sut = MicrosoftAuth.create({
+        configApi: new ConfigReader(undefined),
+        oauthRequestApi: {
+          createAuthRequester: jest.fn().mockReturnValue(mockRequester),
+          authRequest$: jest.fn(),
+        },
+        discoveryApi: UrlPatternDiscovery.compile(
+          'http://backstage.test/api/{{ pluginId }}',
+        ),
+      });
+      server.use(
+        rest.get(
+          'http://backstage.test/api/auth/microsoft/refresh',
+          (_, res, ctx) => {
+            return res(
+              ctx.status(401),
+              ctx.json({
+                error: {
+                  name: 'AuthenticationError',
+                  message:
+                    'Refresh failed; caused by InputError: Missing session cookie',
+                  cause: {
+                    name: 'InputError',
+                    message: 'Missing session cookie',
+                  },
+                },
+                request: {
+                  method: 'GET',
+                  url: '/api/auth/microsoft/refresh?env=development',
+                },
+                response: {
+                  statusCode: 401,
+                },
+              }),
+            );
+          },
+        ),
+      );
+    });
+
+    it('gets access token for Microsoft Graph via popup', async () => {
+      await sut.getAccessToken();
+
+      expect(mockRequester).toHaveBeenCalledWith(
+        new Set(['User.Read', 'email', 'offline_access', 'openid', 'profile']),
+      );
+    });
+
+    it('gets access token for other azure resources via popup', async () => {
+      await sut.getAccessToken('azure-resource/scope');
+
+      expect(mockRequester).toHaveBeenCalledWith(
+        new Set(['azure-resource/scope']),
+      );
+    });
+
+    it('requests scopes for resource ID when scope contains a resource URI', async () => {
+      await sut.getAccessToken('api://customApiClientId/some.scope');
+
+      expect(mockRequester).toHaveBeenCalledWith(
+        new Set(['api://customApiClientId/some.scope']),
+      );
+    });
+  });
+});

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -69,6 +69,16 @@ describe('MicrosoftAuth', () => {
 
       expect(accessToken).toEqual('tokenForOtherResource');
     });
+
+    it('fails when requesting scopes for multiple resources at once', async () => {
+      const accessTokenPromise = microsoftAuth.getAccessToken(
+        'one-resource/scope other-resource/scope',
+      );
+
+      await expect(accessTokenPromise).rejects.toThrow(
+        'Requested access token with scopes from multiple Azure resources: one-resource, other-resource. Access tokens can only have a single audience.',
+      );
+    });
   });
 
   describe('without a refresh token', () => {

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -125,11 +125,11 @@ describe('MicrosoftAuth', () => {
       );
     });
 
-    it('gets access token for other azure resources via popup', async () => {
+    it('gets access + refresh token for other azure resources via popup', async () => {
       await sut.getAccessToken('azure-resource/scope');
 
       expect(mockRequester).toHaveBeenCalledWith(
-        new Set(['azure-resource/scope']),
+        new Set(['azure-resource/scope', 'offline_access']),
       );
     });
 
@@ -137,7 +137,7 @@ describe('MicrosoftAuth', () => {
       await sut.getAccessToken('api://customApiClientId/some.scope');
 
       expect(mockRequester).toHaveBeenCalledWith(
-        new Set(['api://customApiClientId/some.scope']),
+        new Set(['api://customApiClientId/some.scope', 'offline_access']),
       );
     });
   });

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
@@ -22,8 +22,7 @@ import {
   DiscoveryApi,
   OAuthRequestApi,
 } from '@backstage/core-plugin-api';
-import { OAuth2 } from '../oauth2';
-import { OAuthApiCreateOptions } from '../types';
+import { OAuth2, OAuth2CreateOptions } from '../oauth2';
 
 const DEFAULT_PROVIDER = {
   id: 'microsoft',
@@ -43,13 +42,14 @@ export default class MicrosoftAuth {
   private provider: AuthProviderInfo;
   private oauthRequestApi: OAuthRequestApi;
   private discoveryApi: DiscoveryApi;
+  private scopeTransform: (scopes: string[]) => string[];
 
   private static MicrosoftGraphID = '00000003-0000-0000-c000-000000000000';
 
-  static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T {
+  static create(options: OAuth2CreateOptions): typeof microsoftAuthApiRef.T {
     return new MicrosoftAuth(options);
   }
-  private constructor(options: OAuthApiCreateOptions) {
+  private constructor(options: OAuth2CreateOptions) {
     const {
       configApi,
       environment = 'development',
@@ -63,6 +63,7 @@ export default class MicrosoftAuth {
         'email',
         'User.Read',
       ],
+      scopeTransform = scopes => scopes.concat('offline_access'),
     } = options;
 
     this.configApi = configApi;
@@ -70,6 +71,7 @@ export default class MicrosoftAuth {
     this.provider = provider;
     this.oauthRequestApi = oauthRequestApi;
     this.discoveryApi = discoveryApi;
+    this.scopeTransform = scopeTransform;
 
     this.oauth2 = {
       [MicrosoftAuth.MicrosoftGraphID]: OAuth2.create({
@@ -78,6 +80,7 @@ export default class MicrosoftAuth {
         oauthRequestApi: this.oauthRequestApi,
         provider: this.provider,
         environment: this.environment,
+        scopeTransform: this.scopeTransform,
         defaultScopes,
       }),
     };
@@ -132,6 +135,7 @@ export default class MicrosoftAuth {
         oauthRequestApi: this.oauthRequestApi,
         provider: this.provider,
         environment: this.environment,
+        scopeTransform: this.scopeTransform,
       });
     }
     return this.oauth2[aud].getAccessToken(scope, options);

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
@@ -91,11 +91,20 @@ export default class MicrosoftAuth {
   }
 
   private static resourceForScopes(scope: string): Promise<string> {
-    const audience =
-      scope
-        .split(' ')
-        .map(MicrosoftAuth.resourceForScope)
-        .find(aud => aud !== 'openid') ?? MicrosoftAuth.MicrosoftGraphID;
+    const audiences = scope
+      .split(' ')
+      .map(MicrosoftAuth.resourceForScope)
+      .filter(aud => aud !== 'openid');
+    if (audiences.length > 1) {
+      return Promise.reject(
+        new Error(
+          `Requested access token with scopes from multiple Azure resources: ${audiences.join(
+            ', ',
+          )}. Access tokens can only have a single audience.`,
+        ),
+      );
+    }
+    const audience = audiences[0] ?? MicrosoftAuth.MicrosoftGraphID;
     return Promise.resolve(audience);
   }
 

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { microsoftAuthApiRef } from '@backstage/core-plugin-api';
+import {
+  microsoftAuthApiRef,
+  AuthRequestOptions,
+  AuthProviderInfo,
+  DiscoveryApi,
+  OAuthRequestApi,
+} from '@backstage/core-plugin-api';
 import { OAuth2 } from '../oauth2';
 import { OAuthApiCreateOptions } from '../types';
 
@@ -30,7 +36,18 @@ const DEFAULT_PROVIDER = {
  * @public
  */
 export default class MicrosoftAuth {
+  private oauth2: Record<string, OAuth2>;
+  private environment: string;
+  private provider: AuthProviderInfo;
+  private oauthRequestApi: OAuthRequestApi;
+  private discoveryApi: DiscoveryApi;
+
+  private static MicrosoftGraphID = '00000003-0000-0000-c000-000000000000';
+
   static create(options: OAuthApiCreateOptions): typeof microsoftAuthApiRef.T {
+    return new MicrosoftAuth(options);
+  }
+  private constructor(options: OAuthApiCreateOptions) {
     const {
       configApi,
       environment = 'development',
@@ -46,13 +63,53 @@ export default class MicrosoftAuth {
       ],
     } = options;
 
-    return OAuth2.create({
-      configApi,
-      discoveryApi,
-      oauthRequestApi,
-      provider,
-      environment,
-      defaultScopes,
-    });
+    this.configApi = configApi;
+    this.environment = environment;
+    this.provider = provider;
+    this.oauthRequestApi = oauthRequestApi;
+    this.discoveryApi = discoveryApi;
+
+    this.oauth2 = {
+      [MicrosoftAuth.MicrosoftGraphID]: OAuth2.create({
+        configApi: this.configApi,
+        discoveryApi: this.discoveryApi,
+        oauthRequestApi: this.oauthRequestApi,
+        provider: this.provider,
+        environment: this.environment,
+        defaultScopes,
+      }),
+    };
+  }
+
+  private microsoftGraph(): OAuth2 {
+    return this.oauth2[MicrosoftAuth.MicrosoftGraphID];
+  }
+
+  getAccessToken(scope?: string | string[], options?: AuthRequestOptions) {
+    return this.microsoftGraph().getAccessToken(scope, options);
+  }
+
+  getIdToken(options?: AuthRequestOptions) {
+    return this.microsoftGraph().getIdToken(options);
+  }
+
+  getProfile(options?: AuthRequestOptions) {
+    return this.microsoftGraph().getProfile(options);
+  }
+
+  getBackstageIdentity(options?: AuthRequestOptions) {
+    return this.microsoftGraph().getBackstageIdentity(options);
+  }
+
+  signIn() {
+    return this.microsoftGraph().signIn();
+  }
+
+  signOut() {
+    return this.microsoftGraph().signOut();
+  }
+
+  sessionState$() {
+    return this.microsoftGraph().sessionState$();
   }
 }

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
@@ -126,9 +126,12 @@ export class DefaultAuthConnector<AuthSession>
     return this.authRequester(options.scopes);
   }
 
-  async refreshSession(): Promise<any> {
+  async refreshSession(scopes?: Set<string>): Promise<any> {
     const res = await fetch(
-      await this.buildUrl('/refresh', { optional: true }),
+      await this.buildUrl('/refresh', {
+        optional: true,
+        ...(scopes && { scope: this.joinScopesFunc(scopes) }),
+      }),
       {
         headers: {
           'x-requested-with': 'XMLHttpRequest',

--- a/packages/core-app-api/src/lib/AuthConnector/types.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/types.ts
@@ -25,6 +25,6 @@ export type CreateSessionOptions = {
  */
 export type AuthConnector<AuthSession> = {
   createSession(options: CreateSessionOptions): Promise<AuthSession>;
-  refreshSession(): Promise<AuthSession>;
+  refreshSession(scopes?: Set<string>): Promise<AuthSession>;
   removeSession(): Promise<void>;
 };

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
@@ -47,7 +47,7 @@ describe('RefreshingAuthSessionManager', () => {
     await manager.getSession({});
     expect(createSession).toHaveBeenCalledTimes(1);
 
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledWith(undefined);
     expect(stateSubscriber.mock.calls).toEqual([
       [SessionState.SignedOut],
       [SessionState.SignedIn],
@@ -103,7 +103,7 @@ describe('RefreshingAuthSessionManager', () => {
 
     await manager.getSession({ scopes: new Set(['a']) });
     expect(createSession).toHaveBeenCalledTimes(1);
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledWith(new Set(['a']));
 
     await manager.getSession({ scopes: new Set(['a']) });
     expect(createSession).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe('RefreshingAuthSessionManager', () => {
 
     expect(await manager.getSession({ optional: true })).toBe(undefined);
     expect(createSession).toHaveBeenCalledTimes(0);
-    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(refreshSession).toHaveBeenCalledWith(undefined);
   });
 
   it('should forward option to instantly show auth popup and not attempt refresh', async () => {

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -73,7 +73,9 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
       }
 
       try {
-        const refreshedSession = await this.collapsedSessionRefresh();
+        const refreshedSession = await this.collapsedSessionRefresh(
+          options.scopes,
+        );
         const currentScopes = this.sessionScopesFunc(this.currentSession!);
         const refreshedScopes = this.sessionScopesFunc(refreshedSession);
         if (hasScopes(refreshedScopes, currentScopes)) {
@@ -97,7 +99,7 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
     // already had an existing session.
     if (!this.currentSession && !options.instantPopup) {
       try {
-        const newSession = await this.collapsedSessionRefresh();
+        const newSession = await this.collapsedSessionRefresh(options.scopes);
         this.currentSession = newSession;
         // The session might not have the scopes requested so go back and check again
         return this.getSession(options);
@@ -130,12 +132,12 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
     return this.stateTracker.sessionState$();
   }
 
-  private async collapsedSessionRefresh(): Promise<T> {
+  private async collapsedSessionRefresh(scopes?: Set<string>): Promise<T> {
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
 
-    this.refreshPromise = this.connector.refreshSession();
+    this.refreshPromise = this.connector.refreshSession(scopes);
 
     try {
       const session = await this.refreshPromise;

--- a/plugins/auth-backend/src/providers/microsoft/__testUtils__/fake.test.ts
+++ b/plugins/auth-backend/src/providers/microsoft/__testUtils__/fake.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FakeMicrosoftAPI } from './fake';
+
+describe('FakeMicrosoftAPI', () => {
+  const api = new FakeMicrosoftAPI();
+
+  describe('#token', () => {
+    it('exchanges auth codes', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('User.Read'),
+        }),
+      );
+
+      expect(api.tokenHasScope(access_token, 'User.Read')).toBe(true);
+    });
+
+    it('supports scopes for the first requested audience only', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('someaudience/somescope User.Read'),
+        }),
+      );
+
+      expect(api.tokenHasScope(access_token, 'User.Read')).toBe(false);
+    });
+
+    it('special openid scopes do not count towards the 1-audience limit', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('openid offline_access User.Read'),
+        }),
+      );
+
+      expect(api.tokenHasScope(access_token, 'User.Read')).toBe(true);
+    });
+
+    it('refreshes tokens', () => {
+      const { access_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: api.generateRefreshToken(
+            'email openid profile User.Read',
+          ),
+        }),
+      );
+
+      expect(
+        api.tokenHasScope(access_token, 'email openid profile User.Read'),
+      ).toBe(true);
+    });
+    it('requires `openid` scope for ID token', () => {
+      const { id_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('User.Read'),
+        }),
+      );
+
+      expect(id_token).toBeUndefined();
+    });
+    it('requires `offline_access` scope for refresh token', () => {
+      const { refresh_token } = api.token(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: api.generateAuthCode('User.Read'),
+        }),
+      );
+
+      expect(refresh_token).toBeUndefined();
+    });
+  });
+});

--- a/plugins/auth-backend/src/providers/microsoft/__testUtils__/fake.ts
+++ b/plugins/auth-backend/src/providers/microsoft/__testUtils__/fake.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { decodeJwt } from 'jose';
+
+type Claims = { aud: string; scp: string };
+
+export class FakeMicrosoftAPI {
+  generateAccessToken(scope: string): string {
+    return this.tokenWithClaims(this.allClaimsForScope(scope)).access_token;
+  }
+  generateAuthCode(scope: string): string {
+    return this.encodeClaims(this.allClaimsForScope(scope));
+  }
+  generateRefreshToken(scope: string): string {
+    return this.encodeClaims(this.allClaimsForScope(scope));
+  }
+  token(formData: URLSearchParams): {
+    access_token: string;
+    scope: string;
+    refresh_token?: string;
+    id_token?: string;
+  } {
+    const scopeParameter = formData.get('scope');
+    const claims =
+      (scopeParameter && this.allClaimsForScope(scopeParameter)) ??
+      formData.get('grant_type') === 'refresh_token'
+        ? this.decodeClaims(formData.get('refresh_token')!)
+        : this.decodeClaims(formData.get('code')!);
+    return {
+      ...this.tokenWithClaims(claims),
+      ...(this.hasScope(claims, 'offline_access') && {
+        refresh_token: this.encodeClaims(claims),
+      }),
+      ...(this.hasScope(claims, 'openid') && {
+        id_token: 'header.e30K.microsoft',
+      }),
+    };
+  }
+  tokenHasScope(token: string, scope: string): boolean {
+    const { aud, scp } = decodeJwt(token);
+    return this.hasScope({ aud: aud as string, scp: scp as string }, scope);
+  }
+  private tokenWithClaims(claims: Claims): {
+    access_token: string;
+    scope: string;
+  } {
+    const filteredClaims = {
+      ...claims,
+      scp: claims.scp
+        .split(' ')
+        .filter(s => s !== 'offline_access')
+        .join(' '),
+    };
+    return {
+      access_token: `header.${Buffer.from(
+        JSON.stringify(filteredClaims),
+      ).toString('base64')}.signature`,
+      scope: this.scopeFromClaims(filteredClaims),
+    };
+  }
+  private allClaimsForScope(scope: string): Claims {
+    const scopes = scope.split(' ').map(this.parseScope);
+    const firstAudience = scopes
+      .map(({ aud }) => aud)
+      .find(aud => aud !== 'openid');
+    return {
+      aud: firstAudience ?? '00000003-0000-0000-c000-000000000000',
+      scp: scopes
+        .filter(({ aud }) => aud === 'openid' || aud === firstAudience)
+        .map(({ scp }) => scp)
+        .join(' '),
+    };
+  }
+  // auth codes and refresh tokens in this fake system are base64-encoded JSON
+  // strings of claims
+  private encodeClaims(claims: Claims): string {
+    return Buffer.from(JSON.stringify(claims)).toString('base64');
+  }
+  private decodeClaims(encoded: string): Claims {
+    return JSON.parse(Buffer.from(encoded, 'base64').toString());
+  }
+  private hasScope(claims: Claims, scope: string): boolean {
+    return this.scopeFromClaims(claims).includes(scope);
+  }
+  private parseScope(s: string): Claims {
+    if (s.includes('/')) {
+      const [aud, scp] = s.split('/');
+      return { aud, scp };
+    }
+    switch (s) {
+      case 'email':
+      case 'openid':
+      case 'offline_access':
+      case 'profile': {
+        return { aud: 'openid', scp: s };
+      }
+      default:
+        return { aud: '00000003-0000-0000-c000-000000000000', scp: s };
+    }
+  }
+  private scopeFromClaims(claims: Claims): string {
+    return claims.scp
+      .split(' ')
+      .map(this.parseScope)
+      .map(({ aud, scp }) =>
+        aud === 'openid' ||
+        claims.aud === '00000003-0000-0000-c000-000000000000'
+          ? scp
+          : `${claims.aud}/${scp}`,
+      )
+      .join(' ');
+  }
+}

--- a/plugins/auth-backend/src/providers/microsoft/provider.test.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.test.ts
@@ -14,37 +14,73 @@
  * limitations under the License.
  */
 
-import { MicrosoftAuthProvider } from './provider';
+import { microsoft } from './provider';
 import { getVoidLogger } from '@backstage/backend-common';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { AuthResolverContext } from '../types';
+import { AuthProviderRouteHandlers, AuthResolverContext } from '../types';
 import express from 'express';
+import crypto from 'crypto';
+import { FakeMicrosoftAPI } from './__testUtils__/fake';
 
-describe('MicrosoftAuthProvider#handle', () => {
+describe('MicrosoftAuthProvider', () => {
+  const nonce = 'AAAAAAAAAAAAAAAAAAAAAA=='; // 16 bytes of zeros in base64
+  const state = Buffer.from(
+    `nonce=${encodeURIComponent(nonce)}&env=development`,
+  ).toString('hex');
+
   const server = setupServer();
+  const microsoftApi = new FakeMicrosoftAPI();
+  let provider: AuthProviderRouteHandlers;
+  let response: jest.Mocked<express.Response>;
+
   setupRequestMockHandlers(server);
 
   beforeEach(() => {
+    provider = microsoft.create()({
+      providerId: 'microsoft',
+      globalConfig: {
+        baseUrl: 'http://backstage.test/api/auth',
+        appUrl: 'http://backstage.test',
+        isOriginAllowed: _ => true,
+      },
+      config: new ConfigReader({
+        development: {
+          tenantId: 'tenantId',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret',
+        },
+      }),
+      logger: getVoidLogger(),
+      resolverContext: {} as AuthResolverContext,
+    });
+
     server.use(
       rest.post(
-        'https://login.microsoftonline.com/common/oauth2/v2.0/token',
-        (_, res, ctx) =>
-          res(
+        'https://login.microsoftonline.com/tenantId/oauth2/v2.0/token',
+        async (req, res, ctx) => {
+          return res(
             ctx.json({
+              ...microsoftApi.token(new URLSearchParams(await req.text())),
               token_type: 'Bearer',
-              scope: 'email openid profile User.Read',
               expires_in: 123,
               ext_expires_in: 123,
-              access_token: 'accessToken',
-              refresh_token: 'refreshToken',
-              id_token: 'idToken',
             }),
-          ),
+          );
+        },
       ),
-      rest.get('https://graph.microsoft.com/v1.0/me/', (_, res, ctx) =>
-        res(
+      rest.get('https://graph.microsoft.com/v1.0/me/', (req, res, ctx) => {
+        if (
+          !microsoftApi.tokenHasScope(
+            req.headers.get('authorization')!.replace(/^Bearer /, ''),
+            'User.Read',
+          )
+        ) {
+          return res(ctx.status(403));
+        }
+        return res(
           ctx.json({
             id: 'conrad',
             displayName: 'Conrad',
@@ -52,11 +88,19 @@ describe('MicrosoftAuthProvider#handle', () => {
             givenName: 'Francisco',
             mail: 'conrad@example.com',
           }),
-        ),
-      ),
+        );
+      }),
       rest.get(
         'https://graph.microsoft.com/v1.0/me/photos/*',
-        async (_, res, ctx) => {
+        async (req, res, ctx) => {
+          if (
+            !microsoftApi.tokenHasScope(
+              req.headers.get('authorization')!.replace(/^Bearer /, ''),
+              'User.Read',
+            )
+          ) {
+            return res(ctx.status(403));
+          }
           const imageBuffer = new Uint8Array([104, 111, 119, 100, 121]).buffer;
           return res(
             ctx.set('Content-Length', imageBuffer.byteLength.toString()),
@@ -66,85 +110,265 @@ describe('MicrosoftAuthProvider#handle', () => {
         },
       ),
     );
+    response = {
+      cookie: jest.fn(),
+      end: jest.fn(),
+      json: jest.fn(),
+      setHeader: jest.fn(),
+      status: jest.fn(),
+    } as unknown as jest.Mocked<express.Response>;
+    response.status.mockReturnValue(response);
   });
 
-  it('returns providerInfo and profile', async () => {
-    const provider = new MicrosoftAuthProvider({
-      logger: getVoidLogger(),
-      resolverContext: {} as AuthResolverContext,
-      authHandler: async ({ fullProfile }) => ({
-        profile: {
-          email: fullProfile.emails![0]!.value,
-          displayName: fullProfile.displayName,
-          picture: 'http://microsoft.com/lols',
-        },
-      }),
-      clientId: 'mock',
-      clientSecret: 'mock',
-      callbackUrl: 'http://backstage.test/api/auth/microsoft/handler/frame',
+  describe('#start', () => {
+    const randomBytes = jest.spyOn(
+      crypto,
+      'randomBytes',
+    ) as unknown as jest.MockedFunction<(size: number) => Buffer>;
+
+    afterEach(() => {
+      randomBytes.mockRestore();
     });
 
-    const { response } = await provider.handler({
-      method: 'GET',
-      url: 'http://backstage.test/api/auth/microsoft/handler/frame',
-      query: {
-        code: 'authorizationcode',
-      },
-      headers: { host: 'backstage.test' },
-      connection: {},
-    } as unknown as express.Request);
+    it('redirects to authorize URL', async () => {
+      randomBytes.mockReturnValue(Buffer.from(nonce, 'base64'));
 
-    expect(response).toEqual({
-      providerInfo: {
-        accessToken: 'accessToken',
-        expiresInSeconds: 123,
-        idToken: 'idToken',
-        scope: 'email openid profile User.Read',
-      },
-      profile: {
-        email: 'conrad@example.com',
-        displayName: 'Conrad',
-        picture: 'http://microsoft.com/lols',
-      },
+      await provider.start(
+        {
+          query: {
+            env: 'development',
+            scope: 'email openid profile User.Read',
+          },
+        } as unknown as express.Request,
+        response,
+      );
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Location',
+        'https://login.microsoftonline.com/tenantId/oauth2/v2.0/authorize' +
+          '?response_type=code' +
+          '&redirect_uri=http%3A%2F%2Fbackstage.test%2Fapi%2Fauth%2Fmicrosoft%2Fhandler%2Fframe' +
+          '&scope=email%20openid%20profile%20User.Read' +
+          `&state=${state}` +
+          '&client_id=clientId',
+      );
     });
   });
 
-  it('returns base64 encoded photo data', async () => {
-    const provider = new MicrosoftAuthProvider({
-      logger: getVoidLogger(),
-      resolverContext: {} as AuthResolverContext,
-      authHandler: async ({ fullProfile }) => ({
-        profile: {
-          email: fullProfile.emails![0]!.value,
-          displayName: fullProfile.displayName,
-          picture: 'http://microsoft.com/lols',
-        },
-      }),
-      clientId: 'mock',
-      clientSecret: 'mock',
-      callbackUrl: 'mock',
-      // define resolver to return user `info` for photo validation
-      signInResolver: async (info, _) => {
-        return {
-          id: 'user.name',
-          token: 'token',
-          info: info,
-        };
-      },
+  describe('#handle', () => {
+    it('returns provider info and profile with photo data', async () => {
+      await provider.frameHandler(
+        {
+          query: {
+            env: 'development',
+            code: microsoftApi.generateAuthCode(
+              'email openid profile User.Read',
+            ),
+            state,
+          },
+          cookies: {
+            'microsoft-nonce': nonce,
+          },
+        } as unknown as express.Request,
+        response,
+      );
+
+      expect(response.end).toHaveBeenCalledWith(
+        expect.stringContaining(
+          encodeURIComponent(
+            JSON.stringify({
+              type: 'authorization_response',
+              response: {
+                providerInfo: {
+                  idToken: 'header.e30K.microsoft',
+                  accessToken: microsoftApi.generateAccessToken(
+                    'email openid profile User.Read',
+                  ),
+                  scope: 'email openid profile User.Read',
+                  expiresInSeconds: 123,
+                },
+                profile: {
+                  email: 'conrad@example.com',
+                  picture: 'data:image/jpeg;base64,aG93ZHk=',
+                  displayName: 'Conrad',
+                },
+              },
+            }),
+          ),
+        ),
+      );
     });
 
-    const { response } = await provider.handler({
-      method: 'GET',
-      url: 'http://backstage.test/api/auth/microsoft/handler/frame',
-      query: {
-        code: 'authorizationcode',
-      },
-      headers: { host: 'backstage.test' },
-      connection: {},
-    } as unknown as express.Request);
+    it('sets refresh token', async () => {
+      await provider.frameHandler(
+        {
+          query: {
+            env: 'development',
+            code: microsoftApi.generateAuthCode(
+              'email offline_access openid profile User.Read',
+            ),
+            state,
+          },
+          cookies: {
+            'microsoft-nonce': nonce,
+          },
+        } as unknown as express.Request,
+        response,
+      );
 
-    const overloadedIdentity = response.backstageIdentity as any;
-    const photo = overloadedIdentity.info.result.fullProfile.photos[0];
-    expect(photo.value).toEqual('data:image/jpeg;base64,aG93ZHk=');
+      expect(response.cookie).toHaveBeenCalledWith(
+        'microsoft-refresh-token',
+        microsoftApi.generateRefreshToken(
+          'email offline_access openid profile User.Read',
+        ),
+        {
+          domain: 'backstage.test',
+          httpOnly: true,
+          maxAge: 86400000000,
+          path: '/api/auth/microsoft',
+          sameSite: 'lax',
+          secure: false,
+        },
+      );
+    });
+
+    it('omits photo data when fetching it fails', async () => {
+      server.use(
+        rest.get('https://graph.microsoft.com/v1.0/me/photos/*', (_, res) =>
+          res.networkError('remote hung up'),
+        ),
+      );
+
+      await provider.frameHandler(
+        {
+          query: {
+            env: 'development',
+            code: microsoftApi.generateAuthCode(
+              'email openid profile User.Read',
+            ),
+            state,
+          },
+          cookies: {
+            'microsoft-nonce': nonce,
+          },
+        } as unknown as express.Request,
+        response,
+      );
+
+      expect(response.end).toHaveBeenCalledWith(
+        expect.stringContaining(
+          encodeURIComponent(
+            JSON.stringify({
+              type: 'authorization_response',
+              response: {
+                providerInfo: {
+                  idToken: 'header.e30K.microsoft',
+                  accessToken: microsoftApi.generateAccessToken(
+                    'email openid profile User.Read',
+                  ),
+                  scope: 'email openid profile User.Read',
+                  expiresInSeconds: 123,
+                },
+                profile: {
+                  email: 'conrad@example.com',
+                  displayName: 'Conrad',
+                },
+              },
+            }),
+          ),
+        ),
+      );
+    });
+  });
+
+  describe('#refresh', () => {
+    it('returns provider info and profile with photo data', async () => {
+      await provider.refresh!(
+        {
+          query: {
+            env: 'development',
+            scope: 'email openid profile User.Read',
+          },
+          header: jest.fn(_ => 'XMLHttpRequest'),
+          cookies: {
+            'microsoft-refresh-token': microsoftApi.generateRefreshToken(
+              'email openid profile User.Read',
+            ),
+          },
+          get: jest.fn(),
+        } as unknown as express.Request,
+        response,
+      );
+
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerInfo: {
+            accessToken: microsoftApi.generateAccessToken(
+              'email openid profile User.Read',
+            ),
+            expiresInSeconds: 123,
+            idToken: 'header.e30K.microsoft',
+            scope: 'email openid profile User.Read',
+          },
+          profile: {
+            email: 'conrad@example.com',
+            displayName: 'Conrad',
+            picture: 'data:image/jpeg;base64,aG93ZHk=',
+          },
+        }),
+      );
+    });
+
+    it('returns backstage identity when sign-in resolver is configured', async () => {
+      provider = microsoft.create({
+        signIn: {
+          resolver: _ =>
+            Promise.resolve({
+              token: 'protectedheader.e30K.signature',
+            }),
+        },
+      })({
+        providerId: 'microsoft',
+        globalConfig: {
+          baseUrl: 'http://backstage.test/api/auth',
+          appUrl: 'http://backstage.test',
+          isOriginAllowed: _ => true,
+        },
+        config: new ConfigReader({
+          development: {
+            tenantId: 'tenantId',
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+          },
+        }),
+        logger: getVoidLogger(),
+        resolverContext: {} as AuthResolverContext,
+      }) as AuthProviderRouteHandlers;
+
+      await provider.refresh!(
+        {
+          query: {
+            env: 'development',
+            scope: 'email openid profile User.Read',
+          },
+          header: jest.fn(_ => 'XMLHttpRequest'),
+          cookies: {
+            'microsoft-refresh-token': microsoftApi.generateRefreshToken(
+              'email openid profile User.Read',
+            ),
+          },
+          get: jest.fn(),
+        } as unknown as express.Request,
+        response,
+      );
+
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backstageIdentity: expect.objectContaining({
+            token: 'protectedheader.e30K.signature',
+          }),
+        }),
+      );
+    });
   });
 });

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -49,6 +49,8 @@ import {
 } from '../resolvers';
 import { Logger } from 'winston';
 import fetch from 'node-fetch';
+import { decodeJwt } from 'jose';
+import { Profile as PassportProfile } from 'passport';
 
 const BACKSTAGE_SESSION_EXPIRATION = 3600;
 
@@ -86,6 +88,12 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
         authorizationURL: options.authorizationUrl,
         tokenURL: options.tokenUrl,
         passReqToCallback: false,
+        skipUserProfile: (
+          accessToken: string,
+          done: (err: unknown, skip: boolean) => void,
+        ) => {
+          done(null, this.skipUserProfile(accessToken));
+        },
       },
       (
         accessToken: any,
@@ -98,6 +106,17 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
       },
     );
   }
+
+  private skipUserProfile = (accessToken: string): boolean => {
+    const { aud, scp } = decodeJwt(accessToken);
+    const hasGraphReadScope =
+      aud === '00000003-0000-0000-c000-000000000000' &&
+      (scp as string)
+        .split(' ')
+        .map(s => s.toLowerCase())
+        .includes('user.read');
+    return !hasGraphReadScope;
+  };
 
   async start(req: OAuthStartRequest): Promise<OAuthStartResponse> {
     return await executeRedirectStrategy(req, this._strategy, {
@@ -126,53 +145,62 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
         req.scope,
       );
 
-    const fullProfile = await executeFetchUserProfileStrategy(
-      this._strategy,
-      accessToken,
-    );
-
     return {
       response: await this.handleResult({
-        fullProfile,
         params,
         accessToken,
+        ...(!this.skipUserProfile(accessToken) && {
+          fullProfile: await executeFetchUserProfileStrategy(
+            this._strategy,
+            accessToken,
+          ),
+        }),
       }),
       refreshToken,
     };
   }
 
-  private async handleResult(result: OAuthResult) {
-    const photo = await this.getUserPhoto(result.accessToken);
-    result.fullProfile.photos = photo ? [{ value: photo }] : undefined;
-
-    const { profile } = await this.authHandler(result, this.resolverContext);
+  private async handleResult(result: {
+    fullProfile?: PassportProfile;
+    params: {
+      id_token?: string;
+      scope: string;
+      expires_in: number;
+    };
+    accessToken: string;
+    refreshToken?: string;
+  }): Promise<OAuthResponse> {
+    let profile = {};
+    if (result.fullProfile) {
+      const photo = await this.getUserPhoto(result.accessToken);
+      result.fullProfile.photos = photo ? [{ value: photo }] : undefined;
+      ({ profile } = await this.authHandler(
+        result as OAuthResult,
+        this.resolverContext,
+      ));
+    }
 
     const expiresInSeconds =
       result.params.expires_in === undefined
         ? BACKSTAGE_SESSION_EXPIRATION
         : Math.min(result.params.expires_in, BACKSTAGE_SESSION_EXPIRATION);
 
-    const response: OAuthResponse = {
+    return {
       providerInfo: {
-        idToken: result.params.id_token,
         accessToken: result.accessToken,
         scope: result.params.scope,
         expiresInSeconds,
+        ...{ idToken: result.params.id_token },
       },
       profile,
+      ...(result.fullProfile &&
+        this.signInResolver && {
+          backstageIdentity: await this.signInResolver(
+            { result: result as OAuthResult, profile },
+            this.resolverContext,
+          ),
+        }),
     };
-
-    if (this.signInResolver) {
-      response.backstageIdentity = await this.signInResolver(
-        {
-          result,
-          profile,
-        },
-        this.resolverContext,
-      );
-    }
-
-    return response;
   }
 
   private async getUserPhoto(accessToken: string): Promise<string | undefined> {
@@ -236,7 +264,7 @@ export const microsoft = createAuthProviderIntegration({
         const authHandler: AuthHandler<OAuthResult> = options?.authHandler
           ? options.authHandler
           : async ({ fullProfile, params }) => ({
-              profile: makeProfileInfo(fullProfile, params.id_token),
+              profile: makeProfileInfo(fullProfile ?? {}, params.id_token),
             });
 
         const provider = new MicrosoftAuthProvider({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Highlights

#### Backend (auth-backend plugin):
* Converted the tests for the `MicrosoftAuthProvider` to exercise a wider boundary, integrating with `OAuthAdapter`.
* When the `/frame/handler` endpoint is called with an authorization code for a non-Microsoft Graph scope, the user profile will not be fetched. Similarly no user profile or photo data will be fetched by the backend if the `/refresh` endpoint is called where the `scope` query parameter is missing the `User.Read` scope from Microsoft Graph.
#### Frontend (core-app-api package):
* when its `getAccessToken` method is called, `MicrosoftAuth` parses scopes to determine the audience of the token that azure will provision. Then it maintains a map of (audience, `OAuth2`) pairs so that each audience has its own notion of the current session.
* `MicrosoftAuth` always appends an `offline_access` scope to any token requests, so that tokens are always refreshable.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] ~Screenshots attached (for UI changes)~ n/a
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
