### PR TITLE
fix: elastic search for missing or no indexes

### DIFF
--- a/.changeset/shaggy-crews-carry.md
+++ b/.changeset/shaggy-crews-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+fix ElasticSearch throwing error when index is missing

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
@@ -119,7 +119,12 @@ describe('ElasticSearchClientWrapper', () => {
     it('search', async () => {
       const wrapper = ElasticSearchClientWrapper.fromClientOptions(esOptions);
 
-      const searchInput = { index: 'xyz', body: { eg: 'etc' } };
+      const searchInput = {
+        index: 'xyz',
+        body: { eg: 'etc' },
+        ignore_unavailable: true,
+        allow_no_indices: true,
+      };
       const result = (await wrapper.search(searchInput)) as any;
 
       // Should call the ElasticSearch client's search with expected input.
@@ -241,7 +246,12 @@ describe('ElasticSearchClientWrapper', () => {
     it('search', async () => {
       const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
 
-      const searchInput = { index: 'xyz', body: { eg: 'etc' } };
+      const searchInput = {
+        index: 'xyz',
+        body: { eg: 'etc' },
+        ignore_unavailable: true,
+        allow_no_indices: true,
+      };
       const result = (await wrapper.search(searchInput)) as any;
 
       // Should call the OpenSearch client's search with expected input.
@@ -350,7 +360,12 @@ describe('ElasticSearchClientWrapper', () => {
       const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
       expect(OpenSearchClient).toHaveBeenCalledWith(osOptions);
 
-      const searchInput = { index: 'xyz', body: { eg: 'etc' } };
+      const searchInput = {
+        index: 'xyz',
+        body: { eg: 'etc' },
+        ignore_unavailable: true,
+        allow_no_indices: true,
+      };
       const result = (await wrapper.search(searchInput)) as any;
       expect(result.client).toBe('os');
       expect(result.args).toStrictEqual(searchInput);

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
@@ -91,12 +91,23 @@ export class ElasticSearchClientWrapper {
   }
 
   search(options: { index: string | string[]; body: Object }) {
+    const searchOptions = {
+      ignore_unavailable: true,
+      allow_no_indices: true,
+    };
+
     if (this.openSearchClient) {
-      return this.openSearchClient.search(options);
+      return this.openSearchClient.search({
+        ...options,
+        ...searchOptions,
+      });
     }
 
     if (this.elasticSearchClient) {
-      return this.elasticSearchClient.search(options);
+      return this.elasticSearchClient.search({
+        ...options,
+        ...searchOptions,
+      });
     }
 
     throw new Error('No client defined');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this occurs when the index is missing during the search for example the TechDocs provider creates the index when initiating, but if there's no docs to index, it removes the index but still tries to search from it.

fixes #16423

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
