### PR TITLE
Add reusable kubernetes-backend proxy client

### DIFF
--- a/.changeset/sweet-eels-hunt.md
+++ b/.changeset/sweet-eels-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+`KubernetesBackendClient` now requires a `kubernetesAuthProvidersApi` value to be provided. `KubernetesApi` interface now has a proxy method requirement.

--- a/docs/features/kubernetes/proxy.md
+++ b/docs/features/kubernetes/proxy.md
@@ -14,42 +14,16 @@ Kubernetes backend plugin's proxy endpoint to allow them to make arbitrary
 requests to the [REST
 API](https://kubernetes.io/docs/reference/using-api/api-concepts/).
 
-Here is a snippet fetching namespaces from a cluster configured with the
-`google` [auth provider](https://backstage.io/docs/features/kubernetes/configuration#clustersauthprovider):
+Here is a snippet fetching namespaces using the `KubernetesBackendClient` library
 
 ```typescript
-import {
-  discoveryApiRef,
-  googleAuthApiRef,
-  useApi,
-  identityApiRef,
-} from '@backstage/core-plugin-api';
+import { useApi } from '@backstage/core-plugin-api';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes';
 
 const CLUSTER_NAME = ''; // use a known cluster name
 
-// get a bearer token from Google
-const googleAuthApi = useApi(googleAuthApiRef);
-const token = await googleAuthApi.getAccessToken(
-  'https://www.googleapis.com/auth/cloud-platform',
-);
-
-// get a backstage ID token
-const identityApi = useApi(identityApiRef);
-const { token: userToken } = await identityApi.getCredentials();
-
-const discoveryApi = useApi(discoveryApiRef);
-const kubernetesBaseUrl = await discoveryApi.getBaseUrl('kubernetes');
-const kubernetesProxyEndpoint = `${kubernetesBaseUrl}/proxy`;
-
-// fetch namespaces
-await fetch(`${kubernetesProxyEndpoint}/api/v1/namespaces`, {
-  method: 'GET',
-  headers: {
-    'Backstage-Kubernetes-Cluster': CLUSTER_NAME,
-    'Backstage-Kubernetes-Authorization': `Bearer ${token}`,
-    Authorization: `Bearer ${userToken}`,
-  },
-});
+const kubernetesApi = useApi(kubernetesApiRef);
+await kubernetesApi.proxy(CLUSTER_NAME, '/api/v1/namespaces');
 ```
 
 ## How it works

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -184,6 +184,8 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
   decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
+  // (undocumented)
+  getBearerToken(): Promise<string>;
 }
 
 // Warning: (ae-missing-release-tag) "GroupedResponses" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -259,6 +261,12 @@ export interface KubernetesApi {
   getWorkloadsByEntity(
     request: WorkloadsByEntityRequest,
   ): Promise<ObjectsByEntityResponse>;
+  // (undocumented)
+  proxy(options: {
+    clusterName: string;
+    path: string;
+    init?: RequestInit;
+  }): Promise<Response>;
 }
 
 // Warning: (ae-missing-release-tag) "kubernetesApiRef" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -281,6 +289,8 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     authProvider: string,
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
+  // (undocumented)
+  getBearerToken(authProvider: string): Promise<string>;
 }
 
 // Warning: (ae-missing-release-tag) "KubernetesAuthProvidersApi" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -292,6 +302,8 @@ export interface KubernetesAuthProvidersApi {
     authProvider: string,
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
+  // (undocumented)
+  getBearerToken(authProvider: string): Promise<string>;
 }
 
 // Warning: (ae-missing-release-tag) "kubernetesAuthProvidersApiRef" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -306,6 +318,7 @@ export class KubernetesBackendClient implements KubernetesApi {
   constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
+    kubernetesAuthProvidersApi: KubernetesAuthProvidersApi;
   });
   // (undocumented)
   getClusters(): Promise<
