### PR TITLE
fix: fix getting credentials for Bitbucket Server in the RepoUrlPicker

### DIFF
--- a/.changeset/famous-sloths-tie.md
+++ b/.changeset/famous-sloths-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Getting credentials in the RepoUrlPicker now also works for targets without owner (e.g. Bitbucket Server).

--- a/plugins/auth-backend/src/providers/bitbucketServer/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucketServer/provider.ts
@@ -216,7 +216,7 @@ export class BitbucketServerAuthProvider implements OAuthHandlers {
       throw new Error(`Failed to retrieve the user '${username}'`);
     }
 
-    const user = (await userResponse.json()) as any;
+    const user = await userResponse.json();
 
     const passportProfile = {
       provider: 'bitbucketServer',

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -38,6 +38,11 @@ describe('RepoUrlPicker', () => {
       integrations: [
         { host: 'github.com', type: 'github', title: 'github.com' },
         { host: 'dev.azure.com', type: 'azure', title: 'dev.azure.com' },
+        {
+          host: 'server.bitbucket.org',
+          type: 'bitbucketServer',
+          title: 'server.bitbucket.org',
+        },
       ],
     }),
   };
@@ -168,6 +173,65 @@ describe('RepoUrlPicker', () => {
           customScopes: {
             github: ['workflow'],
           },
+        },
+      });
+
+      const currentSecrets = JSON.parse(
+        getByTestId('current-secrets').textContent!,
+      );
+
+      expect(currentSecrets).toEqual({
+        secrets: { testKey: 'abc123' },
+      });
+    });
+    it('should call the scmAuthApi with the correct params if only a project is set', async () => {
+      const SecretsComponent = () => {
+        const { secrets } = useTemplateSecrets();
+        return (
+          <div data-testid="current-secrets">{JSON.stringify({ secrets })}</div>
+        );
+      };
+      const { getAllByRole, getByTestId } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scmIntegrationsApiRef, mockIntegrationsApi],
+            [scmAuthApiRef, mockScmAuthApi],
+            [scaffolderApiRef, mockScaffolderApi],
+          ]}
+        >
+          <SecretsContextProvider>
+            <Form
+              schema={{ type: 'string' }}
+              uiSchema={{
+                'ui:field': 'RepoUrlPicker',
+                'ui:options': {
+                  allowedHosts: ['server.bitbucket.org'],
+                  requestUserCredentials: {
+                    secretsKey: 'testKey',
+                  },
+                },
+              }}
+              fields={{ RepoUrlPicker: RepoUrlPicker }}
+            />
+            <SecretsComponent />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+      );
+
+      const [projectInput, repoInput] = getAllByRole('textbox');
+
+      await act(async () => {
+        fireEvent.change(projectInput, { target: { value: 'backstage' } });
+        fireEvent.change(repoInput, { target: { value: 'repo123' } });
+
+        // need to wait for the debounce to finish
+        await new Promise(resolve => setTimeout(resolve, 600));
+      });
+
+      expect(mockScmAuthApi.getCredentials).toHaveBeenCalledWith({
+        url: 'https://server.bitbucket.org/backstage/repo123',
+        additionalScope: {
+          repoWrite: true,
         },
       });
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -120,16 +120,17 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
     async () => {
       const { requestUserCredentials } = uiSchema?.['ui:options'] ?? {};
 
+      const workspace = state.owner ? state.owner : state.project;
       if (
         !requestUserCredentials ||
-        !(state.host && state.owner && state.repoName)
+        !(state.host && workspace && state.repoName)
       ) {
         return;
       }
 
-      const [encodedHost, encodedOwner, encodedRepoName] = [
+      const [encodedHost, encodedWorkspace, encodedRepoName] = [
         state.host,
-        state.owner,
+        workspace,
         state.repoName,
       ].map(encodeURIComponent);
 
@@ -137,14 +138,14 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
       // so lets grab them using the scmAuthApi and pass through
       // any additional scopes from the ui:options
       const { token } = await scmAuthApi.getCredentials({
-        url: `https://${encodedHost}/${encodedOwner}/${encodedRepoName}`,
+        url: `https://${encodedHost}/${encodedWorkspace}/${encodedRepoName}`,
         additionalScope: {
           repoWrite: true,
           customScopes: requestUserCredentials.additionalScopes,
         },
       });
 
-      // set the secret using the key provided in the the ui:options for use
+      // set the secret using the key provided in the ui:options for use
       // in the templating the manifest with ${{ secrets[secretsKey] }}
       setSecrets({ [requestUserCredentials.secretsKey]: token });
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I am using the `RepoUrlPicker` for Bitbucket Server hosts. A few weeks ago, we contributed an OAuth provider for Bitbucket Server to use it with the Scaffolder. Today I wanted to build a template using it, but noticed that it doesn't work because for Bitbucket Server hosts no owner can be set but only a project. Therefore, getting the credentials with the `RepoUrlPicker` doesn't work -> I configured the `RepoUrlPicker` to use the project as a fallback if no owner is specified.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
