### PR TITLE
createPermissionIntegrationRouter: accept an array of options

### DIFF
--- a/.changeset/slimy-turkeys-return.md
+++ b/.changeset/slimy-turkeys-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': minor
+---
+
+createPermissionIntegrationRouter now can also take an array of CreatePermissionIntegrationRouterResourceOptions, accepting rules and permissions for multiple resource types.

--- a/.changeset/slimy-turkeys-return.md
+++ b/.changeset/slimy-turkeys-return.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-node': minor
 ---
 
-createPermissionIntegrationRouter now can also take an array of CreatePermissionIntegrationRouterResourceOptions, accepting rules and permissions for multiple resource types.
+`createPermissionIntegrationRouter` now can also take an array of `CreatePermissionIntegrationRouterResourceOptions`, accepting rules and permissions for multiple resource types.

--- a/.changeset/slimy-turkeys-return.md
+++ b/.changeset/slimy-turkeys-return.md
@@ -1,5 +1,22 @@
 ---
-'@backstage/plugin-permission-node': minor
+'@backstage/plugin-permission-node': patch
 ---
 
-`createPermissionIntegrationRouter` now can also take an array of `CreatePermissionIntegrationRouterResourceOptions`, accepting rules and permissions for multiple resource types.
+`createPermissionIntegrationRouter` now accepts rules and permissions for multiple resource types. Example:
+
+```typescript
+createPermissionIntegrationRouter({
+  resources: [
+    {
+      resourceType: 'resourceType-1',
+      permissions: permissionsResourceType1,
+      rules: rulesResourceType1,
+    },
+    {
+      resourceType: 'resourceType-2',
+      permissions: permissionsResourceType2,
+      rules: rulesResourceType2,
+    },
+  ],
+});
+```

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -118,75 +118,30 @@ export const createConditionTransformer: <
 
 // @public
 export function createPermissionIntegrationRouter<
-  TResourceType extends string,
-  TResource,
->(
-  options:
-    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
-    | {
-        resources: CreatePermissionIntegrationRouterResourceOptions<
-          TResourceType,
-          TResource
-        >;
-      },
-): express.Router;
-
-// @public
-export function createPermissionIntegrationRouter(
-  options:
-    | {
-        permissions: Array<Permission>;
-      }
-    | {
-        resources: {
-          permissions: Array<Permission>;
-        };
-      },
-): express.Router;
-
-// @public
-export function createPermissionIntegrationRouter<
-  TResourceType1 extends string,
-  TResource1,
-  TResourceType2 extends string,
-  TResource2,
->(options: {
-  resources: [
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType1,
-      TResource1
-    >,
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType2,
-      TResource2
-    >,
-  ];
-}): express.Router;
-
-// @public
-export function createPermissionIntegrationRouter<
   TResourceType1 extends string,
   TResource1,
   TResourceType2 extends string,
   TResource2,
   TResourceType3 extends string,
   TResource3,
->(options: {
-  resources: [
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType1,
-      TResource1
-    >,
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType2,
-      TResource2
-    >,
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType3,
-      TResource3
-    >,
-  ];
-}): express.Router;
+>(
+  options:
+    | {
+        permissions: Array<Permission>;
+      }
+    | CreatePermissionIntegrationRouterResourceOptions<
+        TResourceType1,
+        TResource1
+      >
+    | OptionResources<
+        TResourceType1,
+        TResource1,
+        TResourceType2,
+        TResource2,
+        TResourceType3,
+        TResource3
+      >,
+): express.Router;
 
 // @public
 export type CreatePermissionIntegrationRouterResourceOptions<
@@ -250,13 +205,46 @@ export type MetadataResponseSerializedRule = {
 };
 
 // @public
