### PR TITLE
fix(plugins-catalog): align icon in CatalogSearchResultListItem

### DIFF
--- a/.changeset/fuzzy-trains-search.md
+++ b/.changeset/fuzzy-trains-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix icon alignment in `CatalogSearchResultListItem`

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -31,7 +31,9 @@ import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
 
 const useStyles = makeStyles(
   {
-    item: {},
+    item: {
+      display: 'flex',
+    },
     flexContainer: {
       flexWrap: 'wrap',
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Correctly align icon and content. Fixes #16376

![image](https://user-images.githubusercontent.com/2379631/219182383-7fa3e038-5d7a-4f95-a6a6-0e29b7538531.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
