### PR TITLE
use `jest.setTimeout` consistently

### DIFF
--- a/packages/backend-tasks/src/migrations.test.ts
+++ b/packages/backend-tasks/src/migrations.test.ts
@@ -39,6 +39,8 @@ async function migrateUntilBefore(knex: Knex, target: string): Promise<void> {
   }
 }
 
+jest.setTimeout(60_000);
+
 describe('migrations', () => {
   const databases = TestDatabases.create({
     ids: ['POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -80,6 +82,5 @@ describe('migrations', () => {
 
       await knex.destroy();
     },
-    60_000,
   );
 });

--- a/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.test.ts
+++ b/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.test.ts
@@ -32,6 +32,8 @@ function defer() {
   return { promise, resolve };
 }
 
+jest.setTimeout(60_000);
+
 describe('PluginTaskManagerImpl', () => {
   const databases = TestDatabases.create({
     ids: ['POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -77,7 +79,6 @@ describe('PluginTaskManagerImpl', () => {
         await promise;
         expect(fn).toHaveBeenCalledWith(expect.any(AbortSignal));
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -98,7 +99,6 @@ describe('PluginTaskManagerImpl', () => {
         await promise;
         expect(fn).toHaveBeenCalledWith(expect.any(AbortSignal));
       },
-      60_000,
     );
   });
 
@@ -125,7 +125,6 @@ describe('PluginTaskManagerImpl', () => {
         await promise;
         expect(fn).toHaveBeenCalledWith(expect.any(AbortSignal));
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -146,7 +145,6 @@ describe('PluginTaskManagerImpl', () => {
           NotFoundError,
         );
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -172,7 +170,6 @@ describe('PluginTaskManagerImpl', () => {
           ConflictError,
         );
       },
-      60_000,
     );
   });
 
@@ -300,7 +297,6 @@ describe('PluginTaskManagerImpl', () => {
         await promise;
         expect(fn).toHaveBeenCalledWith(expect.any(AbortSignal));
       },
-      60_000,
     );
   });
 
@@ -340,7 +336,6 @@ describe('PluginTaskManagerImpl', () => {
           },
         ]);
       },
-      60_000,
     );
   });
 

--- a/packages/backend-tasks/src/tasks/TaskScheduler.test.ts
+++ b/packages/backend-tasks/src/tasks/TaskScheduler.test.ts
@@ -20,6 +20,8 @@ import { Duration } from 'luxon';
 import waitForExpect from 'wait-for-expect';
 import { TaskScheduler } from './TaskScheduler';
 
+jest.setTimeout(60_000);
+
 describe('TaskScheduler', () => {
   const logger = getVoidLogger();
   const databases = TestDatabases.create({
@@ -56,7 +58,6 @@ describe('TaskScheduler', () => {
         expect(fn).toHaveBeenCalled();
       });
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -77,6 +78,5 @@ describe('TaskScheduler', () => {
         expect(fn).toHaveBeenCalled();
       });
     },
-    60_000,
   );
 });

--- a/packages/backend-tasks/src/tasks/TaskWorker.test.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.test.ts
@@ -23,6 +23,8 @@ import { DbTasksRow, DB_TASKS_TABLE } from '../database/tables';
 import { TaskWorker } from './TaskWorker';
 import { TaskSettingsV2 } from './types';
 
+jest.setTimeout(60_000);
+
 describe('TaskWorker', () => {
   const logger = getVoidLogger();
   const databases = TestDatabases.create({
@@ -115,7 +117,6 @@ describe('TaskWorker', () => {
         }),
       );
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -140,7 +141,6 @@ describe('TaskWorker', () => {
         expect(logger.error).toHaveBeenCalled();
       });
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -164,7 +164,6 @@ describe('TaskWorker', () => {
         expect(fn).toHaveBeenCalledTimes(3);
       });
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -223,7 +222,6 @@ describe('TaskWorker', () => {
         }),
       );
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -280,7 +278,6 @@ describe('TaskWorker', () => {
         false,
       );
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -334,6 +331,5 @@ describe('TaskWorker', () => {
       await promise2;
       expect(fn1.mock.calls.length).toBeGreaterThan(before);
     },
-    60_000,
   );
 });

--- a/packages/backend-test-utils/src/database/TestDatabases.test.ts
+++ b/packages/backend-test-utils/src/database/TestDatabases.test.ts
@@ -22,12 +22,16 @@ import { TestDatabases } from './TestDatabases';
 
 const itIfDocker = isDockerDisabledForTests() ? it.skip : it;
 
+jest.setTimeout(60_000);
+
 describe('TestDatabases', () => {
   const OLD_ENV = process.env;
+
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...OLD_ENV };
   });
