### PR TITLE
Add support for different Sonarqube token types

### DIFF
--- a/.changeset/few-squids-dress.md
+++ b/.changeset/few-squids-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube-backend': patch
+---
+
+Retry SonarQube api requests with Bearer auth to support different token types


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently the plugin will only work if the token provided is a User token. 

The following endpoints fail if a [Project Analysis or Global Analysis](https://docs.sonarqube.org/9.6/user-guide/user-account/generating-and-using-tokens/) token is used:
- api/components/show
- api/measures/component

This PR supports the use of Project Analysis and Global Analysis tokens should they be used. 

Currently, if a Project or Global token is used the plugin just shows `There is no SonarQube project with key xyz` in the frontend and the backend api calls all succeed even though a 403 is returned by the SonarQube API, so it is very hard to understand what is wrong. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
