### PR TITLE
BazaarPage card style options

### DIFF
--- a/.changeset/tall-oranges-own.md
+++ b/.changeset/tall-oranges-own.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Added the `fullWidth` and `fullHeight` optional properties to the `BazaarPage`,
+to replicate the styling options available on the `BazaarOverviewCard`.

--- a/plugins/bazaar/README.md
+++ b/plugins/bazaar/README.md
@@ -39,6 +39,8 @@ const routes = (
 
 ```
 
+`BazaarPage` can be given the optional properties `fullHeight` and `fullWidth` which are used to adjust the cards styling to fit more or less on the page as required (both default to `true`).
+
 Add a **Bazaar icon** to the Sidebar to easily access the Bazaar. In `packages/app/src/components/Root.tsx` add:
 
 ```diff

--- a/plugins/bazaar/api-report.md
+++ b/plugins/bazaar/api-report.md
@@ -30,6 +30,8 @@ export const BazaarPage: (props: BazaarPageProps) => JSX.Element;
 export type BazaarPageProps = {
   title?: string;
   subtitle?: string;
+  fullWidth?: boolean;
+  fullHeight?: boolean;
 };
 
 // @public (undocumented)
@@ -53,7 +55,13 @@ export const isBazaarAvailable: (
 ) => Promise<boolean>;
 
 // @public (undocumented)
-export const SortView: () => JSX.Element;
+export const SortView: (props: SortViewProps) => JSX.Element;
+
+// @public (undocumented)
+export type SortViewProps = {
+  fullWidth?: boolean;
+  fullHeight?: boolean;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/bazaar/src/components/HomePage/HomePage.tsx
+++ b/plugins/bazaar/src/components/HomePage/HomePage.tsx
@@ -23,16 +23,18 @@ import { About } from '../About';
 export type HomePageProps = {
   title?: string;
   subtitle?: string;
+  fullWidth?: boolean;
+  fullHeight?: boolean;
 };
 
 export const HomePage = (props: HomePageProps) => {
-  const { title, subtitle } = props;
+  const { title, subtitle, fullWidth, fullHeight } = props;
 
   const tabContent = [
     {
       path: '/',
       title: 'Home',
-      children: <SortView />,
+      children: <SortView fullWidth={fullWidth} fullHeight={fullHeight} />,
     },
     {
       path: '/about',

--- a/plugins/bazaar/src/components/SortView/SortView.tsx
+++ b/plugins/bazaar/src/components/SortView/SortView.tsx
@@ -67,7 +67,14 @@ const getUnlinkedCatalogEntities = (
 };
 
 /** @public */
-export const SortView = () => {
+export type SortViewProps = {
+  fullWidth?: boolean;
+  fullHeight?: boolean;
+};
+
+/** @public */
+export const SortView = (props: SortViewProps) => {
+  const { fullWidth = true, fullHeight = true } = props;
   const bazaarApi = useApi(bazaarApiRef);
   const catalogApi = useApi(catalogApiRef);
   const classes = useStyles();
@@ -199,7 +206,8 @@ export const SortView = () => {
         bazaarProjects={getSearchResults() || []}
         fetchBazaarProjects={fetchBazaarProjects}
         catalogEntities={unlinkedCatalogEntities || []}
-        height="large"
+        gridSize={fullWidth ? 2 : 4}
+        height={fullHeight ? 'large' : 'small'}
       />
       <Content noPadding className={classes.container} />
     </Content>

--- a/plugins/bazaar/src/components/SortView/index.ts
+++ b/plugins/bazaar/src/components/SortView/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { SortView } from './SortView';
+export type { SortViewProps } from './SortView';

--- a/plugins/bazaar/src/index.ts
+++ b/plugins/bazaar/src/index.ts
@@ -20,4 +20,5 @@ export { BazaarOverviewCard } from './components/BazaarOverviewCard';
 export type { BazaarOverviewCardProps } from './components/BazaarOverviewCard';
 export { EntityBazaarInfoCard } from './components/EntityBazaarInfoCard';
 export { SortView } from './components/SortView';
+export type { SortViewProps } from './components/SortView';
 export type { HomePageProps as BazaarPageProps } from './components/HomePage';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#14217 and #14804 allowed the user to set styling changes via `fullWidth` and `fullHeight` props in `BazaarOverviewCard` to allow the project preview cards to look different/better when running in full sized grids. This PR allows those same values and card styling changes to also be passed into `BazaarPage` (aka `HomePage.tsx`). This also has the effect of allowing the cards to be styled on that page as they were before the previously mentioned PRs, for users that preferred that look. 

Note that for backcompat they are both defaulted to `true` in order to maintain current styling compared to the previous release.

Current styling (true/true):
![truetrue](https://user-images.githubusercontent.com/7984422/226947398-e7f3a812-0895-494a-822b-e8ac280893d6.PNG)

New styling if deliberately overridden to false/false:
![falsefalse](https://user-images.githubusercontent.com/7984422/226947435-d63786cb-8f0b-4670-8d47-82465bda9aa1.PNG)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info]
