### PR TITLE
fix: Prevent deletion of non-empty directories

### DIFF
--- a/.changeset/purple-days-film.md
+++ b/.changeset/purple-days-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fixed bug that prevented deletion of stale files when non-empty directories where tried to be deleted as well.

--- a/plugins/techdocs-node/src/stages/publish/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/helpers.test.ts
@@ -158,6 +158,16 @@ describe('getStaleFiles', () => {
     expect(staleFiles).toHaveLength(1);
     expect(staleFiles).toEqual(expect.arrayContaining(['stale_file.png']));
   });
+
+  it('should not return directories as stale files if they are parent directories of new files', () => {
+    const oldFiles = [...defaultFiles, 'default/Component/backstage/foo'];
+    const newFiles = [
+      ...defaultFiles,
+      'default/Component/backstage/foo/bar/index.html',
+    ];
+    const staleFiles = getStaleFiles(newFiles, oldFiles);
+    expect(staleFiles).toHaveLength(0);
+  });
 });
 
 describe('getCloudPathForLocalPath', () => {

--- a/plugins/techdocs-node/src/stages/publish/helpers.ts
+++ b/plugins/techdocs-node/src/stages/publish/helpers.ts
@@ -169,8 +169,21 @@ export const getStaleFiles = (
   oldFiles: string[],
 ): string[] => {
   const staleFiles = new Set(oldFiles);
+  const removedParentDirs = new Set();
   newFiles.forEach(newFile => {
     staleFiles.delete(newFile);
+
+    // We have to traverse through the directory hierarchy of a new file and
+    // ensure that we won't try to delete one of the parent directories.
+    let parentDir = newFile.substring(0, newFile.lastIndexOf('/'));
+    while (
+      !removedParentDirs.has(parentDir) &&
+      parentDir.length >= newFile.indexOf('/')
+    ) {
+      staleFiles.delete(parentDir);
+      removedParentDirs.add(parentDir);
+      parentDir = parentDir.substring(0, parentDir.lastIndexOf('/'));
+    }
   });
   return Array.from(staleFiles);
 };


### PR DESCRIPTION
fixes https://github.com/backstage/backstage/issues/15992

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This should fix the issue where non-empty directories where falsely considered stale files #15992 

I did a little more digging and found the root-cause of this issue, which is the return value of [`getStaleFiles(newFiles: string[], oldFiles: string[]): string[]`](https://github.com/backstage/backstage/blob/da033811816d0fc1711da5f73ce2913615e43e75/plugins/techdocs-node/src/stages/publish/helpers.ts#L167) and how it is used.

If the `newFiles` array contains a path string in for a file in a directory, e.g., `'default/system/example/assets/javascripts/lunr/min/lunr.multi.min.js'` **but not the directory itself**, i.e., `'default/system/example/assets/javascripts/lunr/min/`, and the `oldFiles` array contains both of them (or at least the directory), the resulting return value will be an array that contains the directory, which is non-empty and therefore won't (and shouldn't) be deleted.  
And there is another case where a directory shouldn't be deleted: if a directory already exists, e.g., `default/system/example/foo` and it is either already an empty directory or all existing files from it are to be removed **but** there is also a new file that should be added to it, maybe even in a new sub-directory, e.g., `/default/system/example/foo/bar/index.html`, we'll get the same error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
