### PR TITLE
backend-test-utils: mark backend system utils as stable

### DIFF
--- a/.changeset/silent-roses-join.md
+++ b/.changeset/silent-roses-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+The new backend system testing utilities have now been marked as stable API.

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -28,7 +28,7 @@ import { UrlReaderService } from '@backstage/backend-plugin-api';
 // @public (undocumented)
 export function isDockerDisabledForTests(): boolean;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export namespace mockServices {
   // (undocumented)
   export namespace cache {
@@ -126,7 +126,7 @@ export function setupRequestMockHandlers(worker: {
   resetHandlers: () => void;
 }): void;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export function startTestBackend<
   TServices extends any[],
   TExtensionPoints extends any[],
@@ -134,12 +134,12 @@ export function startTestBackend<
   options: TestBackendOptions<TServices, TExtensionPoints>,
 ): Promise<TestBackend>;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface TestBackend extends Backend {
   readonly server: ExtendedHttpServer;
 }
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface TestBackendOptions<
   TServices extends any[],
   TExtensionPoints extends any[],

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -58,7 +58,7 @@ function simpleFactory<
 }
 
 /**
- * @alpha
+ * @public
  */
 export namespace mockServices {
   export function config(options?: config.Options): ConfigService {

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -36,7 +36,7 @@ import { mockServices } from '../services';
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
 
-/** @alpha */
+/** @public */
 export interface TestBackendOptions<
   TServices extends any[],
   TExtensionPoints extends any[],
@@ -60,7 +60,7 @@ export interface TestBackendOptions<
   features?: BackendFeature[];
 }
 
-/** @alpha */
+/** @public */
 export interface TestBackend extends Backend {
   /**
    * Provides access to the underling HTTP server for use with utilities
@@ -89,7 +89,7 @@ const defaultServiceFactories = [
 
 const backendInstancesToCleanUp = new Array<Backend>();
 
-/** @alpha */
+/** @public */
 export async function startTestBackend<
   TServices extends any[],
   TExtensionPoints extends any[],


### PR DESCRIPTION
Backend test utils are still on 0.1.x, I'm feeling that having these marked as alpha just adds more friction than what it's worth, especially since we will start encouraging migration of plugins.