### PR TITLE
use getDefaultFormState to initialise formData in handleNext

### DIFF
--- a/.changeset/grumpy-hounds-look.md
+++ b/.changeset/grumpy-hounds-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+use `getDefaultFormState` from `@rjsf/utils` to initialise undefined `formData` key values.

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
@@ -436,4 +436,48 @@ describe('Stepper', () => {
       expect(getByRole('textbox', { name: 'field1' })).toBeInTheDocument();
     });
   });
+
+  it('should call validator in extension if no key initially exists in formData', async () => {
+    const manifest: TemplateParameterSchema = {
+      title: 'Fill in some steps',
+      steps: [
+        {
+          title: 'Step 1',
+          schema: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                'ui:field': 'Mock',
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const MockComponent = () => <h2>Mock</h2>;
+
+    const customExtension = {
+      name: 'Mock',
+      component: MockComponent,
+      validation: jest.fn(),
+    };
+
+    const { getByRole } = await renderInTestApp(
+      <Stepper
+        manifest={manifest}
+        onCreate={jest.fn()}
+        extensions={[customExtension]}
+      />,
+    );
+
+    const reviewButton = getByRole('button', { name: 'Review' });
+
+    await act(async () => {
+      await fireEvent.click(reviewButton);
+    });
+
+    expect(customExtension.validation).toHaveBeenCalled();
+  });
 });

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -136,7 +136,7 @@ export const Stepper = (stepperProps: StepperProps) => {
     // to display it's own loading? Or should we grey out the entire form.
     setErrors(undefined);
 
-    const formDataWithDefaults = getDefaultFormState(
+    const newFormData = getDefaultFormState(
       validator,
       currentStep.schema,
       formData,
@@ -144,7 +144,7 @@ export const Stepper = (stepperProps: StepperProps) => {
       true,
     );
 
-    const returnedValidation = await validation(formDataWithDefaults);
+    const returnedValidation = await validation(newFormData);
 
     if (hasErrors(returnedValidation)) {
       setErrors(returnedValidation);

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -41,6 +41,7 @@ import { useTransformSchemaToProps } from '../../hooks/useTransformSchemaToProps
 import { hasErrors } from './utils';
 import * as FieldOverrides from './FieldOverrides';
 import { Form } from '../Form';
+import { getDefaultFormState } from '@rjsf/utils';
 
 const useStyles = makeStyles(theme => ({
   backButton: {
@@ -135,7 +136,15 @@ export const Stepper = (stepperProps: StepperProps) => {
     // to display it's own loading? Or should we grey out the entire form.
     setErrors(undefined);
 
-    const returnedValidation = await validation(formData);
+    const formDataWithDefaults = getDefaultFormState(
+      validator,
+      currentStep.schema,
+      formData,
+      currentStep.mergedSchema,
+      true,
+    );
+
+    const returnedValidation = await validation(formDataWithDefaults);
 
     if (hasErrors(returnedValidation)) {
       setErrors(returnedValidation);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `validate` function returned from `createAsyncValidators`  relies on the `formData` having all the keys for custom validations to be called.  If there are no keys, then the custom validators will not be called.

This PR adds `getDefaultFormState` from `@rjsf/utils` to ensure the `formData` is initialised correctly.

I had this in before but removed it in #15402, which was a mistake.

A client raised this bug today where a custom validation in an extension was not triggering its validations, and adding this fix got it working.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
