### PR TITLE
bug: Invert `templateFilter` predicate to align with `Array.filter`

### DIFF
--- a/.changeset/modern-snakes-check.md
+++ b/.changeset/modern-snakes-check.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+bug: Invert `templateFilter` predicate to align with `Array.filter`

--- a/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.test.tsx
@@ -214,7 +214,7 @@ describe('TemplateGroups', () => {
 
     expect(TemplateGroup).toHaveBeenCalledWith(
       expect.objectContaining({
-        templates: [expect.objectContaining({ template: mockEntities[1] })],
+        templates: [expect.objectContaining({ template: mockEntities[0] })],
       }),
       {},
     );

--- a/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.tsx
@@ -91,7 +91,7 @@ export const TemplateGroups = (props: TemplateGroupsProps) => {
       {groups.map(({ title, filter }, index) => {
         const templates = entities
           .filter(isTemplateEntityV1beta3)
-          .filter(e => (templateFilter ? !templateFilter(e) : true))
+          .filter(e => (templateFilter ? templateFilter(e) : true))
           .filter(filter)
           .map(template => {
             const additionalLinks =

--- a/plugins/scaffolder/src/components/TemplateList/TemplateList.test.tsx
+++ b/plugins/scaffolder/src/components/TemplateList/TemplateList.test.tsx
@@ -77,7 +77,7 @@ describe('TemplateList', () => {
       { mountedRoutes: { '/': rootRouteRef } },
     );
 
-    expect(() => screen.getByTestId('t1')).toThrow();
-    expect(screen.getByTestId('t2')).toBeDefined();
+    expect(() => screen.getByTestId('t2')).toThrow();
+    expect(screen.getByTestId('t1')).toBeDefined();
   });
 });

--- a/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
+++ b/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
@@ -59,7 +59,7 @@ export const TemplateList = ({
   const templateEntities = entities.filter(isTemplateEntityV1beta3);
   const maybeFilteredEntities = (
     group ? templateEntities.filter(group.filter) : templateEntities
-  ).filter(e => (templateFilter ? !templateFilter(e) : true));
+  ).filter(e => (templateFilter ? templateFilter(e) : true));
 
   const titleComponent: React.ReactNode = (() => {
     if (group && group.title) {


### PR DESCRIPTION
## Changes
- bug: Invert `templateFilter` predicate to align with `Array.filter`

@acierto, I think this makes for a better API design. Thoughts?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
