### PR TITLE
Fix the scaffolder validator for arrays when the item is a field in the object

### DIFF
--- a/.changeset/silent-dryers-end.md
+++ b/.changeset/silent-dryers-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Fix the scaffolder validator for arrays when the item is a field in the object

--- a/.changeset/silent-dryers-end.md
+++ b/.changeset/silent-dryers-end.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder': patch
 ---
 
 Fix the scaffolder validator for arrays when the item is a field in the object

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.test.ts
@@ -406,4 +406,39 @@ describe('createAsyncValidators', () => {
 
     expect(validators.TagField).not.toHaveBeenCalled();
   });
+
+  it('should call validator for array object property from a custom field extension', async () => {
+    const schema: JsonObject = {
+      type: 'object',
+      properties: {
+        links: {
+          title: 'Links',
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['url', 'title', 'icon'],
+            properties: {
+              url: {
+                title: 'url',
+                description: 'url',
+                type: 'object',
+                'ui:field': 'CustomLinkField',
+              },
+            },
+          },
+        },
+      },
+    };
+    const validators = { CustomLinkField: jest.fn() };
+
+    const validate = createAsyncValidators(schema, validators, {
+      apiHolder: { get: jest.fn() },
+    });
+
+    await validate({
+      links: [{ url: 'http://my-url.spotify.com' }],
+    });
+
+    expect(validators.CustomLinkField).toHaveBeenCalled();
+  });
 });

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts
@@ -103,6 +103,26 @@ export const createAsyncValidators = (
             itemsUiSchema,
           );
         }
+      } else if (
+        definitionInSchema &&
+        definitionInSchema.items &&
+        definitionInSchema.items.type === 'object'
+      ) {
+        const properties = (definitionInSchema.items?.properties ??
+          []) as JsonObject[];
+        for (const [, propValue] of Object.entries(properties)) {
+          if ('ui:field' in propValue) {
+            const { schema: itemsSchema, uiSchema: itemsUiSchema } =
+              extractSchemaFromStep(definitionInSchema.items);
+            await validateForm(
+              propValue['ui:field'] as string,
+              key,
+              value,
+              itemsSchema,
+              itemsUiSchema,
+            );
+          }
+        }
       } else if (isObject(value)) {
         formValidation[key] = await validate(formData, path, value);
       }