@@ -326,6 +339,12 @@ export class KubernetesBackendClient implements KubernetesApi {
   getWorkloadsByEntity(
     request: WorkloadsByEntityRequest,
   ): Promise<ObjectsByEntityResponse>;
+  // (undocumented)
+  proxy(options: {
+    clusterName: string;
+    path: string;
+    init?: RequestInit;
+  }): Promise<Response>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "KubernetesContentProps" needs to be exported by the entry point index.d.ts
@@ -416,6 +435,8 @@ export class ServerSideKubernetesAuthProvider
   decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
+  // (undocumented)
+  getBearerToken(): Promise<string>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ServicesAccordionsProps" needs to be exported by the entry point index.d.ts

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -185,7 +185,9 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
   // (undocumented)
-  getBearerToken(): Promise<string>;
+  getCredentials(): Promise<{
+    token: string;
+  }>;
 }
 
 // Warning: (ae-missing-release-tag) "GroupedResponses" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -290,7 +292,9 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
   // (undocumented)
-  getBearerToken(authProvider: string): Promise<string>;
+  getCredentials(authProvider: string): Promise<{
+    token: string;
+  }>;
 }
 
 // Warning: (ae-missing-release-tag) "KubernetesAuthProvidersApi" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -303,7 +307,9 @@ export interface KubernetesAuthProvidersApi {
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
   // (undocumented)
-  getBearerToken(authProvider: string): Promise<string>;
+  getCredentials(authProvider: string): Promise<{
+    token: string;
+  }>;
 }
 
 // Warning: (ae-missing-release-tag) "kubernetesAuthProvidersApiRef" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -436,7 +442,9 @@ export class ServerSideKubernetesAuthProvider
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
   // (undocumented)
-  getBearerToken(): Promise<string>;
+  getCredentials(): Promise<{
+    token: string;
+  }>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ServicesAccordionsProps" needs to be exported by the entry point index.d.ts

