### PR TITLE
[PRFC] Allow `TemplateListPage` and `TemplateWizardPage` to accept overrides for the default header components

### DIFF
--- a/.changeset/big-fishes-tie.md
+++ b/.changeset/big-fishes-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Allow `TemplateListPage` and `TemplateWizardPage` to accept overrides for header components

--- a/plugins/scaffolder/alpha-api-report.md
+++ b/plugins/scaffolder/alpha-api-report.md
@@ -35,6 +35,8 @@ export type NextRouterProps = {
     TemplateOutputsComponent?: React_2.ComponentType<{
       output?: ScaffolderTaskOutput;
     }>;
+    TemplatePageHeaderComponent?: React_2.ComponentType<{}>;
+    TemplateListContentHeaderComponent?: React_2.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
   FormProps?: FormProps_2;

--- a/plugins/scaffolder/src/next/Router/Router.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.tsx
@@ -59,6 +59,8 @@ export type NextRouterProps = {
     TemplateOutputsComponent?: React.ComponentType<{
       output?: ScaffolderTaskOutput;
     }>;
+    TemplatePageHeaderComponent?: React.ComponentType<{}>;
+    TemplateListContentHeaderComponent?: React.ComponentType<{}>;
   };
   groups?: TemplateGroupFilter[];
   // todo(blam): rename this to formProps
@@ -84,6 +86,8 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
       TemplateCardComponent,
       TemplateOutputsComponent,
       TaskPageComponent = OngoingTask,
+      TemplatePageHeaderComponent,
+      TemplateListContentHeaderComponent,
     } = {},
   } = props;
   const outlet = useOutlet() || props.children;
@@ -111,6 +115,10 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
             TemplateCardComponent={TemplateCardComponent}
             contextMenu={props.contextMenu}
             groups={props.groups}
+            TemplatePageHeaderComponent={TemplatePageHeaderComponent}
+            TemplateListContentHeaderComponent={
+              TemplateListContentHeaderComponent
+            }
           />
         }
       />
@@ -122,6 +130,7 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
               customFieldExtensions={fieldExtensions}
               layouts={customLayouts}
               FormProps={props.FormProps}
+              TemplatePageHeaderComponent={TemplatePageHeaderComponent}
             />
           </SecretsContextProvider>
         }

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListContentHeader.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListContentHeader.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { ContentHeader, SupportButton } from '@backstage/core-components';
+import { RegisterExistingButton } from './RegisterExistingButton';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { registerComponentRouteRef } from '../../routes';
+
+export function TemplateListContentHeader() {
+  const registerComponentLink = useRouteRef(registerComponentRouteRef);
+  return (
+    <ContentHeader title="Available Templates">
+      <RegisterExistingButton
+        title="Register Existing Component"
+        to={registerComponentLink && registerComponentLink()}
+      />
+      <SupportButton>
+        Create new software components using standard templates. Different
+        templates create different kinds of components (services, websites,
+        documentation, ...).
+      </SupportButton>
+    </ContentHeader>
+  );
+}

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
@@ -27,6 +27,7 @@ import {
 import React from 'react';
 import { nextRouteRef } from '../routes';
 import { TemplateListPage } from './TemplateListPage';
+import { ContentHeader, Header } from '@backstage/core-components';
 
 describe('TemplateListPage', () => {
   const mockCatalogApi = {
@@ -112,6 +113,65 @@ describe('TemplateListPage', () => {
     );
 
     expect(getByText('Categories')).toBeInTheDocument();
+  });
+
+  it('should render the passed in TemplateListContentHeader', async () => {
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+          [permissionApiRef, {}],
+        ]}
+      >
+        <TemplateListPage
+          TemplateListContentHeaderComponent={() => {
+            return <ContentHeader title="My Custom Content Header Title" />;
+          }}
+        />
+      </TestApiProvider>,
+      { mountedRoutes: { '/': nextRouteRef } },
+    );
+
+    expect(getByText('My Custom Content Header Title')).toBeInTheDocument();
+  });
+
+  it('should render the passed in TemplatePageHeader', async () => {
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+          [permissionApiRef, {}],
+        ]}
+      >
+        <TemplateListPage
+          TemplatePageHeaderComponent={() => {
+            return (
+              <Header
+                title="My Custom Header Title"
+                pageTitleOverride="My Custom Header Title"
+                subtitle="My Custom Subtitle"
+              />
+            );
+          }}
+        />
+      </TestApiProvider>,
+      { mountedRoutes: { '/': nextRouteRef } },
+    );
+
+    expect(getByText('My Custom Header Title')).toBeInTheDocument();
+    expect(getByText('My Custom Subtitle')).toBeInTheDocument();
   });
 
   // eslint-disable-next-line jest/no-disabled-tests

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -17,13 +17,7 @@
 import React from 'react';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 
