### PR TITLE
[TechDocs CLI] print the mkdocs output when running the generate command with the --…

### DIFF
--- a/.changeset/quick-coats-sneeze.md
+++ b/.changeset/quick-coats-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Running `@techdocs/cli generate` with the `--verbose` flag will now print the mkdocs output.

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -31,8 +31,8 @@ import { ConfigReader } from '@backstage/config';
 import {
   convertTechDocsRefToLocationAnnotation,
   createLogger,
+  getLogStream,
 } from '../../lib/utility';
-import { stdout } from 'process';
 
 export default async function generate(opts: OptionValues) {
   // Use techdocs-node package to generate docs. Keep consistency between Backstage and CI generating docs.
@@ -110,7 +110,7 @@ export default async function generate(opts: OptionValues) {
       : {}),
     logger,
     etag: opts.etag,
-    ...(process.env.LOG_LEVEL === 'debug' ? { logStream: stdout } : {}),
+    logStream: getLogStream(logger),
     siteOptions: { name: opts.siteName },
   });
 

--- a/packages/techdocs-cli/src/lib/utility.ts
+++ b/packages/techdocs-cli/src/lib/utility.ts
@@ -18,6 +18,8 @@ import {
   ParsedLocationAnnotation,
 } from '@backstage/plugin-techdocs-node';
 import * as winston from 'winston';
+import { Writable } from 'stream';
+import { stdout } from 'process';
 
 export const convertTechDocsRefToLocationAnnotation = (
   techdocsRef: string,
@@ -51,4 +53,18 @@ export const createLogger = ({
   });
 
   return logger;
+};
+
+export const getLogStream = (logger: winston.Logger): Writable => {
+  if (process.env.LOG_LEVEL === 'debug') {
+    return stdout;
+  }
+
+  return new Writable({
+    defaultEncoding: 'utf8',
+    write(chunk, _encoding, next) {
+      logger.verbose(chunk.toString().trim());
+      next();
+    },
+  });
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!
### Why?
We get a lot of internal support requests from documentation authors whose build fail without any helpful information, just a `Docker container returned a non-zero exit code (1)`

This PR makes running `generate` with the `--verbose` flag print the whole mkdocs output. The idea is that people can fix their issues without having to reach out to the team that owns techdocs.

### Trying to generate docs with problem in it
Previously with `--verbose` flag
```
info: Using source dir /Users/agentbellnorm/kod/morgans-test-docs/docs
info: Will output generated files in /Users/agentbellnorm/kod/morgans-test-docs/docs/site
verbose: Creating output directory if it does not exist.
info: Generating documentation...
Failed to generate docs from /Users/agentbellnorm/kod/morgans-test-docs/docs into /Users/agentbellnorm/kod/morgans-test-docs/docs/site; caused by Error: Docker container returned a non-zero exit code (1)
```

Now with `--verbose` flag
```
info: Using source dir /Users/agentbellnorm/kod/morgans-test-docs/docs
info: Will output generated files in /Users/agentbellnorm/kod/morgans-test-docs/docs/site
verbose: Creating output directory if it does not exist.
info: Generating documentation...
verbose: {"status":"Pulling from spotify/techdocs","id":"v1.1.0"}
verbose: {"status":"Digest: sha256:79ff0ca98454e7e8dbcc908af2a9e85ccda08e56213ff21c15507a2081aa5776"}
{"status":"Status: Image is up to date for spotify/techdocs:v1.1.0"}
verbose: ERROR    -  Config value: 'docs_dir'. Error: The path /input/docs isn't an existing directory.
verbose: Aborted with 1 Configuration Errors!
Failed to generate docs from /Users/agentbellnorm/kod/morgans-test-docs/docs into /Users/agentbellnorm/kod/morgans-test-docs/docs/site; caused by Error: Docker container returned a non-zero exit code (1)
```
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