--- a/plugins/kubernetes/dev/index.tsx
+++ b/plugins/kubernetes/dev/index.tsx
@@ -106,6 +106,16 @@ class MockKubernetesClient implements KubernetesApi {
   async getClusters(): Promise<{ name: string; authProvider: string }[]> {
     return [{ name: 'mock-cluster', authProvider: 'serviceAccount' }];
   }
+
+  async proxy(_options: { clusterName: String; path: String }): Promise<any> {
+    return {
+      kind: 'Namespace',
+      apiVersion: 'v1',
+      metadata: {
+        name: 'mock-ns',
+      },
+    };
+  }
 }
 
 createDevApp()

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -37,6 +37,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
+    "@backstage/errors": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/plugin-kubernetes-common": "workspace:^",
     "@backstage/theme": "workspace:^",

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.test.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.test.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthProvidersApi } from '../kubernetes-auth-provider';
+import { KubernetesBackendClient } from './KubernetesBackendClient';
+import { rest } from 'msw';
+import { UrlPatternDiscovery } from '@backstage/core-app-api';
+import { setupServer } from 'msw/node';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
+import {
+  CustomObjectsByEntityRequest,
+  KubernetesRequestBody,
+  ObjectsByEntityResponse,
+  WorkloadsByEntityRequest,
+} from '@backstage/plugin-kubernetes-common';
+import { NotFoundError } from '@backstage/errors';
+
+describe('KubernetesBackendClient', () => {
+  let backendClient: KubernetesBackendClient;
+  const kubernetesAuthProvidersApi: jest.Mocked<KubernetesAuthProvidersApi> = {
+    decorateRequestBodyForAuth: jest.fn(),
+    getBearerToken: jest.fn(),
+  };
+  let mockResponse: ObjectsByEntityResponse;
+  const worker = setupServer();
+  setupRequestMockHandlers(worker);
+
+  const identityApi = {
+    getCredentials: jest.fn(),
+    getProfileInfo: jest.fn(),
+    getBackstageIdentity: jest.fn(),
+    signOut: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    backendClient = new KubernetesBackendClient({
+      discoveryApi: UrlPatternDiscovery.compile(
+        'http://localhost:1234/api/{{ pluginId }}',
+      ),
+      identityApi,
+      kubernetesAuthProvidersApi,
+    });
+    mockResponse = {
+      items: [
+        {
+          cluster: {
+            name: 'cluster-a',
+          },
+          resources: [{ type: 'pods', resources: [] }],
+          podMetrics: [
+            {
+              pod: {},
+              cpu: { currentUsage: 8, requestTotal: 2, limitTotal: 1 },
+              memory: { currentUsage: 8, requestTotal: 2, limitTotal: 1 },
+              containers: [
+                {
+                  container: 'test',
+                  cpuUsage: { currentUsage: 8, requestTotal: 2, limitTotal: 1 },
+                  memoryUsage: {
+                    currentUsage: 8,
+                    requestTotal: 2,
+                    limitTotal: 1,
+                  },
+                },
+              ],
+            },
+          ],
+          errors: [],
+        },
+      ],
+    };
+  });
+
+  it('hits the /clusters API', async () => {
+    identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
+    worker.use(
+      rest.get('http://localhost:1234/api/kubernetes/clusters', (_, res, ctx) =>
+        res(ctx.json({ items: [{ name: 'cluster-a', authProvider: 'aws' }] })),
+      ),
+    );
+
+    const clusters = await backendClient.getClusters();
+
+    expect(clusters).toStrictEqual([
+      { name: 'cluster-a', authProvider: 'aws' },
+    ]);
+  });
+
+  it('hits the /resources/custom/query API', async () => {
+    identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
+    worker.use(
+      rest.post(
+        'http://localhost:1234/api/kubernetes/resources/custom/query',
+        (_, res, ctx) => res(ctx.json(mockResponse)),
+      ),
+    );
+
+    const request: CustomObjectsByEntityRequest = {
+      auth: {},
+      customResources: [
+        {
+          group: 'test-group',
+          apiVersion: 'v1',
+          plural: 'none',
+        },
+      ],
+      entity: {
+        apiVersion: 'v1',
+        kind: 'pod',
+        metadata: {
+          name: 'test-name',
+        },
+      },
+    };
+
+    const customObject: ObjectsByEntityResponse =
+      await backendClient.getCustomObjectsByEntity(request);
+
+    expect(customObject).toStrictEqual(mockResponse);
+  });
+
+  it('hits the /services/{entityName} api', async () => {
+    identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
+    worker.use(
+      rest.post(
+        'http://localhost:1234/api/kubernetes/services/test-name',
+        (_, res, ctx) => res(ctx.json(mockResponse)),
+      ),
+    );
+
+    const request: KubernetesRequestBody = {
+      entity: {
+        apiVersion: 'v1',
+        kind: 'pod',
+        metadata: {
+          name: 'test-name',
+        },
+      },
+    };
+
+    const entityObject: ObjectsByEntityResponse =
+      await backendClient.getObjectsByEntity(request);
+
+    expect(entityObject).toStrictEqual(mockResponse);
+  });
+
+  it('hits the /resources/workloads/query API', async () => {
+    identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
+    worker.use(
+      rest.post(
+        'http://localhost:1234/api/kubernetes/resources/workloads/query',
+        (_, res, ctx) => res(ctx.json(mockResponse)),
+      ),
+    );
+
+    const request: WorkloadsByEntityRequest = {
+      auth: {},
+      entity: {
+        apiVersion: 'v1',
+        kind: 'pod',
+        metadata: {
+          name: 'test-name',
+        },
+      },
+    };
+
+    const response: ObjectsByEntityResponse =
+      await backendClient.getWorkloadsByEntity(request);
+
+    expect(response).toStrictEqual(mockResponse);
+  });
+
+  it('hits the /proxy API', async () => {
+    identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
+    kubernetesAuthProvidersApi.getBearerToken.mockResolvedValue(
+      'Bearer k8-token',
+    );
+    const nsResponse = {
+      kind: 'Namespace',
+      apiVersion: 'v1',
+      metadata: {
+        name: 'new-ns',
+      },
+    };
+    worker.use(
+      rest.get(
+        'http://localhost:1234/api/kubernetes/proxy/api/v1/namespaces',
+        (_, res, ctx) => res(ctx.json(nsResponse)),
+      ),
+      rest.get('http://localhost:1234/api/kubernetes/clusters', (_, res, ctx) =>
+        res(ctx.json({ items: [{ name: 'cluster-a', authProvider: 'aws' }] })),
+      ),
+    );
+
+    const request = {
+      clusterName: 'cluster-a',
+      path: '/api/v1/namespaces',
+    };
+
+    const response = await backendClient.proxy(request);
+
+    expect(response).toStrictEqual(nsResponse);
+  });
+
+  it('/proxy API throws a ERROR_NOT_FOUND if the cluster in the request is not found', async () => {
+    identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
+    worker.use(
+      rest.get('http://localhost:1234/api/kubernetes/clusters', (_, res, ctx) =>
+        res(ctx.json({ items: [{ name: 'cluster-b', authProvider: 'aws' }] })),
+      ),
+    );
+
+    const request = {
+      clusterName: 'cluster-a',
+      path: '/api/v1/namespaces',
+    };
+
+    await expect(backendClient.proxy(request)).rejects.toThrow(NotFoundError);
+  });
+
+  it('hits /proxy api when signed in as a guest', async () => {
+    // when a user is signed in as a guest the result of the getCredentials() method resolves to the {} value.
+    identityApi.getCredentials.mockResolvedValue({});
+    kubernetesAuthProvidersApi.getBearerToken.mockResolvedValue(
+      'Bearer k8-token',
+    );
+    const nsResponse = {
+      kind: 'Namespace',
+      apiVersion: 'v1',
+      metadata: {
+        name: 'new-ns',
+      },
+    };
+    worker.use(
+      rest.get(
+        'http://localhost:1234/api/kubernetes/proxy/api/v1/namespaces',
+        (_, res, ctx) => res(ctx.status(200), ctx.json(nsResponse)),
+      ),
+      rest.get('http://localhost:1234/api/kubernetes/clusters', (_, res, ctx) =>
+        res(ctx.json({ items: [{ name: 'cluster-a', authProvider: 'aws' }] })),
+      ),
+    );
+
+    const request = {
+      clusterName: 'cluster-a',
+      path: '/api/v1/namespaces',
+    };
+
+    const response = await backendClient.proxy(request);
+    expect(response).toStrictEqual(nsResponse);
+  });
+});

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -74,6 +74,23 @@ export class KubernetesBackendClient implements KubernetesApi {
     return this.handleResponse(response);
   }
 
