### PR TITLE
Allow custom commit message when publishing a GitHub Pull Request

### DIFF
--- a/.changeset/slow-ravens-destroy.md
+++ b/.changeset/slow-ravens-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Allow for a commit message to differ from the PR title when publishing a GitHub pull request.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -559,6 +559,7 @@ export const createPublishGithubPullRequestAction: (
     token?: string | undefined;
     reviewers?: string[] | undefined;
     teamReviewers?: string[] | undefined;
+    commitMessage?: string | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -545,4 +545,56 @@ describe('createPublishGithubPullRequestAction', () => {
       expect(ctx.output).toHaveBeenCalledWith('pullRequestNumber', 123);
     });
   });
+
+  describe('with commit message', () => {
+    let input: GithubPullRequestActionInput;
+    let ctx: ActionContext<GithubPullRequestActionInput>;
+
+    beforeEach(() => {
+      input = {
+        repoUrl: 'github.com?owner=myorg&repo=myrepo',
+        title: 'Create my new app',
+        branchName: 'new-app',
+        description: 'This PR is really good',
+        commitMessage: 'Create my new app, but in the commit message',
+      };
+
+      mockFs({
+        [workspacePath]: { 'file.txt': 'Hello there!' },
+      });
+
+      ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+    });
+
+    it('creates a pull request', async () => {
+      await instance.handler(ctx);
+
+      expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+        owner: 'myorg',
+        repo: 'myrepo',
+        title: 'Create my new app',
+        head: 'new-app',
+        body: 'This PR is really good',
+        changes: [
+          {
+            commit: 'Create my new app, but in the commit message',
+            files: {
+              'file.txt': {
+                content: Buffer.from('Hello there!').toString('base64'),
+                encoding: 'base64',
+                mode: '100644',
+              },
+            },
+          },
+        ],
+      });
+    });
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -206,7 +206,7 @@ export const createPublishGithubPullRequestAction = (
           commitMessage: {
             type: 'string',
             title: 'Commit Message',
-            description: 'The commit message for the PR commit',
+            description: 'The commit message for the pull request commit',
           },
         },
       },
@@ -305,7 +305,7 @@ export const createPublishGithubPullRequestAction = (
           changes: [
             {
               files,
-              commit: commitMessage || title,
+              commit: commitMessage ?? title,
             },
           ],
           body: description,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -136,6 +136,7 @@ export const createPublishGithubPullRequestAction = (
     token?: string;
     reviewers?: string[];
     teamReviewers?: string[];
+    commitMessage?: string;
   }>({
     id: 'publish:github:pull-request',
     schema: {
@@ -202,6 +203,11 @@ export const createPublishGithubPullRequestAction = (
             description:
               'The teams that will be added as reviewers to the pull request',
           },
+          commitMessage: {
+            type: 'string',
+            title: 'Commit Message',
+            description: 'The commit message for the PR commit',
+          },
         },
       },
       output: {
@@ -233,6 +239,7 @@ export const createPublishGithubPullRequestAction = (
         token: providedToken,
         reviewers,
         teamReviewers,
+        commitMessage,
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -298,7 +305,7 @@ export const createPublishGithubPullRequestAction = (
           changes: [
             {
               files,
-              commit: title,
+              commit: commitMessage || title,
             },
           ],
           body: description,


### PR DESCRIPTION
## Hey, I just made a Pull Request! 👋 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Currently, in the `publish:github:pull-request` built-in scaffolder action, you specify a pull request title. This pull request title is then used as the commit message for the commit done in the context of the PR (oh and also for the PR title, who would have guessed 😜). 

In our instance of Backstage, we have a template that would require a commit message that differs from the pull request's title. This is for various commit conventions and/or CI. This is currently not doable and this is what led to this pull request.

This pull request adds a new option in the inputs for the action that allows users to specify a custom commit message. The new behaviour is to check if the commit message option is set and to fallback to the pull request title if it is not. In other words, it's a non breaking change that can be released without affecting anyone currently using the action.

tl;dr: In the `publish:github:pull-request` built-in action for the scaffolder, it adds an option to specify a custom, different commit message instead of it being the PR title. It is non breaking since it will fallback to the title like before when unset.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
