### PR TITLE
feat(microsite-next): Add nominate page with basic styles

### DIFF
--- a/microsite-next/src/pages/nominate/index.tsx
+++ b/microsite-next/src/pages/nominate/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import nominateStyles from './nominate.module.scss';
+import Layout from '@theme/Layout';
+import clsx from 'clsx';
+import { BannerSection } from '@site/src/components/bannerSection/bannerSection';
+import { BannerSectionGrid } from '../../components/bannerSection/bannerSectionGrid';
+import { ContentBlock } from '@site/src/components/contentBlock/contentBlock';
+
+const Nominate = () => {
+  return (
+    <Layout>
+      <div className={clsx(nominateStyles.nominatePage)}>
+        <BannerSection greyBackground>
+          <ContentBlock title={<h1>Contributor Spotlight nomination</h1>}>
+            <iframe
+              src="https://docs.google.com/forms/d/e/1FAIpQLSdiZ28O7vwHo6NrwirEzGSbuVyBANSv7ItHqRlgVvSz3Z5xqQ/viewform?embedded=true"
+              allowFullScreen
+            ></iframe>
+          </ContentBlock>
+        </BannerSection>
+      </div>
+    </Layout>
+  );
+};
+
+export default Nominate;

--- a/microsite-next/src/pages/nominate/nominate.module.scss
+++ b/microsite-next/src/pages/nominate/nominate.module.scss
@@ -1,0 +1,32 @@
+.nominatePage {
+  font-size: 1.25rem;
+
+  &,
+  & > section,
+  & > section > div {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  & > section > div > div {
+    flex: 1;
+    grid-template-rows: auto 1fr;
+  }
+
+  h1 {
+    font-size: 54px;
+    line-height: 56px;
+    word-break: break-word;
+  }
+
+  p {
+    text-align: justify;
+  }
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    min-height: 400px;
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrated Nominate page linked from Community page to microsite-next.

Before:
![Screenshot 2023-03-06 at 6 06 33 PM](https://user-images.githubusercontent.com/9698639/223282905-391e3102-7226-4adb-b64b-3ce3d1ad8ee7.png)

After:
![Screenshot 2023-03-06 at 6 51 57 PM](https://user-images.githubusercontent.com/9698639/223283046-f039bca2-6f74-4604-8e97-aca0da3ca16c.png)



#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
