### PR TITLE
Adding new EntitySwitch for differing views depending on ResourceType

### DIFF
--- a/.changeset/hungry-monkeys-reply.md
+++ b/.changeset/hungry-monkeys-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added a new EntitySwitch isResourceType to allow different views depending on Resource type

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -434,6 +434,11 @@ export function isComponentType(
 ): (entity: Entity) => boolean;
 
 // @public
+export function isResourceType(
+  types: string | string[],
+): (entity: Entity) => boolean;
+
+// @public
 export function isKind(kinds: string | string[]): (entity: Entity) => boolean;
 
 // @public

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -434,11 +434,6 @@ export function isComponentType(
 ): (entity: Entity) => boolean;
 
 // @public
-export function isResourceType(
-  types: string | string[],
-): (entity: Entity) => boolean;
-
-// @public
 export function isKind(kinds: string | string[]): (entity: Entity) => boolean;
 
 // @public
@@ -448,6 +443,11 @@ export function isNamespace(
 
 // @public
 export function isOrphan(entity: Entity): boolean;
+
+// @public
+export function isResourceType(
+  types: string | string[],
+): (entity: Entity) => boolean;
 
 // @public (undocumented)
 export type PluginCatalogComponentsNameToClassKey = {

--- a/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
@@ -24,16 +24,23 @@ import {
 
 const kubernetesClusterResource: Entity = {
   apiVersion: '',
-  kind: 'resource',
+  kind: 'Resource',
   metadata: { name: 'aKubernetesCluster' },
   spec: { type: 'kubernetes-cluster' },
 };
 
 const databaseResource: Entity = {
   apiVersion: '',
-  kind: 'resource',
+  kind: 'Resource',
   metadata: { name: 'aDatabase' },
   spec: { type: 'database' },
+};
+
+const notResource: Entity = {
+  apiVersion: '',
+  kind: 'not-Resource',
+  metadata: { name: 'aService' },
+  spec: { type: 'service' },
 };
 
 const serviceComponent: Entity = {
@@ -79,10 +86,10 @@ const bNamespace: Entity = {
 };
 
 describe('isResourceType', () => {
-  it('should false on non component kinds', () => {
-    const checkEntity = isResourceType('service');
+  it('should false on non resource kinds', () => {
+    const checkEntity = isResourceType('kubernetes-cluster');
 
-    expect(checkEntity(notComponent)).not.toBeTruthy();
+    expect(checkEntity(notResource)).not.toBeTruthy();
   });
   it('should check for the intended type', () => {
     const checkEntity = isResourceType('kubernetes-cluster');

--- a/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
@@ -15,7 +15,26 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { isComponentType, isKind, isNamespace } from './conditions';
+import {
+  isComponentType,
+  isKind,
+  isNamespace,
+  isResourceType,
+} from './conditions';
+
+const kubernetesClusterResource: Entity = {
+  apiVersion: '',
+  kind: 'resource',
+  metadata: { name: 'aKubernetesCluster' },
+  spec: { type: 'kubernetes-cluster' },
+};
+
+const databaseResource: Entity = {
+  apiVersion: '',
+  kind: 'resource',
+  metadata: { name: 'aDatabase' },
+  spec: { type: 'database' },
+};
 
 const serviceComponent: Entity = {
   apiVersion: '',
@@ -58,6 +77,26 @@ const bNamespace: Entity = {
   metadata: { name: 'aService', namespace: 'b' },
   spec: { type: 'service' },
 };
+
+describe('isResourceType', () => {
+  it('should false on non component kinds', () => {
+    const checkEntity = isResourceType('service');
+
+    expect(checkEntity(notComponent)).not.toBeTruthy();
+  });
+  it('should check for the intended type', () => {
+    const checkEntity = isResourceType('kubernetes-cluster');
+
+    expect(checkEntity(databaseResource)).not.toBeTruthy();
+    expect(checkEntity(kubernetesClusterResource)).toBeTruthy();
+  });
+  it('should check for multiple types', () => {
+    const checkEntity = isResourceType(['database', 'kubernetes-cluster']);
+
+    expect(checkEntity(databaseResource)).toBeTruthy();
+    expect(checkEntity(kubernetesClusterResource)).toBeTruthy();
+  });
+});
 
 describe('isComponentType', () => {
   it('should false on non component kinds', () => {

--- a/plugins/catalog/src/components/EntitySwitch/conditions.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { ComponentEntity, Entity } from '@backstage/catalog-model';
+import {
+  ComponentEntity,
+  ResourceEntity,
+  Entity,
+} from '@backstage/catalog-model';
 
 function strCmp(a: string | undefined, b: string | undefined): boolean {
   return Boolean(
@@ -47,6 +51,20 @@ export function isComponentType(types: string | string[]) {
     }
     const componentEntity = entity as ComponentEntity;
     return strCmpAll(componentEntity.spec.type, types);
+  };
+}
+
+/**
+ * For use in EntitySwitch.Case. Matches if the entity is a Resource of a given spec.type.
+ * @public
+ */
+export function isResourceType(types: string | string[]) {
+  return (entity: Entity) => {
+    if (!strCmp(entity.kind, 'resource')) {
+      return false;
+    }
+    const resourceEntity = entity as ResourceEntity;
+    return strCmpAll(resourceEntity.spec.type, types);
   };
 }
 

--- a/plugins/catalog/src/components/EntitySwitch/index.ts
+++ b/plugins/catalog/src/components/EntitySwitch/index.ts
@@ -16,4 +16,9 @@
 
 export { EntitySwitch } from './EntitySwitch';
 export type { EntitySwitchProps, EntitySwitchCaseProps } from './EntitySwitch';
-export { isKind, isNamespace, isComponentType } from './conditions';
+export {
+  isKind,
+  isNamespace,
+  isComponentType,
+  isResourceType,
+} from './conditions';


### PR DESCRIPTION
## Added new Entity Switch

I have added a `isResourceType` EntitySwitch.  This is so that in the EntityPage I can use this construct:
```ts
    <EntityLayout.Route if={isResourceType('kubernetes-cluster')} path="/kubernetes" title="Kubernetes">
      ...
    </EntityLayout.Route>
```

This allows me to show different widgets on the Resources pages - which can be of various types:
- S3 Buckets
- kubernetes-clusters
- databases
- etc...

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
