### PR TITLE
Relocate some UI components into `scaffolder-react`

### DIFF
--- a/.changeset/thick-forks-prove.md
+++ b/.changeset/thick-forks-prove.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+Move `CategoryPicker` from `scaffolder` into `scaffolder-react`
+Move `ContextMenu` into `scaffolder-react` and rename it to `ScaffolderPageContextMenu`

--- a/.changeset/thin-spoons-prove.md
+++ b/.changeset/thin-spoons-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+---
+
+To offer better customization options, `ScaffolderPageContextMenu` takes callbacks as props instead of booleans

--- a/plugins/scaffolder-react/alpha-api-report.md
+++ b/plugins/scaffolder-react/alpha-api-report.md
@@ -5,6 +5,7 @@
 ```ts
 /// <reference types="react" />
 
+import { AnyParams } from '@backstage/core-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { CustomFieldExtensionSchema } from '@backstage/plugin-scaffolder-react';
@@ -22,6 +23,7 @@ import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
 import { RJSFSchema } from '@rjsf/utils';
+import { RouteFunc } from '@backstage/core-plugin-api';
 import { ScaffolderStep } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';
 import { SetStateAction } from 'react';
@@ -130,6 +132,18 @@ export const ReviewState: (props: ReviewStateProps) => JSX.Element;
 export type ReviewStateProps = {
   schemas: ParsedTemplateSchema[];
   formState: JsonObject;
+};
+
+// @alpha (undocumented)
+export function ScaffolderPageContextMenu(
+  props: ScaffolderPageContextMenuProps,
+): JSX.Element | null;
+
+// @alpha (undocumented)
+export type ScaffolderPageContextMenuProps = {
+  editor?: RouteFunc<AnyParams>;
+  actions?: RouteFunc<AnyParams>;
+  tasks?: RouteFunc<AnyParams>;
 };
 
 // @alpha

--- a/plugins/scaffolder-react/alpha-api-report.md
+++ b/plugins/scaffolder-react/alpha-api-report.md
@@ -5,7 +5,6 @@
 ```ts
 /// <reference types="react" />
 
-import { AnyParams } from '@backstage/core-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { CustomFieldExtensionSchema } from '@backstage/plugin-scaffolder-react';
@@ -23,7 +22,6 @@ import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
 import { RJSFSchema } from '@rjsf/utils';
-import { RouteFunc } from '@backstage/core-plugin-api';
 import { ScaffolderStep } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';
 import { SetStateAction } from 'react';
@@ -141,9 +139,9 @@ export function ScaffolderPageContextMenu(
 
 // @alpha (undocumented)
 export type ScaffolderPageContextMenuProps = {
-  editor?: RouteFunc<AnyParams>;
-  actions?: RouteFunc<AnyParams>;
-  tasks?: RouteFunc<AnyParams>;
+  onEditorClicked?: () => void;
+  onActionsClicked?: () => void;
+  onTasksClicked?: () => void;
 };
 
 // @alpha

--- a/plugins/scaffolder-react/alpha-api-report.md
+++ b/plugins/scaffolder-react/alpha-api-report.md
@@ -191,6 +191,9 @@ export interface TemplateCardProps {
 }
 
 // @alpha
+export const TemplateCategoryPicker: () => JSX.Element | null;
+
+// @alpha
 export const TemplateGroup: (props: TemplateGroupProps) => JSX.Element;
 
 // @alpha

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { RouteFunc, AnyParams } from '@backstage/core-plugin-api';
 import { BackstageTheme } from '@backstage/theme';
 import IconButton from '@material-ui/core/IconButton';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -28,7 +27,6 @@ import Edit from '@material-ui/icons/Edit';
 import List from '@material-ui/icons/List';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   button: {
@@ -40,9 +38,9 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
  * @alpha
  */
 export type ScaffolderPageContextMenuProps = {
-  editor?: RouteFunc<AnyParams>;
-  actions?: RouteFunc<AnyParams>;
-  tasks?: RouteFunc<AnyParams>;
+  onEditorClicked?: () => void;
+  onActionsClicked?: () => void;
+  onTasksClicked?: () => void;
 };
 
 /**
@@ -51,13 +49,11 @@ export type ScaffolderPageContextMenuProps = {
 export function ScaffolderPageContextMenu(
   props: ScaffolderPageContextMenuProps,
 ) {
-  const { editor, actions, tasks } = props;
+  const { onEditorClicked, onActionsClicked, onTasksClicked } = props;
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
 
-  const navigate = useNavigate();
-
-  if (!editor && !actions) {
+  if (!onEditorClicked && !onActionsClicked) {
     return null;
   }
 
@@ -90,24 +86,24 @@ export function ScaffolderPageContextMenu(
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
         <MenuList>
-          {editor && (
-            <MenuItem onClick={() => navigate(editor())}>
+          {onEditorClicked && (
+            <MenuItem onClick={onEditorClicked}>
               <ListItemIcon>
                 <Edit fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Template Editor" />
             </MenuItem>
           )}
-          {actions && (
-            <MenuItem onClick={() => navigate(actions())}>
+          {onActionsClicked && (
+            <MenuItem onClick={onActionsClicked}>
               <ListItemIcon>
                 <Description fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Installed Actions" />
             </MenuItem>
           )}
-          {tasks && (
-            <MenuItem onClick={() => navigate(tasks())}>
+          {onTasksClicked && (
+            <MenuItem onClick={onTasksClicked}>
               <ListItemIcon>
                 <List fontSize="small" />
               </ListItemIcon>

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
@@ -36,12 +36,18 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
   },
 }));
 
+/**
+ * @alpha
+ */
 export type ScaffolderPageContextMenuProps = {
   editor?: RouteFunc<AnyParams>;
   actions?: RouteFunc<AnyParams>;
   tasks?: RouteFunc<AnyParams>;
 };
 
+/**
+ * @alpha
+ */
 export function ScaffolderPageContextMenu(
   props: ScaffolderPageContextMenuProps,
 ) {

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRouteRef } from '@backstage/core-plugin-api';
+import { RouteFunc, AnyParams } from '@backstage/core-plugin-api';
 import { BackstageTheme } from '@backstage/theme';
 import IconButton from '@material-ui/core/IconButton';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -29,11 +29,6 @@ import List from '@material-ui/icons/List';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  actionsRouteRef,
-  editRouteRef,
-  scaffolderListTaskRouteRef,
-} from '../../routes';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   button: {
@@ -42,25 +37,21 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
 }));
 
 export type ScaffolderPageContextMenuProps = {
-  editor?: boolean;
-  actions?: boolean;
-  tasks?: boolean;
+  editor?: RouteFunc<AnyParams>;
+  actions?: RouteFunc<AnyParams>;
+  tasks?: RouteFunc<AnyParams>;
 };
 
