### PR TITLE
Make JSON schema available in field validator functions

### DIFF
--- a/.changeset/friendly-steaks-teach.md
+++ b/.changeset/friendly-steaks-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+---
+
+Augmented the field parameter for custom validation functions to include the field's JSON schema.

--- a/.changeset/great-ants-scream.md
+++ b/.changeset/great-ants-scream.md
@@ -1,0 +1,41 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Augment the field parameter of custom validator functions to include the
+field's JSON schema. This makes it possible to retrive things like regular
+expressions rather than duplicating them in the code.
+
+Given the following template:
+
+```yaml
+parameters:
+  - title: Custom Fields
+    required:
+      - emailValue
+    properties:
+      emailValue:
+        title: An email address
+        type: string
+        pattern: '^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$'
+        ui:field: EmailValuePicker
+```
+
+The custom validator function can reach in and extract the regular expression like so:
+
+```typescript
+export const EmailValuePickerFieldExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'EmailValuePicker',
+    component: TextValuePicker,
+    validation: (value: string, validation: ExtendedFieldValidation) => {
+      const { pattern } = fieldValidation.schema.properties.emailValue;
+      const validEmailCheck = new RegExp(pattern);
+
+      if (!validEmailCheck.test(value)) {
+        validation.addError('Not a valid email address.');
+      }
+    },
+  }),
+);
+```

--- a/plugins/scaffolder-react/src/extensions/types.ts
+++ b/plugins/scaffolder-react/src/extensions/types.ts
@@ -14,8 +14,21 @@
  * limitations under the License.
  */
 import { ApiHolder } from '@backstage/core-plugin-api';
+import { JsonObject } from '@backstage/types';
 import { FieldValidation, FieldProps } from '@rjsf/core';
 import { JSONSchema7 } from 'json-schema';
+
+/**
+ * Type for field validation that includes
+ * errors and, optionally, the JSON schema for
+ * the field in question.
+ *
+ * @public
+ */
+export type ExtendedFieldValidation =
+  | FieldValidation & {
+      schema?: JsonObject;
+    };
 
 /**
  * Field validation type for Custom Field Extensions.
@@ -24,7 +37,7 @@ import { JSONSchema7 } from 'json-schema';
  */
 export type CustomFieldValidator<TFieldReturnValue> = (
   data: TFieldReturnValue,
-  field: FieldValidation,
+  field: ExtendedFieldValidation,
   context: { apiHolder: ApiHolder },
 ) => void | Promise<void>;
 

--- a/plugins/scaffolder/src/components/TemplatePage/createValidator.test.ts
+++ b/plugins/scaffolder/src/components/TemplatePage/createValidator.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { createValidator } from './createValidator';
-import { CustomFieldValidator } from '@backstage/plugin-scaffolder-react';
+import {
+  ExtendedFieldValidation,
+  CustomFieldValidator,
+} from '@backstage/plugin-scaffolder-react';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { FieldValidation, FormValidation } from '@rjsf/core';
 
@@ -56,12 +59,16 @@ describe('createValidator', () => {
       },
       TagPicker: (
         values: unknown,
-        fieldValidation: FieldValidation,
+        fieldValidation: ExtendedFieldValidation,
         _context: { apiHolder: ApiHolder },
       ) => {
         const input = values as string[];
+
+        const { pattern } = fieldValidation.schema.properties.tags;
+        const validTagCheck = new RegExp(pattern);
+
         for (const item of input) {
-          if (!/^[a-z0-9-]+$/.test(item)) {
+          if (!validTagCheck.test(item)) {
             fieldValidation.addError(
               'A tag name can only contain lowercase letters, numeric characters or dashes',
             );
@@ -124,6 +131,7 @@ describe('createValidator', () => {
             type: 'string',
             'ui:field': 'TagPicker',
           },
+          pattern: '^[a-z0-9-]+$',
         },
       },
     };
@@ -137,6 +145,13 @@ describe('createValidator', () => {
       tags: {
         addError: jest.fn(),
       } as unknown as FormValidation,
+      schema: {
+        properties: {
+          tags: {
+            pattern: '^[a-z0-9-]+$',
+          },
+        },
+      },
     } as unknown as FormValidation;
 
     /* WHEN */

--- a/plugins/scaffolder/src/components/TemplatePage/createValidator.ts
+++ b/plugins/scaffolder/src/components/TemplatePage/createValidator.ts
@@ -18,6 +18,7 @@ import { CustomFieldValidator } from '@backstage/plugin-scaffolder-react';
 import { FormValidation } from '@rjsf/core';
 import { JsonObject, JsonValue } from '@backstage/types';
 import { ApiHolder } from '@backstage/core-plugin-api';
+import { ExtendedFieldValidation } from '@backstage/plugin-scaffolder-react';
 
 function isObject(obj: unknown): obj is JsonObject {
   return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
@@ -48,7 +49,7 @@ export const createValidator = (
 
     if (schemaProps) {
       for (const [key, propData] of Object.entries(formData)) {
-        const propValidation = errors[key];
+        const propValidation = { ...errors[key], schema };
 
         const doValidate = (item: JsonValue | undefined) => {
           if (item && isObject(item)) {
@@ -68,7 +69,7 @@ export const createValidator = (
           validate(
             propSchemaProps,
             propData as JsonObject,
-            propValidation as FormValidation,
+            propValidation as ExtendedFieldValidation,
           );
         } else if (isArray(propData)) {
           if (isObject(propSchemaProps)) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR augments the field parameter in custom field validator functions with
the JSON schema of the field in question. This allows for validation checks in
the form of regular expressions or the like that are included in the form's JSON
schema to be reused in the code rather than having to duplicate them.

Implements #15465. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

