### PR TITLE
fix bug in hasErrors with nested errors object

### DIFF
--- a/.changeset/happy-boxes-arrive.md
+++ b/.changeset/happy-boxes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+fix bug with `hasErrors` returning false when dealing with empty objects

--- a/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { type FormValidation } from './createAsyncValidators';
 import { hasErrors } from './utils';
 
 describe('hasErrors', () => {

--- a/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { type FormValidation } from './createAsyncValidators';
 import { hasErrors } from './utils';
 
 describe('hasErrors', () => {
@@ -57,5 +58,36 @@ describe('hasErrors', () => {
         },
       }),
     ).toBe(true);
+  });
+
+  it('should not return false when the error is an empty object', () => {
+    const errors = {
+      something: {},
+      otherThing: {},
+      someName: {
+        __errors: [
+          'Accepts alphanumeric values along with _(underscore) and -(hypen) as special characters',
+        ],
+        addError: jest.fn(),
+      },
+      someOtherName: {
+        __errors: ['Must start with an alphabet & not contain .(period)'],
+        addError: jest.fn(),
+      },
+      aName: {
+        __errors: [],
+        addError: jest.fn(),
+      },
+      bName: {
+        __errors: [],
+        addError: jest.fn(),
+      },
+      cName: {
+        __errors: [],
+        addError: jest.fn(),
+      },
+    };
+
+    expect(hasErrors(errors)).toBe(true);
   });
 });

--- a/plugins/scaffolder-react/src/next/components/Stepper/utils.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/utils.ts
@@ -35,7 +35,9 @@ export function hasErrors(errors?: FormValidation): boolean {
       continue;
     }
 
-    return hasErrors(error);
+    if (hasErrors(error)) {
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The test in the PR describes the bug well and fixes a bug in `hasErrors` that is used by `handleNext` of the `<Stepper />` component.

If `hasErrors` is given an `errors` object like this:

```ts
const errors = {
  something: {},
  otherThing: {},
  someName: {
    __errors: [
      'Accepts alphanumeric values along with _(underscore) and -(hypen) as special characters',
    ],
    addError: jest.fn(),
  },
  someOtherName: {
    __errors: ['Must start with an alphabet & not contain .(period)'],
    addError: jest.fn(),
  },
  aName: {
    __errors: [],
    addError: jest.fn(),
  },
  bName: {
    __errors: [],
    addError: jest.fn(),
  },
  cName: {
    __errors: [],
    addError: jest.fn(),
  },
};
```

The `hasErrors` function will return `false` if it encounters an empty object. 

If the first error is an empty object, it will bottom out at the first error ignoring the other objects with validation errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
