### PR TITLE
GitLab auth provider gets ID tokens and be used as a k8s oidcTokenProvider

### DIFF
--- a/.changeset/light-bees-end.md
+++ b/.changeset/light-bees-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+GitLab can now be used as an `oidcTokenProvider` for Kubernetes clusters

--- a/.changeset/rotten-cats-matter.md
+++ b/.changeset/rotten-cats-matter.md
@@ -1,0 +1,19 @@
+---
+'@backstage/core-app-api': minor
+---
+
+`OAuth2` now gets ID tokens from a session with the `openid` scope explicitly
+requested.
+
+This should not be considered a breaking change, because spec-compliant OIDC
+providers will already be returning ID tokens if and only if the `openid` scope
+is granted.
+
+This change makes the dependence explicit, and removes the burden on
+OAuth2-based providers which require an ID token (e.g. this is done by various
+default [auth
+handlers](https://backstage.io/docs/auth/identity-resolver/#authhandler)) to add
+`openid` to their default scopes. _That_ could carry another indirect benefit:
+by removing `openid` from the default scopes for a provider, grants for
+resource-specific access tokens can avoid requesting excess ID token-related
+scopes.

--- a/.changeset/young-walls-prove.md
+++ b/.changeset/young-walls-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': minor
+---
+
+The GitLab auth provider can now be used to get OpenID tokens.

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -18,7 +18,11 @@ Settings for local development:
 
 - Name: Backstage (or your custom app name)
 - Redirect URI: `http://localhost:7007/api/auth/gitlab/handler/frame`
-- Scopes: `read_api` and `read_user`
+- Scopes: `read_user` for sign-in. If you also need ID tokens (e.g. if you are
+  using the Kubernetes plugin and have clusters with `authProvider: oidc` and
+  [`oidcTokenProvider:
+gitlab`](https://backstage.io/docs/features/kubernetes/configuration/#clustersoidctokenprovider-optional)),
+  add the `openid` scope.
 
 ## Configuration
 

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -160,8 +160,9 @@ auth:
         audience: ${AUTH_OKTA_AUDIENCE}
 ```
 
-The following values are supported out-of-the-box by the frontend: `google`, `microsoft`,
-`okta`, `onelogin`.
+The following values are supported out-of-the-box by the frontend: `gitlab` (the
+application whose `clientId` is used by the auth provider should be granted the
+`openid` scope), `google`, `microsoft`, `okta`, `onelogin`.
 
 Take note that `oidcTokenProvider` is just the issuer for the token, you can use any
 of these with an OIDC enabled cluster, like using `microsoft` as the issuer for a EKS

--- a/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.test.ts
@@ -48,9 +48,8 @@ describe('OAuth2', () => {
     expect(await oauth2.getAccessToken('my-scope my-scope2')).toBe(
       'access-token',
     );
-    expect(getSession).toHaveBeenCalledTimes(1);
-    expect(getSession.mock.calls[0][0].scopes).toEqual(
-      new Set(['my-scope', 'my-scope2']),
+    expect(getSession).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: new Set(['my-scope', 'my-scope2']) }),
     );
   });
 
@@ -65,9 +64,10 @@ describe('OAuth2', () => {
     });
 
     expect(await oauth2.getAccessToken('my-scope')).toBe('access-token');
-    expect(getSession).toHaveBeenCalledTimes(1);
-    expect(getSession.mock.calls[0][0].scopes).toEqual(
-      new Set(['my-prefix/my-scope']),
+    expect(getSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: new Set(['my-prefix/my-scope']),
+      }),
     );
   });
 
@@ -82,7 +82,11 @@ describe('OAuth2', () => {
     });
 
     expect(await oauth2.getIdToken()).toBe('id-token');
-    expect(getSession).toHaveBeenCalledTimes(1);
+    expect(getSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: new Set(['openid']),
+      }),
+    );
   });
 
   it('should get optional id token', async () => {
@@ -96,7 +100,11 @@ describe('OAuth2', () => {
     });
 
     expect(await oauth2.getIdToken({ optional: true })).toBe('id-token');
-    expect(getSession).toHaveBeenCalledTimes(1);
+    expect(getSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: new Set(['openid']),
+      }),
+    );
   });
 
   it('should share popup closed errors', async () => {

--- a/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts
@@ -153,7 +153,10 @@ export default class OAuth2
   }
 
   async getIdToken(options: AuthRequestOptions = {}) {
-    const session = await this.sessionManager.getSession(options);
+    const session = await this.sessionManager.getSession({
+      ...options,
+      scopes: new Set(['openid']),
+    });
     return session?.providerInfo.idToken ?? '';
   }
 

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -482,7 +482,11 @@ export const githubAuthApiRef: ApiRef<
 
 // @public
 export const gitlabAuthApiRef: ApiRef<
-  OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
+  OAuthApi &
+    OpenIdConnectApi &
+    ProfileInfoApi &
+    BackstageIdentityApi &
+    SessionApi
 >;
 
 // @public

--- a/packages/core-plugin-api/src/apis/definitions/auth.ts
+++ b/packages/core-plugin-api/src/apis/definitions/auth.ts
@@ -357,7 +357,11 @@ export const oktaAuthApiRef: ApiRef<
  * for a full list of supported scopes.
  */
 export const gitlabAuthApiRef: ApiRef<
-  OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
+  OAuthApi &
+    OpenIdConnectApi &
+    ProfileInfoApi &
+    BackstageIdentityApi &
+    SessionApi
 > = createApiRef({
   id: 'core.auth.gitlab',
 });

--- a/packages/integration-react/api-report.md
+++ b/packages/integration-react/api-report.md
@@ -23,7 +23,11 @@ export class ScmAuth implements ScmAuthApi {
     ScmAuthApi,
     {
       github: OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi;
-      gitlab: OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi;
+      gitlab: OAuthApi &
+        OpenIdConnectApi &
+        ProfileInfoApi &
+        BackstageIdentityApi &
+        SessionApi;
       azure: OAuthApi &
         OpenIdConnectApi &
         ProfileInfoApi &

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -23,6 +23,7 @@ import {
   createRouteRef,
   discoveryApiRef,
   identityApiRef,
+  gitlabAuthApiRef,
   googleAuthApiRef,
   microsoftAuthApiRef,
   oktaAuthApiRef,
@@ -49,18 +50,21 @@ export const kubernetesPlugin = createPlugin({
     createApiFactory({
       api: kubernetesAuthProvidersApiRef,
       deps: {
+        gitlabAuthApi: gitlabAuthApiRef,
         googleAuthApi: googleAuthApiRef,
         microsoftAuthApi: microsoftAuthApiRef,
         oktaAuthApi: oktaAuthApiRef,
         oneloginAuthApi: oneloginAuthApiRef,
       },
       factory: ({
+        gitlabAuthApi,
         googleAuthApi,
         microsoftAuthApi,
         oktaAuthApi,
         oneloginAuthApi,
       }) => {
         const oidcProviders = {
+          gitlab: gitlabAuthApi,
           google: googleAuthApi,
           microsoft: microsoftAuthApi,
           okta: oktaAuthApi,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The use case I wanted to support here is viewing `http://localhost:3000/catalog/default/component/demo-k8s-service/kubernetes`, logging in via gitlab and successfully seeing kube-dns objects.

The setup is extensive, including a kind cluster with config:
```yaml
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
kubeadmConfigPatches:
- |-
  kind: ClusterConfiguration
  apiServer:
    extraArgs:
      oidc-issuer-url: https://${GITLAB_HOST}
      oidc-client-id: ${CLIENT_ID}
      oidc-username-claim: email
```
and app-config
```yaml
auth:
  environment: development
  providers:
    gitlab:
      development:
        audience: https://${GITLAB_HOST}
        clientId: ${CLIENT_ID}
        clientSecret: ${CLIENT_SECRET}
kubernetes:
  serviceLocatorMethod:
    type: 'multiTenant'
  clusterLocatorMethods:
    - type: 'config'
      clusters:
        - name: kind-kind
          url: $(kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="kind-kind")].cluster.server}')
          authProvider: oidc
          oidcTokenProvider: gitlab
          skipTLSVerify: true
          skipMetricsLookup: true
catalog:
  locations:
    - type: file
      target: ../../kubernetes.yaml
      rules:
        - allow: [User, Component]
```
where `kubernetes.yaml` is
```yaml
---
apiVersion: backstage.io/v1alpha1
kind: User
metadata:
  name: "${GITLAB_USERID}"
spec:
  memberOf: []
---
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: demo-k8s-service
  annotations:
    'backstage.io/kubernetes-label-selector': 'k8s-app=kube-dns'
spec:
  type: service
  lifecycle: stable
  owner: user:${GITLAB_USERID}
```

where `GITLAB_HOST`, `CLIENT_ID`, `CLIENT_SECRET` and `GITLAB_USERID` are hopefully self-explanatory!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~ n/a
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
