### PR TITLE
Providing a way to define initial state for the scaffolder template form not via GET parameters

### DIFF
--- a/.changeset/fast-pots-knock.md
+++ b/.changeset/fast-pots-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Providing a way to define initial state for the form not via GET parameters.

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -69,7 +69,7 @@ export type CustomFieldValidator<TReturnFieldData> =
 export const EntityNamePickerFieldExtension: FieldExtensionComponent_2<
   string,
   {}
->;
+  >;
 
 // @public
 export const EntityPickerFieldExtension: FieldExtensionComponent_2<
@@ -84,7 +84,7 @@ export const EntityPickerFieldExtension: FieldExtensionComponent_2<
       | Record<string, string | string[]>[]
       | undefined;
   }
->;
+  >;
 
 // @public (undocumented)
 export const EntityPickerFieldSchema: FieldSchema<
@@ -99,7 +99,7 @@ export const EntityPickerFieldSchema: FieldSchema<
       | Record<string, string | string[]>[]
       | undefined;
   }
->;
+  >;
 
 // @public
 export type EntityPickerUiOptions =
@@ -113,7 +113,7 @@ export const EntityTagsPickerFieldExtension: FieldExtensionComponent_2<
     kinds?: string[] | undefined;
     helperText?: string | undefined;
   }
->;
+  >;
 
 // @public (undocumented)
 export const EntityTagsPickerFieldSchema: FieldSchema<
@@ -123,7 +123,7 @@ export const EntityTagsPickerFieldSchema: FieldSchema<
     kinds?: string[] | undefined;
     helperText?: string | undefined;
   }
->;
+  >;
 
 // @public
 export type EntityTagsPickerUiOptions =
@@ -137,7 +137,7 @@ export type FieldExtensionComponent<_TReturnValue, _TInputProps> =
 export type FieldExtensionComponentProps<
   TFieldReturnValue,
   TUiOptions extends {} = {},
-> = FieldExtensionComponentProps_2<TFieldReturnValue, TUiOptions>;
+  > = FieldExtensionComponentProps_2<TFieldReturnValue, TUiOptions>;
 
 // @public @deprecated (undocumented)
 export type FieldExtensionOptions = FieldExtensionOptions_2;
@@ -168,7 +168,7 @@ export type LogEvent = LogEvent_2;
 export function makeFieldSchemaFromZod<
   TReturnSchema extends z.ZodType,
   TUiOptionsSchema extends z.ZodType = z.ZodType<any, any, {}>,
->(
+  >(
   returnSchema: TReturnSchema,
   uiOptionsSchema?: TUiOptionsSchema,
 ): FieldSchema<
@@ -176,7 +176,7 @@ export function makeFieldSchemaFromZod<
   TUiOptionsSchema extends z.ZodType<any, any, infer IUiOptions>
     ? IUiOptions
     : never
->;
+  >;
 
 // @public
 export const OwnedEntityPickerFieldExtension: FieldExtensionComponent_2<
@@ -187,7 +187,7 @@ export const OwnedEntityPickerFieldExtension: FieldExtensionComponent_2<
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
   }
->;
+  >;
 
 // @public (undocumented)
 export const OwnedEntityPickerFieldSchema: FieldSchema<
@@ -198,7 +198,7 @@ export const OwnedEntityPickerFieldSchema: FieldSchema<
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
   }
->;
+  >;
 
 // @public
 export type OwnedEntityPickerUiOptions =
@@ -216,7 +216,7 @@ export const OwnerPickerFieldExtension: FieldExtensionComponent_2<
       | Record<string, string | string[]>[]
       | undefined;
   }
->;
+  >;
 
 // @public (undocumented)
 export const OwnerPickerFieldSchema: FieldSchema<
@@ -230,7 +230,7 @@ export const OwnerPickerFieldSchema: FieldSchema<
       | Record<string, string | string[]>[]
       | undefined;
   }
->;
+  >;
 
 // @public
 export type OwnerPickerUiOptions = typeof OwnerPickerFieldSchema.uiOptionsType;
@@ -255,20 +255,20 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
     allowedRepos?: string[] | undefined;
     requestUserCredentials?:
       | {
-          additionalScopes?:
-            | {
-                azure?: string[] | undefined;
-                github?: string[] | undefined;
-                gitlab?: string[] | undefined;
-                bitbucket?: string[] | undefined;
-                gerrit?: string[] | undefined;
-              }
-            | undefined;
-          secretsKey: string;
-        }
+      additionalScopes?:
+        | {
+        azure?: string[] | undefined;
+        github?: string[] | undefined;
+        gitlab?: string[] | undefined;
+        bitbucket?: string[] | undefined;
+        gerrit?: string[] | undefined;
+      }
+        | undefined;
+      secretsKey: string;
+    }
       | undefined;
   }
->;
+  >;
 
 // @public (undocumented)
 export const RepoUrlPickerFieldSchema: FieldSchema<
@@ -281,20 +281,20 @@ export const RepoUrlPickerFieldSchema: FieldSchema<
     allowedRepos?: string[] | undefined;
     requestUserCredentials?:
       | {
-          additionalScopes?:
-            | {
-                azure?: string[] | undefined;
-                github?: string[] | undefined;
-                gitlab?: string[] | undefined;
-                bitbucket?: string[] | undefined;
-                gerrit?: string[] | undefined;
-              }
-            | undefined;
-          secretsKey: string;
-        }
+      additionalScopes?:
+        | {
+        azure?: string[] | undefined;
+        github?: string[] | undefined;
+        gitlab?: string[] | undefined;
+        bitbucket?: string[] | undefined;
+        gerrit?: string[] | undefined;
+      }
+        | undefined;
+      secretsKey: string;
+    }
       | undefined;
   }
