### PR TITLE
microsite-next: redirects for new index pages + fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Out of the box, Backstage includes:
 
 - [Backstage Software Catalog](https://backstage.io/docs/features/software-catalog/) for managing all your software (microservices, libraries, data pipelines, websites, ML models, etc.)
 - [Backstage Software Templates](https://backstage.io/docs/features/software-templates/) for quickly spinning up new projects and standardizing your tooling with your organization’s best practices
-- [Backstage TechDocs](https://backstage.io/docs/features/techdocs/techdocs-overview) for making it easy to create, maintain, find, and use technical documentation, using a "docs like code" approach
+- [Backstage TechDocs](https://backstage.io/docs/features/techdocs/) for making it easy to create, maintain, find, and use technical documentation, using a "docs like code" approach
 - Plus, a growing ecosystem of [open source plugins](https://github.com/backstage/backstage/tree/master/plugins) that further expand Backstage’s customizability and functionality
 
 Backstage was created by Spotify but is now hosted by the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io) as an Incubation level project. Read the announcement [here](https://backstage.io/blog/2022/03/16/backstage-turns-two#out-of-the-sandbox-and-into-incubation).

--- a/contrib/catalog/README.md
+++ b/contrib/catalog/README.md
@@ -1,6 +1,6 @@
 # Catalog Contrib
 
-This directory contains various community contributions related to [the Backstage catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).
+This directory contains various community contributions related to [the Backstage catalog](https://backstage.io/docs/features/software-catalog/).
 
 There is no guarantee of correctness or fitness of purpose of these
 contributions, but we hope that they are helpful to someone!

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -176,7 +176,7 @@ By far, our most-used plugin is our TechDocs plugin, which we use for creating
 technical documentation. Our philosophy at Spotify is to treat "docs like code",
 where you write documentation using the same workflow as you write your code.
 This makes it easier to create, find, and update documentation.
-[TechDocs is now open source.](https://backstage.io/docs/features/techdocs/techdocs-overview)
+[TechDocs is now open source.](https://backstage.io/docs/features/techdocs/)
 (See also:
 "[Will Spotify's internal plugins be open sourced, too?](#will-spotifys-internal-plugins-be-open-sourced-too)"
 above)

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -8,7 +8,7 @@ description: TechDocs CLI - a utility command line interface for managing TechDo
 Utility command line interface for managing TechDocs sites in
 [Backstage](https://github.com/backstage/backstage).
 
-https://backstage.io/docs/features/techdocs/techdocs-overview
+https://backstage.io/docs/features/techdocs/
 
 ## Features
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -433,7 +433,7 @@ const app = createApp({
 
 ## How to add the documentation setup to your software templates
 
-[Software Templates](https://backstage.io/docs/features/software-templates/software-templates-index)
+[Software Templates](https://backstage.io/docs/features/software-templates/)
 in Backstage is a tool that can help your users to create new components out of
 already configured templates. It comes with a set of default templates to use,
 but you can also

--- a/docs/getting-started/create-an-app.md
+++ b/docs/getting-started/create-an-app.md
@@ -71,9 +71,9 @@ app
   good starting point for you to get to know Backstage.
 - **packages/backend/**: We include a backend that helps power features such as
   [Authentication](https://backstage.io/docs/auth/),
-  [Software Catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview),
-  [Software Templates](https://backstage.io/docs/features/software-templates/software-templates-index)
-  and [TechDocs](https://backstage.io/docs/features/techdocs/techdocs-overview)
+  [Software Catalog](https://backstage.io/docs/features/software-catalog/),
+  [Software Templates](https://backstage.io/docs/features/software-templates/)
+  and [TechDocs](https://backstage.io/docs/features/techdocs/)
   amongst other things.
 
 ### Troubleshooting

--- a/docs/plugins/integrating-search-into-plugins.md
+++ b/docs/plugins/integrating-search-into-plugins.md
@@ -146,7 +146,7 @@ Look at [DefaultTechDocsCollatorFactory test](https://github.com/backstage/backs
 
 #### 6. Make your plugins collator discoverable for others
 
-If you want to make your collator discoverable for other adopters, add it to the list of [plugins integrated to search](https://backstage.io/docs/features/search/search-overview#plugins-integrated-with-backstage-search).
+If you want to make your collator discoverable for other adopters, add it to the list of [plugins integrated to search](https://backstage.io/docs/features/search/#plugins-integrated-with-backstage-search).
 
 ## Building a search experience into your plugin
 

--- a/microsite-next/docusaurus.config.js
+++ b/microsite-next/docusaurus.config.js
@@ -104,6 +104,22 @@ module.exports = {
             from: '/docs',
             to: '/docs/overview/what-is-backstage',
           },
+          {
+            from: '/docs/features/software-catalog/software-catalog-overview',
+            to: '/docs/features/software-catalog/',
+          },
+          {
+            from: '/docs/features/software-templates/software-templates-index',
+            to: '/docs/features/software-templates/',
+          },
+          {
+            from: '/docs/features/techdocs/techdocs-overview',
+            to: '/docs/features/techdocs/',
+          },
+          {
+            from: '/docs/features/search/search-overview',
+            to: '/docs/features/search/',
+          },
         ],
       },
     ],
@@ -181,7 +197,7 @@ module.exports = {
               },
               {
                 label: 'Software Catalog',
-                to: 'docs/features/software-catalog/software-catalog-overview',
+                to: 'docs/features/software-catalog/',
               },
               {
                 label: 'Create a Plugin',

--- a/microsite-next/src/pages/home/_home.tsx
+++ b/microsite-next/src/pages/home/_home.tsx
@@ -188,7 +188,7 @@ const HomePage = () => {
             <h1>Learn more about the software catalog</h1>
 
             <Link
-              to="https://backstage.io/docs/features/software-catalog/software-catalog-overview"
+              to="https://backstage.io/docs/features/software-catalog/"
               className="button button--secondary"
             >
               READ
@@ -312,7 +312,7 @@ const HomePage = () => {
             <h1>Learn more about TechDocs</h1>
 
             <Link
-              to="https://backstage.io/docs/features/techdocs/techdocs-overview"
+              to="https://backstage.io/docs/features/techdocs/"
               className="button button--secondary"
             >
               DOCS
@@ -373,7 +373,7 @@ const HomePage = () => {
             <h1>Learn more about Backstage Search</h1>
 
             <Link
-              to="https://backstage.io/docs/features/search/search-overview"
+              to="https://backstage.io/docs/features/search/"
               className="button button--secondary"
             >
               READ

--- a/microsite/blog/2020-08-05-announcing-backstage-software-templates.md
+++ b/microsite/blog/2020-08-05-announcing-backstage-software-templates.md
@@ -69,7 +69,7 @@ New components, of course, get added automatically to the Backstage Service Cata
 
 ## Define your standards
 
-Backstage ships with four example templates, but since these are likely not the (only) ones you want to promote inside your company, the next step is to add [your own templates](https://backstage.io/docs/features/software-templates/software-templates-index). Using Backstage’s Software Templates feature, it’s easy to help your engineers get started building software with your organization’s best practices built-in.
+Backstage ships with four example templates, but since these are likely not the (only) ones you want to promote inside your company, the next step is to add [your own templates](https://backstage.io/docs/features/software-templates/). Using Backstage’s Software Templates feature, it’s easy to help your engineers get started building software with your organization’s best practices built-in.
 
 We have learned that one of the keys to getting these standards adopted is to keep an open process. Templates are code. By making it clear to your engineers that you are open to pull requests, and that teams with different needs can add their own templates, you are on the path of striking a good balance between autonomy and standardization.
 

--- a/microsite/blog/2020-09-08-announcing-tech-docs.md
+++ b/microsite/blog/2020-09-08-announcing-tech-docs.md
@@ -40,7 +40,7 @@ More specifically, with this first iteration, you can:
 - Choose your own storage solution for the documentation.
 - Define your own API to interface with your documentation solution.
 
-For a full overview, including getting started instructions, check out our [TechDocs Documentation](https://backstage.io/docs/features/techdocs/techdocs-overview).
+For a full overview, including getting started instructions, check out our [TechDocs Documentation](https://backstage.io/docs/features/techdocs/).
 
 But before you go there, let me tell you a bit about the TechDocs story — and why we believe TechDocs is such a powerful yet simple solution for great documentation.
 

--- a/microsite/blog/2021-06-24-announcing-backstage-search-platform.md
+++ b/microsite/blog/2021-06-24-announcing-backstage-search-platform.md
@@ -97,6 +97,6 @@ Whichever situation you’re in, we have you covered.
 
 We’ve built the foundation for the Backstage Search platform, and we can't wait to see the exciting engines, collators, and components the community builds on the platform.
 
-You can check out our [project roadmap](https://backstage.io/docs/features/search/search-overview#project-roadmap) in our search documentation or track the progress of our [Beta milestone](https://github.com/backstage/backstage/milestone/27) and [GA milestone](https://github.com/backstage/backstage/milestone/28).
+You can check out our [project roadmap](https://backstage.io/docs/features/search/#project-roadmap) in our search documentation or track the progress of our [Beta milestone](https://github.com/backstage/backstage/milestone/27) and [GA milestone](https://github.com/backstage/backstage/milestone/28).
 
 For any questions, feedback or ideas about the Backstage Search platform, join us in the #search channel on [Discord](https://discord.gg/backstage-687207715902193673)!

--- a/microsite/blog/2022-03-17-backstage-1.0.md
+++ b/microsite/blog/2022-03-17-backstage-1.0.md
@@ -25,11 +25,11 @@ To start, let’s define Backstage: it’s an open platform for building develop
 Our definition of Backstage 1.0 includes:
 
 - Backstage Core 1.0 libraries as the set of libraries to make the platform work
-- [Backstage Software Catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview) 1.0
-- [Backstage Software Templates](https://backstage.io/docs/features/software-templates/software-templates-index) 1.0
-- [Backstage TechDocs](https://backstage.io/docs/features/techdocs/techdocs-overview) 1.0
+- [Backstage Software Catalog](https://backstage.io/docs/features/software-catalog/) 1.0
+- [Backstage Software Templates](https://backstage.io/docs/features/software-templates/) 1.0
+- [Backstage TechDocs](https://backstage.io/docs/features/techdocs/) 1.0
 
-Coming soon: [Backstage Search](https://backstage.io/docs/features/search/search-overview) 1.0 will be included in the near future as part of the regular releases to the Backstage platform.
+Coming soon: [Backstage Search](https://backstage.io/docs/features/search/) 1.0 will be included in the near future as part of the regular releases to the Backstage platform.
 
 In terms of features, the maintainers will not be shipping new stuff as part of the major release but instead:
 

--- a/microsite/blog/2022-05-13-techdocs-addon-framework.md
+++ b/microsite/blog/2022-05-13-techdocs-addon-framework.md
@@ -14,7 +14,7 @@ _TL;DR:_ Introducing the TechDocs Addon Framework — a way for us all to contri
 
 <!--truncate-->
 
-[TechDocs](https://backstage.io/docs/features/techdocs/techdocs-overview) is a centralized platform for publishing, viewing, and discovering technical documentation across an entire organization. It's a solid foundation! But TechDocs doesn't solve higher order documentation needs on its own such as: How do you create and reinforce a culture of documentation? How do you build trust in the quality of technical documentation?
+[TechDocs](https://backstage.io/docs/features/techdocs/) is a centralized platform for publishing, viewing, and discovering technical documentation across an entire organization. It's a solid foundation! But TechDocs doesn't solve higher order documentation needs on its own such as: How do you create and reinforce a culture of documentation? How do you build trust in the quality of technical documentation?
 
 To address this need, we’re proud to introduce the [TechDocs Addon Framework](https://github.com/backstage/backstage/issues/9636) — a way for us all to contribute and share additional features, TechDocs Addons, on top of the base docs-like-code experience. Using TechDocs Addons, you can customize the TechDocs experience to address some of these higher order needs.
 

--- a/microsite/blog/2022-07-19-releasing-backstage-search-1.0.md
+++ b/microsite/blog/2022-07-19-releasing-backstage-search-1.0.md
@@ -1,11 +1,11 @@
 ---
 # prettier-ignore
-title: Releasing Backstage Search 1.0 
+title: Releasing Backstage Search 1.0
 author: Emma Indal, Spotify
 authorURL: https://www.linkedin.com/in/emma-indal
 ---
 
-**TL;DR** If you’ve been waiting for Backstage Search to come out of beta, we’re excited to announce that [Backstage Search 1.0](https://backstage.io/docs/features/search/search-overview#backstage-search-10) is here!
+**TL;DR** If you’ve been waiting for Backstage Search to come out of beta, we’re excited to announce that [Backstage Search 1.0](https://backstage.io/docs/features/search/#backstage-search-10) is here!
 
 We first released the Backstage Search Platform over a year ago. Backstage Search Platform is a search experience built for you, by you.
 

--- a/microsite/blog/2023-01-31-incremental-entity-provider.md
+++ b/microsite/blog/2023-01-31-incremental-entity-provider.md
@@ -4,13 +4,13 @@ author: Paul Cowan & Taras Mankovski
 authorURL: https://frontside.com/
 ---
 
-At the heart of [Backstage](https://backstage.io/) is the [Backstage Software Catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview), which is a data store that allows an organization to centralize and visualize its many software services and components. Backstage inspects and transforms an organization's disparate software services and parts into a centralized data store. This blog post introduces the concept of incremental entity providers, which allow Backstage to scale ingestion to even larger datasets.
+At the heart of [Backstage](https://backstage.io/) is the [Backstage Software Catalog](https://backstage.io/docs/features/software-catalog/), which is a data store that allows an organization to centralize and visualize its many software services and components. Backstage inspects and transforms an organization's disparate software services and parts into a centralized data store. This blog post introduces the concept of incremental entity providers, which allow Backstage to scale ingestion to even larger datasets.
 
 ![catalog pipeline](assets/2023-01-31/catalog-pipeline.png)
 
 <!--truncate-->
 
-A common use case is for an organization to want to surface ownership and metadata about repositories. Backstage provides a mechanism for discovering and transforming repository information into a standard data structure and persisting it into the Backstage [Catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview). This process is known as ingestion, where all data is transformed into a standard Backstage data structure known as an entity. Entities in the Catalog’s data store are accessible to the Backstage App via the REST API.
+A common use case is for an organization to want to surface ownership and metadata about repositories. Backstage provides a mechanism for discovering and transforming repository information into a standard data structure and persisting it into the Backstage [Catalog](https://backstage.io/docs/features/software-catalog/). This process is known as ingestion, where all data is transformed into a standard Backstage data structure known as an entity. Entities in the Catalog’s data store are accessible to the Backstage App via the REST API.
 
 Data is transformed into entities via what is known as the ingestion and processing loop, which can be thought of as an [extract, transform and load (ETL) pipeline](https://en.wikipedia.org/wiki/Extract,_transform,_load), where raw data such as GitHub repositories are loaded from GitHub, transformed into entities and outputted to the Catalog.
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -44,7 +44,7 @@ To debug the backend in [Visual Studio Code](https://code.visualstudio.com/):
 If you want to use the catalog functionality, you need to add so called
 locations to the backend. These are places where the backend can find some
 entity descriptor data to consume and serve. For more information, see
-[Software Catalog Overview - Adding Components to the Catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview#adding-components-to-the-catalog).
+[Software Catalog Overview - Adding Components to the Catalog](https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog).
 
 For convenience we already include some statically configured example locations
 in `app-config.yaml` under `catalog.locations`. For local development you can override these in your own `app-config.local.yaml`.

--- a/packages/create-app/templates/default-app/app-config.production.yaml
+++ b/packages/create-app/templates/default-app/app-config.production.yaml
@@ -30,6 +30,6 @@ backend:
 
 catalog:
   # Overrides the default list locations from app-config.yaml as these contain example data.
-  # See https://backstage.io/docs/features/software-catalog/software-catalog-overview#adding-components-to-the-catalog for more details
+  # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
   # on how to get entities into the catalog.
   locations: []

--- a/packages/create-app/templates/default-app/packages/backend/README.md
+++ b/packages/create-app/templates/default-app/packages/backend/README.md
@@ -36,7 +36,7 @@ The backend starts up on port 7007 per default.
 If you want to use the catalog functionality, you need to add so called
 locations to the backend. These are places where the backend can find some
 entity descriptor data to consume and serve. For more information, see
-[Software Catalog Overview - Adding Components to the Catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview#adding-components-to-the-catalog).
+[Software Catalog Overview - Adding Components to the Catalog](https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog).
 
 To get started quickly, this template already includes some statically configured example locations
 in `app-config.yaml` under `catalog.locations`. You can remove and replace these locations as you

--- a/plugins/catalog-backend/README.md
+++ b/plugins/catalog-backend/README.md
@@ -1,7 +1,7 @@
 # Catalog Backend
 
 This is the backend for the default Backstage [software
-catalog](http://backstage.io/docs/features/software-catalog/software-catalog-overview).
+catalog](http://backstage.io/docs/features/software-catalog/).
 This provides an API for consumers such as the frontend [catalog
 plugin](https://github.com/backstage/backstage/tree/master/plugins/catalog).
 

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -22,7 +22,7 @@ import {
 /**
  * Permission resource type which corresponds to catalog entities.
  *
- * {@link https://backstage.io/docs/features/software-catalog/software-catalog-overview}
+ * {@link https://backstage.io/docs/features/software-catalog/}
  * @alpha
  */
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';

--- a/plugins/catalog-customized/README.md
+++ b/plugins/catalog-customized/README.md
@@ -1,7 +1,7 @@
 # Backstage Catalog Frontend
 
 This is the React frontend to customize Backstage [software
-catalog](http://backstage.io/docs/features/software-catalog/software-catalog-overview).
+catalog](http://backstage.io/docs/features/software-catalog/).
 This package supplies the example how it can be achieved.
 
 ## Installation

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -164,7 +164,7 @@ export class CatalogImportClient implements CatalogImportApi {
 to this repository so that the component can be added to the \
 [${appTitle} software catalog](${appBaseUrl}).\n\nAfter this pull request is merged, \
 the component will become available.\n\nFor more information, read an \
-[overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).`,
+[overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).`,
     };
   }
 

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -56,7 +56,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
       titleTypographyProps={{ component: 'h3' }}
       deepLink={{
         title: 'Learn more about the Software Catalog',
-        link: 'https://backstage.io/docs/features/software-catalog/software-catalog-overview',
+        link: 'https://backstage.io/docs/features/software-catalog/',
       }}
     >
       <Typography variant="body2" paragraph>

--- a/plugins/catalog/README.md
+++ b/plugins/catalog/README.md
@@ -1,7 +1,7 @@
 # Backstage Catalog Frontend
 
 This is the React frontend for the default Backstage [software
-catalog](http://backstage.io/docs/features/software-catalog/software-catalog-overview).
+catalog](http://backstage.io/docs/features/software-catalog/).
 This package supplies interfaces related to listing catalog entities or showing
 more information about them on entity pages.
 

--- a/plugins/scaffolder-backend/README.md
+++ b/plugins/scaffolder-backend/README.md
@@ -1,7 +1,7 @@
 # Scaffolder Backend
 
 This is the backend for the default Backstage [software
-templates](https://backstage.io/docs/features/software-templates/software-templates-index).
+templates](https://backstage.io/docs/features/software-templates/).
 This provides the API for the frontend [scaffolder
 plugin](https://github.com/backstage/backstage/tree/master/plugins/scaffolder),
 as well as the built-in template actions, tasks and stages.

--- a/plugins/scaffolder/README.md
+++ b/plugins/scaffolder/README.md
@@ -1,7 +1,7 @@
 # Scaffolder Frontend
 
 This is the React frontend for the default Backstage [software
-templates](https://backstage.io/docs/features/software-templates/software-templates-index).
+templates](https://backstage.io/docs/features/software-templates/).
 This package supplies interfaces related to showing available templates in the
 Backstage catalog and the workflow to create software using those templates.
 

--- a/plugins/techdocs-backend/examples/documented-component/docs/index.md
+++ b/plugins/techdocs-backend/examples/documented-component/docs/index.md
@@ -35,7 +35,7 @@ Check out the [Markdown Guide](https://www.markdownguide.org/) to learn more abo
 simply create documentation.
 
 You can also learn more about how to configure and setup this documentation in Backstage,
-[read up on the TechDocs Overview](https://backstage.io/docs/features/techdocs/techdocs-overview).
+[read up on the TechDocs Overview](https://backstage.io/docs/features/techdocs/).
 
 ## Image Example
 


### PR DESCRIPTION
🧹 , redirects for all of the core feature overview pages, which currently have a lot of broken incoming links.

I updated all our links everywhere as well. Not bothering with changesets since redirects are in place.