### PR TITLE
OWNERS: add Helm Charts project area

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -38,6 +38,18 @@ Scope: Discoverability within Backstage, including the home page, information ar
 | Raghunandan Balachandran | Spotify      | BUX  | [soapraj](http://github.com/soapraj)     | raghunandanb#1114  |
 | Renan Mendes Carvalho    | Spotify      | BUX  | [aitherios](http://github.com/aitherios) | aitherios#0593     |
 
+### Helm Charts
+
+Team: @backstage/helm-chart-maintainers
+
+Scope: The Backstage [Helm Chart(s)](https://github.com/backstage/charts).
+
+| Name                 | Organization | Team | GitHub                                   | Discord        |
+| -------------------- | ------------ | ---- | ---------------------------------------- | -------------- |
+| Andrew Block         | Red Hat      |      | [sabre1041](http://github.com/sabre1041) | sabre1041#2622 |
+| Tom Coufal           | Red Hat      |      | [tumido](http://github.com/tumido)       | Tumi#4346      |
+| Vincenzo Scamporlino | Spotify      |      | [vinzscam](http://github.com/vinzscam)   | vinzscam#6944  |
+
 ### Kubernetes
 
 Team: @backstage/kubernetes-maintainers


### PR DESCRIPTION
This introduces the Helm Charts project area, which has been championed by Andrew and Tom from Red Hat with colleagues, along with Vincenzo from Spotify 🎉 

As part of this change the `@backstage/helm-charts-maintainers` team will be created.