### PR TITLE
Use page theme fontColor consistently in scaffolder headers and cards.

### DIFF
--- a/.changeset/cool-feet-speak.md
+++ b/.changeset/cool-feet-speak.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-Make scaffolder adhere to page themes by using page fontColor consistently. If your theme overwrites template list or card headers, review those stylings.
+Make scaffolder adhere to page themes by using page `fontColor` consistently. If your theme overwrites template list or card headers, review those styles.

--- a/.changeset/cool-feet-speak.md
+++ b/.changeset/cool-feet-speak.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-scaffolder-react': minor
-'@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
 ---
 
 Make scaffolder adhere to page themes by using page `fontColor` consistently. If your theme overwrites template list or card headers, review those styles.

--- a/.changeset/cool-feet-speak.md
+++ b/.changeset/cool-feet-speak.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+Make scaffolder adhere to page themes by using page fontColor consistently. If your theme overwrites template list or card headers, review those stylings.

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
@@ -21,17 +21,22 @@ import { BackstageTheme } from '@backstage/theme';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { FavoriteEntity } from '@backstage/plugin-catalog-react';
 
-const useStyles = makeStyles<BackstageTheme, { cardBackgroundImage: string }>(
-  () => ({
-    header: {
-      backgroundImage: ({ cardBackgroundImage }) => cardBackgroundImage,
-    },
-    subtitleWrapper: {
-      display: 'flex',
-      justifyContent: 'space-between',
-    },
-  }),
-);
+const useStyles = makeStyles<
+  BackstageTheme,
+  {
+    cardFontColor: string;
+    cardBackgroundImage: string;
+  }
+>(() => ({
+  header: {
+    backgroundImage: ({ cardBackgroundImage }) => cardBackgroundImage,
+    color: ({ cardFontColor }) => cardFontColor,
+  },
+  subtitleWrapper: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+}));
 
 /**
  * Props for the CardHeader component
@@ -54,6 +59,7 @@ export const CardHeader = (props: CardHeaderProps) => {
   const themeForType = getPageTheme({ themeId: type });
 
   const styles = useStyles({
+    cardFontColor: themeForType.fontColor,
     cardBackgroundImage: themeForType.backgroundImage,
   });
 

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPageContextMenu.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useRouteRef } from '@backstage/core-plugin-api';
+import { BackstageTheme } from '@backstage/theme';
 import IconButton from '@material-ui/core/IconButton';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -34,9 +35,9 @@ import {
   scaffolderListTaskRouteRef,
 } from '../../routes';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<BackstageTheme>(theme => ({
   button: {
-    color: theme.palette.common.white,
+    color: theme.page.fontColor,
   },
 }));
 

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -64,12 +64,16 @@ import WarningIcon from '@material-ui/icons/Warning';
 import React from 'react';
 import { selectedTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<
+  BackstageTheme,
+  { fontColor: string; backgroundImage: string }
+>(theme => ({
   cardHeader: {
     position: 'relative',
   },
   title: {
-    backgroundImage: ({ backgroundImage }: any) => backgroundImage,
+    backgroundImage: ({ backgroundImage }) => backgroundImage,
+    color: ({ fontColor }) => fontColor,
   },
   box: {
     overflow: 'hidden',
@@ -186,7 +190,10 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
     ? templateProps.type
     : 'other';
   const theme = backstageTheme.getPageTheme({ themeId });
-  const classes = useStyles({ backgroundImage: theme.backgroundImage });
+  const classes = useStyles({
+    fontColor: theme.fontColor,
+    backgroundImage: theme.backgroundImage,
+  });
   const { name, namespace } = parseEntityRef(stringifyEntityRef(template));
   const href = templateRoute({ templateName: name, namespace });
 

--- a/plugins/scaffolder/src/next/TemplateListPage/ContextMenu.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/ContextMenu.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useRouteRef } from '@backstage/core-plugin-api';
+import { BackstageTheme } from '@backstage/theme';
 import IconButton from '@material-ui/core/IconButton';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -34,9 +35,9 @@ import {
   nextScaffolderListTaskRouteRef,
 } from '../routes';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme: BackstageTheme) => ({
   button: {
-    color: theme.palette.common.white,
+    color: theme.page.fontColor,
   },
 }));
 


### PR DESCRIPTION
This fixes problems with themes with white header background, which end up with white-on-white text for card heads and context menus.

## Hey, I just made a Pull Request!

There's a few places in scaffolder classic and next that hard-code a white font color. This renders as white-on-white text with a theme like the demo aperture theme.

I've converted those to consistently use the `fontColor` from the page theme.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

You can reproduce the problem by applying the following patchlet:

```diff
diff --git a/packages/theme/src/pageTheme.ts b/packages/theme/src/pageTheme.ts
index dd36d7641b..43f21b9e5f 100644
--- a/packages/theme/src/pageTheme.ts
+++ b/packages/theme/src/pageTheme.ts
@@ -80,8 +80,8 @@ export function genPageTheme(props: {
   return {
     colors: colors,
     shape: shape,
-    backgroundImage: backgroundImage,
-    fontColor: fontColor,
+    backgroundImage: 'unset',
+    fontColor: colors[0],
   };
 }
 
```

With this fix, the UI then looks like this:

<img width="1373" alt="Screenshot 2023-03-06 at 14 19 08" src="https://user-images.githubusercontent.com/43494/223121338-67bd419c-a2c4-49cd-b0bd-49852729e071.png">


