### PR TITLE
Support full entity refs in the EntityPicker

### DIFF
--- a/.changeset/eighty-chairs-roll.md
+++ b/.changeset/eighty-chairs-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Update `EntityPicker` to use the fully qualified entity ref instead of the humanized version.

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -37,19 +37,11 @@ export function humanizeEntityRef(
   let kind;
   let namespace;
   let name;
-  console.log(entityRef);
 
   if ('metadata' in entityRef) {
     kind = entityRef.kind;
     namespace = entityRef.metadata.namespace;
     name = entityRef.metadata.name;
-
-    // Escapes when we know more about an entity.
-    if (entityRef.metadata.title) {
-      return entityRef.metadata.title;
-    } else if ((entityRef as UserEntity).spec?.profile?.displayName) {
-      return (entityRef as UserEntity).spec?.profile?.displayName;
-    }
   } else {
     kind = entityRef.kind;
     namespace = entityRef.namespace;

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -18,7 +18,6 @@ import {
   Entity,
   CompoundEntityRef,
   DEFAULT_NAMESPACE,
-  UserEntity,
 } from '@backstage/catalog-model';
 
 /**

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -18,6 +18,7 @@ import {
   Entity,
   CompoundEntityRef,
   DEFAULT_NAMESPACE,
+  UserEntity,
 } from '@backstage/catalog-model';
 
 /**
@@ -36,11 +37,19 @@ export function humanizeEntityRef(
   let kind;
   let namespace;
   let name;
+  console.log(entityRef);
 
   if ('metadata' in entityRef) {
     kind = entityRef.kind;
     namespace = entityRef.metadata.namespace;
     name = entityRef.metadata.name;
+
+    // Escapes when we know more about an entity.
+    if (entityRef.metadata.title) {
+      return entityRef.metadata.title;
+    } else if ((entityRef as UserEntity).spec?.profile?.displayName) {
+      return (entityRef as UserEntity).spec?.profile?.displayName;
+    }
   } else {
     kind = entityRef.kind;
     namespace = entityRef.namespace;

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -236,4 +236,54 @@ describe('<EntityPicker />', () => {
       });
     });
   });
+
+  describe('uses full entity ref', () => {
+    beforeEach(() => {
+      uiSchema = {
+        'ui:options': {
+          defaultKind: 'Group',
+        },
+      };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps<any>;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+    });
+
+    it('returns the full entityRef when entity exists in the list', async () => {
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      const input = getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: 'team-a' } });
+      fireEvent.blur(input);
+
+      expect(onChange).toHaveBeenCalledWith('group:default/team-a');
+    });
+
+    it('returns the full entityRef when entity does not exist in the list', async () => {
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      const input = getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: 'team-b' } });
+      fireEvent.blur(input);
+
+      expect(onChange).toHaveBeenCalledWith('group:default/team-b');
+    });
+  });
 });

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { GetEntitiesResponse } from '@backstage/catalog-client';
-import { RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   catalogApiRef,
@@ -54,12 +54,9 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
     uiSchema['ui:options']?.allowArbitraryValues ?? true;
   const { ownedEntities, loading } = useOwnedEntities(allowedKinds);
 
-  const entityRefs = ownedEntities?.items
-    .map(e => humanizeEntityRef(e, { defaultKind, defaultNamespace }))
-    .filter(n => n);
-
-  const onSelect = (_: any, value: string | null) => {
-    onChange(value || '');
+  const entities = ownedEntities?.items.filter(n => n);
+  const onSelect = (_: any, value: Entity | null) => {
+    onChange(value?.metadata.name || '');
   };
 
   return (
@@ -70,10 +67,10 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
     >
       <Autocomplete
         id={idSchema?.$id}
-        value={(formData as string) || ''}
+        // value={(formData as string) || ''}
         loading={loading}
         onChange={onSelect}
-        options={entityRefs || []}
+        options={entities || []}
         autoSelect
         freeSolo={allowArbitraryValues}
         renderInput={params => (

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -13,18 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GetEntitiesResponse } from '@backstage/catalog-client';
-import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
-import {
-  catalogApiRef,
-  humanizeEntityRef,
-} from '@backstage/plugin-catalog-react';
 import { TextField } from '@material-ui/core';
-import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-import React, { useMemo } from 'react';
+import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
+import { EntityPicker } from '../EntityPicker/EntityPicker';
 
 import { OwnedEntityPickerProps } from './schema';
 
@@ -38,95 +33,57 @@ export { OwnedEntityPickerSchema } from './schema';
  */
 export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
   const {
-    onChange,
     schema: { title = 'Entity', description = 'An entity from the catalog' },
-    required,
     uiSchema,
-    rawErrors,
-    formData,
-    idSchema,
+    required,
   } = props;
 
+  const identityApi = useApi(identityApiRef);
+  const { loading, value: identityRefs } = useAsync(async () => {
+    const identity = await identityApi.getBackstageIdentity();
+    return identity.ownershipEntityRefs;
+  });
+
   const allowedKinds = uiSchema['ui:options']?.allowedKinds;
-  const defaultKind = uiSchema['ui:options']?.defaultKind;
-  const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
-  const allowArbitraryValues =
-    uiSchema['ui:options']?.allowArbitraryValues ?? true;
-  const { ownedEntities, loading } = useOwnedEntities(allowedKinds);
-
-  const entities = ownedEntities?.items.filter(n => n);
-  const onSelect = (_: any, value: Entity | null) => {
-    onChange(value?.metadata.name || '');
-  };
-
-  return (
-    <FormControl
-      margin="normal"
-      required={required}
-      error={rawErrors?.length > 0 && !formData}
-    >
+  if (loading)
+    return (
       <Autocomplete
-        id={idSchema?.$id}
-        // value={(formData as string) || ''}
         loading={loading}
-        onChange={onSelect}
-        options={entities || []}
-        autoSelect
-        freeSolo={allowArbitraryValues}
         renderInput={params => (
           <TextField
             {...params}
             label={title}
-            margin="normal"
+            margin="dense"
             helperText={description}
+            FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
             variant="outlined"
             required={required}
             InputProps={params.InputProps}
           />
         )}
+        options={[]}
       />
-    </FormControl>
+    );
+
+  return (
+    <EntityPicker
+      {...props}
+      schema={{ title, description }}
+      allowedKinds={allowedKinds}
+      catalogFilter={
+        allowedKinds
+          ? {
+              filter: {
+                kind: allowedKinds,
+                [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
+              },
+            }
+          : {
+              filter: {
+                [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
+              },
+            }
+      }
+    />
   );
 };
-
-/**
- * Takes the relevant parts of the Backstage identity, and translates them into
- * a list of entities which are owned by the user. Takes an optional parameter
- * to filter the entities based on allowedKinds
- *
- *
- * @param allowedKinds - Array of allowed kinds to filter the entities
- */
-function useOwnedEntities(allowedKinds?: string[]): {
-  loading: boolean;
-  ownedEntities: GetEntitiesResponse | undefined;
-} {
-  const identityApi = useApi(identityApiRef);
-  const catalogApi = useApi(catalogApiRef);
-
-  const { loading, value: refs } = useAsync(async () => {
-    const identity = await identityApi.getBackstageIdentity();
-    const identityRefs = identity.ownershipEntityRefs;
-    const catalogs = await catalogApi.getEntities(
-      allowedKinds
-        ? {
-            filter: {
-              kind: allowedKinds,
-              [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
-            },
-          }
-        : {
-            filter: {
-              [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
-            },
-          },
-    );
-    return catalogs;
-  }, []);
-
-  const ownedEntities = useMemo(() => {
-    return refs;
-  }, [refs]);
-
-  return useMemo(() => ({ loading, ownedEntities }), [loading, ownedEntities]);
-}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/16301, by passing full entity refs through the scaffolder template.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


https://user-images.githubusercontent.com/34432188/221051676-0a72b0b2-041c-488c-a179-61f8ec2337e0.mov

