### PR TITLE
Proof of Concept for Ephemeral Backstage Demo Environments

### DIFF
--- a/.github/demo/docker-compose.demo.uffizzi.yml
+++ b/.github/demo/docker-compose.demo.uffizzi.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+x-uffizzi:
+  ingress:
+    service: backstage
+    port: 7007
+
+services:
+  backstage:
+    image: registry.uffizzi.com/backstage/backstage:demo
+
+    environment:
+      NODE_ENV: production
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+    entrypoint: '/bin/sh'
+    command:
+      - '-c'
+      - "APP_CONFIG_app_baseUrl=$$UFFIZZI_URL APP_CONFIG_backend_baseUrl=$$UFFIZZI_URL APP_CONFIG_auth_environment='production' node packages/backend --config app-config.yaml"

--- a/.github/demo/packages/app/src/App.tsx
+++ b/.github/demo/packages/app/src/App.tsx
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  RELATION_API_CONSUMED_BY,
+  RELATION_API_PROVIDED_BY,
+  RELATION_CONSUMES_API,
+  RELATION_DEPENDENCY_OF,
+  RELATION_DEPENDS_ON,
+  RELATION_HAS_PART,
+  RELATION_OWNED_BY,
+  RELATION_OWNER_OF,
+  RELATION_PART_OF,
+  RELATION_PROVIDES_API,
+} from '@backstage/catalog-model';
+import { createApp } from '@backstage/app-defaults';
+import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
+import {
+  AlertDisplay,
+  OAuthRequestDialog,
+  SignInPage,
+} from '@backstage/core-components';
+import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';
+import { AzurePullRequestsPage } from '@backstage/plugin-azure-devops';
+
+import {
+  CatalogEntityPage,
+  CatalogIndexPage,
+  catalogPlugin,
+} from '@internal/plugin-catalog-customized';
+
+import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
+import {
+  CatalogImportPage,
+  catalogImportPlugin,
+} from '@backstage/plugin-catalog-import';
+import {
+  CostInsightsLabelDataflowInstructionsPage,
+  CostInsightsPage,
+  CostInsightsProjectGrowthInstructionsPage,
+} from '@backstage/plugin-cost-insights';
+import { orgPlugin } from '@backstage/plugin-org';
+import { ExplorePage } from '@backstage/plugin-explore';
+import { GcpProjectsPage } from '@backstage/plugin-gcp-projects';
+import { GraphiQLPage } from '@backstage/plugin-graphiql';
+import { HomepageCompositionRoot } from '@backstage/plugin-home';
+import { LighthousePage } from '@backstage/plugin-lighthouse';
+import { NewRelicPage } from '@backstage/plugin-newrelic';
+import {
+  ScaffolderPage,
+  NextScaffolderPage,
+  scaffolderPlugin,
+  ScaffolderLayouts,
+} from '@backstage/plugin-scaffolder';
+import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
+import { SearchPage } from '@backstage/plugin-search';
+import { TechRadarPage } from '@backstage/plugin-tech-radar';
+import {
+  TechDocsIndexPage,
+  TechDocsReaderPage,
+  techdocsPlugin,
+} from '@backstage/plugin-techdocs';
+import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
+import {
+  ExpandableNavigation,
+  ReportIssue,
+  TextSize,
+  LightBox,
+} from '@backstage/plugin-techdocs-module-addons-contrib';
+import {
+  SettingsLayout,
+  UserSettingsPage,
+} from '@backstage/plugin-user-settings';
+import { AdvancedSettings } from './components/advancedSettings';
+import AlarmIcon from '@material-ui/icons/Alarm';
+import React from 'react';
+import { Navigate, Route } from 'react-router-dom';
+import { apis } from './apis';
+import { entityPage } from './components/catalog/EntityPage';
+import { homePage } from './components/home/HomePage';
+import { Root } from './components/Root';
+import {
+  DelayingComponentFieldExtension,
+  LowerCaseValuePickerFieldExtension,
+} from './components/scaffolder/customScaffolderExtensions';
+import { defaultPreviewTemplate } from './components/scaffolder/defaultPreviewTemplate';
+import { searchPage } from './components/search/SearchPage';
+import { providers } from './identityProviders';
+import * as plugins from './plugins';
+
+import { techDocsPage } from './components/techdocs/TechDocsPage';
+import { ApacheAirflowPage } from '@backstage/plugin-apache-airflow';
+import { RequirePermission } from '@backstage/plugin-permission-react';
+import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
+import { PlaylistIndexPage } from '@backstage/plugin-playlist';
+import { TwoColumnLayout } from './components/scaffolder/customScaffolderLayouts';
+import { ScoreBoardPage } from '@oriflame/backstage-plugin-score-card';
+import { StackstormPage } from '@backstage/plugin-stackstorm';
+
+import { PulsePage } from '@spotify/backstage-plugin-pulse';
+
+const app = createApp({
+  apis,
+  plugins: Object.values(plugins),
+  icons: {
+    // Custom icon example
+    alert: AlarmIcon,
+  },
+  // Example of application level feature flag
+  // featureFlags: [
+  // { name: 'tech-radar', description: 'Enables the tech radar plugin' },
+  // ],
+  components: {
+    SignInPage: props => {
+      return (
+        <SignInPage
+          {...props}
+          providers={['guest', 'custom', ...providers]}
+          title="Select a sign-in method"
+          align="center"
+        />
+      );
+    },
+  },
+  bindRoutes({ bind }) {
+    bind(catalogPlugin.externalRoutes, {
+      createComponent: scaffolderPlugin.routes.root,
+      viewTechDoc: techdocsPlugin.routes.docRoot,
+    });
+    bind(apiDocsPlugin.externalRoutes, {
+      registerApi: catalogImportPlugin.routes.importPage,
+    });
+    bind(scaffolderPlugin.externalRoutes, {
+      registerComponent: catalogImportPlugin.routes.importPage,
+      viewTechDoc: techdocsPlugin.routes.docRoot,
+    });
+    bind(orgPlugin.externalRoutes, {
+      catalogIndex: catalogPlugin.routes.catalogIndex,
+    });
+  },
+});
+
+const routes = (
+  <FlatRoutes>
+    <Route path="/" element={<Navigate to="catalog" />} />
+    {/* TODO(rubenl): Move this to / once its more mature and components exist */}
+    <Route path="/home" element={<HomepageCompositionRoot />}>
+      {homePage}
+    </Route>
+    <Route path="/catalog" element={<CatalogIndexPage />} />
+    <Route
+      path="/catalog/:namespace/:kind/:name"
+      element={<CatalogEntityPage />}
+    >
+      {entityPage}
+    </Route>
+    <Route
+      path="/catalog-import"
+      element={
+        <RequirePermission permission={catalogEntityCreatePermission}>
+          <CatalogImportPage />
+        </RequirePermission>
+      }
+    />
+    <Route
+      path="/catalog-graph"
+      element={
+        <CatalogGraphPage
+          initialState={{
+            selectedKinds: ['component', 'domain', 'system', 'api', 'group'],
+            selectedRelations: [
+              RELATION_OWNER_OF,
+              RELATION_OWNED_BY,
+              RELATION_CONSUMES_API,
+              RELATION_API_CONSUMED_BY,
+              RELATION_PROVIDES_API,
+              RELATION_API_PROVIDED_BY,
+              RELATION_HAS_PART,
+              RELATION_PART_OF,
+              RELATION_DEPENDS_ON,
+              RELATION_DEPENDENCY_OF,
+            ],
+          }}
+        />
+      }
+    />
+    <Route path="/docs" element={<TechDocsIndexPage />} />
+    <Route
+      path="/docs/:namespace/:kind/:name/*"
+      element={<TechDocsReaderPage />}
+    >
+      {techDocsPage}
+      <TechDocsAddons>
+        <ExpandableNavigation />
+        <ReportIssue />
+        <TextSize />
+        <LightBox />
+      </TechDocsAddons>
+    </Route>
+    <Route
+      path="/create"
+      element={
+        <ScaffolderPage
+          defaultPreviewTemplate={defaultPreviewTemplate}
+          groups={[
+            {
+              title: 'Recommended',
+              filter: entity =>
+                entity?.metadata?.tags?.includes('recommended') ?? false,
+            },
+          ]}
+        />
+      }
+    >
+      <ScaffolderFieldExtensions>
+        <LowerCaseValuePickerFieldExtension />
+      </ScaffolderFieldExtensions>
+      <ScaffolderLayouts>
+        <TwoColumnLayout />
+      </ScaffolderLayouts>
+    </Route>
+    <Route
+      path="/create/next"
+      element={
+        <NextScaffolderPage
+          groups={[
+            {
+              title: 'Recommended',
+              filter: entity =>
+                entity?.metadata?.tags?.includes('recommended') ?? false,
+            },
+          ]}
+        />
+      }
+    >
+      <ScaffolderFieldExtensions>
+        <DelayingComponentFieldExtension />
+      </ScaffolderFieldExtensions>
+      <ScaffolderLayouts>
+        <TwoColumnLayout />
+      </ScaffolderLayouts>
+    </Route>
+    <Route path="/explore" element={<ExplorePage />} />
+    <Route path="/pulse" element={<PulsePage />} />;
+    <Route
+      path="/tech-radar"
+      element={<TechRadarPage width={1500} height={800} />}
+    />
+    <Route path="/graphiql" element={<GraphiQLPage />} />
+    <Route path="/lighthouse" element={<LighthousePage />} />
+    <Route path="/api-docs" element={<ApiExplorerPage />} />
+    <Route path="/gcp-projects" element={<GcpProjectsPage />} />
+    <Route path="/newrelic" element={<NewRelicPage />} />
+    <Route path="/search" element={<SearchPage />}>
+      {searchPage}
+    </Route>
+    <Route path="/cost-insights" element={<CostInsightsPage />} />
+    <Route
+      path="/cost-insights/investigating-growth"
+      element={<CostInsightsProjectGrowthInstructionsPage />}
+    />
+    <Route
+      path="/cost-insights/labeling-jobs"
+      element={<CostInsightsLabelDataflowInstructionsPage />}
+    />
+    <Route path="/settings" element={<UserSettingsPage />}>
+      <SettingsLayout.Route path="/advanced" title="Advanced">
+        <AdvancedSettings />
+      </SettingsLayout.Route>
+    </Route>
+    <Route path="/azure-pull-requests" element={<AzurePullRequestsPage />} />
+    <Route path="/apache-airflow" element={<ApacheAirflowPage />} />
+    <Route path="/playlist" element={<PlaylistIndexPage />} />
+    <Route path="/score-board" element={<ScoreBoardPage />} />
+    <Route path="/stackstorm" element={<StackstormPage />} />
+  </FlatRoutes>
+);
+
+export default app.createRoot(
+  <>
+    <AlertDisplay transientTimeoutMs={2500} />
+    <OAuthRequestDialog />
+    <AppRouter>
+      <Root>{routes}</Root>
+    </AppRouter>
+  </>,
+);

