### PR TITLE
Scaffolder next docs: Fix import of createNextScaffolderFieldExtension

### DIFF
--- a/docs/features/software-templates/testing-scaffolder-alpha.md
+++ b/docs/features/software-templates/testing-scaffolder-alpha.md
@@ -97,7 +97,7 @@ References for `createScaffolderFieldExtension` have an `/alpha` version of `cre
 
 ```diff
 -import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder';
-+import { createNextScaffolderFieldExtension } from '@backstage/plugin-scaffolder/alpha';
++import { createNextScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react/alpha';
 
 export const EntityNamePickerFieldExtension = scaffolderPlugin.provide(
 -  createScaffolderFieldExtension({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The export createNextScaffolderFieldExtension was removed from "plugin-scaffolder" in b4955ed7b9 and moved to
"plugin-scaffolder-react". This patch also updates the code example. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
