### PR TITLE
Allow a domain entity to have an optional domain

### DIFF
--- a/.changeset/dry-sloths-impress.md
+++ b/.changeset/dry-sloths-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Introduce a domain attribute to the domain entity to allow a hierarchy of domains to exist.

--- a/.changeset/sour-socks-approve.md
+++ b/.changeset/sour-socks-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Emit well known relationships for the Domain entity kind.

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1240,7 +1240,7 @@ metadata:
   description: Everything about artists
 spec:
   owner: artist-relations-team
-  domain: audio-domain
+  subdomainOf: audio-domain
 ```
 
 In addition to the [common envelope metadata](#common-to-all-kinds-the-metadata)

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1276,7 +1276,7 @@ which the domain is a part, e.g. `audio`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
-| [`Domain`](#kind-domain)                | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
+| [`Domain`](#kind-domain) (default)      | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
 
 ## Kind: Location
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1269,6 +1269,15 @@ but there will always be one ultimate owner.
 | ------------------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
 | [`Group`](#kind-group) (default), [`User`](#kind-user) | Same as this entity, typically `default`   | [`ownerOf`, and reverse `ownedBy`](well-known-relations.md#ownedby-and-ownerof) |
 
+### `spec.subdomainOf` [optional]
+
+An [entity reference](references.md#string-references) to another domain of
+which the domain is a part, e.g. `audio`. This field is optional.
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
+| --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
+| [`Domain`](#kind-domain)                | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
+
 ## Kind: Location
 
 Describes the following entity kind:

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1240,6 +1240,7 @@ metadata:
   description: Everything about artists
 spec:
   owner: artist-relations-team
+  domain: audio-domain
 ```
 
 In addition to the [common envelope metadata](#common-to-all-kinds-the-metadata)

--- a/docs/features/software-catalog/well-known-relations.md
+++ b/docs/features/software-catalog/well-known-relations.md
@@ -99,11 +99,12 @@ A relation with a [Domain](descriptor-format.md#kind-domain),
 [System](descriptor-format.md#kind-system) or
 [Component](descriptor-format.md#kind-component) entity, typically from a
 [Component](descriptor-format.md#kind-component),
-[API](descriptor-format.md#kind-api), or
-[System](descriptor-format.md#kind-system).
+[API](descriptor-format.md#kind-api),
+[System](descriptor-format.md#kind-system), or
+[Domain](descriptor-format.md#kind-domain),
 
 These relations express that a component belongs to a larger component; a
-component, API or resource belongs to a system; or that a system is grouped
-under a domain.
+component, API or resource belongs to a system; that a system is grouped
+under a domain; or that a domain belongs to a larger domain.
 
 This relation is commonly based on `spec.system` or `spec.domain`.

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -122,6 +122,7 @@ interface DomainEntityV1alpha1 extends Entity {
   // (undocumented)
   spec: {
     owner: string;
+    domain?: string;
   };
 }
 export { DomainEntityV1alpha1 as DomainEntity };

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -122,7 +122,7 @@ interface DomainEntityV1alpha1 extends Entity {
   // (undocumented)
   spec: {
     owner: string;
-    domain?: string;
+    subdomainOf?: string;
   };
 }
 export { DomainEntityV1alpha1 as DomainEntity };

--- a/packages/catalog-model/examples/all-domains.yaml
+++ b/packages/catalog-model/examples/all-domains.yaml
@@ -5,5 +5,6 @@ metadata:
   description: A collection of all Backstage example domains
 spec:
   targets:
+    - ./domains/audio-domain.yaml
     - ./domains/artists-domain.yaml
     - ./domains/playback-domain.yaml

--- a/packages/catalog-model/examples/domains/artists-domain.yaml
+++ b/packages/catalog-model/examples/domains/artists-domain.yaml
@@ -11,4 +11,4 @@ metadata:
       icon: dashboard
 spec:
   owner: team-a
-  domain: audio
+  subdomainOf: audio

--- a/packages/catalog-model/examples/domains/artists-domain.yaml
+++ b/packages/catalog-model/examples/domains/artists-domain.yaml
@@ -11,3 +11,4 @@ metadata:
       icon: dashboard
 spec:
   owner: team-a
+  domain: audio

--- a/packages/catalog-model/examples/domains/audio-domain.yaml
+++ b/packages/catalog-model/examples/domains/audio-domain.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: audio
+  description: Everything related to audio
+  links:
+    - url: http://example.com/domain/audio/
+      title: Domain Readme
+    - url: http://example.com/domains/audio/dashboard
+      title: Domain Metrics Dashboard
+      icon: dashboard
+spec:
+  owner: acme-corp

--- a/packages/catalog-model/examples/domains/playback-domain.yaml
+++ b/packages/catalog-model/examples/domains/playback-domain.yaml
@@ -5,3 +5,4 @@ metadata:
   description: Everything related to audio playback
 spec:
   owner: user:frank.tiernan
+  subdomainOf: audio

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
@@ -31,6 +31,7 @@ describe('DomainV1alpha1Validator', () => {
       },
       spec: {
         owner: 'me',
+        domain: 'parent',
       },
     };
   });
@@ -67,5 +68,20 @@ describe('DomainV1alpha1Validator', () => {
   it('rejects empty owner', async () => {
     (entity as any).spec.owner = '';
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts missing domain', async () => {
+    delete (entity as any).spec.domain;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects wrong domain', async () => {
+    (entity as any).spec.domain = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/domain/);
+  });
+
+  it('rejects empty domain', async () => {
+    (entity as any).spec.domain = '';
+    await expect(validator.check(entity)).rejects.toThrow(/domain/);
   });
 });

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
@@ -31,7 +31,7 @@ describe('DomainV1alpha1Validator', () => {
       },
       spec: {
         owner: 'me',
-        domain: 'parent',
+        subdomainOf: 'parent-domain',
       },
     };
   });
@@ -70,18 +70,18 @@ describe('DomainV1alpha1Validator', () => {
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 
-  it('accepts missing domain', async () => {
-    delete (entity as any).spec.domain;
+  it('accepts missing subdomainOf', async () => {
+    delete (entity as any).spec.subdomainOf;
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
-  it('rejects wrong domain', async () => {
-    (entity as any).spec.domain = 7;
-    await expect(validator.check(entity)).rejects.toThrow(/domain/);
+  it('rejects wrong subdomainOf', async () => {
+    (entity as any).spec.subdomainOf = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/subdomainOf/);
   });
 
-  it('rejects empty domain', async () => {
-    (entity as any).spec.domain = '';
-    await expect(validator.check(entity)).rejects.toThrow(/domain/);
+  it('rejects empty subdomainOf', async () => {
+    (entity as any).spec.subdomainOf = '';
+    await expect(validator.check(entity)).rejects.toThrow(/subdomainOf/);
   });
 });

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
@@ -32,7 +32,7 @@ export interface DomainEntityV1alpha1 extends Entity {
   kind: 'Domain';
   spec: {
     owner: string;
-    domain?: string;
+    subdomainOf?: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
@@ -32,6 +32,7 @@ export interface DomainEntityV1alpha1 extends Entity {
   kind: 'Domain';
   spec: {
     owner: string;
+    domain?: string;
   };
 }
 

--- a/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
@@ -11,7 +11,8 @@
         "description": "Everything about artists"
       },
       "spec": {
-        "owner": "artist-relations-team"
+        "owner": "artist-relations-team",
+        "domain": "artists"
       }
     }
   ],
@@ -37,6 +38,12 @@
               "type": "string",
               "description": "An entity reference to the owner of the component.",
               "examples": ["artist-relations-team", "user:john.johnson"],
+              "minLength": 1
+            },
+            "domain": {
+              "type": "string",
+              "description": "An entity reference to the domain that the system belongs to.",
+              "examples": ["artists"],
               "minLength": 1
             }
           }

--- a/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
@@ -12,7 +12,7 @@
       },
       "spec": {
         "owner": "artist-relations-team",
-        "domain": "artists"
+        "subdomainOf": "audio"
       }
     }
   ],
@@ -40,10 +40,10 @@
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
             },
-            "domain": {
+            "subdomainOf": {
               "type": "string",
-              "description": "An entity reference to the domain that the system belongs to.",
-              "examples": ["artists"],
+              "description": "An entity reference to another domain of which the domain is a part.",
+              "examples": ["audio"],
               "minLength": 1
             }
           }

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
@@ -418,12 +418,13 @@ describe('BuiltinKindsEntityProcessor', () => {
         metadata: { name: 'n' },
         spec: {
           owner: 'o',
+          subdomainOf: 'p',
         },
       };
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit).toHaveBeenCalledTimes(4);
       expect(emit).toHaveBeenCalledWith({
         type: 'relation',
         relation: {
@@ -438,6 +439,22 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Domain', namespace: 'default', name: 'n' },
           type: 'ownedBy',
           target: { kind: 'Group', namespace: 'default', name: 'o' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Domain', namespace: 'default', name: 'n' },
+          type: 'partOf',
+          target: { kind: 'Domain', namespace: 'default', name: 'p' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Domain', namespace: 'default', name: 'p' },
+          type: 'hasPart',
+          target: { kind: 'Domain', namespace: 'default', name: 'n' },
         },
       });
     });

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
@@ -298,6 +298,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
       );
+      doEmit(
+        domain.spec.subdomainOf,
+        { defaultKind: 'Domain', defaultNamespace: selfRef.namespace },
+        RELATION_PART_OF,
+        RELATION_HAS_PART,
+      );
     }
 
     return entity;


### PR DESCRIPTION
For large organisations, a hierarchy of domains might make life easier. This PR introduces an optional `domain` field into the Domain entity so that a domain can have a parent domain.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
