### PR TITLE
cli: fix package build to avoid duplicate modules for multiple entry points

### DIFF
--- a/.changeset/chatty-coats-thank.md
+++ b/.changeset/chatty-coats-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix the build for packages with multiple entry points to avoid duplicated modules.

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -75,117 +75,126 @@ export async function makeRollupConfigs(
   const distDir = resolvePath(targetDir, 'dist');
   const entryPoints = readEntryPoints(targetPkg);
 
-  for (const { path, name, ext } of entryPoints) {
-    if (!SCRIPT_EXTS.includes(ext)) {
-      continue;
-    }
+  const scriptEntryPoints = entryPoints.filter(e =>
+    SCRIPT_EXTS.includes(e.ext),
+  );
 
-    if (options.outputs.has(Output.cjs) || options.outputs.has(Output.esm)) {
-      const output = new Array<OutputOptions>();
-      const mainFields = ['module', 'main'];
+  if (options.outputs.has(Output.cjs) || options.outputs.has(Output.esm)) {
+    const output = new Array<OutputOptions>();
+    const mainFields = ['module', 'main'];
 
-      if (options.outputs.has(Output.cjs)) {
-        output.push({
-          dir: distDir,
-          entryFileNames: `${name}.cjs.js`,
-          chunkFileNames: `cjs/${name}/[name]-[hash].cjs.js`,
-          format: 'commonjs',
-          sourcemap: true,
-        });
-      }
-      if (options.outputs.has(Output.esm)) {
-        output.push({
-          dir: distDir,
-          entryFileNames: `${name}.esm.js`,
-          chunkFileNames: `esm/${name}/[name]-[hash].esm.js`,
-          format: 'module',
-          sourcemap: true,
-        });
-        // Assume we're building for the browser if ESM output is included
-        mainFields.unshift('browser');
-      }
-
-      configs.push({
-        input: resolvePath(targetDir, path),
-        output,
-        onwarn,
-        preserveEntrySignatures: 'strict',
-        // All module imports are always marked as external
-        external: (source, importer, isResolved) =>
-          Boolean(importer && !isResolved && !isFileImport(source)),
-        plugins: [
-          resolve({ mainFields }),
-          commonjs({
-            include: /node_modules/,
-            exclude: [/\/[^/]+\.(?:stories|test)\.[^/]+$/],
-          }),
-          postcss(),
-          forwardFileImports({
-            exclude: /\.icon\.svg$/,
-            include: [
-              /\.svg$/,
-              /\.png$/,
-              /\.gif$/,
-              /\.jpg$/,
-              /\.jpeg$/,
-              /\.eot$/,
-              /\.woff$/,
-              /\.woff2$/,
-              /\.ttf$/,
-              /\.md$/,
-            ],
-          }),
-          json(),
-          yaml(),
-          svgr({
-            include: /\.icon\.svg$/,
-            template: svgrTemplate,
-          }),
-          esbuild({
-            target: 'es2019',
-            minify: options.minify,
-          }),
-        ],
+    if (options.outputs.has(Output.cjs)) {
+      output.push({
+        dir: distDir,
+        entryFileNames: `[name].cjs.js`,
+        chunkFileNames: `cjs/[name]-[hash].cjs.js`,
+        format: 'commonjs',
+        sourcemap: true,
       });
     }
+    if (options.outputs.has(Output.esm)) {
+      output.push({
+        dir: distDir,
+        entryFileNames: `[name].esm.js`,
+        chunkFileNames: `esm/[name]-[hash].esm.js`,
+        format: 'module',
+        sourcemap: true,
+      });
+      // Assume we're building for the browser if ESM output is included
+      mainFields.unshift('browser');
+    }
 
-    if (options.outputs.has(Output.types) && !options.useApiExtractor) {
-      const typesInput = paths.resolveTargetRoot(
-        'dist-types',
-        relativePath(paths.targetRoot, targetDir),
-        path.replace(/\.ts$/, '.d.ts'),
-      );
+    configs.push({
+      input: Object.fromEntries(
+        scriptEntryPoints.map(e => [e.name, resolvePath(targetDir, e.path)]),
+      ),
+      output,
+      onwarn,
+      preserveEntrySignatures: 'strict',
+      // All module imports are always marked as external
+      external: (source, importer, isResolved) =>
+        Boolean(importer && !isResolved && !isFileImport(source)),
+      plugins: [
+        resolve({ mainFields }),
+        commonjs({
+          include: /node_modules/,
+          exclude: [/\/[^/]+\.(?:stories|test)\.[^/]+$/],
+        }),
+        postcss(),
+        forwardFileImports({
+          exclude: /\.icon\.svg$/,
+          include: [
+            /\.svg$/,
+            /\.png$/,
+            /\.gif$/,
+            /\.jpg$/,
+            /\.jpeg$/,
+            /\.eot$/,
+            /\.woff$/,
+            /\.woff2$/,
+            /\.ttf$/,
+            /\.md$/,
+          ],
+        }),
+        json(),
+        yaml(),
+        svgr({
+          include: /\.icon\.svg$/,
+          template: svgrTemplate,
+        }),
+        esbuild({
+          target: 'es2019',
+          minify: options.minify,
+        }),
+      ],
+    });
+  }
 
-      const declarationsExist = await fs.pathExists(typesInput);
+  if (options.outputs.has(Output.types) && !options.useApiExtractor) {
+    const input = Object.fromEntries(
+      scriptEntryPoints.map(e => [
+        e.name,
+        paths.resolveTargetRoot(
+          'dist-types',
+          relativePath(paths.targetRoot, targetDir),
+          e.path.replace(/\.ts$/, '.d.ts'),
+        ),
+      ]),
+    );
+
+    for (const path of Object.values(input)) {
+      const declarationsExist = await fs.pathExists(path);
       if (!declarationsExist) {
-        const declarationPath = relativePath(targetDir, typesInput);
+        const declarationPath = relativePath(targetDir, path);
         throw new Error(
           `No declaration files found at ${declarationPath}, be sure to run ${chalk.bgRed.white(
             'yarn tsc',
           )} to generate .d.ts files before packaging`,
         );
       }
-
-      configs.push({
-        input: typesInput,
-        output: {
-          file: resolvePath(distDir, `${name}.d.ts`),
-          format: 'es',
-        },
-        external: [
-          /\.css$/,
-          /\.scss$/,
-          /\.sass$/,
-          /\.svg$/,
-          /\.eot$/,
-          /\.woff$/,
-          /\.woff2$/,
-          /\.ttf$/,
-        ],
-        onwarn,
-        plugins: [dts()],
-      });
     }
+
+    configs.push({
+      input,
+      output: {
+        dir: distDir,
+        entryFileNames: `[name].d.ts`,
+        chunkFileNames: `types/[name]-[hash].d.ts`,
+        format: 'es',
+      },
+      external: [
+        /\.css$/,
+        /\.scss$/,
+        /\.sass$/,
+        /\.svg$/,
+        /\.eot$/,
+        /\.woff$/,
+        /\.woff2$/,
+        /\.ttf$/,
+      ],
+      onwarn,
+      plugins: [dts()],
+    });
   }
 
   return configs;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This was an oversight in #15816, where each entry point uses a separate rollup config, rather than a single config with multiple entry points. That lead to issues where some pieces of the package would be duplicated at runtime, such as plugin instances, in turn leading to bugs such as #17073. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
