### PR TITLE
fix(shortcuts): refactor client to observe storageApi and store updates

### DIFF
--- a/.changeset/pink-apples-design.md
+++ b/.changeset/pink-apples-design.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+Fixed bug in LocalStoredShortcuts client where adding new Shortcut results in replacing entire shortcut list.
+
+Refactored LocalStoredShortcuts client to listen to `storageApi` updates to ensure that local state is always up to date.

--- a/plugins/shortcuts/api-report.md
+++ b/plugins/shortcuts/api-report.md
@@ -9,24 +9,25 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { Observable } from '@backstage/types';
-import { default as Observable_2 } from 'zen-observable';
-import { StorageApi } from '@backstage/core-plugin-api';
+import { Shortcut as Shortcut_2 } from '@backstage/plugin-shortcuts';
+import { ShortcutApi as ShortcutApi_2 } from '@backstage/plugin-shortcuts';
+import type { StorageApi } from '@backstage/core-plugin-api';
 
 // @public
-export class LocalStoredShortcuts implements ShortcutApi {
+export class LocalStoredShortcuts implements ShortcutApi_2 {
   constructor(storageApi: StorageApi);
   // (undocumented)
-  add(shortcut: Omit<Shortcut, 'id'>): Promise<void>;
+  add(shortcut: Omit<Shortcut_2, 'id'>): Promise<void>;
   // (undocumented)
-  get(): Shortcut[];
+  get(): Shortcut_2[];
   // (undocumented)
   getColor(url: string): string;
   // (undocumented)
   remove(id: string): Promise<void>;
   // (undocumented)
-  shortcut$(): Observable_2<Shortcut[]>;
+  shortcut$(): Observable<Shortcut_2[]>;
   // (undocumented)
-  update(shortcut: Shortcut): Promise<void>;
+  update(shortcut: Shortcut_2): Promise<void>;
 }
 
 // @public (undocumented)

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -30,7 +30,6 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
-    "@types/zen-observable": "^0.8.2",
     "react-hook-form": "^7.12.2",
     "react-use": "^17.2.4",
     "uuid": "^8.3.2",
@@ -49,6 +48,7 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "^16.11.26",
+    "@types/zen-observable": "^0.8.2",
     "cross-fetch": "^3.1.5",
     "msw": "^1.0.0"
   },

--- a/plugins/shortcuts/src/api/LocalStoredShortcuts.test.ts
+++ b/plugins/shortcuts/src/api/LocalStoredShortcuts.test.ts
@@ -36,8 +36,9 @@ describe('LocalStoredShortcuts', () => {
           resolve();
         },
       });
-      shortcutApi.add(shortcut);
     });
+    observerNextHandler.mockClear(); // handler is called with current state to start
+    await shortcutApi.add(shortcut);
 
     expect(observerNextHandler).toHaveBeenCalledTimes(1);
     expect(observerNextHandler).toHaveBeenCalledWith(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #16817

Refactors the `LocalStoredShortcuts` client that already uses the `storageApi` to observe updates to `storageApi` and make updates to local shortcuts. 

Doing so ensures that `add` will properly append instead of doing a full replace

Heavily follows how the [DefaultStarredEntitiesApi](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/apis/StarredEntitiesApi/DefaultStarredEntitiesApi.ts) interfaces with the `storageApi`

The `api-report.md` changes should be non-breaking - I just changed it to `import type` for types/interfaces instead of the full thing. Happy to remove and change that back if that is preferred!

### Demos

#### Using Local Storage as the storageApi

https://user-images.githubusercontent.com/12898497/224771552-ae93e612-67b5-4e60-bfa7-7c578fa0e316.mov

#### Using `UserSettingsStorage` from `user-settings` plugin as the storageApi (with the `user-settings-backend` configured locally)

https://user-images.githubusercontent.com/12898497/224771714-84eaf2a7-939a-43f8-9704-e82d062c5945.mov



## :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
