### PR TITLE
createPermissionIntegrationRouter - optional getResources

### DIFF
--- a/.changeset/clean-planes-join.md
+++ b/.changeset/clean-planes-join.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-node': patch
 ---
 
-Changed the `createPermissionIntegrationRouter` API to allow `getResources` to be optional
+Changed the `createPermissionIntegrationRouter` API to allow `getResources`, `resourceType` and `rules` to be optional

--- a/.changeset/clean-planes-join.md
+++ b/.changeset/clean-planes-join.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-node': patch
 ---
 
-Changed the createPermissionIntegrationRouter API to allow getResources to be optional
+Changed the `createPermissionIntegrationRouter` API to allow `getResources` to be optional

--- a/.changeset/clean-planes-join.md
+++ b/.changeset/clean-planes-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Changed the createPermissionIntegrationRouter API to allow getResources to be optional

--- a/.changeset/polite-wombats-smash.md
+++ b/.changeset/polite-wombats-smash.md
@@ -1,6 +1,5 @@
 ---
-'@backstage/backend-app-api': patch
 '@backstage/errors': patch
 ---
 
-Add NotImplementedError
+Added `NotImplementedError`, which can be used when the server does not recognize the request method and is incapable of supporting it for any resource.

--- a/.changeset/polite-wombats-smash.md
+++ b/.changeset/polite-wombats-smash.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-app-api': patch
+'@backstage/errors': patch
+---
+
+Add NotImplementedError

--- a/.changeset/what-is-going-on-babe.md
+++ b/.changeset/what-is-going-on-babe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Add support for `NotImplementedError`, properly returning 501 as status code.

--- a/packages/backend-app-api/src/http/MiddlewareFactory.ts
+++ b/packages/backend-app-api/src/http/MiddlewareFactory.ts
@@ -38,6 +38,7 @@ import {
   NotModifiedError,
   serializeError,
 } from '@backstage/errors';
