### PR TITLE
fix: only run changeset action if target is master

### DIFF
--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -1,6 +1,7 @@
 name: Automate changeset feedback
 on:
   pull_request_target:
+    branches: ['master']
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Right now if I create a PR from `branch-a` to `branch-b` it will fail because it is not targeting the master branch. Because we are calling the action with `diff-ref: 'origin/master'`. So, lets only run this action if the PR is targeting master.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
