### PR TITLE
[Stack Overflow] fix broken stack overflow stories - mock stack overflow api

### DIFF
--- a/.changeset/silver-donkeys-eat.md
+++ b/.changeset/silver-donkeys-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow': patch
+---
+
+Export api ref and StackOverflowApi type

--- a/packages/app/src/components/home/templates/DefaultTemplate.stories.tsx
+++ b/packages/app/src/components/home/templates/DefaultTemplate.stories.tsx
@@ -19,7 +19,7 @@ import {
   HomePageCompanyLogo,
   HomePageStarredEntities,
   TemplateBackstageLogo,
-  TemplateBackstageLogoIcon
+  TemplateBackstageLogoIcon,
 } from '@backstage/plugin-home';
 import { wrapInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { Content, Page, InfoCard } from '@backstage/core-components';
@@ -31,12 +31,12 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { ConfigReader } from '@backstage/config';
+import { HomePageSearchBar, searchPlugin } from '@backstage/plugin-search';
 import {
-  HomePageSearchBar,
-  searchPlugin,
-} from '@backstage/plugin-search';
-import { searchApiRef, SearchContextProvider } from '@backstage/plugin-search-react';
-import { HomePageStackOverflowQuestions } from '@backstage/plugin-stack-overflow';
+  searchApiRef,
+  SearchContextProvider,
+} from '@backstage/plugin-search-react';
+import { stackOverflowApiRef, HomePageStackOverflowQuestions } from '@backstage/plugin-stack-overflow';
 import { Grid, makeStyles } from '@material-ui/core';
 import React, { ComponentType } from 'react';
 
@@ -79,6 +79,25 @@ const mockCatalogApi = {
   getEntities: async () => ({ items: entities }),
 };
 
+const mockStackOverflowApi = {
+  listQuestions: async () => [
+    {
+      title: 'Customizing Spotify backstage UI',
+      link: 'stackoverflow.question/1',
+      answer_count: 0,
+      tags: ['backstage'],
+      owner: { 'some owner': 'name' },
+    },
+    {
+      title: 'Customizing Spotify backstage UI',
+      link: 'stackoverflow.question/1',
+      answer_count: 0,
+      tags: ['backstage'],
+      owner: { 'some owner': 'name' },
+    },
+  ],
+};
+
 const starredEntitiesApi = new MockStarredEntitiesApi();
 starredEntitiesApi.toggleStarred('component:default/example-starred-entity');
 starredEntitiesApi.toggleStarred('component:default/example-starred-entity-2');
@@ -93,6 +112,7 @@ export default {
         <>
           <TestApiProvider
             apis={[
+              [stackOverflowApiRef, mockStackOverflowApi],
               [catalogApiRef, mockCatalogApi],
               [starredEntitiesApiRef, starredEntitiesApi],
               [searchApiRef, { query: () => Promise.resolve({ results: [] }) }],

--- a/plugins/stack-overflow/api-report.md
+++ b/plugins/stack-overflow/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CardExtensionProps } from '@backstage/plugin-home';
 import { ReactNode } from 'react';
@@ -14,6 +15,16 @@ import { ResultHighlight } from '@backstage/plugin-search-common';
 export const HomePageStackOverflowQuestions: (
   props: CardExtensionProps<StackOverflowQuestionsContentProps>,
 ) => JSX.Element;
+
+// @public (undocumented)
+export type StackOverflowApi = {
+  listQuestions(options?: {
+    requestParams: StackOverflowQuestionsRequestParams;
+  }): Promise<StackOverflowQuestion[]>;
+};
+
+// @public (undocumented)
+export const stackOverflowApiRef: ApiRef<StackOverflowApi>;
 
 // @public
 export const StackOverflowIcon: () => JSX.Element;

--- a/plugins/stack-overflow/src/api/StackOverflowApi.ts
+++ b/plugins/stack-overflow/src/api/StackOverflowApi.ts
@@ -20,10 +20,16 @@ import {
   StackOverflowQuestionsRequestParams,
 } from '../types';
 
+/**
+ * @public
+ */
 export const stackOverflowApiRef = createApiRef<StackOverflowApi>({
   id: 'plugin.stackoverflow.service',
 });
 
+/**
+ * @public
+ */
 export type StackOverflowApi = {
   listQuestions(options?: {
     requestParams: StackOverflowQuestionsRequestParams;

--- a/plugins/stack-overflow/src/home/StackOverflowQuestions/StackOverflowQuestions.stories.tsx
+++ b/plugins/stack-overflow/src/home/StackOverflowQuestions/StackOverflowQuestions.stories.tsx
@@ -21,6 +21,26 @@ import { ConfigReader } from '@backstage/config';
 import { Grid } from '@material-ui/core';
 import React, { ComponentType } from 'react';
 import { StackOverflowIcon } from '../../icons';
+import { stackOverflowApiRef } from '../../api';
+
+const mockStackOverflowApi = {
+  listQuestions: async () => [
+    {
+      title: 'Customizing Spotify backstage UI',
+      link: 'stackoverflow.question/1',
+      answer_count: 0,
+      tags: ['backstage'],
+      owner: { 'some owner': 'name' },
+    },
+    {
+      title: 'Customizing Spotify backstage UI',
+      link: 'stackoverflow.question/1',
+      answer_count: 0,
+      tags: ['backstage'],
+      owner: { 'some owner': 'name' },
+    },
+  ],
+};
 
 export default {
   title: 'Plugins/Home/Components/StackOverflow',
@@ -39,6 +59,7 @@ export default {
                   },
                 }),
               ],
+              [stackOverflowApiRef, mockStackOverflowApi],
             ]}
           >
             <Story />

--- a/plugins/stack-overflow/src/index.ts
+++ b/plugins/stack-overflow/src/index.ts
@@ -30,3 +30,5 @@ export type {
   StackOverflowQuestionsContentProps,
   StackOverflowQuestionsRequestParams,
 } from './types';
+export { stackOverflowApiRef } from './api';
+export type { StackOverflowApi } from './api';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Had a couple of storybook examples for stack overflow components that was broken. This fixes them by mocking the stack overflow api. 

<img width="1726" alt="Screenshot 2023-03-10 at 15 41 23" src="https://user-images.githubusercontent.com/25153114/224344770-e85a9e3b-3bde-4b1c-93d8-91fce14c3612.png">

<img width="1725" alt="Screenshot 2023-03-10 at 15 42 24" src="https://user-images.githubusercontent.com/25153114/224344817-9be296e0-bb8f-4e9f-b2f4-3f9738ad2617.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