+import { NotImplementedError } from '@backstage/errors';
 
 /**
  * Options used to create a {@link MiddlewareFactory}.
@@ -257,6 +258,8 @@ function getStatusCode(error: Error): number {
       return 404;
     case ConflictError.name:
       return 409;
+    case NotImplementedError.name:
+      return 501;
     default:
       break;
   }

--- a/packages/errors/api-report.md
+++ b/packages/errors/api-report.md
@@ -85,6 +85,9 @@ export class NotAllowedError extends CustomErrorBase {}
 export class NotFoundError extends CustomErrorBase {}
 
 // @public
+export class NotImplementedError extends CustomErrorBase {}
+
+// @public
 export class NotModifiedError extends CustomErrorBase {}
 
 // @public

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -75,6 +75,13 @@ export class ConflictError extends CustomErrorBase {}
 export class NotModifiedError extends CustomErrorBase {}
 
 /**
+ * The server does not support the functionality required to fulfill the request.
+ *
+ * @public
+ */
+export class NotImplementedError extends CustomErrorBase {}
+
+/**
  * An error that forwards an underlying cause with additional context in the message.
  *
  * The `name` property of the error will be inherited from the `cause` if

--- a/packages/errors/src/errors/index.ts
+++ b/packages/errors/src/errors/index.ts
@@ -24,6 +24,7 @@ export {
   NotAllowedError,
   NotFoundError,
   NotModifiedError,
+  NotImplementedError,
 } from './common';
 export { CustomErrorBase } from './CustomErrorBase';
 export { ResponseError } from './ResponseError';

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -112,22 +112,20 @@ export const createConditionTransformer: <
 ) => ConditionTransformer<TQuery>;
 
 // @public
-export const createPermissionIntegrationRouter: <
+export function createPermissionIntegrationRouter<
   TResourceType extends string,
   TResource,
 >(
-  options: CreatePermissionIntegrationRouterOptions<TResourceType, TResource>,
-) => express.Router;
+  options: CreatePermissionIntegrationRouterResourceOptions<
+    TResourceType,
+    TResource
+  >,
+): express.Router;
 
 // @public
-export type CreatePermissionIntegrationRouterOptions<
-  TResourceType extends string,
-  TResource,
-> =
-  | {
-      permissions: Array<Permission>;
-    }
-  | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>;
+export function createPermissionIntegrationRouter(options: {
+  permissions: Array<Permission>;
+}): express.Router;
 
 // @public
 export type CreatePermissionIntegrationRouterResourceOptions<

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -137,7 +137,9 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   resourceType: TResourceType;
   permissions?: Array<Permission>;
   rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
-  getResources?: GetResourcesFn<TResource>;
+  getResources?: (
+    resourceRefs: string[],
+  ) => Promise<Array<TResource | undefined>>;
 };
 
 // @public
@@ -149,11 +151,6 @@ export const createPermissionRule: <
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
-
-// @public
-export type GetResourcesFn<TResource> = (
-  resourceRefs: string[],
-) => Promise<Array<TResource | undefined>>;
 
 // @alpha
 export const isAndCriteria: <T>(

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -112,6 +112,11 @@ export const createConditionTransformer: <
 ) => ConditionTransformer<TQuery>;
 
 // @public
+export const createIsAuthorized: <TResource, TQuery>(
+  rules: PermissionRule<TResource, TQuery, string, PermissionRuleParams>[],
+) => (decision: PolicyDecision, resource: TResource | undefined) => boolean;
+
+// @public
 export const createPermissionIntegrationRouter: <
   TResourceType extends string,
   TResource,
@@ -124,7 +129,7 @@ export const createPermissionIntegrationRouter: <
     NoInfer<TResourceType>,
     PermissionRuleParams
   >[];
-  getResources?: GetResourcesFn<TResource> | undefined;
+  getResources: (resourceRefs: string[]) => Promise<(TResource | undefined)[]>;
 }) => express.Router;
 
 // @public
@@ -136,11 +141,6 @@ export const createPermissionRule: <
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
-
-// @public
-export type GetResourcesFn<TResource> = (
-  resourceRefs: string[],
-) => Promise<Array<TResource | undefined>>;
 
 // @alpha
 export const isAndCriteria: <T>(

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -112,25 +112,33 @@ export const createConditionTransformer: <
 ) => ConditionTransformer<TQuery>;
 
 // @public
-export const createIsAuthorized: <TResource, TQuery>(
-  rules: PermissionRule<TResource, TQuery, string, PermissionRuleParams>[],
-) => (decision: PolicyDecision, resource: TResource | undefined) => boolean;
-
-// @public
 export const createPermissionIntegrationRouter: <
   TResourceType extends string,
   TResource,
->(options: {
+>(
+  options: CreatePermissionIntegrationRouterOptions<TResourceType, TResource>,
+) => express.Router;
+
+// @public
+export type CreatePermissionIntegrationRouterOptions<
+  TResourceType extends string,
+  TResource,
+> =
+  | {
+      permissions: Array<Permission>;
+    }
+  | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>;
+
+// @public
+export type CreatePermissionIntegrationRouterResourceOptions<
+  TResourceType extends string,
+  TResource,
+> = {
   resourceType: TResourceType;
-  permissions?: Permission[] | undefined;
-  rules: PermissionRule<
-    TResource,
-    any,
-    NoInfer<TResourceType>,
-    PermissionRuleParams
-  >[];
-  getResources: (resourceRefs: string[]) => Promise<(TResource | undefined)[]>;
-}) => express.Router;
+  permissions?: Array<Permission>;
+  rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
+  getResources?: GetResourcesFn<TResource>;
+};
 
 // @public
 export const createPermissionRule: <
@@ -141,6 +149,11 @@ export const createPermissionRule: <
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
+
+// @public
+export type GetResourcesFn<TResource> = (
+  resourceRefs: string[],
+) => Promise<Array<TResource | undefined>>;
 
 // @alpha
 export const isAndCriteria: <T>(

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -124,7 +124,7 @@ export const createPermissionIntegrationRouter: <
     NoInfer<TResourceType>,
     PermissionRuleParams
   >[];
-  getResources: (resourceRefs: string[]) => Promise<(TResource | undefined)[]>;
+  getResources?: GetResourcesFn<TResource> | undefined;
 }) => express.Router;
 
 // @public
@@ -136,6 +136,11 @@ export const createPermissionRule: <
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
+
+// @public
+export type GetResourcesFn<TResource> = (
+  resourceRefs: string[],
+) => Promise<Array<TResource | undefined>>;
 
 // @alpha
 export const isAndCriteria: <T>(

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -65,16 +65,14 @@ const createApp = (
     | typeof defaultMockedGetResources
     | null = defaultMockedGetResources,
 ) => {
-  const router = createPermissionIntegrationRouter(
-    mockedGetResources
-      ? {
-          resourceType: 'test-resource',
-          permissions: [testPermission],
-          getResources: mockedGetResources,
-          rules: [testRule1, testRule2],
-        }
-      : { permissions: [testPermission] },
-  );
+  const router = mockedGetResources
+    ? createPermissionIntegrationRouter({
+        resourceType: 'test-resource',
+        permissions: [testPermission],
+        getResources: mockedGetResources,
+        rules: [testRule1, testRule2],
+      })
+    : createPermissionIntegrationRouter({ permissions: [testPermission] });
 
   return express().use(router);
 };

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -24,7 +24,7 @@ import request, { Response } from 'supertest';
 import { z } from 'zod';
 import {
   createPermissionIntegrationRouter,
-  GetResourcesFn,
+  CreatePermissionIntegrationRouterResourceOptions,
 } from './createPermissionIntegrationRouter';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -53,8 +53,11 @@ const testRule2 = createPermissionRule({
   toQuery: () => ({}),
 });
 
-const defaultMockedGetResources: GetResourcesFn<{ id: string }> = jest.fn(
-  async resourceRefs => resourceRefs.map(resourceRef => ({ id: resourceRef })),
+const defaultMockedGetResources: CreatePermissionIntegrationRouterResourceOptions<
+  string,
+  { id: string }
+>['getResources'] = jest.fn(async resourceRefs =>
+  resourceRefs.map(resourceRef => ({ id: resourceRef })),
 );
 
 const createApp = (
@@ -415,8 +418,11 @@ describe('createPermissionIntegrationRouter', () => {
     });
 
     it('returns 200/DENY when resource is not found', async () => {
-      const mockedGetResources: GetResourcesFn<{ id: string }> = jest.fn(
-        async resourceRefs => resourceRefs.map(() => undefined),
+      const mockedGetResources: CreatePermissionIntegrationRouterResourceOptions<
+        string,
+        { id: string }
+      >['getResources'] = jest.fn(async resourceRefs =>
+        resourceRefs.map(() => undefined),
       );
 
       const response = await request(createApp(mockedGetResources))
@@ -448,13 +454,15 @@ describe('createPermissionIntegrationRouter', () => {
     });
 
     it('interleaves responses for present and missing resources', async () => {
-      const mockedGetResources: GetResourcesFn<{ id: string }> = jest.fn(
-        async resourceRefs =>
-          resourceRefs.map(resourceRef =>
-            resourceRef === 'default:test/missing-resource'
-              ? undefined
-              : { id: resourceRef },
-          ),
+      const mockedGetResources: CreatePermissionIntegrationRouterResourceOptions<
+        string,
+        { id: string }
+      >['getResources'] = jest.fn(async resourceRefs =>
+        resourceRefs.map(resourceRef =>
+          resourceRef === 'default:test/missing-resource'
+            ? undefined
+            : { id: resourceRef },
+        ),
       );
 
       const response = await request(createApp(mockedGetResources))

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -62,12 +62,16 @@ const createApp = (
     | typeof defaultMockedGetResources
     | null = defaultMockedGetResources,
 ) => {
-  const router = createPermissionIntegrationRouter({
-    resourceType: 'test-resource',
-    permissions: [testPermission],
-    getResources: mockedGetResources || undefined,
-    rules: [testRule1, testRule2],
-  });
+  const router = createPermissionIntegrationRouter(
+    mockedGetResources
+      ? {
+          resourceType: 'test-resource',
+          permissions: [testPermission],
+          getResources: mockedGetResources,
+          rules: [testRule1, testRule2],
+        }
+      : { permissions: [testPermission] },
+  );
 
   return express().use(router);
 };
@@ -555,16 +559,16 @@ describe('createPermissionIntegrationRouter', () => {
       expect(response.error && response.error.text).toMatch(/invalid/i);
     });
 
-    it('returns 400 with no getResources implementation', async () => {
+    it('returns 501 with no getResources implementation', async () => {
       const response = await request(createApp(null))
         .post('/.well-known/backstage/permissions/apply-conditions')
         .send({
           items: [],
         });
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toEqual(501);
       expect(response.body.error.message).toEqual(
-        'This plugin does not support the apply-conditions API.',
+        'This plugin does not support the apply-conditions API',
       );
     });
   });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -568,7 +568,7 @@ describe('createPermissionIntegrationRouter', () => {
 
       expect(response.status).toEqual(501);
       expect(response.body.error.message).toEqual(
-        'This plugin does not support the apply-conditions API',
+        `This plugin does not expose any permission rule or can't evaluate conditional decisions`,
       );
     });
   });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -183,25 +183,14 @@ export type CreatePermissionIntegrationRouterResourceOptions<
 };
 
 /**
- * Options for creating a permission integration router.
- *
- * @public
- */
-export type CreatePermissionIntegrationRouterOptions<
-  TResourceType extends string,
-  TResource,
-> =
-  | {
-      permissions: Array<Permission>;
-    }
-  | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>;
-
-/**
  * Create an express Router which provides an authorization route to allow
  * integration between the permission backend and other Backstage backend
  * plugins. Plugin owners that wish to support conditional authorization for
  * their resources should add the router created by this function to their
  * express app inside their `createRouter` implementation.
+ *
+ * In case the `permissions` option is provided, the router also
+ * provides a route that exposes permissions and routes of a plugin.
  *
  * @remarks
  *
@@ -231,12 +220,40 @@ export type CreatePermissionIntegrationRouterOptions<
  *
  * @public
  */
