### PR TITLE
cli: only try to lint source files with --check

### DIFF
--- a/.changeset/light-sheep-trade.md
+++ b/.changeset/light-sheep-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated the ESLint plugin configuration that is enabled through `yarn start --check` to only pick up valid source files.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -100,7 +100,7 @@ export async function createConfig(
       }),
       new ESLintPlugin({
         context: paths.targetPath,
-        files: ['**', '!**/__tests__/**', '!**/?(*.)(spec|test).*'],
+        files: ['**/*.(ts|tsx|mts|cts|js|jsx|mjs|cjs)'],
       }),
     );
   }
@@ -325,7 +325,7 @@ export async function createBackendConfig(
               typescript: { configFile: paths.targetTsConfig },
             }),
             new ESLintPlugin({
-              files: ['**', '!**/__tests__/**', '!**/?(*.)(spec|test).*'],
+              files: ['**/*.(ts|tsx|mts|cts|js|jsx|mjs|cjs)'],
             }),
           ]
         : []),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #16296

Not quite sure why the existing config ignores tests tbh, any file that's covered should be alright to lint. Either way this makes sure that we only try to lint things that our default config knows how to lint. There's definitely some gap here in configurability, but it seems like this is not a very commonly used feature so I'm not feeling it's worth the time investment at this point.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
