### PR TITLE
Allow simple type mismatches in config and coerce their values accordingly

### DIFF
--- a/.changeset/config-the-dane.md
+++ b/.changeset/config-the-dane.md
@@ -1,0 +1,7 @@
+---
+'@backstage/config-loader': minor
+---
+
+Configuration validation is now more permissive when it comes to config whose values are `string` but whose schemas declare them to be `boolean` or `number`.
+
+For example, configuration was previously marked invalid when a string `'true'` was set on a property expecting type `boolean` or a string `'146'` was set on a property expecting type `number` (as when providing configuration via variable substitution sourced from environment variables). Now, such configurations will be considered valid and their values will be coerced to the right type at read-time.

--- a/packages/config-loader/src/lib/schema/compile.test.ts
+++ b/packages/config-loader/src/lib/schema/compile.test.ts
@@ -28,7 +28,7 @@ describe('compileConfigSchemas', () => {
         value: { type: 'object', properties: { b: { type: 'number' } } },
       },
     ]);
-    expect(validate([{ data: { a: 1 }, context: 'test' }])).toEqual({
+    expect(validate([{ data: { a: [1] }, context: 'test' }])).toEqual({
       errors: [
         {
           keyword: 'type',

--- a/packages/config-loader/src/lib/schema/compile.ts
+++ b/packages/config-loader/src/lib/schema/compile.ts
@@ -45,6 +45,7 @@ export function compileConfigSchemas(
   const ajv = new Ajv({
     allErrors: true,
     allowUnionTypes: true,
+    coerceTypes: true,
     schemas: {
       'https://backstage.io/schema/config-v1': true,
     },

--- a/packages/config-loader/src/lib/schema/load.test.ts
+++ b/packages/config-loader/src/lib/schema/load.test.ts
@@ -103,7 +103,7 @@ describe('loadConfigSchema', () => {
       },
     ]);
     expect(() =>
-      schema2.process([...configs, { data: { key1: 3 }, context: 'test2' }]),
+      schema2.process([...configs, { data: { key1: [3] }, context: 'test2' }]),
     ).toThrow(
       'Config validation failed, Config must be string { type=string } at /key1',
     );
@@ -202,11 +202,11 @@ describe('loadConfigSchema', () => {
           context: 'test',
         },
       ]);
-      expect(() => schema.process(mkConfig({ y: 1 }))).toThrow(
+      expect(() => schema.process(mkConfig({ y: [1] }))).toThrow(
         'Config validation failed, Config must be string { type=string } at /nested/0/y',
       );
       expect(() =>
-        schema.process(mkConfig({ y: 1 }), { visibility: ['frontend'] }),
+        schema.process(mkConfig({ y: [1] }), { visibility: ['frontend'] }),
       ).toThrow(
         'Config validation failed, Config must be string { type=string } at /nested/0/y',
       );

--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -59,6 +59,8 @@ function expectValidValues(config: ConfigReader) {
   expect(config.has('nested.null')).toBe(true);
   expect(config.getNumber('zero')).toBe(0);
   expect(config.getNumber('one')).toBe(1);
+  expect(config.getNumber('zeroString')).toBe(0);
+  expect(config.getNumber('oneString')).toBe(1);
   expect(config.getOptional('true')).toBe(true);
   expect(config.getBoolean('true')).toBe(true);
   expect(config.getBoolean('false')).toBe(false);


### PR DESCRIPTION
## What / Why

With this, we'll be able to have configs YAMLs like this...

```yaml
app:
  analytics:
    ga:
      debug: ${DEBUG_GA}
      testMode:
        $env: TEST_GA
```

And boot up the app like this...

```
DEBUG_GA=true TEST_GA=true yarn start
```

Closes #16842

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
