### PR TITLE
backend-app-api: register global error handlers

### DIFF
--- a/.changeset/rotten-carrots-cheer.md
+++ b/.changeset/rotten-carrots-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Register unhandled rejection and uncaught exception handlers to avoid backend crashes.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -165,6 +165,25 @@ export class BackendInitializer {
       );
       await registerInit.init.func(deps);
     }
+
+    // Once the backend is started, any uncaught errors or unhandled rejections are caught
+    // and logged, in order to avoid crashing the entire backend on local failures.
+    if (process.env.NODE_ENV !== 'test') {
+      const rootLogger = await this.#serviceHolder.get(
+        coreServices.rootLogger,
+        'root',
+      );
+      process.on('unhandledRejection', (reason: Error) => {
+        rootLogger
+          ?.child({ type: 'unhandledRejection' })
+          ?.error('Unhandled rejection', reason);
+      });
+      process.on('uncaughtException', error => {
+        rootLogger
+          ?.child({ type: 'uncaughtException' })
+          ?.error('Uncaught exception', error);
+      });
+    }
   }
 
   #resolveInitOrder(registerInits: Array<BackendRegisterInit>) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹 , fixes #16841

Figured we can wait with registering the handlers until after startup

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
