### PR TITLE
OWNERS: update TechDocs + add Discoverability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,14 +8,14 @@
 yarn.lock                                           @backstage/maintainers @backstage-service
 */yarn.lock                                         @backstage/maintainers @backstage-service
 /.changeset/*.md                                        
-/cypress/src/integration/plugins/techdocs.spec.ts   @backstage/techdocs-core
-/docs/assets/search                                 @backstage/techdocs-core
-/docs/features/search                               @backstage/techdocs-core
-/docs/features/techdocs                             @backstage/techdocs-core
-/docs/plugins/integrating-search-into-plugins.md    @backstage/techdocs-core
+/cypress/src/integration/plugins/techdocs.spec.ts   @backstage/techdocs-maintainers
+/docs/assets/search                                 @backstage/discoverability-maintainers
+/docs/features/search                               @backstage/discoverability-maintainers
+/docs/features/techdocs                             @backstage/techdocs-maintainers
+/docs/plugins/integrating-search-into-plugins.md    @backstage/discoverability-maintainers
 /packages/cli/src/commands/onboard                  @backstage/sharks
-/packages/techdocs-cli                              @backstage/techdocs-core
-/packages/techdocs-cli-embedded-app                 @backstage/techdocs-core
+/packages/techdocs-cli                              @backstage/techdocs-maintainers
+/packages/techdocs-cli-embedded-app                 @backstage/techdocs-maintainers
 /plugins/adr                                        @backstage/maintainers @kuangp
 /plugins/adr-*                                      @backstage/maintainers @kuangp
 /plugins/allure                                     @backstage/maintainers @deepak-bhardwaj-ps
@@ -55,7 +55,7 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/fossa                                      @backstage/maintainers @backstage/sda-se-reviewers
 /plugins/gcalendar                                  @backstage/maintainers @szubster @ptychu @kielosz @alexrybch
 /plugins/git-release-manager                        @backstage/maintainers @erikengervall
-/plugins/home                                       @backstage/techdocs-core
+/plugins/home                                       @backstage/discoverability-maintainers
 /plugins/ilert                                      @backstage/maintainers @yacut
 /plugins/jenkins                                    @backstage/maintainers @timja
 /plugins/jenkins-backend                            @backstage/maintainers @timja
@@ -71,13 +71,13 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/rollbar-backend                            @backstage/maintainers @andrewthauer
 /plugins/scaffolder-backend-module-rails            @backstage/maintainers @angeliski
 /plugins/scaffolder-backend-module-yeoman           @backstage/maintainers @pawelmitka
-/plugins/search                                     @backstage/techdocs-core
-/plugins/search-*                                   @backstage/techdocs-core
+/plugins/search                                     @backstage/discoverability-maintainers
+/plugins/search-*                                   @backstage/discoverability-maintainers
 /plugins/sonarqube                                  @backstage/maintainers @backstage/sda-se-reviewers
-/plugins/stack-overflow                             @backstage/techdocs-core
-/plugins/stack-overflow-backend                     @backstage/techdocs-core
-/plugins/techdocs                                   @backstage/techdocs-core
-/plugins/techdocs-*                                 @backstage/techdocs-core
+/plugins/stack-overflow                             @backstage/discoverability-maintainers
+/plugins/stack-overflow-backend                     @backstage/discoverability-maintainers
+/plugins/techdocs                                   @backstage/techdocs-maintainers
+/plugins/techdocs-*                                 @backstage/techdocs-maintainers
 /plugins/user-settings-backend                      @backstage/maintainers @backstage/sda-se-reviewers
 /tech-insights-backend                              @backstage/maintainers @xantier @iain-b
 /tech-insights-backend-module-jsonfc                @backstage/maintainers @xantier @iain-b

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -24,6 +24,20 @@ Team: @backstage/catalog-maintainers
 | ---- | ------------ | --------- | ---------------------------- | ------- |
 | TBD  | Spotify      | Chipmunks | [TBD](http://github.com/TBD) | -       |
 
+### Discoverability
+
+Team: @backstage/discoverability-maintainers
+
+Scope: Discoverability within Backstage, including the home page, information architecture, and search
+
+| Name                     | Organization | Team | GitHub                                   | Discord            |
+| ------------------------ | ------------ | ---- | ---------------------------------------- | ------------------ |
+| Avantika Iyer            | Spotify      | BUX  | [tikabom](http://github.com/tikabom)     | -                  |
+| Camila Belo              | Spotify      | BUX  | [camilaibs](http://github.com/camilaibs) | Camila Loiola#0226 |
+| Emma Indal               | Spotify      | BUX  | [emmaindal](http://github.com/emmaindal) | emmaindal#7503     |
+| Raghunandan Balachandran | Spotify      | BUX  | [soapraj](http://github.com/soapraj)     | raghunandanb#1114  |
+| Renan Mendes Carvalho    | Spotify      | BUX  | [aitherios](http://github.com/aitherios) | aitherios#0593     |
+
 ### Kubernetes
 
 Team: @backstage/kubernetes-maintainers
@@ -38,17 +52,12 @@ Scope: The Kubernetes plugin and the base it provides for other plugins to build
 
 Team: @backstage/techdocs-maintainers
 
-| Name | Organization | Team         | GitHub                       | Discord |
-| ---- | ------------ | ------------ | ---------------------------- | ------- |
-| TBD  | Spotify      | Pulp Fiction | [TBD](http://github.com/TBD) | -       |
+Scope: The TechDocs plugin and related tooling
 
-### Search
-
-Team: @backstage/search-maintainers
-
-| Name | Organization | Team | GitHub                       | Discord |
-| ---- | ------------ | ---- | ---------------------------- | ------- |
-| TBD  | Spotify      | BUX  | [TBD](http://github.com/TBD) | -       |
+| Name                     | Organization | Team         | GitHub                                           | Discord            |
+| ------------------------ | ------------ | ------------ | ------------------------------------------------ | ------------------ |
+| Morgan Bentell           | Spotify      | Pulp Fiction | [agentbellnorm](http://github.com/agentbellnorm) | morganbentell#9030 |
+| Raghunandan Balachandran | Spotify      | Pulp Fiction | [soapraj](http://github.com/soapraj)             | raghunandanb#1114  |
 
 ## Sponsors
 


### PR DESCRIPTION
As the original TechDocs team has taken on broader responsibility of Discovery within Backstage, focused has been shifting away from TechDocs, which is in maintenance mode for the time being.

This forms the "Discoverability" project area, where the goal of helping end users find what they are looking for within Backstage. This includes making sure we have a delightful landing page experience, solid search in Backstage itself, and an information architecture that makes it easy to browse Backstage.

In addition to this change, the `@backstage/techdocs-core` team will be renamed to `@backstage/techdocs-maintainers`, and the new `@backstage/discoverability-maintainers` will be created.

^ describes the proposed change, please chime in with any feedback 😁 