### PR TITLE
Fix HTTP 401 on badges endpoint when authentication is disabled

### DIFF
--- a/.changeset/curvy-banana-roll.md
+++ b/.changeset/curvy-banana-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges-backend': patch
+---
+
+Fixes a bug where the badge endpoint would return a 401 even if the authMiddleware was disabled.

--- a/packages/backend/src/plugins/badges.ts
+++ b/packages/backend/src/plugins/badges.ts
@@ -28,6 +28,6 @@ export default async function createPlugin(
     config: env.config,
     discovery: env.discovery,
     badgeFactories: createDefaultBadgeFactories(),
-    env: env,
+    tokenManager: env.tokenManager,
   });
 }

--- a/packages/backend/src/plugins/badges.ts
+++ b/packages/backend/src/plugins/badges.ts
@@ -28,5 +28,6 @@ export default async function createPlugin(
     config: env.config,
     discovery: env.discovery,
     badgeFactories: createDefaultBadgeFactories(),
+    env: env,
   });
 }

--- a/plugins/badges-backend/README.md
+++ b/plugins/badges-backend/README.md
@@ -126,6 +126,34 @@ The badges backend api exposes two main endpoints for entity badges. The
   an SVG image. If the `accept` request header prefers `application/json` the
   badge spec as JSON will be returned instead of the image.
 
+## External access to badges if authentification is enabled
+
+To access the badges from third party applications, you need to make sure that the authMiddleware is disabled for this route. in `src/index.ts`
+
+from :
+
+```ts
+  const apiRouter = Router();
+  ...
+  // 3. Register the badges plugin in the router
+  apiRouter.use('/badges', authMiddleware, await badges(badgesEnv));
+  ...
+  apiRouter.use(notFoundHandler());
+```
+
+to :
+
+```ts
+  const apiRouter = Router();
+  ...
+  // 3. Register the badges plugin in the router
+  apiRouter.use('/badges', await badges(badgesEnv));
+  ...
+  apiRouter.use(notFoundHandler());
+```
+
+> Please think about the security implications of this change before you apply it. It will mean anybody will be able to use the badges API
+
 ## Links
 
 - [Frontend part of the plugin](https://github.com/backstage/backstage/tree/master/plugins/badges)

--- a/plugins/badges-backend/README.md
+++ b/plugins/badges-backend/README.md
@@ -126,7 +126,7 @@ The badges backend api exposes two main endpoints for entity badges. The
   an SVG image. If the `accept` request header prefers `application/json` the
   badge spec as JSON will be returned instead of the image.
 
-## External access to badges if authentification is enabled
+## External access to badges if authentication is enabled
 
 To access the badges from third party applications, you need to make sure that the authMiddleware is disabled for this route. in `src/index.ts`
 

--- a/plugins/badges-backend/api-report.md
+++ b/plugins/badges-backend/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { TokenManager } from '@backstage/backend-common';
 
 // @public (undocumented)
 export interface Badge {
@@ -112,5 +113,7 @@ export interface RouterOptions {
   config: Config;
   // (undocumented)
   discovery: PluginEndpointDiscovery;
+  // (undocumented)
+  tokenManager: TokenManager;
 }
 ```

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -86,7 +86,7 @@ describe('createRouter', () => {
       catalog: catalog as Partial<CatalogApi> as CatalogApi,
       config,
       discovery,
-      env: { tokenManager },
+      tokenManager,
     });
     app = express().use(router);
   });
@@ -96,12 +96,13 @@ describe('createRouter', () => {
   });
 
   it('works', async () => {
+    const tokenManager = ServerTokenManager.noop();
     const router = await createRouter({
       badgeBuilder,
       catalog: catalog as Partial<CatalogApi> as CatalogApi,
       config,
       discovery,
-      env: {},
+      tokenManager,
     });
     expect(router).toBeDefined();
   });

--- a/plugins/badges-backend/src/service/router.ts
+++ b/plugins/badges-backend/src/service/router.ts
@@ -19,6 +19,7 @@ import Router from 'express-promise-router';
 import {
   errorHandler,
   PluginEndpointDiscovery,
+  TokenManager,
 } from '@backstage/backend-common';
 import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
@@ -33,7 +34,7 @@ export interface RouterOptions {
   catalog?: CatalogApi;
   config: Config;
   discovery: PluginEndpointDiscovery;
-  env: any;
+  tokenManager: TokenManager;
 }
 
 /** @public */
@@ -46,7 +47,7 @@ export async function createRouter(
     options.badgeBuilder ||
     new DefaultBadgeBuilder(options.badgeFactories || {});
   const router = Router();
-  const { tokenManager } = options.env;
+  const tokenManager = options.tokenManager;
 
   router.get('/entity/:namespace/:kind/:name/badge-specs', async (req, res) => {
     const token = await tokenManager.getToken();

--- a/plugins/badges-backend/src/service/standaloneServer.ts
+++ b/plugins/badges-backend/src/service/standaloneServer.ts
@@ -20,6 +20,7 @@ import {
   createServiceBuilder,
   loadBackendConfig,
   SingleHostDiscovery,
+  ServerTokenManager,
 } from '@backstage/backend-common';
 import { createRouter } from './router';
 
@@ -37,8 +38,8 @@ export async function startStandaloneServer(
   const discovery = SingleHostDiscovery.fromConfig(config);
 
   logger.debug('Creating application...');
-
-  const router = await createRouter({ config, discovery, env: undefined });
+  const tokenManager = ServerTokenManager.noop();
+  const router = await createRouter({ config, discovery, tokenManager });
 
   let service = createServiceBuilder(module)
     .setPort(options.port)

--- a/plugins/badges-backend/src/service/standaloneServer.ts
+++ b/plugins/badges-backend/src/service/standaloneServer.ts
@@ -38,7 +38,7 @@ export async function startStandaloneServer(
 
   logger.debug('Creating application...');
 
-  const router = await createRouter({ config, discovery });
+  const router = await createRouter({ config, discovery, env: undefined });
 
   let service = createServiceBuilder(module)
     .setPort(options.port)


### PR DESCRIPTION
Fixes a bug where the badge endpoint would return a 401 even if the authMiddleware was disabled.

## Hey, I just made a Pull Request!

### Context

Related to [this issue](https://github.com/backstage/backstage/issues/5039).

Today, if backend to backend authentication is enabled, even if the `/badges` route is not protected by the `authMiddleware`, trying to load a badge while being unauthenticated generate a HTTP 401.

The actual behavior with the `authMiddleware` enabled is the following : 

![image](https://user-images.githubusercontent.com/17565349/223739331-4362f357-0d24-4264-b151-796b1621e186.png)

If you disable the `authMiddleware` because you want to exposes badges (like in Github readme) :

![image](https://user-images.githubusercontent.com/17565349/223739014-cd9191c9-a13e-4e07-bda3-1e5907ac02b2.png)

It is impossible.

**This PR fixes that behavior by requesting a token to the `tokenManager` instead of extracting if from the client call.**

Doing this you can still protect your /badge route with the authMiddleware 

![image](https://user-images.githubusercontent.com/17565349/223740214-f3a453dc-4716-49d5-a597-4061bc4159b6.png)


And if you want to expose publicly your badge endpoint to use it on third party websites : 

![image](https://user-images.githubusercontent.com/17565349/223740668-fa05a5ef-f30a-4694-9e80-166fa5397faa.png)


### Security implications

- You can still protect your badges endpoint with the authMiddleware if you do not want to expose it.
- If you disable the `authMiddleware` for the /badges endpoint, with that fix, **anybody** can call the `badges-backend API`, so this endpoint could be used to enumerate the available entities for example.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
