### PR TITLE
Filter GitLab groups by prefix in GitlabOrgDiscoveryEntityProvider

### DIFF
--- a/.changeset/wild-bulldogs-suffer.md
+++ b/.changeset/wild-bulldogs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+filter gitlab groups by prefix

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -31,4 +31,10 @@ catalog:
       yourProviderId:
         host: gitlab.com
         orgEnabled: true
+        group: org/teams # Optional. Must not end with slash. Accepts only groups under the provided path (excluded)
+        groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided patter. Defaults to `[\s\S]*`, which means to not filter anything
 ```
+
+When the `group` parameter is provided, the corresponding path prefix will be stripped out from each matching group
+when computing the unique entity name. e.g. If `group` is `org/teams`, the name for `org/teams/avengers/gotg` will
+be `avengers-gotg`.

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -32,7 +32,7 @@ catalog:
         host: gitlab.com
         orgEnabled: true
         group: org/teams # Optional. Must not end with slash. Accepts only groups under the provided path (which will be stripped)
-        groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided patter. Defaults to `[\s\S]*`, which means to not filter anything
+        groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
 ```
 
 When the `group` parameter is provided, the corresponding path prefix will be stripped out from each matching group

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -31,7 +31,7 @@ catalog:
       yourProviderId:
         host: gitlab.com
         orgEnabled: true
-        group: org/teams # Optional. Must not end with slash. Accepts only groups under the provided path (excluded)
+        group: org/teams # Optional. Must not end with slash. Accepts only groups under the provided path (which will be stripped)
         groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided patter. Defaults to `[\s\S]*`, which means to not filter anything
 ```
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -350,9 +350,10 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
           kind: 'User',
           metadata: {
             annotations: {
-              'backstage.io/managed-by-location': 'url:test-gitlab/test1',
+              'backstage.io/managed-by-location':
+                'url:https://test-gitlab/test1',
               'backstage.io/managed-by-origin-location':
-                'url:test-gitlab/test1',
+                'url:https://test-gitlab/test1',
               'test-gitlab/user-login': 'https://gitlab.example/test1',
             },
             name: 'test1',
@@ -375,9 +376,9 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
           metadata: {
             annotations: {
               'backstage.io/managed-by-location':
-                'url:test-gitlab/teams/group1-group2',
+                'url:https://test-gitlab/teams/group1-group2',
               'backstage.io/managed-by-origin-location':
-                'url:test-gitlab/teams/group1-group2',
+                'url:https://test-gitlab/teams/group1-group2',
               'test-gitlab/team-path': 'group1/group2',
             },
             description: 'Group2',

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -184,7 +184,6 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
           gitlab: {
             'test-id': {
               host: 'test-gitlab',
-              group: 'test-group',
               orgEnabled: true,
             },
           },
@@ -376,9 +375,9 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
           metadata: {
             annotations: {
               'backstage.io/managed-by-location':
-                'url:https://test-gitlab/teams/group1-group2',
+                'url:https://test-gitlab/group1/group2',
               'backstage.io/managed-by-origin-location':
-                'url:https://test-gitlab/teams/group1-group2',
+                'url:https://test-gitlab/group1/group2',
               'test-gitlab/team-path': 'group1/group2',
             },
             description: 'Group2',

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -199,6 +199,10 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
         continue;
       }
 
+      if (!group.full_path.startsWith(this.config.group)) {
+        continue;
+      }
+
       groupRes.scanned++;
       groupRes.matches.push(group);
 
@@ -253,7 +257,11 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       type: 'full',
       entities: [...userEntities, ...groupEntities].map(entity => ({
         locationKey: this.getProviderName(),
-        entity: this.withLocations(this.integration.config.host, entity),
+        entity: this.withLocations(
+          this.integration.config.host,
+          this.integration.config.baseUrl,
+          entity,
+        ),
       })),
     });
   }
@@ -273,7 +281,9 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       const entity = this.createGroupEntity(group, host);
 
       if (group.parent_id && idMapped.hasOwnProperty(group.parent_id)) {
-        entity.spec.parent = idMapped[group.parent_id].full_path;
+        entity.spec.parent = this.groupName(
+          idMapped[group.parent_id].full_path,
+        );
       }
 
       entities.push(entity);
@@ -282,11 +292,11 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
     return entities;
   }
 
-  private withLocations(host: string, entity: Entity): Entity {
+  private withLocations(host: string, baseUrl: string, entity: Entity): Entity {
     const location =
       entity.kind === 'Group'
-        ? `url:${host}/teams/${entity.metadata.name}`
-        : `url:${host}/${entity.metadata.name}`;
+        ? `url:${baseUrl}/${entity.metadata.annotations[`${host}/team-path`]}`
+        : `url:${baseUrl}/${entity.metadata.name}`;
     return merge(
       {
         metadata: {
@@ -338,11 +348,15 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
         if (!entity.spec.memberOf) {
           entity.spec.memberOf = [];
         }
-        entity.spec.memberOf.push(group.full_path.replace('/', '-'));
+        entity.spec.memberOf.push(this.groupName(group.full_path));
       }
     }
 
     return entity;
+  }
+
+  private groupName(full_path: string): string {
+    return full_path.replace(`${this.config.group}/`, '').replaceAll('/', '-');
   }
 
   private createGroupEntity(group: GitLabGroup, host: string): GroupEntity {
@@ -354,7 +368,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Group',
       metadata: {
-        name: group.full_path.replace('/', '-'),
+        name: this.groupName(group.full_path),
         annotations: annotations,
       },
       spec: {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -295,7 +295,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
   private withLocations(host: string, baseUrl: string, entity: Entity): Entity {
     const location =
       entity.kind === 'Group'
-        ? `url:${baseUrl}/${entity.metadata.annotations[`${host}/team-path`]}`
+        ? `url:${baseUrl}/${entity.metadata.annotations?.[`${host}/team-path`]}`
         : `url:${baseUrl}/${entity.metadata.name}`;
     return merge(
       {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -356,7 +356,12 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
   }
 
   private groupName(full_path: string): string {
-    return full_path.replace(`${this.config.group}/`, '').replaceAll('/', '-');
+    if (this.config.group && full_path.startsWith(`${this.config.group}/`)) {
+      return full_path
+        .replace(`${this.config.group}/`, '')
+        .replaceAll('/', '-');
+    }
+    return full_path.replaceAll('/', '-');
   }
 
   private createGroupEntity(group: GitLabGroup, host: string): GroupEntity {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -199,7 +199,10 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
         continue;
       }
 
-      if (!group.full_path.startsWith(this.config.group)) {
+      if (
+        this.config.group &&
+        !group.full_path.startsWith(`${this.config.group}/`)
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## Filter GitLab groups by prefix in GitlabOrgDiscoveryEntityProvider

- fixed invalid URL without scheme in produced annotations
- filter and compute the right dashed name for the imported group, by stripping the group path prefix if provided in configuration

