### PR TITLE
Save conflicting location data and add retrieval endpoint

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -223,7 +223,7 @@ catalog:
         - System
         - Domain
         - Location
-
+  saveConflicts: true
   processors:
     ldapOrg:
       ### Example for how to add your enterprise LDAP server

--- a/packages/catalog-model/package.json
+++ b/packages/catalog-model/package.json
@@ -50,7 +50,8 @@
     "ajv": "^8.10.0",
     "json-schema": "^0.4.0",
     "lodash": "^4.17.21",
-    "uuid": "^8.0.0"
+    "uuid": "^8.0.0",
+    "luxon": "^3.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/catalog-backend/migrations/20230308174406_add_conflict_columns.js
+++ b/plugins/catalog-backend/migrations/20230308174406_add_conflict_columns.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('refresh_state', table => {
+    table
+      .dateTime('last_conflict_at')
+      .nullable()
+      .comment('The datetime that the last conflict was found');
+    table
+      .string('conflicting_location_key')
+      .nullable()
+      .comment('The last attempted conflict location');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('refresh_state', table => {
+    table.dropColumn('last_conflict_at');
+    table.dropColumn('conflicting_location_key');
+  });
+};

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
+import { DateTime } from 'luxon';
 
 /**
  * A filter expression for entities.
@@ -184,6 +185,13 @@ export interface EntitiesCatalog {
   queryEntities(request: QueryEntitiesRequest): Promise<QueryEntitiesResponse>;
 
   /**
+   * Request conflicting entities in the refresh state.
+   */
+  getConflictingEntities(options?: {
+    authorizationToken?: string;
+  }): Promise<EntityWithConflict[]>;
+
+  /**
    * Removes a single entity.
    *
    * @param uid - The metadata.uid of the entity
@@ -271,6 +279,18 @@ export interface QueryEntitiesResponse {
    */
   totalItems: number;
 }
