### PR TITLE
fix: catalog:fetch to throw error for null entity

### DIFF
--- a/.changeset/eight-radios-bake.md
+++ b/.changeset/eight-radios-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+throw error from catalog:fetch scaffolder action when entity is null and optional is false

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.test.ts
@@ -90,7 +90,7 @@ describe('catalog:fetch', () => {
     expect(mockContext.output).toHaveBeenCalledWith('entity', null);
   });
 
-  it('should throw error if entity not in catalog and optional is false', async () => {
+  it('should throw error if entity fetch fails from catalog and optional is false', async () => {
     getEntityByRef.mockImplementationOnce(() => {
       throw new Error('Not found');
     });
@@ -103,6 +103,24 @@ describe('catalog:fetch', () => {
         },
       }),
     ).rejects.toThrow('Not found');
+
+    expect(getEntityByRef).toHaveBeenCalledWith('component:default/test', {
+      token: 'secret',
+    });
+    expect(mockContext.output).not.toHaveBeenCalled();
+  });
+
+  it('should throw error if entity not in catalog and optional is false', async () => {
+    getEntityByRef.mockReturnValueOnce(null);
+
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          entityRef: 'component:default/test',
+        },
+      }),
+    ).rejects.toThrow('Entity component:default/test not found');
 
     expect(getEntityByRef).toHaveBeenCalledWith('component:default/test', {
       token: 'secret',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.ts
@@ -93,6 +93,11 @@ export function createFetchCatalogEntityAction(options: {
           throw e;
         }
       }
+
+      if (!entity && !optional) {
+        throw new Error(`Entity ${entityRef} not found`);
+      }
+
       ctx.output('entity', entity ?? null);
     },
   });


### PR DESCRIPTION
fixes #16447

## Hey, I just made a Pull Request!

Make catalog:fetch scaffolder action to throw an error when entity is null

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
