### PR TITLE
[GitlabDiscoveryEntityProvider] add config to distinguish between `branch` and `fallbackBranch`

### DIFF
--- a/.changeset/fresh-schools-fly.md
+++ b/.changeset/fresh-schools-fly.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-gitlab': major
+'@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
 The configuration of the `GitlabDiscoveryEntityProvider` has changed as follows:

--- a/.changeset/fresh-schools-fly.md
+++ b/.changeset/fresh-schools-fly.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-The configuration of the `GitlabDiscoveryEntityProvider` has changed as follows:
+**BREAKING**: The configuration of the `GitlabDiscoveryEntityProvider` has changed as follows:
 
 - The configuration key `branch` is now used to define the branch from which the catalog-info should be discovered.
 - The old configuration key `branch` is now called `fallbackBranch`. This value specifies which branch should be used

--- a/.changeset/fresh-schools-fly.md
+++ b/.changeset/fresh-schools-fly.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': major
+---
+
+The configuration of the `GitlabDiscoveryEntityProvider` has changed as follows:
+
+- The configuration key `branch` is now used to define the branch from which the catalog-info should be discovered.
+- The old configuration key `branch` is now called `fallbackBranch`. This value specifies which branch should be used
+  if no default branch is defined on the project itself.
+
+To migrate to the new configuration value, rename `branch` to `fallbackBranch`

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -21,7 +21,7 @@ catalog:
     gitlab:
       yourProviderId:
         host: gitlab-host # Identifies one of the hosts set up in the integrations
-        branch: main # Optional. Used to discover on a concrete branch
+        branch: main # Optional. Used to discover on a specific branch
         fallbackBranch: main # Optional. Fallback to be used if there is no default branch configured at the Gitlab repository. It is only used, if `branch` is undefined. Uses `master` as default
         group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -21,6 +21,7 @@ catalog:
     gitlab:
       yourProviderId:
         host: gitlab-host # Identifies one of the hosts set up in the integrations
+        branch: main # Optional. Used to discover on a concrete branch
         fallbackBranch: main # Optional. Fallback to be used if there is no default branch configured at the Gitlab repository. It is only used, if `branch` is undefined. Uses `master` as default
         group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -70,11 +70,12 @@ export type GitlabProviderConfig = {
   group: string;
   id: string;
   /**
-   * @deprecated use `fallbackBranch` instead
+   * The name of the branch to be used, to discover catalog files.
    */
   branch?: string;
   /**
-   * If there is no default branch defined at the project, this fallback is used to discover catalog files.
+   * If no `branch` is configured and there is no default branch defined at the project as well, this fallback is used
+   * to discover catalog files.
    * Defaults to: `master`
    */
   fallbackBranch: string;

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -61,10 +61,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       throw new Error('Either schedule or scheduler must be provided.');
     }
 
-    const providerConfigs = readGitlabConfigs(
-      config,
-      options.logger.child({ target: 'GitlabDiscoveryEntityProvider' }),
-    );
+    const providerConfigs = readGitlabConfigs(config);
     const integrations = ScmIntegrations.fromConfig(config).gitlab;
     const providers: GitlabDiscoveryEntityProvider[] = [];
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -181,6 +181,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       }
 
       if (
+        !this.config.branch &&
         this.config.fallbackBranch === '*' &&
         project.default_branch === undefined
       ) {
@@ -188,7 +189,9 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       }
 
       const project_branch =
