### PR TITLE
Ensure that `http-proxy-middleware` logs requests when log level is set to `debug`

### DIFF
--- a/.changeset/twenty-insects-live.md
+++ b/.changeset/twenty-insects-live.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-proxy-backend': patch
 ---
 
-Pass the current log level to `http-proxy-middleware` to ensure that proxies requests are shown when log level is set to `debug`.
+Ensure that `@backstage/plugin-proxy-backend` logs the requests that it proxies when log level is set to `debug`.

--- a/.changeset/twenty-insects-live.md
+++ b/.changeset/twenty-insects-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Pass the current log level to `http-proxy-middleware` to ensure that proxies requests are shown when log level is set to `debug`.

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -63,6 +63,12 @@ export interface ProxyConfig extends Options {
   reviveRequestBody?: boolean;
 }
 
+function isValidHttpProxyMiddlewareLogLevel(
+  level: string,
+): level is Exclude<Options['logLevel'], undefined> {
+  return ['debug', 'info', 'warn', 'error', 'silent'].includes(level);
+}
+
 // Creates a proxy middleware, possibly with defaults added on top of the
 // given config.
 export function buildMiddleware(
@@ -121,6 +127,9 @@ export function buildMiddleware(
 
   // Attach the logger to the proxy config
   fullConfig.logProvider = () => logger;
+  if (isValidHttpProxyMiddlewareLogLevel(logger.level)) {
+    fullConfig.logLevel = logger.level;
+  }
 
   // Only return the allowed HTTP headers to not forward unwanted secret headers
   const requestHeaderAllowList = new Set<string>(

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -63,12 +63,6 @@ export interface ProxyConfig extends Options {
   reviveRequestBody?: boolean;
 }
 
-function isValidHttpProxyMiddlewareLogLevel(
-  level: string,
-): level is Exclude<Options['logLevel'], undefined> {
-  return ['debug', 'info', 'warn', 'error', 'silent'].includes(level);
-}
-
 // Creates a proxy middleware, possibly with defaults added on top of the
 // given config.
 export function buildMiddleware(
@@ -127,9 +121,11 @@ export function buildMiddleware(
 
   // Attach the logger to the proxy config
   fullConfig.logProvider = () => logger;
-  if (isValidHttpProxyMiddlewareLogLevel(logger.level)) {
-    fullConfig.logLevel = logger.level;
-  }
+  // http-proxy-middleware uses this log level to check if it should log the
+  // requests that it proxies. Setting this to the most verbose log level
+  // ensures that it always logs these requests. Our logger ends up deciding
+  // if the logs are displayed or not.
+  fullConfig.logLevel = 'debug';
 
   // Only return the allowed HTTP headers to not forward unwanted secret headers
   const requestHeaderAllowList = new Set<string>(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR ensures that we pass the log level to `http-proxy-middleware`. Under the hood, `http-proxy-middleware` checks its log level to see if it should log requests. Passing in the log level ensures that we see those messages when we run with `LOG_LEVEL=debug`.

For reference, here's the log level checking behaviour from `http-proxy-middleware`: https://github.com/chimurai/http-proxy-middleware/blob/2.x/src/http-proxy-middleware.ts#L140

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
