### PR TITLE
OWNERS: add Kubernetes project area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,8 +61,8 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/jenkins-backend                            @backstage/maintainers @timja
 /plugins/kafka                                      @backstage/maintainers @nirga @andrewthauer
 /plugins/kafka-backend                              @backstage/maintainers @nirga @andrewthauer
-/plugins/kubernetes                                 @backstage/maintainers @backstage/warpspeed
-/plugins/kubernetes-*                               @backstage/maintainers @backstage/warpspeed
+/plugins/kubernetes                                 @backstage/maintainers @backstage/kubernetes-maintainers
+/plugins/kubernetes-*                               @backstage/maintainers @backstage/kubernetes-maintainers
 /plugins/microsoft-calendar                         @backstage/maintainers @abhay-soni-developer @NishkarshRaj
 /plugins/newrelic-dashboard                         @backstage/maintainers @mufaddal7
 /plugins/playlist                                   @backstage/maintainers @kuangp

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -24,6 +24,16 @@ Team: @backstage/catalog-maintainers
 | ---- | ------------ | --------- | ---------------------------- | ------- |
 | TBD  | Spotify      | Chipmunks | [TBD](http://github.com/TBD) | -       |
 
+### Kubernetes
+
+Team: @backstage/kubernetes-maintainers
+
+Scope: The Kubernetes plugin and the base it provides for other plugins to build upon.
+
+| Name           | Organization | Team | GitHub                                   | Discord      |
+| -------------- | ------------ | ---- | ---------------------------------------- | ------------ |
+| Matthew Clarke | Spotify      |      | [mclarke47](http://github.com/mclarke47) | mclarke#0725 |
+
 ### TechDocs
 
 Team: @backstage/techdocs-maintainers


### PR DESCRIPTION
This formally introduces the Kubernetes project area, which @mclarke47 has been leading since he started the k8s plugin.

As part of this change we'll also create the `@backstage/kubernetes-maintainers` team.
