### PR TITLE
add new scaffolder action to ensure a gitlab group exists

### DIFF
--- a/.changeset/moody-shrimps-train.md
+++ b/.changeset/moody-shrimps-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+Add a new scaffolder action for gitlab to ensure a group exists

--- a/plugins/scaffolder-backend-module-gitlab/README.md
+++ b/plugins/scaffolder-backend-module-gitlab/README.md
@@ -45,6 +45,9 @@ const actions = [
   createGitlabProjectDeployTokenAction({
     integrations: integrations,
   }),
+  createGitlabGroupEnsureExistsAction({
+    integrations: integrations,
+  }),
 ];
 
 // Create Scaffolder Router
@@ -104,13 +107,22 @@ spec:
         url: https://github.com/TEMPLATE
         values:
           name: ${{ parameters.name }}
+    - id: createGitlabGroup
+      name: Ensure Gitlab group exists
+      action: gitlab:group:ensureExists
+      input:
+        repoUrl: ${{ parameters.repoUrl }}
+        path:
+          - path
+          - to
+          - group
 
     - id: publish
       name: Publish
       action: publish:gitlab
       input:
         description: This is ${{ parameters.name }}
-        repoUrl: ${{ parameters.repoUrl }}
+        repoUrl: ${{ parameters.repoUrl }}?owner=${{ steps.createGitlabGroup.output.groupId }}
         sourcePath: pimcore
         defaultBranch: main
 

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -32,7 +32,7 @@ export const createGitlabProjectAccessTokenAction: (options: {
   } & {
     projectId: string | number;
     name?: string | undefined;
-    accessLevel?: string | undefined;
+    accessLevel?: number | undefined;
     scopes?: string[] | undefined;
   },
   {

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -8,6 +8,18 @@ import { ScmIntegrationRegistry } from '@backstage/integration';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';
 
 // @public
+export const createGitlabGroupEnsureExistsAction: (options: {
+  integrations: ScmIntegrationRegistry;
+}) => TemplateAction<
+  {
+    repoUrl: string;
+    token?: string | undefined;
+  } & {
+    path: string[];
+  }
+>;
+
+// @public
 export const createGitlabProjectAccessTokenAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
@@ -43,16 +55,18 @@ export const createGitlabProjectVariableAction: (options: {
 }) => TemplateAction<
   {
     repoUrl: string;
-    projectId: string | number;
+    token?: string | undefined;
+  } & {
     key: string;
     value: string;
+    projectId: string | number;
     variableType: string;
-    variableProtected: boolean;
-    masked: boolean;
-    raw: boolean;
-    environmentScope: string;
-    token?: string | undefined;
-  },
+    variableProtected?: boolean | undefined;
+    masked?: boolean | undefined;
+    raw?: boolean | undefined;
+    environmentScope?: string | undefined;
+  }
+,
   JsonObject
 >;
 ```

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -16,6 +16,9 @@ export const createGitlabGroupEnsureExistsAction: (options: {
     token?: string | undefined;
   } & {
     path: string[];
+  },
+  {
+    groupId?: number | undefined;
   }
 >;
 
@@ -25,13 +28,16 @@ export const createGitlabProjectAccessTokenAction: (options: {
 }) => TemplateAction<
   {
     repoUrl: string;
-    projectId: string | number;
-    name: string;
-    accessLevel: number;
-    scopes: string[];
     token?: string | undefined;
+  } & {
+    projectId: string | number;
+    name?: string | undefined;
+    accessLevel?: string | undefined;
+    scopes?: string[] | undefined;
   },
-  JsonObject
+  {
+    access_token: string;
+  }
 >;
 
 // @public
@@ -40,13 +46,17 @@ export const createGitlabProjectDeployTokenAction: (options: {
 }) => TemplateAction<
   {
     repoUrl: string;
-    projectId: string | number;
-    name: string;
-    username: string;
-    scopes: string[];
     token?: string | undefined;
+  } & {
+    name: string;
+    projectId: string | number;
+    username?: string | undefined;
+    scopes?: string[] | undefined;
   },
-  JsonObject
+  {
+    user: string;
+    deploy_token: string;
+  }
 >;
 
 // @public
@@ -65,8 +75,7 @@ export const createGitlabProjectVariableAction: (options: {
     masked?: boolean | undefined;
     raw?: boolean | undefined;
     environmentScope?: string | undefined;
-  }
-,
+  },
   JsonObject
 >;
 ```

--- a/plugins/scaffolder-backend-module-gitlab/package.json
+++ b/plugins/scaffolder-backend-module-gitlab/package.json
@@ -35,7 +35,8 @@
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
-    "@gitbeaker/node": "^35.8.0"
+    "@gitbeaker/node": "^35.8.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@backstage/backend-common": "workspace:^",

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PassThrough } from 'stream';
+import { createGitlabGroupEnsureExistsAction } from './createGitlabGroupEnsureExistsAction';
+import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/core-app-api';
+import { ScmIntegrations } from '@backstage/integration';
+
+const mockGitlabClient = {
+  Groups: {
+    search: jest.fn(),
+    create: jest.fn(),
+  },
+};
+jest.mock('@gitbeaker/node', () => ({
+  Gitlab: class {
+    constructor() {
+      return mockGitlabClient;
+    }
+  },
+}));
+
+describe('gitlab:group:ensureExists', () => {
+  const mockContext = {
+    workspacePath: 'lol',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should create a new group if it does not exists', async () => {
+    mockGitlabClient.Groups.search.mockResolvedValue([
+      {
+        id: 1,
+        full_path: 'repos/bar',
+      },
+      {
+        id: 2,
+        full_path: 'repos/foo',
+      },
+    ]);
+
+    mockGitlabClient.Groups.create.mockResolvedValue({
+      id: 3,
+      full_path: 'repos/foo/bar',
+    });
+
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            token: 'tokenlols',
+            apiBaseUrl: 'https://api.gitlab.com',
+          },
+        ],
+      },
+    });
+    const integrations = ScmIntegrations.fromConfig(config);
+
+    const action = createGitlabGroupEnsureExistsAction({ integrations });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'gitlab.com',
+        path: ['foo', 'bar'],
+      },
+    });
+
+    expect(mockGitlabClient.Groups.create).toHaveBeenCalledWith('bar', 'bar', {
+      parent_id: 2,
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith('groupId', 3);
+  });
+
+  it('should return existing group if it does exists', async () => {
+    mockGitlabClient.Groups.search.mockResolvedValue([
+      {
+        id: 1,
+        full_path: 'repos/bar',
+      },
+      {
+        id: 2,
+        full_path: 'repos/foo',
+      },
+      {
+        id: 42,
+        full_path: 'repos/foo/bar',
+      },
+    ]);
+
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            token: 'tokenlols',
+            apiBaseUrl: 'https://api.gitlab.com',
+          },
+        ],
+      },
+    });
+    const integrations = ScmIntegrations.fromConfig(config);
+
+    const action = createGitlabGroupEnsureExistsAction({ integrations });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'gitlab.com',
+        path: ['foo', 'bar'],
+      },
+    });
+
+    expect(mockGitlabClient.Groups.create).not.toHaveBeenCalled();
+
+    expect(mockContext.output).toHaveBeenCalledWith('groupId', 42);
+  });
+});

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
@@ -22,20 +22,6 @@ import commonGitlabConfig from '../commonGitlabConfig';
 import { getToken } from '../util';
 import { z } from 'zod';
 
