### PR TITLE
Fix default icon for plugins broken link

### DIFF
--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -24,7 +24,7 @@ const truncate = text =>
 const newForDays = 100;
 
 const addPluginDocsLink = '/docs/plugins/add-to-marketplace';
-const defaultIconUrl = '/static/img/logo-gradient-on-dark.svg';
+const defaultIconUrl = '../../../static/img/logo-gradient-on-dark.svg';
 
 const Plugins = () => (
   <main className="MainContent">

--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -24,7 +24,7 @@ const truncate = text =>
 const newForDays = 100;
 
 const addPluginDocsLink = '/docs/plugins/add-to-marketplace';
-const defaultIconUrl = 'img/logo-gradient-on-dark.svg';
+const defaultIconUrl = '/static/img/logo-gradient-on-dark.svg';
 
 const Plugins = () => (
   <main className="MainContent">

--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -24,7 +24,7 @@ const truncate = text =>
 const newForDays = 100;
 
 const addPluginDocsLink = '/docs/plugins/add-to-marketplace';
-const defaultIconUrl = '../../../static/img/logo-gradient-on-dark.svg';
+const defaultIconUrl = '../img/logo-gradient-on-dark.svg';
 
 const Plugins = () => (
   <main className="MainContent">

--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -24,7 +24,7 @@ const truncate = text =>
 const newForDays = 100;
 
 const addPluginDocsLink = '/docs/plugins/add-to-marketplace';
-const defaultIconUrl = '../img/logo-gradient-on-dark.svg';
+const defaultIconUrl = '/img/logo-gradient-on-dark.svg';
 
 const Plugins = () => (
   <main className="MainContent">


### PR DESCRIPTION
Edit the default icon path in the plugin.js page to point to the right asset.

## Hey, I just made a Pull Request!

I edited the path for the default icon in the **plugin.js** file to reflect the actual location and avoid broken links as in the picture.
![Screenshot from 2023-03-03 09-34-56](https://user-images.githubusercontent.com/4215912/222672370-f69cf349-15ec-4a9f-899b-93686784ffcf.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