-export function ContextMenu(props: ScaffolderPageContextMenuProps) {
+export function ScaffolderPageContextMenu(
+  props: ScaffolderPageContextMenuProps,
+) {
+  const { editor, actions, tasks } = props;
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
-  const editLink = useRouteRef(editRouteRef);
-  const actionsLink = useRouteRef(actionsRouteRef);
-  const tasksLink = useRouteRef(scaffolderListTaskRouteRef);
 
   const navigate = useNavigate();
 
-  const showEditor = props.editor !== false;
-  const showActions = props.actions !== false;
-  const showTasks = props.tasks !== false;
-
-  if (!showEditor && !showActions) {
+  if (!editor && !actions) {
     return null;
   }
 
@@ -93,24 +84,24 @@ export function ContextMenu(props: ScaffolderPageContextMenuProps) {
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
         <MenuList>
-          {showEditor && (
-            <MenuItem onClick={() => navigate(editLink())}>
+          {editor && (
+            <MenuItem onClick={() => navigate(editor())}>
               <ListItemIcon>
                 <Edit fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Template Editor" />
             </MenuItem>
           )}
-          {showActions && (
-            <MenuItem onClick={() => navigate(actionsLink())}>
+          {actions && (
+            <MenuItem onClick={() => navigate(actions())}>
               <ListItemIcon>
                 <Description fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Installed Actions" />
             </MenuItem>
           )}
-          {showTasks && (
-            <MenuItem onClick={() => navigate(tasksLink())}>
+          {tasks && (
+            <MenuItem onClick={() => navigate(tasks())}>
               <ListItemIcon>
                 <List fontSize="small" />
               </ListItemIcon>

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/index.ts
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/index.ts
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Stepper';
-export * from './TemplateCard';
-export * from './ReviewState';
-export * from './TemplateGroup';
-export * from './Workflow';
-export * from './TemplateOutputs';
-export * from './Form';
-export * from './TaskSteps';
-export * from './TaskLogStream';
-export * from './TemplateCategoryPicker';
-export * from './ScaffolderPageContextMenu';
+export {
+  ScaffolderPageContextMenu,
+  type ScaffolderPageContextMenuProps,
+} from './ScaffolderPageContextMenu';

--- a/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/TemplateCategoryPicker.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/TemplateCategoryPicker.test.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { useEntityTypeFilter } from '@backstage/plugin-catalog-react';
-import { CategoryPicker } from './CategoryPicker';
+import { TemplateCategoryPicker } from './TemplateCategoryPicker';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { fireEvent } from '@testing-library/react';
@@ -25,7 +25,7 @@ jest.mock('@backstage/plugin-catalog-react', () => ({
   useEntityTypeFilter: jest.fn(),
 }));
 
-describe('CategoryPicker', () => {
+describe('TemplateCategoryPicker', () => {
   const mockAlertApi = { post: jest.fn() };
 
   beforeEach(() => {
@@ -39,7 +39,7 @@ describe('CategoryPicker', () => {
 
     await renderInTestApp(
       <TestApiProvider apis={[[alertApiRef, mockAlertApi]]}>
-        <CategoryPicker />
+        <TemplateCategoryPicker />
       </TestApiProvider>,
     );
 
@@ -56,7 +56,7 @@ describe('CategoryPicker', () => {
 
     const { findByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[alertApiRef, mockAlertApi]]}>
-        <CategoryPicker />
+        <TemplateCategoryPicker />
       </TestApiProvider>,
     );
 
@@ -70,7 +70,7 @@ describe('CategoryPicker', () => {
 
     const { queryByText } = await renderInTestApp(
       <TestApiProvider apis={[[alertApiRef, mockAlertApi]]}>
-        <CategoryPicker />
+        <TemplateCategoryPicker />
       </TestApiProvider>,
     );
 
@@ -86,7 +86,7 @@ describe('CategoryPicker', () => {
 
     const { getByRole } = await renderInTestApp(
       <TestApiProvider apis={[[alertApiRef, mockAlertApi]]}>
-        <CategoryPicker />
+        <TemplateCategoryPicker />
       </TestApiProvider>,
     );
 
@@ -108,7 +108,7 @@ describe('CategoryPicker', () => {
 
     const { getByRole } = await renderInTestApp(
       <TestApiProvider apis={[[alertApiRef, mockAlertApi]]}>
-        <CategoryPicker />
+        <TemplateCategoryPicker />
       </TestApiProvider>,
     );
 
@@ -139,7 +139,7 @@ describe('CategoryPicker', () => {
 
     const { getByRole } = await renderInTestApp(
       <TestApiProvider apis={[[alertApiRef, mockAlertApi]]}>
-        <CategoryPicker />
+        <TemplateCategoryPicker />
       </TestApiProvider>,
     );
 

--- a/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/TemplateCategoryPicker.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/TemplateCategoryPicker.tsx
@@ -37,8 +37,10 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 /**
  * The Category Picker that is rendered on the left side for picking
  * categories and filtering the template list.
+ *
+ * @alpha
  */
-export const CategoryPicker = () => {
+export const TemplateCategoryPicker = () => {
   const alertApi = useApi(alertApiRef);
   const { error, loading, availableTypes, selectedTypes, setSelectedTypes } =
     useEntityTypeFilter();

--- a/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/index.ts
+++ b/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Stepper';
-export * from './TemplateCard';
-export * from './ReviewState';
-export * from './TemplateGroup';
-export * from './Workflow';
-export * from './TemplateOutputs';
-export * from './Form';
-export * from './TaskSteps';
-export * from './TaskLogStream';
-export * from './TemplateCategoryPicker';
+export { TemplateCategoryPicker } from './TemplateCategoryPicker';

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
@@ -135,4 +135,54 @@ describe('TemplateListPage', () => {
 
     expect(getByText('Tags')).toBeInTheDocument();
   });
+
+  describe('scaffolder page context menu', () => {
+    it('should render if context menu props are not set to false', async () => {
+      const { queryByTestId } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [catalogApiRef, mockCatalogApi],
+            [
+              starredEntitiesApiRef,
+              new DefaultStarredEntitiesApi({
+                storageApi: MockStorageApi.create(),
+              }),
+            ],
+            [permissionApiRef, {}],
+          ]}
+        >
+          <TemplateListPage />
+        </TestApiProvider>,
+        { mountedRoutes: { '/': rootRouteRef } },
+      );
+      expect(queryByTestId('menu-button')).toBeInTheDocument();
+    });
+
+    it('should not render if context menu props are set to false', async () => {
+      const { queryByTestId } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [catalogApiRef, mockCatalogApi],
+            [
+              starredEntitiesApiRef,
+              new DefaultStarredEntitiesApi({
+                storageApi: MockStorageApi.create(),
+              }),
+            ],
+            [permissionApiRef, {}],
+          ]}
+        >
+          <TemplateListPage
+            contextMenu={{
+              editor: false,
+              actions: false,
+              tasks: false,
+            }}
+          />
+        </TestApiProvider>,
+        { mountedRoutes: { '/': rootRouteRef } },
+      );
+      expect(queryByTestId('menu-button')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -32,13 +32,20 @@ import {
   CatalogFilterLayout,
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
-import { TemplateCategoryPicker } from '@backstage/plugin-scaffolder-react/alpha';
+import {
+  ScaffolderPageContextMenu,
+  TemplateCategoryPicker,
+} from '@backstage/plugin-scaffolder-react/alpha';
 
 import { RegisterExistingButton } from './RegisterExistingButton';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { TemplateGroupFilter, TemplateGroups } from './TemplateGroups';
-import { registerComponentRouteRef } from '../../routes';
-import { ContextMenu } from './ContextMenu';
+import {
+  actionsRouteRef,
+  editRouteRef,
+  registerComponentRouteRef,
+  scaffolderListTaskRouteRef,
+} from '../../routes';
 
 export type TemplateListPageProps = {
   TemplateCardComponent?: React.ComponentType<{
@@ -75,10 +82,19 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
     groups: givenGroups = [],
     templateFilter,
   } = props;
+  const editorLink = useRouteRef(editRouteRef);
+  const actionsLink = useRouteRef(actionsRouteRef);
+  const tasksLink = useRouteRef(scaffolderListTaskRouteRef);
 
   const groups = givenGroups.length
     ? createGroupsWithOther(givenGroups)
     : [defaultGroup];
+
+  const scaffolderPageContextMenuProps = {
+    editor: props?.contextMenu?.editor !== false ? editorLink : undefined,
+    actions: props?.contextMenu?.actions !== false ? actionsLink : undefined,
+    tasks: props?.contextMenu?.tasks !== false ? tasksLink : undefined,
+  };
 
   return (
     <EntityListProvider>
@@ -88,7 +104,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
           title="Create a new component"
           subtitle="Create new software components using standard templates in your organization"
         >
-          <ContextMenu {...props.contextMenu} />
+          <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
         </Header>
         <Content>
           <ContentHeader title="Available Templates">

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
+import { useRouteRef } from '@backstage/core-plugin-api';
 
 import {
   Content,
@@ -38,7 +40,6 @@ import {
 } from '@backstage/plugin-scaffolder-react/alpha';
 
 import { RegisterExistingButton } from './RegisterExistingButton';
-import { useRouteRef } from '@backstage/core-plugin-api';
 import { TemplateGroupFilter, TemplateGroups } from './TemplateGroups';
 import {
   actionsRouteRef,
@@ -82,6 +83,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
     groups: givenGroups = [],
     templateFilter,
   } = props;
+  const navigate = useNavigate();
   const editorLink = useRouteRef(editRouteRef);
   const actionsLink = useRouteRef(actionsRouteRef);
   const tasksLink = useRouteRef(scaffolderListTaskRouteRef);
@@ -91,9 +93,18 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
     : [defaultGroup];
 
   const scaffolderPageContextMenuProps = {
-    editor: props?.contextMenu?.editor !== false ? editorLink : undefined,
-    actions: props?.contextMenu?.actions !== false ? actionsLink : undefined,
-    tasks: props?.contextMenu?.tasks !== false ? tasksLink : undefined,
+    onEditorClicked:
+      props?.contextMenu?.editor !== false
+        ? () => navigate(editorLink())
+        : undefined,
+    onActionsClicked:
+      props?.contextMenu?.actions !== false
+        ? () => navigate(actionsLink())
+        : undefined,
+    onTasksClicked:
+      props?.contextMenu?.tasks !== false
+        ? () => navigate(tasksLink())
+        : undefined,
   };
 
   return (

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -32,7 +32,8 @@ import {
   CatalogFilterLayout,
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
-import { CategoryPicker } from './CategoryPicker';
+import { TemplateCategoryPicker } from '@backstage/plugin-scaffolder-react/alpha';
+
 import { RegisterExistingButton } from './RegisterExistingButton';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { TemplateGroupFilter, TemplateGroups } from './TemplateGroups';
@@ -110,7 +111,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
                 initialFilter="all"
                 availableFilters={['all', 'starred']}
               />
-              <CategoryPicker />
+              <TemplateCategoryPicker />
               <EntityTagPicker />
             </CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

See conversation [here](https://github.com/backstage/backstage/pull/16915#discussion_r1140310793).

Moving the following components into `scaffolder-react`:
- [x] `CategoryPicker` => `TemplateCategoryPicker`
- [x] `ContextMenu` => `ScaffolderPageContextMenu`
  - Wanted to maintain as much of the original API as possible so for those who are still using the default `TemplateListPage` can [configure the `contextMenu` at the plugin level as it was done previously](https://github.com/minkimcello/backstage/blob/mk/move-scaf-comps/plugins/scaffolder/src/next/Router/Router.tsx#L67-L74) and it'll continue using the routeRefs defined by the plugin (which are not exported)
    - For those who wish to use their own custom `TemplateListPage` ([PR #16915](https://github.com/backstage/backstage/pull/16915)) must now define their own explicit routes for [`editor`, `actions`, and `tasks`](https://github.com/minkimcello/backstage/blob/mk/move-scaf-comps/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx#L85-L87)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~ ⚠️ All the changes are for alpha-version packages 
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~~Screenshots attached (for UI changes)~~ ⚠️ No UI changes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
