### PR TITLE
Add support for ARM64 docker image

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -55,6 +55,7 @@ jobs:
           context: './example-app'
           file: ./example-app/packages/backend/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/backstage:latest
             ghcr.io/${{ github.repository_owner }}/backstage:${{ github.event.client_payload.version }}


### PR DESCRIPTION
The image has built successfully using the ARM platform according to [this](https://github.com/ssakuh/backstage/actions/runs/4342309536/jobs/7582969835) build run. 

Please let me know if any other tests are required.