### PR TITLE
chore(create-app): Remove unused Lerna dep in template app

### DIFF
--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -32,7 +32,6 @@
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@spotify/prettier-config": "^12.0.0",
     "concurrently": "^6.0.0",
-    "lerna": "^4.0.0",
     "node-gyp": "^9.0.0",
     "prettier": "^2.3.2",
     "typescript": "~4.6.4"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Best I can tell, Lerna was removed from the core app and moved to the CLI.  However, newly templated packages are still including it.

> IN PROGRESS: I can't actually yet identify the exact version where this change was made, so I've not created the changeset yet but once I can tie that back I'll add a reference changeset.  Welcome any pointers if anyone recalls of the top of their head :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
