### PR TITLE
Fix export of catalog collator entity transformer

### DIFF
--- a/.changeset/four-lizards-grin.md
+++ b/.changeset/four-lizards-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix export of `defaultCatalogCollatorEntityTransformer`.

--- a/plugins/catalog-backend/src/search/index.ts
+++ b/plugins/catalog-backend/src/search/index.ts
@@ -17,7 +17,7 @@
 export { DefaultCatalogCollatorFactory } from './DefaultCatalogCollatorFactory';
 export type { DefaultCatalogCollatorFactoryOptions } from './DefaultCatalogCollatorFactory';
 export type { CatalogCollatorEntityTransformer } from './CatalogCollatorEntityTransformer';
-export type { defaultCatalogCollatorEntityTransformer } from './defaultCatalogCollatorEntityTransformer';
+export { defaultCatalogCollatorEntityTransformer } from './defaultCatalogCollatorEntityTransformer';
 
 /**
  * todo(backstage/techdocs-core): stop exporting this in a future release.


### PR DESCRIPTION
Fix export of `defaultCatalogCollatorEntityTransformer`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