-const input = commonGitlabConfig.and(
-  z.object({
-    path: z
-      .array(z.string(), {
-        description: 'A path of group names that is ensured to exist',
-      })
-      .min(1),
-  }),
-);
-
-const output = z.object({
-  groupId: z.string({ description: 'The id of the innermost sub-group' }),
-});
-
 /**
  * Creates an `gitlab:group:ensureExists` Scaffolder action.
  *
@@ -46,10 +32,25 @@ export const createGitlabGroupEnsureExistsAction = (options: {
 }) => {
   const { integrations } = options;
 
-  return createTemplateAction<z.infer<typeof input>>({
+  return createTemplateAction({
     id: 'gitlab:group:ensureExists',
     description: 'Ensures a Gitlab group exists',
-    schema: { input, output },
+    schema: {
+      input: commonGitlabConfig.and(
+        z.object({
+          path: z
+            .array(z.string(), {
+              description: 'A path of group names that is ensured to exist',
+            })
+            .min(1),
+        }),
+      ),
+      output: z.object({
+        groupId: z
+          .number({ description: 'The id of the innermost sub-group' })
+          .optional(),
+      }),
+    },
     async handler(ctx) {
       const { path } = ctx.input;
       const { token, integrationConfig } = getToken(ctx.input, integrations);

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
@@ -66,7 +66,7 @@ export const createGitlabGroupEnsureExistsAction = (options: {
         const fullPath = `${currentPath}/${pathElement}`;
         const result = (await api.Groups.search(
           fullPath,
-        )) as any as Array<GroupSchema>;
+        )) as any as Array<GroupSchema>; // recast since the return type for search is wrong in the gitbeaker typings
         const subGroup = result.find(
           searchPathElem => searchPathElem.full_path === fullPath,
         );

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import { ScmIntegrationRegistry } from '@backstage/integration';
+import { Gitlab } from '@gitbeaker/node';
+import { GroupSchema } from '@gitbeaker/core/dist/types/resources/Groups';
+import commonGitlabConfig from '../commonGitlabConfig';
+import { getToken } from '../util';
+import { z } from 'zod';
+
+const input = commonGitlabConfig.and(
+  z.object({
+    path: z
+      .array(z.string(), {
+        description: 'A path of group names that is ensured to exist',
+      })
+      .min(1),
+  }),
+);
+
+const output = z.object({
+  groupId: z.string({ description: 'The id of the innermost sub-group' }),
+});
+
+/**
+ * Creates an `gitlab:group:ensureExists` Scaffolder action.
+ *
+ * @public
+ */
+export const createGitlabGroupEnsureExistsAction = (options: {
+  integrations: ScmIntegrationRegistry;
+}) => {
+  const { integrations } = options;
+
+  return createTemplateAction<z.infer<typeof input>>({
+    id: 'gitlab:group:ensureExists',
+    description: 'Ensures a Gitlab group exists',
+    schema: { input, output },
+    async handler(ctx) {
+      const { path } = ctx.input;
+      const { token, integrationConfig } = getToken(ctx.input, integrations);
+
+      const api = new Gitlab({
+        host: integrationConfig.config.baseUrl,
+        token: token,
+      });
+
+      let currentPath: string = 'repos';
+      let parent: GroupSchema | null = null;
+      for (const pathElement of path) {
+        const fullPath = `${currentPath}/${pathElement}`;
+        const result = (await api.Groups.search(
+          fullPath,
+        )) as any as Array<GroupSchema>;
+        const subGroup = result.find(
+          searchPathElem => searchPathElem.full_path === fullPath,
+        );
+        if (!subGroup) {
+          ctx.logger.info(`creating missing group ${fullPath}`);
+          parent = await api.Groups.create(
+            pathElement,
+            pathElement,
+            parent
+              ? {
+                  parent_id: parent.id,
+                }
+              : {},
+          );
+        } else {
+          parent = subGroup;
+        }
+        currentPath = fullPath;
+      }
+      if (parent !== null) {
+        ctx.output('groupId', parent?.id);
+      }
+    },
+  });
+};

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
@@ -40,7 +40,7 @@ export const createGitlabProjectAccessTokenAction = (options: {
           }),
           name: z.string({ description: 'Deploy Token Name' }).optional(),
           accessLevel: z
