### PR TITLE
feat(circleci): Add hover to CircleCI avatar icon to show user's name

### DIFF
--- a/.changeset/clean-items-draw.md
+++ b/.changeset/clean-items-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-circleci': patch
+---
+
+Add hover over CircleCI avatar icon to show user name in builds table

--- a/plugins/circleci/README.md
+++ b/plugins/circleci/README.md
@@ -74,4 +74,4 @@ spec:
 ## Limitations
 
 - CircleCI has pretty strict rate limits per token, be careful with opened tabs
-- CircleCI doesn't provide a way to auth by 3rd party (e.g. GitHub) token, nor by calling their OAuth endpoints, which currently stands in the way of better auth integration with Backstage (https://discuss.circleci.com/t/circleci-api-authorization-with-github-token/5356)
+- CircleCI doesn't provide a way to auth by 3rd party (e.g. GitHub) token, nor by calling their OAuth endpoints, which currently stands in the way of better auth integration with Backstage (reference [feature request](https://ideas.circleci.com/api-feature-requests/p/allow-circleci-api-calls-using-github-auth) and [discussion topic](https://discuss.circleci.com/t/circleci-api-authorization-with-github-token/5356))

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -21,6 +21,7 @@ import {
   Box,
   IconButton,
   makeStyles,
+  Tooltip,
 } from '@material-ui/core';
 import RetryIcon from '@material-ui/icons/Replay';
 import GitHubIcon from '@material-ui/icons/GitHub';
@@ -116,7 +117,13 @@ const SourceInfo = ({ build }: { build: CITableBuildInfo }) => {
 
   return (
     <Box display="flex" alignItems="center" className={classes.root}>
-      <Avatar alt={user.name} src={user.avatarUrl} className={classes.small} />
+      <Tooltip title={user.name ?? user.login}>
+        <Avatar
+          alt={user.name}
+          src={user.avatarUrl}
+          className={classes.small}
+        />
+      </Tooltip>
       <Box>
         <Typography variant="button">{source?.branchName}</Typography>
         <Typography variant="body1">
@@ -217,7 +224,11 @@ const generatedColumns: TableColumn[] = [
       <Link
         to={`https://app.circleci.com/pipelines/workflows/${row?.workflow?.id}`}
       >
-        {row?.workflow?.name}
+        <Box display="flex" alignItems="center">
+          <LaunchIcon fontSize="small" color="disabled" />
+          <Box mr={1} />
+          {row?.workflow?.name}
+        </Box>
       </Link>
     ),
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Partially addresses https://github.com/backstage/backstage/issues/17092.

Previously, you could see the avatar icon but couldn't tell who the user was from the Backstage builds table. You could click into the workflow, opening it on CircleCI's web site, and then could identify the user.

This just provides a quick hover so you can more quickly identify who the user is, but it took a few clicks.

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/33203301/228262110-d840f71b-f456-4f95-ad5e-72c66f5bc52e.png">

This also adds an "external link" icon to the workflow column, so it better matches up with the job link (where a user can assume that icon means they'll click OUT of Backstage), and finally a quick tweak to the README to link up an official feature request for simplifying token auth.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
