### PR TITLE
feat(vault): add approle auth + subkeys support

### DIFF
--- a/.changeset/purple-teachers-think.md
+++ b/.changeset/purple-teachers-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-vault-backend': minor
+---
+
+Extend vault backend plugin with support for AppRole auth method as well as subkeys.

--- a/plugins/vault-backend/README.md
+++ b/plugins/vault-backend/README.md
@@ -65,12 +65,16 @@ To get started, first you need a running instance of Vault. You can follow [this
    vault:
      baseUrl: http://your-internal-vault-url.svc
      publicUrl: https://your-vault-url.example.com
-     token: <VAULT_TOKEN>
+     token: <VAULT_TOKEN> # Required for authMethod 'token'. Set to 'none' for authMethod 'approle'.
      secretEngine: 'customSecretEngine' # Optional. By default it uses 'secrets'
      kvVersion: <kv-version> # Optional. The K/V version that your instance is using. The available options are '1' or '2'
+     listType: metadata # Optional, values: metadata | subkeys, default: metadata
+     authMethod: token # Optional, values: token | approle, default: token
+     authRoleId: <VAULT_ROLEID> # Required for authMethod 'approle'
+     authSecretId: <VAULT_SECRETID> # Required for authMethod 'approle'
    ```
 
-4. Get a `VAULT_TOKEN` with **LIST** permissions, as it's enough for the plugin. You can check [this tutorial](https://learn.hashicorp.com/tutorials/vault/tokens) for more info.
+4. Get a `VAULT_TOKEN` with **LIST** permissions, as it's enough for the plugin, when using the `token` authentication method. You can check [this tutorial](https://learn.hashicorp.com/tutorials/vault/tokens) for more info. For the authentication method `approle` follow [this tutorial](https://developer.hashicorp.com/vault/docs/auth/approle) to get the values for `authRoleId` and `authSecretId`.
 
 5. If you also want to use the `renew` functionality, you need to attach the following block to your custom policy, so that Backstage can perform a token-renew:
    ```

--- a/plugins/vault-backend/config.d.ts
+++ b/plugins/vault-backend/config.d.ts
@@ -44,5 +44,25 @@ export interface Config {
      * The version of the K/V API. Defaults to `2`.
      */
     kvVersion?: 1 | 2;
+
+    /**
+     * The list type for K/V API v2. Defaults to `metadata`.
+     */
+    listType?: 'metadata' | 'subkeys';
+
+    /**
+     * The authentication method. Defaults to `token`.
+     */
+    authMethod?: 'token' | 'approle';
+
+    /**
+     * The role id for authentication method `approle`.
+     */
+    authRoleId?: string;
+
+    /**
+     * The secret id for authentication method `approle`.
+     */
+    authSecretId?: string;
   };
 }

--- a/plugins/vault-backend/src/config/config.ts
+++ b/plugins/vault-backend/src/config/config.ts
@@ -46,6 +46,26 @@ export interface VaultConfig {
    * The version of the K/V API. Defaults to `2`.
    */
   kvVersion: number;
+
+  /**
+   * The list type for K/V API v2. Defaults to `metadata`.
+   */
+  listType: string;
+
+  /**
+   * The authentication method. Defaults to `token`.
+   */
+  authMethod: string;
+
+  /**
+   * The role id for authentication method `approle`.
+   */
+  authRoleId?: string;
+
+  /**
+   * The secret id for authentication method `approle`.
+   */
+  authSecretId?: string;
 }
 
 /**
@@ -62,5 +82,9 @@ export function getVaultConfig(config: Config): VaultConfig {
     token: config.getString('vault.token'),
     kvVersion: config.getOptionalNumber('vault.kvVersion') ?? 2,
     secretEngine: config.getOptionalString('vault.secretEngine') ?? 'secrets',
+    listType: config.getOptionalString('vault.listType') ?? 'metadata',
+    authMethod: config.getOptionalString('vault.authMethod') ?? 'token',
+    authRoleId: config.getOptionalString('vault.authRoleId') ?? '',
+    authSecretId: config.getOptionalString('vault.authSecretId') ?? '',
   };
 }

--- a/plugins/vault-backend/src/service/vaultApi.test.ts
+++ b/plugins/vault-backend/src/service/vaultApi.test.ts
@@ -35,11 +35,13 @@ describe('VaultApi', () => {
   const mockListResult: VaultSecretList = {
     data: {
       keys: ['secret::one', 'secret::two'],
+      subkeys: [],
     },
   };
   const mockListResultEmpty: VaultSecretList = {
     data: {
       keys: [],
+      subkeys: [],
     },
   };
 

--- a/plugins/vault-backend/src/service/vaultApi.ts
+++ b/plugins/vault-backend/src/service/vaultApi.ts
@@ -27,7 +27,7 @@ import { getVaultConfig, VaultConfig } from '../config';
 export type VaultSecretList = {
   data: {
     keys: string[];
-    subkeys: string[];
+    subkeys: { [key: string]: any };
   };
 };
 
@@ -92,7 +92,7 @@ export class VaultClient implements VaultApi {
   ): Promise<T> {
     const url = new URL(path, this.vaultConfig.baseUrl);
     let fullUrl = url.toString();
-    if (query) {
+    if (Object.keys(query).length > 0) {
       fullUrl += `?${new URLSearchParams(query).toString()}`;
     }
     const headers: Record<string, string> = {
@@ -158,7 +158,7 @@ export class VaultClient implements VaultApi {
       const vaultUrl = this.vaultConfig.publicUrl || this.vaultConfig.baseUrl;
       secrets.push({
         name: key,
-        path: '',
+        path: `${secretPath}/`, // NOTE: The trailing slash fixes wrong UI display behavior
         editUrl: `${vaultUrl}/ui/vault/secrets/${this.vaultConfig.secretEngine}/edit/${secretPath}`,
         showUrl: `${vaultUrl}/ui/vault/secrets/${this.vaultConfig.secretEngine}/show/${secretPath}`,
       });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Extend the vault backend plugin with support for [AppRole authentication method](https://developer.hashicorp.com/vault/docs/auth/approle) as well as support for [subkeys](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-subkeys).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
