### PR TITLE
fix(docs): Special encoding not needed in code fence examples

### DIFF
--- a/docs/local-dev/cli-commands.md
+++ b/docs/local-dev/cli-commands.md
@@ -73,7 +73,7 @@ Build packages in the project, excluding bundled app and backend packages.
 
 Options:
   --all          Build all packages, including bundled app and backend packages.
-  --since &lt;ref&gt;  Only build packages and their dev dependents that changed since the specified ref
+  --since <ref>  Only build packages and their dev dependents that changed since the specified ref
 ```
 
 ## repo lint
@@ -86,8 +86,8 @@ Usage: backstage-cli repo lint [options]
 Lint all packages in the project
 
 Options:
-  --format &lt;format&gt;  Lint report output format (default: "eslint-formatter-friendly")
-  --since &lt;ref&gt;      Only lint packages that changed since the specified ref
+  --format <format>  Lint report output format (default: "eslint-formatter-friendly")
+  --since <ref>      Only lint packages that changed since the specified ref
   --fix              Attempt to automatically fix violations
 ```
 
@@ -101,8 +101,8 @@ Usage: backstage-cli package start [options]
 Start a package for local development
 
 Options:
-  --config &lt;path&gt;  Config files to load instead of app-config.yaml (default: [])
-  --role &lt;name&gt;    Run the command with an explicit package role
+  --config <path>  Config files to load instead of app-config.yaml (default: [])
+  --role <name>    Run the command with an explicit package role
   --check          Enable type checking and linting if available
   --inspect        Enable debugger in Node.js environments
   --inspect-brk    Enable debugger in Node.js environments, breaking before code starts
@@ -118,11 +118,11 @@ Usage: backstage-cli package build [options]
 Build a package for production deployment or publishing
 
 Options:
-  --role &lt;name&gt;              Run the command with an explicit package role
+  --role <name>              Run the command with an explicit package role
   --minify                   Minify the generated code. Does not apply to app or backend packages.
   --skip-build-dependencies  Skip the automatic building of local dependencies. Applies to backend packages only.
   --stats                    If bundle stats are available, write them to the output directory. Applies to app packages only.
-  --config &lt;path&gt;            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])
+  --config <path>            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])
 ```
 
 ## package lint
@@ -138,7 +138,7 @@ Usage: backstage-cli package lint [options]
 Lint a package
 
 Options:
-  --format &lt;format&gt;  Lint report output format (default: "eslint-formatter-friendly")
+  --format <format>  Lint report output format (default: "eslint-formatter-friendly")
   --fix              Attempt to automatically fix violations
 ```
 
@@ -227,10 +227,10 @@ that owns the app repo. For example you may have it set up like this:
 Usage: backstage-cli create [options]
 
 Options:
-  --select &lt;name&gt;          Select the thing you want to be creating upfront
-  --option &lt;name&gt;=&lt;value&gt;  Pre-fill options for the creation process (default: [])
-  --scope &lt;scope&gt;          The scope to use for new packages
-  --npm-registry &lt;URL&gt;     The package registry to use for new packages
+  --select <name>          Select the thing you want to be creating upfront
+  --option <name>=<value>  Pre-fill options for the creation process (default: [])
+  --scope <scope>          The scope to use for new packages
+  --npm-registry <URL>     The package registry to use for new packages
   --no-private             Do not mark new packages as private
   -h, --help               display help for command
 ```
@@ -248,7 +248,7 @@ Usage: backstage-cli config:docs [options]
 Browse the configuration reference documentation
 
 Options:
-  --package &lt;name&gt;  Only include the schema that applies to the given package
+  --package <name>  Only include the schema that applies to the given package
   -h, --help        display help for command
 ```
 
@@ -268,12 +268,12 @@ yarn backstage-cli config:print --frontend --package my-app
 Usage: backstage-cli config:print [options]
 
 Options:
-  --package &lt;name&gt;   Only load config schema that applies to the given package
+  --package <name>   Only load config schema that applies to the given package
   --lax              Do not require environment variables to be set
   --frontend         Print only the frontend configuration
   --with-secrets     Include secrets in the printed configuration
-  --format &lt;format&gt;  Format to print the configuration in, either json or yaml [yaml]
-  --config &lt;path&gt;    Config files to load instead of app-config.yaml (default: [])
+  --format <format>  Format to print the configuration in, either json or yaml [yaml]
+  --config <path>    Config files to load instead of app-config.yaml (default: [])
   -h, --help         display help for command
 ```
 
@@ -287,11 +287,11 @@ local packages in the repo.
 Usage: backstage-cli config:check [options]
 
 Options:
-  --package &lt;name&gt;  Only load config schema that applies to the given package
+  --package <name>  Only load config schema that applies to the given package
   --lax             Do not require environment variables to be set
   --frontend        Only validate the frontend configuration
   --deprecated      List all deprecated configuration settings
-  --config &lt;path&gt;   Config files to load instead of app-config.yaml (default: [])
+  --config <path>   Config files to load instead of app-config.yaml (default: [])
   -h, --help        display help for command
 ```
 
@@ -309,8 +309,8 @@ Usage: backstage-cli config:schema [options]
 Print configuration schema
 
 Options:
-  --package &lt;name&gt;   Only output config schema that applies to the given package
-  --format &lt;format&gt;  Format to print the schema in, either json or yaml [yaml]
+  --package <name>   Only output config schema that applies to the given package
+  --format <format>  Format to print the schema in, either json or yaml [yaml]
   -h, --help         display help for command
 ```
 
@@ -325,8 +325,8 @@ Usage: backstage-cli versions:bump [options]
 
 Options:
   -h, --help        display help for command
-  --pattern &lt;glob&gt;  Override glob for matching packages to upgrade
-  --release &lt;version|next|main&gt; Bump to a specific Backstage release line or version (default: "main")
+  --pattern <glob>  Override glob for matching packages to upgrade
+  --release <version|next|main> Bump to a specific Backstage release line or version (default: "main")
 ```
 
 ## versions:check


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes the CLI examples in the docs which were using an ampersand encoding, which within the code fence actually gets displayed as-is. So in this case, just removing the encoding and raw listing the greater than/less than signs.

<img width="616" alt="image" src="https://user-images.githubusercontent.com/33203301/225369716-877f4809-cfb1-48a5-bdf8-a337e0efc009.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