+
   afterAll(() => {
     process.env = OLD_ENV;
   });
@@ -49,109 +53,84 @@ describe('TestDatabases', () => {
           { a: 1 },
         ]);
       },
-      60_000,
     );
   });
 
-  itIfDocker(
-    'obeys a provided connection string for postgres 13',
-    async () => {
-      const dbs = TestDatabases.create();
-      const { host, port, user, password, stop } = await startPostgresContainer(
-        'postgres:13',
-      );
+  itIfDocker('obeys a provided connection string for postgres 13', async () => {
+    const dbs = TestDatabases.create();
+    const { host, port, user, password, stop } = await startPostgresContainer(
+      'postgres:13',
+    );
 
-      try {
-        // Leave a mark
-        process.env.BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
-        const input = await dbs.init('POSTGRES_13');
-        await input.schema.createTable('a', table =>
-          table.string('x').primary(),
-        );
-        await input.insert({ x: 'y' }).into('a');
+    try {
+      // Leave a mark
+      process.env.BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
+      const input = await dbs.init('POSTGRES_13');
+      await input.schema.createTable('a', table => table.string('x').primary());
+      await input.insert({ x: 'y' }).into('a');
 
-        // Look for the mark
-        const database = input.client.config.connection.database;
-        const output = knexFactory({
-          client: 'pg',
-          connection: { host, port, user, password, database },
-        });
-        // eslint-disable-next-line jest/no-standalone-expect
-        await expect(output.select('x').from('a')).resolves.toEqual([
-          { x: 'y' },
-        ]);
-      } finally {
-        await stop();
-      }
-    },
-    60_000,
-  );
+      // Look for the mark
+      const database = input.client.config.connection.database;
+      const output = knexFactory({
+        client: 'pg',
+        connection: { host, port, user, password, database },
+      });
+      // eslint-disable-next-line jest/no-standalone-expect
+      await expect(output.select('x').from('a')).resolves.toEqual([{ x: 'y' }]);
+    } finally {
+      await stop();
+    }
+  });
 
-  itIfDocker(
-    'obeys a provided connection string for postgres 9',
-    async () => {
-      const dbs = TestDatabases.create();
-      const { host, port, user, password, stop } = await startPostgresContainer(
-        'postgres:9',
-      );
+  itIfDocker('obeys a provided connection string for postgres 9', async () => {
+    const dbs = TestDatabases.create();
+    const { host, port, user, password, stop } = await startPostgresContainer(
+      'postgres:9',
+    );
 
-      try {
-        // Leave a mark
-        process.env.BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
-        const input = await dbs.init('POSTGRES_9');
-        await input.schema.createTable('a', table =>
-          table.string('x').primary(),
-        );
-        await input.insert({ x: 'y' }).into('a');
+    try {
+      // Leave a mark
+      process.env.BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
+      const input = await dbs.init('POSTGRES_9');
+      await input.schema.createTable('a', table => table.string('x').primary());
+      await input.insert({ x: 'y' }).into('a');
 
-        // Look for the mark
-        const database = input.client.config.connection.database;
-        const output = knexFactory({
-          client: 'pg',
-          connection: { host, port, user, password, database },
-        });
-        // eslint-disable-next-line jest/no-standalone-expect
-        await expect(output.select('x').from('a')).resolves.toEqual([
-          { x: 'y' },
-        ]);
-      } finally {
-        await stop();
-      }
-    },
-    60_000,
-  );
+      // Look for the mark
+      const database = input.client.config.connection.database;
+      const output = knexFactory({
+        client: 'pg',
+        connection: { host, port, user, password, database },
+      });
+      // eslint-disable-next-line jest/no-standalone-expect
+      await expect(output.select('x').from('a')).resolves.toEqual([{ x: 'y' }]);
+    } finally {
+      await stop();
+    }
+  });
 