-export const createPermissionIntegrationRouter = <
+export function createPermissionIntegrationRouter<
   TResourceType extends string,
   TResource,
 >(
-  options: CreatePermissionIntegrationRouterOptions<TResourceType, TResource>,
-): express.Router => {
+  options: CreatePermissionIntegrationRouterResourceOptions<
+    TResourceType,
+    TResource
+  >,
+): express.Router;
+
+/**
+ *
+ * Create an express Router which provides a route that exposes
+ * permissions and routes of a plugin.
+ * @public
+ */
+export function createPermissionIntegrationRouter(options: {
+  permissions: Array<Permission>;
+}): express.Router;
+
+/**
+ * @public
+ */
+export function createPermissionIntegrationRouter<
+  TResourceType extends string,
+  TResource,
+>(
+  options:
+    | { permissions: Array<Permission> }
+    | CreatePermissionIntegrationRouterResourceOptions<
+        TResourceType,
+        TResource
+      >,
+): express.Router {
   const router = Router();
   router.use(express.json());
 
@@ -326,13 +343,18 @@ export const createPermissionIntegrationRouter = <
   router.use(errorHandler());
 
   return router;
-};
+}
 
 function isCreatePermissionIntegrationRouterResourceOptions<
   TResourceType extends string,
   TResource,
 >(
-  options: CreatePermissionIntegrationRouterOptions<TResourceType, TResource>,
+  options:
+    | { permissions: Array<Permission> }
+    | CreatePermissionIntegrationRouterResourceOptions<
+        TResourceType,
+        TResource
+      >,
 ): options is CreatePermissionIntegrationRouterResourceOptions<
   TResourceType,
   TResource

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -126,16 +126,6 @@ export type MetadataResponse = {
   rules: MetadataResponseSerializedRule[];
 };
 
