### PR TITLE
Fix SonarQube rexporting of `/alpha` types

### DIFF
--- a/.changeset/swift-bags-wave.md
+++ b/.changeset/swift-bags-wave.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-sonarqube-react': patch
+'@backstage/plugin-sonarqube': patch
+---
+
+Moved imports from `/alpha` to main public exports.

--- a/plugins/sonarqube-react/api-report.md
+++ b/plugins/sonarqube-react/api-report.md
@@ -6,7 +6,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface FindingSummary {
   // (undocumented)
   getComponentMeasuresUrl: SonarUrlProcessorFunc;
@@ -25,7 +25,7 @@ export interface FindingSummary {
 // @public (undocumented)
 export const isSonarQubeAvailable: (entity: Entity) => boolean;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type MetricKey =
   | 'alert_status'
   | 'bugs'
@@ -39,7 +39,7 @@ export type MetricKey =
   | 'coverage'
   | 'duplicated_lines_density';
 
-// @alpha
+// @public
 export type Metrics = {
   [key in MetricKey]: string | undefined;
 };
@@ -47,7 +47,7 @@ export type Metrics = {
 // @public (undocumented)
 export const SONARQUBE_PROJECT_KEY_ANNOTATION = 'sonarqube.org/project-key';
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type SonarQubeApi = {
   getFindingSummary(options: {
     componentKey?: string;
@@ -55,13 +55,13 @@ export type SonarQubeApi = {
   }): Promise<FindingSummary | undefined>;
 };
 
-// @alpha (undocumented)
+// @public (undocumented)
 export const sonarQubeApiRef: ApiRef<SonarQubeApi>;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type SonarUrlProcessorFunc = (identifier: string) => string;
 
-// @alpha
+// @public
 export const useProjectInfo: (entity: Entity) => {
   projectInstance: string | undefined;
   projectKey: string | undefined;

--- a/plugins/sonarqube-react/src/api/SonarQubeApi.ts
+++ b/plugins/sonarqube-react/src/api/SonarQubeApi.ts
@@ -16,7 +16,7 @@
 
 import { createApiRef } from '@backstage/core-plugin-api';
 
-/** @alpha */
+/** @public */
 export type MetricKey =
   // alert status
   | 'alert_status'
@@ -43,11 +43,11 @@ export type MetricKey =
   // duplicated lines
   | 'duplicated_lines_density';
 
-/** @alpha */
+/** @public */
 export type SonarUrlProcessorFunc = (identifier: string) => string;
 
 /**
- * @alpha
+ * @public
  *
  * Define a type to make sure that all metrics are used
  */
@@ -55,7 +55,7 @@ export type Metrics = {
   [key in MetricKey]: string | undefined;
 };
 
-/** @alpha */
+/** @public */
 export interface FindingSummary {
   lastAnalysis: string;
   metrics: Metrics;
@@ -65,12 +65,12 @@ export interface FindingSummary {
   getSecurityHotspotsUrl: () => string;
 }
 
-/** @alpha */
+/** @public */
 export const sonarQubeApiRef = createApiRef<SonarQubeApi>({
   id: 'plugin.sonarqube.service',
 });
 
-/** @alpha */
+/** @public */
 export type SonarQubeApi = {
   getFindingSummary(options: {
     componentKey?: string;

--- a/plugins/sonarqube-react/src/hooks/useProjectInfo.ts
+++ b/plugins/sonarqube-react/src/hooks/useProjectInfo.ts
@@ -25,7 +25,7 @@ export const SONARQUBE_PROJECT_INSTANCE_SEPARATOR = '/';
  *
  * If part or all info are not found, they will default to undefined
  *
- * @alpha
+ * @public
  * @param entity - entity to find the sonarqube information from.
  * @returns a ProjectInfo properly populated.
  */

--- a/plugins/sonarqube/api-report.md
+++ b/plugins/sonarqube/api-report.md
@@ -42,7 +42,7 @@ export const SonarQubeCard: (props: {
   duplicationRatings?: DuplicationRating[];
 }) => JSX.Element;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export class SonarQubeClient implements SonarQubeApi {
   constructor({
     discoveryApi,

--- a/plugins/sonarqube/src/api/SonarQubeClient.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.ts
@@ -23,7 +23,7 @@ import {
 import { InstanceUrlWrapper, FindingsWrapper } from './types';
 import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
 
-/** @alpha */
+/** @public */
 export class SonarQubeClient implements SonarQubeApi {
   discoveryApi: DiscoveryApi;
   identityApi: IdentityApi;


### PR DESCRIPTION
Moving the `/alpha` exports to the main package. These `/alpha` exports don't really make sense when the package is <1.0.0 and there's issues around rexporting alpha types in our current tooling until #15816 is merged.

If you've got any `@backstage/plugin-sonarqube/alpha` imports, you'll need to move them to `@backstage/plugin-sonarqube` but this is not classed as a breaking change as it's `/alpha` changes on packages <1.0.0

Fixes #16358 

