### PR TITLE
fix(catalog-backend): Support full text searches across multiple fields

### DIFF
--- a/.changeset/orange-rabbits-jam.md
+++ b/.changeset/orange-rabbits-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add full text search support to the `by-query` endpoint.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -51,7 +51,6 @@ import {
 } from '../database/tables';
 
 import { Stitcher } from '../stitching/Stitcher';
-import { parseFullTextFilterFields } from './request/parseFullTextFilterFields';
 
 import {
   isQueryEntitiesCursorRequest,

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -384,16 +384,28 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const normalizedFullTextFilterTerm = cursor.fullTextFilter?.term?.trim();
     const textFilterFields = cursor.fullTextFilter?.fields ?? [sortField.field];
     if (normalizedFullTextFilterTerm) {
-      const matchQuery = db<DbSearchRow>('search')
-        .select('search.entity_id')
-        .whereIn('key', textFilterFields)
-        .andWhere(function keyFilter() {
-          this.andWhereRaw(
-            'value like ?',
-            `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
-          );
-        });
-      dbQuery.andWhere('search.entity_id', 'in', matchQuery);
+      if (
+        textFilterFields.length === 1 &&
+        textFilterFields[0] === sortField.field
+      ) {
+        // If there is one item, apply the like query to the top level query which is already
+        //   filtered based on the singular sortField.
+        dbQuery.andWhereRaw(
+          'value like ?',
+          `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+        );
+      } else {
+        const matchQuery = db<DbSearchRow>('search')
+          .select('search.entity_id')
+          .whereIn('key', textFilterFields)
+          .andWhere(function keyFilter() {
+            this.andWhereRaw(
+              'value like ?',
+              `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+            );
+          });
+        dbQuery.andWhere('search.entity_id', 'in', matchQuery);
+      }
     }
 
     const countQuery = dbQuery.clone();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #16920. `fullTextFilterFields` is unused and `fullTextFilterTerm` is currently filtering on the values defined by the `sortOrder.field` key, this PR seeks to add full text search functionality to the `by-query` endpoint for use with #16021.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
