### PR TITLE
Include the failureMetadata and successMetadata in TechInsightsApi

### DIFF
--- a/.changeset/lazy-monkeys-worry.md
+++ b/.changeset/lazy-monkeys-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': minor
+---
+
+The Check class now includes the failureMetadata and successMetadata as returned by the runChecks call.

--- a/.changeset/lazy-monkeys-worry.md
+++ b/.changeset/lazy-monkeys-worry.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-tech-insights': minor
+'@backstage/plugin-tech-insights': patch
 ---
 
-The Check class now includes the failureMetadata and successMetadata as returned by the runChecks call.
+The `Check` type now optionally includes the `failureMetadata` and `successMetadata` as returned by the `runChecks` call.

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -27,6 +27,8 @@ export type Check = {
   name: string;
   description: string;
   factIds: string[];
+  successMetadata?: Record<string, unknown>;
+  failureMetadata?: Record<string, unknown>;
 };
 
 // @public

--- a/plugins/tech-insights/src/api/types.ts
+++ b/plugins/tech-insights/src/api/types.ts
@@ -22,11 +22,48 @@ import { JsonValue } from '@backstage/types';
  * @public
  */
 export type Check = {
+  /**
+   * Unique identifier of the check
+   *
+   * Used to identify which checks to use when running checks.
+   */
   id: string;
+
+  /**
+   * Type identifier for the check.
+   * Can be used to determine storage options, logical routing to correct FactChecker implementation
+   * or to help frontend render correct component types based on this
+   */
   type: string;
+
+  /**
+   * Human readable name of the check, may be displayed in the UI
+   */
   name: string;
+
+  /**
+   * Human readable description of the check, may be displayed in the UI
+   */
   description: string;
+
+  /**
+   * A collection of string referencing fact rows that a check will be run against.
+   *
+   * References the fact container, aka fact retriever itself which may or may not contain multiple individual facts and values
+   */
   factIds: string[];
+
+  /**
+   * Metadata to be returned in case a check has been successfully evaluated
+   * Can contain links, description texts or other actionable items
+   */
+  successMetadata?: Record<string, any>;
+
+  /**
+   * Metadata to be returned in case a check evaluation has ended in failure
+   * Can contain links, description texts or other actionable items
+   */
+  failureMetadata?: Record<string, any>;
 };
 
 /**

--- a/plugins/tech-insights/src/api/types.ts
+++ b/plugins/tech-insights/src/api/types.ts
@@ -57,13 +57,13 @@ export type Check = {
    * Metadata to be returned in case a check has been successfully evaluated
    * Can contain links, description texts or other actionable items
    */
-  successMetadata?: Record<string, any>;
+  successMetadata?: Record<string, unknown>;
 
   /**
    * Metadata to be returned in case a check evaluation has ended in failure
    * Can contain links, description texts or other actionable items
    */
-  failureMetadata?: Record<string, any>;
+  failureMetadata?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `failureMetadata` and `successMetadata` fields to the `Check` returned by the `getAllChecks` API so we can use them to show metadata in the UI.

Also copied over the documentation from the backend code while I was at it.

These fields already exist and are returned by the backend server.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
