### PR TITLE
Fix techdocs open issue link when repository is in a Gitlab subgroup

### DIFF
--- a/.changeset/unlucky-sloths-explain.md
+++ b/.changeset/unlucky-sloths-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+---
+
+Fixed bug in IssueLink component where the URL was not generated properly when the repository was located inside a Gitlab subgroup

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/IssueLink.test.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/IssueLink.test.tsx
@@ -26,7 +26,7 @@ import {
 
 import { IssueLink } from './IssueLink';
 
-const defaultProps = {
+const defaultGithubProps = {
   repository: {
     type: 'github',
     name: 'backstage',
@@ -40,14 +40,28 @@ const defaultProps = {
   },
 };
 
+const defaultGitlabProps = {
+  repository: {
+    type: 'gitlab',
+    name: 'backstageSubgroup/backstage',
+    owner: 'backstage',
+    protocol: 'https',
+    resource: 'gitlab.com',
+  },
+  template: {
+    title: 'Documentation feedback',
+    body: '## Documentation Feedback 📝',
+  },
+};
+
 describe('FeedbackLink', () => {
   const apiSpy = new MockAnalyticsApi();
 
-  it('Should open new issue tab', () => {
+  it('Should open new Github issue tab', () => {
     render(
       wrapInTestApp(
         <TestApiProvider apis={[[analyticsApiRef, apiSpy]]}>
-          <IssueLink {...defaultProps} />
+          <IssueLink {...defaultGithubProps} />
         </TestApiProvider>,
       ),
     );
@@ -55,11 +69,31 @@ describe('FeedbackLink', () => {
     const link = screen.getByText(/Open new Github issue/);
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('target', '_blank');
-    const encodedTitle = encodeURIComponent(defaultProps.template.title);
-    const encodedBody = encodeURIComponent(defaultProps.template.body);
+    const encodedTitle = encodeURIComponent(defaultGithubProps.template.title);
+    const encodedBody = encodeURIComponent(defaultGithubProps.template.body);
     expect(link).toHaveAttribute(
       'href',
       `https://github.com/backstage/backstage/issues/new?title=${encodedTitle}&body=${encodedBody}`,
+    );
+  });
+
+  it('Should open new Gitlab issue tab', () => {
+    render(
+      wrapInTestApp(
+        <TestApiProvider apis={[[analyticsApiRef, apiSpy]]}>
+          <IssueLink {...defaultGitlabProps} />
+        </TestApiProvider>,
+      ),
+    );
+
+    const link = screen.getByText(/Open new Gitlab issue/);
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('target', '_blank');
+    const encodedTitle = encodeURIComponent(defaultGithubProps.template.title);
+    const encodedBody = encodeURIComponent(defaultGithubProps.template.body);
+    expect(link).toHaveAttribute(
+      'href',
+      `https://gitlab.com/backstage/backstageSubgroup/backstage/issues/new?issue[title]=${encodedTitle}&issue[description]=${encodedBody}`,
     );
   });
 
@@ -67,7 +101,7 @@ describe('FeedbackLink', () => {
     render(
       wrapInTestApp(
         <TestApiProvider apis={[[analyticsApiRef, apiSpy]]}>
-          <IssueLink {...defaultProps} />
+          <IssueLink {...defaultGithubProps} />
         </TestApiProvider>,
       ),
     );

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/IssueLink.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/IssueLink.tsx
@@ -59,14 +59,13 @@ const getUrl = (repository: Repository, template: ReportIssueTemplate) => {
   const encodedTitle = encodeURIComponent(title);
   const encodedBody = encodeURIComponent(body);
   const { protocol, resource, owner, name, type } = repository;
-  const encodedOwner = encodeURIComponent(owner);
-  const encodedName = encodeURIComponent(name);
 
-  const url = `${protocol}://${resource}/${encodedOwner}/${encodedName}`;
+  const url = `${protocol}://${resource}/${owner}/${name}`;
+  const encodedUrl = encodeURI(url);
   if (type === 'github') {
-    return `${url}/issues/new?title=${encodedTitle}&body=${encodedBody}`;
+    return `${encodedUrl}/issues/new?title=${encodedTitle}&body=${encodedBody}`;
   }
-  return `${url}/issues/new?issue[title]=${encodedTitle}&issue[description]=${encodedBody}`;
+  return `${encodedUrl}/issues/new?issue[title]=${encodedTitle}&issue[description]=${encodedBody}`;
 };
 
 export const IssueLink = ({ template, repository }: IssueLinkProps) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The url generated for an IssueLink is malformed when a Gitlab repository is located in a subgroup. It is caused by the encoding of the repository name:
Original name: `subgroup/backstage`
Encoded name: `subgroup%2Fbackstage`

The fix consists of building the url using unencoded components, followed by encoding the whole url and using it further to build the new issue url.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