--- a/.github/demo/packages/app/src/components/Root/Root.tsx
+++ b/.github/demo/packages/app/src/components/Root/Root.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { PropsWithChildren } from 'react';
+import { makeStyles } from '@material-ui/core';
+import HomeIcon from '@material-ui/icons/Home';
+import ExtensionIcon from '@material-ui/icons/Extension';
+import RuleIcon from '@material-ui/icons/AssignmentTurnedIn';
+import MapIcon from '@material-ui/icons/MyLocation';
+import LayersIcon from '@material-ui/icons/Layers';
+import LibraryBooks from '@material-ui/icons/LibraryBooks';
+import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay';
+import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
+import SearchIcon from '@material-ui/icons/Search';
+import MenuIcon from '@material-ui/icons/Menu';
+import MoneyIcon from '@material-ui/icons/MonetizationOn';
+import LogoFull from './LogoFull';
+import LogoIcon from './LogoIcon';
+import { GraphiQLIcon } from '@backstage/plugin-graphiql';
+import {
+  Settings as SidebarSettings,
+  UserSettingsSignInAvatar,
+} from '@backstage/plugin-user-settings';
+import { SidebarSearchModal } from '@backstage/plugin-search';
+import { Shortcuts } from '@backstage/plugin-shortcuts';
+import {
+  Sidebar,
+  sidebarConfig,
+  SidebarDivider,
+  SidebarGroup,
+  SidebarItem,
+  SidebarPage,
+  SidebarScrollWrapper,
+  SidebarSpace,
+  Link,
+  useSidebarOpenState,
+  SidebarSubmenu,
+  SidebarSubmenuItem,
+} from '@backstage/core-components';
+import { MyGroupsSidebarItem } from '@backstage/plugin-org';
+import GroupIcon from '@material-ui/icons/People';
+import { SearchModal } from '../search/SearchModal';
+import Score from '@material-ui/icons/Score';
+
+import ApiIcon from '@material-ui/icons/Extension';
+import ComponentIcon from '@material-ui/icons/Memory';
+import DomainIcon from '@material-ui/icons/Apartment';
+import ResourceIcon from '@material-ui/icons/Work';
+import SystemIcon from '@material-ui/icons/Category';
+import UserIcon from '@material-ui/icons/Person';
+import BallotIcon from '@material-ui/icons/Ballot';
+
+const useSidebarLogoStyles = makeStyles({
+  root: {
+    width: sidebarConfig.drawerWidthClosed,
+    height: 3 * sidebarConfig.logoHeight,
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    marginBottom: -14,
+  },
+  link: {
+    width: sidebarConfig.drawerWidthClosed,
+    marginLeft: 24,
+  },
+});
+
+const SidebarLogo = () => {
+  const classes = useSidebarLogoStyles();
+  const { isOpen } = useSidebarOpenState();
+
+  return (
+    <div className={classes.root}>
+      <Link to="/" underline="none" className={classes.link} aria-label="Home">
+        {isOpen ? <LogoFull /> : <LogoIcon />}
+      </Link>
+    </div>
+  );
+};
+
+export const Root = ({ children }: PropsWithChildren<{}>) => (
+  <SidebarPage>
+    <Sidebar>
+      <SidebarLogo />
+      <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+        <SidebarSearchModal>
+          {({ toggleModal }) => <SearchModal toggleModal={toggleModal} />}
+        </SidebarSearchModal>
+      </SidebarGroup>
+      <SidebarDivider />
+      <SidebarGroup label="Menu" icon={<MenuIcon />}>
+        {/* Global nav, not org-specific */}
+        <SidebarItem icon={HomeIcon} to="catalog" text="Home">
+          <SidebarSubmenu title="Catalog">
+            <SidebarSubmenuItem
+              title="Domains"
+              to="catalog?filters[kind]=domain"
+              icon={DomainIcon}
+            />
+            <SidebarSubmenuItem
+              title="Systems"
+              to="catalog?filters[kind]=system"
+              icon={SystemIcon}
+            />
+            <SidebarSubmenuItem
+              title="Components"
+              to="catalog?filters[kind]=component"
+              icon={ComponentIcon}
+            />
+            <SidebarSubmenuItem
+              title="APIs"
+              to="catalog?filters[kind]=api"
+              icon={ApiIcon}
+            />
+            <SidebarDivider />
+            <SidebarSubmenuItem
+              title="Resources"
+              to="catalog?filters[kind]=resource"
+              icon={ResourceIcon}
+            />
+            <SidebarDivider />
+            <SidebarSubmenuItem
+              title="Groups"
+              to="catalog?filters[kind]=group"
+              icon={GroupIcon}
+            />
+            <SidebarSubmenuItem
+              title="Users"
+              to="catalog?filters[kind]=user"
+              icon={UserIcon}
+            />
+          </SidebarSubmenu>
+        </SidebarItem>
+        <MyGroupsSidebarItem
+          singularTitle="My Squad"
+          pluralTitle="My Squads"
+          icon={GroupIcon}
+        />
+        <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
+        <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
+        <SidebarItem icon={PlaylistPlayIcon} to="playlist" text="Playlists" />
+        <SidebarItem icon={LayersIcon} to="explore" text="Explore" />
+        <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
+        <SidebarItem icon={BallotIcon} to="pulse" text="Pulse" />;
+        {/* End global nav */}
+        <SidebarDivider />
+        <SidebarScrollWrapper>
+          <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
+          <SidebarItem icon={RuleIcon} to="lighthouse" text="Lighthouse" />
+          <SidebarItem
+            icon={MoneyIcon}
+            to="cost-insights"
+            text="Cost Insights"
+          />
+          <SidebarItem icon={GraphiQLIcon} to="graphiql" text="GraphiQL" />
+          <SidebarItem icon={Score} to="score-board" text="Score board" />
+        </SidebarScrollWrapper>
+        <SidebarDivider />
+        <Shortcuts />
+      </SidebarGroup>
+      <SidebarSpace />
+      <SidebarDivider />
+      <SidebarGroup
+        label="Settings"
+        icon={<UserSettingsSignInAvatar />}
+        to="/settings"
+      >
+        <SidebarSettings />
+      </SidebarGroup>
+    </Sidebar>
+    {children}
+  </SidebarPage>
+);

