### PR TITLE
scaffolder/next: fixing alignment of `CardActions` in `TemplateCard`

### DIFF
--- a/.changeset/spotty-wasps-complain.md
+++ b/.changeset/spotty-wasps-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix alignment bug for owners on `TemplateCard`

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.tsx
@@ -162,7 +162,7 @@ export const TemplateCard = (props: TemplateCardProps) => {
           )}
         </Grid>
       </CardContent>
-      <CardActions style={{ padding: '16px' }}>
+      <CardActions style={{ padding: '16px', flex: 1, alignItems: 'flex-end' }}>
         <div className={styles.footer}>
           <div className={styles.ownedBy}>
             {ownedByRelations.length > 0 && (


### PR DESCRIPTION
**before**
![Screenshot 2023-02-16 at 20 39 58](https://user-images.githubusercontent.com/3645856/219470038-4d1efa2c-03bf-4fe3-aa4b-c18d13a46ed9.png)

**after**
![Screenshot 2023-02-16 at 20 40 15](https://user-images.githubusercontent.com/3645856/219470033-73a3593e-a8c6-495f-a6c7-9fc0f9539530.png)