->;
+  >;
 
 // @public
 export type RepoUrlPickerUiOptions =
@@ -323,8 +323,8 @@ export type RouterProps = {
     ReviewStepComponent?: ComponentType<ReviewStepProps>;
     TemplateCardComponent?:
       | ComponentType<{
-          template: TemplateEntityV1beta3;
-        }>
+      template: TemplateEntityV1beta3;
+    }>
       | undefined;
     TaskPageComponent?: ComponentType<{}>;
   };
@@ -342,6 +342,7 @@ export type RouterProps = {
     editor?: boolean;
     actions?: boolean;
   };
+  getTemplateInitialState?(templateRef: string): Promise<any>;
 };
 
 // @public @deprecated (undocumented)
@@ -421,7 +422,7 @@ export const scaffolderPlugin: BackstagePlugin<
     root: RouteRef<undefined>;
     selectedTemplate: SubRouteRef<
       PathParams<'/templates/:namespace/:templateName'>
-    >;
+      >;
     ongoingTask: SubRouteRef<PathParams<'/tasks/:taskId'>>;
   },
   {
@@ -433,10 +434,10 @@ export const scaffolderPlugin: BackstagePlugin<
         namespace: string;
       },
       true
-    >;
+      >;
   },
   {}
->;
+  >;
 
 // @public @deprecated (undocumented)
 export type ScaffolderScaffoldOptions = ScaffolderScaffoldOptions_2;

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -73,6 +73,12 @@ export type RouterProps = {
     /** Whether to show a link to the actions documentation */
     actions?: boolean;
   };
+  /**
+   * Optional function returning the initial state for a specific template.
+   *
+   * @param templateRef - reference to a template, i.e. template:default/my-template
+   */
+  getTemplateInitialState?(templateRef: string): Promise<any>;
 };
 
 /**
@@ -81,7 +87,12 @@ export type RouterProps = {
  * @public
  */
 export const Router = (props: RouterProps) => {
-  const { groups, components = {}, defaultPreviewTemplate } = props;
+  const {
+    groups,
+    components = {},
+    defaultPreviewTemplate,
+    getTemplateInitialState,
+  } = props;
 
   const { ReviewStepComponent, TemplateCardComponent, TaskPageComponent } =
     components;
@@ -145,6 +156,7 @@ export const Router = (props: RouterProps) => {
               customFieldExtensions={fieldExtensions}
               layouts={customLayouts}
               headerOptions={props.headerOptions}
+              getTemplateInitialState={getTemplateInitialState}
             />
           </SecretsContextProvider>
         }

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -16,7 +16,7 @@
 import { LinearProgress } from '@material-ui/core';
 import { IChangeEvent } from '@rjsf/core';
 import qs from 'qs';
-import React, { ComponentType, useCallback, useState } from 'react';
+import React, { ComponentType, useCallback, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import useAsync from 'react-use/lib/useAsync';
 import {
@@ -44,6 +44,7 @@ import {
   scaffolderTaskRouteRef,
   selectedTemplateRouteRef,
 } from '../../routes';
+import lodash from 'lodash';
 
 const useTemplateParameterSchema = (templateRef: string) => {
   const scaffolderApi = useApi(scaffolderApiRef);
@@ -63,6 +64,7 @@ type Props = {
     title?: string;
     subtitle?: string;
   };
+  getTemplateInitialState?(templateRef: string): Promise<any>;
 };
 
 export const TemplatePage = ({
@@ -70,6 +72,7 @@ export const TemplatePage = ({
   customFieldExtensions = [],
   layouts = [],
   headerOptions,
+  getTemplateInitialState,
 }: Props) => {
   const apiHolder = useApiHolder();
   const secretsContext = useTemplateSecrets();
@@ -98,6 +101,14 @@ export const TemplatePage = ({
       return query.formData ?? {};
     }
   });
+
+  useMemo(() => {
+    getTemplateInitialState?.(templateRef).then((data: any) => {
+      setFormState(lodash.merge(JSON.parse(data), formState));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleFormReset = () => setFormState({});
   const handleChange = useCallback(
     (e: IChangeEvent) => setFormState(e.formData),
@@ -111,16 +122,18 @@ export const TemplatePage = ({
       secrets: secretsContext?.secrets,
     });
 
-    const formParams = qs.stringify(
-      { formData: formState },
-      { addQueryPrefix: true },
-    );
-    const newUrl = `${window.location.pathname}${formParams}`;
-    // We use direct history manipulation since useSearchParams and
-    // useNavigate in react-router-dom cause unnecessary extra rerenders.
-    // Also make sure to replace the state rather than pushing to avoid
-    // extra back/forward slots.
-    window.history?.replaceState(null, document.title, newUrl);
+    if (!getTemplateInitialState) {
+      const formParams = qs.stringify(
+        { formData: formState },
+        { addQueryPrefix: true },
+      );
+      const newUrl = `${window.location.pathname}${formParams}`;
+      // We use direct history manipulation since useSearchParams and
+      // useNavigate in react-router-dom cause unnecessary extra rerenders.
+      // Also make sure to replace the state rather than pushing to avoid
+      // extra back/forward slots.
+      window.history?.replaceState(null, document.title, newUrl);
+    }
 
     navigate(scaffolderTaskRoute({ taskId }));
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I would like to define the initial state for the scaffolder form not via GET parameters to support all browsers. 
Get parameters is not the best place to keep such data due to browser limitations there https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers 
When form contains such fields as a list of links, description, etc. 2k of characters is not so hard to exceed.

Instead of that, I suggest to define by the user a lazy map of initial states for each template where it is required. 
Where the key is a key ref for the template and value is the async function, which will return the initial state. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
