### PR TITLE
Make CatalogClient's props protected

### DIFF
--- a/.changeset/young-buses-mate.md
+++ b/.changeset/young-buses-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Make the CatalogClient's `discoveryApi` and `fetchApi` properties protected instead of private.

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -95,6 +95,10 @@ export class CatalogClient implements CatalogApi {
     request: AddLocationRequest,
     options?: CatalogRequestOptions,
   ): Promise<AddLocationResponse>;
+  // (undocumented)
+  protected readonly discoveryApi: DiscoveryApi;
+  // (undocumented)
+  protected readonly fetchApi: FetchApi;
   getEntities(
     request?: GetEntitiesRequest,
     options?: CatalogRequestOptions,
@@ -158,6 +162,11 @@ export interface CatalogRequestOptions {
 }
 
 // @public
+export type DiscoveryApi = {
+  getBaseUrl(pluginId: string): Promise<string>;
+};
+
+// @public
 export const ENTITY_STATUS_CATALOG_PROCESSING_TYPE =
   'backstage.io/catalog-processing';
 
@@ -179,6 +188,11 @@ export type EntityOrderQuery =
       field: string;
       order: 'asc' | 'desc';
     }>;
+
+// @public
+export type FetchApi = {
+  fetch: typeof fetch;
+};
 
 // @public
 export interface GetEntitiesByRefsRequest {

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -54,8 +54,8 @@ import { isQueryEntitiesInitialRequest } from './utils';
  * @public
  */
 export class CatalogClient implements CatalogApi {
-  private readonly discoveryApi: DiscoveryApi;
-  private readonly fetchApi: FetchApi;
+  protected readonly discoveryApi: DiscoveryApi;
+  protected readonly fetchApi: FetchApi;
 
   constructor(options: {
     discoveryApi: { getBaseUrl(pluginId: string): Promise<string> };

--- a/packages/catalog-client/src/types/discovery.ts
+++ b/packages/catalog-client/src/types/discovery.ts
@@ -16,6 +16,7 @@
 
 /**
  * This is a copy of the DiscoveryApi, to avoid importing core-plugin-api.
+ * @public
  */
 export type DiscoveryApi = {
   getBaseUrl(pluginId: string): Promise<string>;

--- a/packages/catalog-client/src/types/fetch.ts
+++ b/packages/catalog-client/src/types/fetch.ts
@@ -16,6 +16,7 @@
 
 /**
  * This is a copy of FetchApi, to avoid importing core-plugin-api.
+ * @public
  */
 export type FetchApi = {
   fetch: typeof fetch;

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -38,4 +38,6 @@ export type {
   QueryEntitiesRequest,
   QueryEntitiesResponse,
 } from './api';
+export type { DiscoveryApi } from './discovery';
+export type { FetchApi } from './fetch';
 export { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from './status';


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Change the CatalogClient's private properties to be protected so the extending classes can use them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
