### PR TITLE
[Techdocs] A11y: Change anchor links color in Techdocs content

### DIFF
--- a/.changeset/olive-cycles-join.md
+++ b/.changeset/olive-cycles-join.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Change anchor links color in Techdocs content
+
+With the color (mkdocs supplied) used for anchor links the background and foreground colors do not have a sufficient contrast ratio. Using the link color from theme palette.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { RuleOptions } from './types';
 import { alpha, lighten } from '@material-ui/core';
+import { RuleOptions } from './types';
 
 export default ({ theme }: RuleOptions) => `
 /*==================  Variables  ==================*/
@@ -133,7 +133,7 @@ export default ({ theme }: RuleOptions) => `
   /* TYPESET */
   --md-typeset-font-size: 1rem;
   --md-typeset-color: var(--md-default-fg-color);
-  --md-typeset-a-color: var(--md-accent-fg-color);
+  --md-typeset-a-color: ${theme.palette.link};
   --md-typeset-table-color: ${theme.palette.text.primary};
   --md-typeset-del-color: ${
     theme.palette.type === 'dark'


### PR DESCRIPTION
With the color (mkdocs supplied) used for anchor links the background and foreground colors do not have a sufficient contrast ratio. Using the link color from theme palette.