-  itIfDocker(
-    'obeys a provided connection string for mysql 8',
-    async () => {
-      const dbs = TestDatabases.create();
-      const { host, port, user, password, stop } = await startMysqlContainer(
-        'mysql:8',
-      );
+  itIfDocker('obeys a provided connection string for mysql 8', async () => {
+    const dbs = TestDatabases.create();
+    const { host, port, user, password, stop } = await startMysqlContainer(
+      'mysql:8',
+    );
 
-      try {
-        // Leave a mark
-        process.env.BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING = `mysql://${user}:${password}@${host}:${port}/ignored`;
-        const input = await dbs.init('MYSQL_8');
-        await input.schema.createTable('a', table =>
-          table.string('x').primary(),
-        );
-        await input.insert({ x: 'y' }).into('a');
+    try {
+      // Leave a mark
+      process.env.BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING = `mysql://${user}:${password}@${host}:${port}/ignored`;
+      const input = await dbs.init('MYSQL_8');
+      await input.schema.createTable('a', table => table.string('x').primary());
+      await input.insert({ x: 'y' }).into('a');
 
-        // Look for the mark
-        const database = input.client.config.connection.database;
-        const output = knexFactory({
-          client: 'mysql2',
-          connection: { host, port, user, password, database },
-        });
-        // eslint-disable-next-line jest/no-standalone-expect
-        await expect(output.select('x').from('a')).resolves.toEqual([
-          { x: 'y' },
-        ]);
-      } finally {
-        await stop();
-      }
-    },
-    60_000,
-  );
+      // Look for the mark
+      const database = input.client.config.connection.database;
+      const output = knexFactory({
+        client: 'mysql2',
+        connection: { host, port, user, password, database },
+      });
+      // eslint-disable-next-line jest/no-standalone-expect
+      await expect(output.select('x').from('a')).resolves.toEqual([{ x: 'y' }]);
+    } finally {
+      await stop();
+    }
+  });
 });

--- a/packages/backend-test-utils/src/database/startMysqlContainer.test.ts
+++ b/packages/backend-test-utils/src/database/startMysqlContainer.test.ts
@@ -20,21 +20,19 @@ import { startMysqlContainer } from './startMysqlContainer';
 
 const itIfDocker = isDockerDisabledForTests() ? it.skip : it;
 
+jest.setTimeout(60_000);
+
 describe('startMysqlContainer', () => {
-  itIfDocker(
-    'successfully launches the container',
-    async () => {
-      const { stop, ...connection } = await startMysqlContainer('mysql:8');
-      const db = createConnection({ client: 'mysql2', connection });
-      try {
-        const result = await db.select(db.raw('version() AS version'));
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(result[0]?.version).toContain('8.');
-      } finally {
-        await db.destroy();
-        await stop();
-      }
-    },
-    60_000,
-  );
+  itIfDocker('successfully launches the container', async () => {
+    const { stop, ...connection } = await startMysqlContainer('mysql:8');
+    const db = createConnection({ client: 'mysql2', connection });
+    try {
+      const result = await db.select(db.raw('version() AS version'));
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(result[0]?.version).toContain('8.');
+    } finally {
+      await db.destroy();
+      await stop();
+    }
+  });
 });

--- a/packages/backend-test-utils/src/database/startPostgresContainer.test.ts
+++ b/packages/backend-test-utils/src/database/startPostgresContainer.test.ts
@@ -20,23 +20,19 @@ import { startPostgresContainer } from './startPostgresContainer';
 
 const itIfDocker = isDockerDisabledForTests() ? it.skip : it;
 
+jest.setTimeout(60_000);
+
 describe('startPostgresContainer', () => {
-  itIfDocker(
-    'successfully launches the container',
-    async () => {
-      const { stop, ...connection } = await startPostgresContainer(
-        'postgres:13',
-      );
-      const db = createConnection({ client: 'pg', connection });
-      try {
-        const result = await db.select(db.raw('version()'));
-        // eslint-disable-next-line jest/no-standalone-expect
-        expect(result[0]?.version).toContain('PostgreSQL');
-      } finally {
-        await db.destroy();
-        await stop();
-      }
-    },
-    60_000,
-  );
+  itIfDocker('successfully launches the container', async () => {
+    const { stop, ...connection } = await startPostgresContainer('postgres:13');
+    const db = createConnection({ client: 'pg', connection });
+    try {
+      const result = await db.select(db.raw('version()'));
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(result[0]?.version).toContain('PostgreSQL');
+    } finally {
+      await db.destroy();
+      await stop();
+    }
+  });
 });