--- a/.github/demo/packages/backend/src/index.ts
+++ b/.github/demo/packages/backend/src/index.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Hi!
+ *
+ * Note that this is an EXAMPLE Backstage backend. Please check the README.
+ *
+ * Happy hacking!
+ */
+
+import Router from 'express-promise-router';
+import {
+  CacheManager,
+  createServiceBuilder,
+  getRootLogger,
+  loadBackendConfig,
+  notFoundHandler,
+  DatabaseManager,
+  SingleHostDiscovery,
+  UrlReaders,
+  useHotMemoize,
+  ServerTokenManager,
+} from '@backstage/backend-common';
+import { TaskScheduler } from '@backstage/backend-tasks';
+import { Config } from '@backstage/config';
+import healthcheck from './plugins/healthcheck';
+import { metricsInit, metricsHandler } from './metrics';
+import auth from './plugins/auth';
+import azureDevOps from './plugins/azure-devops';
+import catalog from './plugins/catalog';
+import catalogEventBasedProviders from './plugins/catalogEventBasedProviders';
+import codeCoverage from './plugins/codecoverage';
+import entityFeedback from './plugins/entityFeedback';
+import events from './plugins/events';
+import explore from './plugins/explore';
+import kubernetes from './plugins/kubernetes';
+import kafka from './plugins/kafka';
+import rollbar from './plugins/rollbar';
+import scaffolder from './plugins/scaffolder';
+import proxy from './plugins/proxy';
+import search from './plugins/search';
+import techdocs from './plugins/techdocs';
+import techInsights from './plugins/techInsights';
+import todo from './plugins/todo';
+import graphql from './plugins/graphql';
+import app from './plugins/app';
+import badges from './plugins/badges';
+import jenkins from './plugins/jenkins';
+import permission from './plugins/permission';
+import pulse from './plugins/pulse';
+import playlist from './plugins/playlist';
+import adr from './plugins/adr';
+import lighthouse from './plugins/lighthouse';
+import linguist from './plugins/linguist';
+import { PluginEnvironment } from './types';
+import { ServerPermissionClient } from '@backstage/plugin-permission-node';
+import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
+
+function makeCreateEnv(config: Config) {
+  const root = getRootLogger();
+  const reader = UrlReaders.default({ logger: root, config });
+  const discovery = SingleHostDiscovery.fromConfig(config);
+  const tokenManager = ServerTokenManager.fromConfig(config, { logger: root });
+  const permissions = ServerPermissionClient.fromConfig(config, {
+    discovery,
+    tokenManager,
+  });
+  const databaseManager = DatabaseManager.fromConfig(config, { logger: root });
+  const cacheManager = CacheManager.fromConfig(config);
+  const taskScheduler = TaskScheduler.fromConfig(config);
+  const identity = DefaultIdentityClient.create({
+    discovery,
+  });
+
+  root.info(`Created UrlReader ${reader}`);
+
+  return (plugin: string): PluginEnvironment => {
+    const logger = root.child({ type: 'plugin', plugin });
+    const database = databaseManager.forPlugin(plugin);
+    const cache = cacheManager.forPlugin(plugin);
+    const scheduler = taskScheduler.forPlugin(plugin);
+
+    return {
+      logger,
+      cache,
+      database,
+      config,
+      reader,
+      discovery,
+      tokenManager,
+      permissions,
+      scheduler,
+      identity,
+    };
+  };
+}
+
+async function main() {
+  metricsInit();
+  const logger = getRootLogger();
+
+  logger.info(
+    `You are running an example backend, which is supposed to be mainly used for contributing back to Backstage. ` +
+      `Do NOT deploy this to production. Read more here https://backstage.io/docs/getting-started/`,
+  );
+
+  const config = await loadBackendConfig({
+    argv: process.argv,
+    logger,
+  });
+
+  const createEnv = makeCreateEnv(config);
+
+  const healthcheckEnv = useHotMemoize(module, () => createEnv('healthcheck'));
+  const catalogEnv = useHotMemoize(module, () => createEnv('catalog'));
+  const codeCoverageEnv = useHotMemoize(module, () =>
+    createEnv('code-coverage'),
+  );
+  const scaffolderEnv = useHotMemoize(module, () => createEnv('scaffolder'));
+  const authEnv = useHotMemoize(module, () => createEnv('auth'));
+  const azureDevOpsEnv = useHotMemoize(module, () => createEnv('azure-devops'));
+  const proxyEnv = useHotMemoize(module, () => createEnv('proxy'));
+  const rollbarEnv = useHotMemoize(module, () => createEnv('rollbar'));
+  const searchEnv = useHotMemoize(module, () => createEnv('search'));
+  const techdocsEnv = useHotMemoize(module, () => createEnv('techdocs'));
+  const todoEnv = useHotMemoize(module, () => createEnv('todo'));
+  const kubernetesEnv = useHotMemoize(module, () => createEnv('kubernetes'));
+  const kafkaEnv = useHotMemoize(module, () => createEnv('kafka'));
+  const graphqlEnv = useHotMemoize(module, () => createEnv('graphql'));
+  const appEnv = useHotMemoize(module, () => createEnv('app'));
+  const pulseEnv = useHotMemoize(module, () => createEnv('pulse'));
+  const badgesEnv = useHotMemoize(module, () => createEnv('badges'));
+  const jenkinsEnv = useHotMemoize(module, () => createEnv('jenkins'));
+  const adrEnv = useHotMemoize(module, () => createEnv('adr'));
+  const techInsightsEnv = useHotMemoize(module, () =>
+    createEnv('tech-insights'),
+  );
+  const permissionEnv = useHotMemoize(module, () => createEnv('permission'));
+  const playlistEnv = useHotMemoize(module, () => createEnv('playlist'));
+  const entityFeedbackEnv = useHotMemoize(module, () =>
+    createEnv('entityFeedback'),
+  );
+  const eventsEnv = useHotMemoize(module, () => createEnv('events'));
+  const exploreEnv = useHotMemoize(module, () => createEnv('explore'));
+  const lighthouseEnv = useHotMemoize(module, () => createEnv('lighthouse'));
+
+  const eventBasedEntityProviders = await catalogEventBasedProviders(
+    catalogEnv,
+  );
+  const linguistEnv = useHotMemoize(module, () => createEnv('linguist'));
+
+  const apiRouter = Router();
+  apiRouter.use(
+    '/catalog',
+    await catalog(catalogEnv, eventBasedEntityProviders),
+  );
+  apiRouter.use('/code-coverage', await codeCoverage(codeCoverageEnv));
+  apiRouter.use('/events', await events(eventsEnv, eventBasedEntityProviders));
+  apiRouter.use('/rollbar', await rollbar(rollbarEnv));
+  apiRouter.use('/scaffolder', await scaffolder(scaffolderEnv));
+  apiRouter.use('/tech-insights', await techInsights(techInsightsEnv));
+  apiRouter.use('/auth', await auth(authEnv));
+  apiRouter.use('/azure-devops', await azureDevOps(azureDevOpsEnv));
+  apiRouter.use('/search', await search(searchEnv));
+  apiRouter.use('/pulse', await pulse(pulseEnv));
+  apiRouter.use('/techdocs', await techdocs(techdocsEnv));
+  apiRouter.use('/todo', await todo(todoEnv));
+  apiRouter.use('/kubernetes', await kubernetes(kubernetesEnv));
+  apiRouter.use('/kafka', await kafka(kafkaEnv));
+  apiRouter.use('/proxy', await proxy(proxyEnv));
+  apiRouter.use('/graphql', await graphql(graphqlEnv));
+  apiRouter.use('/badges', await badges(badgesEnv));
+  apiRouter.use('/jenkins', await jenkins(jenkinsEnv));
+  apiRouter.use('/permission', await permission(permissionEnv));
+  apiRouter.use('/playlist', await playlist(playlistEnv));
+  apiRouter.use('/explore', await explore(exploreEnv));
+  apiRouter.use('/entity-feedback', await entityFeedback(entityFeedbackEnv));
+  apiRouter.use('/adr', await adr(adrEnv));
+  apiRouter.use('/linguist', await linguist(linguistEnv));
+  apiRouter.use(notFoundHandler());
+
+  await lighthouse(lighthouseEnv);
+
+  const service = createServiceBuilder(module)
+    .loadConfig(config)
+    .addRouter('', await healthcheck(healthcheckEnv))
+    .addRouter('', metricsHandler())
+    .addRouter('/api', apiRouter)
+    .addRouter('', await app(appEnv));
+
+  await service.start().catch(err => {
+    logger.error(err);
+    process.exit(1);
+  });
+}
+
+module.hot?.accept();
+main().catch(error => {
+  console.error('Backend failed to start up', error);
+  process.exit(1);
+});

