### PR TITLE
Familiarize entity names before sending them to GitHub

### DIFF
--- a/.changeset/serious-items-walk.md
+++ b/.changeset/serious-items-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Removed entity types and namespacing before passing to GitHub API

--- a/.changeset/serious-items-walk.md
+++ b/.changeset/serious-items-walk.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Removed entity types and namespacing before passing to GitHub API
+Stripped entity types and namespace before passing to GitHub API

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
@@ -28,7 +28,7 @@ import {
 import { when } from 'jest-when';
 import { PassThrough } from 'stream';
 import { createGithubRepoCreateAction } from './githubRepoCreate';
-import { familiarizeEntityName } from '../helpers';
+import { entityRefToName } from '../helpers';
 
 const mockOctokit = {
   rest: {
@@ -90,7 +90,7 @@ describe('github:repo:create', () => {
       integrations,
       githubCredentialsProvider,
     });
-    (familiarizeEntityName as jest.Mock).mockImplementation((s: string) => s);
+    (entityRefToName as jest.Mock).mockImplementation((s: string) => s);
   });
 
   afterEach(jest.resetAllMocks);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubRepoCreate.test.ts
@@ -28,6 +28,7 @@ import {
 import { when } from 'jest-when';
 import { PassThrough } from 'stream';
 import { createGithubRepoCreateAction } from './githubRepoCreate';
+import { familiarizeEntityName } from '../helpers';
 
 const mockOctokit = {
   rest: {
@@ -83,14 +84,16 @@ describe('github:repo:create', () => {
   };
 
   beforeEach(() => {
-    jest.resetAllMocks();
     githubCredentialsProvider =
       DefaultGithubCredentialsProvider.fromIntegrations(integrations);
     action = createGithubRepoCreateAction({
       integrations,
       githubCredentialsProvider,
     });
+    (familiarizeEntityName as jest.Mock).mockImplementation((s: string) => s);
   });
+
+  afterEach(jest.resetAllMocks);
 
   it('should call the githubApis with the correct values for createInOrg', async () => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -29,6 +29,7 @@ import {
   initRepoAndPush,
 } from '../helpers';
 import { getRepoSourceDirectory, parseRepoUrl } from '../publish/util';
+import { familiarizeEntityName } from '../../builtin/helpers';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
@@ -218,13 +219,13 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           await client.rest.repos.addCollaborator({
             owner,
             repo,
-            username: collaborator.user,
+            username: familiarizeEntityName(collaborator.user),
             permission: collaborator.access,
           });
         } else if ('team' in collaborator) {
           await client.rest.teams.addOrUpdateRepoPermissionsInOrg({
             org: owner,
-            team_slug: collaborator.team,
+            team_slug: familiarizeEntityName(collaborator.team),
             owner,
             repo,
             permission: collaborator.access,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -29,7 +29,7 @@ import {
   initRepoAndPush,
 } from '../helpers';
 import { getRepoSourceDirectory, parseRepoUrl } from '../publish/util';
-import { familiarizeEntityName } from '../../builtin/helpers';
+import { entityRefToName } from '../../builtin/helpers';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
@@ -219,13 +219,13 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           await client.rest.repos.addCollaborator({
             owner,
             repo,
-            username: familiarizeEntityName(collaborator.user),
+            username: entityRefToName(collaborator.user),
             permission: collaborator.access,
           });
         } else if ('team' in collaborator) {
           await client.rest.teams.addOrUpdateRepoPermissionsInOrg({
             org: owner,
-            team_slug: familiarizeEntityName(collaborator.team),
+            team_slug: entityRefToName(collaborator.team),
             owner,
             repo,
             permission: collaborator.access,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { Git, getVoidLogger } from '@backstage/backend-common';
-import {
-  commitAndPushRepo,
-  familiarizeEntityName,
-  initRepoAndPush,
-} from './helpers';
+import { commitAndPushRepo, entityRefToName, initRepoAndPush } from './helpers';
 
 jest.mock('@backstage/backend-common', () => ({
   Git: {
@@ -306,7 +302,7 @@ describe('commitAndPushRepo', () => {
   });
 });
 
-describe('familiarizeEntityName', () => {
+describe('entityRefToName', () => {
   it.each([
     'user:default/catpants',
     'group:default/catpants',
@@ -316,6 +312,6 @@ describe('familiarizeEntityName', () => {
     'group:custom/catpants',
     'catpants',
   ])('should parse: "%s"', (entityName: string) => {
-    expect(familiarizeEntityName(entityName)).toEqual('catpants');
+    expect(entityRefToName(entityName)).toEqual('catpants');
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
@@ -15,7 +15,12 @@
  */
 
 import { Git, getVoidLogger } from '@backstage/backend-common';
-import { commitAndPushRepo, initRepoAndPush } from './helpers';
+import { entityNamePickerValidation } from '@backstage/plugin-scaffolder/src/components/fields/EntityNamePicker';
+import {
+  commitAndPushRepo,
+  familiarizeEntityName,
+  initRepoAndPush,
+} from './helpers';
 
 jest.mock('@backstage/backend-common', () => ({
   Git: {
@@ -299,5 +304,19 @@ describe('commitAndPushRepo', () => {
         email: 'scaffolder@example.org',
       },
     });
+  });
+});
+
+describe('familiarizeEntityName', () => {
+  it.each([
+    'user:default/catpants',
+    'group:default/catpants',
+    'user:catpants',
+    'default/catpants',
+    'user:custom/catpants',
+    'group:custom/catpants',
+    'catpants',
+  ])('should parse: "%s"', (entityName: string) => {
+    expect(familiarizeEntityName(entityName)).toEqual('catpants');
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { Git, getVoidLogger } from '@backstage/backend-common';
-import { entityNamePickerValidation } from '@backstage/plugin-scaffolder/src/components/fields/EntityNamePicker';
 import {
   commitAndPushRepo,
   familiarizeEntityName,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -297,6 +297,6 @@ export function getGitCommitMessage(
     : config.getOptionalString('scaffolder.defaultCommitMessage');
 }
 
-export function familiarizeEntityName(name: string): string {
+export function entityRefToName(name: string): string {
   return name.replace(/^.*[:/]/g, '');
 }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -296,3 +296,7 @@ export function getGitCommitMessage(
     ? gitCommitMessage
     : config.getOptionalString('scaffolder.defaultCommitMessage');
 }
+
+export function familiarizeEntityName(name: string): string {
+  return name.replace(/^.*[:/]/g, '');
+}

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -29,7 +29,7 @@ import { when } from 'jest-when';
 import { PassThrough } from 'stream';
 import {
   enableBranchProtectionOnDefaultRepoBranch,
-  familiarizeEntityName,
+  entityRefToName,
   initRepoAndPush,
 } from '../helpers';
 import { createPublishGithubAction } from './github';
@@ -69,7 +69,7 @@ describe('publish:github', () => {
     },
   });
 
-  const { familiarizeEntityName: realFamiliarizeEntityName } =
+  const { entityRefToName: realFamiliarizeEntityName } =
     jest.requireActual('../helpers');
   const integrations = ScmIntegrations.fromConfig(config);
   let githubCredentialsProvider: GithubCredentialsProvider;
@@ -99,7 +99,7 @@ describe('publish:github', () => {
     });
 
     // restore real implmentation
-    (familiarizeEntityName as jest.Mock).mockImplementation(
+    (entityRefToName as jest.Mock).mockImplementation(
       realFamiliarizeEntityName,
     );
   });
@@ -709,8 +709,8 @@ describe('publish:github', () => {
       permission: 'push',
     });
 
-    expect(familiarizeEntityName).toHaveBeenCalledWith('user:robot-1');
-    expect(familiarizeEntityName).toHaveBeenCalledWith('group:default/robot-2');
+    expect(entityRefToName).toHaveBeenCalledWith('user:robot-1');
+    expect(entityRefToName).toHaveBeenCalledWith('group:default/robot-2');
   });
 
   it('should ignore failures when adding multiple collaborators', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -100,7 +100,7 @@ describe('publish:github', () => {
     });
 
     // restore real implmentation
-    (familiarizeEntityName as jest.MockedFunction).mockImplementation(
+    (familiarizeEntityName as jest.Mock).mockImplementation(
       realFamiliarizeEntityName,
     );
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -90,7 +90,6 @@ describe('publish:github', () => {
   };
 
   beforeEach(() => {
-    jest.resetAllMocks();
     githubCredentialsProvider =
       DefaultGithubCredentialsProvider.fromIntegrations(integrations);
     action = createPublishGithubAction({
@@ -104,6 +103,8 @@ describe('publish:github', () => {
       realFamiliarizeEntityName,
     );
   });
+
+  afterEach(jest.resetAllMocks);
 
   it('should fail to create if the team is not found in the org', async () => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({


### PR DESCRIPTION
## Problem

I'm taking input from the `EntityPicker` to select groups and users that are then passed to the `publish:github` step as `collaborators`. The problem I'm having is `EntityPicker` returns the values in the form `group:default/group-name` and `user:user-name`. 

## Solution in this PR

These types and namespaces are *exclusively* used by Backstage. They have no meaning to GitHub, GitLab, etc. so there is no value in sending those invalid API requests to those endpoints (since usernames and groups can't contain `:` and `/` for instance). This attempts to resolve that.  

I put this in helpers instead of GitHub utils, because I suspect this will be useful for other vendors besides GitHub.

## Background

I know there's a related ticket #17091 that allows users to manually remove these in some cases (not sure how this applies to arrays of entities). My thinking for this change is that I did not add nor request that Backstage add the type and namespace to the entity so it feels a bit counterintuitive that I have to tell it to remove something that it implicitly added.

### Note

While committing this I received ESLint errors from unchanged code:

```shell
✖ eslint --fix:

/home/fearphage/src/git/backstage/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
  18:1  error  @backstage/plugin-scaffolder does not export src/components/fields/EntityNamePicker  @backstage/no-forbidden-package-imports

✖ 1 problem (1 error, 0 warnings)
````

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
