### PR TITLE
Handle token difference in Microsoft provider

### DIFF
--- a/.changeset/many-carpets-act.md
+++ b/.changeset/many-carpets-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Handle difference in expiration time between Microsoft session and Backstage session which caused the Backstage token to be invalid during a time frame.

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -50,6 +50,8 @@ import {
 import { Logger } from 'winston';
 import fetch from 'node-fetch';
 
+const BACKSTAGE_SESSION_EXPIRATION = 3600;
+
 type PrivateInfo = {
   refreshToken: string;
 };
@@ -145,12 +147,17 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
 
     const { profile } = await this.authHandler(result, this.resolverContext);
 
+    const expiresInSeconds =
+      result.params.expires_in === undefined
+        ? BACKSTAGE_SESSION_EXPIRATION
+        : Math.min(result.params.expires_in, BACKSTAGE_SESSION_EXPIRATION);
+
     const response: OAuthResponse = {
       providerInfo: {
         idToken: result.params.id_token,
         accessToken: result.accessToken,
         scope: result.params.scope,
-        expiresInSeconds: result.params.expires_in,
+        expiresInSeconds,
       },
       profile,
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Handled difference in expiration time between Microsoft session and Backstage session which caused the Backstage token to be invalid during a time frame.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
