### PR TITLE
repo-tools: Improve error message when API report is missing

### DIFF
--- a/.changeset/witty-berries-love.md
+++ b/.changeset/witty-berries-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Log API report instructions when api-report is missing.

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -487,6 +487,9 @@ export async function runApiExtraction({
       showVerboseMessages: false,
       showDiagnostics: false,
       messageCallback(message) {
+        if (message.text.includes('The API report file is missing')) {
+          shouldLogInstructions = true;
+        }
         if (
           message.text.includes(
             'You have changed the public API signature for this project.',
@@ -506,7 +509,11 @@ export async function runApiExtraction({
 
     // This release tag validation makes sure that the release tag of known entry points match expectations.
     // The root index entrypoint is only allowed @public exports, while /alpha and /beta only allow @alpha and @beta.
-    if (validateReleaseTags && !usesExperimentalTypeBuild) {
+    if (
+      validateReleaseTags &&
+      !usesExperimentalTypeBuild &&
+      fs.pathExistsSync(extractorConfig.reportFilePath)
+    ) {
       if (['index', 'alpha', 'beta'].includes(name)) {
         const report = await fs.readFile(
           extractorConfig.reportFilePath,


### PR DESCRIPTION
before

```
yarn build:api-reports:only plugins/scaffolder-backend-module-cookiecutter --ci --docs                                                                                  

# Generating package API reports
## Processing plugins/scaffolder-backend-module-cookiecutter
Warning: The API report file is missing. Please copy the file "/Users/jhaals/src/backstage/node_modules/.cache/api-extractor/plugin-scaffolder-backend-module-cookiecutter/api-report.md" to "api-report.md", or perform a local build (which does this automatically). See the Git repo documentation for more info.

Error: ENOENT: no such file or directory, open '/Users/jhaals/src/backstage/plugins/scaffolder-backend-module-cookiecutter/api-report.md'
```

after

```
yarn build:api-reports:only plugins/scaffolder-backend-module-cookiecutter --ci --docs                                                                                  

# Generating package API reports
## Processing plugins/scaffolder-backend-module-cookiecutter
Warning: The API report file is missing. Please copy the file "/Users/jhaals/src/backstage/node_modules/.cache/api-extractor/plugin-scaffolder-backend-module-cookiecutter/api-report.md" to "api-report.md", or perform a local build (which does this automatically). See the Git repo documentation for more info.

*************************************************************************************
* You have uncommitted changes to the public API of a package.                      *
* To solve this, run `yarn build:api-reports` and commit all api-report.md changes. *
*************************************************************************************


Error: API Extractor completed with 0 errors and 1 warnings
```