### PR TITLE
fix(api-docs): Corrected styling of nested objects in AsyncAPI to avo…

### DIFF
--- a/.changeset/curly-boats-trade.md
+++ b/.changeset/curly-boats-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Corrected styling of nested objects in AsyncAPI to avoid inappropriate uppercase text transformation of nested objects.

--- a/plugins/api-docs/dev/asyncapi-example-api.yaml
+++ b/plugins/api-docs/dev/asyncapi-example-api.yaml
@@ -133,6 +133,8 @@ spec:
               description: Light intensity measured in lumens.
             sentAt:
               $ref: "#/components/schemas/sentAt"
+            sentBy:
+              $ref: "#/components/schemas/sentBy"
         turnOnOffPayload:
           type: object
           properties:
@@ -144,6 +146,8 @@ spec:
               description: Whether to turn on or off the light.
             sentAt:
               $ref: "#/components/schemas/sentAt"
+            sentBy:
+              $ref: "#/components/schemas/sentBy"
         dimLightPayload:
           type: object
           properties:
@@ -154,10 +158,25 @@ spec:
               maximum: 100
             sentAt:
               $ref: "#/components/schemas/sentAt"
+            sentBy:
+              $ref: "#/components/schemas/sentBy"
         sentAt:
           type: string
           format: date-time
           description: Date and time when the message was sent.
+        sentBy:
+          type: object
+          description: Description of the message sender.
+          properties:
+            name:
+              type: string
+              description: Name of the sender.
+            type:
+              type: string
+              description: Type of the sender.
+              enum:
+              - user
+              - machine
 
       securitySchemes:
         apiKey:

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
@@ -76,6 +76,8 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
       ...theme.typography.button,
       borderRadius: theme.shape.borderRadius,
       color: theme.palette.primary.main,
+      // override whatever may be in the theme's typography to ensure consistency with asyncapi
+      textTransform: 'inherit',
     },
     '& a': {
       color: theme.palette.link,


### PR DESCRIPTION
…id inappropriate uppercasing of nested objects

Fixes #16848

## Hey, I just made a Pull Request!

Overrode the potential `text-transform: uppercase` from `theme.typography.button` so that asyncapi's default styling (of no text transformation) could be applied to nested objects.

Also updated the sample AsyncAPI document to include a relevant example of this case.

Result:

![image](https://user-images.githubusercontent.com/103767938/225038519-0ea08369-440f-47b0-bf25-6431311214bf.png)

(Compare with screenshot in #16848)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
