### PR TITLE
feat(techdocs-backend): adds a Publish Strategy

### DIFF
--- a/.changeset/angry-squids-tan.md
+++ b/.changeset/angry-squids-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+Adds a Publish Strategy feature to allow custom publish paths

--- a/docs/features/techdocs/concepts.md
+++ b/docs/features/techdocs/concepts.md
@@ -64,6 +64,17 @@ config as well as the entity being processed to make a decision.
 For an example of how the Build Strategy can be used to implement a 'hybrid' build model, refer to
 the [How to implement a hybrid build strategy](./how-to-guides.md#how-to-implement-a-hybrid-build-strategy) guide.
 
+## TechDocs Publish Strategy
+
+To allow more complex logic surrounding the publishing location of the generated TechDocs, the TechDocs
+backend supports a Publish Strategy.
+The Publish Strategy is responsible for determining the resolution path of the techdocs for the entity.
+By default, the path is `{namespace}/{kind}/{name}`. This is sufficient for most cases however the ability to
+override this behaviour removes the limitations.
+
+For an example of how the Publish Strategy can be used to implement a 'custom' publish model, refer to
+the [How to implement a custom publish strategy](./how-to-guides.md#how-to-implement-a-custom-publish-strategy) guide.
+
 ## TechDocs Container
 
 The TechDocs container is a Docker container available at

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -7,6 +7,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { CatalogClient } from '@backstage/catalog-client';
+import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { DocumentCollatorFactory } from '@backstage/plugin-search-common';
 import { Entity } from '@backstage/catalog-model';
@@ -69,6 +70,20 @@ export interface DocsBuildStrategy {
 }
 
 // @public
+export interface DocsPublishStrategy {
+  // (undocumented)
+  resolveEntityName(params: EntityNameParameters): Promise<CompoundEntityRef>;
+  // (undocumented)
+  usePublishStrategy(param: UsePublishStrategyParameters): Promise<boolean>;
+}
+
+// @public
+export type EntityNameParameters = {
+  entity: Entity;
+  alternateName?: string;
+};
+
+// @public
 export type OutOfTheBoxDeploymentOptions = {
   preparers: PreparerBuilder;
   generators: GeneratorBuilder;
@@ -79,6 +94,7 @@ export type OutOfTheBoxDeploymentOptions = {
   config: Config;
   cache: PluginCacheManager;
   docsBuildStrategy?: DocsBuildStrategy;
+  docsPublishStrategy?: DocsPublishStrategy;
   buildLogTransport?: winston.transport;
   catalogClient?: CatalogClient;
 };
@@ -91,6 +107,7 @@ export type RecommendedDeploymentOptions = {
   config: Config;
   cache: PluginCacheManager;
   docsBuildStrategy?: DocsBuildStrategy;
+  docsPublishStrategy?: DocsPublishStrategy;
   buildLogTransport?: winston.transport;
   catalogClient?: CatalogClient;
 };
@@ -128,6 +145,11 @@ export type TechDocsCollatorOptions = {
 };
 
 export { TechDocsDocument };
+
+// @public
+export type UsePublishStrategyParameters = {
+  entity: Entity;
+};
 
 export * from '@backstage/plugin-techdocs-node';
 ```

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -27,6 +27,12 @@ export interface Config {
     builder: 'local' | 'external';
 
     /**
+     * Documentation entity name resolution can be overridden with the alternateEntityName attr
+     * and a custom DocsPublishStrategy
+     */
+    alternateName?: string;
+
+    /**
      * Techdocs generator information
      */
     generator?: {

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -27,8 +27,8 @@ export interface Config {
     builder: 'local' | 'external';
 
     /**
-     * Documentation entity name resolution can be overridden with the alternateEntityName attr
-     * and a custom DocsPublishStrategy
+     * Documentation entity name resolution can be overridden with the alternateName
+     * attr and a custom DocsPublishStrategy.
      */
     alternateName?: string;
 

--- a/plugins/techdocs-backend/src/index.ts
+++ b/plugins/techdocs-backend/src/index.ts
@@ -27,6 +27,9 @@ export type {
   OutOfTheBoxDeploymentOptions,
   DocsBuildStrategy,
   ShouldBuildParameters,
+  DocsPublishStrategy,
+  EntityNameParameters,
+  UsePublishStrategyParameters,
 } from './service';
 
 export {

--- a/plugins/techdocs-backend/src/service/DocsPublishStrategy.test.ts
+++ b/plugins/techdocs-backend/src/service/DocsPublishStrategy.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DefaultDocsPublishStrategy } from './DocsPublishStrategy';
+import { ConfigReader } from '@backstage/config';
+import { CompoundEntityRef } from '@backstage/catalog-model';
+
+const MockedConfigReader = ConfigReader as jest.MockedClass<
+  typeof ConfigReader
+>;
+
+jest.mock('@backstage/config');
+
+describe('DefaultDocsPublishStrategy', () => {
+  const entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      uid: '0',
+      name: 'test',
+    },
+  };
+
+  const config = new ConfigReader({});
+  const expectedDefault: CompoundEntityRef = {
+    name: entity.metadata.name,
+    kind: entity.kind,
+    namespace: 'default',
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('customEntityResolver', () => {
+    it('should return the default entity', async () => {
+      const defaultDocsPublishStrategy =
+        DefaultDocsPublishStrategy.fromConfig(config);
+
+      const result = await defaultDocsPublishStrategy.resolveEntityName({
+        entity,
+      });
+
+      expect(result).toEqual(expectedDefault);
+    });
+
+    it('should return true when techdocs.alternateName is set', async () => {
+      const defaultDocsPublishStrategy =
+        DefaultDocsPublishStrategy.fromConfig(config);
+
+      MockedConfigReader.prototype.getOptionalString.mockReturnValue('isset');
+
+      const result = await defaultDocsPublishStrategy.usePublishStrategy({
+        entity,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when techdocs.alternateName is not set', async () => {
+      const defaultDocsPublishStrategy =
+        DefaultDocsPublishStrategy.fromConfig(config);
+
+      MockedConfigReader.prototype.getOptionalString.mockReturnValue(undefined);
+
+      const result = await defaultDocsPublishStrategy.usePublishStrategy({
+        entity,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/plugins/techdocs-backend/src/service/DocsPublishStrategy.ts
+++ b/plugins/techdocs-backend/src/service/DocsPublishStrategy.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
+
+/**
+ * Parameters passed to the usePublishStrategy method on the DocsPublishStrategy interface
+ *
+ * @public
+ */
+export type UsePublishStrategyParameters = {
+  entity: Entity;
+};
+
+/**
+ * Parameters passed to the resolveEntityName method on the DOcsPublishStrategy interface
+ *
+ * @public
+ */
+export type EntityNameParameters = {
+  entity: Entity;
+  alternateName?: string;
+};
+
+/**
+ * A strategy for how to resolve the techdocs publishing path.
+ * Implment an override when a non-standard path is required for storage.
+ *
+ * @public
+ */
+export interface DocsPublishStrategy {
+  usePublishStrategy(param: UsePublishStrategyParameters): Promise<boolean>;
+  resolveEntityName(params: EntityNameParameters): Promise<CompoundEntityRef>;
+}
+
+export class DefaultDocsPublishStrategy {
+  private readonly config: Config;
+
+  private constructor(config: Config) {
+    this.config = config;
+  }
+
+  static fromConfig(config: Config): DefaultDocsPublishStrategy {
+    return new DefaultDocsPublishStrategy(config);
+  }
+
+  async usePublishStrategy(_: UsePublishStrategyParameters): Promise<boolean> {
+    return Boolean(this.config.getOptionalString('techdocs.alternateName'));
+  }
+
+  async resolveEntityName(
+    params: EntityNameParameters,
+  ): Promise<CompoundEntityRef> {
+    return {
+      name: params.entity.metadata.name,
+      namespace: params.entity.metadata.namespace || 'default',
+      kind: params.entity.kind,
+    };
+  }
+}

--- a/plugins/techdocs-backend/src/service/index.ts
+++ b/plugins/techdocs-backend/src/service/index.ts
@@ -24,3 +24,8 @@ export type {
   DocsBuildStrategy,
   ShouldBuildParameters,
 } from './DocsBuildStrategy';
+export type {
+  UsePublishStrategyParameters,
+  EntityNameParameters,
+  DocsPublishStrategy,
+} from './DocsPublishStrategy';


### PR DESCRIPTION
This feature will allow customization of the techdocs publishing location

## Hey, I just made a Pull Request!

This allows users to override the default publishing location. 
Uses the same pattern as the DocsBuildStrategy.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