-/**
- * Function type for returning an array of resources
- * matching the given resourceRefs.
- *
- * @public
- */
-export type GetResourcesFn<TResource> = (
-  resourceRefs: string[],
-) => Promise<Array<TResource | undefined>>;
-
 const applyConditions = <TResourceType extends string, TResource>(
   criteria: PermissionCriteria<PermissionCondition<TResourceType>>,
   resource: TResource | undefined,
@@ -187,7 +177,9 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   // consider any rules whose resource type does not match
   // to be an error.
   rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
-  getResources?: GetResourcesFn<TResource>;
+  getResources?: (
+    resourceRefs: string[],
+  ) => Promise<Array<TResource | undefined>>;
 };
 
 /**

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -171,6 +171,40 @@ const applyConditions = <TResourceType extends string, TResource>(
 };
 
 /**
+ * Options for creating a permission integration router specific
+ * for a particular resource type.
+ *
+ * @public
+ */
+export type CreatePermissionIntegrationRouterResourceOptions<
+  TResourceType extends string,
+  TResource,
+> = {
+  resourceType: TResourceType;
+  permissions?: Array<Permission>;
+  // Do not infer value of TResourceType from supplied rules.
+  // instead only consider the resourceType parameter, and
+  // consider any rules whose resource type does not match
+  // to be an error.
+  rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
+  getResources: GetResourcesFn<TResource>;
+};
+
+/**
+ * Options for creating a permission integration router.
+ *
+ * @public
+ */
+export type CreatePermissionIntegrationRouterOptions<
+  TResourceType extends string,
+  TResource,
+> =
+  | {
+      permissions: Array<Permission>;
+    }
+  | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>;
+
+/**
  * Create an express Router which provides an authorization route to allow
  * integration between the permission backend and other Backstage backend
  * plugins. Plugin owners that wish to support conditional authorization for
@@ -205,30 +239,6 @@ const applyConditions = <TResourceType extends string, TResource>(
  *
  * @public
  */
