### PR TITLE
Gitlab Org Data integration fetches memberships via graphQL

### DIFF
--- a/.changeset/hungry-lies-cry.md
+++ b/.changeset/hungry-lies-cry.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+The gitlab org data integration now makes use of the GraphQL API to determine
+the relationships between imported User and Group entities, effectively making
+this integration usable without an administrator account's Personal Access
+Token.

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -2,15 +2,14 @@
 id: org
 title: GitLab Organizational Data
 sidebar_label: Org Data
-description: Importing users and groups from a GitLab organization into Backstage
+description: Importing users and groups from GitLab into Backstage
 ---
 
-The Backstage catalog can be set up to ingest organizational data - users and
-teams - directly from an organization in GitLab. The result
-is a hierarchy of
+The Backstage catalog can be set up to ingest organizational data -- users and
+groups -- directly from GitLab. The result is a hierarchy of
 [`User`](../../features/software-catalog/descriptor-format.md#kind-user) and
-[`Group`](../../features/software-catalog/descriptor-format.md#kind-group) kind
-entities that mirror your org setup.
+[`Group`](../../features/software-catalog/descriptor-format.md#kind-group)
+entities that mirrors your org setup.
 
 ```yaml
 integrations:
@@ -19,10 +18,11 @@ integrations:
       token: ${GITLAB_TOKEN}
 ```
 
-This will query all users and groups from your gitlab installation. Depending on the size
-of the Gitlab Instance, this can take some time and resources.
+This will query all users and groups from your GitLab instance. Depending on the
+amount of data, this can take significant time and resources.
 
-The token that is used for the Organization Integration, has to be an Admin Personal Access Token (PAT).
+The token used must have the `read_api` scope, and the Users and Groups fetched
+will be those visible to the account which provisioned the token.
 
 ```yaml
 catalog:
@@ -35,6 +35,7 @@ catalog:
         groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
 ```
 
-When the `group` parameter is provided, the corresponding path prefix will be stripped out from each matching group
-when computing the unique entity name. e.g. If `group` is `org/teams`, the name for `org/teams/avengers/gotg` will
-be `avengers-gotg`.
+When the `group` parameter is provided, the corresponding path prefix will be
+stripped out from each matching group when computing the unique entity name.
+e.g. If `group` is `org/teams`, the name for `org/teams/avengers/gotg` will be
+`avengers-gotg`.

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.test.ts
@@ -21,6 +21,7 @@ import { getVoidLogger } from '@backstage/backend-common';
 import { rest } from 'msw';
 import { setupServer, SetupServerApi } from 'msw/node';
 import { GitLabClient, paginated } from './client';
+import { GitLabUser } from './types';
 
 const server = setupServer();
 setupRequestMockHandlers(server);
@@ -258,6 +259,141 @@ describe('GitLabClient', () => {
       }
       expect(allProjects).toHaveLength(2);
     });
+  });
+
+  it('listUsers gets all users in the instance', async () => {
+    server.use(
+      rest.get(`${MOCK_CONFIG.apiBaseUrl}/users`, (_, res, ctx) =>
+        res(
+          ctx.set('x-next-page', ''),
+          ctx.json([
+            {
+              id: 1,
+              username: 'test1',
+              name: 'Test Testit',
+              state: 'active',
+              avatar_url: 'https://secure.gravatar.com/',
+              web_url: 'https://gitlab.example/test1',
+              created_at: '2023-01-19T07:27:03.333Z',
+              bio: '',
+              location: null,
+              public_email: null,
+              skype: '',
+              linkedin: '',
+              twitter: '',
+              website_url: '',
+              organization: null,
+              job_title: '',
+              pronouns: null,
+              bot: false,
+              work_information: null,
+              followers: 0,
+              following: 0,
+              is_followed: false,
+              local_time: null,
+              last_sign_in_at: '2023-01-19T07:27:49.601Z',
+              confirmed_at: '2023-01-19T07:27:02.905Z',
+              last_activity_on: '2023-01-19',
+              email: 'test@example.com',
+              theme_id: 1,
+              color_scheme_id: 1,
+              projects_limit: 100000,
+              current_sign_in_at: '2023-01-19T09:09:10.676Z',
+              identities: [],
+              can_create_group: true,
+              can_create_project: true,
+              two_factor_enabled: false,
+              external: false,
+              private_profile: false,
+              commit_email: 'test@example.com',
+              is_admin: false,
+              note: '',
+            },
+          ]),
+        ),
+      ),
+    );
+    const client = new GitLabClient({
+      config: MOCK_CONFIG,
+      logger: getVoidLogger(),
+    });
+
+    const allUsers: GitLabUser[] = [];
+    for await (const user of paginated(
+      options => client.listUsers(options),
+      {},
+    )) {
+      allUsers.push(user);
+    }
+
+    expect(allUsers).toMatchObject([
+      {
+        id: 1,
+        username: 'test1',
+        email: 'test@example.com',
+        name: 'Test Testit',
+        state: 'active',
+        web_url: 'https://gitlab.example/test1',
+        avatar_url: 'https://secure.gravatar.com/',
+      },
+    ]);
+  });
+  it('listGroups gets all groups in the instance', async () => {
+    server.use(
+      rest.get(`${MOCK_CONFIG.apiBaseUrl}/groups`, (_, res, ctx) =>
+        res(
+          ctx.set('x-next-page', ''),
+          ctx.json([
+            {
+              id: 1,
+              web_url: 'https://gitlab.example/groups/group1',
+              name: 'group1',
+              path: 'group1',
+              description: '',
+              visibility: 'internal',
+              share_with_group_lock: false,
+              require_two_factor_authentication: false,
+              two_factor_grace_period: 48,
+              project_creation_level: 'developer',
+              auto_devops_enabled: null,
+              subgroup_creation_level: 'owner',
+              emails_disabled: null,
+              mentions_disabled: null,
+              lfs_enabled: true,
+              default_branch_protection: 2,
+              avatar_url: null,
+              request_access_enabled: false,
+              full_name: '8020',
+              full_path: '8020',
+              created_at: '2017-06-19T06:42:34.160Z',
+              parent_id: null,
+            },
+          ]),
+        ),
+      ),
+    );
+    const client = new GitLabClient({
+      config: MOCK_CONFIG,
+      logger: getVoidLogger(),
+    });
+
+    const allGroups: GitLabGroup[] = [];
+    for await (const group of paginated(
+      options => client.listGroups(options),
+      {},
+    )) {
+      allGroups.push(group);
+    }
+
+    expect(allGroups).toMatchObject([
+      {
+        id: 1,
+        name: 'group1',
+        full_path: '8020',
+        description: '',
+        parent_id: null,
+      },
+    ]);
   });
 });
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -116,7 +116,9 @@ export class GitLabClient {
         }),
       },
     ).then(r => r.json());
