### PR TITLE
Add zod as dependency for example todolist plugin to specify version

### DIFF
--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -91,7 +91,7 @@ This enables decisions based on characteristics of the resource, but it's import
 Install the missing module:
 
 ```bash
-$ yarn workspace @internal/plugin-todo-list-backend add @backstage/plugin-permission-node zod
+$ yarn workspace @internal/plugin-todo-list-backend add @backstage/plugin-permission-node
 ```
 
 Create a new `plugins/todo-list-backend/src/service/rules.ts` file and append the following code:

--- a/plugins/example-todo-list-backend/package.json
+++ b/plugins/example-todo-list-backend/package.json
@@ -34,7 +34,8 @@
     "express-promise-router": "^4.1.0",
     "uuid": "^8.3.2",
     "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "yn": "^4.0.0",
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This specifies the zod version for the example permissions todolist plugin. This is needed because there were TS errors with the newest version of zod which gets installed from the CLI.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
