### PR TITLE
fix: github integration for branches whose name includes a `/`

### DIFF
--- a/.changeset/hot-planets-smell.md
+++ b/.changeset/hot-planets-smell.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+'@backstage/integration': patch
+---
+
+Introduces a new type of GitHub URL to reference catalog files `https://github.com/a/b/blob/release/production?path=path/to/c.yaml`, allowing backstage to distinguish between branch names like `release/production` (including `/`) from the catalog path. Fixes https://github.com/backstage/backstage/issues/16403

--- a/packages/integration/src/github/GithubIntegration.test.ts
+++ b/packages/integration/src/github/GithubIntegration.test.ts
@@ -50,23 +50,41 @@ describe('GithubIntegration', () => {
     expect(integration.config.host).toBe('h.com');
   });
 
-  it('resolveUrl', () => {
-    const integration = new GithubIntegration({ host: 'h.com' });
+  describe('resolveUrl', () => {
+    let integration: GithubIntegration;
+    beforeAll(() => {
+      integration = new GithubIntegration({ host: 'h.com' });
+    });
 
-    expect(
-      integration.resolveUrl({
-        url: '../a.yaml',
-        base: 'https://github.com/backstage/backstage/blob/master/test/README.md',
-        lineNumber: 17,
-      }),
-    ).toBe('https://github.com/backstage/backstage/tree/master/a.yaml#L17');
+    it('should resolve a relative URL pointing to file in parent directory', () => {
+      expect(
+        integration.resolveUrl({
+          url: '../a.yaml',
+          base: 'https://github.com/backstage/backstage/blob/master/test/README.md',
+          lineNumber: 17,
+        }),
+      ).toBe('https://github.com/backstage/backstage/tree/master/a.yaml#L17');
+    });
 
-    expect(
-      integration.resolveUrl({
-        url: './',
-        base: 'https://github.com/backstage/backstage/blob/master/test/README.md',
-      }),
-    ).toBe('https://github.com/backstage/backstage/tree/master/test/');
+    it('should resolve a relative URL pointing to current directory', () => {
+      expect(
+        integration.resolveUrl({
+          url: './',
+          base: 'https://github.com/backstage/backstage/blob/master/test/README.md',
+        }),
+      ).toBe('https://github.com/backstage/backstage/tree/master/test/');
+    });
+
+    it('should not change query parameters when resolving full URLs', () => {
+      expect(
+        integration.resolveUrl({
+          url: 'https://github.com/backstage/backstage/blob/release/production?path=catalog-info.yaml',
+          base: '',
+        }),
+      ).toBe(
+        'https://github.com/backstage/backstage/tree/release/production?path=catalog-info.yaml',
+      );
+    });
   });
 
   it('resolve edit URL', () => {

--- a/packages/integration/src/github/core.test.ts
+++ b/packages/integration/src/github/core.test.ts
@@ -176,5 +176,22 @@ describe('github core', () => {
         ),
       ).toEqual('https://ghe.mycompany.net/raw/a/b/branchname/path/to/c.yaml');
     });
+
+    it('should return url for branch names with a /', () => {
+      // Fixes https://github.com/backstage/backstage/issues/16403
+      const config: GithubIntegrationConfig = {
+        host: 'github.com',
+        apiBaseUrl: 'https://api.github.com',
+      };
+      expect(
+        getGithubFileFetchUrl(
+          'https://github.com/a/b/blob/release/production?path=path/to/c.yaml',
+          config,
+          tokenCredentials,
+        ),
+      ).toEqual(
+        'https://api.github.com/repos/a/b/contents/path/to/c.yaml?ref=release/production',
+      );
+    });
   });
 });

--- a/packages/integration/src/github/core.ts
+++ b/packages/integration/src/github/core.ts
@@ -39,7 +39,17 @@ export function getGithubFileFetchUrl(
   credentials: GithubCredentials,
 ): string {
   try {
-    const { owner, name, ref, filepathtype, filepath } = parseGitUrl(url);
+    const gitUrlObject = parseGitUrl(url);
+    const { owner, name, filepathtype } = gitUrlObject;
+    let { ref, filepath } = gitUrlObject;
+
+    const searchparams = new URLSearchParams(gitUrlObject.search);
+    const pathAtSearchParams = searchparams.get('path');
+    if (pathAtSearchParams) {
+      ref = `${ref}/${filepath}`;
+      filepath = pathAtSearchParams;
+    }
+
     if (
       !owner ||
       !name ||

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -265,6 +265,11 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     const catalogFile = this.config.catalogPath.startsWith('/')
       ? this.config.catalogPath.substring(1)
       : this.config.catalogPath;
+
+    if (branch.includes('/')) {
+      // Fixes https://github.com/backstage/backstage/issues/16403
+      return `${repository.url}/blob/${branch}?path=${catalogFile}`;
+    }
     return `${repository.url}/blob/${branch}/${catalogFile}`;
   }
 


### PR DESCRIPTION
Fixes #16403, #2815

## Hey, I just made a Pull Request!

Introduces the GitHub url type https://github.com/santunioni/backstage/blob/fix/integration/github/branches-with-slashs-on-their-name?path=catalog-info.yaml, where `fix/integration/github/branches-with-slashs-on-their-name` is the branch name. The new type allows backstage to differentiate between branch name and catalog-info path when the branch name includes a slash `/`. More context is provided here https://github.com/backstage/backstage/issues/16403.

I opened the PR as a conversation starter to collect feedback from backstage maintainers. Do not hesitate to criticize it in case it doesn't fit on the overall backstage architecture. In case you don't like it, how would you solve this problem? Do you think the problem is high priority?

Thanks in advance 🙏 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
