### PR TITLE
scaffolder/next: Move `uiSchema` from `schema` into it's own property

### DIFF
--- a/.changeset/mighty-years-own.md
+++ b/.changeset/mighty-years-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Move the `uiSchema` to its own property to align with component development and access of `ui:options`

--- a/plugins/scaffolder-react/alpha-api-report.md
+++ b/plugins/scaffolder-react/alpha-api-report.md
@@ -64,13 +64,17 @@ export type FormProps = Pick<
 >;
 
 // @alpha
-export type NextCustomFieldValidator<TFieldReturnValue> = (
+export type NextCustomFieldValidator<
+  TFieldReturnValue,
+  TUiOptions = unknown,
+> = (
   data: TFieldReturnValue,
   field: FieldValidation,
   context: {
     apiHolder: ApiHolder;
     formData: JsonObject;
     schema: JsonObject;
+    uiSchema?: NextFieldExtensionUiSchema<TFieldReturnValue, TUiOptions>;
   },
 ) => void | Promise<void>;
 
@@ -80,23 +84,28 @@ export interface NextFieldExtensionComponentProps<
   TUiOptions = {},
 > extends PropsWithChildren<FieldProps<TFieldReturnValue>> {
   // (undocumented)
-  uiSchema?: UiSchema<TFieldReturnValue> & {
-    'ui:options'?: TUiOptions & UIOptionsType;
-  };
+  uiSchema?: NextFieldExtensionUiSchema<TFieldReturnValue, TUiOptions>;
 }
 
 // @alpha
 export type NextFieldExtensionOptions<
   TFieldReturnValue = unknown,
-  TInputProps = unknown,
+  TUiOptions = unknown,
 > = {
   name: string;
   component: (
-    props: NextFieldExtensionComponentProps<TFieldReturnValue, TInputProps>,
+    props: NextFieldExtensionComponentProps<TFieldReturnValue, TUiOptions>,
   ) => JSX.Element | null;
-  validation?: NextCustomFieldValidator<TFieldReturnValue>;
+  validation?: NextCustomFieldValidator<TFieldReturnValue, TUiOptions>;
   schema?: CustomFieldExtensionSchema;
 };
+
+// @alpha
+export interface NextFieldExtensionUiSchema<TFieldReturnValue, TUiOptions>
+  extends UiSchema<TFieldReturnValue> {
+  // (undocumented)
+  'ui:options'?: TUiOptions & UIOptionsType;
+}
 
 // @alpha
 export interface ParsedTemplateSchema {

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
@@ -100,10 +100,12 @@ describe('createAsyncValidators', () => {
       expect.objectContaining({
         schema: {
           type: 'string',
+          pattern: 'lols',
+        },
+        uiSchema: {
           'ui:options': {
             bob: true,
           },
-          pattern: 'lols',
           'ui:field': 'NameField',
         },
       }),
@@ -115,7 +117,6 @@ describe('createAsyncValidators', () => {
       expect.objectContaining({
         schema: {
           type: 'object',
-          'ui:field': 'AddressField',
           properties: {
             street: {
               type: 'string',
@@ -124,6 +125,11 @@ describe('createAsyncValidators', () => {
               type: 'string',
             },
           },
+        },
+        uiSchema: {
+          'ui:field': 'AddressField',
+          street: {},
+          postcode: {},
         },
       }),
     );

--- a/plugins/scaffolder-react/src/next/extensions/index.tsx
+++ b/plugins/scaffolder-react/src/next/extensions/index.tsx
@@ -18,6 +18,7 @@ import {
   NextCustomFieldValidator,
   NextFieldExtensionOptions,
   NextFieldExtensionComponentProps,
+  NextFieldExtensionUiSchema,
 } from './types';
 import { Extension, attachComponentData } from '@backstage/core-plugin-api';
 import { UIOptionsType } from '@rjsf/utils';
@@ -55,4 +56,5 @@ export type {
   NextCustomFieldValidator,
   NextFieldExtensionOptions,
   NextFieldExtensionComponentProps,
+  NextFieldExtensionUiSchema,
 };

--- a/plugins/scaffolder-react/src/next/extensions/types.ts
+++ b/plugins/scaffolder-react/src/next/extensions/types.ts
@@ -33,9 +33,17 @@ export interface NextFieldExtensionComponentProps<
   TFieldReturnValue,
   TUiOptions = {},
 > extends PropsWithChildren<FieldPropsV5<TFieldReturnValue>> {
-  uiSchema?: UiSchemaV5<TFieldReturnValue> & {
-    'ui:options'?: TUiOptions & UIOptionsType;
-  };
+  uiSchema?: NextFieldExtensionUiSchema<TFieldReturnValue, TUiOptions>;
+}
+
+/**
+ * Type for Field Extension UiSchema
+ *
+ * @alpha
+ */
+export interface NextFieldExtensionUiSchema<TFieldReturnValue, TUiOptions>
+  extends UiSchemaV5<TFieldReturnValue> {
+  'ui:options'?: TUiOptions & UIOptionsType;
 }
 
 /**
@@ -43,13 +51,17 @@ export interface NextFieldExtensionComponentProps<
  *
  * @alpha
  */
-export type NextCustomFieldValidator<TFieldReturnValue> = (
+export type NextCustomFieldValidator<
+  TFieldReturnValue,
+  TUiOptions = unknown,
+> = (
   data: TFieldReturnValue,
   field: FieldValidationV5,
   context: {
     apiHolder: ApiHolder;
     formData: JsonObject;
     schema: JsonObject;
+    uiSchema?: NextFieldExtensionUiSchema<TFieldReturnValue, TUiOptions>;
   },
 ) => void | Promise<void>;
 
@@ -61,12 +73,12 @@ export type NextCustomFieldValidator<TFieldReturnValue> = (
  */
 export type NextFieldExtensionOptions<
   TFieldReturnValue = unknown,
-  TInputProps = unknown,
+  TUiOptions = unknown,
 > = {
   name: string;
   component: (
-    props: NextFieldExtensionComponentProps<TFieldReturnValue, TInputProps>,
+    props: NextFieldExtensionComponentProps<TFieldReturnValue, TUiOptions>,
   ) => JSX.Element | null;
-  validation?: NextCustomFieldValidator<TFieldReturnValue>;
+  validation?: NextCustomFieldValidator<TFieldReturnValue, TUiOptions>;
   schema?: CustomFieldExtensionSchema;
 };


### PR DESCRIPTION
- chore: split out the uiSchema in the context to align with components
- chore: added changeset
- cyhore: fixing api reports

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
