### PR TITLE
upgrade aws-sdk to v3 for AwsS3UrlReader

### DIFF
--- a/.changeset/rotten-panthers-share.md
+++ b/.changeset/rotten-panthers-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+AwsS3UrlReader upgraded to use aws-sdk v3

--- a/.changeset/rotten-panthers-share.md
+++ b/.changeset/rotten-panthers-share.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/backend-common': minor
-'@backstage/plugin-catalog-backend-module-aws': minor
+'@backstage/backend-common': patch
+'@backstage/plugin-catalog-backend-module-aws': patch
 ---
 
 AwsS3UrlReader upgraded to use aws-sdk v3

--- a/.changeset/rotten-panthers-share.md
+++ b/.changeset/rotten-panthers-share.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/backend-common': minor
+'@backstage/plugin-catalog-backend-module-aws': minor
 ---
 
 AwsS3UrlReader upgraded to use aws-sdk v3

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -6,7 +6,6 @@
 /// <reference types="node" />
 /// <reference types="webpack-env" />
 
-import aws from 'aws-sdk';
 import { AwsS3Integration } from '@backstage/integration';
 import { AzureIntegration } from '@backstage/integration';
 import { BackendFeature } from '@backstage/backend-plugin-api';
@@ -51,6 +50,7 @@ import { ReadUrlOptions } from '@backstage/backend-plugin-api';
 import { ReadUrlResponse } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { Router } from 'express';
+import { S3Client } from '@aws-sdk/client-s3';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { SearchOptions } from '@backstage/backend-plugin-api';
 import { SearchResponse } from '@backstage/backend-plugin-api';
