### PR TITLE
Add optional sign out url for OAuth2 Proxy

### DIFF
--- a/.changeset/tricky-mails-retire.md
+++ b/.changeset/tricky-mails-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Adds the optional `signOutUrl` value to the app config that can be used in combination with Oauth2 Proxy. The `AppRouter` will check if the value is within the app config, set it to the `IdentityApi`, and use this value to navigate to the sign out page of the configured authentication provider on `signOut`.

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -80,3 +80,14 @@ const app = createApp({
 ```
 
 See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page to also work smoothly for local development.
+
+## Signing out using the provider
+
+There is an optional config value `signOutUrl` within the `app-config.yaml` to enable the ability to sign out when using `oauth2Proxy`. Specifying this value will allow backstage to redirect to the sign out page of the authentication provider that is being used.
+
+```yaml title="app-config.yaml"
+app:
+  signOutUrl: http://localhost:4180/oauth2/sign_out?rd=http%3A%2F%2Fmy-provider.com%2Fend_session_endpoint
+```
+
+Note the above example has `oauth2Proxy` running on port 4180. There is also the requirement of using an encoded url for the redirect to the authentication provider's sign out page. The `end_session_endpoint` should be the end session endpoint of the provider.

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -90,4 +90,4 @@ app:
   signOutUrl: http://localhost:4180/oauth2/sign_out?rd=http%3A%2F%2Fmy-provider.com%2Fend_session_endpoint
 ```
 
-Note the above example has `oauth2Proxy` running on port 4180. There is also the requirement of using an encoded url for the redirect to the authentication provider's sign out page. The `end_session_endpoint` should be the end session endpoint of the provider.
+Note the above example has `oauth2Proxy` running on port 4180. There is also the requirement of using an encoded URL for the redirect to the authentication provider's sign out page. The `end_session_endpoint` should be the end session endpoint of the provider.

--- a/packages/core-app-api/config.d.ts
+++ b/packages/core-app-api/config.d.ts
@@ -65,6 +65,12 @@ export interface Config {
         }>;
       }>;
     };
+
+    /**
+     * An optional sign out url that can be used with oauth2 proxy
+     * @visibility frontend
+     */
+    signOutUrl?: string;
   };
 
   /**

--- a/packages/core-app-api/src/app/AppRouter.tsx
+++ b/packages/core-app-api/src/app/AppRouter.tsx
@@ -71,13 +71,14 @@ function SignInPageWrapper({
   const [identityApi, setIdentityApi] = useState<IdentityApi>();
   const configApi = useApi(configApiRef);
   const basePath = getBasePath(configApi);
+  const optionalSignOut = configApi.getOptionalString('app.signOutUrl');
 
   if (!identityApi) {
     return <Component onSignInSuccess={setIdentityApi} />;
   }
 
   appIdentityProxy.setTarget(identityApi, {
-    signOutTargetUrl: basePath || '/',
+    signOutTargetUrl: optionalSignOut || basePath || '/',
   });
   return <>{children}</>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: #12016

This PR adds an optional sign out config value for signing out with OAuth2 Proxy. This would allow users to be able to click on the sign out button from within backstage and be navigated to the sign out page of the authentication provider. 

I ended up choosing to use the option of defining the URL as a config value due to the fact that the `/oauth2/sign_out` endpoint will only clear the [OAuth2 Proxy cookies](https://oauth2-proxy.github.io/oauth2-proxy/docs/features/endpoints/#sign-out) and still leave the user authenticated to their provider. This will result in them being logged back into Backstage. The way around this issue is to add a redirect parameter to the URL so that the user will be redirected to the sign out page. 

The URL ends up in the form of 
`http://localhost:4180/oauth2/sign_out?rd=http%3A%2F%2Fmy-provider.com%2Fend_session_endpoint`
Where the end session endpoint is the sign out page of the authentication provider and OAuth2 Proxy is running on port 4180. 



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