+
+/**
+ * The response object for {@link EntitiesCatalog.getConflictingEntities}.
+ * Represents an entity in the refresh_state table that has had a conflicting entity attempt to override it.
+ */
+export type EntityWithConflict = {
+  entityId: string;
+  entityRef: string;
+  locationKey: string;
+  conflictingLocationKey: string;
+  lastConflictAt: DateTime;
+};
 
 /**
  * The Cursor used internally by the catalog.

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -32,6 +32,7 @@ import {
 import { createRandomProcessingInterval } from '../processing/refresh';
 import { timestampToDateTime } from './conversion';
 import { generateStableHash } from './util';
+import { ConfigReader } from '@backstage/config';
 
 describe('DefaultProcessingDatabase', () => {
   const defaultLogger = getVoidLogger();
@@ -44,6 +45,8 @@ describe('DefaultProcessingDatabase', () => {
     logger: Logger = defaultLogger,
   ) {
     const knex = await databases.init(databaseId);
+    const mockConfig = new ConfigReader({});
+
     await applyDatabaseMigrations(knex);
     return {
       knex,
@@ -54,6 +57,7 @@ describe('DefaultProcessingDatabase', () => {
           minSeconds: 100,
           maxSeconds: 150,
         }),
+        config: mockConfig,
       }),
     };
   }

--- a/plugins/catalog-backend/src/database/tables.ts
+++ b/plugins/catalog-backend/src/database/tables.ts
@@ -41,6 +41,8 @@ export type DbRefreshStateRow = {
   last_discovery_at: string | Date; // remove?
   errors?: string;
   location_key?: string;
+  conflicting_location_key?: string;
+  last_conflict_at?: string | Date;
 };
 
 export type DbRefreshKeysRow = {

--- a/plugins/catalog-backend/src/integration.test.ts
+++ b/plugins/catalog-backend/src/integration.test.ts
@@ -237,6 +237,7 @@ class TestHarness {
       database: db,
       logger,
       refreshInterval: () => 0.05,
+      config,
     });
 
     const integrations = ScmIntegrations.fromConfig(config);

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -30,9 +30,8 @@ describe('AuthorizedEntitiesCatalog', () => {
     removeEntityByUid: jest.fn(),
     entityAncestry: jest.fn(),
     facets: jest.fn(),
-    refresh: jest.fn(),
-    listAncestors: jest.fn(),
     queryEntities: jest.fn(),
+    getConflictingEntities: jest.fn(),
   };
   const fakePermissionApi = {
     authorize: jest.fn(),

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
@@ -36,6 +36,7 @@ import {
   EntityFacetsRequest,
   EntityFacetsResponse,
   EntityFilter,
+  EntityWithConflict,
   QueryEntitiesRequest,
   QueryEntitiesResponse,
 } from '../catalog/types';
@@ -262,6 +263,22 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
           ),
       ),
     };
+  }
+
+  async getConflictingEntities(options?: {
+    authorizationToken?: string;
+  }): Promise<EntityWithConflict[]> {
+    const authorizeDecision = (
+      await this.permissionApi.authorizeConditional(
+        [{ permission: catalogEntityReadPermission }],
+        { token: options?.authorizationToken },
+      )
+    )[0];
+    if (authorizeDecision.result === AuthorizeResult.DENY) {
+      throw new NotAllowedError();
+    }
+
+    return this.entitiesCatalog.getConflictingEntities();
   }
 
   async facets(request: EntityFacetsRequest): Promise<EntityFacetsResponse> {

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -440,6 +440,7 @@ export class CatalogBuilder {
       database: dbClient,
       logger,
       refreshInterval: this.processingInterval,
+      config,
     });
     const providerDatabase = new DefaultProviderDatabase({
       database: dbClient,

--- a/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
@@ -33,6 +33,7 @@ import { DefaultCatalogProcessingEngine } from '../processing/DefaultCatalogProc
 import { EntityProcessingRequest } from '../processing/types';
 import { Stitcher } from '../stitching/Stitcher';
 import { DefaultRefreshService } from './DefaultRefreshService';
+import { ConfigReader } from '@backstage/config';
 
 describe('DefaultRefreshService', () => {
   const defaultLogger = getVoidLogger();
@@ -44,6 +45,7 @@ describe('DefaultRefreshService', () => {
     databaseId: TestDatabaseId,
     logger: Logger = defaultLogger,
   ) {
+    const mockConfig = new ConfigReader({});
     const knex = await databases.init(databaseId);
     await applyDatabaseMigrations(knex);
     return {
@@ -52,6 +54,7 @@ describe('DefaultRefreshService', () => {
         database: knex,
         logger,
         refreshInterval: () => 100,
+        config: mockConfig,
       }),
       catalogDb: new DefaultCatalogDatabase({
         database: knex,

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -54,6 +54,7 @@ describe('createRouter readonly disabled', () => {
       entityAncestry: jest.fn(),
       facets: jest.fn(),
       queryEntities: jest.fn(),
+      getConflictingEntities: jest.fn(),
     };
     locationService = {
       getLocation: jest.fn(),
@@ -675,6 +676,7 @@ describe('createRouter readonly enabled', () => {
       entityAncestry: jest.fn(),
       facets: jest.fn(),
       queryEntities: jest.fn(),
+      getConflictingEntities: jest.fn(),
     };
     locationService = {
       getLocation: jest.fn(),
@@ -866,6 +868,7 @@ describe('NextRouter permissioning', () => {
       entityAncestry: jest.fn(),
       facets: jest.fn(),
       queryEntities: jest.fn(),
+      getConflictingEntities: jest.fn(),
     };
     locationService = {
       getLocation: jest.fn(),

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -215,6 +215,12 @@ export async function createRouter(
           authorizationToken: getBearerToken(req.header('authorization')),
         });
         res.status(200).json(response);
+      })
+      .get('/entities/conflicts', async (req, res) => {
+        const items = await entitiesCatalog.getConflictingEntities({
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
+        res.status(200).json(items);
       });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR allows the saving of conflicting locations when they are processed and adds an api endpoint to query entities that have conflicts registered against them so that they can be resolved. 

<img width="1094" alt="Screenshot 2023-03-09 at 18 30 25" src="https://user-images.githubusercontent.com/7934833/224108090-24fad21e-a087-43d4-925b-b87b395948b8.png">

To Do:
- Add tests
- Add conflict resolution endpoint??

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
