### PR TITLE
Fixing issue where installation do not work with helm due postgresql deprecated chart

### DIFF
--- a/contrib/chart/backstage/Chart.yaml
+++ b/contrib/chart/backstage/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   - name: postgresql
     condition: postgresql.enabled
     version: 9.8.12
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://marketplace.azurecr.io/helm/v1/repo
 
 maintainers:
   - name: Martina Iglesias Fernández


### PR DESCRIPTION
## Fixing chart unable to deploys the desired postgresql version
The previous repo was deprecated so not able to install using the desired postgresql version.
So in order to fix it was needed to update it and then we were able to fetch the database version.



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
