### PR TITLE
Rename output parameter `mergeRequestURL` of `publish:gitlab:merge-re…

### DIFF
--- a/.changeset/bright-pumpkins-bake.md
+++ b/.changeset/bright-pumpkins-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Rename output parameter `mergeRequestURL` of `publish:gitlab:merge-request` action to `mergeRequestUrl`.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -127,7 +127,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
             title: 'Gitlab Project path',
             type: 'string',
           },
-          mergeRequestURL: {
+          mergeRequestUrl: {
             title: 'MergeRequest(MR) URL',
             type: 'string',
             description: 'Link to the merge request in GitLab',


### PR DESCRIPTION
…quest` action to `mergeRequestUrl`

This fixes a discrepancy between the output parameter defined in the JSON-Schema and the one actually used in the action.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
