### PR TITLE
Add isEntityWith helper method to EntitySwitch conditions

### DIFF
--- a/.changeset/soft-roses-cover.md
+++ b/.changeset/soft-roses-cover.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Added isEntityWith condition helper
+Added `isEntityWith` condition helper for `EntitySwitch` case statements.

--- a/.changeset/soft-roses-cover.md
+++ b/.changeset/soft-roses-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added isEntityWith condition helper

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -480,7 +480,7 @@ function isKind(kind: string) {
 ```
 
 The `@backstage/catalog` plugin provides a couple of built-in conditions,
-`isKind`, `isComponentType`, and `isNamespace`.
+`isKind`, `isComponentType`, `isResourceType`, `isEntityWith`, and `isNamespace`.
 
 In addition to the `EntitySwitch` component, the catalog plugin also exports a
 new `EntityLayout` component. It is a tweaked version and replacement for the

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -355,8 +355,6 @@ export const EntityListContainer: (props: {
 // @public
 export function EntityOrphanWarning(): JSX.Element;
 
-// Warning: (ae-missing-release-tag) "EntityPredicates" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export interface EntityPredicates {
   // (undocumented)

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -355,6 +355,16 @@ export const EntityListContainer: (props: {
 // @public
 export function EntityOrphanWarning(): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "EntityPredicates" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface EntityPredicates {
+  // (undocumented)
+  kind?: string | string[];
+  // (undocumented)
+  type?: string | string[];
+}
+
 // @public
 export function EntityProcessingErrorsPanel(): JSX.Element | null;
 
@@ -431,6 +441,11 @@ export interface HasSystemsCardProps {
 // @public
 export function isComponentType(
   types: string | string[],
+): (entity: Entity) => boolean;
+
+// @public
+export function isEntityWith(
+  predicate: EntityPredicates,
 ): (entity: Entity) => boolean;
 
 // @public

--- a/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
@@ -20,6 +20,7 @@ import {
   isKind,
   isNamespace,
   isResourceType,
+  isEntityWith,
 } from './conditions';
 
 const kubernetesClusterResource: Entity = {
@@ -62,6 +63,13 @@ const notComponent: Entity = {
   kind: 'not-component',
   metadata: { name: 'aService' },
   spec: { type: 'service' },
+};
+
+const missingSpecType: Entity = {
+  apiVersion: '',
+  kind: 'another-type',
+  metadata: { name: 'anEntity' },
+  spec: {},
 };
 
 const apiKind: Entity = {
@@ -122,6 +130,17 @@ describe('isComponentType', () => {
 
     expect(checkEntity(serviceComponent)).toBeTruthy();
     expect(checkEntity(websiteComponent)).toBeTruthy();
+  });
+});
+
+describe('isEntityWith', () => {
+  it('allows for a kind-only check (empty type array)', () => {
+    const checkEntity = isEntityWith({kind: 'api', type: []});
+    expect(checkEntity(apiKind)).toBeTruthy();
+  });
+  it('handles missing spec.type field', () => {
+    const checkEntity = isEntityWith({kind: 'another-type', type: 'service'});
+    expect(checkEntity(missingSpecType)).not.toBeTruthy();
   });
 });
 

--- a/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
@@ -135,11 +135,11 @@ describe('isComponentType', () => {
 
 describe('isEntityWith', () => {
   it('allows for a kind-only check (empty type array)', () => {
-    const checkEntity = isEntityWith({kind: 'api', type: []});
+    const checkEntity = isEntityWith({ kind: 'api', type: [] });
     expect(checkEntity(apiKind)).toBeTruthy();
   });
   it('handles missing spec.type field', () => {
-    const checkEntity = isEntityWith({kind: 'another-type', type: 'service'});
+    const checkEntity = isEntityWith({ kind: 'another-type', type: 'service' });
     expect(checkEntity(missingSpecType)).not.toBeTruthy();
   });
 });

--- a/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
@@ -142,6 +142,14 @@ describe('isEntityWith', () => {
     const checkEntity = isEntityWith({ kind: 'another-type', type: 'service' });
     expect(checkEntity(missingSpecType)).not.toBeTruthy();
   });
+  it('allows a check against no criteria', () => {
+    const checkEntity = isEntityWith({});
+    expect(checkEntity(apiKind)).toBeTruthy();
+  });
+  it('allows a check against empty criteria', () => {
+    const checkEntity = isEntityWith({ kind: [], type: [] });
+    expect(checkEntity(apiKind)).toBeTruthy();
+  });
 });
 
 describe('isKind', () => {

--- a/plugins/catalog/src/components/EntitySwitch/conditions.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.ts
@@ -38,7 +38,7 @@ function strCmpAll(value: string | undefined, cmpValues: string | string[]) {
  * @public
  */
 export function isKind(kinds: string | string[]) {
-  return isEntityWith({kind: kinds});
+  return isEntityWith({ kind: kinds });
 }
 
 /**
@@ -68,7 +68,10 @@ export function isEntityWith(predicate: EntityPredicates) {
       return false;
     }
 
-    if (!predicate.type || (Array.isArray(predicate.type) && predicate.type.length === 0)) {
+    if (
+      !predicate.type ||
+      (Array.isArray(predicate.type) && predicate.type.length === 0)
+    ) {
       // there's no type check, return true
       return true;
     } else if (typeof entity.spec?.type !== 'string') {
@@ -79,7 +82,6 @@ export function isEntityWith(predicate: EntityPredicates) {
     return strCmpAll(entity.spec.type, predicate.type);
   };
 }
-
 
 /**
  * For use in EntitySwitch.Case. Matches if the entity is in a given namespace.

--- a/plugins/catalog/src/components/EntitySwitch/conditions.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.ts
@@ -16,6 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 
+/** @public */
 export interface EntityPredicates {
   kind?: string | string[];
   type?: string | string[];

--- a/plugins/catalog/src/components/EntitySwitch/index.ts
+++ b/plugins/catalog/src/components/EntitySwitch/index.ts
@@ -16,9 +16,11 @@
 
 export { EntitySwitch } from './EntitySwitch';
 export type { EntitySwitchProps, EntitySwitchCaseProps } from './EntitySwitch';
+export type { EntityPredicates } from './conditions';
 export {
   isKind,
   isNamespace,
   isComponentType,
   isResourceType,
+  isEntityWith,
 } from './conditions';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will make it easier to conditionally show content for a given
entity based on the `spec.type` field beyond just component entity kinds
(e.g. api, group and resource, all have a spec.type field)

Here's an example of how this might be used:

```tsx
<EntitySwitch>
  <EntitySwitch.Case if={isEntityWith({ type: 'group', type: 'team' })}>
    {teamEntityPage}
  </EntitySwitch.Case>

  <EntitySwitch.Case if={isEntityKindAndType({ type: 'group', type: ['department', 'division'] })}>
    {departmentOrDivisionEntityPage}
  </EntitySwitch.Case>

  <EntitySwitch.Case>{defaultGroupEntityPage}</EntitySwitch.Case>
</EntitySwitch>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
