### PR TITLE
Add an "Other Templates" group for scaffolder/next when groups are passed in

### DIFF
--- a/.changeset/odd-waves-rescue.md
+++ b/.changeset/odd-waves-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Create an "Other Templates" group when groups are given to scaffolder/next.

--- a/plugins/scaffolder/dev/index.tsx
+++ b/plugins/scaffolder/dev/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { scaffolderApiRef, ScaffolderClient } from '../src';
-import { ScaffolderPage } from '../src/plugin';
+import { NextScaffolderPage, ScaffolderPage } from '../src/plugin';
 import {
   discoveryApiRef,
   fetchApiRef,
@@ -67,5 +67,46 @@ createDevApp()
     path: '/create',
     title: 'Create',
     element: <ScaffolderPage />,
+  })
+  .addPage({
+    path: '/next-create',
+    title: 'Create (next)',
+    element: <NextScaffolderPage />,
+  })
+  .addPage({
+    path: '/create-groups',
+    title: 'Groups',
+    element: (
+      <ScaffolderPage
+        groups={[
+          {
+            filter: e => e.metadata.tags?.includes('techdocs') || false,
+            title: 'Techdocs',
+          },
+          {
+            filter: e => e.metadata.tags?.includes('react') || false,
+            title: 'React',
+          },
+        ]}
+      />
+    ),
+  })
+  .addPage({
+    path: '/next-create-groups',
+    title: 'Groups (next)',
+    element: (
+      <NextScaffolderPage
+        groups={[
+          {
+            filter: e => e.metadata.tags?.includes('techdocs') || false,
+            title: 'Techdocs',
+          },
+          {
+            filter: e => e.metadata.tags?.includes('react') || false,
+            title: 'React',
+          },
+        ]}
+      />
+    ),
   })
   .render();

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -52,13 +52,27 @@ export type TemplateListPageProps = {
 };
 
 const defaultGroup: TemplateGroupFilter = {
-  title: 'All Templates',
+  title: 'Templates',
   filter: () => true,
 };
 
+const createGroupsWithOther = (
+  groups: TemplateGroupFilter[],
+): TemplateGroupFilter[] => [
+  ...groups,
+  {
+    title: 'Other Templates',
+    filter: e => ![...groups].some(({ filter }) => filter(e)),
+  },
+];
+
 export const TemplateListPage = (props: TemplateListPageProps) => {
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
-  const { TemplateCardComponent, groups = [] } = props;
+  const { TemplateCardComponent, groups: givenGroups = [] } = props;
+
+  const groups = givenGroups.length
+    ? createGroupsWithOther(givenGroups)
+    : [defaultGroup];
 
   return (
     <EntityListProvider>
@@ -96,7 +110,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
             </CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>
               <TemplateGroups
-                groups={[...groups, defaultGroup]}
+                groups={groups}
                 TemplateCardComponent={TemplateCardComponent}
               />
             </CatalogFilterLayout.Content>


### PR DESCRIPTION
Also adding a number of options to the dev page to see this change in action.

Fixes #16454

## Hey, I just made a Pull Request!

This is making the behavior of the Template groups in scaffolder/next match that of stable.

The reasons for this are laid out in #16454. I've also renames "All Templates" to "Templates" again, as I find the "All" weird when a user is searching. But that's just me.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Screenshot of the dev page, next with groups:

<img width="818" alt="Screenshot 2023-02-23 at 11 47 46" src="https://user-images.githubusercontent.com/43494/220885638-914d084a-f9e0-4c9f-bba5-a79ff55b3aa3.png">