--- a/plugins/app-backend/src/lib/assets/StaticAssetsStore.test.ts
+++ b/plugins/app-backend/src/lib/assets/StaticAssetsStore.test.ts
@@ -33,6 +33,8 @@ function createDatabaseManager(
   };
 }
 
+jest.setTimeout(60_000);
+
 describe('StaticAssetsStore', () => {
   const databases = TestDatabases.create({
     ids: ['POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -78,7 +80,6 @@ describe('StaticAssetsStore', () => {
         store.getAsset('does-not-exist.txt'),
       ).resolves.toBeUndefined();
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -130,7 +131,6 @@ describe('StaticAssetsStore', () => {
       const sameBar = await store.getAsset('bar');
       expect(oldBar!.lastModifiedAt).toEqual(sameBar!.lastModifiedAt);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -172,6 +172,5 @@ describe('StaticAssetsStore', () => {
       await expect(store.getAsset('new')).resolves.toBeDefined();
       await expect(store.getAsset('old')).resolves.toBeUndefined();
     },
-    60_000,
   );
 });

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
@@ -31,6 +31,8 @@ const bazaarProject: any = {
   responsible: 'r',
 };
 
+jest.setTimeout(60_000);
+
 describe('DatabaseHandler', () => {
   const databases = TestDatabases.create({
     ids: ['POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -96,6 +98,5 @@ describe('DatabaseHandler', () => {
         res[0].members_count === '1' || res[0].members_count === 1,
       ).toBeTruthy();
     },
-    60_000,
   );
 });

--- a/plugins/catalog-backend/src/database/DefaultCatalogDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultCatalogDatabase.test.ts
@@ -21,6 +21,8 @@ import { DefaultCatalogDatabase } from './DefaultCatalogDatabase';
 import { applyDatabaseMigrations } from './migrations';
 import { DbRefreshStateReferencesRow, DbRefreshStateRow } from './tables';
 
+jest.setTimeout(60_000);
+
 describe('DefaultCatalogDatabase', () => {
   const defaultLogger = getVoidLogger();
   const databases = TestDatabases.create({
@@ -105,7 +107,6 @@ describe('DefaultCatalogDatabase', () => {
           'location:default/root-2',
         ]);
       },
-      60_000,
     );
   });
 });

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -33,6 +33,8 @@ import { createRandomProcessingInterval } from '../processing/refresh';
 import { timestampToDateTime } from './conversion';
 import { generateStableHash } from './util';
 
+jest.setTimeout(60_000);
+
 describe('DefaultProcessingDatabase', () => {
   const defaultLogger = getVoidLogger();
   const databases = TestDatabases.create({
@@ -106,7 +108,6 @@ describe('DefaultProcessingDatabase', () => {
           );
         });
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -153,7 +154,6 @@ describe('DefaultProcessingDatabase', () => {
           ),
         );
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -193,7 +193,6 @@ describe('DefaultProcessingDatabase', () => {
         expect(entities[0].errors).toEqual("['something broke']");
         expect(entities[0].location_key).toEqual('key');
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -279,7 +278,6 @@ describe('DefaultProcessingDatabase', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -328,7 +326,6 @@ describe('DefaultProcessingDatabase', () => {
 
         expect(refreshStateEntries).toHaveLength(1);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -478,7 +475,6 @@ describe('DefaultProcessingDatabase', () => {
           }
         });
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -583,7 +579,6 @@ describe('DefaultProcessingDatabase', () => {
         expect(entities2.length).toBe(1);
         expect(entities2[0].cache).toEqual('{}');
       },
-      60_000,
     );
   });
 
@@ -636,7 +631,6 @@ describe('DefaultProcessingDatabase', () => {
           ).resolves.toEqual({ items: [] });
         });
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -672,7 +666,6 @@ describe('DefaultProcessingDatabase', () => {
         const nextUpdateDiff = nextUpdate.diff(now, 'seconds');
         expect(nextUpdateDiff.seconds).toBeGreaterThanOrEqual(90);
       },
-      60_000,
     );
   });
 

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -24,6 +24,8 @@ import { DefaultProviderDatabase } from './DefaultProviderDatabase';
 import { applyDatabaseMigrations } from './migrations';
 import { DbRefreshStateReferencesRow, DbRefreshStateRow } from './tables';
 
+jest.setTimeout(60_000);
+
 describe('DefaultProviderDatabase', () => {
   const defaultLogger = getVoidLogger();
   const databases = TestDatabases.create({
@@ -184,7 +186,6 @@ describe('DefaultProviderDatabase', () => {
           ),
         ).toBeTruthy();
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -321,7 +322,6 @@ describe('DefaultProviderDatabase', () => {
           ),
         ).toBeFalsy();
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -392,7 +392,6 @@ describe('DefaultProviderDatabase', () => {
           ),
         ).toBeTruthy();
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -443,7 +442,6 @@ describe('DefaultProviderDatabase', () => {
           }),
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -493,7 +491,6 @@ describe('DefaultProviderDatabase', () => {
           ),
         ).toBeFalsy();
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -560,7 +557,6 @@ describe('DefaultProviderDatabase', () => {
           }),
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -688,7 +684,6 @@ describe('DefaultProviderDatabase', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -743,7 +738,6 @@ describe('DefaultProviderDatabase', () => {
           ]),
         );
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -777,7 +771,6 @@ describe('DefaultProviderDatabase', () => {
         const state = await knex<DbRefreshStateRow>('refresh_state').select();
         expect(state).toEqual([]);
       },
-      60_000,
     );
   });
 });

--- a/plugins/catalog-backend/src/database/operations/provider/deleteWithEagerPruningOfChildren.test.ts
+++ b/plugins/catalog-backend/src/database/operations/provider/deleteWithEagerPruningOfChildren.test.ts
@@ -21,6 +21,8 @@ import { applyDatabaseMigrations } from '../../migrations';
 import { DbRefreshStateReferencesRow, DbRefreshStateRow } from '../../tables';
 import { deleteWithEagerPruningOfChildren } from './deleteWithEagerPruningOfChildren';
 
+jest.setTimeout(60_000);
+
 describe('deleteWithEagerPruningOfChildren', () => {
   const databases = TestDatabases.create({
     ids: ['MYSQL_8', 'POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -111,7 +113,6 @@ describe('deleteWithEagerPruningOfChildren', () => {
       await run(knex, { sourceKey: 'P1', entityRefs: ['E1', 'E3'] });
       await expect(remainingEntities(knex)).resolves.toEqual(['E4', 'E5']);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -141,7 +142,6 @@ describe('deleteWithEagerPruningOfChildren', () => {
       await run(knex, { sourceKey: 'P1', entityRefs: ['E1'] });
       await expect(remainingEntities(knex)).resolves.toEqual(['E2']);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -170,7 +170,6 @@ describe('deleteWithEagerPruningOfChildren', () => {
       await run(knex, { sourceKey: 'P1', entityRefs: ['E1'] });
       await expect(remainingEntities(knex)).resolves.toEqual(['E2', 'E3']);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -199,7 +198,6 @@ describe('deleteWithEagerPruningOfChildren', () => {
       await run(knex, { sourceKey: 'P1', entityRefs: ['E1'] });
       await expect(remainingEntities(knex)).resolves.toEqual(['E2', 'E3']);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -240,7 +238,6 @@ describe('deleteWithEagerPruningOfChildren', () => {
       await run(knex, { sourceKey: 'P1', entityRefs: ['E3'] });
       await expect(remainingEntities(knex)).resolves.toEqual([]);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -273,6 +270,5 @@ describe('deleteWithEagerPruningOfChildren', () => {
         'E4',
       ]);
     },
-    60_000,
   );
 });

--- a/plugins/catalog-backend/src/migrations.test.ts
+++ b/plugins/catalog-backend/src/migrations.test.ts
@@ -39,6 +39,8 @@ async function migrateUntilBefore(knex: Knex, target: string): Promise<void> {
   }
 }
 
+jest.setTimeout(60_000);
+
 describe('migrations', () => {
   const databases = TestDatabases.create({
     ids: ['MYSQL_8', 'POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -159,7 +161,6 @@ describe('migrations', () => {
 
       await knex.destroy();
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -237,6 +238,5 @@ describe('migrations', () => {
 
       await knex.destroy();
     },
-    60_000,
   );
 });

--- a/plugins/catalog-backend/src/modules/core/DefaultLocationStore.test.ts
+++ b/plugins/catalog-backend/src/modules/core/DefaultLocationStore.test.ts
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
 import { v4 as uuid } from 'uuid';
 import { applyDatabaseMigrations } from '../../database/migrations';
 import { DefaultLocationStore } from './DefaultLocationStore';
+
+jest.setTimeout(60_000);
 
 describe('DefaultLocationStore', () => {
   const databases = TestDatabases.create({
@@ -42,7 +45,6 @@ describe('DefaultLocationStore', () => {
         entities: [],
       });
     },
-    60_000,
   );
 
   describe('listLocations', () => {
@@ -52,7 +54,6 @@ describe('DefaultLocationStore', () => {
         const { store } = await createLocationStore(databaseId);
         expect(await store.listLocations()).toEqual([]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -77,7 +78,6 @@ describe('DefaultLocationStore', () => {
           ]),
         );
       },
-      60_000,
     );
   });
 
@@ -96,7 +96,6 @@ describe('DefaultLocationStore', () => {
           new RegExp(`Location ${spec.type}:${spec.target} already exists`),
         );
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -127,7 +126,6 @@ describe('DefaultLocationStore', () => {
           ]),
         });
       },
-      60_000,
     );
   });
 
@@ -141,7 +139,6 @@ describe('DefaultLocationStore', () => {
           new RegExp(`Found no location with ID ${id}`),
         );
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -175,7 +172,6 @@ describe('DefaultLocationStore', () => {
           ],
         });
       },
-      60_000,
     );
   });
 });

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -35,6 +35,8 @@ import { buildEntitySearch } from '../stitching/buildEntitySearch';
 import { DefaultEntitiesCatalog } from './DefaultEntitiesCatalog';
 import { EntitiesRequest } from '../catalog/types';
 
+jest.setTimeout(60_000);
+
 describe('DefaultEntitiesCatalog', () => {
   let knex: Knex;
 
@@ -184,7 +186,6 @@ describe('DefaultEntitiesCatalog', () => {
           ]),
         );
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -200,7 +201,6 @@ describe('DefaultEntitiesCatalog', () => {
           catalog.entityAncestry('k:default/root'),
         ).rejects.toThrow('No such entity k:default/root');
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -273,7 +273,6 @@ describe('DefaultEntitiesCatalog', () => {
           ]),
         );
       },
-      60_000,
     );
   });
 
@@ -313,7 +312,6 @@ describe('DefaultEntitiesCatalog', () => {
         expect(entities.length).toBe(1);
         expect(entities[0]).toEqual(entity2);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -353,7 +351,6 @@ describe('DefaultEntitiesCatalog', () => {
         expect(entities.length).toBe(1);
         expect(entities[0]).toEqual(entity1);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -427,7 +424,6 @@ describe('DefaultEntitiesCatalog', () => {
         expect(entities).toContainEqual(entity2);
         expect(entities).toContainEqual(entity4);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -473,7 +469,6 @@ describe('DefaultEntitiesCatalog', () => {
         expect(entities.length).toBe(1);
         expect(entities).toContainEqual(entity1);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -510,7 +505,6 @@ describe('DefaultEntitiesCatalog', () => {
 
         expect(entities.length).toBe(0);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -569,7 +563,6 @@ describe('DefaultEntitiesCatalog', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -665,7 +658,6 @@ describe('DefaultEntitiesCatalog', () => {
           }),
         ).resolves.toEqual(['n4', 'n3', 'n1', 'n2']);
       },
-      60_000,
     );
   });
 
@@ -722,7 +714,6 @@ describe('DefaultEntitiesCatalog', () => {
           'k:default/two',
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -767,7 +758,6 @@ describe('DefaultEntitiesCatalog', () => {
           null,
         ]);
       },
-      60_000,
     );
   });
 
@@ -1617,7 +1607,6 @@ describe('DefaultEntitiesCatalog', () => {
           new Set(['k:default/unrelated1', 'k:default/unrelated2']),
         );
       },
-      60_000,
     );
   });
 
@@ -1660,7 +1649,6 @@ describe('DefaultEntitiesCatalog', () => {
           },
         });
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -1711,7 +1699,6 @@ describe('DefaultEntitiesCatalog', () => {
           },
         });
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -1757,7 +1744,6 @@ describe('DefaultEntitiesCatalog', () => {
           },
         });
       },
