### PR TITLE
Allow to pass lazy GraphQL endpoint url to graphiql plugin

### DIFF
--- a/.changeset/twelve-vans-sell.md
+++ b/.changeset/twelve-vans-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphiql': patch
+---
+
+Allow to pass lazy GraphQL endpoint URL

--- a/plugins/graphiql/api-report.md
+++ b/plugins/graphiql/api-report.md
@@ -16,7 +16,7 @@ import { RouteRef } from '@backstage/core-plugin-api';
 export type EndpointConfig = {
   id: string;
   title: string;
-  url: string;
+  url: string | Promise<string>;
   method?: 'POST';
   headers?: {
     [name in string]: string;

--- a/plugins/graphiql/src/lib/api/GraphQLEndpoints.ts
+++ b/plugins/graphiql/src/lib/api/GraphQLEndpoints.ts
@@ -26,7 +26,7 @@ export type EndpointConfig = {
   id: string;
   title: string;
   // Endpoint URL
-  url: string;
+  url: string | Promise<string>;
   // only supports POST right now
   method?: 'POST';
   // Defaults to setting Content-Type to application/json
@@ -66,7 +66,7 @@ export class GraphQLEndpoints implements GraphQLBrowseApi {
           ...config.headers,
           ...options.headers,
         };
-        const res = await fetch(url, {
+        const res = await fetch(await url, {
           method,
           headers,
           body,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Separate changes from #15519 to be able to use `discoveryApi` for creating GraphQL endpoint configs

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
