### PR TITLE
Humanize entity title

### DIFF
--- a/.changeset/wise-phones-develop.md
+++ b/.changeset/wise-phones-develop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+humanizeEntityRef: prefer spec.profile.displayName > metadata.title > metadata.name

--- a/packages/catalog-model/examples/acme/org.yaml
+++ b/packages/catalog-model/examples/acme/org.yaml
@@ -2,7 +2,8 @@ apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
   name: acme-corp
-  description: The acme-corp organization
+  title: ACME Corp
+  description: The ACME Corp organization
   links:
     - url: http://www.acme.com/
       title: Website

--- a/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml
+++ b/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml
@@ -2,6 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: artist-engagement-portal
+  title: Artist Engagement Portal
   description: Everything related to artists
   tags:
     - portal

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.test.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.test.ts
@@ -34,6 +34,62 @@ describe('humanizeEntityRef', () => {
     expect(title).toEqual('component:software');
   });
 
+  it('overrides name with title', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        title: 'Software!',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const title = humanizeEntityRef(entity);
+    expect(title).toEqual('component:Software!');
+  });
+
+  it('overrides group name and title with spec.profile.displayName', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Group',
+      metadata: {
+        name: 'group1',
+        title: 'Group One',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'organization',
+        profile: {
+          displayName: 'Group 1',
+        },
+      },
+    };
+    const title = humanizeEntityRef(entity);
+    expect(title).toEqual('group:Group 1');
+  });
+
+  it('overrides user name and title with spec.profile.displayName', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'User',
+      metadata: {
+        name: 'don.knotts',
+        title: 'Don Knotts',
+      },
+      spec: {
+        profile: {
+          displayName: 'Barney Fife',
+        },
+      },
+    };
+    const title = humanizeEntityRef(entity);
+    expect(title).toEqual('user:Barney Fife');
+  });
+
   it('formats entity in default namespace without skipping default namespace', () => {
     const entity = {
       apiVersion: 'v1',

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -40,13 +40,22 @@ export function humanizeEntityRef(
   if ('metadata' in entityRef) {
     kind = entityRef.kind;
     namespace = entityRef.metadata.namespace;
-    name = entityRef.metadata.name;
+    if (
+      entityRef.spec &&
+      'profile' in entityRef.spec &&
+      entityRef.spec.profile instanceof Object &&
+      'displayName' in entityRef.spec.profile &&
+      entityRef.spec.profile.displayName
+    ) {
+      name = entityRef.spec.profile.displayName;
+    } else {
+      name = entityRef.metadata.title ?? entityRef.metadata.name;
+    }
   } else {
     kind = entityRef.kind;
     namespace = entityRef.namespace;
     name = entityRef.name;
   }
-
   if (namespace === undefined || namespace === '') {
     namespace = DEFAULT_NAMESPACE;
   }

--- a/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/remote-templates.yaml
@@ -9,5 +9,6 @@ spec:
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/create-react-app/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/docs-template/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/pull-request/template.yaml
+    - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/rails-demo/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
     - https://github.com/backstage/software-templates/blob/main/scaffolder-templates/springboot-grpc-template/template.yaml


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Modified `EntityPicker`'s `humanizeEntityRef` utility function to prefer `spec.profile.displayName`, then `metadata.title` in favor of `metadata.name`.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
<img width="560" alt="Screenshot 2023-03-02 at 1 30 15 PM" src="https://user-images.githubusercontent.com/487462/222534052-bbbf9e6f-3b21-41e6-9eeb-5fda42ef6d23.png">
<img width="337" alt="Screenshot 2023-03-02 at 1 30 52 PM" src="https://user-images.githubusercontent.com/487462/222534061-c6daee89-c3de-4b44-8a05-f254426873ee.png">
