### PR TITLE
Fix font size and color in search result item

### DIFF
--- a/.changeset/many-eggs-press.md
+++ b/.changeset/many-eggs-press.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Fixes a UI bug in search result item which rendered the item text with incorrect font size and color

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -81,6 +81,8 @@ export const DefaultResultListItemComponent = ({
               WebkitLineClamp: lineClamp,
               overflow: 'hidden',
             }}
+            color="textSecondary"
+            variant="body2"
           >
             {highlight?.fields.text ? (
               <HighlightedSearchResultText

--- a/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
@@ -132,6 +132,8 @@ export const TechDocsSearchResultListItem = (
               WebkitLineClamp: lineClamp,
               overflow: 'hidden',
             }}
+            color="textSecondary"
+            variant="body2"
           >
             {highlight?.fields.text ? (
               <HighlightedSearchResultText


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR fixes the font size and color of a list item. The bug was introduced in release 1.10.0 when the ` linter <span> rule` was imposed and all the `span`s were replaced by `<Typography>` elements. This adversely affected the `span`s used inside MUI's `<ListItem>`'s secondary attribute. Earlier, they were rendered using the styles for the `body2` variant and `textSecondary` color. But after the change to `<Typography>` they started rendering using `body1` variant with the default color of text. Here are the screenshots of how it looks before and after the fix.

Current
![image](https://user-images.githubusercontent.com/60712256/223812945-83b841e9-21dc-43ca-ab80-b06a55e29004.png)

After this fix
![image](https://user-images.githubusercontent.com/60712256/223813194-35caa7b9-8243-4594-b10c-da8b2648c4e8.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