-    this.logger.debug(`got GraphQL response: ${JSON.stringify(response)}`);
+    if (response.errors) {
+      throw new Error(`GraphQL errors: ${JSON.stringify(response.errors)}`);
+    }
 
     return response.data.group.groupMembers.nodes.map(
       (node: { user: { id: string } }) =>

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -78,16 +78,11 @@ export class GitLabClient {
   async listUsers(
     options?: UserListOptions,
   ): Promise<PagedResponse<GitLabUser>> {
-    let requestOptions = options;
-
-    if (!requestOptions) {
-      requestOptions = {};
-    }
-
-    requestOptions.without_project_bots = true;
-    requestOptions.exclude_internal = true;
-
-    return this.pagedRequest(`/users?`, requestOptions);
+    return this.pagedRequest(`/users?`, {
+      ...options,
+      without_project_bots: true,
+      exclude_internal: true,
+    });
   }
 
   async listGroups(

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -50,11 +50,19 @@ export type GitLabGroup = {
   parent_id?: number;
 };
 
-export type GitLabMembership = {
-  source_id: number;
-  source_name: string;
-  source_type: string;
-  access_level: number;
+export type GitLabGroupMembersResponse = {
+  errors: { message: string }[];
+  data: {
+    group: {
+      groupMembers: {
+        nodes: { user: { id: string } }[];
+        pageInfo: {
+          endCursor: string;
+          hasNextPage: boolean;
+        };
+      };
+    };
+  };
 };
 
 export type GitlabProviderConfig = {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -23,7 +23,7 @@ import {
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { rest } from 'msw';
+import { graphql, rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { GitlabOrgDiscoveryEntityProvider } from './GitlabOrgDiscoveryEntityProvider';
 
@@ -318,20 +318,22 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
         ];
         return res(ctx.json(response));
       }),
-      rest.get(
-        `https://api.gitlab.example/api/v4/users/1/memberships`,
-        (_req, res, ctx) => {
-          const response = [
-            {
-              source_id: 2,
-              source_name: 'Group 2',
-              source_type: 'Namespace',
-              access_level: 50,
-            },
-          ];
-          return res(ctx.json(response));
-        },
-      ),
+      graphql
+        .link('https://test-gitlab/api/graphql')
+        .operation(async (req, res, ctx) =>
+          res(
+            ctx.data({
+              group: {
+                groupMembers: {
+                  nodes:
+                    req.variables.group === 'group1/group2'
+                      ? [{ user: { id: 'gid://gitlab/User/1' } }]
+                      : [],
+                },
+              },
+            }),
+          ),
+        ),
     );
 
     await provider.connect(entityProviderConnection);

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -329,6 +329,10 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
                     req.variables.group === 'group1/group2'
                       ? [{ user: { id: 'gid://gitlab/User/1' } }]
                       : [],
+                  pageInfo: {
+                    endCursor: 'end',
+                    hasNextPage: false,
+                  },
                 },
               },
             }),

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -185,7 +185,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       },
     );
 
