### PR TITLE
Fix for plugin entity validation: using stated location for the value rather then default

### DIFF
--- a/.changeset/khaki-poems-run.md
+++ b/.changeset/khaki-poems-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-validation': patch
+---
+
+Fixed bug in EntityVaidation plugin where string in text box was unable to be updated.

--- a/plugins/entity-validation/dev/index.tsx
+++ b/plugins/entity-validation/dev/index.tsx
@@ -16,9 +16,18 @@
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { entityValidationPlugin, EntityValidationPage } from '../src/plugin';
+import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
 
 createDevApp()
   .registerPlugin(entityValidationPlugin)
+  .registerApi({
+    api: catalogApiRef,
+    deps: {},
+    factory: () =>
+      ({
+        getEntities: () => ({}),
+      } as CatalogApi),
+  })
   .addPage({
     element: <EntityValidationPage />,
     title: 'Root Page',

--- a/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
+++ b/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { useState } from 'react';
-import { Button, Content, Header, Page } from '@backstage/core-components';
+import { Content, Header, LinkButton, Page } from '@backstage/core-components';
 import { EntityTextArea } from '../EntityTextArea';
 import { Grid, TextField } from '@material-ui/core';
 import { CatalogProcessorResult } from '../../types';
@@ -47,7 +47,7 @@ export const EntityValidationPage = (props: {
 
   const [catalogYaml, setCatalogYaml] = useState(defaultYaml);
   const [yamlFiles, setYamlFiles] = useState<CatalogProcessorResult[]>();
-  const [locationUrl, setLocationUrl] = useState('');
+  const [locationUrl, setLocationUrl] = useState(defaultLocation);
 
   const parseYaml = () => {
     const parsedFiles = [
@@ -66,15 +66,15 @@ export const EntityValidationPage = (props: {
         subtitle="Tool to validate catalog-info.yaml files"
       />
       <Content>
-        <Grid container direction="row">
+        <Grid container>
           <Grid item md={9} xs={12}>
             <TextField
-              style={{ width: '100%' }}
+              fullWidth
               label="File Location"
               margin="normal"
               variant="outlined"
               required
-              value={defaultLocation}
+              value={locationUrl}
               placeholder={defaultLocation}
               helperText="Location where you catalog-info.yaml file is, or will be, located"
               onChange={e => setLocationUrl(e.target.value)}
@@ -83,14 +83,9 @@ export const EntityValidationPage = (props: {
           <Grid item md={3} xs={12}>
             <Grid container alignItems="center" style={{ height: '100%' }}>
               <Grid item>
-                <Button
-                  style={{ textDecoration: 'none' }}
-                  variant="outlined"
-                  to="#"
-                  onClick={parseYaml}
-                >
+                <LinkButton size="large" onClick={parseYaml} to="#">
                   Validate
-                </Button>
+                </LinkButton>
               </Grid>
             </Grid>
           </Grid>


### PR DESCRIPTION
Fixes #16406

## Hey, I just made a Pull Request!

Using the locationUrl from the set state.

Also added some basic style updates and fixed the button deprecation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