-        project.default_branch ?? this.config.fallbackBranch;
+        this.config.branch ??
+        project.default_branch ??
+        this.config.fallbackBranch;
 
       const projectHasFile: boolean = await client.hasFile(
         project.path_with_namespace ?? '',
@@ -211,7 +214,10 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
   }
 
   private createLocationSpec(project: GitLabProject): LocationSpec {
-    const project_branch = project.default_branch ?? this.config.fallbackBranch;
+    const project_branch =
+      this.config.branch ??
+      project.default_branch ??
+      this.config.fallbackBranch;
     return {
       type: 'url',
       target: `${project.web_url}/-/blob/${project_branch}/${this.config.catalogFile}`,

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -72,10 +72,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       throw new Error('Either schedule or scheduler must be provided.');
     }
 
-    const providerConfigs = readGitlabConfigs(
-      config,
-      options.logger.child({ target: 'GitlabOrgDiscoveryEntityProvider' }),
-    );
+    const providerConfigs = readGitlabConfigs(config);
     const integrations = ScmIntegrations.fromConfig(config).gitlab;
     const providers: GitlabOrgDiscoveryEntityProvider[] = [];
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -17,9 +17,6 @@
 import { ConfigReader } from '@backstage/config';
 import { Duration } from 'luxon';
 import { readGitlabConfigs } from './config';
-import { getVoidLogger } from '@backstage/backend-common';
-
-const logger = getVoidLogger();
 
 describe('config', () => {
   it('empty gitlab config', () => {
@@ -29,7 +26,7 @@ describe('config', () => {
       },
     });
 
-    const result = readGitlabConfigs(config, logger);
+    const result = readGitlabConfigs(config);
     expect(result).toHaveLength(0);
   });
 
@@ -47,13 +44,13 @@ describe('config', () => {
       },
     });
 
-    const result = readGitlabConfigs(config, logger);
+    const result = readGitlabConfigs(config);
     expect(result).toHaveLength(1);
     result.forEach(r =>
       expect(r).toStrictEqual({
         id: 'test',
         group: 'group',
-        fallbackBranch: undefined,
+        branch: undefined,
         fallbackBranch: 'master',
         host: 'host',
         catalogFile: 'catalog-info.yaml',
@@ -83,13 +80,13 @@ describe('config', () => {
       },
     });
 
-    const result = readGitlabConfigs(config, logger);
+    const result = readGitlabConfigs(config);
     expect(result).toHaveLength(1);
     result.forEach(r =>
       expect(r).toStrictEqual({
         id: 'test',
         group: 'group',
-        fallbackBranch: 'not-master',
+        branch: 'not-master',
         fallbackBranch: 'main',
         host: 'host',
         catalogFile: 'custom-file.yaml',
@@ -122,13 +119,13 @@ describe('config', () => {
       },
     });
 
-    const result = readGitlabConfigs(config, logger);
+    const result = readGitlabConfigs(config);
     expect(result).toHaveLength(1);
     result.forEach(r =>
       expect(r).toStrictEqual({
         id: 'test',
         group: 'group',
-        fallbackBranch: undefined,
+        branch: undefined,
         fallbackBranch: 'master',
         host: 'host',
         catalogFile: 'catalog-info.yaml',
@@ -162,7 +159,7 @@ describe('config', () => {
       },
     });
 
-    expect(() => readGitlabConfigs(config, logger)).toThrow(
+    expect(() => readGitlabConfigs(config)).toThrow(
       "Missing required config value at 'catalog.providers.gitlab.test.host'",
     );
   });
@@ -181,7 +178,7 @@ describe('config', () => {
       },
     });
 
-    const result = readGitlabConfigs(config, logger);
+    const result = readGitlabConfigs(config);
     expect(result).toHaveLength(1);
     expect(result[0].group).toEqual('');
   });

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -53,6 +53,7 @@ describe('config', () => {
       expect(r).toStrictEqual({
         id: 'test',
         group: 'group',
+        fallbackBranch: undefined,
         fallbackBranch: 'master',
         host: 'host',
         catalogFile: 'catalog-info.yaml',
@@ -74,6 +75,7 @@ describe('config', () => {
               group: 'group',
               host: 'host',
               branch: 'not-master',
+              fallbackBranch: 'main',
               entityFilename: 'custom-file.yaml',
             },
           },
@@ -88,6 +90,7 @@ describe('config', () => {
         id: 'test',
         group: 'group',
         fallbackBranch: 'not-master',
+        fallbackBranch: 'main',
         host: 'host',
         catalogFile: 'custom-file.yaml',
         projectPattern: /[\s\S]*/,
@@ -125,6 +128,7 @@ describe('config', () => {
       expect(r).toStrictEqual({
         id: 'test',
         group: 'group',
+        fallbackBranch: undefined,
         fallbackBranch: 'master',
         host: 'host',
         catalogFile: 'catalog-info.yaml',

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -36,15 +36,7 @@ function readGitlabConfig(
   const group = config.getOptionalString('group') ?? '';
   const host = config.getString('host');
   const branch = config.getOptionalString('branch');
-
-  if (branch) {
-    logger.warn(
-      'The configuration key `branch` has been deprecated in favor of the configuration key `fallbackBranch`.',
-    );
-  }
-
-  const fallbackBranch =
-    config.getOptionalString('fallbackBranch') ?? branch ?? 'master';
+  const fallbackBranch = config.getOptionalString('fallbackBranch') ?? 'master';
   const catalogFile =
     config.getOptionalString('entityFilename') ?? 'catalog-info.yaml';
   const projectPattern = new RegExp(
@@ -65,6 +57,7 @@ function readGitlabConfig(
   return {
     id,
     group,
+    branch,
     fallbackBranch,
     host,
     catalogFile,

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -17,7 +17,6 @@
 import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
 import { Config } from '@backstage/config';
 import { GitlabProviderConfig } from '../lib';
-import { Logger } from 'winston';
 
 /**
  * Extracts the gitlab config from a config object
@@ -26,13 +25,8 @@ import { Logger } from 'winston';
  *
  * @param id - The provider key
  * @param config - The config object to extract from
- * @param logger - The logger
  */
-function readGitlabConfig(
-  id: string,
-  config: Config,
-  logger: Logger,
-): GitlabProviderConfig {
+function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
   const group = config.getOptionalString('group') ?? '';
   const host = config.getString('host');
   const branch = config.getOptionalString('branch');
@@ -75,12 +69,8 @@ function readGitlabConfig(
  * @public
  *
  * @param config - The config object to extract from
- * @param logger - The logger
  */
-export function readGitlabConfigs(
-  config: Config,
-  logger: Logger,
-): GitlabProviderConfig[] {
+export function readGitlabConfigs(config: Config): GitlabProviderConfig[] {
   const configs: GitlabProviderConfig[] = [];
 
   const providerConfigs = config.getOptionalConfig('catalog.providers.gitlab');
@@ -90,13 +80,7 @@ export function readGitlabConfigs(
   }
 
   for (const id of providerConfigs.keys()) {
-    configs.push(
-      readGitlabConfig(
-        id,
-        providerConfigs.getConfig(id),
-        logger.child({ target: id }),
-      ),
-    );
+    configs.push(readGitlabConfig(id, providerConfigs.getConfig(id)));
   }
 
   return configs;


### PR DESCRIPTION
* A new config option `fallbackBranch` is added to the GitlabDiscoveryEntityProvider, to define the branch to use , if there is no default branch configured at the repository
* The existing `branch` configuration is now used to explicitly set the branch to look up the catalog-info

resolves #13587

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
