### PR TITLE
Allow Replacement Of BuiltinKindsEntityProcessor

### DIFF
--- a/.changeset/silly-adults-accept.md
+++ b/.changeset/silly-adults-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow replacement of the BuiltinKindsEntityProcessor which enables customization of schema validation and connections emitted.

--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -170,6 +170,7 @@ its schema. There is a builtin processor that implements this for all known core
 kinds and matches the data against their fixed validation schema. This processor
 can be replaced when building the backend catalog using the `CatalogBuilder`,
 with a processor of your own that validates the data differently.
+This replacement processor must have a name that matches the builtin processor, `BuiltinKindsEntityProcessor`.
 
 This type of extension is high risk, and may have high impact across the
 ecosystem depending on the type of change that is made. It is therefore not

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -599,15 +599,25 @@ export class CatalogBuilder {
       ...this.placeholderResolvers,
     };
 
-    // These are always there no matter what
+    // The placeholder is always there no matter what
     const processors: CatalogProcessor[] = [
       new PlaceholderProcessor({
         resolvers: placeholderResolvers,
         reader,
         integrations,
       }),
-      new BuiltinKindsEntityProcessor(),
     ];
+
+    // If the user adds a processor named 'BuiltinKindsEntityProcessor',
+    //   skip inclusion of the catalog-backend version.
+    if (
+      !this.processors.find(
+        processor =>
+          processor.getProcessorName() === 'BuiltinKindsEntityProcessor',
+      )
+    ) {
+      processors.push(new BuiltinKindsEntityProcessor());
+    }
 
     // These are only added unless the user replaced them all
     if (!this.processorsReplace) {

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -608,15 +608,17 @@ export class CatalogBuilder {
       }),
     ];
 
+    const builtinKindsEntityProcessor = new BuiltinKindsEntityProcessor();
     // If the user adds a processor named 'BuiltinKindsEntityProcessor',
     //   skip inclusion of the catalog-backend version.
     if (
-      !this.processors.find(
+      !this.processors.some(
         processor =>
-          processor.getProcessorName() === 'BuiltinKindsEntityProcessor',
+          processor.getProcessorName() ===
+          builtinKindsEntityProcessor.getProcessorName(),
       )
     ) {
-      processors.push(new BuiltinKindsEntityProcessor());
+      processors.push(builtinKindsEntityProcessor);
     }
 
     // These are only added unless the user replaced them all


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The documentation suggests that, [while high risk, `BuiltinKindsEntityProcessor` can be replaced](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/extending-the-model.md?plain=1#L171). The existing functionality was sufficient to enable this capability. This PR adds the functionality to replace the existing `BuiltinKindsEntityProcessor` if the user adds a processor which has the same name.

I haven't adjusted any tests, but I don't see any which make sense to update. Happy to adjust per y'all suggestions.

### Example code for a BuiltinKindsEntityProcessor replacement

For the specific use case that we were interested in, we needed to set the `Domain` owner as optional. As this is a replacement, we ended up creating a new processor and delegating to the original one. We made the tweak to the validator to set the owner as optional, and an additional logic check on the `emit` to skip if there isn't an owner.

```typescript
import { entityKindSchemaValidator, Entity } from '@backstage/catalog-model';
import { BuiltinKindsEntityProcessor } from '@backstage/plugin-catalog-backend';
import { LocationSpec } from '@backstage/plugin-catalog-common';
import {
  CatalogProcessor,
  CatalogProcessorEmit,
} from '@backstage/plugin-catalog-node';
import domainSchema from './domainEntityV1alpha1Validator.json';

const domainEntityCustomerValidator = entityKindSchemaValidator(domainSchema);

export class CustomBuiltinEntityProcessor implements CatalogProcessor {
  readonly #delegate = new BuiltinKindsEntityProcessor();

  getProcessorName(): string {
    return this.#delegate.getProcessorName();
  }

  async validateEntityKind(entity: Entity): Promise<boolean> {
    if (entity.kind === 'Domain') {
      return domainEntityCustomerValidator(entity) === entity;
    }
    return this.#delegate.validateEntityKind(entity);
  }

  postProcessEntity(
    entity: Entity,
    _location: LocationSpec,
    emit: CatalogProcessorEmit,
  ): Promise<Entity> {
    return this.#delegate.postProcessEntity(entity, _location, emit);
  }
}

```

This closes #16886.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
