### PR TITLE
e2e-test: ignore AWS SDK v2 deprecation message

### DIFF
--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -490,6 +490,17 @@ async function testBackendStart(appDir: string, ...args: string[]) {
           !l.includes('Update this package.json to use a subpath') &&
           !l.includes(
             '(Use `node --trace-deprecation ...` to show where the warning was created)',
+          ) &&
+          // These 4 are all for the AWS SDK v2 deprecation
+          !l.includes(
+            'The AWS SDK for JavaScript (v2) will be put into maintenance mode',
+          ) &&
+          !l.includes(
+            'Please migrate your code to use AWS SDK for JavaScript',
+          ) &&
+          !l.includes('check the migration guide at https://a.co/7PzMCcy') &&
+          !l.includes(
+            '(Use `node --trace-warnings ...` to show where the warning was created)',
           ),
       ).length !== 0
     );


### PR DESCRIPTION
🧹 