### PR TITLE
catalog-client: getEntitiesByRefs should return undefined

### DIFF
--- a/.changeset/tidy-ties-guess.md
+++ b/.changeset/tidy-ties-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Ensure that `getEntitiesByRefs` returns `undefined` instead of `null` for missing items

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -249,7 +249,7 @@ describe('CatalogClient', () => {
         { token },
       );
 
-      expect(response).toEqual({ items: [entity, null] });
+      expect(response).toEqual({ items: [entity, undefined] });
     });
   });
 

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -199,9 +199,11 @@ export class CatalogClient implements CatalogApi {
       throw await ResponseError.fromResponse(response);
     }
 
-    const { items } = await response.json();
+    const { items } = (await response.json()) as {
+      items: Array<Entity | null>;
+    };
 
-    return { items };
+    return { items: items.map(i => i ?? undefined) };
   }
 
   /**


### PR DESCRIPTION
The pitfalls of `any`.

Chose to obey the contract here, both because it's a 1.x package and because it aligns with other similar use cases already using undefined for this.