### PR TITLE
Stack Overflow plugin support for PAT authentication

### DIFF
--- a/.changeset/tricky-wombats-explode.md
+++ b/.changeset/tricky-wombats-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stack-overflow-backend': minor
+---
+
+Adding support for v2.3 API and PAT authentication

--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -17,14 +17,21 @@ stackoverflow:
 
 ### Stack Overflow for Teams
 
-If you have a private Stack Overflow instance and/or a private Stack Overflow Team you will need to supply an API key. You can read more about how to set this up by going to [Stack Overflow's Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).
+If you have a private Stack Overflow instance and/or a private Stack Overflow Team you will need to supply an API key or Personal Access Token. You can read more about how to set this up by going to [Stack Overflow's Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).
 
-A private Stack Overflow Team requires both an API key and an API Access Token. Step 3 ("Generate an Access Token via OAuth") from the previously mentioned Help Page explains the process for generating an API Access Token with no expiration.
+The existing API key approach remains the default, to support the new v2.3 API and PAT authentication model you need to pass the team name and the new PAT into the existing apiAccessToken parameter. See [15770](https://github.com/backstage/backstage/issues/15770) for more details.
 
 ```yaml
 stackoverflow:
   baseUrl: https://api.stackexchange.com/2.2 # alternative: your internal stack overflow instance
   apiKey: $STACK_OVERFLOW_API_KEY
+  apiAccessToken: $STACK_OVERFLOW_API_ACCESS_TOKEN
+```
+
+```yaml
+stackoverflow:
+  baseUrl: https://api.stackexchange.com/2.3 # alternative: your internal stack overflow instance
+  teamName: $STACK_OVERFLOW_TEAM_NAME
   apiAccessToken: $STACK_OVERFLOW_API_ACCESS_TOKEN
 ```
 

--- a/plugins/stack-overflow-backend/README.md
+++ b/plugins/stack-overflow-backend/README.md
@@ -19,7 +19,7 @@ stackoverflow:
 
 If you have a private Stack Overflow instance and/or a private Stack Overflow Team you will need to supply an API key or Personal Access Token. You can read more about how to set this up by going to [Stack Overflow's Help Page](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).
 
-The existing API key approach remains the default, to support the new v2.3 API and PAT authentication model you need to pass the team name and the new PAT into the existing apiAccessToken parameter. See [15770](https://github.com/backstage/backstage/issues/15770) for more details.
+The existing API key approach remains the default, to support the new v2.3 API and PAT authentication model you need to pass the team name and the new PAT into the existing apiAccessToken parameter to the new URL. See [15770](https://github.com/backstage/backstage/issues/15770) for more details.
 
 ```yaml
 stackoverflow:
@@ -30,7 +30,7 @@ stackoverflow:
 
 ```yaml
 stackoverflow:
-  baseUrl: https://api.stackexchange.com/2.3 # alternative: your internal stack overflow instance
+  baseUrl: https://api.stackoverflowteams.com/2.3 # alternative: your internal stack overflow instance
   teamName: $STACK_OVERFLOW_TEAM_NAME
   apiAccessToken: $STACK_OVERFLOW_API_ACCESS_TOKEN
 ```

--- a/plugins/stack-overflow-backend/api-report.md
+++ b/plugins/stack-overflow-backend/api-report.md
@@ -44,6 +44,7 @@ export type StackOverflowQuestionsCollatorFactoryOptions = {
   maxPage?: number;
   apiKey?: string;
   apiAccessToken?: string;
+  teamName?: string;
   requestParams: StackOverflowQuestionsRequestParams;
   logger: Logger;
 };

--- a/plugins/stack-overflow-backend/config.d.ts
+++ b/plugins/stack-overflow-backend/config.d.ts
@@ -31,6 +31,11 @@ export interface Config {
     apiKey?: string;
 
     /**
+     * The name of the team for a Stack Overflow for Teams account
+     */
+    teamName?: string;
+
+    /**
      * The API Access Token to authenticate to Stack Overflow API
      * @visibility secret
      */

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.test.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.test.ts
@@ -139,5 +139,49 @@ describe('StackOverflowQuestionsCollatorFactory', () => {
 
       expect(documents).toHaveLength(mockOverrideQuestion.items.length);
     });
+
+    it('uses API key when provided', async () => {
+      worker.use(
+        rest.get('http://stack.overflow.override/questions', (req, res, ctx) =>
+          req.url.searchParams.get('key') === 'abcdefg'
+            ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
+            : res(ctx.status(401), ctx.json({})),
+        ),
+      );
+      const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
+        logger,
+        baseUrl: 'http://stack.overflow.override',
+        apiKey: 'abcdefg',
+        requestParams: defaultOptions.requestParams,
+      });
+      const collator = await factory.getCollator();
+
+      const pipeline = TestPipeline.fromCollator(collator);
+      const { documents } = await pipeline.execute();
+
+      expect(documents).toHaveLength(mockOverrideQuestion.items.length);
+    });
+
+    it('uses teamName when provided', async () => {
+      worker.use(
+        rest.get('http://stack.overflow.override/questions', (req, res, ctx) =>
+          req.url.searchParams.get('team') === 'abcdefg'
+            ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
+            : res(ctx.status(401), ctx.json({})),
+        ),
+      );
+      const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
+        logger,
+        baseUrl: 'http://stack.overflow.override',
+        teamName: 'abcdefg',
+        requestParams: defaultOptions.requestParams,
+      });
+      const collator = await factory.getCollator();
+
+      const pipeline = TestPipeline.fromCollator(collator);
+      const { documents } = await pipeline.execute();
+
+      expect(documents).toHaveLength(mockOverrideQuestion.items.length);
+    });
   });
 });

--- a/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/stack-overflow-backend/src/search/StackOverflowQuestionsCollatorFactory.ts
@@ -93,7 +93,6 @@ export class StackOverflowQuestionsCollatorFactory
     const apiAccessToken = config.getOptionalString(
       'stackoverflow.apiAccessToken',
     );
-    const pat = config.getOptionalString('stackoverflow.pat');
     const teamName = config.getOptionalString('stackoverflow.teamName');
     const baseUrl =
       config.getOptionalString('stackoverflow.baseUrl') ||


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #15770 by adding support for the new PAT authentication for Stack Overflow as per [docs](https://stackoverflow.help/en/articles/4385859-stack-overflow-for-teams-api).

Deliberately keeping as a minor change - I've not bumped the default API version number and added a new optional parameter. This is because it isn't clear whether the API key approach is still required for other Stack Overflow integrations.

My first PR against Backstage - great documentation but apologies in advance if I've missed anything!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
