### PR TITLE
Added an 'actions' prop to EntityLayout allowing it to override the E…

### DIFF
--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -150,13 +150,27 @@ interface EntityContextMenuOptions {
   disableUnregister: boolean | VisibleType;
 }
 
-/** @public */
-export interface EntityLayoutProps {
-  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
-  UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
-  children?: React.ReactNode;
+interface EntityLayoutDefaultProps {
+  children: React.ReactNode;
   NotFoundComponent?: React.ReactNode;
 }
+
+interface EntityLayoutDefaultActions extends EntityLayoutDefaultProps {
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+  UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
+  actions?: never;
+}
+
+interface EntityLayoutCustomActions extends EntityLayoutDefaultProps {
+  UNSTABLE_extraContextMenuItems?: never;
+  UNSTABLE_contextMenuOptions?: never;
+  actions?: React.ReactNode;
+}
+
+/** @public */
+export type EntityLayoutProps =
+  | EntityLayoutDefaultActions
+  | EntityLayoutCustomActions;
 
 /**
  * EntityLayout is a compound component, which allows you to define a layout for
@@ -179,6 +193,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   const {
     UNSTABLE_extraContextMenuItems,
     UNSTABLE_contextMenuOptions,
+    actions,
     children,
     NotFoundComponent,
   } = props;
@@ -245,17 +260,20 @@ export const EntityLayout = (props: EntityLayoutProps) => {
         pageTitleOverride={headerTitle}
         type={headerType}
       >
-        {entity && (
-          <>
-            <EntityLabels entity={entity} />
-            <EntityContextMenu
-              UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
-              UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
-              onUnregisterEntity={() => setConfirmationDialogOpen(true)}
-              onInspectEntity={() => setInspectionDialogOpen(true)}
-            />
-          </>
-        )}
+        {entity &&
+          (Boolean(actions) ? (
+            actions
+          ) : (
+            <>
+              <EntityLabels entity={entity} />
+              <EntityContextMenu
+                UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
+                UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
+                onUnregisterEntity={() => setConfirmationDialogOpen(true)}
+                onInspectEntity={() => setInspectionDialogOpen(true)}
+              />
+            </>
+          ))}
       </Header>
 
       {loading && <Progress />}


### PR DESCRIPTION
…ntityLabels and EntityContextMenu

## Hey, I just made a Pull Request!

Following the discussion in #16173 , I added a non-breaking prop called `actions` to `EntityLayout` 
* it replaces the (left) actions side of the component header overriding the EntityLabels and EntityContextMenu components. 
* it is optional and exclusive, not allowing any context menu prop (`UNSTABLE_extraContextMenuItems` and `UNSTABLE_contextMenuOptions`) to be used when it's present and vice-versa.

Default behavior:
![entity-layout-default-behavior](https://user-images.githubusercontent.com/10953022/221710934-68e79f8a-9f2e-49a9-871d-c9d22c258393.png)

With `actions` prop
![entity-layout-actions-prop](https://user-images.githubusercontent.com/10953022/221711006-4a02e2e5-6a05-479b-8499-b4ecd6b2c2dd.png)

Note: I haven't written tests for this feature yet as I'd like to verify that this approach is acceptable before proceeding.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