--- a/.github/demo/packages/backend/src/plugins/pulse.ts
+++ b/.github/demo/packages/backend/src/plugins/pulse.ts
@@ -1,0 +1,11 @@
+import { createRouter } from '@spotify/backstage-plugin-pulse-backend';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    ...env,
+  });
+}

--- a/.github/demo/uffizzi.demonstration.app-config.yaml
+++ b/.github/demo/uffizzi.demonstration.app-config.yaml
@@ -1,0 +1,173 @@
+app:
+  title: Backstage Uffizzi Demonstration
+  baseUrl: ${UFFIZZI_URL}
+
+organization:
+  name: My Organization
+
+backend:
+  baseUrl: ${UFFIZZI_URL}
+  auth:
+    keys:
+      # random mock key for Uffizzi deployments
+      - secret: 5TXvdjVZFxF7qf9K5RAYRDoGrLzJooqa
+  listen:
+    port: 7007
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+  cache:
+    store: memory
+  cors:
+    origin: ${UFFIZZI_URL}
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+
+auth:
+  environment: production
+  providers: {}
+  proxy:
+    enabled: true
+    url: https://demo.backstage.io/api/auth
+
+pulse:
+  surveyAdministrators:
+    - user:default/testUser
+
+catalog:
+  locations:
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
+
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
+      rules:
+        - allow: [User, Group]
+
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/all-templates.yaml
+      rules:
+        - allow: [Template]
+
+techdocs:
+  builder: 'local' # Alternatives - 'external'
+  generator:
+    runIn: 'docker'
+    # dockerImage: my-org/techdocs # use a custom docker image
+    # pullImage: true # or false to disable automatic pulling of image (e.g. if custom docker login is required)
+  publisher:
+    type: 'local' # Alternatives - 'googleGcs' or 'awsS3' or 'azureBlobStorage' or 'openStackSwift'. Read documentation for using alternatives.
+
+dynatrace:
+  baseUrl: https://your.dynatrace.instance.com
+
+# Score-cards sample configuration.
+scorecards:
+  jsonDataUrl: https://raw.githubusercontent.com/Oriflame/backstage-plugins/main/plugins/score-card/sample-data/
+  wikiLinkTemplate: https://link-to-wiki/{id}
+
+sentry:
+  organization: my-company
+
+rollbar:
+  organization: my-company
+  # NOTE: The rollbar-backend & accountToken key may be deprecated in the future (replaced by a proxy config)
+  accountToken: my-rollbar-account-token
+
+lighthouse:
+  baseUrl: http://localhost:3003
+
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters: []
+
+kafka:
+  clientId: backstage
+  clusters:
+    - name: cluster
+      dashboardUrl: https://akhq.io/
+      brokers:
+        - localhost:9092
+
+allure:
+  baseUrl: http://localhost:5050/allure-docker-service
+
+costInsights:
+  engineerCost: 200000
+  engineerThreshold: 0.5
+  products:
+    computeEngine:
+      name: Compute Engine
+      icon: compute
+    cloudDataflow:
+      name: Cloud Dataflow
+      icon: data
+    cloudStorage:
+      name: Cloud Storage
+      icon: storage
+    bigQuery:
+      name: BigQuery
+      icon: search
+    events:
+      name: Events
+      icon: data
+  metrics:
+    DAU:
+      name: Daily Active Users
+      default: true
+    MSC:
+      name: Monthly Subscribers
+  currencies:
+    engineers:
+      label: 'Engineers 🛠'
+      unit: 'engineer'
+    usd:
+      label: 'US Dollars 💵'
+      kind: 'USD'
+      unit: 'dollar'
+      prefix: '$'
+      rate: 1
+    carbonOffsetTons:
+      label: 'Carbon Offset Tons ♻️⚖️s'
+      kind: 'CARBON_OFFSET_TONS'
+      unit: 'carbon offset ton'
+      rate: 3.5
+    beers:
+      label: 'Beers 🍺'
+      kind: 'BEERS'
+      unit: 'beer'
+      rate: 4.5
+    pintsIceCream:
+      label: 'Pints of Ice Cream 🍦'
+      kind: 'PINTS_OF_ICE_CREAM'
+      unit: 'ice cream pint'
+      rate: 5.5
+pagerduty:
+  eventsBaseUrl: 'https://events.pagerduty.com/v2'
+jenkins:
+  instances:
+    - name: default
+      baseUrl: https://jenkins.example.com
+      username: backstage-bot
+      apiKey: 123456789abcdef0123456789abcedf012
+
+azureDevOps:
+  host: dev.azure.com
+  token: my-token
+  organization: my-company
+
+apacheAirflow:
+  baseUrl: https://your.airflow.instance.com
+
+gocd:
+  baseUrl: https://your.gocd.instance.com
+
+permission:
+  enabled: true

