### PR TITLE
OWNERS: update Catalog project area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,13 +26,13 @@ yarn.lock                                           @backstage/maintainers @back
 /plugins/azure-devops-common                        @backstage/maintainers @marleypowell @awanlin
 /plugins/bitbucket-cloud-common                     @backstage/maintainers @pjungermann
 /plugins/bitrise                                    @backstage/maintainers @backstage/sda-se-reviewers
-/plugins/catalog                                    @backstage/maintainers @backstage/catalog-core
-/plugins/catalog-*                                  @backstage/maintainers @backstage/catalog-core
-/plugins/catalog-backend-module-aws                 @backstage/maintainers @backstage/catalog-core @pjungermann
-/plugins/catalog-backend-module-bitbucket-cloud     @backstage/maintainers @backstage/catalog-core @pjungermann
-/plugins/catalog-backend-module-msgraph             @backstage/maintainers @backstage/catalog-core @pjungermann
-/plugins/catalog-backend-module-puppetdb            @backstage/maintainers @backstage/catalog-core @tdabasinskas
-/plugins/catalog-graph                              @backstage/maintainers @backstage/catalog-core @backstage/sda-se-reviewers
+/plugins/catalog                                    @backstage/maintainers @backstage/catalog-maintainers
+/plugins/catalog-*                                  @backstage/maintainers @backstage/catalog-maintainers
+/plugins/catalog-backend-module-aws                 @backstage/maintainers @backstage/catalog-maintainers @pjungermann
+/plugins/catalog-backend-module-bitbucket-cloud     @backstage/maintainers @backstage/catalog-maintainers @pjungermann
+/plugins/catalog-backend-module-msgraph             @backstage/maintainers @backstage/catalog-maintainers @pjungermann
+/plugins/catalog-backend-module-puppetdb            @backstage/maintainers @backstage/catalog-maintainers @tdabasinskas
+/plugins/catalog-graph                              @backstage/maintainers @backstage/catalog-maintainers @backstage/sda-se-reviewers
 /plugins/circleci                                   @backstage/maintainers @adamdmharvey
 /plugins/cloudbuild                                 @backstage/maintainers @trivago/ebarrios
 /plugins/code-coverage                              @backstage/maintainers @alde @nissayeva

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -20,9 +20,14 @@ These are the separate project areas of Backstage, each with their own project a
 
 Team: @backstage/catalog-maintainers
 
-| Name | Organization | Team      | GitHub                       | Discord |
-| ---- | ------------ | --------- | ---------------------------- | ------- |
-| TBD  | Spotify      | Chipmunks | [TBD](http://github.com/TBD) | -       |
+Scope: The catalog plugin and catalog model
+
+| Name           | Organization | Team      | GitHub                                   | Discord          |
+| -------------- | ------------ | --------- | ---------------------------------------- | ---------------- |
+| Rickard Dybeck | Spotify      | Chipmunks | [alde](http://github.com/alde)           | rdybeck#8083     |
+| Mike Blockley  | Spotify      | Chipmunks | [mikeyhc](http://github.com/mikeyhc)     | -                |
+| Elon Jefferson | Spotify      | Chipmunks | [Edje-C](http://github.com/Edje-C)       | elon-spotty#6086 |
+| Nurit Izrailov | Spotify      | Chipmunks | [nuritizra](http://github.com/nuritizra) | -                |
 
 ### Discoverability
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -25,7 +25,7 @@ Scope: The catalog plugin and catalog model
 | Name           | Organization | Team      | GitHub                                   | Discord          |
 | -------------- | ------------ | --------- | ---------------------------------------- | ---------------- |
 | Rickard Dybeck | Spotify      | Chipmunks | [alde](http://github.com/alde)           | rdybeck#8083     |
-| Mike Blockley  | Spotify      | Chipmunks | [mikeyhc](http://github.com/mikeyhc)     | -                |
+| Mike Blockley  | Spotify      | Chipmunks | [mikeyhc](http://github.com/mikeyhc)     | mikey-spot#5363  |
 | Elon Jefferson | Spotify      | Chipmunks | [Edje-C](http://github.com/Edje-C)       | elon-spotty#6086 |
 | Nurit Izrailov | Spotify      | Chipmunks | [nuritizra](http://github.com/nuritizra) | -                |
 


### PR DESCRIPTION
This formalizes the Catalog project area, along with its maintainers. You've likely seen the Chipmunks squad in the catalog SIG and other places, who have been taking over responsibility of the catalog.

In addition to this change the @backstage/catalog-core team will be renamed to @backstage/catalog-maintainers.