### PR TITLE
[TechDocs] Fix footer links for newer versions of mkdocs-material

### DIFF
--- a/.changeset/great-trains-jam.md
+++ b/.changeset/great-trains-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix bug that caused next and previous links not to work with certain versions of mkdocs-material

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -108,7 +108,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
   pointer-events: none;
 }
 
-.md-footer-nav__link {
+.md-footer-nav__link, .md-footer__link {
   pointer-events: all;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A bug was fixed in [#15708](https://github.com/backstage/backstage/pull/15708/), by adding some styles to a `mkdocs-material` owned class. 

This class changed names so this PR enables the fix for the new classname.

Details here: https://squidfunk.github.io/mkdocs-material/upgrade/#partialsfooterhtml_1

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
