### PR TITLE
Properly expose easy auth provider

### DIFF
--- a/.changeset/sour-laws-walk.md
+++ b/.changeset/sour-laws-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Export Azure Easy Auth provider so it can actually be used.

--- a/docs/auth/microsoft/azure-easyauth.md
+++ b/docs/auth/microsoft/azure-easyauth.md
@@ -1,9 +1,11 @@
 ---
-id: azure-easy-auth
+id: easy-auth
 title: Azure EasyAuth Provider
-sidebar_label: Azure EasyAuth
+sidebar_label: Azure Easy Auth
 description: Adding Azure's EasyAuth Proxy as an authentication provider in Backstage
 ---
+
+The Backstage `core-plugin-api` package comes with a Microsoft authentication provider that can authenticate users using Azure Active Directory for PaaS service hosted in Azure that support Easy Auth, such as Azure App Services.
 
 ## Backstage Changes
 

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -278,7 +278,7 @@
           "auth/auth0/provider",
           "auth/atlassian/provider",
           "auth/microsoft/provider",
-          "auth/microsoft/easyauth",
+          "auth/microsoft/easy-auth",
           "auth/bitbucket/provider",
           "auth/github/provider",
           "auth/gitlab/provider",

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -277,15 +277,16 @@
         "items": [
           "auth/auth0/provider",
           "auth/atlassian/provider",
-          "auth/bitbucket/provider",
           "auth/microsoft/provider",
+          "auth/microsoft/easyauth",
+          "auth/bitbucket/provider",
           "auth/github/provider",
           "auth/gitlab/provider",
           "auth/google/provider",
           "auth/google/gcp-iap-auth",
           "auth/okta/provider",
-          "auth/onelogin/provider",
-          "auth/oauth2-proxy/provider"
+          "auth/oauth2-proxy/provider",
+          "auth/onelogin/provider"
         ]
       },
       "auth/identity-resolver",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/master/docs
 plugins:
   - techdocs-core
 
+# For sidebar navigation on https://backstage.io/, see `microsite/sidebars.json`
 nav:
   - Overview:
       - What is Backstage?: 'overview/what-is-backstage.md'

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -230,6 +230,12 @@ export const defaultAuthProviderFactories: {
 };
 
 // @public (undocumented)
+export type EasyAuthResult = {
+  fullProfile: Profile;
+  accessToken?: string;
+};
+
+// @public (undocumented)
 export const encodeState: (state: OAuthState) => string;
 
 // @public (undocumented)
@@ -693,6 +699,19 @@ export const providers: Readonly<{
     resolvers: Readonly<{
       nameIdMatchingUserEntityName(): SignInResolver<SamlAuthResult>;
     }>;
+  }>;
+  easyAuth: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<EasyAuthResult> | undefined;
+            signIn: {
+              resolver: SignInResolver<EasyAuthResult>;
+            };
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
   }>;
 }>;
 

--- a/plugins/auth-backend/src/providers/azure-easyauth/index.ts
+++ b/plugins/auth-backend/src/providers/azure-easyauth/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { easyAuth } from './provider';
-export type { EasyAuthResponse } from './provider';
+export type { EasyAuthResult } from './provider';

--- a/plugins/auth-backend/src/providers/azure-easyauth/provider.ts
+++ b/plugins/auth-backend/src/providers/azure-easyauth/provider.ts
@@ -38,6 +38,7 @@ type Options = {
   resolverContext: AuthResolverContext;
 };
 
+/** @public */
 export type EasyAuthResult = {
   fullProfile: Profile;
   accessToken?: string;

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -15,6 +15,7 @@
  */
 
 export type { AwsAlbResult } from './aws-alb';
+export type { EasyAuthResult } from './azure-easyauth';
 export type {
   BitbucketOAuthResult,
   BitbucketPassportProfile,

--- a/plugins/auth-backend/src/providers/providers.ts
+++ b/plugins/auth-backend/src/providers/providers.ts
@@ -32,6 +32,7 @@ import { onelogin } from './onelogin';
 import { saml } from './saml';
 import { AuthProviderFactory } from './types';
 import { bitbucketServer } from './bitbucketServer';
+import { easyAuth } from './azure-easyauth';
 
 /**
  * All built-in auth provider integrations.
@@ -56,6 +57,7 @@ export const providers = Object.freeze({
   okta,
   onelogin,
   saml,
+  easyAuth,
 });
 
 /**
@@ -73,6 +75,7 @@ export const defaultAuthProviderFactories: {
   okta: okta.create(),
   auth0: auth0.create(),
   microsoft: microsoft.create(),
+  easyAuth: easyAuth.create(),
   oauth2: oauth2.create(),
   oidc: oidc.create(),
   onelogin: onelogin.create(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#16108 added support for Azure easy auth, however the provider wasn't properly exposed so it can't be used. This PR fixes that by properly exposing the provider

One remaining issue I can't work out - the docs aren't showing up on the docs site.  It's listed in the `mkdocs.yml` file, but doesn't show up in the sidebar. I guess combined with the above issue, the docs being missing for a broken feature wasn't a problem, but that shouldn't be the case after this PR.  
https://github.com/backstage/backstage/blob/99a6dfa9646909d2c0f71d32abea4b6474b109cc/mkdocs.yml#L157
![image](https://user-images.githubusercontent.com/289860/227810915-4df1b851-c872-45b6-826b-e04ea9a6a739.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
