### PR TITLE
Added `fetch:plain:file` action to fetch a single file

### DIFF
--- a/.changeset/fuzzy-wombats-search.md
+++ b/.changeset/fuzzy-wombats-search.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': minor
 ---
 
-Added `fetch:plain:file` action to fetch a single file
+Added `fetch:plain:file` action to fetch a single file, this action is also added to the list of built-in actions.

--- a/.changeset/fuzzy-wombats-search.md
+++ b/.changeset/fuzzy-wombats-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added `fetch:plain:file` action to fetch a single file

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -106,6 +106,15 @@ export function createFetchPlainAction(options: {
 }>;
 
 // @public
+export function createFetchPlainFileAction(options: {
+  reader: UrlReader;
+  integrations: ScmIntegrations;
+}): TemplateAction_2<{
+  url: string;
+  targetPath: string;
+}>;
+
+// @public
 export function createFetchTemplateAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -31,7 +31,11 @@ import {
 
 import { TemplateFilter, TemplateGlobal } from '../../../lib';
 import { createDebugLogAction, createWaitAction } from './debug';
-import { createFetchPlainAction, createFetchTemplateAction } from './fetch';
+import {
+  createFetchPlainAction,
+  createFetchPlainFileAction,
+  createFetchTemplateAction,
+} from './fetch';
 import {
   createFilesystemDeleteAction,
   createFilesystemRenameAction,
@@ -109,6 +113,10 @@ export const createBuiltinActions = (
 
   const actions = [
     createFetchPlainAction({
+      reader,
+      integrations,
+    }),
+    createFetchPlainFileAction({
       reader,
       integrations,
     }),

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
@@ -51,158 +51,165 @@ describe('fetchContent helper', () => {
     outputPath: os.tmpdir(),
   };
 
-  it('fetch contents should reject absolute file locations', async () => {
-    await expect(
-      fetchContents({
-        ...options,
-        baseUrl: 'file:///some/path',
-        fetchUrl: '/etc/passwd',
-      }),
-    ).rejects.toThrow(
-      'Relative path is not allowed to refer to a directory outside its parent',
-    );
-  });
-
-  it('fetch contents should reject relative file locations that exit the baseUrl', async () => {
-    await expect(
-      fetchContents({
-        ...options,
-        baseUrl: 'file:///some/path',
-        fetchUrl: '../test',
-      }),
-    ).rejects.toThrow(
-      'Relative path is not allowed to refer to a directory outside its parent',
-    );
-  });
-
-  it('fetch contents should copy file to outputpath', async () => {
-    await fetchContents({
-      ...options,
-      baseUrl: 'file:///some/path',
-      fetchUrl: 'foo',
-      outputPath: 'somepath',
+  describe('fetch contents', () => {
+    it('should reject absolute file locations', async () => {
+      await expect(
+        fetchContents({
+          ...options,
+          baseUrl: 'file:///some/path',
+          fetchUrl: '/etc/passwd',
+        }),
+      ).rejects.toThrow(
+        'Relative path is not allowed to refer to a directory outside its parent',
+      );
     });
-    expect(fs.copy).toHaveBeenCalledWith(resolvePath('/some/foo'), 'somepath');
-  });
 
-  it('fetch contents should reject if no integration matches location', async () => {
-    await expect(
-      fetchContents({
-        ...options,
-        baseUrl: 'http://example.com/some/folder',
-      }),
-    ).rejects.toThrow(
-      'No integration found for location http://example.com/some/folder',
-    );
-  });
+    it('should reject relative file locations that exit the baseUrl', async () => {
+      await expect(
+        fetchContents({
+          ...options,
+          baseUrl: 'file:///some/path',
+          fetchUrl: '../test',
+        }),
+      ).rejects.toThrow(
+        'Relative path is not allowed to refer to a directory outside its parent',
+      );
+    });
 
-  it('fetch contents should reject if fetch url is relative and no base url is specified', async () => {
-    await expect(
-      fetchContents({
+    it('should copy file to outputpath', async () => {
+      await fetchContents({
         ...options,
+        baseUrl: 'file:///some/path',
         fetchUrl: 'foo',
-      }),
-    ).rejects.toThrow(
-      'Failed to fetch, template location could not be determined and the fetch URL is relative, foo',
-    );
+        outputPath: 'somepath',
+      });
+      expect(fs.copy).toHaveBeenCalledWith(
+        resolvePath('/some/foo'),
+        'somepath',
+      );
+    });
+
+    it('should reject if no integration matches location', async () => {
+      await expect(
+        fetchContents({
+          ...options,
+          baseUrl: 'http://example.com/some/folder',
+        }),
+      ).rejects.toThrow(
+        'No integration found for location http://example.com/some/folder',
+      );
+    });
+
+    it('should reject if fetch url is relative and no base url is specified', async () => {
+      await expect(
+        fetchContents({
+          ...options,
+          fetchUrl: 'foo',
+        }),
+      ).rejects.toThrow(
+        'Failed to fetch, template location could not be determined and the fetch URL is relative, foo',
+      );
+    });
+
+    it('should fetch url contents', async () => {
+      const dirFunction = jest.fn();
+      readTree.mockResolvedValue({
+        dir: dirFunction,
+      });
+      await fetchContents({
+        ...options,
+        outputPath: 'foo',
+        fetchUrl: 'https://github.com/backstage/foo',
+      });
+      expect(fs.ensureDir).toHaveBeenCalledWith('foo');
+      expect(dirFunction).toHaveBeenCalledWith({ targetDir: 'foo' });
+    });
   });
 
-  it('fetch contents should fetch url contents', async () => {
-    const dirFunction = jest.fn();
-    readTree.mockResolvedValue({
-      dir: dirFunction,
+  describe('fetch file', () => {
+    it('should reject absolute file locations', async () => {
+      await expect(
+        fetchFile({
+          ...options,
+          baseUrl: 'file:///some/path',
+          fetchUrl: '/etc/passwd',
+        }),
+      ).rejects.toThrow(
+        'Relative path is not allowed to refer to a directory outside its parent',
+      );
     });
-    await fetchContents({
-      ...options,
-      outputPath: 'foo',
-      fetchUrl: 'https://github.com/backstage/foo',
-    });
-    expect(fs.ensureDir).toHaveBeenCalledWith('foo');
-    expect(dirFunction).toHaveBeenCalledWith({ targetDir: 'foo' });
-  });
 
-  it('fetch file should reject absolute file locations', async () => {
-    await expect(
-      fetchFile({
+    it('should reject relative file locations that exit the baseUrl', async () => {
+      await expect(
+        fetchFile({
+          ...options,
+          baseUrl: 'file:///some/path',
+          fetchUrl: '../test',
+        }),
+      ).rejects.toThrow(
+        'Relative path is not allowed to refer to a directory outside its parent',
+      );
+    });
+
+    it('should copy file to outputpath', async () => {
+      await fetchFile({
         ...options,
         baseUrl: 'file:///some/path',
-        fetchUrl: '/etc/passwd',
-      }),
-    ).rejects.toThrow(
-      'Relative path is not allowed to refer to a directory outside its parent',
-    );
-  });
-
-  it('fetch file should reject relative file locations that exit the baseUrl', async () => {
-    await expect(
-      fetchFile({
-        ...options,
-        baseUrl: 'file:///some/path',
-        fetchUrl: '../test',
-      }),
-    ).rejects.toThrow(
-      'Relative path is not allowed to refer to a directory outside its parent',
-    );
-  });
-
-  it('fetch file should copy file to outputpath', async () => {
-    await fetchFile({
-      ...options,
-      baseUrl: 'file:///some/path',
-      fetchUrl: 'foo',
-      outputPath: 'somepath',
-    });
-    expect(fs.copyFile).toHaveBeenCalledWith(
-      resolvePath('/some/foo'),
-      'somepath',
-    );
-  });
-
-  it('fetch file should reject if no integration matches location', async () => {
-    await expect(
-      fetchFile({
-        ...options,
-        baseUrl: 'http://example.com/some/folder',
-      }),
-    ).rejects.toThrow(
-      'No integration found for location http://example.com/some/folder',
-    );
-  });
-
-  it('fetch file should reject if fetch url is relative and no base url is specified', async () => {
-    await expect(
-      fetchFile({
-        ...options,
         fetchUrl: 'foo',
-      }),
-    ).rejects.toThrow(
-      'Failed to fetch, template location could not be determined and the fetch URL is relative, foo',
-    );
-  });
+        outputPath: 'somepath',
+      });
+      expect(fs.copyFile).toHaveBeenCalledWith(
+        resolvePath('/some/foo'),
+        'somepath',
+      );
+    });
 
-  it('fetch file should fetch content from url', async () => {
-    readUrl.mockResolvedValue({
-      buffer: () => Buffer.from('test', 'utf8'),
+    it('should reject if no integration matches location', async () => {
+      await expect(
+        fetchFile({
+          ...options,
+          baseUrl: 'http://example.com/some/folder',
+        }),
+      ).rejects.toThrow(
+        'No integration found for location http://example.com/some/folder',
+      );
     });
-    await fetchFile({
-      ...options,
-      outputPath: 'foo',
-      fetchUrl: 'https://github.com/backstage/foo',
-    });
-    expect(fs.ensureDir).toHaveBeenCalledWith('.');
-    expect(fs.outputFile).toHaveBeenCalledWith('foo', 'test');
-  });
 
-  it('fetch file should fetch content from url into directory', async () => {
-    readUrl.mockResolvedValue({
-      buffer: () => Buffer.from('test', 'utf8'),
+    it('should reject if fetch url is relative and no base url is specified', async () => {
+      await expect(
+        fetchFile({
+          ...options,
+          fetchUrl: 'foo',
+        }),
+      ).rejects.toThrow(
+        'Failed to fetch, template location could not be determined and the fetch URL is relative, foo',
+      );
     });
-    await fetchFile({
-      ...options,
-      outputPath: 'mydir/foo',
-      fetchUrl: 'https://github.com/backstage/foo',
+
+    it('should fetch content from url', async () => {
+      readUrl.mockResolvedValue({
+        buffer: () => Buffer.from('test', 'utf8'),
+      });
+      await fetchFile({
+        ...options,
+        outputPath: 'foo',
+        fetchUrl: 'https://github.com/backstage/foo',
+      });
+      expect(fs.ensureDir).toHaveBeenCalledWith('.');
+      expect(fs.outputFile).toHaveBeenCalledWith('foo', 'test');
     });
-    expect(fs.ensureDir).toHaveBeenCalledWith('mydir');
-    expect(fs.outputFile).toHaveBeenCalledWith('mydir/foo', 'test');
+
+    it('should fetch content from url into directory', async () => {
+      readUrl.mockResolvedValue({
+        buffer: () => Buffer.from('test', 'utf8'),
+      });
+      await fetchFile({
+        ...options,
+        outputPath: 'mydir/foo',
+        fetchUrl: 'https://github.com/backstage/foo',
+      });
+      expect(fs.ensureDir).toHaveBeenCalledWith('mydir');
+      expect(fs.outputFile).toHaveBeenCalledWith('mydir/foo', 'test');
+    });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.ts
@@ -53,9 +53,7 @@ export async function fetchContents(options: {
 
 /**
  * A helper function that reads the content of a single file from the given URL.
- * Can be used in your own actions, and also used behind fetch:plain:file
- *
- * @public
+ * Can be used in your own actions, and also used behind `fetch:plain:file`
  */
 export async function fetchFile(options: {
   reader: UrlReader;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/index.ts
@@ -15,5 +15,6 @@
  */
 
 export { createFetchPlainAction } from './plain';
+export { createFetchPlainFileAction } from './plainFile';
 export { createFetchTemplateAction } from './template';
 export { fetchContents } from './helpers';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('./helpers');
+
+import os from 'os';
+import { resolve as resolvePath } from 'path';
+import { getVoidLogger, UrlReader } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
+import { createFetchPlainFileAction } from './plainFile';
+import { PassThrough } from 'stream';
+import { fetchFile } from './helpers';
+
+describe('fetch:plain:file', () => {
+  const integrations = ScmIntegrations.fromConfig(
+    new ConfigReader({
+      integrations: {
+        github: [{ host: 'github.com', token: 'token' }],
+      },
+    }),
+  );
+  const reader: UrlReader = {
+    readUrl: jest.fn(),
+    readTree: jest.fn(),
+    search: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const action = createFetchPlainFileAction({ integrations, reader });
+  const mockContext = {
+    workspacePath: os.tmpdir(),
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+
+  it('should disallow a target path outside working directory', async () => {
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          url: 'https://github.com/backstage/community/tree/main/backstage-community-sessions/assets/Backstage%20Community%20Sessions.png',
+          targetPath: '/foobar',
+        },
+      }),
+    ).rejects.toThrow(
+      /Relative path is not allowed to refer to a directory outside its parent/,
+    );
+  });
+
+  it('should fetch plain', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        url: 'https://github.com/backstage/community/tree/main/backstage-community-sessions/assets/Backstage%20Community%20Sessions.png',
+        targetPath: 'lol',
+      },
+    });
+    expect(fetchFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputPath: resolvePath(mockContext.workspacePath, 'lol'),
+        fetchUrl:
+          'https://github.com/backstage/community/tree/main/backstage-community-sessions/assets/Backstage%20Community%20Sessions.png',
+      }),
+    );
+  });
+});

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UrlReader, resolveSafeChildPath } from '@backstage/backend-common';
+import { ScmIntegrations } from '@backstage/integration';
+import { fetchFile } from './helpers';
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+
+/**
+ * Downloads content and places it in the workspace, or optionally
+ * in a subdirectory specified by the 'targetPath' input option.
+ * @public
+ */
+export function createFetchPlainFileAction(options: {
+  reader: UrlReader;
+  integrations: ScmIntegrations;
+}) {
+  const { reader, integrations } = options;
+
+  return createTemplateAction<{ url: string; targetPath: string }>({
+    id: 'fetch:plain:file',
+    description: 'Downloads single file and places it in the workspace.',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['url', 'targetPath'],
+        properties: {
+          url: {
+            title: 'Fetch URL',
+            description:
+              'Relative path or absolute URL pointing to the single file to fetch.',
+            type: 'string',
+          },
+          targetPath: {
+            title: 'Target Path',
+            description:
+              'Target path within the working directory to download the file as.',
+            type: 'string',
+          },
+        },
+      },
+    },
+    supportsDryRun: true,
+    async handler(ctx) {
+      ctx.logger.info('Fetching plain content from remote URL');
+
+      // Finally move the template result into the task workspace
+      const outputPath = resolveSafeChildPath(
+        ctx.workspacePath,
+        ctx.input.targetPath,
+      );
+
+      await fetchFile({
+        reader,
+        integrations,
+        baseUrl: ctx.templateInfo?.baseUrl,
+        fetchUrl: ctx.input.url,
+        outputPath,
+      });
+    },
+  });
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR adds `fetch:plain:file` action as discussed in the original issue #15388. Main reason for this separate action is that `fetch:plain` only allows to fetch directories:
```yaml
    - id: fetch-docs
      name: Fetch Docs
      action: fetch:plain
      input:
        targetPath: ./community
        url: https://github.com/backstage/community/tree/main/backstage-community-sessions
```
but not a single file (i.e. https://github.com/backstage/community/tree/main/backstage-community-sessions/assets/Backstage%20Community%20Sessions.png).

Alternatively one could fetch directory and remove all other files, but for some cases that's not a trivial thing to do - our main use-case is to fetch `CODEOWNERS` file from root of a large repository.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #15388
