### PR TITLE
Fix catalog write action so that you can pass through props

### DIFF
--- a/.changeset/honest-clouds-shout.md
+++ b/.changeset/honest-clouds-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+catalog write action should allow any shape of object

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
@@ -70,6 +70,7 @@ export function createCatalogWriteAction() {
         // TODO: this should reference an zod entity validator if it existed.
         entity: z
           .object({})
+          .passthrough()
           .describe(
             'You can provide the same values used in the Entity schema.',
           ),


### PR DESCRIPTION
`z.object({})` to `jsonschema` is `additionalProperties: false` which is a problem for the `entity` input :)