@@ -67,12 +67,18 @@ import { Writable } from 'stream';
 // @public
 export class AwsS3UrlReader implements UrlReader {
   constructor(
+    defaultConfig: Config,
     integration: AwsS3Integration,
     deps: {
-      s3: aws.S3;
       treeResponseFactory: ReadTreeResponseFactory;
     },
   );
+  // (undocumented)
+  buildS3Client(
+    defaultConfig: Config,
+    region: string,
+    integration: AwsS3Integration,
+  ): Promise<S3Client>;
   // (undocumented)
   static factory: ReaderFactory;
   // (undocumented)
@@ -81,6 +87,8 @@ export class AwsS3UrlReader implements UrlReader {
   readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
   // (undocumented)
   readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  // (undocumented)
+  retrieveS3ObjectData(stream: Readable): Promise<Readable>;
   // (undocumented)
   search(): Promise<SearchResponse>;
   // (undocumented)

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 /// <reference types="webpack-env" />
 
+import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsS3Integration } from '@backstage/integration';
 import { AzureIntegration } from '@backstage/integration';
 import { BackendFeature } from '@backstage/backend-plugin-api';
@@ -66,7 +67,7 @@ import { Writable } from 'stream';
 // @public
 export class AwsS3UrlReader implements UrlReader {
   constructor(
-    defaultConfig: Config,
+    credsManager: AwsCredentialsManager,
     integration: AwsS3Integration,
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -50,7 +50,6 @@ import { ReadUrlOptions } from '@backstage/backend-plugin-api';
 import { ReadUrlResponse } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { Router } from 'express';
-import { S3Client } from '@aws-sdk/client-s3';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { SearchOptions } from '@backstage/backend-plugin-api';
 import { SearchResponse } from '@backstage/backend-plugin-api';
@@ -74,12 +73,6 @@ export class AwsS3UrlReader implements UrlReader {
     },
   );
   // (undocumented)
-  buildS3Client(
-    defaultConfig: Config,
-    region: string,
-    integration: AwsS3Integration,
-  ): Promise<S3Client>;
-  // (undocumented)
   static factory: ReaderFactory;
   // (undocumented)
   read(url: string): Promise<Buffer>;
@@ -87,8 +80,6 @@ export class AwsS3UrlReader implements UrlReader {
   readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
   // (undocumented)
   readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
-  // (undocumented)
-  retrieveS3ObjectData(stream: Readable): Promise<Readable>;
   // (undocumented)
   search(): Promise<SearchResponse>;
   // (undocumented)

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -46,10 +46,10 @@
     "test:kubernetes": "backstage-cli package test -t KubernetesContainerRunner --no-watch"
   },
   "dependencies": {
-    "@aws-sdk/abort-controller": "^3.272.0",
-    "@aws-sdk/client-s3": "^3.276.0",
-    "@aws-sdk/credential-providers": "^3.276.0",
-    "@aws-sdk/types": "^3.272.0",
+    "@aws-sdk/abort-controller": "^3.208.0",
+    "@aws-sdk/client-s3": "^3.208.0",
+    "@aws-sdk/credential-providers": "^3.208.0",
+    "@aws-sdk/types": "^3.208.0",
     "@backstage/backend-app-api": "workspace:^",
     "@backstage/backend-dev-utils": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
@@ -114,7 +114,7 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/util-stream-node": "^3.272.0",
+    "@aws-sdk/util-stream-node": "^3.208.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/archiver": "^5.1.0",
@@ -133,7 +133,7 @@
     "@types/tar": "^6.1.1",
     "@types/webpack-env": "^1.15.2",
     "@types/yauzl": "^2.10.0",
-    "aws-sdk-client-mock": "^2.0.1",
+    "aws-sdk-client-mock": "^2.0.0",
     "aws-sdk-mock": "^5.2.1",
     "better-sqlite3": "^8.0.0",
     "http-errors": "^2.0.0",

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -136,6 +136,7 @@
     "aws-sdk-client-mock": "^2.0.1",
     "aws-sdk-mock": "^5.2.1",
     "better-sqlite3": "^8.0.0",
+    "http-errors": "^2.0.0",
     "mock-fs": "^5.1.0",
     "msw": "^1.0.0",
     "mysql2": "^2.2.5",

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -46,6 +46,10 @@
     "test:kubernetes": "backstage-cli package test -t KubernetesContainerRunner --no-watch"
   },
   "dependencies": {
+    "@aws-sdk/abort-controller": "^3.272.0",
+    "@aws-sdk/client-s3": "^3.276.0",
+    "@aws-sdk/credential-providers": "^3.276.0",
+    "@aws-sdk/types": "^3.272.0",
     "@backstage/backend-app-api": "workspace:^",
     "@backstage/backend-dev-utils": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
@@ -54,6 +58,7 @@
     "@backstage/config-loader": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
+    "@backstage/integration-aws-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "@google-cloud/storage": "^6.0.0",
     "@keyv/memcache": "^1.3.5",
@@ -67,7 +72,6 @@
     "@types/luxon": "^3.0.0",
     "@types/webpack-env": "^1.15.2",
     "archiver": "^5.0.2",
-    "aws-sdk": "^2.840.0",
     "base64-stream": "^1.0.0",
     "compression": "^1.7.4",
     "concat-stream": "^2.0.0",
@@ -110,6 +114,7 @@
     }
   },
   "devDependencies": {
+    "@aws-sdk/util-stream-node": "^3.272.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/archiver": "^5.1.0",
@@ -128,9 +133,9 @@
     "@types/tar": "^6.1.1",
     "@types/webpack-env": "^1.15.2",
     "@types/yauzl": "^2.10.0",
+    "aws-sdk-client-mock": "^2.0.1",
     "aws-sdk-mock": "^5.2.1",
     "better-sqlite3": "^8.0.0",
-    "http-errors": "^2.0.0",
     "mock-fs": "^5.1.0",
     "msw": "^1.0.0",
     "mysql2": "^2.2.5",

--- a/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
@@ -18,8 +18,6 @@ import { ConfigReader } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import { getVoidLogger } from '../logging';
 import { DefaultReadTreeResponseFactory } from './tree';
-import { setupServer } from 'msw/node';
-import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { DEFAULT_REGION, AwsS3UrlReader, parseUrl } from './AwsS3UrlReader';
 import {
   AwsS3Integration,
@@ -130,8 +128,6 @@ describe('parseUrl', () => {
 
 describe('AwsS3UrlReader', () => {
   const s3Client = mockClient(S3Client);
-  const worker = setupServer();
-  setupRequestMockHandlers(worker);
 
   const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
     return AwsS3UrlReader.factory({

--- a/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
@@ -23,6 +23,7 @@ import {
   AwsS3Integration,
   readAwsS3IntegrationConfig,
 } from '@backstage/integration';
+import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { UrlReaderPredicateTuple } from './types';
 import path from 'path';
 import { NotModifiedError } from '@backstage/errors';
@@ -440,8 +441,10 @@ describe('AwsS3UrlReader', () => {
         secretAccessKey: 'fake-secret-key',
       });
 
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+
       awsS3UrlReader = new AwsS3UrlReader(
-        config,
+        credsManager,
         new AwsS3Integration(readAwsS3IntegrationConfig(config)),
         { treeResponseFactory },
       );

--- a/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
@@ -18,19 +18,26 @@ import { ConfigReader } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import { getVoidLogger } from '../logging';
 import { DefaultReadTreeResponseFactory } from './tree';
-import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
-import { AwsS3UrlReader, parseUrl } from './AwsS3UrlReader';
+import { DEFAULT_REGION, AwsS3UrlReader, parseUrl } from './AwsS3UrlReader';
 import {
   AwsS3Integration,
   readAwsS3IntegrationConfig,
 } from '@backstage/integration';
 import { UrlReaderPredicateTuple } from './types';
-import AWSMock from 'aws-sdk-mock';
-import aws from 'aws-sdk';
 import path from 'path';
 import { NotModifiedError } from '@backstage/errors';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  ListObjectsV2Output,
+  GetObjectCommand,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
+import fs from 'fs';
 
 const treeResponseFactory = DefaultReadTreeResponseFactory.create({
   config: new ConfigReader({}),
@@ -97,7 +104,7 @@ describe('parseUrl', () => {
     ).toEqual({
       path: 'a/puppy.jpg',
       bucket: 'my.bucket-3',
-      region: '',
+      region: DEFAULT_REGION,
     });
     expect(
       parseUrl('https://my.bucket-3.my-host.com/a/puppy.jpg', {
@@ -106,7 +113,7 @@ describe('parseUrl', () => {
     ).toEqual({
       path: 'a/puppy.jpg',
       bucket: 'my.bucket-3',
-      region: '',
+      region: DEFAULT_REGION,
     });
     expect(
       parseUrl('https://ignored.my-host.com/my.bucket-3/a/puppy.jpg', {
@@ -116,12 +123,13 @@ describe('parseUrl', () => {
     ).toEqual({
       path: 'a/puppy.jpg',
       bucket: 'my.bucket-3',
-      region: '',
+      region: DEFAULT_REGION,
     });
   });
 });
 
 describe('AwsS3UrlReader', () => {
+  const s3Client = mockClient(S3Client);
   const worker = setupServer();
   setupRequestMockHandlers(worker);
 
@@ -232,17 +240,19 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      worker.use(
-        rest.get(
-          'https://test-bucket.s3.amazonaws.com/awsS3-mock-object.yaml',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('ETag', '123abc'),
-              ctx.body('site_name: Test'),
+      s3Client.reset();
+
+      s3Client.on(GetObjectCommand).resolves({
+        Body: sdkStreamMixin(
+          fs.createReadStream(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
             ),
+          ),
         ),
-      );
+        ETag: '123abc',
+      });
     });
 
     it('returns contents of an object in a bucket', async () => {
@@ -280,17 +290,19 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      worker.use(
-        rest.get(
-          'https://test-bucket.s3.amazonaws.com/awsS3-mock-object.yaml',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('ETag', '123abc'),
-              ctx.body('site_name: Test'),
+      s3Client.reset();
+
+      s3Client.on(GetObjectCommand).resolves({
+        Body: sdkStreamMixin(
+          fs.createReadStream(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
             ),
+          ),
         ),
-      );
+        ETag: '123abc',
+      });
     });
 
     it('returns contents of an object in a bucket via buffer', async () => {
@@ -340,17 +352,17 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      worker.use(
-        rest.get(
-          'http://localhost:4566/test-bucket/awsS3-mock-object.yaml',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('ETag', '123abc'),
-              ctx.body('site_name: Test'),
+      s3Client.on(GetObjectCommand).resolves({
+        Body: sdkStreamMixin(
+          fs.createReadStream(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
             ),
+          ),
         ),
-      );
+        ETag: '123abc',
+      });
     });
 
     it('returns contents of an object in a bucket via buffer', async () => {
@@ -377,12 +389,13 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      worker.use(
-        rest.get(
-          'https://test-bucket.s3.amazonaws.com/awsS3-mock-object.yaml',
-          (_, res, ctx) => res(ctx.status(304)),
-        ),
-      );
+      s3Client.reset();
+      const t = new S3ServiceException({
+        name: '304',
+        $fault: 'client',
+        $metadata: { httpStatusCode: 304 },
+      });
+      s3Client.on(GetObjectCommand).rejects(t);
     });
 
     it('returns contents of an object in a bucket', async () => {
@@ -400,44 +413,41 @@ describe('AwsS3UrlReader', () => {
   describe('readTree', () => {
     let awsS3UrlReader: AwsS3UrlReader;
 
-    beforeAll(() => {
-      const object: aws.S3.Types.Object = {
+    beforeEach(() => {
+      s3Client.reset();
+
+      const object: Object = {
         Key: 'awsS3-mock-object.yaml',
       };
 
-      const objectList: aws.S3.ObjectList = [object];
-      const output: aws.S3.Types.ListObjectsV2Output = {
+      const objectList: Object[] = [object];
+      const output: ListObjectsV2Output = {
         Contents: objectList,
       };
 
-      AWSMock.setSDKInstance(aws);
-      AWSMock.mock('S3', 'listObjectsV2', output);
+      s3Client.on(ListObjectsV2Command).resolves(output);
 
-      AWSMock.mock(
-        'S3',
-        'getObject',
-        Buffer.from(
-          require('fs').readFileSync(
+      s3Client.on(GetObjectCommand).resolves({
+        Body: sdkStreamMixin(
+          fs.createReadStream(
             path.resolve(
               __dirname,
               '__fixtures__/awsS3/awsS3-mock-object.yaml',
             ),
           ),
         ),
-      );
+      });
 
-      const s3 = new aws.S3();
+      const config = new ConfigReader({
+        host: '.amazonaws.com',
+        accessKeyId: 'fake-access-key',
+        secretAccessKey: 'fake-secret-key',
+      });
+
       awsS3UrlReader = new AwsS3UrlReader(
-        new AwsS3Integration(
-          readAwsS3IntegrationConfig(
-            new ConfigReader({
-              host: '.amazonaws.com',
-              accessKeyId: 'fake-access-key',
-              secretAccessKey: 'fake-secret-key',
-            }),
-          ),
-        ),
-        { s3, treeResponseFactory },
+        config,
+        new AwsS3Integration(readAwsS3IntegrationConfig(config)),
+        { treeResponseFactory },
       );
     });
 

--- a/packages/backend-common/src/reading/AwsS3UrlReader.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.ts
@@ -180,7 +180,6 @@ export class AwsS3UrlReader implements UrlReader {
       return (await credsManager.getCredentialProvider()).sdkCredentialProvider;
     }
 
-    // Pull credentials from the techdocs config section (deprecated)
     const accessKeyId = integration.config.accessKeyId;
     const secretAccessKey = integration.config.secretAccessKey;
     let explicitCredentials: AwsCredentialIdentityProvider;

--- a/packages/backend-common/src/reading/AwsS3UrlReader.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.ts
@@ -162,10 +162,10 @@ export class AwsS3UrlReader implements UrlReader {
     secretAccessKey: string,
   ): AwsCredentialIdentityProvider {
     return async () => {
-      return Promise.resolve({
+      return {
         accessKeyId,
         secretAccessKey,
-      });
+      };
     };
   }
 
@@ -210,7 +210,7 @@ export class AwsS3UrlReader implements UrlReader {
     return explicitCredentials;
   }
 
-  async buildS3Client(
+  private async buildS3Client(
     defaultConfig: Config,
     region: string,
     integration: AwsS3Integration,
@@ -231,7 +231,7 @@ export class AwsS3UrlReader implements UrlReader {
     return s3;
   }
 
-  async retrieveS3ObjectData(stream: Readable): Promise<Readable> {
+  private async retrieveS3ObjectData(stream: Readable): Promise<Readable> {
     return new Promise((resolve, reject) => {
       try {
         const chunks: any[] = [];

--- a/packages/backend-common/src/reading/AwsS3UrlReader.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-// note: We do the import like this so that we don't get issues destructuring
-// and it not being mocked by the aws-sdk-mock package which is unfortunate.
-import aws from 'aws-sdk';
-import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 import {
   ReaderFactory,
   ReadTreeOptions,
@@ -29,15 +25,29 @@ import {
   UrlReader,
 } from './types';
 import {
+  AwsCredentialsManager,
+  DefaultAwsCredentialsManager,
+} from '@backstage/integration-aws-node';
+import {
   AwsS3Integration,
   ScmIntegrations,
   AwsS3IntegrationConfig,
 } from '@backstage/integration';
+import { Config } from '@backstage/config';
 import { ForwardedError, NotModifiedError } from '@backstage/errors';
-import { ListObjectsV2Output, ObjectList } from 'aws-sdk/clients/s3';
+import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
+import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  ListObjectsV2CommandOutput,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { AbortController } from '@aws-sdk/abort-controller';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
+import { Readable } from 'stream';
 
-const DEFAULT_REGION = 'us-east-1';
+export const DEFAULT_REGION = 'us-east-1';
 
 /**
  * Path style URLs: https://s3.(region).amazonaws.com/(bucket)/(key)
@@ -105,14 +115,14 @@ export function parseUrl(
     return {
       path: pathname.substring(slashIndex + 1),
       bucket: pathname.substring(0, slashIndex),
-      region: '',
+      region: DEFAULT_REGION,
     };
   }
 
   return {
     path: pathname,
     bucket: host.substring(0, host.length - config.host.length - 1),
-    region: '',
+    region: DEFAULT_REGION,
   };
 }
 
@@ -126,16 +136,7 @@ export class AwsS3UrlReader implements UrlReader {
     const integrations = ScmIntegrations.fromConfig(config);
 
     return integrations.awsS3.list().map(integration => {
-      const credentials = AwsS3UrlReader.buildCredentials(integration);
-
-      const s3 = new aws.S3({
-        apiVersion: '2006-03-01',
-        credentials,
-        endpoint: integration.config.endpoint,
-        s3ForcePathStyle: integration.config.s3ForcePathStyle,
-      });
-      const reader = new AwsS3UrlReader(integration, {
-        s3,
+      const reader = new AwsS3UrlReader(config, integration, {
         treeResponseFactory,
       });
       const predicate = (url: URL) =>
@@ -145,9 +146,9 @@ export class AwsS3UrlReader implements UrlReader {
   };
 
   constructor(
+    private readonly defaultConfig: Config,
     private readonly integration: AwsS3Integration,
     private readonly deps: {
-      s3: aws.S3;
       treeResponseFactory: ReadTreeResponseFactory;
     },
   ) {}
@@ -156,37 +157,93 @@ export class AwsS3UrlReader implements UrlReader {
    * If accessKeyId and secretAccessKey are missing, the standard credentials provider chain will be used:
    * https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
    */
-  private static buildCredentials(
-    integration?: AwsS3Integration,
-  ): aws.Credentials | CredentialsOptions | undefined {
-    if (!integration) {
-      return undefined;
-    }
-
-    const accessKeyId = integration.config.accessKeyId;
-    const secretAccessKey = integration.config.secretAccessKey;
-    let explicitCredentials: aws.Credentials | undefined;
-
-    if (accessKeyId && secretAccessKey) {
-      explicitCredentials = new aws.Credentials({
+  private static buildStaticCredentials(
+    accessKeyId: string,
+    secretAccessKey: string,
+  ): AwsCredentialIdentityProvider {
+    return async () => {
+      return Promise.resolve({
         accessKeyId,
         secretAccessKey,
       });
+    };
+  }
+
+  private static async buildCredentials(
+    credsManager: AwsCredentialsManager,
+    region: string,
+    integration?: AwsS3Integration,
+  ): Promise<AwsCredentialIdentityProvider> {
+    // Fall back to the default credential chain if neither account ID
+    // nor explicit credentials are provided
+    if (!integration) {
+      return (await credsManager.getCredentialProvider()).sdkCredentialProvider;
+    }
+
+    // Pull credentials from the techdocs config section (deprecated)
+    const accessKeyId = integration.config.accessKeyId;
+    const secretAccessKey = integration.config.secretAccessKey;
+    let explicitCredentials: AwsCredentialIdentityProvider;
+    if (accessKeyId && secretAccessKey) {
+      explicitCredentials = AwsS3UrlReader.buildStaticCredentials(
+        accessKeyId,
+        secretAccessKey,
+      );
+    } else {
+      explicitCredentials = (await credsManager.getCredentialProvider())
+        .sdkCredentialProvider;
     }
 
     const roleArn = integration.config.roleArn;
     if (roleArn) {
-      return new aws.ChainableTemporaryCredentials({
+      return fromTemporaryCredentials({
         masterCredentials: explicitCredentials,
         params: {
           RoleSessionName: 'backstage-aws-s3-url-reader',
           RoleArn: roleArn,
           ExternalId: integration.config.externalId,
         },
+        clientConfig: { region },
       });
     }
 
     return explicitCredentials;
+  }
+
+  async buildS3Client(
+    defaultConfig: Config,
+    region: string,
+    integration: AwsS3Integration,
+  ): Promise<S3Client> {
+    const credsManager = DefaultAwsCredentialsManager.fromConfig(defaultConfig);
+    const credentials = await AwsS3UrlReader.buildCredentials(
+      credsManager,
+      region,
+      integration,
+    );
+
+    const s3 = new S3Client({
+      region: region,
+      credentials: credentials,
+      endpoint: integration.config.endpoint,
+      forcePathStyle: integration.config.s3ForcePathStyle,
+    });
+    return s3;
+  }
+
+  async retrieveS3ObjectData(stream: Readable): Promise<Readable> {
+    return new Promise((resolve, reject) => {
+      try {
+        const chunks: any[] = [];
+        stream.on('data', chunk => chunks.push(chunk));
+        stream.on('error', (e: Error) =>
+          reject(new ForwardedError('Unable to read stream', e)),
+        );
+        stream.on('end', () => resolve(Readable.from(Buffer.concat(chunks))));
+      } catch (e) {
+        throw new ForwardedError('Unable to parse the response data', e);
+      }
+    });
   }
 
   async read(url: string): Promise<Buffer> {
@@ -200,7 +257,12 @@ export class AwsS3UrlReader implements UrlReader {
   ): Promise<ReadUrlResponse> {
     try {
       const { path, bucket, region } = parseUrl(url, this.integration.config);
-      aws.config.update({ region: region });
+      const s3Client = await this.buildS3Client(
+        this.defaultConfig,
+        region,
+        this.integration,
+      );
+      const abortController = new AbortController();
 
       let params;
       if (options?.etag) {
@@ -215,44 +277,22 @@ export class AwsS3UrlReader implements UrlReader {
           Key: path,
         };
       }
-
-      const request = this.deps.s3.getObject(params);
-      options?.signal?.addEventListener('abort', () => request.abort());
-
-      // Since we're consuming the read stream we need to consume headers and errors via events.
-      const etagPromise = new Promise<string | undefined>((resolve, reject) => {
-        request.on('httpHeaders', (status, headers) => {
-          if (status < 400) {
-            if (status === 200) {
-              resolve(headers.etag);
-            } else if (status !== 304 /* not modified */) {
-              reject(
-                new Error(
-                  `S3 readUrl request received unexpected status '${status}' in response`,
-                ),
-              );
-            }
-          }
-        });
-        request.on('error', error => reject(error));
-        request.on('complete', () =>
-          reject(
-            new Error('S3 readUrl request completed without receiving headers'),
-          ),
-        );
+      options?.signal?.addEventListener('abort', () => abortController.abort());
+      const getObjectCommand = new GetObjectCommand(params);
+      const response = await s3Client.send(getObjectCommand, {
+        abortSignal: abortController.signal,
       });
 
-      const stream = request.createReadStream();
-      stream.on('error', () => {
-        // The AWS SDK forwards request errors to the stream, so we need to
-        // ignore those errors here or the process will crash.
-      });
+      const s3ObjectData = await this.retrieveS3ObjectData(
+        response.Body as Readable,
+      );
+      const etag = response.ETag;
 
-      return ReadUrlResponseFactory.fromReadable(stream, {
-        etag: await etagPromise,
+      return ReadUrlResponseFactory.fromReadable(s3ObjectData, {
+        etag: etag,
       });
     } catch (e) {
-      if (e.statusCode === 304) {
+      if (e.$metadata && e.$metadata.httpStatusCode === 304) {
         throw new NotModifiedError();
       }
 
@@ -266,35 +306,49 @@ export class AwsS3UrlReader implements UrlReader {
   ): Promise<ReadTreeResponse> {
     try {
       const { path, bucket, region } = parseUrl(url, this.integration.config);
-      const allObjects: ObjectList = [];
+      const s3Client = await this.buildS3Client(
+        this.defaultConfig,
+        region,
+        this.integration,
+      );
+      const abortController = new AbortController();
+      const allObjects: String[] = [];
       const responses = [];
       let continuationToken: string | undefined;
-      let output: ListObjectsV2Output;
+      let output: ListObjectsV2CommandOutput;
       do {
-        aws.config.update({ region: region });
-        const request = this.deps.s3.listObjectsV2({
+        const listObjectsV2Command = new ListObjectsV2Command({
           Bucket: bucket,
           ContinuationToken: continuationToken,
           Prefix: path,
         });
-        options?.signal?.addEventListener('abort', () => request.abort());
-        output = await request.promise();
+        options?.signal?.addEventListener('abort', () =>
+          abortController.abort(),
+        );
+        output = await s3Client.send(listObjectsV2Command, {
+          abortSignal: abortController.signal,
+        });
         if (output.Contents) {
           output.Contents.forEach(contents => {
-            allObjects.push(contents);
+            allObjects.push(contents.Key!);
           });
         }
         continuationToken = output.NextContinuationToken;
       } while (continuationToken);
 
       for (let i = 0; i < allObjects.length; i++) {
-        const object = this.deps.s3.getObject({
+        const getObjectCommand = new GetObjectCommand({
           Bucket: bucket,
-          Key: String(allObjects[i].Key),
+          Key: String(allObjects[i]),
         });
+        const response = await s3Client.send(getObjectCommand);
+        const s3ObjectData = await this.retrieveS3ObjectData(
+          response.Body as Readable,
+        );
+
         responses.push({
-          data: object.createReadStream(),
-          path: String(allObjects[i].Key),
+          data: s3ObjectData,
+          path: String(allObjects[i]),
         });
       }
 

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -45,7 +45,7 @@
     "clean": "backstage-cli package clean"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.281.0",
+    "@aws-sdk/client-s3": "^3.208.0",
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
@@ -65,11 +65,11 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "@aws-sdk/util-stream-node": "^3.272.0",
+    "@aws-sdk/util-stream-node": "^3.208.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "aws-sdk-client-mock": "^2.0.1",
+    "aws-sdk-client-mock": "^2.0.0",
     "aws-sdk-mock": "^5.2.1",
     "luxon": "^3.0.0",
     "yaml": "^2.0.0"

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -45,6 +45,7 @@
     "clean": "backstage-cli package clean"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.281.0",
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
@@ -64,9 +65,11 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
+    "@aws-sdk/util-stream-node": "^3.272.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/lodash": "^4.14.151",
+    "aws-sdk-client-mock": "^2.0.1",
     "aws-sdk-mock": "^5.2.1",
     "luxon": "^3.0.0",
     "yaml": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,7 +373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.272.0":
+"@aws-sdk/abort-controller@npm:3.272.0, @aws-sdk/abort-controller@npm:^3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/abort-controller@npm:3.272.0"
   dependencies:
@@ -402,21 +402,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.276.0":
-  version: 3.276.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.276.0"
+"@aws-sdk/client-cognito-identity@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.281.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.276.0
+    "@aws-sdk/client-sts": 3.281.0
     "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/credential-provider-node": 3.272.0
+    "@aws-sdk/credential-provider-node": 3.281.0
     "@aws-sdk/fetch-http-handler": 3.272.0
     "@aws-sdk/hash-node": 3.272.0
     "@aws-sdk/invalid-dependency": 3.272.0
     "@aws-sdk/middleware-content-length": 3.272.0
     "@aws-sdk/middleware-endpoint": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.272.0
+    "@aws-sdk/middleware-host-header": 3.278.0
     "@aws-sdk/middleware-logger": 3.272.0
     "@aws-sdk/middleware-recursion-detection": 3.272.0
     "@aws-sdk/middleware-retry": 3.272.0
@@ -427,34 +427,34 @@ __metadata:
     "@aws-sdk/node-config-provider": 3.272.0
     "@aws-sdk/node-http-handler": 3.272.0
     "@aws-sdk/protocol-http": 3.272.0
-    "@aws-sdk/smithy-client": 3.272.0
+    "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
     "@aws-sdk/util-base64": 3.208.0
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
-    "@aws-sdk/util-defaults-mode-browser": 3.272.0
-    "@aws-sdk/util-defaults-mode-node": 3.272.0
+    "@aws-sdk/util-defaults-mode-browser": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.279.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
     "@aws-sdk/util-user-agent-browser": 3.272.0
     "@aws-sdk/util-user-agent-node": 3.272.0
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
-  checksum: ff79c1c727d956e03510307b001c24534d522b327871b2b0a1d39120e6d6717e17d7b9c2b7a6d28c3e5c3f41cd8ff28e5150ddd1fda9bff0c239fdfef0a78e00
+  checksum: 13c350badfdd7fc1df05687314ade61b407a7094d082ade35ff67c4ac870f4fb5bfda902e21c9dedf13898dbd76e74fc03707b632359fd2619a3f709bee5ac8c
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.208.0":
-  version: 3.276.0
-  resolution: "@aws-sdk/client-s3@npm:3.276.0"
+"@aws-sdk/client-s3@npm:^3.208.0, @aws-sdk/client-s3@npm:^3.276.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/client-s3@npm:3.281.0"
   dependencies:
     "@aws-crypto/sha1-browser": 3.0.0
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.276.0
+    "@aws-sdk/client-sts": 3.281.0
     "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/credential-provider-node": 3.272.0
+    "@aws-sdk/credential-provider-node": 3.281.0
     "@aws-sdk/eventstream-serde-browser": 3.272.0
     "@aws-sdk/eventstream-serde-config-resolver": 3.272.0
     "@aws-sdk/eventstream-serde-node": 3.272.0
@@ -469,7 +469,7 @@ __metadata:
     "@aws-sdk/middleware-endpoint": 3.272.0
     "@aws-sdk/middleware-expect-continue": 3.272.0
     "@aws-sdk/middleware-flexible-checksums": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.272.0
+    "@aws-sdk/middleware-host-header": 3.278.0
     "@aws-sdk/middleware-location-constraint": 3.272.0
     "@aws-sdk/middleware-logger": 3.272.0
     "@aws-sdk/middleware-recursion-detection": 3.272.0
@@ -484,14 +484,14 @@ __metadata:
     "@aws-sdk/node-http-handler": 3.272.0
     "@aws-sdk/protocol-http": 3.272.0
     "@aws-sdk/signature-v4-multi-region": 3.272.0
-    "@aws-sdk/smithy-client": 3.272.0
+    "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
     "@aws-sdk/util-base64": 3.208.0
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
-    "@aws-sdk/util-defaults-mode-browser": 3.272.0
-    "@aws-sdk/util-defaults-mode-node": 3.272.0
+    "@aws-sdk/util-defaults-mode-browser": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.279.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
     "@aws-sdk/util-stream-browser": 3.272.0
@@ -503,7 +503,7 @@ __metadata:
     "@aws-sdk/xml-builder": 3.201.0
     fast-xml-parser: 4.1.2
     tslib: ^2.3.1
-  checksum: f7f475b92c0cff800536fb910bb6ffefcee6e650208f1791ea64c95bcbb6c63ef7a55e3f72af44e2e730a53865857ac4b974f00cb7da1e369d742cc95e33f02a
+  checksum: 30447fefd4fd1c98388457aab53cdb6db26a2610389912f5a389136db7a5992d358adf5116c8102eb82262b8c78864902c78437390ec7ffe7ef076dd78ab3b9a
   languageName: node
   linkType: hard
 
@@ -593,6 +593,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sso-oidc@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.281.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.272.0
+    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/hash-node": 3.272.0
+    "@aws-sdk/invalid-dependency": 3.272.0
+    "@aws-sdk/middleware-content-length": 3.272.0
+    "@aws-sdk/middleware-endpoint": 3.272.0
+    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-logger": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.272.0
+    "@aws-sdk/middleware-retry": 3.272.0
+    "@aws-sdk/middleware-serde": 3.272.0
+    "@aws-sdk/middleware-stack": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/node-config-provider": 3.272.0
+    "@aws-sdk/node-http-handler": 3.272.0
+    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/smithy-client": 3.279.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/url-parser": 3.272.0
+    "@aws-sdk/util-base64": 3.208.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.208.0
+    "@aws-sdk/util-defaults-mode-browser": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-endpoints": 3.272.0
+    "@aws-sdk/util-retry": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.272.0
+    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-utf8": 3.254.0
+    tslib: ^2.3.1
+  checksum: ce0515dbdf02f82f4f301e31e9f63adfa8660e776e665f41cd59d9f1a9a4ee373c1fa489d3f2286f0da6ddb55905562d34d799d05eef8ab2f04d9a4133e3b228
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sso@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/client-sso@npm:3.272.0"
@@ -633,7 +673,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.276.0, @aws-sdk/client-sts@npm:^3.208.0":
+"@aws-sdk/client-sso@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/client-sso@npm:3.281.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.272.0
+    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/hash-node": 3.272.0
+    "@aws-sdk/invalid-dependency": 3.272.0
+    "@aws-sdk/middleware-content-length": 3.272.0
+    "@aws-sdk/middleware-endpoint": 3.272.0
+    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-logger": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.272.0
+    "@aws-sdk/middleware-retry": 3.272.0
+    "@aws-sdk/middleware-serde": 3.272.0
+    "@aws-sdk/middleware-stack": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/node-config-provider": 3.272.0
+    "@aws-sdk/node-http-handler": 3.272.0
+    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/smithy-client": 3.279.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/url-parser": 3.272.0
+    "@aws-sdk/util-base64": 3.208.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.208.0
+    "@aws-sdk/util-defaults-mode-browser": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-endpoints": 3.272.0
+    "@aws-sdk/util-retry": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.272.0
+    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-utf8": 3.254.0
+    tslib: ^2.3.1
+  checksum: 6607a853af57c435ce09c81876b1a89d7658bd60a9468f8c888273364a50d35c431e823302a7f6e5366ce6b947028a2ce6451171f5dfd869443e2569f2bb9c6d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.276.0":
   version: 3.276.0
   resolution: "@aws-sdk/client-sts@npm:3.276.0"
   dependencies:
@@ -677,6 +757,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sts@npm:3.281.0, @aws-sdk/client-sts@npm:^3.208.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/client-sts@npm:3.281.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.272.0
+    "@aws-sdk/credential-provider-node": 3.281.0
+    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/hash-node": 3.272.0
+    "@aws-sdk/invalid-dependency": 3.272.0
+    "@aws-sdk/middleware-content-length": 3.272.0
+    "@aws-sdk/middleware-endpoint": 3.272.0
+    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-logger": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.272.0
+    "@aws-sdk/middleware-retry": 3.272.0
+    "@aws-sdk/middleware-sdk-sts": 3.272.0
+    "@aws-sdk/middleware-serde": 3.272.0
+    "@aws-sdk/middleware-signing": 3.272.0
+    "@aws-sdk/middleware-stack": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/node-config-provider": 3.272.0
+    "@aws-sdk/node-http-handler": 3.272.0
+    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/smithy-client": 3.279.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/url-parser": 3.272.0
+    "@aws-sdk/util-base64": 3.208.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.208.0
+    "@aws-sdk/util-defaults-mode-browser": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-endpoints": 3.272.0
+    "@aws-sdk/util-retry": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.272.0
+    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-utf8": 3.254.0
+    fast-xml-parser: 4.1.2
+    tslib: ^2.3.1
+  checksum: c88b660279ca6fe56cb8ac7bb245a417b9ccd1a973b7e7c2b511b254f2eace11c92826c80f84423988d47796f1fb18b09363f867d9ffce436ae81f10695e31e5
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/config-resolver@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/config-resolver@npm:3.272.0"
@@ -690,15 +814,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-cognito-identity@npm:3.276.0":
-  version: 3.276.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.276.0"
+"@aws-sdk/credential-provider-cognito-identity@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.281.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.276.0
+    "@aws-sdk/client-cognito-identity": 3.281.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 2d255475f08beeccd000745b2f2c46553559fd6fe15c0ea9960956655535fb927df9ec3431cf743b80f9a460d033ede7e1c47e91aff44956559a70c5f43f7bab
+  checksum: 35a0c2193aafd329e0ecbb66bdb5630d707a3cb2ad75969a847a72306518c8eb08cf46f6aebd461ba824fe444bdf58384cc45f3714d024d3c636913f1656932d
   languageName: node
   linkType: hard
 
@@ -743,7 +867,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.272.0, @aws-sdk/credential-provider-node@npm:^3.208.0":
+"@aws-sdk/credential-provider-ini@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.281.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.272.0
+    "@aws-sdk/credential-provider-imds": 3.272.0
+    "@aws-sdk/credential-provider-process": 3.272.0
+    "@aws-sdk/credential-provider-sso": 3.281.0
+    "@aws-sdk/credential-provider-web-identity": 3.272.0
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/shared-ini-file-loader": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 3be8151f2dd7a09b0f3f887e83e43eaf1bc22a7d25e5c91397dbc756ef3df53667001ef39d276e545fad7d1b9680a050fb0aad6ac65c1ee7be593b9c2d353d39
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/credential-provider-node@npm:3.272.0"
   dependencies:
@@ -758,6 +899,24 @@ __metadata:
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
   checksum: 25c5ab8583821f63c7eb1a5257869dd21159d0b7643ff9a9c094e9b5c78c887bc441f1a2f974eaace62c1879d13e7d590bb3ea2623f5a5de822bf773b1aab100
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.281.0, @aws-sdk/credential-provider-node@npm:^3.208.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.281.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.272.0
+    "@aws-sdk/credential-provider-imds": 3.272.0
+    "@aws-sdk/credential-provider-ini": 3.281.0
+    "@aws-sdk/credential-provider-process": 3.272.0
+    "@aws-sdk/credential-provider-sso": 3.281.0
+    "@aws-sdk/credential-provider-web-identity": 3.272.0
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/shared-ini-file-loader": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 583eaba8fac99c7c05ee35f72946b4df2da4ddc620ae8d70a1f1211a0e1ec032616971649cbd2a825d0208b8f3361a61d86a68a56a94eb4075f931988a659b6e
   languageName: node
   linkType: hard
 
@@ -787,6 +946,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-sso@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.281.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.281.0
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/shared-ini-file-loader": 3.272.0
+    "@aws-sdk/token-providers": 3.281.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: e1aa53df55352047993c2a63dece7e9f7eaab5358237ae666d6ca9f929fc650cf5a20d140d90d8fb10fdba7a9e6164a709a45ab6665b1ab862a21676d3b3b3dc
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-web-identity@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.272.0"
@@ -798,26 +971,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:^3.208.0":
-  version: 3.276.0
-  resolution: "@aws-sdk/credential-providers@npm:3.276.0"
+"@aws-sdk/credential-providers@npm:^3.208.0, @aws-sdk/credential-providers@npm:^3.276.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/credential-providers@npm:3.281.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.276.0
-    "@aws-sdk/client-sso": 3.272.0
-    "@aws-sdk/client-sts": 3.276.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.276.0
+    "@aws-sdk/client-cognito-identity": 3.281.0
+    "@aws-sdk/client-sso": 3.281.0
+    "@aws-sdk/client-sts": 3.281.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.281.0
     "@aws-sdk/credential-provider-env": 3.272.0
     "@aws-sdk/credential-provider-imds": 3.272.0
-    "@aws-sdk/credential-provider-ini": 3.272.0
-    "@aws-sdk/credential-provider-node": 3.272.0
+    "@aws-sdk/credential-provider-ini": 3.281.0
+    "@aws-sdk/credential-provider-node": 3.281.0
     "@aws-sdk/credential-provider-process": 3.272.0
-    "@aws-sdk/credential-provider-sso": 3.272.0
+    "@aws-sdk/credential-provider-sso": 3.281.0
     "@aws-sdk/credential-provider-web-identity": 3.272.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/shared-ini-file-loader": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 825fb0feda57ef98cc11ab3febc2a337161193dfa24bcc31ad2b47ecb4af564b3b5a5a0d9c17fd1a3ec118321d21fc515948980ba50c323e21ed79905c13dfe4
+  checksum: 48e25c96eafd9e5b8144144d4e87586f9d0be16b1d72fb006ae14b9396b43a16ec595a0d841011af41bcb55f09ed799fb7423346b7737e7a34fca56a050c71e1
   languageName: node
   linkType: hard
 
@@ -1058,6 +1231,17 @@ __metadata:
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
   checksum: 3e191fe72de35b517a20fe47f647527579458091d4d66d55ef7e6b08107a4f4d7abe77afdcdd061776db906309d414525ff63e472c2c05d6e2447f41582f64fb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.278.0":
+  version: 3.278.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.278.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 5b9762f80a8b6041cbe62680e34ddfb0f9d6f687f2f39aa117b1f0a692f594312371cf109c090fe93ccf8084cee924cf3dc134c1d2c929012df4593edaf492bf
   languageName: node
   linkType: hard
 
@@ -1347,6 +1531,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/smithy-client@npm:3.279.0":
+  version: 3.279.0
+  resolution: "@aws-sdk/smithy-client@npm:3.279.0"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 43d933b714ba7249d7f9f007e6e107d88d34e76db2cf934c43f38b6039699da450227f25bf559a3a6f12f9f62c4dec6dd5c4dda2205e6889e7d530521b879d61
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/token-providers@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/token-providers@npm:3.272.0"
@@ -1360,6 +1555,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.281.0":
+  version: 3.281.0
+  resolution: "@aws-sdk/token-providers@npm:3.281.0"
+  dependencies:
+    "@aws-sdk/client-sso-oidc": 3.281.0
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/shared-ini-file-loader": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 15b7ba37cf169662f2ddd85d90b6fb5d077593e6316914b3de381b4c68a613664dc7688848512feb1aa82018345b2ce8d0a33f55878e96d461c2c87486825728
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:3.208.0":
   version: 3.208.0
   resolution: "@aws-sdk/types@npm:3.208.0"
@@ -1367,7 +1575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.272.0, @aws-sdk/types@npm:^3.208.0, @aws-sdk/types@npm:^3.222.0":
+"@aws-sdk/types@npm:3.272.0, @aws-sdk/types@npm:^3.208.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/types@npm:3.272.0"
   dependencies:
@@ -1455,6 +1663,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-defaults-mode-browser@npm:3.279.0":
+  version: 3.279.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.279.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: 727700ae9c741a24cb8d30991344d778ca5e9ec3ad30364a63f22af8889f03a5fedecad87c76b7022118ab2c6a3dfc48abd530502b7e1f0926bf467081189645
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-defaults-mode-node@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/util-defaults-mode-node@npm:3.272.0"
@@ -1466,6 +1686,20 @@ __metadata:
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
   checksum: ee0e44d78d70b6eab73d6e8455972218cb1a15950f47d81d72d094420b2719add34bf46218016f85242a2a155216d2a0542ed5f4e68e171efc09691125fcb6fd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.279.0":
+  version: 3.279.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.279.0"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.272.0
+    "@aws-sdk/credential-provider-imds": 3.272.0
+    "@aws-sdk/node-config-provider": 3.272.0
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 8b1e89a9ef092c6a25d354823ed3e172a2f6415389f7f66034a8571321b8100b909435a238097f016dceb58a4894ebebd8a52e33698f069f8a9d3c5bb6bd633a
   languageName: node
   linkType: hard
 
@@ -1530,7 +1764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-stream-node@npm:3.272.0":
+"@aws-sdk/util-stream-node@npm:3.272.0, @aws-sdk/util-stream-node@npm:^3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/util-stream-node@npm:3.272.0"
   dependencies:
@@ -3422,6 +3656,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/backend-common@workspace:packages/backend-common"
   dependencies:
+    "@aws-sdk/abort-controller": ^3.272.0
+    "@aws-sdk/client-s3": ^3.276.0
+    "@aws-sdk/credential-providers": ^3.276.0
+    "@aws-sdk/types": ^3.272.0
+    "@aws-sdk/util-stream-node": ^3.272.0
     "@backstage/backend-app-api": "workspace:^"
     "@backstage/backend-dev-utils": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
@@ -3432,6 +3671,7 @@ __metadata:
     "@backstage/config-loader": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
+    "@backstage/integration-aws-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@google-cloud/storage": ^6.0.0
     "@keyv/memcache": ^1.3.5
@@ -3460,7 +3700,7 @@ __metadata:
     "@types/webpack-env": ^1.15.2
     "@types/yauzl": ^2.10.0
     archiver: ^5.0.2
-    aws-sdk: ^2.840.0
+    aws-sdk-client-mock: ^2.0.1
     aws-sdk-mock: ^5.2.1
     base64-stream: ^1.0.0
     better-sqlite3: ^8.0.0
@@ -3473,7 +3713,6 @@ __metadata:
     fs-extra: 10.1.0
     git-url-parse: ^13.0.0
     helmet: ^6.0.0
-    http-errors: ^2.0.0
     isomorphic-git: ^1.8.0
     jose: ^4.6.0
     keyv: ^4.5.2
@@ -17509,7 +17748,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk-client-mock@npm:^2.0.0":
+"aws-sdk-client-mock@npm:^2.0.0, aws-sdk-client-mock@npm:^2.0.1":
   version: 2.0.1
   resolution: "aws-sdk-client-mock@npm:2.0.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,7 +373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.272.0, @aws-sdk/abort-controller@npm:^3.272.0":
+"@aws-sdk/abort-controller@npm:3.272.0, @aws-sdk/abort-controller@npm:^3.208.0":
   version: 3.272.0
   resolution: "@aws-sdk/abort-controller@npm:3.272.0"
   dependencies:
@@ -402,31 +402,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.281.0"
+"@aws-sdk/client-cognito-identity@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.282.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.281.0
-    "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/credential-provider-node": 3.281.0
-    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/client-sts": 3.282.0
+    "@aws-sdk/config-resolver": 3.282.0
+    "@aws-sdk/credential-provider-node": 3.282.0
+    "@aws-sdk/fetch-http-handler": 3.282.0
     "@aws-sdk/hash-node": 3.272.0
     "@aws-sdk/invalid-dependency": 3.272.0
-    "@aws-sdk/middleware-content-length": 3.272.0
-    "@aws-sdk/middleware-endpoint": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-content-length": 3.282.0
+    "@aws-sdk/middleware-endpoint": 3.282.0
+    "@aws-sdk/middleware-host-header": 3.282.0
     "@aws-sdk/middleware-logger": 3.272.0
-    "@aws-sdk/middleware-recursion-detection": 3.272.0
-    "@aws-sdk/middleware-retry": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.282.0
+    "@aws-sdk/middleware-retry": 3.282.0
     "@aws-sdk/middleware-serde": 3.272.0
-    "@aws-sdk/middleware-signing": 3.272.0
+    "@aws-sdk/middleware-signing": 3.282.0
     "@aws-sdk/middleware-stack": 3.272.0
-    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.282.0
     "@aws-sdk/node-config-provider": 3.272.0
-    "@aws-sdk/node-http-handler": 3.272.0
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/node-http-handler": 3.282.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
@@ -434,56 +434,56 @@ __metadata:
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
     "@aws-sdk/util-defaults-mode-browser": 3.279.0
-    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.282.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
-    "@aws-sdk/util-user-agent-browser": 3.272.0
-    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.282.0
+    "@aws-sdk/util-user-agent-node": 3.282.0
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
-  checksum: 13c350badfdd7fc1df05687314ade61b407a7094d082ade35ff67c4ac870f4fb5bfda902e21c9dedf13898dbd76e74fc03707b632359fd2619a3f709bee5ac8c
+  checksum: 9f7790e26dd3d7b0316105dd40092736526f1f6a11b814fcc95736ade3fe40058fb93f1dc2558f1b54b7871908247852e314cb1a892109e6294958eeff1d4439
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.208.0, @aws-sdk/client-s3@npm:^3.276.0, @aws-sdk/client-s3@npm:^3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/client-s3@npm:3.281.0"
+"@aws-sdk/client-s3@npm:^3.208.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/client-s3@npm:3.282.0"
   dependencies:
     "@aws-crypto/sha1-browser": 3.0.0
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.281.0
-    "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/credential-provider-node": 3.281.0
+    "@aws-sdk/client-sts": 3.282.0
+    "@aws-sdk/config-resolver": 3.282.0
+    "@aws-sdk/credential-provider-node": 3.282.0
     "@aws-sdk/eventstream-serde-browser": 3.272.0
     "@aws-sdk/eventstream-serde-config-resolver": 3.272.0
     "@aws-sdk/eventstream-serde-node": 3.272.0
-    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/fetch-http-handler": 3.282.0
     "@aws-sdk/hash-blob-browser": 3.272.0
     "@aws-sdk/hash-node": 3.272.0
     "@aws-sdk/hash-stream-node": 3.272.0
     "@aws-sdk/invalid-dependency": 3.272.0
     "@aws-sdk/md5-js": 3.272.0
-    "@aws-sdk/middleware-bucket-endpoint": 3.272.0
-    "@aws-sdk/middleware-content-length": 3.272.0
-    "@aws-sdk/middleware-endpoint": 3.272.0
-    "@aws-sdk/middleware-expect-continue": 3.272.0
-    "@aws-sdk/middleware-flexible-checksums": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.282.0
+    "@aws-sdk/middleware-content-length": 3.282.0
+    "@aws-sdk/middleware-endpoint": 3.282.0
+    "@aws-sdk/middleware-expect-continue": 3.282.0
+    "@aws-sdk/middleware-flexible-checksums": 3.282.0
+    "@aws-sdk/middleware-host-header": 3.282.0
     "@aws-sdk/middleware-location-constraint": 3.272.0
     "@aws-sdk/middleware-logger": 3.272.0
-    "@aws-sdk/middleware-recursion-detection": 3.272.0
-    "@aws-sdk/middleware-retry": 3.272.0
-    "@aws-sdk/middleware-sdk-s3": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.282.0
+    "@aws-sdk/middleware-retry": 3.282.0
+    "@aws-sdk/middleware-sdk-s3": 3.282.0
     "@aws-sdk/middleware-serde": 3.272.0
-    "@aws-sdk/middleware-signing": 3.272.0
+    "@aws-sdk/middleware-signing": 3.282.0
     "@aws-sdk/middleware-ssec": 3.272.0
     "@aws-sdk/middleware-stack": 3.272.0
-    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.282.0
     "@aws-sdk/node-config-provider": 3.272.0
-    "@aws-sdk/node-http-handler": 3.272.0
-    "@aws-sdk/protocol-http": 3.272.0
-    "@aws-sdk/signature-v4-multi-region": 3.272.0
+    "@aws-sdk/node-http-handler": 3.282.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/signature-v4-multi-region": 3.282.0
     "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
@@ -491,19 +491,19 @@ __metadata:
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
     "@aws-sdk/util-defaults-mode-browser": 3.279.0
-    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.282.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
-    "@aws-sdk/util-stream-browser": 3.272.0
-    "@aws-sdk/util-stream-node": 3.272.0
-    "@aws-sdk/util-user-agent-browser": 3.272.0
-    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-stream-browser": 3.282.0
+    "@aws-sdk/util-stream-node": 3.282.0
+    "@aws-sdk/util-user-agent-browser": 3.282.0
+    "@aws-sdk/util-user-agent-node": 3.282.0
     "@aws-sdk/util-utf8": 3.254.0
     "@aws-sdk/util-waiter": 3.272.0
     "@aws-sdk/xml-builder": 3.201.0
     fast-xml-parser: 4.1.2
     tslib: ^2.3.1
-  checksum: 30447fefd4fd1c98388457aab53cdb6db26a2610389912f5a389136db7a5992d358adf5116c8102eb82262b8c78864902c78437390ec7ffe7ef076dd78ab3b9a
+  checksum: 4f0a1d9ddad89eb71da6f39c210c451461d570d11bc394c6b3d7af139e3ea077bed88fee56fae8318182e7a26464d31119620f191f0d552b51125b9f6ddffe0b
   languageName: node
   linkType: hard
 
@@ -593,28 +593,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso-oidc@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.281.0"
+"@aws-sdk/client-sso-oidc@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.282.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/config-resolver": 3.282.0
+    "@aws-sdk/fetch-http-handler": 3.282.0
     "@aws-sdk/hash-node": 3.272.0
     "@aws-sdk/invalid-dependency": 3.272.0
-    "@aws-sdk/middleware-content-length": 3.272.0
-    "@aws-sdk/middleware-endpoint": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-content-length": 3.282.0
+    "@aws-sdk/middleware-endpoint": 3.282.0
+    "@aws-sdk/middleware-host-header": 3.282.0
     "@aws-sdk/middleware-logger": 3.272.0
-    "@aws-sdk/middleware-recursion-detection": 3.272.0
-    "@aws-sdk/middleware-retry": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.282.0
+    "@aws-sdk/middleware-retry": 3.282.0
     "@aws-sdk/middleware-serde": 3.272.0
     "@aws-sdk/middleware-stack": 3.272.0
-    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.282.0
     "@aws-sdk/node-config-provider": 3.272.0
-    "@aws-sdk/node-http-handler": 3.272.0
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/node-http-handler": 3.282.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
@@ -622,14 +622,14 @@ __metadata:
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
     "@aws-sdk/util-defaults-mode-browser": 3.279.0
-    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.282.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
-    "@aws-sdk/util-user-agent-browser": 3.272.0
-    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.282.0
+    "@aws-sdk/util-user-agent-node": 3.282.0
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
-  checksum: ce0515dbdf02f82f4f301e31e9f63adfa8660e776e665f41cd59d9f1a9a4ee373c1fa489d3f2286f0da6ddb55905562d34d799d05eef8ab2f04d9a4133e3b228
+  checksum: 4b7d40614d5379e30ce800acd60d6c04751f2a1e347474925d74fc4b9bdf9529132fd2e40933ae2fba5ef65569d55387ea80ca5312d810a868826276296b18a4
   languageName: node
   linkType: hard
 
@@ -673,28 +673,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/client-sso@npm:3.281.0"
+"@aws-sdk/client-sso@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/client-sso@npm:3.282.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/config-resolver": 3.282.0
+    "@aws-sdk/fetch-http-handler": 3.282.0
     "@aws-sdk/hash-node": 3.272.0
     "@aws-sdk/invalid-dependency": 3.272.0
-    "@aws-sdk/middleware-content-length": 3.272.0
-    "@aws-sdk/middleware-endpoint": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-content-length": 3.282.0
+    "@aws-sdk/middleware-endpoint": 3.282.0
+    "@aws-sdk/middleware-host-header": 3.282.0
     "@aws-sdk/middleware-logger": 3.272.0
-    "@aws-sdk/middleware-recursion-detection": 3.272.0
-    "@aws-sdk/middleware-retry": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.282.0
+    "@aws-sdk/middleware-retry": 3.282.0
     "@aws-sdk/middleware-serde": 3.272.0
     "@aws-sdk/middleware-stack": 3.272.0
-    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.282.0
     "@aws-sdk/node-config-provider": 3.272.0
-    "@aws-sdk/node-http-handler": 3.272.0
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/node-http-handler": 3.282.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
@@ -702,14 +702,14 @@ __metadata:
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
     "@aws-sdk/util-defaults-mode-browser": 3.279.0
-    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.282.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
-    "@aws-sdk/util-user-agent-browser": 3.272.0
-    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.282.0
+    "@aws-sdk/util-user-agent-node": 3.282.0
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
-  checksum: 6607a853af57c435ce09c81876b1a89d7658bd60a9468f8c888273364a50d35c431e823302a7f6e5366ce6b947028a2ce6451171f5dfd869443e2569f2bb9c6d
+  checksum: e227d6c3dfcb4c0ec8c2a42ba281bca82dc6134ec69e6af6901892567d729be7f4b361cd0b70e18d85117e29f52aa75affc8e91fef1eb8c024f577897480085f
   languageName: node
   linkType: hard
 
@@ -757,31 +757,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.281.0, @aws-sdk/client-sts@npm:^3.208.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/client-sts@npm:3.281.0"
+"@aws-sdk/client-sts@npm:3.282.0, @aws-sdk/client-sts@npm:^3.208.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/client-sts@npm:3.282.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.272.0
-    "@aws-sdk/credential-provider-node": 3.281.0
-    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/config-resolver": 3.282.0
+    "@aws-sdk/credential-provider-node": 3.282.0
+    "@aws-sdk/fetch-http-handler": 3.282.0
     "@aws-sdk/hash-node": 3.272.0
     "@aws-sdk/invalid-dependency": 3.272.0
-    "@aws-sdk/middleware-content-length": 3.272.0
-    "@aws-sdk/middleware-endpoint": 3.272.0
-    "@aws-sdk/middleware-host-header": 3.278.0
+    "@aws-sdk/middleware-content-length": 3.282.0
+    "@aws-sdk/middleware-endpoint": 3.282.0
+    "@aws-sdk/middleware-host-header": 3.282.0
     "@aws-sdk/middleware-logger": 3.272.0
-    "@aws-sdk/middleware-recursion-detection": 3.272.0
-    "@aws-sdk/middleware-retry": 3.272.0
-    "@aws-sdk/middleware-sdk-sts": 3.272.0
+    "@aws-sdk/middleware-recursion-detection": 3.282.0
+    "@aws-sdk/middleware-retry": 3.282.0
+    "@aws-sdk/middleware-sdk-sts": 3.282.0
     "@aws-sdk/middleware-serde": 3.272.0
-    "@aws-sdk/middleware-signing": 3.272.0
+    "@aws-sdk/middleware-signing": 3.282.0
     "@aws-sdk/middleware-stack": 3.272.0
-    "@aws-sdk/middleware-user-agent": 3.272.0
+    "@aws-sdk/middleware-user-agent": 3.282.0
     "@aws-sdk/node-config-provider": 3.272.0
-    "@aws-sdk/node-http-handler": 3.272.0
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/node-http-handler": 3.282.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/smithy-client": 3.279.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/url-parser": 3.272.0
@@ -789,15 +789,15 @@ __metadata:
     "@aws-sdk/util-body-length-browser": 3.188.0
     "@aws-sdk/util-body-length-node": 3.208.0
     "@aws-sdk/util-defaults-mode-browser": 3.279.0
-    "@aws-sdk/util-defaults-mode-node": 3.279.0
+    "@aws-sdk/util-defaults-mode-node": 3.282.0
     "@aws-sdk/util-endpoints": 3.272.0
     "@aws-sdk/util-retry": 3.272.0
-    "@aws-sdk/util-user-agent-browser": 3.272.0
-    "@aws-sdk/util-user-agent-node": 3.272.0
+    "@aws-sdk/util-user-agent-browser": 3.282.0
+    "@aws-sdk/util-user-agent-node": 3.282.0
     "@aws-sdk/util-utf8": 3.254.0
     fast-xml-parser: 4.1.2
     tslib: ^2.3.1
-  checksum: c88b660279ca6fe56cb8ac7bb245a417b9ccd1a973b7e7c2b511b254f2eace11c92826c80f84423988d47796f1fb18b09363f867d9ffce436ae81f10695e31e5
+  checksum: 5af24417f7ef2dbebe6b0c0aa545eeb809e92136bce2b1e7dd07de1159f2308c2d673c3b136440e4137ce7524cbdabe50e80d7ca6f8635a3d9dcd2983532a9e7
   languageName: node
   linkType: hard
 
@@ -814,15 +814,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-cognito-identity@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.281.0"
+"@aws-sdk/config-resolver@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/config-resolver@npm:3.282.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.281.0
+    "@aws-sdk/signature-v4": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/util-config-provider": 3.208.0
+    "@aws-sdk/util-middleware": 3.272.0
+    tslib: ^2.3.1
+  checksum: 47628c4c66d93f2fb109039a55f206f1d9360fd3440ba2354489b5ddf05aab5322791a7e688cb02012342b3ecc7c5a61030838e6b94be76461f7f86d10a3c120
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-cognito-identity@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": 3.282.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 35a0c2193aafd329e0ecbb66bdb5630d707a3cb2ad75969a847a72306518c8eb08cf46f6aebd461ba824fe444bdf58384cc45f3714d024d3c636913f1656932d
+  checksum: c78e08a43e5611d6fbf15871720b38d76168ffbf75e24394ad10550b636d454c97bc6caaf70b0a3b960406b85874c7e45406167e6d38ae18acadfcaac16b2d73
   languageName: node
   linkType: hard
 
@@ -867,20 +880,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.281.0"
+"@aws-sdk/credential-provider-ini@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.282.0"
   dependencies:
     "@aws-sdk/credential-provider-env": 3.272.0
     "@aws-sdk/credential-provider-imds": 3.272.0
     "@aws-sdk/credential-provider-process": 3.272.0
-    "@aws-sdk/credential-provider-sso": 3.281.0
+    "@aws-sdk/credential-provider-sso": 3.282.0
     "@aws-sdk/credential-provider-web-identity": 3.272.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/shared-ini-file-loader": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 3be8151f2dd7a09b0f3f887e83e43eaf1bc22a7d25e5c91397dbc756ef3df53667001ef39d276e545fad7d1b9680a050fb0aad6ac65c1ee7be593b9c2d353d39
+  checksum: e5281422c8e060dbfca271ccb2f80f23fac11d513d2f97954a7070ca3fdfa0293aed55d8bb0e65cc50dbb60c624755436892a9dd41a659dd3ab8f91d1d9ba74e
   languageName: node
   linkType: hard
 
@@ -902,21 +915,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.281.0, @aws-sdk/credential-provider-node@npm:^3.208.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.281.0"
+"@aws-sdk/credential-provider-node@npm:3.282.0, @aws-sdk/credential-provider-node@npm:^3.208.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.282.0"
   dependencies:
     "@aws-sdk/credential-provider-env": 3.272.0
     "@aws-sdk/credential-provider-imds": 3.272.0
-    "@aws-sdk/credential-provider-ini": 3.281.0
+    "@aws-sdk/credential-provider-ini": 3.282.0
     "@aws-sdk/credential-provider-process": 3.272.0
-    "@aws-sdk/credential-provider-sso": 3.281.0
+    "@aws-sdk/credential-provider-sso": 3.282.0
     "@aws-sdk/credential-provider-web-identity": 3.272.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/shared-ini-file-loader": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 583eaba8fac99c7c05ee35f72946b4df2da4ddc620ae8d70a1f1211a0e1ec032616971649cbd2a825d0208b8f3361a61d86a68a56a94eb4075f931988a659b6e
+  checksum: dc76e67a635bb8807e2e80f4095beaa9d19a07cb5ed7e86080dd9ccff9fc23d6a84af88b74994233742032766efaebc2fd621cd3f8462d8ff041fdf5604a0ee4
   languageName: node
   linkType: hard
 
@@ -946,17 +959,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.281.0"
+"@aws-sdk/credential-provider-sso@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.282.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.281.0
+    "@aws-sdk/client-sso": 3.282.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/shared-ini-file-loader": 3.272.0
-    "@aws-sdk/token-providers": 3.281.0
+    "@aws-sdk/token-providers": 3.282.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: e1aa53df55352047993c2a63dece7e9f7eaab5358237ae666d6ca9f929fc650cf5a20d140d90d8fb10fdba7a9e6164a709a45ab6665b1ab862a21676d3b3b3dc
+  checksum: 7888c5fbb0be701a8b6ad0a853959f5de0549e0c54dd475767395cfd9337e429056c948ee332da3b447751899635886955a8cc30e0ffbb1b86b6d887712ac0e4
   languageName: node
   linkType: hard
 
@@ -971,26 +984,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:^3.208.0, @aws-sdk/credential-providers@npm:^3.276.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/credential-providers@npm:3.281.0"
+"@aws-sdk/credential-providers@npm:^3.208.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/credential-providers@npm:3.282.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.281.0
-    "@aws-sdk/client-sso": 3.281.0
-    "@aws-sdk/client-sts": 3.281.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.281.0
+    "@aws-sdk/client-cognito-identity": 3.282.0
+    "@aws-sdk/client-sso": 3.282.0
+    "@aws-sdk/client-sts": 3.282.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.282.0
     "@aws-sdk/credential-provider-env": 3.272.0
     "@aws-sdk/credential-provider-imds": 3.272.0
-    "@aws-sdk/credential-provider-ini": 3.281.0
-    "@aws-sdk/credential-provider-node": 3.281.0
+    "@aws-sdk/credential-provider-ini": 3.282.0
+    "@aws-sdk/credential-provider-node": 3.282.0
     "@aws-sdk/credential-provider-process": 3.272.0
-    "@aws-sdk/credential-provider-sso": 3.281.0
+    "@aws-sdk/credential-provider-sso": 3.282.0
     "@aws-sdk/credential-provider-web-identity": 3.272.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/shared-ini-file-loader": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 48e25c96eafd9e5b8144144d4e87586f9d0be16b1d72fb006ae14b9396b43a16ec595a0d841011af41bcb55f09ed799fb7423346b7737e7a34fca56a050c71e1
+  checksum: ec707176eba558fc5bfc45b2917d624a83995c75bfc38a121d3a3fe6c0be541c25815d4892fc33fd0f1de5f892232014724b0d5c62c19a2d6d3f839258b25840
   languageName: node
   linkType: hard
 
@@ -1072,6 +1085,19 @@ __metadata:
     "@aws-sdk/util-base64": 3.208.0
     tslib: ^2.3.1
   checksum: 63d047db7b7ebfee49af8bf42f3a7aa1bea37cc687e7046bc77913c23ed99056e91b5ab77739157428be73b2a2f29783a7a659ccf29a440dd63b750d313d46cc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/fetch-http-handler@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/querystring-builder": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/util-base64": 3.208.0
+    tslib: ^2.3.1
+  checksum: 20823143bfed12dd25dc77abb8f869b4f013506f5a028477add87213ec184649dd799f4c6db5d25699a050763ef4a24c6363c06ff096e3a9b7413e2e865a10f6
   languageName: node
   linkType: hard
 
@@ -1157,16 +1183,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.272.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.282.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/util-arn-parser": 3.208.0
     "@aws-sdk/util-config-provider": 3.208.0
     tslib: ^2.3.1
-  checksum: 2c9dffb5545e085ce6323e9628d5998b551332f213f33cdbd606e889b4ca4fdac61648e2c0d8cadcf11aa5908049a764083a794082fce611980056a093c78e55
+  checksum: 1b2f2dfcbf808b8f6e24173f05bdec21c8c6d5ea4eda6b01b3d3812e51e69fd39fe4880922f0f8f6ecbf35bf8410622458882b754d24a67eae59871c1273a2d4
   languageName: node
   linkType: hard
 
@@ -1178,6 +1204,17 @@ __metadata:
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
   checksum: e1a9c3e6fec8dcfed90bb44b25a8f4786b4ed0cbd79c6f69e3d8e91d394402ad4f2667231aafdcc05caf136a331434d54fac286a72ab5870dd90705a2e56243b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-content-length@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: ebe0f4f55c30cd8ea3711a412e8f0c216c863b7b313ebd12de35b2c8e857cc38b5638c8acdfeca62307911b1092a516d5eaac60493dbeb76806012cda96f46d5
   languageName: node
   linkType: hard
 
@@ -1197,29 +1234,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.272.0"
+"@aws-sdk/middleware-endpoint@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-endpoint@npm:3.282.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/middleware-serde": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/signature-v4": 3.282.0
     "@aws-sdk/types": 3.272.0
+    "@aws-sdk/url-parser": 3.272.0
+    "@aws-sdk/util-config-provider": 3.208.0
+    "@aws-sdk/util-middleware": 3.272.0
     tslib: ^2.3.1
-  checksum: 19f32623758ccc1d08e2ff08db8efc62c3e04c3e89b15a7ca4b1719fa15ce7bfaad0eea3cceadc395f769405181a356a6a4efdadb2e6f6bd90afd31f8532ca40
+  checksum: 84a9f3d6d5f904e9728c20444f3e2fc369b8a57e9dbc01cf3c3f5a6b6062b2ba470774bddd60a095845bba62ce153590c69a10211f61609d4eebf173338299e7
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.272.0"
+"@aws-sdk/middleware-expect-continue@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 9b940175d545140608f17d7d5aefd798ea36640acfca95923320eab087bdd2edd25986a68f950a1ecfdf3c922bf91c0cae5b1bc4ce32d51c2f3e1915acc3939a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.282.0"
   dependencies:
     "@aws-crypto/crc32": 3.0.0
     "@aws-crypto/crc32c": 3.0.0
     "@aws-sdk/is-array-buffer": 3.201.0
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
-  checksum: 06d0f9edd3c78d17e0669dd913daed67f0c45d59be54bf39e68ad1184fd0dc80d544545bbe09f6dd51ca6dca8a42b585ba83e5be3aa665c6486fb5210b08f8df
+  checksum: 7575ebdf82e62b0a03813acc18dab4c070c019b0e723ffb7be41d36955d29d87603689351ecb612a44ff9b70fd83fe6977c5a36f1d7c9cb80b104e28f19ddf23
   languageName: node
   linkType: hard
 
@@ -1234,14 +1287,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.278.0":
-  version: 3.278.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.278.0"
+"@aws-sdk/middleware-host-header@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.282.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 5b9762f80a8b6041cbe62680e34ddfb0f9d6f687f2f39aa117b1f0a692f594312371cf109c090fe93ccf8084cee924cf3dc134c1d2c929012df4593edaf492bf
+  checksum: 19b5c9284ec5df8732301d5853007613d62ec43657d8793be14bd1dc4b64700748b37d09dbae835750be440faae0105be6d14caaa55f1309842873a701007b72
   languageName: node
   linkType: hard
 
@@ -1276,6 +1329,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-recursion-detection@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 3e2b43e4e3f8ebb4f02a5bf33b15d95b559e5a35a872a94ca254497fdc896508baa8c316f3bec660d6fad2154041d81a5295be8ed245943dcdb3abc2dd75ef27
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-retry@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/middleware-retry@npm:3.272.0"
@@ -1291,15 +1355,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.272.0"
+"@aws-sdk/middleware-retry@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.282.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/service-error-classification": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/util-middleware": 3.272.0
+    "@aws-sdk/util-retry": 3.272.0
+    tslib: ^2.3.1
+    uuid: ^8.3.2
+  checksum: fca7a6c8bac2f52df9987a66f7be5891e85fda0f6eff678ed78bc545ee45e159026d30cc8a136293e731ca69f9e5edc4f9f4895fea73bf28634426d9db0021f6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.282.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/util-arn-parser": 3.208.0
     tslib: ^2.3.1
-  checksum: 464f38d1593866724ce4e793e065c4e23b875ec889384a99c64d7aa34baf765ebdc18b218ed5e83f4f6c257d7b56c560aab8c0b617960a200484970ec8d55526
+  checksum: c373dcb455450897075adb943e454da84eae66e6b223a30a80599e2d8a33b61cf1a5e46ec8f7595adfd9059132ce444316f9e376eff6ca121f05b1bb67e99b2b
   languageName: node
   linkType: hard
 
@@ -1329,6 +1408,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-sdk-sts@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.282.0
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/signature-v4": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: bcd2ee00d30191262da5caf5fda4d6c12a9a4aa1ae76693b5e49dc562c89294b4bd133e7036b3811d69806d3d6277848731a3ff8eb919644c33d58909f6ce42e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-serde@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/middleware-serde@npm:3.272.0"
@@ -1350,6 +1443,20 @@ __metadata:
     "@aws-sdk/util-middleware": 3.272.0
     tslib: ^2.3.1
   checksum: 0b711de21b0f2b28178b211ae2de962676038ed49ff9247810c2213018b77ca399285278a0b448a0242f92796e1360b83c09aa268fe64a7f153428b9ed919edc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/signature-v4": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/util-middleware": 3.272.0
+    tslib: ^2.3.1
+  checksum: bf3040f3939430d2d32ccc893103f34a7ffd3d979021a124d6f03e6dbbe3b1537fe8736143ddee20f13170a46e545ed5774dd08bdc0be2d8d9b610dd90949246
   languageName: node
   linkType: hard
 
@@ -1383,6 +1490,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-user-agent@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 6ad66ec8517deccb6dbbc1c3241d2afc2fa73d9a3bbaf56f3c1e8adbfd0791391f43058f79f2e2ace40090be481b5bbe8db8a42c0f444fc7cc56666c5ca07c72
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/node-config-provider@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/node-config-provider@npm:3.272.0"
@@ -1395,7 +1513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.272.0, @aws-sdk/node-http-handler@npm:^3.208.0":
+"@aws-sdk/node-http-handler@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/node-http-handler@npm:3.272.0"
   dependencies:
@@ -1405,6 +1523,19 @@ __metadata:
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
   checksum: cbcdab82a7611d1d776197e921563ac6248173aa6e5a6f6e6486a735c71763ae69d1d6ae6de8acebcb8020cdfa089a776d9180929397291623db8f11a1f7b8a9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-http-handler@npm:3.282.0, @aws-sdk/node-http-handler@npm:^3.208.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/querystring-builder": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 22bbb8cae68c3405f3695de2a4be4d08ade5ffaad5367badcc40dc06ef08ec634fb95953deed58641775265d852f7afb095675d353cd7c82b7cb21881f5cc549
   languageName: node
   linkType: hard
 
@@ -1435,6 +1566,16 @@ __metadata:
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
   checksum: 59d7c97b1a46bc3c072f56caec365472c9d94638923799ad2418cee52bb0eab945ab080cd63f5351ff45ad943dde9d88b294e096af36524e184c0764b2ea6cc5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/protocol-http@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/protocol-http@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  checksum: 5f9d927a69cc1d51767df86d5bfa76f280866e3ef7bcfb8b7b8dab7fc11638ca92d20e3a8a2708a251748c15c0582ad032dfd89aada8ce6068c58605b193e555
   languageName: node
   linkType: hard
 
@@ -1487,12 +1628,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.272.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.282.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.272.0
-    "@aws-sdk/signature-v4": 3.272.0
+    "@aws-sdk/protocol-http": 3.282.0
+    "@aws-sdk/signature-v4": 3.282.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/util-arn-parser": 3.208.0
     tslib: ^2.3.1
@@ -1501,7 +1642,7 @@ __metadata:
   peerDependenciesMeta:
     "@aws-sdk/signature-v4-crt":
       optional: true
-  checksum: 231eac2d4203a9ed3829d55a93d503d629bbd43301516d4e06c461dd16eba3a72373c004a59789de43487804266ca4ced259adcb1d26b6916f7b3545401ff544
+  checksum: 3f25ba04145d9e274f5bea5ac34de77021c2a06d68085e29cd9bae3b0803aef53a0ab8b184034c67019b7b730730374a9e5a216859ee8f01c11032417ca84f7c
   languageName: node
   linkType: hard
 
@@ -1517,6 +1658,21 @@ __metadata:
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
   checksum: bdf997ed7779e173797bd31a9ae39bc9860e12cb7d0a734b4a47c76bde435c5c1d5f56dbb3c5f1a2b26a828367fd88f34a4527b8a12d4c1a60b3b0049aacf706
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/signature-v4@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.201.0
+    "@aws-sdk/types": 3.272.0
+    "@aws-sdk/util-hex-encoding": 3.201.0
+    "@aws-sdk/util-middleware": 3.272.0
+    "@aws-sdk/util-uri-escape": 3.201.0
+    "@aws-sdk/util-utf8": 3.254.0
+    tslib: ^2.3.1
+  checksum: ef5a5f32c7671979c173cded5ca4749f3d4d156c67b7de11eac881a0141b2f43cc6ac5f29facd3e6af2a3883775de64d0c2789b2f7ccb1c6d14f0da5e22a58f0
   languageName: node
   linkType: hard
 
@@ -1555,16 +1711,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.281.0":
-  version: 3.281.0
-  resolution: "@aws-sdk/token-providers@npm:3.281.0"
+"@aws-sdk/token-providers@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/token-providers@npm:3.282.0"
   dependencies:
-    "@aws-sdk/client-sso-oidc": 3.281.0
+    "@aws-sdk/client-sso-oidc": 3.282.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/shared-ini-file-loader": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 15b7ba37cf169662f2ddd85d90b6fb5d077593e6316914b3de381b4c68a613664dc7688848512feb1aa82018345b2ce8d0a33f55878e96d461c2c87486825728
+  checksum: 064425ec0373269ccc7c4eeb583dd31e79b02af5e4c4ade25258cec59986dd3f8d4d80770d4802b26882dba9a61f66ca9d49d9ade70002417f73bdd46c64bace
   languageName: node
   linkType: hard
 
@@ -1575,7 +1731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.272.0, @aws-sdk/types@npm:^3.208.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.272.0":
+"@aws-sdk/types@npm:3.272.0, @aws-sdk/types@npm:^3.208.0, @aws-sdk/types@npm:^3.222.0":
   version: 3.272.0
   resolution: "@aws-sdk/types@npm:3.272.0"
   dependencies:
@@ -1689,17 +1845,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-node@npm:3.279.0":
-  version: 3.279.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.279.0"
+"@aws-sdk/util-defaults-mode-node@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.282.0"
   dependencies:
-    "@aws-sdk/config-resolver": 3.272.0
+    "@aws-sdk/config-resolver": 3.282.0
     "@aws-sdk/credential-provider-imds": 3.272.0
     "@aws-sdk/node-config-provider": 3.272.0
     "@aws-sdk/property-provider": 3.272.0
     "@aws-sdk/types": 3.272.0
     tslib: ^2.3.1
-  checksum: 8b1e89a9ef092c6a25d354823ed3e172a2f6415389f7f66034a8571321b8100b909435a238097f016dceb58a4894ebebd8a52e33698f069f8a9d3c5bb6bd633a
+  checksum: 56086b64a65f9999923bbba56c87ecdb886cc729d32683107ae3dd8c9077b6aceecdf2acfc934220522883282f03dd6e37690d242a2d63fee3ec7f3db39cecb7
   languageName: node
   linkType: hard
 
@@ -1750,29 +1906,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-stream-browser@npm:3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/util-stream-browser@npm:3.272.0"
+"@aws-sdk/util-stream-browser@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/util-stream-browser@npm:3.282.0"
   dependencies:
-    "@aws-sdk/fetch-http-handler": 3.272.0
+    "@aws-sdk/fetch-http-handler": 3.282.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/util-base64": 3.208.0
     "@aws-sdk/util-hex-encoding": 3.201.0
     "@aws-sdk/util-utf8": 3.254.0
     tslib: ^2.3.1
-  checksum: 18e3dfa4efcf12e5e4eda55da14c9a98154f063b1bbf0a926fc406ffdf791363a1881e93194fa5a160e7bd26dd1b1933d6a57b19134e6f0a4feda8c6f5cfcb13
+  checksum: 30dda128249c30052cc7d92fbc08c423d03938c202bd95ffcbeb0b72804da19defe742ca702062fd96803381bb508cedc27b4b4bf4d418175f905849352fdf71
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-stream-node@npm:3.272.0, @aws-sdk/util-stream-node@npm:^3.272.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/util-stream-node@npm:3.272.0"
+"@aws-sdk/util-stream-node@npm:3.282.0, @aws-sdk/util-stream-node@npm:^3.208.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/util-stream-node@npm:3.282.0"
   dependencies:
-    "@aws-sdk/node-http-handler": 3.272.0
+    "@aws-sdk/node-http-handler": 3.282.0
     "@aws-sdk/types": 3.272.0
     "@aws-sdk/util-buffer-from": 3.208.0
     tslib: ^2.3.1
-  checksum: 7fa500251680e3eb5fa63d47c6d4846ca66f8c781ee0d990ed79d16a12b0bb074eb7d5c9e26390afd7a18159a758fbc333ce1b788c2a8dea7438cbe2f4c6c7c3
+  checksum: 0b19609d0c2608c120e317b6127a49016c90f746e38c300893ee16e276951c294fd4fef8dbee42978e655f34c2c56676e8def637fdb5a3f9284c475c73a67f62
   languageName: node
   linkType: hard
 
@@ -1801,6 +1957,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-user-agent-browser@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/types": 3.272.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: cf751b285e57c4d7a00584ac4eab4c27c5fc6d73dc9d6ed8082d297885b262a27bc0a51b882e57779eb807149c27b4d083e07596b99ae145c9acb46f64edf587
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-user-agent-node@npm:3.272.0":
   version: 3.272.0
   resolution: "@aws-sdk/util-user-agent-node@npm:3.272.0"
@@ -1814,6 +1981,22 @@ __metadata:
     aws-crt:
       optional: true
   checksum: 25d5f39349190e6323f893de4f0e7a931751bf1521808210515ef8d951c1a6a3e5f1dc1773cbd5ca9f999c5d00f3a421ad570b5f79b20dc2692012a9f833ff24
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.282.0":
+  version: 3.282.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.282.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.272.0
+    "@aws-sdk/types": 3.272.0
+    tslib: ^2.3.1
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: b13d7e114610c15d0d4d6137e6b6e2ce2d9b696aec1f3ba60515228b9c59068260fb976a0af2d9166705e00c99408c603abf4ebc65384bcd76abfa9003a4afa4
   languageName: node
   linkType: hard
 
@@ -3656,11 +3839,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/backend-common@workspace:packages/backend-common"
   dependencies:
-    "@aws-sdk/abort-controller": ^3.272.0
-    "@aws-sdk/client-s3": ^3.276.0
-    "@aws-sdk/credential-providers": ^3.276.0
-    "@aws-sdk/types": ^3.272.0
-    "@aws-sdk/util-stream-node": ^3.272.0
+    "@aws-sdk/abort-controller": ^3.208.0
+    "@aws-sdk/client-s3": ^3.208.0
+    "@aws-sdk/credential-providers": ^3.208.0
+    "@aws-sdk/types": ^3.208.0
+    "@aws-sdk/util-stream-node": ^3.208.0
     "@backstage/backend-app-api": "workspace:^"
     "@backstage/backend-dev-utils": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
@@ -3700,7 +3883,7 @@ __metadata:
     "@types/webpack-env": ^1.15.2
     "@types/yauzl": ^2.10.0
     archiver: ^5.0.2
-    aws-sdk-client-mock: ^2.0.1
+    aws-sdk-client-mock: ^2.0.0
     aws-sdk-mock: ^5.2.1
     base64-stream: ^1.0.0
     better-sqlite3: ^8.0.0
@@ -5177,8 +5360,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-catalog-backend-module-aws@workspace:plugins/catalog-backend-module-aws"
   dependencies:
-    "@aws-sdk/client-s3": ^3.281.0
-    "@aws-sdk/util-stream-node": ^3.272.0
+    "@aws-sdk/client-s3": ^3.208.0
+    "@aws-sdk/util-stream-node": ^3.208.0
     "@backstage/backend-common": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-tasks": "workspace:^"
@@ -5195,7 +5378,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@types/lodash": ^4.14.151
     aws-sdk: ^2.840.0
-    aws-sdk-client-mock: ^2.0.1
+    aws-sdk-client-mock: ^2.0.0
     aws-sdk-mock: ^5.2.1
     lodash: ^4.17.21
     luxon: ^3.0.0
@@ -17752,14 +17935,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk-client-mock@npm:^2.0.0, aws-sdk-client-mock@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "aws-sdk-client-mock@npm:2.0.1"
+"aws-sdk-client-mock@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "aws-sdk-client-mock@npm:2.1.0"
   dependencies:
     "@types/sinon": ^10.0.10
     sinon: ^14.0.2
     tslib: ^2.1.0
-  checksum: 447502ba9270777db129ddcf0245502771c1415d4293f7b001e0a3dc18ab0ce778a7f2d40a86dadb2637d3b83be2df4e833d7f4f6c49678495c932340558c465
+  checksum: c6179c5528709ff1ad7e7308d03c74850fb5b973ca3d63836ca9973ca70de0c3dd7846fcbd3fd02bf4dabe6cae1095683b38c4202878458c8369e7e837962cd2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,7 +445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.208.0, @aws-sdk/client-s3@npm:^3.276.0":
+"@aws-sdk/client-s3@npm:^3.208.0, @aws-sdk/client-s3@npm:^3.276.0, @aws-sdk/client-s3@npm:^3.281.0":
   version: 3.281.0
   resolution: "@aws-sdk/client-s3@npm:3.281.0"
   dependencies:
@@ -5177,6 +5177,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-catalog-backend-module-aws@workspace:plugins/catalog-backend-module-aws"
   dependencies:
+    "@aws-sdk/client-s3": ^3.281.0
+    "@aws-sdk/util-stream-node": ^3.272.0
     "@backstage/backend-common": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-tasks": "workspace:^"
@@ -5193,6 +5195,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@types/lodash": ^4.14.151
     aws-sdk: ^2.840.0
+    aws-sdk-client-mock: ^2.0.1
     aws-sdk-mock: ^5.2.1
     lodash: ^4.17.21
     luxon: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3713,6 +3713,7 @@ __metadata:
     fs-extra: 10.1.0
     git-url-parse: ^13.0.0
     helmet: ^6.0.0
+    http-errors: ^2.0.0
     isomorphic-git: ^1.8.0
     jose: ^4.6.0
     keyv: ^4.5.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Upgraded AwsS3UrlReader to use aws-sdk v3.

The `S3Client` instance is created within the `readUrl` and `readTree` methods by parsing the region from the URL. The behavior from `parseUrl` was changed to return the default region if the URL doesn't follow AWS S3's format.


There are many similarities between the code to work with AWS on [techdocs-awsS3](https://github.com/lucasguariscobr/backstage/blob/aws-sdk-v3/plugins/techdocs-node/src/stages/publish/awsS3.ts) and  [backend-common -  awsS3UrlReader](https://github.com/lucasguariscobr/backstage/blob/aws-sdk-v3/packages/backend-common/src/reading/AwsS3UrlReader.ts), which could be centralized into a helper. 

The upgrade also involved replacing the testing dependency `aws-sdk-mock` with `aws-sdk-client-mock`, which uses aws-sdk v3.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
