### PR TITLE
fix: sortField to orderField

### DIFF
--- a/.changeset/eight-trainers-smoke.md
+++ b/.changeset/eight-trainers-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': minor
+---
+
+Fixed bug in queryEntities of CatalogClient where the sortField is supposed to be changed to orderField.

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -230,7 +230,7 @@ export class CatalogClient implements CatalogApi {
       }
       if (orderFields !== undefined) {
         (Array.isArray(orderFields) ? orderFields : [orderFields]).forEach(
-          ({ field, order }) => params.push(`sortField=${field},${order}`),
+          ({ field, order }) => params.push(`orderField=${field},${order}`),
         );
       }
       if (fields.length) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I am using the queryEntities for implementing the paginated catalog table, but the orderFields doesn't really work, I looked into the source code and found it seems you forgot to change the param sortField to orderField in CatalogClient.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
