### PR TITLE
chore: allow undefined containerRunner in cookiecutter

### DIFF
--- a/.changeset/nine-bikes-applaud.md
+++ b/.changeset/nine-bikes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-cookiecutter': patch
+---
+
+allow container runner to be undefined in cookiecutter plugin

--- a/plugins/scaffolder-backend-module-cookiecutter/README.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/README.md
@@ -161,3 +161,5 @@ You can do so by including the following lines in the last step of your Dockerfi
 RUN apt-get update && apt-get install -y python3 python3-pip
 RUN pip3 install cookiecutter
 ```
+
+In this case, you don't have to include `containerRunner` in the action configuration.

--- a/plugins/scaffolder-backend-module-cookiecutter/api-report.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/api-report.md
@@ -15,7 +15,7 @@ import { UrlReader } from '@backstage/backend-common';
 export function createFetchCookiecutterAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
 }): TemplateAction<{
   url: string;
   targetPath?: string | undefined;

--- a/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
@@ -223,4 +223,16 @@ describe('fetch:cookiecutter', () => {
       }),
     );
   });
+
+  it('should throw error if cookiecutter is not installed and containerRunner is undefined', async () => {
+    commandExists.mockResolvedValue(false);
+    const ccAction = createFetchCookiecutterAction({
+      integrations,
+      reader: mockReader,
+    });
+
+    await expect(ccAction.handler(mockContext)).rejects.toThrow(
+      /Invalid state: containerRunner cannot be undefined when cookiecutter is not installed/,
+    );
+  });
 });

--- a/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.ts
+++ b/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.ts
@@ -33,9 +33,9 @@ import {
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 
 export class CookiecutterRunner {
-  private readonly containerRunner: ContainerRunner;
+  private readonly containerRunner?: ContainerRunner;
 
-  constructor({ containerRunner }: { containerRunner: ContainerRunner }) {
+  constructor({ containerRunner }: { containerRunner?: ContainerRunner }) {
     this.containerRunner = containerRunner;
   }
 
@@ -101,6 +101,11 @@ export class CookiecutterRunner {
         logStream,
       });
     } else {
+      if (this.containerRunner === undefined) {
+        throw new Error(
+          'Invalid state: containerRunner cannot be undefined when cookiecutter is not installed',
+        );
+      }
       await this.containerRunner.runContainer({
         imageName: imageName ?? 'spotify/backstage-cookiecutter',
         command: 'cookiecutter',
@@ -139,7 +144,7 @@ export class CookiecutterRunner {
 export function createFetchCookiecutterAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
 }) {
   const { reader, containerRunner, integrations } = options;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this is only needed if the cookiecutter command is not available.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
