### PR TITLE
chore: remove traces of k8s.gcr.io

### DIFF
--- a/plugins/kubernetes-backend/examples/dice-roller/metrics-server.yaml
+++ b/plugins/kubernetes-backend/examples/dice-roller/metrics-server.yaml
@@ -82,7 +82,7 @@ spec:
           emptyDir: {}
       containers:
         - name: metrics-server
-          image: k8s.gcr.io/metrics-server-amd64:v0.3.1
+          image: registry.k8s.io/metrics-server-amd64:v0.3.1
           args:
             - --kubelet-insecure-tls
             - --kubelet-preferred-address-types=InternalIP


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Just wanted to remove the last trace of `k8s.gcr.io` from this repository. 

Part of kubernetes/k8s.io#4780.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
