### PR TITLE
[scaffolder] add support to CATALOG_FILTER_EXISTS

### DIFF
--- a/.changeset/fair-roses-stare.md
+++ b/.changeset/fair-roses-stare.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Allow use of `true` value inside filters to filter entities that has that key.
+
+this example will filter all entities that has the annotation `someAnnotation` set to any value.
+
+```yaml
+ui:options:
+  catalogFilter:
+    kind: Group
+    metadata.annotations.github.com/team-slug: true
+```

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -472,6 +472,20 @@ owner:
       kind: [Group, User]
 ```
 
+#### `catalogFilter`
+
+The `catalogFilter` allow you to filter the list entities using any of the [catalog api filters](https://backstage.io/docs/features/software-catalog/software-catalog-api#filtering):
+
+For example, if you want to show users in the `default` namespace, and groups with the `github.com/team-slug` annotation, you can do the following:
+
+```yaml
+catalogFilter:
+  - kind: [User]
+    metadata.namespace: default
+  - kind: [Group]
+    metadata.annotations.github.com/team-slug: true
+```
+
 ## `spec.steps` - `Action[]`
 
 The `steps` is an array of the things that you want to happen part of this

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -80,8 +80,8 @@ export const EntityPickerFieldExtension: FieldExtensionComponent_2<
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
     catalogFilter?:
-      | Record<string, string | string[]>
-      | Record<string, string | string[]>[]
+      | Record<string, string | boolean | (string | boolean)[]>
+      | Record<string, string | boolean | (string | boolean)[]>[]
       | undefined;
   }
 >;
@@ -95,8 +95,8 @@ export const EntityPickerFieldSchema: FieldSchema<
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
     catalogFilter?:
-      | Record<string, string | string[]>
-      | Record<string, string | string[]>[]
+      | Record<string, string | boolean | (string | boolean)[]>
+      | Record<string, string | boolean | (string | boolean)[]>[]
       | undefined;
   }
 >;
@@ -212,8 +212,8 @@ export const OwnerPickerFieldExtension: FieldExtensionComponent_2<
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
     catalogFilter?:
-      | Record<string, string | string[]>
-      | Record<string, string | string[]>[]
+      | Record<string, string | boolean | (string | boolean)[]>
+      | Record<string, string | boolean | (string | boolean)[]>[]
       | undefined;
   }
 >;
@@ -226,8 +226,8 @@ export const OwnerPickerFieldSchema: FieldSchema<
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
     catalogFilter?:
-      | Record<string, string | string[]>
-      | Record<string, string | string[]>[]
+      | Record<string, string | boolean | (string | boolean)[]>
+      | Record<string, string | boolean | (string | boolean)[]>[]
       | undefined;
   }
 >;

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -20,7 +20,10 @@ import { makeFieldSchemaFromZod } from '../utils';
  * @public
  */
 export const entityQueryFilterExpressionSchema = z.record(
-  z.string().or(z.array(z.string())),
+  z
+    .string()
+    .or(z.array(z.string().or(z.boolean())))
+    .or(z.boolean()),
 );
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR modifies the EntityPicker to allow catalog filters that has one specific key without filtering any value on that key

### Example:
We can filter entities that has `github.com/team-slug` annotation using this [catalog API](https://backstage.io/docs/features/software-catalog/software-catalog-api#filtering) filter: `/catalog/entities?filter=metadata.annotations.github.com/team-slug` bringing all the entities with that annotation with any `team-slug` value

with this PR the same query can be done using the `true` value:

```yaml
catalogFilter:
    metadata.annotations.github.com/team-slug: true
```

## RFC:
- Until this PR, non string values were ignored, with this we convert `true-> CATALOG_FILTER_EXISTS` and `false -> 'false'` but not sure on this last thing, maybe is better to keep ignoring the `false` values.
- We decided to keep this logic inside `EntityPicker` to not "break" the current catalog client behaviour.
- All the keys inside the catalog filter should be flat or will be ignored (as object are not string values)
```yaml
catalogFilter:
    spec:    # this filter is currently ignored
       type: team  
```
we didn't changed any of this behaviour but maybe should be considered as valid filter and flat those before calling the Catalog API?? 

## Posible Alternatives:
### 1. Modify the catalog client
Modify the [catalog client](https://github.com/backstage/backstage/blob/a6f22cbd40781fa25e8fb99f8aaad52a37b46dd8/packages/catalog-client/src/CatalogClient.ts#L534) to allow this type of queries without using a symbol
 simplifies the logic but missing the whole point of using the `CATALOG_FILTER_EXISTS` symbol

### 2. use null value instead of true
this can be also valid and we get a `null` value on that key
 ```yaml
catalogFilter:
    metadata.annotations.github.com/team-slug: 
```
the same logic would be the same but reading the yaml file look more like a type that a feature for me

### 3. using a special key
we can add some special name to considering this cases:
 ```yaml
catalogFilter:
    has: metadata.annotations.github.com/team-slug
```
but will differ with the catalog API logic

### 4. using a special value
using something like:
 ```yaml
catalogFilter:
    metadata.annotations.github.com/team-slug: $$exist$$
```
but not sure if worth it

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
