### PR TITLE
Entity feedback plugin: Add aggregate results by entityRef

### DIFF
--- a/.changeset/fast-snakes-buy.md
+++ b/.changeset/fast-snakes-buy.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-entity-feedback': minor
+'@backstage/plugin-entity-feedback-backend': patch
+'@backstage/plugin-entity-feedback-common': patch
+---
+
+Added an endpoint to fetch anonymous aggregated results from an entity

--- a/plugins/entity-feedback-backend/src/service/router.test.ts
+++ b/plugins/entity-feedback-backend/src/service/router.test.ts
@@ -258,6 +258,22 @@ describe('createRouter', () => {
     });
   });
 
+  describe('GET /ratings/:entityRef/aggregate', () => {
+    it('should get aggregated ratings for an entity correctly', async () => {
+      const response = await request(app)
+        .get('/ratings/component%3Adefault%2Fservice/aggregate')
+        .send();
+      expect(mockDbHandler.getRatings).toHaveBeenCalledWith(
+        'component:default/service',
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        DISLIKE: 1,
+        LIKE: 2,
+      });
+    });
+  });
+
   describe('POST /responses/:entityRef', () => {
     it('should record a response correctly', async () => {
       const body = { response: 'blah', comments: 'feedback', consent: true };

--- a/plugins/entity-feedback-common/api-report.md
+++ b/plugins/entity-feedback-common/api-report.md
@@ -10,9 +10,7 @@ export interface EntityRatingsData {
   // (undocumented)
   entityTitle?: string;
   // (undocumented)
-  ratings: {
-    [ratingValue: string]: number;
-  };
+  ratings: Ratings;
 }
 
 // @public (undocumented)
@@ -37,5 +35,11 @@ export interface Rating {
   rating: string;
   // (undocumented)
   userRef: string;
+}
+
+// @public (undocumented)
+export interface Ratings {
+  // (undocumented)
+  [ratingValue: string]: number;
 }
 ```

--- a/plugins/entity-feedback-common/src/index.ts
+++ b/plugins/entity-feedback-common/src/index.ts
@@ -43,10 +43,15 @@ export interface FeedbackResponse {
 /**
  * @public
  */
+export interface Ratings {
+  [ratingValue: string]: number;
+}
+
+/**
+ * @public
+ */
 export interface EntityRatingsData {
   entityRef: string;
   entityTitle?: string;
-  ratings: {
-    [ratingValue: string]: number;
-  };
+  ratings: Ratings;
 }

--- a/plugins/entity-feedback/api-report.md
+++ b/plugins/entity-feedback/api-report.md
@@ -13,6 +13,7 @@ import { EntityRatingsData } from '@backstage/plugin-entity-feedback-common';
 import { FeedbackResponse } from '@backstage/plugin-entity-feedback-common';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { Rating } from '@backstage/plugin-entity-feedback-common';
+import { Ratings } from '@backstage/plugin-entity-feedback-common';
 import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
@@ -22,6 +23,7 @@ export interface EntityFeedbackApi {
   getAllRatings(): Promise<EntityRatingsData[]>;
   // (undocumented)
   getOwnedRatings(ownerRef: string): Promise<EntityRatingsData[]>;
+  getRatingAggregates(entityRef: string): Promise<Ratings>;
   // (undocumented)
   getRatings(entityRef: string): Promise<Omit<Rating, 'entityRef'>[]>;
   // (undocumented)
@@ -47,6 +49,8 @@ export class EntityFeedbackClient implements EntityFeedbackApi {
   getAllRatings(): Promise<EntityRatingsData[]>;
   // (undocumented)
   getOwnedRatings(ownerRef: string): Promise<EntityRatingsData[]>;
+  // (undocumented)
+  getRatingAggregates(entityRef: string): Promise<Ratings>;
   // (undocumented)
   getRatings(entityRef: string): Promise<Omit<Rating, 'entityRef'>[]>;
   // (undocumented)

--- a/plugins/entity-feedback/src/api/EntityFeedbackApi.ts
+++ b/plugins/entity-feedback/src/api/EntityFeedbackApi.ts
@@ -19,6 +19,7 @@ import {
   EntityRatingsData,
   FeedbackResponse,
   Rating,
+  Ratings,
 } from '@backstage/plugin-entity-feedback-common';
 
 /**
@@ -39,6 +40,11 @@ export interface EntityFeedbackApi {
   recordRating(entityRef: string, rating: string): Promise<void>;
 
   getRatings(entityRef: string): Promise<Omit<Rating, 'entityRef'>[]>;
+
+  /**
+   * Returns anonymized aggregated results for one entityRef
+   */
+  getRatingAggregates(entityRef: string): Promise<Ratings>;
 
   recordResponse(
     entityRef: string,

--- a/plugins/entity-feedback/src/api/EntityFeedbackClient.test.ts
+++ b/plugins/entity-feedback/src/api/EntityFeedbackClient.test.ts
@@ -121,6 +121,24 @@ describe('EntityFeedbackClient', () => {
     expect(response).toEqual(ratings);
   });
 
+  it('getRatingAggregates', async () => {
+    const ratings = { LIKE: 3, DISLIKE: 5 };
+
+    server.use(
+      rest.get(
+        `${mockBaseUrl}/ratings/${encodeURIComponent(
+          'component:default/service',
+        )}/aggregate`,
+        (_, res, ctx) => res(ctx.json(ratings)),
+      ),
+    );
+
+    const response = await client.getRatingAggregates(
+      'component:default/service',
+    );
+    expect(response).toEqual(ratings);
+  });
+
   it('recordResponse', async () => {
     expect.assertions(1);
     const response = {

--- a/plugins/entity-feedback/src/api/EntityFeedbackClient.ts
+++ b/plugins/entity-feedback/src/api/EntityFeedbackClient.ts
@@ -20,6 +20,7 @@ import {
   EntityRatingsData,
   FeedbackResponse,
   Rating,
+  Ratings,
 } from '@backstage/plugin-entity-feedback-common';
 
 import { EntityFeedbackApi } from './EntityFeedbackApi';
@@ -85,6 +86,22 @@ export class EntityFeedbackClient implements EntityFeedbackApi {
     const baseUrl = await this.discoveryApi.getBaseUrl('entity-feedback');
     const resp = await this.fetchApi.fetch(
       `${baseUrl}/ratings/${encodeURIComponent(entityRef)}`,
+      {
+        method: 'GET',
+      },
+    );
+
+    if (!resp.ok) {
+      throw await ResponseError.fromResponse(resp);
+    }
+
+    return resp.json();
+  }
+
+  async getRatingAggregates(entityRef: string): Promise<Ratings> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('entity-feedback');
+    const resp = await this.fetchApi.fetch(
+      `${baseUrl}/ratings/${encodeURIComponent(entityRef)}/aggregate`,
       {
         method: 'GET',
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Added a new endpoint for the entity feedback plugin that returns anonymized aggregated data for one entityRef.
This can be used to, for example, add the average score to a entities.

It returns `{ '1': 0, '2': 1, '3': 5, '4': 2, '5': 1 }` or `{ 'like': 4, 'dislike': 2 }` without returning the users who gave these answers.

Fixes #16771 