### PR TITLE
Update SonarQube card icons

### DIFF
--- a/.changeset/thin-candles-wait.md
+++ b/.changeset/thin-candles-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Show a more appropriate icon if there are no code smells and/or vulnerabilities.

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -203,7 +203,11 @@ export const SonarQubeCard = (props: {
               />
               <RatingCard
                 titleIcon={
-                  value.metrics.vulnerabilities === '0' ? <Lock /> : <LockOpen />
+                  value.metrics.vulnerabilities === '0' ? (
+                    <Lock />
+                  ) : (
+                    <LockOpen />
+                  )
                 }
                 title="Vulnerabilities"
                 link={value.getIssuesUrl('VULNERABILITY')}

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -23,9 +23,11 @@ import {
 import { Chip, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import BugReport from '@material-ui/icons/BugReport';
+import Lock from '@material-ui/icons/Lock';
 import LockOpen from '@material-ui/icons/LockOpen';
 import Security from '@material-ui/icons/Security';
 import SentimentVeryDissatisfied from '@material-ui/icons/SentimentVeryDissatisfied';
+import SentimentVerySatisfied from '@material-ui/icons/SentimentVerySatisfied';
 import React, { useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { Percentage } from './Percentage';
@@ -200,14 +202,22 @@ export const SonarQubeCard = (props: {
                 rightSlot={<Rating rating={value.metrics.reliability_rating} />}
               />
               <RatingCard
-                titleIcon={<LockOpen />}
+                titleIcon={
+                  value.metrics.vulnerabilities === '0' ? <Lock /> : <LockOpen />
+                }
                 title="Vulnerabilities"
                 link={value.getIssuesUrl('VULNERABILITY')}
                 leftSlot={<Value value={value.metrics.vulnerabilities} />}
                 rightSlot={<Rating rating={value.metrics.security_rating} />}
               />
               <RatingCard
-                titleIcon={<SentimentVeryDissatisfied />}
+                titleIcon={
+                  value.metrics.code_smells === '0' ? (
+                    <SentimentVerySatisfied />
+                  ) : (
+                    <SentimentVeryDissatisfied />
+                  )
+                }
                 title="Code Smells"
                 link={value.getIssuesUrl('CODE_SMELL')}
                 leftSlot={<Value value={value.metrics.code_smells} />}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Showing a frowning face when you have no code smells for SonarQube is a bit of a weird UX.

![image](https://user-images.githubusercontent.com/1439341/220171245-7f5bc3a0-3ce2-4b7b-b8d1-edb68c7e777a.png)

This changeset changes the SonarQube plugin so that:

- If there are no vulnerabilities, show a [closed lock](https://materialui.co/icon/lock).
- If there are no code smells, show a [happy face](https://materialui.co/icon/sentiment-very-satisfied).

I'm no React expert and the UI existing tests for the plugin are minimal, so I just checked that things weren't broken and that the code compiled and the linter was happy.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. 
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.