--- a/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts
@@ -77,51 +77,39 @@ export const createAsyncValidators = (
       const definitionInSchema = parsedSchema.getSchema(path, formData);
       const { schema, uiSchema } = extractSchemaFromStep(definitionInSchema);
 
-      if (definitionInSchema && 'ui:field' in definitionInSchema) {
-        if ('ui:field' in definitionInSchema) {
-          await validateForm(
-            definitionInSchema['ui:field'],
-            key,
-            value,
-            schema,
-            uiSchema,
-          );
-        }
-      } else if (
-        definitionInSchema &&
-        definitionInSchema.items &&
-        'ui:field' in definitionInSchema.items
-      ) {
-        if ('ui:field' in definitionInSchema.items) {
+      const hasItems = definitionInSchema && definitionInSchema.items;
+
+      const doValidateItem = async (
+        propValue: JsonObject,
+        itemSchema: JsonObject,
+        itemUiSchema: NextFieldExtensionUiSchema<unknown, unknown>,
+      ) => {
+        await validateForm(
+          propValue['ui:field'] as string,
+          key,
+          value,
+          itemSchema,
+          itemUiSchema,
+        );
+      };
+
+      const doValidate = async (propValue: JsonObject) => {
+        if ('ui:field' in propValue) {
           const { schema: itemsSchema, uiSchema: itemsUiSchema } =
             extractSchemaFromStep(definitionInSchema.items);
-          await validateForm(
-            definitionInSchema.items['ui:field'],
-            key,
-            value,
-            itemsSchema,
-            itemsUiSchema,
-          );
+          await doValidateItem(propValue, itemsSchema, itemsUiSchema);
         }
-      } else if (
-        definitionInSchema &&
-        definitionInSchema.items &&
-        definitionInSchema.items.type === 'object'
-      ) {
+      };
+
+      if (definitionInSchema && 'ui:field' in definitionInSchema) {
+        await doValidateItem(definitionInSchema, schema, uiSchema);
+      } else if (hasItems && 'ui:field' in definitionInSchema.items) {
+        await doValidate(definitionInSchema.items);
+      } else if (hasItems && definitionInSchema.items.type === 'object') {
         const properties = (definitionInSchema.items?.properties ??
           []) as JsonObject[];
         for (const [, propValue] of Object.entries(properties)) {
-          if ('ui:field' in propValue) {
-            const { schema: itemsSchema, uiSchema: itemsUiSchema } =
-              extractSchemaFromStep(definitionInSchema.items);
-            await validateForm(
-              propValue['ui:field'] as string,
-              key,
-              value,
-              itemsSchema,
-              itemsUiSchema,
-            );
-          }
+          await doValidate(propValue);
         }
       } else if (isObject(value)) {
         formValidation[key] = await validate(formData, path, value);

--- a/plugins/scaffolder/src/components/TemplatePage/createValidator.test.ts
+++ b/plugins/scaffolder/src/components/TemplatePage/createValidator.test.ts
@@ -19,6 +19,12 @@ import { CustomFieldValidator } from '@backstage/plugin-scaffolder-react';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { FieldValidation, FormValidation } from '@rjsf/core';
 
+type CustomLinkType = {
+  url: string;
+  title: string;
+  icon: string;
+};
+
 describe('createValidator', () => {
   const validators: Record<string, undefined | CustomFieldValidator<unknown>> =
     {
@@ -29,6 +35,23 @@ describe('createValidator', () => {
       ) => {
         if (!value || !(value as { value?: unknown }).value) {
           fieldValidation.addError('Error !');
+        }
+      },
+      CustomLink: (
+        values: unknown,
+        fieldValidation: FieldValidation,
+        _context: { apiHolder: ApiHolder },
+      ) => {
+        const input = values as CustomLinkType[];
+        for (const item of input) {
+          const validGitlabUrlRegex =
+            /gitlab\.(?:stg\.)?spotify\.com\?owner=.*&repo=.*/;
+
+          if (!item || !validGitlabUrlRegex.test(item.url)) {
+            fieldValidation.addError(
+              `Make sure to put in a valid gitlab clone url.`,
+            );
+          }
         }
       },
       TagPicker: (
@@ -122,5 +145,54 @@ describe('createValidator', () => {
     /* THEN */
     expect(result).not.toBeNull();
     expect(result.tags.addError).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call validator for array object property from a custom field extension', () => {
+    /* GIVEN */
+    const rootSchema = {
+      title: 'My links',
+      properties: {
+        links: {
+          title: 'Links',
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['url', 'title', 'icon'],
+            properties: {
+              url: {
+                title: 'url',
+                description: 'url',
+                type: 'object',
+                'ui:field': 'CustomLink',
+              },
+            },
+          },
+        },
+      },
+    };
+    const validator = createValidator(rootSchema, validators, context);
+
+    const formData = {
+      links: [
+        {
+          url: 'http://gitlab.spotify.nl/owener=me&repo=test',
+          icon: 'subject',
+          title: 'My repository for testing features',
+        } as CustomLinkType,
+      ],
+    };
+    const errors = {
+      addError: jest.fn(),
+      links: {
+        addError: jest.fn(),
+      } as unknown as FormValidation,
+    } as unknown as FormValidation;
+
+    /* WHEN */
+    const result = validator(formData, errors);
+
+    /* THEN */
+    expect(result).not.toBeNull();
+    expect(result.links.addError).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/scaffolder/src/components/TemplatePage/createValidator.ts
+++ b/plugins/scaffolder/src/components/TemplatePage/createValidator.ts
@@ -50,40 +50,42 @@ export const createValidator = (
       for (const [key, propData] of Object.entries(formData)) {
         const propValidation = errors[key];
 
-        const propSchemaProps = schemaProps[key];
-        if (isObject(propData)) {
-          if (isObject(propSchemaProps)) {
-            validate(
-              propSchemaProps,
-              propData as JsonObject,
-              propValidation as FormValidation,
-            );
+        const doValidate = (item: JsonValue | undefined) => {
+          if (item && isObject(item)) {
+            const fieldName = item['ui:field'] as string;
+            if (fieldName && typeof validators[fieldName] === 'function') {
+              validators[fieldName]!(
+                propData as JsonObject[],
+                propValidation,
+                context,
+              );
+            }
           }
+        };
+
+        const propSchemaProps = schemaProps[key];
+        if (isObject(propData) && isObject(propSchemaProps)) {
+          validate(
+            propSchemaProps,
+            propData as JsonObject,
+            propValidation as FormValidation,
+          );
         } else if (isArray(propData)) {
           if (isObject(propSchemaProps)) {
             const { items } = propSchemaProps;
             if (isObject(items)) {
-              const fieldName = items['ui:field'] as string;
-              if (fieldName && typeof validators[fieldName] === 'function') {
-                validators[fieldName]!(
-                  propData as JsonObject[],
-                  propValidation,
-                  context,
-                );
+              if (items.type === 'object') {
+                const properties = (items?.properties ?? []) as JsonObject[];
+                for (const [, value] of Object.entries(properties)) {
+                  doValidate(value);
+                }
+              } else {
+                doValidate(items);
               }
             }
           }
         } else {
-          const fieldName =
-            isObject(propSchemaProps) &&
-            (propSchemaProps['ui:field'] as string);
-          if (fieldName && typeof validators[fieldName] === 'function') {
-            validators[fieldName]!(
-              propData as JsonValue,
-              propValidation,
-              context,
-            );
-          }
+          doValidate(propSchemaProps);
         }
       }
     } else if (customObject) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I found the issue on not triggered validation on the object field of the array field.

Example to reproduce is:

```

apiVersion: scaffolder.backstage.io/v1beta3
kind: Template
metadata:
  name: some-template
spec:
  owner: myteam
  type: other
  parameters:
    - title: Provide information about the service
      required:
        - project_description
      properties:
        project_description:
          title: Project description
          type: string
        catalogLinks:
          title: Links for your service
          description: '(Optional) Add links that are related to the service: documentation, dashboard, internal page, etc.'
          type: array
          items:
            type: object
            required:
              - url
              - title
              - icon
            properties:
              url:
                title: url
                description: url
                type: string
                ui:field: UrlExtension
              title:
                title: title
                description: title of your url
                type: string
              icon:
                title: icon
                type: string
                description: 'Icons are from: https://v4.mui.com/components/material-icons/'
                enum:
                  - description
                  - chat
                  - dashboard
                  - subject
                  - webasset
                  - whatshot
                default: description
    - title: Choose location of existing repository
      description: Provide the GitLab clone URL. Both SSH and https urls are fine.
      properties:
        repoUrl:
          title: Repository Location
          type: string
          ui:field: GitlabUrlPicker
          ui:options:
            requestUserCredentials:
              secretsKey: USER_OAUTH_TOKEN

  # here's the steps that are executed in series in the scaffolder backend
  steps:
    - id: fetch
      name: Template Docs Skeleton
      action: fetch:template
      input:
        url: ./skeleton
        values:
          name: ${{ parameters.name }}
          description: ${{ parameters.project_description }}
          destination: ${{ parameters.repoUrl | parseRepoUrl }}
          owner: ${{ parameters.owner }}

    - id: publish
      name: Publish
      action: publish:github
      input:
        allowedHosts: [ "github.com" ]
        description: This is ${{ parameters.name }}
        repoUrl: ${{ parameters.repoUrl }}

    - id: register
      name: Register
      action: catalog:register
      input:
        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
        catalogInfoPath: "/catalog-info.yaml"

  output:
    links:
      - title: Repository
        url: ${{ steps.publish.output.remoteUrl }}
      - title: Open in catalog
        icon: catalog
        entityRef: ${{ steps.register.output.entityRef }}
```

where `UrlExtension` can be something like

```
import React from 'react';
import {
  createScaffolderFieldExtension,
  FieldExtensionComponentProps,
} from '@backstage/plugin-scaffolder-react';
import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
import { TextField } from '@material-ui/core';
import { FieldValidation } from '@rjsf/core';

type UrlItem = {
  icon: string;
  title: string;
  url: string;
};

/**
 * URL Picker
 */
export const UrlPicker = (props: FieldExtensionComponentProps<any>) => {
  const {
    onChange,
    required,
    schema: { title = 'Urltest' },
    rawErrors,
    formData,
    uiSchema: { 'ui:autofocus': autoFocus },
    idSchema,
    placeholder,
  } = props;

  return (
    <TextField
      id={idSchema?.$id}
      label={title}
      placeholder={placeholder}
      required={required}
      value={formData}
      onChange={({ target: { value } }) => onChange(value)}
      margin="normal"
      error={rawErrors?.length > 0 && !formData}
      inputProps={{ autoFocus }}
    />
  );
};

export const validation = (
  items: UrlItem[],
  fieldValidation: FieldValidation,
) => {
  const regex = /https:\/\/(\S+)/;
  const invalidUrls = items.reduce(
    (acc: string[], item: UrlItem) =>
      regex.test(item.url) ? acc : [...acc, item.url],
    [],
  );
  if (invalidUrls.length > 0) {
    fieldValidation.addError(
      `Url(s) [${invalidUrls}] are invalid. Urls must start with https://`,
    );
  }
};

export const UrlExtension = scaffolderPlugin.provide(
  createScaffolderFieldExtension({
    name: 'UrlExtension',
    component: UrlPicker,
    validation,
  }),
);
```

That how it looks, if to apply the validation on a url field, which is one of properties in the object field.


![Screenshot 2023-03-02 at 14 41 36](https://user-images.githubusercontent.com/2265094/222445021-75a5848b-7ffa-4fe6-ad4a-3d6ae642b954.png)


There is also a unit test to cover this case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