-import {
-  Content,
-  ContentHeader,
-  Header,
-  Page,
-  SupportButton,
-} from '@backstage/core-components';
+import { Content, Header, Page } from '@backstage/core-components';
 import {
   EntityKindPicker,
   EntityListProvider,
@@ -33,16 +27,16 @@ import {
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
 import { CategoryPicker } from './CategoryPicker';
-import { RegisterExistingButton } from './RegisterExistingButton';
-import { useRouteRef } from '@backstage/core-plugin-api';
 import { TemplateGroupFilter, TemplateGroups } from './TemplateGroups';
-import { registerComponentRouteRef } from '../../routes';
 import { ContextMenu } from './ContextMenu';
+import { TemplateListContentHeader } from './TemplateListContentHeader';
 
 export type TemplateListPageProps = {
   TemplateCardComponent?: React.ComponentType<{
     template: TemplateEntityV1beta3;
   }>;
+  TemplatePageHeaderComponent?: typeof Header;
+  TemplateListContentHeaderComponent?: React.ComponentType<{}>;
   groups?: TemplateGroupFilter[];
   contextMenu?: {
     editor?: boolean;
@@ -67,8 +61,12 @@ const createGroupsWithOther = (
 ];
 
 export const TemplateListPage = (props: TemplateListPageProps) => {
-  const registerComponentLink = useRouteRef(registerComponentRouteRef);
-  const { TemplateCardComponent, groups: givenGroups = [] } = props;
+  const {
+    TemplateCardComponent,
+    TemplatePageHeaderComponent = Header,
+    TemplateListContentHeaderComponent = TemplateListContentHeader,
+    groups: givenGroups = [],
+  } = props;
 
   const groups = givenGroups.length
     ? createGroupsWithOther(givenGroups)
@@ -77,26 +75,15 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
   return (
     <EntityListProvider>
       <Page themeId="website">
-        <Header
+        <TemplatePageHeaderComponent
           pageTitleOverride="Create a new component"
           title="Create a new component"
           subtitle="Create new software components using standard templates in your organization"
         >
           <ContextMenu {...props.contextMenu} />
-        </Header>
+        </TemplatePageHeaderComponent>
         <Content>
-          <ContentHeader title="Available Templates">
-            <RegisterExistingButton
-              title="Register Existing Component"
-              to={registerComponentLink && registerComponentLink()}
-            />
-            <SupportButton>
-              Create new software components using standard templates. Different
-              templates create different kinds of components (services,
-              websites, documentation, ...).
-            </SupportButton>
-          </ContentHeader>
-
+          <TemplateListContentHeaderComponent />
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
               <EntitySearchBar />

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 
-import { Content, Header, Page } from '@backstage/core-components';
+import { Content, Page } from '@backstage/core-components';
 import {
   EntityKindPicker,
   EntityListProvider,
@@ -30,12 +30,13 @@ import { CategoryPicker } from './CategoryPicker';
 import { TemplateGroupFilter, TemplateGroups } from './TemplateGroups';
 import { ContextMenu } from './ContextMenu';
 import { TemplateListContentHeader } from './TemplateListContentHeader';
+import { TemplatePageHeader } from '../TemplatePageHeader';
 
 export type TemplateListPageProps = {
   TemplateCardComponent?: React.ComponentType<{
     template: TemplateEntityV1beta3;
   }>;
-  TemplatePageHeaderComponent?: typeof Header;
+  TemplatePageHeaderComponent?: React.ComponentType<{}>;
   TemplateListContentHeaderComponent?: React.ComponentType<{}>;
   groups?: TemplateGroupFilter[];
   contextMenu?: {
@@ -63,7 +64,7 @@ const createGroupsWithOther = (
 export const TemplateListPage = (props: TemplateListPageProps) => {
   const {
     TemplateCardComponent,
-    TemplatePageHeaderComponent = Header,
+    TemplatePageHeaderComponent = TemplatePageHeader,
     TemplateListContentHeaderComponent = TemplateListContentHeader,
     groups: givenGroups = [],
   } = props;
@@ -75,11 +76,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
   return (
     <EntityListProvider>
       <Page themeId="website">
-        <TemplatePageHeaderComponent
-          pageTitleOverride="Create a new component"
-          title="Create a new component"
-          subtitle="Create new software components using standard templates in your organization"
-        >
+        <TemplatePageHeaderComponent>
           <ContextMenu {...props.contextMenu} />
         </TemplatePageHeaderComponent>
         <Content>

--- a/plugins/scaffolder/src/next/TemplatePageHeader/TemplatePageHeader.tsx
+++ b/plugins/scaffolder/src/next/TemplatePageHeader/TemplatePageHeader.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Header } from '@backstage/core-components';
+
+type PropsFrom<TComponent> = TComponent extends React.FC<infer Props>
+  ? Props
+  : TComponent extends React.Component<infer Props>
+  ? Props
+  : never;
+
+type TemplatePageHeaderProps = Partial<PropsFrom<typeof Header>>;
+
+export const TemplatePageHeader = (props: TemplatePageHeaderProps) => {
+  return (
+    <Header
+      pageTitleOverride="Create a new component"
+      title="Create a new component"
+      subtitle="Create new software components using standard templates in your organization"
+      {...props}
+    />
+  );
+};

--- a/plugins/scaffolder/src/next/TemplatePageHeader/index.ts
+++ b/plugins/scaffolder/src/next/TemplatePageHeader/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './TemplatePageHeader';

--- a/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.test.tsx
@@ -30,6 +30,7 @@ import {
 import { TemplateWizardPage } from './TemplateWizardPage';
 import { rootRouteRef } from '../../routes';
 import { nextRouteRef } from '../routes';
+import { Header } from '@backstage/core-components';
 
 jest.mock('react-router-dom', () => {
   return {
@@ -117,5 +118,35 @@ describe('TemplateWizardPage', () => {
       subject: 'expected-name',
       context: { entityRef: 'template:default/test' },
     });
+  });
+
+  it('should render the passed in TemplatePageHeader', async () => {
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <SecretsContextProvider>
+          <TemplateWizardPage
+            customFieldExtensions={[]}
+            TemplatePageHeaderComponent={() => {
+              return (
+                <Header
+                  title="My Custom Header Title"
+                  pageTitleOverride="My Custom Header Title"
+                  subtitle="My Custom Subtitle"
+                />
+              );
+            }}
+          />
+          ,
+        </SecretsContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/create': nextRouteRef,
+        },
+      },
+    );
+
+    expect(getByText('My Custom Header Title')).toBeInTheDocument();
+    expect(getByText('My Custom Subtitle')).toBeInTheDocument();
   });
 });

--- a/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
@@ -33,20 +33,23 @@ import {
   NextFieldExtensionOptions,
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { JsonValue } from '@backstage/types';
-import { Header, Page } from '@backstage/core-components';
+import { Page } from '@backstage/core-components';
 import {
   nextRouteRef,
   nextScaffolderTaskRouteRef,
   nextSelectedTemplateRouteRef,
 } from '../routes';
+import { TemplatePageHeader } from '../TemplatePageHeader';
 
 export type TemplateWizardPageProps = {
   customFieldExtensions: NextFieldExtensionOptions<any, any>[];
   layouts?: LayoutOptions[];
   FormProps?: FormProps;
+  TemplatePageHeaderComponent?: React.ComponentType<{}>;
 };
 
 export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
+  const { TemplatePageHeaderComponent = TemplatePageHeader } = props;
   const rootRef = useRouteRef(nextRouteRef);
   const taskRoute = useRouteRef(nextScaffolderTaskRouteRef);
   const { secrets } = useTemplateSecrets();
@@ -77,11 +80,7 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
   return (
     <AnalyticsContext attributes={{ entityRef: templateRef }}>
       <Page themeId="website">
-        <Header
-          pageTitleOverride="Create a new component"
-          title="Create a new component"
-          subtitle="Create new software components using standard templates in your organization"
-        />
+        <TemplatePageHeaderComponent />
         <Workflow
           namespace={namespace}
           templateName={templateName}


### PR DESCRIPTION
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## Motivation

Currently, there are no ways of modifying the headers for the `TemplateListPage` and `TemplateWizardPage` of the scaffolder without forking the _entire_ plugin. I created this pull request to allow users to be able to pass in their own custom headers.

I understand we're [trying to come up with a cleaner solution for replacing components in plugins](https://github.com/backstage/backstage/pull/16633#issuecomment-1459690851), so If custom headers is too granular, I could try to lift the scope of this work so that users can pass in replacements for the entire pages instead. Thoughts?

## Approach

This PR in its current state will allow users to be able to pass in `TemplatePageHeaderComponent` and `TemplateListContentHeaderComponent` to their scaffolder:

```diff
// ./packages/app/src/App.tsx
<Route
  path="/create"
  element={
    <NextScaffolderPage
      groups={[
        {
          title: 'Recommended',
          filter: entity =>
            entity?.metadata?.tags?.includes('recommended') ?? false,
        },
      ]}
      components={{
+        TemplatePageHeaderComponent: () => {
+          return (
+            <Header title="My Header" subtitle="My Description" />
+          )
+        },
+        TemplateListContentHeaderComponent: () => {
+          return (
+            <ContentHeader title="My Content Header" />
+          )
+        }
      }}
    />
  }
>
```

![Screenshot 2023-03-15 at 9 18 36 AM](https://user-images.githubusercontent.com/29791650/225326581-67119e9b-2ff7-43b8-a008-a59b1a59c1d5.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
  - ⚠️ The changes proposed are for the alpha version of the scaffolder
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (~~for UI changes~~)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
