### PR TITLE
Fix for next version of template scaffolder for the steps without properties

### DIFF
--- a/.changeset/olive-berries-poke.md
+++ b/.changeset/olive-berries-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': major
+---
+
+Fix for next version of template scaffolder for the steps without properties

--- a/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.test.tsx
+++ b/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.test.tsx
@@ -232,5 +232,39 @@ describe('useTemplateSchema', () => {
         },
       });
     });
+
+    it('should deal with steps having no properties', () => {
+      const manifest: TemplateParameterSchema = {
+        title: 'Test Template',
+        description: 'Test Template Description',
+        steps: [
+          {
+            title: 'About step',
+            description:
+              'The first step giving the initial information about the template',
+            schema: {
+              type: 'object',
+            },
+          },
+        ],
+      };
+
+      const { result } = renderHook(() => useTemplateSchema(manifest), {
+        wrapper: ({ children }) => (
+          <TestApiProvider
+            apis={[[featureFlagsApiRef, { isActive: () => false }]]}
+          >
+            {children}
+          </TestApiProvider>
+        ),
+      });
+
+      const [first] = result.current.steps;
+
+      expect(first.schema).toEqual({
+        type: 'object',
+        properties: {},
+      });
+    });
   });
 });

--- a/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.ts
+++ b/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.ts
@@ -62,7 +62,7 @@ export const useTemplateSchema = (
         // Title is rendered at the top of the page, so let's ignore this from jsonschemaform
         title: undefined,
         properties: Object.fromEntries(
-          Object.entries(step.schema.properties as JsonObject).filter(
+          Object.entries((step.schema.properties || []) as JsonObject).filter(
             ([key]) => {
               const stepFeatureFlag =
                 step.uiSchema[key]?.['ui:backstage']?.featureFlag;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There is a fix for the case which works in the current version of scaffolder but fails in the next alpha version.
The case is very simple, by having a step which has no properties.

Steps to reproduce 
```
apiVersion: scaffolder.backstage.io/v1beta3
kind: Template
metadata:
  name: test-template
  title: Test template
  description: My best template so far
spec:
  owner: myteam
  type: other
  parameters:
    - title: About this template
      ui:ObjectFieldTemplate: AboutStep
``` 

Where about step can approx like (removed all unnecessary stuff):

```
const CatalogAboutStep: LayoutTemplate = () => {

  return (
    <Box sx={{ fontSize: '1rem', marginTop: 30 }}>
      <Box>
        This wizard will assist you ...
      </Box>
    </Box>
  );
};

export const AboutStepLayout = scaffolderPlugin.provide(
  createScaffolderLayout({
    name: 'AboutStep',
    component: AboutStep,
  }),
);

```

But basically is having an informative step for the user without executing any actions or getting any input.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
