### PR TITLE
scaffolder/next: Added the fields schema definition in the validator function

### DIFF
--- a/.changeset/six-melons-rhyme.md
+++ b/.changeset/six-melons-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+scaffolder/next: Added the ability to get the fields definition in the schema in the validation function

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -176,6 +176,7 @@ export type NextCustomFieldValidator<TFieldReturnValue> = (
   context: {
     apiHolder: ApiHolder;
     formData: JsonObject;
+    schema: JsonObject;
   },
 ) => void | Promise<void>;
 

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
@@ -56,6 +56,79 @@ describe('createAsyncValidators', () => {
     expect(validators.AddressField).toHaveBeenCalled();
   });
 
+  it('should call the validator function with the correct schema in the context', async () => {
+    const schema: JsonObject = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          'ui:options': {
+            bob: true,
+          },
+          pattern: 'lols',
+          'ui:field': 'NameField',
+        },
+        address: {
+          type: 'object',
+          'ui:field': 'AddressField',
+          properties: {
+            street: {
+              type: 'string',
+            },
+            postcode: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    };
+
+    const validators = { NameField: jest.fn(), AddressField: jest.fn() };
+
+    const validate = createAsyncValidators(schema, validators, {
+      apiHolder: { get: jest.fn() },
+    });
+
+    await validate({
+      name: 'asd',
+      address: { street: 'street', postcode: 'postcode' },
+    });
+
+    expect(validators.NameField).toHaveBeenCalledWith(
+      'asd',
+      expect.anything(),
+      expect.objectContaining({
+        schema: {
+          type: 'string',
+          'ui:options': {
+            bob: true,
+          },
+          pattern: 'lols',
+          'ui:field': 'NameField',
+        },
+      }),
+    );
+
+    expect(validators.AddressField).toHaveBeenCalledWith(
+      { street: 'street', postcode: 'postcode' },
+      expect.anything(),
+      expect.objectContaining({
+        schema: {
+          type: 'object',
+          'ui:field': 'AddressField',
+          properties: {
+            street: {
+              type: 'string',
+            },
+            postcode: {
+              type: 'string',
+            },
+          },
+        },
+      }),
+    );
+  });
+
   it('should return the correct errors to the frontend', async () => {
     const schema: JsonObject = {
       type: 'object',

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts
@@ -48,12 +48,17 @@ export const createAsyncValidators = (
       validatorName: string,
       key: string,
       value: JsonValue | undefined,
+      schema: JsonObject,
     ) => {
       const validator = validators[validatorName];
       if (validator) {
         const fieldValidation = createFieldValidation();
         try {
-          await validator(value, fieldValidation, { ...context, formData });
+          await validator(value, fieldValidation, {
+            ...context,
+            formData,
+            schema,
+          });
         } catch (ex) {
           fieldValidation.addError(ex.message);
         }
@@ -67,7 +72,12 @@ export const createAsyncValidators = (
 
       if (definitionInSchema && 'ui:field' in definitionInSchema) {
         if ('ui:field' in definitionInSchema) {
-          await validateForm(definitionInSchema['ui:field'], key, value);
+          await validateForm(
+            definitionInSchema['ui:field'],
+            key,
+            value,
+            definitionInSchema,
+          );
         }
       } else if (
         definitionInSchema &&
@@ -75,7 +85,12 @@ export const createAsyncValidators = (
         'ui:field' in definitionInSchema.items
       ) {
         if ('ui:field' in definitionInSchema.items) {
-          await validateForm(definitionInSchema.items['ui:field'], key, value);
+          await validateForm(
+            definitionInSchema.items['ui:field'],
+            key,
+            value,
+            definitionInSchema.items,
+          );
         }
       } else if (isObject(value)) {
         formValidation[key] = await validate(formData, path, value);

--- a/plugins/scaffolder-react/src/next/extensions/types.ts
+++ b/plugins/scaffolder-react/src/next/extensions/types.ts
@@ -49,7 +49,7 @@ export type NextCustomFieldValidator<TFieldReturnValue> = (
   context: {
     apiHolder: ApiHolder;
     formData: JsonObject;
-    schema?: JsonObject;
+    schema: JsonObject;
   },
 ) => void | Promise<void>;
 

--- a/plugins/scaffolder-react/src/next/extensions/types.ts
+++ b/plugins/scaffolder-react/src/next/extensions/types.ts
@@ -46,7 +46,11 @@ export interface NextFieldExtensionComponentProps<
 export type NextCustomFieldValidator<TFieldReturnValue> = (
   data: TFieldReturnValue,
   field: FieldValidationV5,
-  context: { apiHolder: ApiHolder; formData: JsonObject },
+  context: {
+    apiHolder: ApiHolder;
+    formData: JsonObject;
+    schema?: JsonObject;
+  },
 ) => void | Promise<void>;
 
 /**


### PR DESCRIPTION
This is useful for when you want to include some of the `ui:options` in the validation function. For instance, error messages for failed regex validations.