### PR TITLE
Fix Select component useEffect behaviour when selected props updated to undefined

### DIFF
--- a/packages/core-components/src/components/Select/Select.test.tsx
+++ b/packages/core-components/src/components/Select/Select.test.tsx
@@ -57,7 +57,7 @@ describe('<Select />', () => {
 
   it('display the placeholder value when selected props updated to undefined', async () => {
     const { getByTestId, rerender } = render(
-      <Select {...minProps} selected="test 1" />,
+      <Select {...minProps} selected="test_1" />,
     );
 
     expect(getByTestId('select').textContent).toBe('test 1');

--- a/packages/core-components/src/components/Select/Select.test.tsx
+++ b/packages/core-components/src/components/Select/Select.test.tsx
@@ -54,4 +54,16 @@ describe('<Select />', () => {
     fireEvent.click(option);
     expect(input.textContent).toBe('test 1');
   });
+
+  it('display the placeholder value when selected props updated to undefined', async () => {
+    const { getByTestId, rerender } = render(
+      <Select {...minProps} selected="test 1" />,
+    );
+
+    expect(getByTestId('select').textContent).toBe('test 1');
+
+    rerender(<Select {...minProps} selected={undefined} />);
+
+    expect(getByTestId('select').textContent).toBe('All results');
+  });
 });

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -163,10 +163,8 @@ export function SelectComponent(props: SelectProps) {
   }, [triggerReset, multiple]);
 
   useEffect(() => {
-    if (selected !== undefined) {
-      setValue(selected);
-    }
-  }, [selected]);
+    setValue(selected || (multiple ? [] : ''));
+  }, [selected, multiple]);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setValue(event.target.value as SelectedItems);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I made a fix to the Select component in the `@backstage/core-components` package with following details:

**Problem**
When the Select component is used as follow:
```
<Select 
   {...props}
   selected={someSelectedValue}
/>
```

The `someSelectedValue` variable can change from time to time. When the `someSelectedValue` changed from any value to `undefined`, somehow the UI does not get updated properly, the UI will shows that the Select component still select the old value. This is caused by this `useEffect`:

```
  useEffect(() => {
    if (selected !== undefined) {
      setValue(selected);
    }
  }, [selected]);
```

This caused the value to be not updated when the new `selected` value is `undefined`.

**Expected behaviour**

The Select component should be re-rendered with correct internal state. If the `selected` props value changed to `undefined` it should reset it to the "empty" value.

**Solution**

Solution is quite simple, which is to update the value with the "empty" value when `selected` props changed to `undefined`. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation N/A
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) N/A
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
