### PR TITLE
[a11y] Techdocs: Preserve html tag attributes in generated HTML

### DIFF
--- a/.changeset/ninety-turtles-wait.md
+++ b/.changeset/ninety-turtles-wait.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-The html tag attributes in the documentation content inserted to shadow DOM is preserved to improve accessibility
+The HTML tag attributes in the documentation content inserted to shadow DOM is preserved to improve accessibility

--- a/.changeset/ninety-turtles-wait.md
+++ b/.changeset/ninety-turtles-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+The html tag attributes in the documentation content inserted to shadow DOM is preserved to improve accessibility

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -15,12 +15,12 @@
  */
 
 import DOMPurify from 'dompurify';
-import { useMemo, useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
-import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 import { Transformer } from '../transformer';
-import { removeUnsafeLinks, removeUnsafeIframes } from './hooks';
+import { removeUnsafeIframes, removeUnsafeLinks } from './hooks';
 
 /**
  * Returns html sanitizer configuration
@@ -34,7 +34,7 @@ const useSanitizerConfig = () => {
 };
 
 /**
- * Returns a transformer that sanitizes the dom's internal html.
+ * Returns a transformer that sanitizes the dom
  */
 export const useSanitizerTransformer = (): Transformer => {
   const config = useSanitizerConfig();
@@ -51,7 +51,8 @@ export const useSanitizerTransformer = (): Transformer => {
         DOMPurify.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
       }
 
-      return DOMPurify.sanitize(dom.innerHTML, {
+      // using outerHTML as we want to preserve the html tag attributes (lang)
+      return DOMPurify.sanitize(dom.outerHTML, {
         ADD_TAGS: tags,
         FORBID_TAGS: ['style'],
         WHOLE_DOCUMENT: true,


### PR DESCRIPTION
When adding the document content (HTML generated from Markdown files) in the techdocs shadow DOM the html attribute lang gets lost. Use outerHTML instead of innerHTML during sanitize to preserve html tag attributes.