### PR TITLE
feat(catalog-backend-module-gitlab): Added option to skip forked repos

### DIFF
--- a/.changeset/silent-garlics-drum.md
+++ b/.changeset/silent-garlics-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': minor
+---
+
+Added option to skip forked repos

--- a/.changeset/silent-garlics-drum.md
+++ b/.changeset/silent-garlics-drum.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-gitlab': minor
+'@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
 Added option to skip forked repos

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -109,3 +109,5 @@ export default async function createPlugin(
 ```
 
 If you don't want create location object if file with component definition do not exists in project, you can set the `skipReposWithoutExactFileMatch` option. That can reduce count of request to gitlab with 404 status code.
+
+If you don't want to create location object if the project is a fork, you can set the `skipForkedRepos` option.

--- a/plugins/catalog-backend-module-gitlab/api-report.md
+++ b/plugins/catalog-backend-module-gitlab/api-report.md
@@ -40,6 +40,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     options: {
       logger: Logger;
       skipReposWithoutExactFileMatch?: boolean;
+      skipForkedRepos?: boolean;
     },
   ): GitLabDiscoveryProcessor;
   // (undocumented)

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -42,10 +42,11 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
   private readonly logger: Logger;
   private readonly cache: CacheClient;
   private readonly skipReposWithoutExactFileMatch: boolean;
+  private readonly skipForkedRepos: boolean;
 
   static fromConfig(
     config: Config,
-    options: { logger: Logger; skipReposWithoutExactFileMatch?: boolean },
+    options: { logger: Logger; skipReposWithoutExactFileMatch?: boolean; skipForkedRepos?: boolean },
   ): GitLabDiscoveryProcessor {
     const integrations = ScmIntegrations.fromConfig(config);
     const pluginCache =
@@ -63,12 +64,14 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     pluginCache: PluginCacheManager;
     logger: Logger;
     skipReposWithoutExactFileMatch?: boolean;
+    skipForkedRepos?: boolean;
   }) {
     this.integrations = options.integrations;
     this.cache = options.pluginCache.getClient();
     this.logger = options.logger;
     this.skipReposWithoutExactFileMatch =
       options.skipReposWithoutExactFileMatch || false;
+    this.skipForkedRepos = options.skipForkedRepos || false;
   }
 
   getProcessorName(): string {
@@ -138,6 +141,10 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
         if (!projectHasFile) {
           continue;
         }
+      }
+
+      if (this.skipForkedRepos && project.hasOwnProperty('forked_from_project')) {
+        continue;
       }
 
       res.matches.push(project);

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -46,7 +46,11 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
 
   static fromConfig(
     config: Config,
-    options: { logger: Logger; skipReposWithoutExactFileMatch?: boolean; skipForkedRepos?: boolean },
+    options: {
+      logger: Logger;
+      skipReposWithoutExactFileMatch?: boolean;
+      skipForkedRepos?: boolean;
+    },
   ): GitLabDiscoveryProcessor {
     const integrations = ScmIntegrations.fromConfig(config);
     const pluginCache =
@@ -143,7 +147,10 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
         }
       }
 
-      if (this.skipForkedRepos && project.hasOwnProperty('forked_from_project')) {
+      if (
+        this.skipForkedRepos &&
+        project.hasOwnProperty('forked_from_project')
+      ) {
         continue;
       }
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -22,6 +22,10 @@ export type GitlabGroupDescription = {
   projects: GitLabProject[];
 };
 
+export type GitlabProjectForkedFrom = {
+  id: number
+}
+
 export type GitLabProject = {
   id: number;
   default_branch?: string;
@@ -29,6 +33,7 @@ export type GitLabProject = {
   last_activity_at: string;
   web_url: string;
   path_with_namespace?: string;
+  forked_from_project?: GitlabProjectForkedFrom;
 };
 
 export type GitLabUser = {

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -23,8 +23,8 @@ export type GitlabGroupDescription = {
 };
 
 export type GitlabProjectForkedFrom = {
-  id: number
-}
+  id: number;
+};
 
 export type GitLabProject = {
   id: number;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added an option in the gitlab catalog plugin to skip importing projects that are forks

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