+  private async getCluster(
+    clusterName: string,
+  ): Promise<{ name: string; authProvider: string }> {
+    const cluster = await this.getClusters().then(clusters =>
+      clusters.find(c => c.name === clusterName),
+    );
+    if (!cluster) {
+      throw new NotFoundError(`Cluster ${clusterName} not found`);
+    }
+
+    return cluster;
+  }
+
+  private async getBearerToken(authProvider: string): Promise<string> {
+    return await this.kubernetesAuthProvidersApi.getBearerToken(authProvider);
+  }
+
   async getObjectsByEntity(
     requestBody: KubernetesRequestBody,
   ): Promise<ObjectsByEntityResponse> {
@@ -105,7 +122,6 @@ export class KubernetesBackendClient implements KubernetesApi {
   async getClusters(): Promise<{ name: string; authProvider: string }[]> {
     const { token: idToken } = await this.identityApi.getCredentials();
     const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}/clusters`;
-
     const response = await fetch(url, {
       method: 'GET',
       headers: {
@@ -116,67 +132,31 @@ export class KubernetesBackendClient implements KubernetesApi {
     return (await this.handleResponse(response)).items;
   }
 
-  async proxy(
-    clusterName: string,
-    path: string,
-    init?: RequestInit,
-  ): Promise<Response> {
-    const { authProvider } = await this.getCluster(clusterName);
-    const token = await this.getBearerToken(authProvider);
+  async proxy(options: {
+    clusterName: string;
+    path: string;
+    init?: RequestInit;
+  }): Promise<Response> {
+    const { authProvider } = await this.getCluster(options.clusterName);
+    const k8sToken = await this.getBearerToken(authProvider);
+    const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}/proxy${
+      options.path
+    }`;
+    const identityResponse = await this.identityApi.getCredentials();
+    const headers = identityResponse.token
+      ? {
+          ...options.init?.headers,
+          [`Backstage-Kubernetes-Cluster`]: options.clusterName,
+          [`Backstage-Kubernetes-Authorization`]: `Bearer ${k8sToken}`,
+          Authorization: `Bearer ${identityResponse.token}`,
+        }
+      : {
+          ...options.init?.headers,
+          [`Backstage-Kubernetes-Cluster`]: options.clusterName,
+          [`Backstage-Kubernetes-Authorization`]: `Bearer ${k8sToken}`,
+        };
+    const response = await fetch(url, { ...options.init, headers });
 
-    const url = `${await this.discoveryApi.getBaseUrl(
-      'kubernetes',
-    )}/proxy${path}`;
-    const headers = {
-      Authorization: `Bearer ${token}`,
-      ...init?.headers,
-      [`X-Kubernetes-Cluster`]: clusterName,
-    };
-    const response = await fetch(url, { ...init, headers });
     return this.handleResponse(response);
-  }
-
-  private async getCluster(
-    clusterName: string,
-  ): Promise<{ name: string; authProvider: string }> {
-    const cluster = await this.getClusters().then(clusters =>
-      clusters.find(c => c.name === clusterName),
-    );
-    if (!cluster) {
-      throw new NotFoundError(`Cluster ${clusterName} not found`);
-    }
-    return cluster;
-  }
-
-  private async getBearerToken(authProvider: string): Promise<string> {
-    // const { auth } =
-    //   await this.kubernetesAuthProvidersApi.decorateRequestBodyForAuth(
-    //     authProvider,
-    //     {
-    //       entity: {
-    //         apiVersion: 'v1',
-    //         kind: 'Pods',
-    //         metadata: {
-    //           name: 'podName',
-    //           annotations: {
-    //             'backstage.io/kubernetes-label-selector': 'k8s-app=kube-dns',
-    //           },
-    //         },
-    //       },
-    //     },
-    //   );
-    return await this.kubernetesAuthProvidersApi.getBearerToken(authProvider);
-
-    // if (auth) {
-    //   if (authProvider === 'google' && auth.google) {
-    //     return auth.google;
-    //   } else if (authProvider.startsWith('oidc.') && auth.oidc) {
-    //     const oidcTokenProvider = authProvider.replace(/^oidc\./, '');
-    //     return auth.oidc[oidcTokenProvider];
-    //   } else {
-    //     throw new Error(`invalid auth provider '${authProvider}'`);
-    //   }
-    // }
-    // return '';
   }
 }

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -43,9 +43,9 @@ export interface KubernetesApi {
   getCustomObjectsByEntity(
     request: CustomObjectsByEntityRequest,
   ): Promise<ObjectsByEntityResponse>;
-  proxy(
-    clusterName: string,
-    path: string,
-    init?: RequestInit,
-  ): Promise<Response>;
+  proxy(options: {
+    clusterName: string;
+    path: string;
+    init?: RequestInit;
+  }): Promise<Response>;
 }

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -43,4 +43,9 @@ export interface KubernetesApi {
   getCustomObjectsByEntity(
     request: CustomObjectsByEntityRequest,
   ): Promise<ObjectsByEntityResponse>;
+  proxy(
+    clusterName: string,
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response>;
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
@@ -28,7 +28,7 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
   async decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
-    const googleAuthToken: string = await this.getBearerToken();
+    const googleAuthToken: string = (await this.getCredentials()).token;
     if ('auth' in requestBody) {
       requestBody.auth!.google = googleAuthToken;
     } else {
@@ -36,9 +36,11 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
     }
     return requestBody;
   }
-  async getBearerToken(): Promise<string> {
-    return await this.authProvider.getAccessToken(
-      'https://www.googleapis.com/auth/cloud-platform',
-    );
+  async getCredentials(): Promise<{ token: string }> {
+    return {
+      token: await this.authProvider.getAccessToken(
+        'https://www.googleapis.com/auth/cloud-platform',
+      ),
+    };
   }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
@@ -38,4 +38,9 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
     }
     return requestBody;
   }
