### PR TITLE
scaffolder: Provide some more filters for `nunjucks` and make sure that they're applied

### DIFF
--- a/.changeset/tough-cameras-beam.md
+++ b/.changeset/tough-cameras-beam.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Provide some more default filters out of the box and refactoring how the filters are applied to the `SecureTemplater`.
+
+- `parseEntityRef` will take an string entity triplet and return a parsed object.
+- `pick` will allow you to reference a specific property in the piped object.
+
+So you can now combine things like this: `${{ parameters.entity | parseEntityRef | pick('name') }}` to get the name of a specific entity, or `${{ parameters.repoUrl | parseRepoUrl | pick('owner) }}` to get the owner of a repo.

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
@@ -69,7 +69,12 @@ describe('SecureTemplater', () => {
       owner: 'my-owner',
       host: 'my-host.com',
     }));
-    const renderWith = await SecureTemplater.loadRenderer({ parseRepoUrl });
+
+    const projectSlug = jest.fn(() => 'my-owner/my-repo');
+
+    const renderWith = await SecureTemplater.loadRenderer({
+      templateFilters: { parseRepoUrl, projectSlug },
+    });
     const renderWithout = await SecureTemplater.loadRenderer();
 
     const ctx = {
@@ -95,7 +100,6 @@ describe('SecureTemplater', () => {
 
     expect(parseRepoUrl.mock.calls).toEqual([
       ['https://my-host.com/my-owner/my-repo'],
-      ['https://my-host.com/my-owner/my-repo'],
     ]);
   });
 
@@ -104,7 +108,7 @@ describe('SecureTemplater', () => {
     const mockFilter2 = jest.fn((var1, var2) => `${var1} ${var2}`);
     const mockFilter3 = jest.fn((var1, var2) => ({ var1, var2 }));
     const renderWith = await SecureTemplater.loadRenderer({
-      additionalTemplateFilters: { mockFilter1, mockFilter2, mockFilter3 },
+      templateFilters: { mockFilter1, mockFilter2, mockFilter3 },
     });
     const renderWithout = await SecureTemplater.loadRenderer();
 
@@ -149,7 +153,7 @@ describe('SecureTemplater', () => {
     const mockGlobal2 = 'foo';
     const mockGlobal3 = 123456;
     const renderWith = await SecureTemplater.loadRenderer({
-      additionalTemplateGlobals: { mockGlobal1, mockGlobal2, mockGlobal3 },
+      templateGlobals: { mockGlobal1, mockGlobal2, mockGlobal3 },
     });
     const renderWithout = await SecureTemplater.loadRenderer();
 
@@ -168,11 +172,13 @@ describe('SecureTemplater', () => {
 
   it('should not allow helpers to be rewritten', async () => {
     const render = await SecureTemplater.loadRenderer({
-      parseRepoUrl: () => ({
-        repo: 'my-repo',
-        owner: 'my-owner',
-        host: 'my-host.com',
-      }),
+      templateFilters: {
+        parseRepoUrl: () => ({
+          repo: 'my-repo',
+          owner: 'my-owner',
+          host: 'my-host.com',
+        }),
+      },
     });
 
     const ctx = {

--- a/plugins/scaffolder-backend/src/lib/templating/filters.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/filters.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { parseEntityRef } from '@backstage/catalog-model';
+import { ScmIntegrations } from '@backstage/integration';
+import { JsonValue } from '@backstage/types';
+import { TemplateFilter } from '..';
+import { parseRepoUrl } from '../../scaffolder/actions/builtin/publish/util';
+
+export const createDefaultFilters = ({
+  integrations,
+}: {
+  integrations: ScmIntegrations;
+}): Record<string, TemplateFilter> => {
+  return {
+    parseRepoUrl: url => parseRepoUrl(url as string, integrations),
+    parseEntityRef: ref => parseEntityRef(ref as string),
+    pick: (obj: JsonValue, key: JsonValue) => {
+      if (
+        typeof obj === 'object' &&
+        !Array.isArray(obj) &&
+        typeof key === 'string'
+      ) {
+        return obj?.[key];
+      }
+
+      throw new Error(
+        `Invalid arguments to pick filter, expected object and string, got ${typeof obj} and ${typeof key}`,
+      );
+    },
+    projectSlug: repoUrl => {
+      const { owner, repo } = parseRepoUrl(repoUrl as string, integrations);
+      return `${owner}/${repo}`;
+    },
+  };
+};

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -28,6 +28,7 @@ import {
   SecureTemplater,
   TemplateGlobal,
 } from '../../../../lib/templating/SecureTemplater';
+import { createDefaultFilters } from '../../../../lib/templating/filters';
 
 /**
  * Downloads a skeleton, templates variables into file and directory names and content.
@@ -48,6 +49,11 @@ export function createFetchTemplateAction(options: {
     additionalTemplateFilters,
     additionalTemplateGlobals,
   } = options;
+
+  const templateFilters = {
+    ...createDefaultFilters({ integrations }),
+    ...additionalTemplateFilters,
+  };
 
   return createTemplateAction<{
     url: string;
@@ -231,8 +237,8 @@ export function createFetchTemplateAction(options: {
 
       const renderTemplate = await SecureTemplater.loadRenderer({
         cookiecutterCompat: ctx.input.cookiecutterCompat,
-        additionalTemplateFilters,
-        additionalTemplateGlobals,
+        templateFilters,
+        templateGlobals: additionalTemplateGlobals,
       });
 
       for (const location of allEntriesInTemplate) {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -698,6 +698,58 @@ describe('DefaultWorkflowRunner', () => {
         repo: 'repo',
       });
     });
+
+    it('provides the parseEntityRef filter', async () => {
+      const task = createMockTaskWithSpec({
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        steps: [
+          {
+            id: 'test',
+            name: 'name',
+            action: 'output-action',
+            input: {},
+          },
+        ],
+        output: {
+          foo: '${{ parameters.entity | parseEntityRef }}',
+        },
+        parameters: {
+          entity: 'component:default/ben',
+        },
+      });
+
+      const { output } = await runner.execute(task);
+
+      expect(output.foo).toEqual({
+        kind: 'component',
+        namespace: 'default',
+        name: 'ben',
+      });
+    });
+
+    it('provides the pick filter', async () => {
+      const task = createMockTaskWithSpec({
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        steps: [
+          {
+            id: 'test',
+            name: 'name',
+            action: 'output-action',
+            input: {},
+          },
+        ],
+        output: {
+          foo: '${{ parameters.entity | parseEntityRef | pick("kind") }}',
+        },
+        parameters: {
+          entity: 'component:default/ben',
+        },
+      });
+
+      const { output } = await runner.execute(task);
+
+      expect(output.foo).toEqual('component');
+    });
   });
 
   describe('dry run', () => {


### PR DESCRIPTION
This fixes #17053, but also fixes a bug that I've seen reported before that `parseRepoUrl` was not found in the filters.

This is because it is never passed to the `fetch:template` `SecureTemplater`.

Now we have a set of defaults that we can create. I would have liked to have changed this similar to have we have `actions` and not have the word `additional` in the props, but I think that's something for later.