-      60_000,
     );
   });
 });

--- a/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
@@ -34,6 +34,8 @@ import { EntityProcessingRequest } from '../processing/types';
 import { Stitcher } from '../stitching/Stitcher';
 import { DefaultRefreshService } from './DefaultRefreshService';
 
+jest.setTimeout(60_000);
+
 describe('DefaultRefreshService', () => {
   const defaultLogger = getVoidLogger();
   const databases = TestDatabases.create({
@@ -221,7 +223,6 @@ describe('DefaultRefreshService', () => {
 
       await engine.stop();
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -275,7 +276,6 @@ describe('DefaultRefreshService', () => {
 
       await engine.stop();
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -337,6 +337,5 @@ describe('DefaultRefreshService', () => {
 
       await engine.stop();
     },
-    60_000,
   );
 });

--- a/plugins/catalog-backend/src/stitching/Stitcher.test.ts
+++ b/plugins/catalog-backend/src/stitching/Stitcher.test.ts
@@ -27,6 +27,8 @@ import {
 } from '../database/tables';
 import { Stitcher } from './Stitcher';
 
+jest.setTimeout(60_000);
+
 describe('Stitcher', () => {
   const databases = TestDatabases.create({
     ids: ['MYSQL_8', 'POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
@@ -267,6 +269,5 @@ describe('Stitcher', () => {
         ]),
       );
     },
-    60_000,
   );
 });

--- a/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.test.ts
+++ b/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.test.ts
@@ -44,6 +44,8 @@ function createDatabaseManager(
   };
 }
 
+jest.setTimeout(60_000);
+
 describe('DatabaseDocumentStore', () => {
   describe('unsupported', () => {
     const databases = TestDatabases.create({
@@ -58,7 +60,6 @@ describe('DatabaseDocumentStore', () => {
 
         expect(supported).toBe(false);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -71,7 +72,6 @@ describe('DatabaseDocumentStore', () => {
           async () => await DatabaseDocumentStore.create(databaseManager),
         ).rejects.toThrow();
       },
-      60_000,
     );
   });
 
@@ -102,7 +102,6 @@ describe('DatabaseDocumentStore', () => {
 
         expect(supported).toBe(true);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -131,7 +130,6 @@ describe('DatabaseDocumentStore', () => {
           await knex.count('*').where('type', 'my-type').from('documents'),
         ).toEqual([{ count: '2' }]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -172,7 +170,6 @@ describe('DatabaseDocumentStore', () => {
           await knex.count('*').where('type', 'my-type').from('documents'),
         ).toEqual([{ count: '4' }]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -219,7 +216,6 @@ describe('DatabaseDocumentStore', () => {
           await knex.count('*').where('type', 'my-type').from('documents'),
         ).toEqual([{ count: '0' }]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -270,7 +266,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -325,7 +320,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -378,7 +372,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -433,7 +426,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -498,7 +490,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -551,7 +542,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
 
     it.each(databases.eachSupportedId())(
@@ -610,7 +600,6 @@ describe('DatabaseDocumentStore', () => {
           },
         ]);
       },
-      60_000,
     );
   });
 });

--- a/plugins/search-backend-module-pg/src/database/util.test.ts
+++ b/plugins/search-backend-module-pg/src/database/util.test.ts
@@ -16,6 +16,8 @@
 import { TestDatabases } from '@backstage/backend-test-utils';
 import { queryPostgresMajorVersion } from './util';
 
+jest.setTimeout(60_000);
+
 describe('util', () => {
   describe('unsupported', () => {
     const databases = TestDatabases.create({
@@ -31,7 +33,6 @@ describe('util', () => {
           async () => await queryPostgresMajorVersion(knex),
         ).rejects.toThrow();
       },
-      60_000,
     );
   });
 
@@ -56,7 +57,6 @@ describe('util', () => {
           expectedVersion,
         );
       },
-      60_000,
     );
   });
 });

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   FactRetriever,
   FactRetrieverRegistration,
@@ -34,6 +35,7 @@ import { ConfigReader } from '@backstage/config';
 import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
 import { TaskScheduler } from '@backstage/backend-tasks';
 
+jest.setTimeout(60_000);
 jest.useFakeTimers();
 
 const testFactRetriever: FactRetriever = {
@@ -175,7 +177,6 @@ describe('FactRetrieverEngine', () => {
       );
       expect(schemaAssertionCallback).toHaveBeenCalled();
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -227,6 +228,5 @@ describe('FactRetrieverEngine', () => {
         }),
       );
     },
-    60_000,
   );
 });


### PR DESCRIPTION
The benefit of setting the timeout like this is that it is way less repetitive and not so easy to forget on individual tests, plus it also applies to beforeEach and its ilk which sometimes could get timeouts when running locally before this change.