-            .string({ description: 'Access Level of the Token' })
+            .number({ description: 'Access Level of the Token' })
             .optional(),
           scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
         }),

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
@@ -16,10 +16,27 @@
 
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { ScmIntegrationRegistry } from '@backstage/integration';
+import commonGitlabConfig from '../commonGitlabConfig';
 import { getToken } from '../util';
+import { z } from 'zod';
+
+const input = commonGitlabConfig.and(
+  z.object({
+    projectId: z.union([z.number(), z.string()], { description: 'Project ID' }),
+    name: z.string({ description: 'Deploy Token Name' }).optional(),
+    accessLevel: z
+      .string({ description: 'Access Level of the Token' })
+      .optional(),
+    scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
+  }),
+);
+
+const output = z.object({
+  access_token: z.string({ description: 'Access Token' }),
+});
 
 /**
- * Creates a `gitlab:create-project-access-token` Scaffolder action.
+ * Creates a `gitlab:projectAccessToken:create` Scaffolder action.
  *
  * @param options - Templating configuration.
  * @public
@@ -28,65 +45,13 @@ export const createGitlabProjectAccessTokenAction = (options: {
   integrations: ScmIntegrationRegistry;
 }) => {
   const { integrations } = options;
-  return createTemplateAction<{
-    repoUrl: string;
-    projectId: string | number;
-    name: string;
-    accessLevel: number;
-    scopes: string[];
-    token?: string;
-  }>({
+  return createTemplateAction<z.infer<typeof input>>({
     id: 'gitlab:projectAccessToken:create',
-    schema: {
-      input: {
-        required: ['projectId', 'repoUrl'],
-        type: 'object',
-        properties: {
-          repoUrl: {
-            title: 'Repository Location',
-            type: 'string',
-          },
-          projectId: {
-            title: 'Project ID',
-            type: ['string', 'number'],
-          },
-          name: {
-            title: 'Deploy Token Name',
-            type: 'string',
-          },
-          accessLevel: {
-            title: 'Access Level of the Token',
-            type: 'number',
-          },
-          scopes: {
-            title: 'Scopes',
-            type: 'array',
-          },
-          token: {
-            title: 'Authentication Token',
-            type: 'string',
-            description: 'The token to use for authorization to GitLab',
-          },
-        },
-      },
-      output: {
-        type: 'object',
-        properties: {
-          access_token: {
-            title: 'Access Token',
-            type: 'string',
-          },
-        },
-      },
-    },
+    schema: { input, output },
     async handler(ctx) {
       ctx.logger.info(`Creating Token for Project "${ctx.input.projectId}"`);
-      const { repoUrl, projectId, name, accessLevel, scopes } = ctx.input;
-      const { token, integrationConfig } = getToken(
-        repoUrl,
-        ctx.input.token,
-        integrations,
-      );
+      const { projectId, name, accessLevel, scopes } = ctx.input;
+      const { token, integrationConfig } = getToken(ctx.input, integrations);
 
       const response = await fetch(
         `${integrationConfig.config.baseUrl}/api/v4/projects/${projectId}/access_tokens`,

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
@@ -20,21 +20,6 @@ import commonGitlabConfig from '../commonGitlabConfig';
 import { getToken } from '../util';
 import { z } from 'zod';
 
-const input = commonGitlabConfig.and(
-  z.object({
-    projectId: z.union([z.number(), z.string()], { description: 'Project ID' }),
-    name: z.string({ description: 'Deploy Token Name' }).optional(),
-    accessLevel: z
-      .string({ description: 'Access Level of the Token' })
-      .optional(),
-    scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
-  }),
-);
-
-const output = z.object({
-  access_token: z.string({ description: 'Access Token' }),
-});
-
 /**
  * Creates a `gitlab:projectAccessToken:create` Scaffolder action.
  *
@@ -45,9 +30,25 @@ export const createGitlabProjectAccessTokenAction = (options: {
   integrations: ScmIntegrationRegistry;
 }) => {
   const { integrations } = options;
-  return createTemplateAction<z.infer<typeof input>>({
+  return createTemplateAction({
     id: 'gitlab:projectAccessToken:create',
-    schema: { input, output },
+    schema: {
+      input: commonGitlabConfig.and(
+        z.object({
+          projectId: z.union([z.number(), z.string()], {
+            description: 'Project ID',
+          }),
+          name: z.string({ description: 'Deploy Token Name' }).optional(),
+          accessLevel: z
+            .string({ description: 'Access Level of the Token' })
+            .optional(),
+          scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
+        }),
+      ),
+      output: z.object({
+        access_token: z.string({ description: 'Access Token' }),
+      }),
+    },
     async handler(ctx) {
       ctx.logger.info(`Creating Token for Project "${ctx.input.projectId}"`);
       const { projectId, name, accessLevel, scopes } = ctx.input;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectDeployTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectDeployTokenAction.ts
@@ -18,11 +18,27 @@ import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { Gitlab } from '@gitbeaker/node';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { DeployTokenScope } from '@gitbeaker/core/dist/types/templates/ResourceDeployTokens';
+import commonGitlabConfig from '../commonGitlabConfig';
 import { getToken } from '../util';
 import { InputError } from '@backstage/errors';
+import { z } from 'zod';
+
+const input = commonGitlabConfig.and(
+  z.object({
+    projectId: z.union([z.number(), z.string()], { description: 'Project ID' }),
+    name: z.string({ description: 'Deploy Token Name' }),
+    username: z.string({ description: 'Deploy Token Username' }).optional(),
+    scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
+  }),
+);
+
+const output = z.object({
+  deploy_token: z.string({ description: 'Deploy Token' }),
+  user: z.string({ description: 'User' }),
+});
 
 /**
- * Creates a `gitlab:create-project-deploy-token` Scaffolder action.
+ * Creates a `gitlab:projectDeployToken:create` Scaffolder action.
  *
  * @param options - Templating configuration.
  * @public
@@ -31,69 +47,13 @@ export const createGitlabProjectDeployTokenAction = (options: {
   integrations: ScmIntegrationRegistry;
 }) => {
   const { integrations } = options;
-  return createTemplateAction<{
-    repoUrl: string;
-    projectId: string | number;
-    name: string;
-    username: string;
-    scopes: string[];
-    token?: string;
-  }>({
+  return createTemplateAction<z.infer<typeof input>>({
     id: 'gitlab:projectDeployToken:create',
-    schema: {
-      input: {
-        required: ['projectId', 'repoUrl'],
-        type: 'object',
-        properties: {
-          repoUrl: {
-            title: 'Repository Location',
-            type: 'string',
-          },
-          projectId: {
-            title: 'Project ID',
-            type: ['string', 'number'],
-          },
-          name: {
-            title: 'Deploy Token Name',
-            type: 'string',
-          },
-          username: {
-            title: 'Deploy Token Username',
-            type: 'string',
-          },
-          scopes: {
-            title: 'Scopes',
-            type: 'array',
-          },
-          token: {
-            title: 'Authentication Token',
-            type: 'string',
-            description: 'The token to use for authorization to GitLab',
-          },
-        },
-      },
-      output: {
-        type: 'object',
-        properties: {
-          deploy_token: {
-            title: 'Deploy Token',
-            type: 'string',
-          },
-          user: {
-            title: 'User',
-            type: 'string',
-          },
-        },
-      },
-    },
+    schema: { input, output },
     async handler(ctx) {
       ctx.logger.info(`Creating Token for Project "${ctx.input.projectId}"`);
-      const { repoUrl, projectId, name, username, scopes } = ctx.input;
-      const { token, integrationConfig } = getToken(
-        repoUrl,
-        ctx.input.token,
-        integrations,
-      );
+      const { projectId, name, username, scopes } = ctx.input;
+      const { token, integrationConfig } = getToken(ctx.input, integrations);
 
       const api = new Gitlab({
         host: integrationConfig.config.baseUrl,

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectDeployTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectDeployTokenAction.ts
@@ -23,20 +23,6 @@ import { getToken } from '../util';
 import { InputError } from '@backstage/errors';
 import { z } from 'zod';
 
-const input = commonGitlabConfig.and(
-  z.object({
-    projectId: z.union([z.number(), z.string()], { description: 'Project ID' }),
-    name: z.string({ description: 'Deploy Token Name' }),
-    username: z.string({ description: 'Deploy Token Username' }).optional(),
-    scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
-  }),
-);
-
-const output = z.object({
-  deploy_token: z.string({ description: 'Deploy Token' }),
-  user: z.string({ description: 'User' }),
-});
-
 /**
  * Creates a `gitlab:projectDeployToken:create` Scaffolder action.
  *
@@ -47,9 +33,26 @@ export const createGitlabProjectDeployTokenAction = (options: {
   integrations: ScmIntegrationRegistry;
 }) => {
   const { integrations } = options;
-  return createTemplateAction<z.infer<typeof input>>({
+  return createTemplateAction({
     id: 'gitlab:projectDeployToken:create',
-    schema: { input, output },
+    schema: {
+      input: commonGitlabConfig.and(
+        z.object({
+          projectId: z.union([z.number(), z.string()], {
+            description: 'Project ID',
+          }),
+          name: z.string({ description: 'Deploy Token Name' }),
+          username: z
+            .string({ description: 'Deploy Token Username' })
+            .optional(),
+          scopes: z.array(z.string(), { description: 'Scopes' }).optional(),
+        }),
+      ),
+      output: z.object({
+        deploy_token: z.string({ description: 'Deploy Token' }),
+        user: z.string({ description: 'User' }),
+      }),
+    },
     async handler(ctx) {
       ctx.logger.info(`Creating Token for Project "${ctx.input.projectId}"`);
       const { projectId, name, username, scopes } = ctx.input;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectVariableAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectVariableAction.ts
@@ -21,36 +21,6 @@ import { getToken } from '../util';
 import commonGitlabConfig from '../commonGitlabConfig';
 import { z } from 'zod';
 
-const input = commonGitlabConfig.and(
-  z.object({
-    projectId: z.union([z.number(), z.string()], { description: 'Project ID' }),
-    key: z
-      .string({
-        description:
-          'The key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed',
-      })
-      .regex(/^[A-Za-z0-9_]{1,255}$/),
-    value: z.string({ description: 'The value of a variable' }),
-    variableType: z.string({ description: 'Variable Type (env_var or file)' }),
-    variableProtected: z
-      .boolean({ description: 'Whether the variable is protected' })
-      .default(false)
-      .optional(),
-    masked: z
-      .boolean({ description: 'Whether the variable is masked' })
-      .default(false)
-      .optional(),
-    raw: z
-      .boolean({ description: 'Whether the variable is expandable' })
-      .default(false)
-      .optional(),
-    environmentScope: z
-      .string({ description: 'The environment_scope of the variable' })
-      .default('*')
-      .optional(),
-  }),
-);
-
 /**
  * Creates a `gitlab:projectVariable:create` Scaffolder action.
  *
@@ -61,9 +31,43 @@ export const createGitlabProjectVariableAction = (options: {
   integrations: ScmIntegrationRegistry;
 }) => {
   const { integrations } = options;
-  return createTemplateAction<z.infer<typeof input>>({
+  return createTemplateAction({
     id: 'gitlab:projectVariable:create',
-    schema: { input },
+    schema: {
+      input: commonGitlabConfig.and(
+        z.object({
+          projectId: z.union([z.number(), z.string()], {
+            description: 'Project ID',
+          }),
+          key: z
+            .string({
+              description:
+                'The key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed',
+            })
+            .regex(/^[A-Za-z0-9_]{1,255}$/),
+          value: z.string({ description: 'The value of a variable' }),
+          variableType: z.string({
+            description: 'Variable Type (env_var or file)',
+          }),
+          variableProtected: z
+            .boolean({ description: 'Whether the variable is protected' })
+            .default(false)
+            .optional(),
+          masked: z
+            .boolean({ description: 'Whether the variable is masked' })
+            .default(false)
+            .optional(),
+          raw: z
+            .boolean({ description: 'Whether the variable is expandable' })
+            .default(false)
+            .optional(),
+          environmentScope: z
+            .string({ description: 'The environment_scope of the variable' })
+            .default('*')
+            .optional(),
+        }),
+      ),
+    },
     async handler(ctx) {
       const {
         projectId,

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectVariableAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectVariableAction.ts
@@ -16,11 +16,43 @@
 
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { ScmIntegrationRegistry } from '@backstage/integration';
-import { getToken } from '../util';
 import { Gitlab } from '@gitbeaker/node';
+import { getToken } from '../util';
+import commonGitlabConfig from '../commonGitlabConfig';
+import { z } from 'zod';
+
+const input = commonGitlabConfig.and(
+  z.object({
+    projectId: z.union([z.number(), z.string()], { description: 'Project ID' }),
+    key: z
+      .string({
+        description:
+          'The key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed',
+      })
+      .regex(/^[A-Za-z0-9_]{1,255}$/),
+    value: z.string({ description: 'The value of a variable' }),
+    variableType: z.string({ description: 'Variable Type (env_var or file)' }),
+    variableProtected: z
+      .boolean({ description: 'Whether the variable is protected' })
+      .default(false)
+      .optional(),
+    masked: z
+      .boolean({ description: 'Whether the variable is masked' })
+      .default(false)
+      .optional(),
+    raw: z
+      .boolean({ description: 'Whether the variable is expandable' })
+      .default(false)
+      .optional(),
+    environmentScope: z
+      .string({ description: 'The environment_scope of the variable' })
+      .default('*')
+      .optional(),
+  }),
+);
 
 /**
- * Creates a `gitlab:create-project-variable` Scaffolder action.
+ * Creates a `gitlab:projectVariable:create` Scaffolder action.
  *
  * @param options - Templating configuration.
  * @public
@@ -29,96 +61,21 @@ export const createGitlabProjectVariableAction = (options: {
   integrations: ScmIntegrationRegistry;
 }) => {
   const { integrations } = options;
-  return createTemplateAction<{
-    repoUrl: string;
-    projectId: string | number;
-    key: string;
-    value: string;
-    variableType: string;
-    variableProtected: boolean;
-    masked: boolean;
-    raw: boolean;
-    environmentScope: string;
-    token?: string;
-  }>({
+  return createTemplateAction<z.infer<typeof input>>({
     id: 'gitlab:projectVariable:create',
-    schema: {
-      input: {
-        required: [
-          'repoUrl',
-          'projectId',
-          'key',
-          'value',
-          'variableType',
-          'variableProtected',
-          'masked',
-          'raw',
-          'environmentScope',
-        ],
-        type: 'object',
-        properties: {
-          repoUrl: {
-            title: 'Repository Location',
-            type: 'string',
-          },
-          projectId: {
-            title: 'Project ID',
-            type: ['string', 'number'],
-          },
-          key: {
-            title:
-              'The key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed',
-            type: 'string',
-          },
-          value: {
-            title: 'The value of a variable',
-            type: 'string',
-          },
-          variableType: {
-            title: 'Variable Type (env_var or file)',
-            type: 'string',
-          },
-          variableProtected: {
-            title: 'Whether the variable is protected. Default: false',
-            type: 'boolean',
-          },
-          masked: {
-            title: 'Whether the variable is masked. Default: false',
-            type: 'boolean',
-          },
-          raw: {
-            title: 'Whether the variable is expandable. Default: false',
-            type: 'boolean',
-          },
-          environmentScope: {
-            title: 'The environment_scope of the variable. Default: *',
-            type: 'string',
-          },
-          token: {
-            title: 'Authentication Token',
-            type: 'string',
-            description: 'The token to use for authorization to GitLab',
-          },
-        },
-      },
-    },
+    schema: { input },
     async handler(ctx) {
       const {
-        repoUrl,
         projectId,
         key,
         value,
         variableType,
-        variableProtected,
-        masked,
-        raw,
-        environmentScope,
+        variableProtected = false,
+        masked = false,
+        raw = false,
+        environmentScope = '*',
       } = ctx.input;
-      const { token, integrationConfig } = getToken(
-        repoUrl,
-        ctx.input.token,
-        integrations,
-      );
+      const { token, integrationConfig } = getToken(ctx.input, integrations);
 
       const api = new Gitlab({
         host: integrationConfig.config.baseUrl,

--- a/plugins/scaffolder-backend-module-gitlab/src/commonGitlabConfig.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/commonGitlabConfig.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-/**
- * A module for the scaffolder backend that lets you interact with gitlab
- *
- * @packageDocumentation
- */
-export * from './actions/createGitlabGroupEnsureExistsAction';
-export * from './actions/createGitlabProjectDeployTokenAction';
-export * from './actions/createGitlabProjectAccessTokenAction';
-export * from './actions/createGitlabProjectVariableAction';
+import { z } from 'zod';
+
+const commonGitlabConfig = z.object({
+  repoUrl: z.string({ description: 'Repository Location' }),
+  token: z
+    .string({ description: 'The token to use for authorization to GitLab' })
+    .optional(),
+});
+
+export default commonGitlabConfig;

