### PR TITLE
feat: add scaffolder action to get multiple entities

### DIFF
--- a/.changeset/sharp-hairs-arrive.md
+++ b/.changeset/sharp-hairs-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Extended scaffolder action `catalog:fetch` to fetch multiple catalog entities by entity references.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -85,7 +85,8 @@ export function createDebugLogAction(): TemplateAction_2<{
 export function createFetchCatalogEntityAction(options: {
   catalogClient: CatalogApi;
 }): TemplateAction_2<{
-  entityRef: string;
+  entityRef?: string | undefined;
+  entityRefs?: string[] | undefined;
   optional?: boolean | undefined;
 }>;
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.test.ts
@@ -23,8 +23,11 @@ import { createFetchCatalogEntityAction } from './fetch';
 
 describe('catalog:fetch', () => {
   const getEntityByRef = jest.fn();
+  const getEntitiesByRefs = jest.fn();
+
   const catalogClient = {
     getEntityByRef: getEntityByRef,
+    getEntitiesByRefs: getEntitiesByRefs,
   };
 
   const action = createFetchCatalogEntityAction({
@@ -71,25 +74,6 @@ describe('catalog:fetch', () => {
     });
   });
 
-  it('should return null if entity not in catalog and optional is true', async () => {
-    getEntityByRef.mockImplementationOnce(() => {
-      throw new Error('Not found');
-    });
-
-    await action.handler({
-      ...mockContext,
-      input: {
-        entityRef: 'component:default/test',
-        optional: true,
-      },
-    });
-
-    expect(getEntityByRef).toHaveBeenCalledWith('component:default/test', {
-      token: 'secret',
-    });
-    expect(mockContext.output).toHaveBeenCalledWith('entity', null);
-  });
-
   it('should throw error if entity fetch fails from catalog and optional is false', async () => {
     getEntityByRef.mockImplementationOnce(() => {
       throw new Error('Not found');
@@ -126,5 +110,115 @@ describe('catalog:fetch', () => {
       token: 'secret',
     });
     expect(mockContext.output).not.toHaveBeenCalled();
+  });
+
+  it('should return entities from catalog', async () => {
+    getEntitiesByRefs.mockReturnValueOnce({
+      items: [
+        {
+          metadata: {
+            namespace: 'default',
+            name: 'test',
+          },
+          kind: 'Component',
+        } as Entity,
+      ],
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        entityRefs: ['component:default/test'],
+      },
+    });
+
+    expect(getEntitiesByRefs).toHaveBeenCalledWith(
+      { entityRefs: ['component:default/test'] },
+      {
+        token: 'secret',
+      },
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('entities', [
+      {
+        metadata: {
+          namespace: 'default',
+          name: 'test',
+        },
+        kind: 'Component',
+      },
+    ]);
+  });
+
+  it('should throw error if undefined is returned for some entity', async () => {
+    getEntitiesByRefs.mockReturnValueOnce({
+      items: [
+        {
+          metadata: {
+            namespace: 'default',
+            name: 'test',
+          },
+          kind: 'Component',
+        } as Entity,
+        undefined,
+      ],
+    });
+
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          entityRefs: ['component:default/test', 'component:default/test2'],
+          optional: false,
+        },
+      }),
+    ).rejects.toThrow('Entity component:default/test2 not found');
+
+    expect(getEntitiesByRefs).toHaveBeenCalledWith(
+      { entityRefs: ['component:default/test', 'component:default/test2'] },
+      {
+        token: 'secret',
+      },
+    );
+    expect(mockContext.output).not.toHaveBeenCalled();
+  });
+
+  it('should return null in case some of the entities not found and optional is true', async () => {
+    getEntitiesByRefs.mockReturnValueOnce({
+      items: [
+        {
+          metadata: {
+            namespace: 'default',
+            name: 'test',
+          },
+          kind: 'Component',
+        } as Entity,
+        undefined,
+      ],
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        entityRefs: ['component:default/test', 'component:default/test2'],
+        optional: true,
+      },
+    });
+
+    expect(getEntitiesByRefs).toHaveBeenCalledWith(
+      { entityRefs: ['component:default/test', 'component:default/test2'] },
+      {
+        token: 'secret',
+      },
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('entities', [
+      {
+        metadata: {
+          namespace: 'default',
+          name: 'test',
+        },
+        kind: 'Component',
+      },
+      null,
+    ]);
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

uses the catalog client getEntitiesByRefs to return the entities for the template

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
