### PR TITLE
docs/backend-system: add extension point example to plugin building docs

### DIFF
--- a/docs/backend-system/building-plugins-and-modules/01-index.md
+++ b/docs/backend-system/building-plugins-and-modules/01-index.md
@@ -189,7 +189,7 @@ export const examplesExtensionPoint =
 class ExamplesExtension implements ExamplesExtensionPoint {
   #examples: Example[] = [];
 
-  addActions(example: Examples): void {
+  addExample(example: Example): void {
     this.#examples.push(example);
   }
 
@@ -210,8 +210,8 @@ export const examplePlugin = createBackendPlugin({
     env.registerInit({
       deps: { logger: coreServices.logger },
       async init({ logger }) {
-        // We can access `actionsExtension` directly, giving us access to the internal interface.
-        const examples = actionsExtension.getRegisteredActions();
+        // We can access `examplesExtension` directly, giving us access to the internal interface.
+        const examples = examplesExtension.getRegisteredExamples();
 
         logger.info(`The following examples have been registered: ${examples}`);
       },


### PR DESCRIPTION
The extension point architecture docs are pretty wordy, so I figured we add in a more lightweight example to the plugin building docs.