--- a/plugins/scaffolder-backend-module-gitlab/src/util.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/util.ts
@@ -19,6 +19,8 @@ import {
   GitLabIntegration,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
+import { z } from 'zod';
+import commonGitlabConfig from './commonGitlabConfig';
 
 export const parseRepoHost = (repoUrl: string): string => {
   let parsed;
@@ -33,11 +35,10 @@ export const parseRepoHost = (repoUrl: string): string => {
 };
 
 export const getToken = (
-  repoUrl: string,
-  inputToken: string | null | undefined,
+  config: z.infer<typeof commonGitlabConfig>,
   integrations: ScmIntegrationRegistry,
 ): { token: string; integrationConfig: GitLabIntegration } => {
-  const host = parseRepoHost(repoUrl);
+  const host = parseRepoHost(config.repoUrl);
   const integrationConfig = integrations.gitlab.byHost(host);
 
   if (!integrationConfig) {
@@ -46,8 +47,8 @@ export const getToken = (
     );
   }
 
-  const token = inputToken || integrationConfig.config.token!;
-  const tokenType = inputToken ? 'oauthToken' : 'token';
+  const token = config.token || integrationConfig.config.token!;
+  const tokenType = config.token ? 'oauthToken' : 'token';
 
   if (tokenType === 'oauthToken') {
     throw new InputError(`OAuth Token is currently not supported`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7855,6 +7855,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@gitbeaker/node": ^35.8.0
+    zod: ^3.21.4
   languageName: unknown
   linkType: soft
 
@@ -40583,6 +40584,13 @@ __metadata:
   peerDependencies:
     zod: ^3.20.0
   checksum: 55bc649dbc82ce25fbfbfdd42ca530d883d83be5d02cb81e89f6401d54bca151fc6b8cc57999c75eb6a3dcaa3f000697315fbd4f505637472621570ed52784d8
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.21.4":
+  version: 3.21.4
+  resolution: "zod@npm:3.21.4"
+  checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40594,13 +40594,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.21.4":
-  version: 3.21.4
-  resolution: "zod@npm:3.21.4"
-  checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
-  languageName: node
-  linkType: hard
-
 "zod@npm:~3.18.0":
   version: 3.18.0
   resolution: "zod@npm:3.18.0"


### PR DESCRIPTION
With this action it can be ensured, that a Gitlab group exists.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
