### PR TITLE
feat(cli): support import of .md files

### DIFF
--- a/.changeset/eleven-coats-refuse.md
+++ b/.changeset/eleven-coats-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Support importing `.md` files in build loader

--- a/docs/local-dev/cli-build-system.md
+++ b/docs/local-dev/cli-build-system.md
@@ -505,6 +505,7 @@ of all supported file extensions:
 | `.jpg`      | URL Path        | Image                                                                         |
 | `.png`      | URL Path        | Image                                                                         |
 | `.svg`      | URL Path        | Image                                                                         |
+| `.md`       | URL Path        | Markdown File                                                                 |
 | `.icon.svg` | React Component | SVG converted into a [MUI SvgIcon](https://mui.com/components/icons/#svgicon) |
 
 ## Jest Configuration

--- a/packages/cli/asset-types/asset-types.d.ts
+++ b/packages/cli/asset-types/asset-types.d.ts
@@ -40,6 +40,11 @@ declare module '*.jpeg' {
   export default src;
 }
 
+declare module '*.md' {
+  const src: string;
+  export default src;
+}
+
 declare module '*.png' {
   const src: string;
   export default src;

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -132,6 +132,7 @@ export async function makeRollupConfigs(
               /\.woff$/,
               /\.woff2$/,
               /\.ttf$/,
+              /\.md$/,
             ],
           }),
           json(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I would like to be able to import local .md files to load Markdown content eg:
```tsx
import mdContent from './example.md'

...
const content = await fetchApi.fetch(mdContent).then(res => res.text());
...
<MarkdownContent content={content} />
```

Let me know if there's a better way to implement this change. As far as I can tell there's no support for a local rollup config override (eg. auto recognizing a local `rollup.config.js`). Alternatively, let me know if there's interest in opening up this API to allow passing custom config options rather then hardcoding this set of file extensions to support. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
