### PR TITLE
Use `postgres` container in preview deployments on Uffizzi

### DIFF
--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -10,9 +10,10 @@ services:
     image: '${BACKSTAGE_IMAGE}'
 
     environment:
-      POSTGRES_HOST: db
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: kiTMoTsiEuyQ43GrL4Hv
       NODE_ENV: production
     deploy:
       resources:
@@ -26,4 +27,8 @@ services:
   db:
     image: postgres
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: kiTMoTsiEuyQ43GrL4Hv
+    deploy:
+      resources:
+        limits:
+          memory: 250M

--- a/.github/uffizzi/uffizzi.production.app-config.yaml
+++ b/.github/uffizzi/uffizzi.production.app-config.yaml
@@ -9,13 +9,17 @@ backend:
   baseUrl: ${UFFIZZI_URL}
   auth:
     keys:
-      # random mock key for uffizi deployments
+      # random mock key for Uffizzi deployments
       - secret: 5TXvdjVZFxF7qf9K5RAYRDoGrLzJooqa
   listen:
     port: 7007
   database:
-    client: better-sqlite3
-    connection: ':memory:'
+    client: pg
+    connection:
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}
   cache:
     store: memory
   cors:


### PR DESCRIPTION
I noticed that Uffizzi previews were deploying a `postgres` container but not using it. I conferred with @benjdlambert who said he intended the container to be used so I've configured it here.  Thanks!