+  async getBearerToken(): Promise<string> {
+    return await this.authProvider.getAccessToken(
+      'https://www.googleapis.com/auth/cloud-platform',
+    );
+  }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
@@ -28,9 +28,7 @@ export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
   async decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
-    const googleAuthToken: string = await this.authProvider.getAccessToken(
-      'https://www.googleapis.com/auth/cloud-platform',
-    );
+    const googleAuthToken: string = await this.getBearerToken();
     if ('auth' in requestBody) {
       requestBody.auth!.google = googleAuthToken;
     } else {

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -92,12 +92,12 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     );
   }
 
-  async getBearerToken(authProvider: string): Promise<string> {
+  async getCredentials(authProvider: string): Promise<{ token: string }> {
     const kubernetesAuthProvider: KubernetesAuthProvider | undefined =
       this.kubernetesAuthProviderMap.get(authProvider);
 
     if (kubernetesAuthProvider) {
-      return await kubernetesAuthProvider.getBearerToken();
+      return await kubernetesAuthProvider.getCredentials();
     }
 
     if (authProvider.startsWith('oidc.')) {

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  KubernetesRequestAuth,
-  KubernetesRequestBody,
-} from '@backstage/plugin-kubernetes-common';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { KubernetesAuthProvider, KubernetesAuthProvidersApi } from './types';
 import { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
 import { ServerSideKubernetesAuthProvider } from './ServerSideAuthProvider';

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+import {
+  KubernetesRequestAuth,
+  KubernetesRequestBody,
+} from '@backstage/plugin-kubernetes-common';
 import { KubernetesAuthProvider, KubernetesAuthProvidersApi } from './types';
 import { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
 import { ServerSideKubernetesAuthProvider } from './ServerSideAuthProvider';
@@ -80,6 +83,24 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
       return await kubernetesAuthProvider.decorateRequestBodyForAuth(
         requestBody,
       );
+    }
+
+    if (authProvider.startsWith('oidc.')) {
+      throw new Error(
+        `KubernetesAuthProviders has no oidcProvider configured for ${authProvider}`,
+      );
+    }
+    throw new Error(
+      `authProvider "${authProvider}" has no KubernetesAuthProvider defined for it`,
+    );
+  }
+
+  async getBearerToken(authProvider: string): Promise<string> {
+    const kubernetesAuthProvider: KubernetesAuthProvider | undefined =
+      this.kubernetesAuthProviderMap.get(authProvider);
+
+    if (kubernetesAuthProvider) {
+      return await kubernetesAuthProvider.getBearerToken();
     }
 
     if (authProvider.startsWith('oidc.')) {

--- a/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
@@ -40,4 +40,8 @@ export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
     requestBody.auth = auth;
     return requestBody;
   }
+
+  async getBearerToken(): Promise<string> {
+    return await this.authProvider.getIdToken();
+  }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
@@ -30,7 +30,7 @@ export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
   async decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
-    const authToken: string = await this.authProvider.getIdToken();
+    const authToken: string = await this.getBearerToken();
     const auth = { ...requestBody.auth };
     if (auth.oidc) {
       auth.oidc[this.providerName] = authToken;

--- a/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
@@ -30,7 +30,7 @@ export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
   async decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
-    const authToken: string = await this.getBearerToken();
+    const authToken: string = (await this.getCredentials()).token;
     const auth = { ...requestBody.auth };
     if (auth.oidc) {
       auth.oidc[this.providerName] = authToken;
@@ -41,7 +41,9 @@ export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
     return requestBody;
   }
 
-  async getBearerToken(): Promise<string> {
-    return await this.authProvider.getIdToken();
+  async getCredentials(): Promise<{ token: string }> {
+    return {
+      token: await this.authProvider.getIdToken(),
+    };
   }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/ServerSideAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/ServerSideAuthProvider.ts
@@ -31,4 +31,8 @@ export class ServerSideKubernetesAuthProvider
     // No-op, auth will be taken care of on the server-side
     return requestBody;
   }
+
+  async getBearerToken(): Promise<string> {
+    return '';
+  }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/ServerSideAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/ServerSideAuthProvider.ts
@@ -32,7 +32,7 @@ export class ServerSideKubernetesAuthProvider
     return requestBody;
   }
 
-  async getBearerToken(): Promise<string> {
-    return '';
+  async getCredentials(): Promise<{ token: string }> {
+    return { token: '' };
   }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+import {
+  KubernetesRequestAuth,
+  KubernetesRequestBody,
+} from '@backstage/plugin-kubernetes-common';
 import { createApiRef } from '@backstage/core-plugin-api';
 
 export interface KubernetesAuthProvider {
   decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
+  getBearerToken(): Promise<string>;
 }
 
 export const kubernetesAuthProvidersApiRef =
@@ -33,4 +37,5 @@ export interface KubernetesAuthProvidersApi {
     authProvider: string,
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
+  getBearerToken(authProvider: string): Promise<string>;
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
@@ -21,7 +21,7 @@ export interface KubernetesAuthProvider {
   decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
-  getBearerToken(): Promise<string>;
+  getCredentials(): Promise<{ token: string }>;
 }
 
 export const kubernetesAuthProvidersApiRef =
@@ -34,5 +34,5 @@ export interface KubernetesAuthProvidersApi {
     authProvider: string,
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody>;
-  getBearerToken(authProvider: string): Promise<string>;
+  getCredentials(authProvider: string): Promise<{ token: string }>;
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  KubernetesRequestAuth,
-  KubernetesRequestBody,
-} from '@backstage/plugin-kubernetes-common';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { createApiRef } from '@backstage/core-plugin-api';
 
 export interface KubernetesAuthProvider {

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -43,9 +43,14 @@ export const kubernetesPlugin = createPlugin({
       deps: {
         discoveryApi: discoveryApiRef,
         identityApi: identityApiRef,
+        kubernetesAuthProvidersApi: kubernetesAuthProvidersApiRef,
       },
-      factory: ({ discoveryApi, identityApi }) =>
-        new KubernetesBackendClient({ discoveryApi, identityApi }),
+      factory: ({ discoveryApi, identityApi, kubernetesAuthProvidersApi }) =>
+        new KubernetesBackendClient({
+          discoveryApi,
+          identityApi,
+          kubernetesAuthProvidersApi,
+        }),
     }),
     createApiFactory({
       api: kubernetesAuthProvidersApiRef,

--- a/plugins/kubernetes/src/setupTests.ts
+++ b/plugins/kubernetes/src/setupTests.ts
@@ -16,6 +16,7 @@
 import '@testing-library/jest-dom';
 // eslint-disable-next-line no-restricted-imports
 import { TextDecoder, TextEncoder } from 'util';
+import 'cross-fetch/polyfill';
 
 // These are missing from jest-node, so not available on global.
 Object.defineProperty(global, 'TextEncoder', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7153,6 +7153,7 @@ __metadata:
     "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/dev-utils": "workspace:^"
+    "@backstage/errors": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-kubernetes-common": "workspace:^"
     "@backstage/test-utils": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!
I am extending the `KubernetesApi` interface to include a proxy method that front-end plugins can use to consume the `KubernetesProxy` endpoint. The new interface can be seen below:
```typescript
export interface KubernetesApi {
  getObjectsByEntity(
    requestBody: KubernetesRequestBody,
  ): Promise<ObjectsByEntityResponse>;
  getClusters(): Promise<
    {
      name: string;
      authProvider: string;
      oidcTokenProvider?: string | undefined;
    }[]
  >;
  getWorkloadsByEntity(
    request: WorkloadsByEntityRequest,
  ): Promise<ObjectsByEntityResponse>;
  getCustomObjectsByEntity(
    request: CustomObjectsByEntityRequest,
  ): Promise<ObjectsByEntityResponse>;
  proxy(options: {
    clusterName: string;
    path: string;
    init?: RequestInit;
  }): Promise<Response>;
}
```
This feature implementation and more context can be found in issue #16065. 

This change allow a front-end plugin to use the proxy endpoint like in the following example:
```typescript
const kubernetesApi = useApi(kubernetesApiRef);
await kubernetesApi.proxy(CLUSTER_NAME, '/api/v1/namespaces');
```
I also backflll missing tests for the `KubernetesBackendClient`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