-
-type CreatePermissionIntegrationRouterResourceOptions<
-  TResourceType extends string,
-  TResource,
-> = {
-  resourceType: TResourceType;
-  permissions?: Array<Permission>;
-  // Do not infer value of TResourceType from supplied rules.
-  // instead only consider the resourceType parameter, and
-  // consider any rules whose resource type does not match
-  // to be an error.
-  rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
-  getResources: GetResourcesFn<TResource>;
-};
-
-type CreatePermissionIntegrationRouterOptions<
-  TResourceType extends string,
-  TResource,
-> =
-  | {
-      permissions: Array<Permission>;
-    }
-  | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>;
-
 export const createPermissionIntegrationRouter = <
   TResourceType extends string,
   TResource,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -187,7 +187,7 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   // consider any rules whose resource type does not match
   // to be an error.
   rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
-  getResources: GetResourcesFn<TResource>;
+  getResources?: GetResourcesFn<TResource>;
 };
 
 /**
@@ -270,9 +270,12 @@ export const createPermissionIntegrationRouter = <
   router.post(
     '/.well-known/backstage/permissions/apply-conditions',
     async (req, res: Response<ApplyConditionsResponse | string>) => {
-      if (!isCreatePermissionIntegrationRouterResourceOptions(options)) {
+      if (
+        !isCreatePermissionIntegrationRouterResourceOptions(options) ||
+        options.getResources === undefined
+      ) {
         throw new NotImplementedError(
-          'This plugin does not support the apply-conditions API',
+          `This plugin does not expose any permission rule or can't evaluate conditional decisions`,
         );
       }
       const { resourceType, getResources } = options;


### PR DESCRIPTION
Changed the createPermissionIntegrationRouter API to allow getResources, rules and resourceType to be optional. This is needed for certain cases where a plugin is not exposing any rules.

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
