### PR TITLE
chore: extend .prettierignore of microsite

### DIFF
--- a/microsite/.prettierignore
+++ b/microsite/.prettierignore
@@ -1,1 +1,2 @@
+build
 .docusaurus


### PR DESCRIPTION
I build the docs locally and then why I ran the `yarn prettier:check` it also checked the `build` folder. Probably don't need that.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
