### PR TITLE
Render database configuration link correctly

### DIFF
--- a/docs/tutorials/configuring-plugin-databases.md
+++ b/docs/tutorials/configuring-plugin-databases.md
@@ -21,8 +21,8 @@ instance or cluster.
 With infrastructure defined as code or data (Terraform, AWS CloudFormation,
 etc.), you may have database credentials which lack permissions to create new
 databases or you do not have control over the database names. In these
-instances, you can set the database connection configuration on a [per plugin basis]
-(#connection-configuration-per-plugin).
+instances, you can set the database connection configuration on a
+[per plugin basis](#connection-configuration-per-plugin).
 
 Backstage supports all of these use cases with the `DatabaseManager` provided by
 `@backstage/backend-common`. We will now cover how to use and configure


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where a markdown link isn't rendered correctly in the 3rd paragraph here: https://backstage.io/docs/tutorials/configuring-plugin-databases#connection-configuration-per-plugin

![Screenshot 2023-02-22 at 11 46 37 am](https://user-images.githubusercontent.com/480719/220492291-bf084c22-15e5-4554-9939-5fb2ec2cc4b3.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