--- a/.github/workflows/deploy_demo-image.yml
+++ b/.github/workflows/deploy_demo-image.yml
@@ -1,0 +1,64 @@
+name: Build and push Demo image
+on:
+  repository_dispatch:
+    types: [release-published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      UFFIZZI_URL: https://app.uffizzi.com
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: v${{ github.event.client_payload.version }}
+          # path: backstage
+
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+
+      - name: yarn install
+        uses: backstage/actions/yarn-install@v0.6.2
+        with:
+          cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
+
+      - name: Use demonstration app config with plugins
+        run: |
+          cp -f ./.github/demo/uffizzi.demonstration.app-config.yaml ./app-config.yaml
+          cp -a ./.github/demo/packages/* ./packages/
+          yarn workspace example-app add @spotify/backstage-plugin-pulse
+          yarn workspace example-backend add @spotify/backstage-plugin-pulse-backend
+
+      - name: typescript build
+        run: |
+          yarn tsc
+
+      - name: backstage build
+        run: |
+          yarn workspace example-backend build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: packages/backend/Dockerfile
+          push: true
+          tags: |
+            registry.uffizzi.com/${{ github.repository_owner }}/backstage:demo
+          labels: |
+            org.opencontainers.image.description=Demonstration image generated from the latest Backstage release; This includes some additional catalogs.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ A detailed project roadmap, including already delivered milestones, is available
 
 ## Getting Started
 
+[![Demo](https://cdn.uffizzi.com/demo-button.svg)](https://app.uffizzi.com/demo/github.com/backstage/backstage)
+
 Check out [the documentation](https://backstage.io/docs/getting-started) on how to start using Backstage.
 
 ## Documentation


### PR DESCRIPTION
As discussed with @benjdlambert,

Proposal- A "Demo Button" can be placed in any strategic location (README, Website, Emails, etc) to allow a potential Backstage User to rapidly create their own Sandbox'ed Demo Environment which has a preset life-cycle of X hours.

The Demo in this PR highlights the "pulse" survey plugin as an example. You can see this in a preview environment here: https://deployment-16817-backstage-gnrn.app.uffizzi.com/

If you find value in this, we can work with you to iterate towards a customized "choose your plug-in" solution and include lead generation tools for potential adopters.

1. Accept the PR.
2. Go to Uffizzi UI and Configure Demo Button (see screenshot below.)
3. Place Demo Button in `README`, website, etc.
4. Potential Backstage Users can 1-click to get their own sandbox.

![image](https://user-images.githubusercontent.com/66315/220198099-9f275639-1c4f-4de5-864f-0298ee75ab43.png)