-export type OptionResources<TResourceType extends string, TResource> = {
-  resources:
-    | {
-        permissions: Array<Permission>;
-      }
-    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
-    | Array<CreatePermissionIntegrationRouterResourceOptions<string, any>>;
+export type OptionResources<
+  TResourceType1 extends string = string,
+  TResource1 = any,
+  TResourceType2 extends string = string,
+  TResource2 = any,
+  TResourceType3 extends string = string,
+  TResource3 = any,
+> = {
+  resources: Readonly<
+    | [
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType1,
+          TResource1
+        >,
+      ]
+    | [
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType1,
+          TResource1
+        >,
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType2,
+          TResource2
+        >,
+      ]
+    | [
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType1,
+          TResource1
+        >,
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType2,
+          TResource2
+        >,
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType3,
+          TResource3
+        >,
+      ]
+  >;
 };
 
 // @public

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -121,15 +121,71 @@ export function createPermissionIntegrationRouter<
   TResourceType extends string,
   TResource,
 >(
-  options: CreatePermissionIntegrationRouterResourceOptions<
-    TResourceType,
-    TResource
-  >,
+  options:
+    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
+    | {
+        resources: CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType,
+          TResource
+        >;
+      },
 ): express.Router;
 
 // @public
-export function createPermissionIntegrationRouter(options: {
-  permissions: Array<Permission>;
+export function createPermissionIntegrationRouter(
+  options:
+    | {
+        permissions: Array<Permission>;
+      }
+    | {
+        resources: {
+          permissions: Array<Permission>;
+        };
+      },
+): express.Router;
+
+// @public
+export function createPermissionIntegrationRouter<
+  TResourceType1 extends string,
+  TResource1,
+  TResourceType2 extends string,
+  TResource2,
+>(options: {
+  resources: [
+    CreatePermissionIntegrationRouterResourceOptions<
+      TResourceType1,
+      TResource1
+    >,
+    CreatePermissionIntegrationRouterResourceOptions<
+      TResourceType2,
+      TResource2
+    >,
+  ];
+}): express.Router;
+
+// @public
+export function createPermissionIntegrationRouter<
+  TResourceType1 extends string,
+  TResource1,
+  TResourceType2 extends string,
+  TResource2,
+  TResourceType3 extends string,
+  TResource3,
+>(options: {
+  resources: [
+    CreatePermissionIntegrationRouterResourceOptions<
+      TResourceType1,
+      TResource1
+    >,
+    CreatePermissionIntegrationRouterResourceOptions<
+      TResourceType2,
+      TResource2
+    >,
+    CreatePermissionIntegrationRouterResourceOptions<
+      TResourceType3,
+      TResource3
+    >,
+  ];
 }): express.Router;
 
 // @public
@@ -191,6 +247,16 @@ export type MetadataResponseSerializedRule = {
   description: string;
   resourceType: string;
   paramsSchema?: ReturnType<typeof zodToJsonSchema>;
+};
+
+// @public
+export type OptionResources<TResourceType extends string, TResource> = {
+  resources:
+    | {
+        permissions: Array<Permission>;
+      }
+    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
+    | Array<CreatePermissionIntegrationRouterResourceOptions<string, any>>;
 };
 
 // @public

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -133,7 +133,7 @@ export function createPermissionIntegrationRouter<
         TResourceType1,
         TResource1
       >
-    | OptionResources<
+    | PermissionIntegrationRouterOptions<
         TResourceType1,
         TResource1,
         TResourceType2,
@@ -205,7 +205,7 @@ export type MetadataResponseSerializedRule = {
 };
 
 // @public
-export type OptionResources<
+export type PermissionIntegrationRouterOptions<
   TResourceType1 extends string = string,
   TResource1 = any,
   TResourceType2 extends string = string,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -26,7 +26,7 @@ import {
   createPermissionIntegrationRouter,
   CreatePermissionIntegrationRouterResourceOptions,
   createConditionAuthorizer,
-  OptionResources,
+  PermissionIntegrationRouterOptions,
 } from './createPermissionIntegrationRouter';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -92,7 +92,7 @@ const defaultMockedGetResources2: CreatePermissionIntegrationRouterResourceOptio
   resourceRefs.map(resourceRef => ({ id: resourceRef })),
 );
 
-const mockedOptionResources: OptionResources = {
+const mockedOptionResources: PermissionIntegrationRouterOptions = {
   resources: [
     {
       resourceType: 'test-resource',

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -92,7 +92,7 @@ const defaultMockedGetResources2: CreatePermissionIntegrationRouterResourceOptio
   resourceRefs.map(resourceRef => ({ id: resourceRef })),
 );
 
-const mockedResourceOptions = {
+const mockedOptionResources: OptionResources = {
   resources: [
     {
       resourceType: 'test-resource',
@@ -122,17 +122,6 @@ const createApp = (
       })
     : createPermissionIntegrationRouter({ permissions: [testPermission] });
 
-  return express().use(router);
-};
-
-const createAppWithResources = (
-  resourceOptions:
-    | CreatePermissionIntegrationRouterResourceOptions<string, any>
-    | OptionResources<string, any>,
-) => {
-  const router = createPermissionIntegrationRouter(
-    resourceOptions as Parameters<typeof createPermissionIntegrationRouter>[0],
-  );
   return express().use(router);
 };
 
@@ -240,7 +229,11 @@ describe('createPermissionIntegrationRouter', () => {
 
       (defaultMockedGetResources1 as jest.Mock).mockClear();
 
-      response = await request(createAppWithResources(mockedResourceOptions))
+      const app = express().use(
+        createPermissionIntegrationRouter(mockedOptionResources),
+      );
+
+      response = await request(app)
         .post('/.well-known/backstage/permissions/apply-conditions')
         .send({
           items: [
@@ -459,7 +452,11 @@ describe('createPermissionIntegrationRouter', () => {
       let response: Response;
 
       beforeEach(async () => {
-        response = await request(createAppWithResources(mockedResourceOptions))
+        const app = express().use(
+          createPermissionIntegrationRouter(mockedOptionResources),
+        );
+
+        response = await request(app)
           .post('/.well-known/backstage/permissions/apply-conditions')
           .send({
             items: [
@@ -763,11 +760,13 @@ describe('createPermissionIntegrationRouter', () => {
 
     it('returns 501 with no getResources implementation', async () => {
       const response = await request(
-        createAppWithResources({
-          resourceType: 'test-resource',
-          permissions: [testPermission],
-          rules: [testRule1, testRule2],
-        }),
+        express().use(
+          createPermissionIntegrationRouter({
+            resourceType: 'test-resource',
+            permissions: [testPermission],
+            rules: [testRule1, testRule2],
+          }),
+        ),
       )
         .post('/.well-known/backstage/permissions/apply-conditions')
         .send({
@@ -841,7 +840,7 @@ describe('createPermissionIntegrationRouter', () => {
     });
     it('returns a list of permissions and rules used by a given backend that was created with an array of resource options', async () => {
       const response = await request(
-        createAppWithResources(mockedResourceOptions),
+        express().use(createPermissionIntegrationRouter(mockedOptionResources)),
       ).get('/.well-known/backstage/permissions/metadata');
 
       expect(response.status).toEqual(200);

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -26,6 +26,7 @@ import {
   createPermissionIntegrationRouter,
   CreatePermissionIntegrationRouterResourceOptions,
   createConditionAuthorizer,
+  OptionResources,
 } from './createPermissionIntegrationRouter';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -91,20 +92,22 @@ const defaultMockedGetResources2: CreatePermissionIntegrationRouterResourceOptio
   resourceRefs.map(resourceRef => ({ id: resourceRef })),
 );
 
-const mockedResourceOptions = [
-  {
-    resourceType: 'test-resource',
-    permissions: [testPermission],
-    getResources: defaultMockedGetResources1,
-    rules: [testRule1, testRule2],
-  },
-  {
-    resourceType: 'test-resource-2',
-    permissions: [testPermission2],
-    getResources: defaultMockedGetResources2,
-    rules: [testRule3],
-  },
-];
+const mockedResourceOptions = {
+  resources: [
+    {
+      resourceType: 'test-resource',
+      permissions: [testPermission],
+      getResources: defaultMockedGetResources1,
+      rules: [testRule1, testRule2],
+    },
+    {
+      resourceType: 'test-resource-2',
+      permissions: [testPermission2],
+      getResources: defaultMockedGetResources2,
+      rules: [testRule3],
+    },
+  ],
+};
 
 const createApp = (
   mockedGetResources:
@@ -125,7 +128,7 @@ const createApp = (
 const createAppWithResources = (
   resourceOptions:
     | CreatePermissionIntegrationRouterResourceOptions<string, any>
-    | CreatePermissionIntegrationRouterResourceOptions<string, any>[],
+    | OptionResources<string, any>,
 ) => {
   const router = createPermissionIntegrationRouter(
     resourceOptions as Parameters<typeof createPermissionIntegrationRouter>[0],

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -207,6 +207,11 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   ) => Promise<Array<TResource | undefined>>;
 };
 
+/**
+ * Options for creating a permission integration router
+ *
+ * @public
+ */
 export type OptionResources<TResourceType extends string, TResource> = {
   resources:
     | { permissions: Array<Permission> }

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -332,11 +332,12 @@ export function createPermissionIntegrationRouter<
         >
       ).rules || [],
   );
-  const allPermissions = allOptions
-    .flatMap(
-      option => (option as { permissions: Array<Permission> }).permissions,
-    )
-    .filter((p): p is Permission => !!p);
+  const allPermissions = [
+    ...((options as { permissions: Permission[] }).permissions || []),
+    ...(optionsWithResources.resources?.flatMap(o => o.permissions || []) ||
+      []),
+  ];
+
   const allResourceTypes = allOptions.reduce((acc, option) => {
     if (
       isCreatePermissionIntegrationRouterResourceOptions(

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -207,6 +207,12 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   ) => Promise<Array<TResource | undefined>>;
 };
 
+/**
+ * Options for creating a permission integration router exposing
+ * permissions and rules from multiple resource types.
+ *
+ * @public
+ */
 export type OptionResources<
   TResourceType1 extends string = string,
   TResource1 = any,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -213,7 +213,7 @@ export type CreatePermissionIntegrationRouterResourceOptions<
  *
  * @public
  */
-export type OptionResources<
+export type PermissionIntegrationRouterOptions<
   TResourceType1 extends string = string,
   TResource1 = any,
   TResourceType2 extends string = string,
@@ -310,7 +310,7 @@ export function createPermissionIntegrationRouter<
         TResourceType1,
         TResource1
       >
-    | OptionResources<
+    | PermissionIntegrationRouterOptions<
         TResourceType1,
         TResource1,
         TResourceType2,
@@ -319,7 +319,7 @@ export function createPermissionIntegrationRouter<
         TResource3
       >,
 ): express.Router {
-  const optionsWithResources = options as OptionResources;
+  const optionsWithResources = options as PermissionIntegrationRouterOptions;
   const allOptions = [
     optionsWithResources.resources ? optionsWithResources.resources : options,
   ].flat();

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -65,27 +65,6 @@ const applyConditionsRequestSchema = z.object({
   ),
 });
 
-/*
-
-BEFORE:
-[
-  { resourceType: 'A', resourceRef: 'ref1', conditions: ... },
-  { resourceType: 'A', resourceRef: 'ref2', conditions: ... }
-]
-
-await getResources(['ref1', 'ref2' ])
-
-NOW:
-[
-  { resourceType: 'A', resourceRef: 'ref1', conditions: ... },
-  { resourceType: 'A', resourceRef: 'ref2', conditions: ... }
-  { resourceType: 'B', resourceRef: 'ref3', conditions: ... }
-]
-
-await getResourcesA(['ref1', 'ref2' ])
-await getResourcesB(['ref3' ])
-*/
-
 /**
  * A request to load the referenced resource and apply conditions in order to
  * finalize a conditional authorization response.
@@ -238,6 +217,9 @@ export type CreatePermissionIntegrationRouterResourceOptions<
  * In case the `permissions` option is provided, the router also
  * provides a route that exposes permissions and routes of a plugin.
  *
+ * In case an array of CreatePermissionIntegrationRouterResourceOptions is
+ * provided, the routes can handle permissions for multiple resource types.
+ *
  * @remarks
  *
  * To make this concrete, we can use the Backstage software catalog as an
@@ -288,6 +270,9 @@ export function createPermissionIntegrationRouter(options: {
 
 /**
  *
+ * Create an express Router which provides an authorization route to allow
+ * integration between the permission backend and other Backstage backend
+ * plugins. Handles permissions for 2 resource types.
  * @public
  */
 export function createPermissionIntegrationRouter<
@@ -310,6 +295,9 @@ export function createPermissionIntegrationRouter<
 
 /**
  *
+ * Create an express Router which provides an authorization route to allow
+ * integration between the permission backend and other Backstage backend
+ * plugins. Handles permissions for 3 resource types.
  * @public
  */
 export function createPermissionIntegrationRouter<

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -207,16 +207,46 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   ) => Promise<Array<TResource | undefined>>;
 };
 
-/**
- * Options for creating a permission integration router
- *
- * @public
- */
-export type OptionResources<TResourceType extends string, TResource> = {
-  resources:
-    | { permissions: Array<Permission> }
-    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
-    | Array<CreatePermissionIntegrationRouterResourceOptions<string, any>>;
+export type OptionResources<
+  TResourceType1 extends string = string,
+  TResource1 = any,
+  TResourceType2 extends string = string,
+  TResource2 = any,
+  TResourceType3 extends string = string,
+  TResource3 = any,
+> = {
+  resources: Readonly<
+    | [
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType1,
+          TResource1
+        >,
+      ]
+    | [
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType1,
+          TResource1
+        >,
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType2,
+          TResource2
+        >,
+      ]
+    | [
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType1,
+          TResource1
+        >,
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType2,
+          TResource2
+        >,
+        CreatePermissionIntegrationRouterResourceOptions<
+          TResourceType3,
+          TResource3
+        >,
+      ]
+  >;
 };
 
 /**
@@ -229,8 +259,8 @@ export type OptionResources<TResourceType extends string, TResource> = {
  * In case the `permissions` option is provided, the router also
  * provides a route that exposes permissions and routes of a plugin.
  *
- * In case an array of CreatePermissionIntegrationRouterResourceOptions is
- * provided, the routes can handle permissions for multiple resource types.
+ * In case resources is provided, the routes can handle permissions
+ * for multiple resource types.
  *
  * @remarks
  *
@@ -261,103 +291,29 @@ export type OptionResources<TResourceType extends string, TResource> = {
  * @public
  */
 export function createPermissionIntegrationRouter<
-  TResourceType extends string,
-  TResource,
->(
-  options:
-    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
-    | {
-        resources: CreatePermissionIntegrationRouterResourceOptions<
-          TResourceType,
-          TResource
-        >;
-      },
-): express.Router;
-
-/**
- *
- * Create an express Router which provides a route that exposes
- * permissions and routes of a plugin.
- * @public
- */
-export function createPermissionIntegrationRouter(
-  options:
-    | { permissions: Array<Permission> }
-    | { resources: { permissions: Array<Permission> } },
-): express.Router;
-
-/**
- *
- * Create an express Router which provides an authorization route to allow
- * integration between the permission backend and other Backstage backend
- * plugins. Handles permissions for 2 resource types.
- * @public
- */
-export function createPermissionIntegrationRouter<
-  TResourceType1 extends string,
-  TResource1,
-  TResourceType2 extends string,
-  TResource2,
->(options: {
-  resources: [
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType1,
-      TResource1
-    >,
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType2,
-      TResource2
-    >,
-  ];
-}): express.Router;
-
-/**
- *
- * Create an express Router which provides an authorization route to allow
- * integration between the permission backend and other Backstage backend
- * plugins. Handles permissions for 3 resource types.
- * @public
- */
-export function createPermissionIntegrationRouter<
   TResourceType1 extends string,
   TResource1,
   TResourceType2 extends string,
   TResource2,
   TResourceType3 extends string,
   TResource3,
->(options: {
-  resources: [
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType1,
-      TResource1
-    >,
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType2,
-      TResource2
-    >,
-    CreatePermissionIntegrationRouterResourceOptions<
-      TResourceType3,
-      TResource3
-    >,
-  ];
-}): express.Router;
-
-/**
- * @public
- */
-export function createPermissionIntegrationRouter<
-  TResourceType extends string,
-  TResource,
 >(
   options:
     | { permissions: Array<Permission> }
-    | CreatePermissionIntegrationRouterResourceOptions<TResourceType, TResource>
-    | OptionResources<TResourceType, TResource>,
+    | CreatePermissionIntegrationRouterResourceOptions<
+        TResourceType1,
+        TResource1
+      >
+    | OptionResources<
+        TResourceType1,
+        TResource1,
+        TResourceType2,
+        TResource2,
+        TResourceType3,
+        TResource3
+      >,
 ): express.Router {
-  const optionsWithResources = options as OptionResources<
-    TResourceType,
-    TResource
-  >;
+  const optionsWithResources = options as OptionResources;
   const allOptions = [
     optionsWithResources.resources ? optionsWithResources.resources : options,
   ].flat();
@@ -365,8 +321,8 @@ export function createPermissionIntegrationRouter<
     option =>
       (
         option as CreatePermissionIntegrationRouterResourceOptions<
-          TResourceType,
-          TResource
+          TResourceType1,
+          TResource1
         >
       ).rules || [],
   );
@@ -381,16 +337,16 @@ export function createPermissionIntegrationRouter<
         option as
           | { permissions: Array<Permission> }
           | CreatePermissionIntegrationRouterResourceOptions<
-              TResourceType,
-              TResource
+              TResourceType1,
+              TResource1
             >,
       )
     ) {
       acc.push(
         (
           option as CreatePermissionIntegrationRouterResourceOptions<
-            TResourceType,
-            TResource
+            TResourceType1,
+            TResource1
           >
         ).resourceType,
       );
@@ -429,8 +385,8 @@ export function createPermissionIntegrationRouter<
       const getResourcesByResourceType: Record<
         string,
         CreatePermissionIntegrationRouterResourceOptions<
-          TResourceType,
-          TResource
+          TResourceType1,
+          TResource1
         >['getResources']
       > = {};
 
@@ -438,8 +394,8 @@ export function createPermissionIntegrationRouter<
         option = option as
           | { permissions: Array<Permission> }
           | CreatePermissionIntegrationRouterResourceOptions<
-              TResourceType,
-              TResource
+              TResourceType1,
+              TResource1
             >;
         if (isCreatePermissionIntegrationRouterResourceOptions(option)) {
           ruleMapByResourceType[option.resourceType] = createGetRule(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some plugins need to export multiple resource types and currently the PermissionIntegrationRouter can only deal with 1 resource type. We have modified the createPermissionIntegrationRouter fn to be able to take an array of CreatePermissionIntegrationRouterResourceOptions. Each one of this options would define permissions for a different resource type.
Then each route the router exposes deals with having permissions for multiple resource types.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
