### PR TITLE
Update kubernetes config schema to match available options

### DIFF
--- a/.changeset/afraid-horses-argue.md
+++ b/.changeset/afraid-horses-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Updated kubernetes config schema to match available options

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -21,11 +21,15 @@ export interface Config {
       | 'services'
       | 'configmaps'
       | 'deployments'
+      | 'limitranges'
       | 'replicasets'
       | 'horizontalpodautoscalers'
       | 'jobs'
       | 'cronjobs'
       | 'ingresses'
+      | 'customresources'
+      | 'statefulsets'
+      | 'daemonsets'
     >;
     serviceLocatorMethod: {
       type: 'multiTenant';
@@ -99,11 +103,15 @@ export interface Config {
       services?: string;
       configmaps?: string;
       deployments?: string;
+      limitranges?: string;
       replicasets?: string;
       horizontalpodautoscalers?: string;
-      cronjobs?: string;
       jobs?: string;
+      cronjobs?: string;
       ingresses?: string;
+      customresources?: string;
+      statefulsets?: string;
+      daemonsets?: string;
     } & { [pluralKind: string]: string };
   };
 }

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -104,6 +104,8 @@ export type KubernetesObjectTypes =
   | 'customresources'
   | 'statefulsets'
   | 'daemonsets';
+// If updating this list, also make sure to update
+// `objectTypes` and `apiVersionOverrides` in config.d.ts!
 
 /**
  * Used to load cluster details from different sources


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change updates the Kubernetes config schema to match the available options.

Fixes: https://github.com/backstage/backstage/issues/16837

I thought about having some kind of shared types file for `src/` and `config.d.ts`, but the change would've been too large for me to feel comfortable proposing. I think something like that could be a good way to keep the two pieces in sync, though.

This does not address the discussed meta-issue of adding a strict config mode, that could be used to prevent this in integration testing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
