### PR TITLE
feat: add functionality to get scheduled tasks

### DIFF
--- a/.changeset/fresh-hairs-switch.md
+++ b/.changeset/fresh-hairs-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': minor
+---
+
+add functionality to get descriptions from the scheduler for triggering

--- a/packages/backend-tasks/api-report.md
+++ b/packages/backend-tasks/api-report.md
@@ -7,6 +7,7 @@ import { Config } from '@backstage/config';
 import { DatabaseManager } from '@backstage/backend-common';
 import { Duration } from 'luxon';
 import { HumanDuration as HumanDuration_2 } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 
@@ -16,7 +17,7 @@ export type HumanDuration = HumanDuration_2;
 // @public
 export interface PluginTaskScheduler {
   createScheduledTaskRunner(schedule: TaskScheduleDefinition): TaskRunner;
-  getScheduledTasks(): TaskDescriptor[];
+  getScheduledTasks(): Promise<TaskDescriptor[]>;
   scheduleTask(
     task: TaskScheduleDefinition & TaskInvocationDefinition,
   ): Promise<void>;
@@ -29,8 +30,13 @@ export function readTaskScheduleDefinitionFromConfig(
 ): TaskScheduleDefinition;
 
 // @public
-export type TaskDescriptor = TaskScheduleDefinition &
-  Exclude<TaskInvocationDefinition, 'fn' | 'signal'>;
+export type TaskDescriptor = {
+  id: string;
+  scope: 'global' | 'local';
+  settings: {
+    version: number;
+  } & JsonObject;
+};
 
 // @public
 export type TaskFunction =

--- a/packages/backend-tasks/api-report.md
+++ b/packages/backend-tasks/api-report.md
@@ -16,6 +16,7 @@ export type HumanDuration = HumanDuration_2;
 // @public
 export interface PluginTaskScheduler {
   createScheduledTaskRunner(schedule: TaskScheduleDefinition): TaskRunner;
+  getScheduledTasks(): TaskDescriptor[];
   scheduleTask(
     task: TaskScheduleDefinition & TaskInvocationDefinition,
   ): Promise<void>;
@@ -26,6 +27,10 @@ export interface PluginTaskScheduler {
 export function readTaskScheduleDefinitionFromConfig(
   config: Config,
 ): TaskScheduleDefinition;
+
+// @public
+export type TaskDescriptor = TaskScheduleDefinition &
+  Exclude<TaskInvocationDefinition, 'fn' | 'signal'>;
 
 // @public
 export type TaskFunction =

--- a/packages/backend-tasks/src/migrations.test.ts
+++ b/packages/backend-tasks/src/migrations.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+import { TestDatabases } from '@backstage/backend-test-utils';
+import fs from 'fs';
+
+const migrationsDir = `${__dirname}/../migrations`;
+const migrationsFiles = fs.readdirSync(migrationsDir).sort();
+
+async function migrateUpOnce(knex: Knex): Promise<void> {
+  await knex.migrate.up({ directory: migrationsDir });
+}
+
+async function migrateDownOnce(knex: Knex): Promise<void> {
+  await knex.migrate.down({ directory: migrationsDir });
+}
+
+async function migrateUntilBefore(knex: Knex, target: string): Promise<void> {
+  const index = migrationsFiles.indexOf(target);
+  if (index === -1) {
+    throw new Error(`Migration ${target} not found`);
+  }
+  for (let i = 0; i < index; i++) {
+    await migrateUpOnce(knex);
+  }
+}
+
+describe('migrations', () => {
+  const databases = TestDatabases.create({
+    ids: ['POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
+  });
+
+  it.each(databases.eachSupportedId())(
+    '20210928160613_init.js, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+
+      await migrateUntilBefore(knex, '20210928160613_init.js');
+      await migrateUpOnce(knex);
+
+      await knex('backstage_backend_tasks__tasks').insert({
+        id: 'test',
+        settings_json: '{}',
+        next_run_start_at: knex.fn.now(),
+      });
+
+      await expect(knex('backstage_backend_tasks__tasks')).resolves.toEqual([
+        {
+          id: 'test',
+          settings_json: '{}',
+          next_run_start_at: expect.anything(),
+          current_run_ticket: null,
+          current_run_started_at: null,
+          current_run_expires_at: null,
+        },
+      ]);
+
+      await migrateDownOnce(knex);
+
+      await expect(knex('backstage_backend_tasks__tasks')).rejects.toThrow(
+        /backstage_backend_tasks__tasks/,
+      );
+
+      await knex.destroy();
+    },
+    60_000,
+  );
+});

--- a/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/LocalTaskWorker.ts
@@ -39,8 +39,9 @@ export class LocalTaskWorker {
     this.logger.info(
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
-    let attemptNum = 1;
+
     (async () => {
+      let attemptNum = 1;
       for (;;) {
         try {
           if (settings.initialDelayDuration) {
@@ -60,6 +61,7 @@ export class LocalTaskWorker {
               options?.signal,
             );
           }
+
           this.logger.info(`Task worker finished: ${this.taskId}`);
           attemptNum = 0;
           break;

--- a/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.test.ts
+++ b/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.test.ts
@@ -309,9 +309,8 @@ describe('PluginTaskManagerImpl', () => {
       'can fetch both global and local task ids, %p',
       async databaseId => {
         const { manager } = await init(databaseId);
-
         const fn = jest.fn();
-        const promise = new Promise(resolve => fn.mockImplementation(resolve));
+
         await manager.scheduleTask({
           id: 'task1',
           timeout: Duration.fromMillis(5000),
@@ -328,18 +327,18 @@ describe('PluginTaskManagerImpl', () => {
           scope: 'local',
         });
 
-        await promise;
-
-        const tasks = manager.getScheduledTasks();
-        expect(tasks.length).toEqual(2);
-        expect(tasks[0].id).toEqual('task1');
-        expect(tasks[1].id).toEqual('task2');
-        expect(tasks[0].scope).toEqual('global');
-        expect(tasks[1].scope).toEqual('local');
-        expect(tasks[0].fn).toBeUndefined();
-        expect(tasks[1].fn).toBeUndefined();
-        expect(tasks[0].signal).toBeUndefined();
-        expect(tasks[1].signal).toBeUndefined();
+        await expect(manager.getScheduledTasks()).resolves.toEqual([
+          {
+            id: 'task1',
+            scope: 'global',
+            settings: expect.objectContaining({ cadence: 'PT5S' }),
+          },
+          {
+            id: 'task2',
+            scope: 'local',
+            settings: expect.objectContaining({ cadence: 'PT5S' }),
+          },
+        ]);
       },
       60_000,
     );

--- a/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.ts
@@ -21,6 +21,7 @@ import { LocalTaskWorker } from './LocalTaskWorker';
 import { TaskWorker } from './TaskWorker';
 import {
   PluginTaskScheduler,
+  TaskDescriptor,
   TaskInvocationDefinition,
   TaskRunner,
   TaskScheduleDefinition,
@@ -32,6 +33,7 @@ import { validateId } from './util';
  */
 export class PluginTaskSchedulerImpl implements PluginTaskScheduler {
   private readonly localTasksById = new Map<string, LocalTaskWorker>();
+  private readonly allScheduledTasks: TaskDescriptor[] = [];
 
   constructor(
     private readonly databaseFactory: () => Promise<Knex>,
@@ -94,6 +96,8 @@ export class PluginTaskSchedulerImpl implements PluginTaskScheduler {
 
       this.localTasksById.set(task.id, worker);
     }
+    const { fn: _, signal: __, ...descriptor } = task;
+    this.allScheduledTasks.push(descriptor as TaskDescriptor);
   }
 
   createScheduledTaskRunner(schedule: TaskScheduleDefinition): TaskRunner {
@@ -102,6 +106,10 @@ export class PluginTaskSchedulerImpl implements PluginTaskScheduler {
         await this.scheduleTask({ ...task, ...schedule });
       },
     };
+  }
+
+  getScheduledTasks(): TaskDescriptor[] {
+    return this.allScheduledTasks;
   }
 }
 

--- a/packages/backend-tasks/src/tasks/index.ts
+++ b/packages/backend-tasks/src/tasks/index.ts
@@ -19,6 +19,7 @@ export { TaskScheduler } from './TaskScheduler';
 export type {
   PluginTaskScheduler,
   TaskFunction,
+  TaskDescriptor,
   TaskInvocationDefinition,
   TaskRunner,
   TaskScheduleDefinition,

--- a/packages/backend-tasks/src/tasks/types.ts
+++ b/packages/backend-tasks/src/tasks/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HumanDuration } from '@backstage/types';
+import { HumanDuration, JsonObject } from '@backstage/types';
 import { CronTime } from 'cron';
 import { Duration } from 'luxon';
 import { z } from 'zod';
@@ -32,12 +32,26 @@ export type TaskFunction =
   | (() => void | Promise<void>);
 
 /**
- * A type to describe a scheduled task.
+ * A semi-opaque type to describe an actively scheduled task.
  *
  * @public
  */
-export type TaskDescriptor = TaskScheduleDefinition &
-  Exclude<TaskInvocationDefinition, 'fn' | 'signal'>;
+export type TaskDescriptor = {
+  /**
+   * The unique identifier of the task.
+   */
+  id: string;
+  /**
+   * The scope of the task.
+   */
+  scope: 'global' | 'local';
+  /**
+   * The settings that control the task flow. This is a semi-opaque structure
+   * that is mainly there for debugging purposes. Do not make any assumptions
+   * about the contents of this field.
+   */
+  settings: { version: number } & JsonObject;
+};
 
 /**
  * Options that control the scheduling of a task.
@@ -327,7 +341,7 @@ export interface PluginTaskScheduler {
    *
    * @returns Scheduled tasks
    */
-  getScheduledTasks(): TaskDescriptor[];
+  getScheduledTasks(): Promise<TaskDescriptor[]>;
 }
 
 function isValidOptionalDurationString(d: string | undefined): boolean {

--- a/packages/backend-tasks/src/tasks/types.ts
+++ b/packages/backend-tasks/src/tasks/types.ts
@@ -32,6 +32,14 @@ export type TaskFunction =
   | (() => void | Promise<void>);
 
 /**
+ * A type to describe a scheduled task.
+ *
+ * @public
+ */
+export type TaskDescriptor = TaskScheduleDefinition &
+  Exclude<TaskInvocationDefinition, 'fn' | 'signal'>;
+
+/**
  * Options that control the scheduling of a task.
  *
  * @public
@@ -307,6 +315,19 @@ export interface PluginTaskScheduler {
    * @param schedule - The task schedule
    */
   createScheduledTaskRunner(schedule: TaskScheduleDefinition): TaskRunner;
+
+  /**
+   * Returns all scheduled tasks registered to this scheduler.
+   *
+   * @remarks
+   *
+   * This method is useful for triggering tasks manually using the triggerTask
+   * functionality. Note that the returned tasks contain only tasks that have
+   * been initialized in this instance of the scheduler.
+   *
+   * @returns Scheduled tasks
+   */
+  getScheduledTasks(): TaskDescriptor[];
 }
 
 function isValidOptionalDurationString(d: string | undefined): boolean {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

add new functionality to PluginTaskScheduler to return local and global tasks. this is to be able to trigger those tasks manually using the triggerTask functionality when there's no clear way to figure out the correct id to use.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
