### PR TITLE
fix: localKubectlProxy auth provider throwing error

### DIFF
--- a/.changeset/poor-cars-fold.md
+++ b/.changeset/poor-cars-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+fix localKubectlProxy auth provider fetching

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -191,7 +191,10 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
 
     let url: URL;
     let requestInit: RequestInit;
-    if (clusterDetails.serviceAccountToken) {
+    if (
+      clusterDetails.serviceAccountToken ||
+      clusterDetails.authProvider === 'localKubectlProxy'
+    ) {
       [url, requestInit] = this.fetchArgsFromClusterDetails(clusterDetails);
     } else if (fs.pathExistsSync(Config.SERVICEACCOUNT_TOKEN_PATH)) {
       [url, requestInit] = this.fetchArgsInCluster();


### PR DESCRIPTION
`localKubectlProxy` auth provider was broken which makes local testing trickier

<img width="1477" alt="Screenshot 2023-03-28 at 11 31 28 AM" src="https://user-images.githubusercontent.com/6514980/228292772-e79edb31-57c6-4d02-a105-66e8e67cb6f6.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