-    const idMappedGroup: { [groupId: number]: GitLabGroup } = {};
+    const idMappedUser: { [userId: number]: GitLabUser } = {};
 
     const res: Result = {
       scanned: 0,
@@ -196,6 +196,21 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       scanned: 0,
       matches: [],
     };
+
+    for await (const user of users) {
+      if (!this.config.userPattern.test(user.email ?? user.username ?? '')) {
+        continue;
+      }
+
+      res.scanned++;
+
+      if (user.state !== 'active') {
+        continue;
+      }
+
+      idMappedUser[user.id] = user;
+      res.matches.push(user);
+    }
 
     for await (const group of groups) {
       if (!this.config.groupPattern.test(group.full_path ?? '')) {
@@ -212,35 +227,12 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       groupRes.scanned++;
       groupRes.matches.push(group);
 
-      idMappedGroup[group.id] = group;
-    }
-
-    for await (const user of users) {
-      if (!this.config.userPattern.test(user.email ?? user.username ?? '')) {
-        continue;
-      }
-
-      res.scanned++;
-
-      if (user.state !== 'active') {
-        continue;
-      }
-
-      const memberships = await client.getUserMemberships(user.id);
-      const userGroups: GitLabGroup[] = [];
-
-      for (const i of memberships) {
-        if (
-          i.source_type === 'Namespace' &&
-          idMappedGroup.hasOwnProperty(i.source_id)
-        ) {
-          userGroups.push(idMappedGroup[i.source_id]);
+      for (const id of await client.getGroupMembers(group.full_path)) {
+        const user = idMappedUser[id];
+        if (user) {
+          user.groups = (user.groups ?? []).concat(group);
         }
       }
-
-      user.groups = userGroups;
-
-      res.matches.push(user);
     }
 
     const groupsWithUsers = groupRes.matches.filter(group => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #16023. The GraphQL API could be leveraged more thoroughly to cut down on traffic to GitLab, but this covers the basic requirement to make the integration usable without an admin PAT.

I performed some end-to-end acceptance testing with the following procedure on my Mac:
1. Create a kind cluster and install gitlab locally via `helm`, running:
    ```bash
    git clone https://gitlab.com/gitlab-org/charts/gitlab.git
    cd gitlab
    helm repo add gitlab https://charts.gitlab.io/
    helm repo update
    kind create cluster --config examples/kind/kind-no-ssl.yaml
    helm upgrade --install gitlab gitlab/gitlab \
      --set global.hosts.domain=$(ipconfig getifaddr en0).nip.io \
      -f examples/kind/values-base.yaml \
      -f examples/kind/values-no-ssl.yaml
    ```
2. Log in at `gitlab.$(ipconfig getifaddr en0).nip.io` with the username `root` and password given by
    ```bash
    kubectl get secret gitlab-gitlab-initial-root-password -o go-template='{{.data.password | base64decode}}'
    ```
3. Create a non-admin user, impersonate them and provision an access token
4. Create any other users and groups to test
5. Add the org data entity provider to the backend via a patch like
    ```patch
     @@ -19,6 +19,7 @@ import { EntityProvider } from '@backstage/plugin-catalog-node';
     import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
     import { Router } from 'express';
     import { PluginEnvironment } from '../types';
    +import { GitlabOrgDiscoveryEntityProvider } from '@backstage/plugin-catalog-backend-module-gitlab';
     
     export default async function createPlugin(
       env: PluginEnvironment,
    @@ -27,6 +28,15 @@ export default async function createPlugin(
       const builder = await CatalogBuilder.create(env);
       builder.addProcessor(new ScaffolderEntitiesProcessor());
       builder.addEntityProvider(providers ?? []);
    +  builder.addEntityProvider(
    +    ...GitlabOrgDiscoveryEntityProvider.fromConfig(env.config, {
    +      logger: env.logger,
    +      schedule: env.scheduler.createScheduledTaskRunner({
    +        frequency: { minutes: 1 },
    +        timeout: { minutes: 5 },
    +      }),
    +    }),
    +  );
       const { processingEngine, router } = await builder.build();
       await processingEngine.start();
       return router;
    ```
6. Run `yarn dev` with an `app-config.local.yaml` like:
    ```yaml
    integrations: 
      gitlab: 
        - host: gitlab.$(ipconfig getifaddr en0).nip.io
          token: glpat-XXXXXXXXXXXXXXXXXXXX # non-admin token from step 3. above
          apiBaseUrl: http://gitlab.$(ipconfig getifaddr en0).nip.io/api/v4
          baseUrl: http://gitlab.$(ipconfig getifaddr en0).nip.io
    catalog: 
      locations: []
      providers: 
        gitlab: 
          providerId: 
            host: gitlab.$(ipconfig getifaddr en0).nip.io
            orgEnabled: true
    ```
6. Browse the catalog.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
