### PR TITLE
Fix dark theme Swagger's clear button font color

### DIFF
--- a/.changeset/orange-experts-hug.md
+++ b/.changeset/orange-experts-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Fix dark theme Swagger's clear button font color.

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -25,6 +25,9 @@ const useStyles = makeStyles(theme => ({
       fontFamily: theme.typography.fontFamily,
       color: theme.palette.text.primary,
 
+      ['& .btn-clear']: {
+        color: theme.palette.text.primary,
+      },
       [`& .scheme-container`]: {
         backgroundColor: theme.palette.background.default,
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The dark theme of MUI bleeds into the Swagger UI components very well except for the clear button, this PR fixes that single instance.

![Screenshot 2023-03-06 at 1 00 12 PM](https://user-images.githubusercontent.com/9698639/223192906-3335491c-08ce-49db-8c4b-e98012488d50.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
