### PR TITLE
Fixed IdentifyClient import inconsistency in permissions tutorial

### DIFF
--- a/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
@@ -100,7 +100,7 @@ Edit `plugins/todo-list-backend/src/service/router.ts`:
 Pass the `permissions` object to the plugin in `packages/backend/src/plugins/todolist.ts`:
 
 ```diff
-  import { IdentityClient } from '@backstage/plugin-auth-backend';
+  import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
   import { createRouter } from '@internal/plugin-todo-list-backend';
   import { Router } from 'express';
   import { PluginEnvironment } from '../types';
@@ -112,7 +112,7 @@ Pass the `permissions` object to the plugin in `packages/backend/src/plugins/tod
   }: PluginEnvironment): Promise<Router> {
     return await createRouter({
       logger,
-      identity: new IdentityClient({
+      identity: DefaultIdentityClient.create({
         discovery,
         issuer: await discovery.getExternalBaseUrl('auth'),
       }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I fixed the `DefaultIdentityClient` import inconsistency and its usage in the Permissions Tutorial section

Issues that are addressed in this PR:
1. Imports are inconsistent in step 1 and step 2, but they should be the same
2. Module `@backstage/plugin-auth-backend` has no exported member `IdentityClient` 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Current UI:
 - In the Permissions tutorial step 1: https://backstage.io/docs/permissions/plugin-authors/01-setup
![image](https://user-images.githubusercontent.com/23202791/219564119-57e06c9e-ce3f-4f1c-b5d6-909a78a0eabb.png)

- In the Permissions tutorial step 2: https://backstage.io/docs/permissions/plugin-authors/02-adding-a-basic-permission-check
![image](https://user-images.githubusercontent.com/23202791/219564498-81ef3968-06b7-4886-b5d5-e4065e6aae8a.png)

UI After the change for Permissions tutorial step 2:
![image](https://user-images.githubusercontent.com/23202791/219564661-22f4f190-bb85-4810-9a73-c16b93db7a97.png)


