### PR TITLE
plugin-github-pull-requests-board: Filter archived repos

### DIFF
--- a/.changeset/great-ways-switch.md
+++ b/.changeset/great-ways-switch.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-github-pull-requests-board': patch
+---
+
+Add a new "Archived" Filter Options to the Github Pull Requests Dashboard.
+
+When toggling this option on, the dashboard will displays PRs in archived repositories.
+These PRs will not be displayed in the default filter.

--- a/.changeset/great-ways-switch.md
+++ b/.changeset/great-ways-switch.md
@@ -4,5 +4,5 @@
 
 Add a new "Archived" Filter Options to the Github Pull Requests Dashboard.
 
-When toggling this option on, the dashboard will displays PRs in archived repositories.
+When toggling this option on, the dashboard will display PRs from archived repositories.
 These PRs will not be displayed in the default filter.

--- a/plugins/github-pull-requests-board/src/api/useGetPullRequestDetails.ts
+++ b/plugins/github-pull-requests-board/src/api/useGetPullRequestDetails.ts
@@ -36,6 +36,7 @@ export const useGetPullRequestDetails = () => {
                   owner {
                     login
                   }
+                  isArchived
                 }
                 title
                 url

--- a/plugins/github-pull-requests-board/src/components/Card/Card.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/Card.tsx
@@ -25,6 +25,8 @@ type Props = {
   authorName: string;
   authorAvatar?: string;
   repositoryName: string;
+  isDraft: boolean;
+  repositoryIsArchived: boolean;
 };
 
 const Card: FunctionComponent<Props> = (props: PropsWithChildren<Props>) => {
@@ -36,6 +38,8 @@ const Card: FunctionComponent<Props> = (props: PropsWithChildren<Props>) => {
     authorName,
     authorAvatar,
     repositoryName,
+    isDraft,
+    repositoryIsArchived,
     children,
   } = props;
 
@@ -51,6 +55,8 @@ const Card: FunctionComponent<Props> = (props: PropsWithChildren<Props>) => {
               authorName={authorName}
               authorAvatar={authorAvatar}
               repositoryName={repositoryName}
+              isDraft={isDraft}
+              repositoryIsArchived={repositoryIsArchived}
             />
             {children}
           </Box>

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 import React, { FunctionComponent } from 'react';
-import { Typography, Box } from '@material-ui/core';
+import { Typography, Box, Tooltip } from '@material-ui/core';
 import { getElapsedTime } from '../../utils/functions';
 import { UserHeader } from '../UserHeader';
+import { DraftPrIcon } from '../icons/DraftPr';
+import UnarchiveIcon from '@material-ui/icons/Unarchive';
 
 type Props = {
   title: string;
@@ -25,6 +27,8 @@ type Props = {
   authorName: string;
   authorAvatar?: string;
   repositoryName: string;
+  isDraft: boolean;
+  repositoryIsArchived: boolean;
 };
 
 const CardHeader: FunctionComponent<Props> = (props: Props) => {
@@ -35,6 +39,8 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
     authorName,
     authorAvatar,
     repositoryName,
+    isDraft,
+    repositoryIsArchived,
   } = props;
 
   return (
@@ -44,6 +50,22 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
           {repositoryName}
         </Typography>
         <UserHeader name={authorName} avatar={authorAvatar} />
+      </Box>
+      <Box display="flex" justifyContent="left">
+        {isDraft && (
+          <Tooltip title="Draft PR">
+            <Box display="flex" justifyContent="center" alignItems="center">
+              <DraftPrIcon />
+            </Box>
+          </Tooltip>
+        )}
+        {repositoryIsArchived && (
+          <Tooltip title="Repository is archived">
+            <Box display="flex" justifyContent="center" alignItems="center">
+              <UnarchiveIcon />
+            </Box>
+          </Tooltip>
+        )}
       </Box>
       <Typography component="h3">
         <b>{title}</b>

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { EntityTeamPullRequestsCard } from '../EntityTeamPullRequestsCard';
+import { PullRequestsColumn } from '../../utils/types';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+
+jest.mock('../../hooks/useUserRepositoriesAndTeam', () => {
+  return {
+    useUserRepositoriesAndTeam: () => {
+      return {
+        loading: false,
+        repositories: ['team-login/team-repo'],
+        teamMembers: ['team-member'],
+        teamMembersOrganization: 'test-org',
+      };
+    },
+  };
+});
+
+jest.mock('../../hooks/usePullRequestsByTeam', () => {
+  const buildPullRequest = (
+    prTitle: string,
+    authorLogin: string,
+    repoName: string,
+    isDraft: boolean,
+    isArchived: boolean,
+  ) => {
+    return {
+      id: 'id',
+      title: prTitle,
+      url: 'url',
+      lastEditedAt: 'last-edited-at',
+      latestReviews: {
+        nodes: [],
+      },
+      mergeable: true,
+      state: 'state',
+      reviewDecision: null,
+      createdAt: 'created-at',
+      repository: {
+        name: repoName,
+        owner: {
+          login: 'team-login',
+        },
+        isArchived: isArchived,
+      },
+      isDraft: isDraft,
+      author: {
+        login: authorLogin,
+        avatarUrl: 'avatar-url',
+        id: 'id',
+        email: 'email',
+        name: 'name',
+      },
+    };
+  };
+
+  const pullRequests: PullRequestsColumn[] = [
+    {
+      title: 'column',
+      content: [
+        buildPullRequest(
+          'non-team-non-draft-non-archive',
+          'non-team-member',
+          'team-repo',
+          false,
+          false,
+        ),
+        buildPullRequest(
+          'non-team-non-draft-is-archive',
+          'non-team-member',
+          'team-repo',
+          false,
+          true,
+        ),
+        buildPullRequest(
+          'non-team-is-draft-non-archive',
+          'non-team-member',
+          'team-repo',
+          true,
+          false,
+        ),
+        buildPullRequest(
+          'non-team-is-draft-is-archive',
+          'non-team-member',
+          'team-repo',
+          true,
+          true,
+        ),
+        buildPullRequest(
+          'is-team-non-draft-non-archive',
+          'team-member',
+          'non-team-repo',
+          false,
+          false,
+        ),
+        buildPullRequest(
+          'is-team-non-draft-is-archive',
+          'team-member',
+          'non-team-repo',
+          false,
+          true,
+        ),
+        buildPullRequest(
+          'is-team-is-draft-non-archive',
+          'team-member',
+          'non-team-repo',
+          true,
+          false,
+        ),
+        buildPullRequest(
+          'is-team-is-draft-is-archive',
+          'team-member',
+          'non-team-repo',
+          true,
+          true,
+        ),
+      ],
+    },
+  ];
+
+  return {
+    usePullRequestsByTeam: () => {
+      return {
+        loading: false,
+        pullRequests: pullRequests,
+        refreshPullRequest: () => {},
+      };
+    },
+  };
+});
+
+describe('EntityTeamPullRequestsCard', () => {
+  it('should render', async () => {
+    await render(<EntityTeamPullRequestsCard />);
+  });
+
+  describe('non-team PRs', () => {
+    describe('non-draft PRs', () => {
+      it('should show non-team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, queryAllByTitle } = await render(
+          <EntityTeamPullRequestsCard />,
+        );
+        expect(getByText('non-team-non-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+
+      it('should show non-team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('non-team-non-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+    });
+
+    describe('draft PRs', () => {
+      it('should show draft non-team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        expect(getByText('non-team-is-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+
+      it('should show draft non-team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('non-team-is-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('team PRs', () => {
+    describe('non-draft PRs', () => {
+      it('should show team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        expect(getByText('is-team-non-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+
+      it('should show team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('is-team-non-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+    });
+
+    describe('draft PRs', () => {
+      it('should show draft team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        expect(getByText('is-team-is-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+
+      it('should show draft team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsCard />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('is-team-is-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
@@ -146,10 +146,6 @@ jest.mock('../../hooks/usePullRequestsByTeam', () => {
 });
 
 describe('EntityTeamPullRequestsCard', () => {
-  it('should render', async () => {
-    await render(<EntityTeamPullRequestsCard />);
-  });
-
   describe('non-team PRs', () => {
     describe('non-draft PRs', () => {
       it('should show non-team PRs for un-archived repos when archived option is not checked', async () => {

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -29,6 +29,7 @@ import { PRCardFormating } from '../../utils/types';
 import { shouldDisplayCard } from '../../utils/functions';
 import { DraftPrIcon } from '../icons/DraftPr';
 import { useUserRepositoriesAndTeam } from '../../hooks/useUserRepositoriesAndTeam';
+import UnarchiveIcon from '@material-ui/icons/Unarchive';
 
 /** @public */
 export interface EntityTeamPullRequestsCardProps {
@@ -70,6 +71,11 @@ const EntityTeamPullRequestsCard = (props: EntityTeamPullRequestsCardProps) => {
             icon: <DraftPrIcon />,
             value: 'draft',
             ariaLabel: 'Show draft PRs',
+          },
+          {
+            icon: <UnarchiveIcon />,
+            value: 'archivedRepo',
+            ariaLabel: 'Show archived repos',
           },
           {
             icon: <FullscreenIcon />,
@@ -127,6 +133,7 @@ const EntityTeamPullRequestsCard = (props: EntityTeamPullRequestsCardProps) => {
                       url={url}
                       reviews={latestReviews.nodes}
                       repositoryName={repository.name}
+                      repositoryIsArchived={repository.isArchived}
                       isDraft={isDraft}
                     />
                   ),

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
@@ -146,10 +146,6 @@ jest.mock('../../hooks/usePullRequestsByTeam', () => {
 });
 
 describe('EntityTeamPullRequestsContent', () => {
-  it('should render', async () => {
-    await render(<EntityTeamPullRequestsContent />);
-  });
-
   describe('non-team PRs', () => {
     describe('non-draft PRs', () => {
       it('should show non-team PRs for un-archived repos when archived option is not checked', async () => {

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { EntityTeamPullRequestsContent } from '../EntityTeamPullRequestsContent';
+import { PullRequestsColumn } from '../../utils/types';
+import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+
+jest.mock('../../hooks/useUserRepositoriesAndTeam', () => {
+  return {
+    useUserRepositoriesAndTeam: () => {
+      return {
+        loading: false,
+        repositories: ['team-login/team-repo'],
+        teamMembers: ['team-member'],
+        teamMembersOrganization: 'test-org',
+      };
+    },
+  };
+});
+
+jest.mock('../../hooks/usePullRequestsByTeam', () => {
+  const buildPullRequest = (
+    prTitle: string,
+    authorLogin: string,
+    repoName: string,
+    isDraft: boolean,
+    isArchived: boolean,
+  ) => {
+    return {
+      id: 'id',
+      title: prTitle,
+      url: 'url',
+      lastEditedAt: 'last-edited-at',
+      latestReviews: {
+        nodes: [],
+      },
+      mergeable: true,
+      state: 'state',
+      reviewDecision: null,
+      createdAt: 'created-at',
+      repository: {
+        name: repoName,
+        owner: {
+          login: 'team-login',
+        },
+        isArchived: isArchived,
+      },
+      isDraft: isDraft,
+      author: {
+        login: authorLogin,
+        avatarUrl: 'avatar-url',
+        id: 'id',
+        email: 'email',
+        name: 'name',
+      },
+    };
+  };
+
+  const pullRequests: PullRequestsColumn[] = [
+    {
+      title: 'column',
+      content: [
+        buildPullRequest(
+          'non-team-non-draft-non-archive',
+          'non-team-member',
+          'team-repo',
+          false,
+          false,
+        ),
+        buildPullRequest(
+          'non-team-non-draft-is-archive',
+          'non-team-member',
+          'team-repo',
+          false,
+          true,
+        ),
+        buildPullRequest(
+          'non-team-is-draft-non-archive',
+          'non-team-member',
+          'team-repo',
+          true,
+          false,
+        ),
+        buildPullRequest(
+          'non-team-is-draft-is-archive',
+          'non-team-member',
+          'team-repo',
+          true,
+          true,
+        ),
+        buildPullRequest(
+          'is-team-non-draft-non-archive',
+          'team-member',
+          'non-team-repo',
+          false,
+          false,
+        ),
+        buildPullRequest(
+          'is-team-non-draft-is-archive',
+          'team-member',
+          'non-team-repo',
+          false,
+          true,
+        ),
+        buildPullRequest(
+          'is-team-is-draft-non-archive',
+          'team-member',
+          'non-team-repo',
+          true,
+          false,
+        ),
+        buildPullRequest(
+          'is-team-is-draft-is-archive',
+          'team-member',
+          'non-team-repo',
+          true,
+          true,
+        ),
+      ],
+    },
+  ];
+
+  return {
+    usePullRequestsByTeam: () => {
+      return {
+        loading: false,
+        pullRequests: pullRequests,
+        refreshPullRequest: () => {},
+      };
+    },
+  };
+});
+
+describe('EntityTeamPullRequestsContent', () => {
+  it('should render', async () => {
+    await render(<EntityTeamPullRequestsContent />);
+  });
+
+  describe('non-team PRs', () => {
+    describe('non-draft PRs', () => {
+      it('should show non-team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, queryAllByTitle } = await render(
+          <EntityTeamPullRequestsContent />,
+        );
+        expect(getByText('non-team-non-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+
+      it('should show non-team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('non-team-non-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+    });
+
+    describe('draft PRs', () => {
+      it('should show draft non-team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        expect(getByText('non-team-is-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+
+      it('should show draft non-team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('non-team-is-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('team PRs', () => {
+    describe('non-draft PRs', () => {
+      it('should show team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        expect(getByText('is-team-non-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+
+      it('should show team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('is-team-non-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(0);
+      });
+    });
+
+    describe('draft PRs', () => {
+      it('should show draft team PRs for un-archived repos when archived option is not checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        expect(getByText('is-team-is-draft-non-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(0);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+
+      it('should show draft team PRs for archived repos when archived option is checked', async () => {
+        const { getByText, getAllByText, getByTitle, queryAllByTitle } =
+          await render(<EntityTeamPullRequestsContent />);
+        const teamToggle = getByTitle('Show PRs from your team');
+        fireEvent.click(teamToggle);
+        const draftToggle = getByTitle('Show draft PRs');
+        fireEvent.click(draftToggle);
+        const archiveToggle = getByTitle('Show archived repos');
+        fireEvent.click(archiveToggle);
+        expect(getByText('is-team-is-draft-is-archive')).toBeInTheDocument();
+        expect(getAllByText('non-team-repo')).toHaveLength(1);
+        expect(queryAllByTitle('Repository is archived')).toHaveLength(1);
+        expect(queryAllByTitle('Draft PR')).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -27,6 +27,7 @@ import { PRCardFormating } from '../../utils/types';
 import { shouldDisplayCard } from '../../utils/functions';
 import { DraftPrIcon } from '../icons/DraftPr';
 import { useUserRepositoriesAndTeam } from '../../hooks/useUserRepositoriesAndTeam';
+import UnarchiveIcon from '@material-ui/icons/Unarchive';
 
 /** @public */
 export interface EntityTeamPullRequestsContentProps {
@@ -70,6 +71,11 @@ const EntityTeamPullRequestsContent = (
             icon: <DraftPrIcon />,
             value: 'draft',
             ariaLabel: 'Show draft PRs',
+          },
+          {
+            icon: <UnarchiveIcon />,
+            value: 'archivedRepo',
+            ariaLabel: 'Show archived repos',
           },
         ]}
       />
@@ -119,6 +125,7 @@ const EntityTeamPullRequestsContent = (
                       url={url}
                       reviews={latestReviews.nodes}
                       repositoryName={repository.name}
+                      repositoryIsArchived={repository.isArchived}
                       isDraft={isDraft}
                     />
                   ),

--- a/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
@@ -31,6 +31,7 @@ type Props = {
   url: string;
   reviews: Reviews;
   repositoryName: string;
+  repositoryIsArchived: boolean;
   isDraft: boolean;
 };
 
@@ -43,6 +44,7 @@ const PullRequestCard: FunctionComponent<Props> = (props: Props) => {
     url,
     reviews,
     repositoryName,
+    repositoryIsArchived,
     isDraft,
   } = props;
 
@@ -50,7 +52,11 @@ const PullRequestCard: FunctionComponent<Props> = (props: Props) => {
   const commentsReviews = getCommentedReviews(reviews);
   const changeRequests = getChangeRequests(reviews);
 
-  const cardTitle = isDraft ? `🔧 DRAFT - ${title}` : title;
+  // Resolved in this way to satisfy merge - Author: tylerhekman-procore
+  // This information should probably be moved into dedicated CardHeader fields
+  // instead of title prefixes
+  const cardTitleModifiers = [isDraft && '🔧 DRAFT', repositoryIsArchived && '📁 ARCHIVED'].filter(Boolean);
+  const cardTitle = cardTitleModifiers.length > 0 ? `(${cardTitleModifiers.join(' | ')}) - ${title}` : title;
 
   return (
     <Card

--- a/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
@@ -52,21 +52,17 @@ const PullRequestCard: FunctionComponent<Props> = (props: Props) => {
   const commentsReviews = getCommentedReviews(reviews);
   const changeRequests = getChangeRequests(reviews);
 
-  // Resolved in this way to satisfy merge - Author: tylerhekman-procore
-  // This information should probably be moved into dedicated CardHeader fields
-  // instead of title prefixes
-  const cardTitleModifiers = [isDraft && '🔧 DRAFT', repositoryIsArchived && '📁 ARCHIVED'].filter(Boolean);
-  const cardTitle = cardTitleModifiers.length > 0 ? `(${cardTitleModifiers.join(' | ')}) - ${title}` : title;
-
   return (
     <Card
-      title={cardTitle}
+      title={title}
       createdAt={createdAt}
       updatedAt={updatedAt}
       authorName={author.login}
       authorAvatar={author.avatarUrl}
       repositoryName={repositoryName}
       prUrl={url}
+      isDraft={isDraft}
+      repositoryIsArchived={repositoryIsArchived}
     >
       {!!approvedReviews.length && (
         <UserHeaderList

--- a/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -139,7 +139,7 @@ export const shouldDisplayCard = (
 
   // hide PRs from archived repositories unless "archivedRepo" filter is toggled
   if (infoCardFormat.includes('archivedRepo') !== repository.isArchived) {
-    return false
+    return false;
   }
 
   // when "team" filter is toggled on, only shows PR from team members

--- a/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -137,6 +137,11 @@ export const shouldDisplayCard = (
     return false;
   }
 
+  // hide PRs from archived repositories unless "archivedRepo" filter is toggled
+  if (infoCardFormat.includes('archivedRepo') !== repository.isArchived) {
+    return false
+  }
+
   // when "team" filter is toggled on, only shows PR from team members
   if (infoCardFormat.includes('team')) {
     return teamMembers.includes(author.login);

--- a/plugins/github-pull-requests-board/src/utils/types.tsx
+++ b/plugins/github-pull-requests-board/src/utils/types.tsx
@@ -73,6 +73,7 @@ export type Repository = {
   owner: {
     login: string;
   };
+  isArchived: boolean;
 };
 
 export type PullRequest = {
@@ -99,7 +100,7 @@ export type PullRequestsColumn = {
   content: PullRequests;
 };
 
-export type PRCardFormating = 'compacted' | 'fullscreen' | 'draft' | 'team';
+export type PRCardFormating = 'compacted' | 'fullscreen' | 'draft' | 'team' | 'archivedRepo';
 
 export type ReviewDecision = 'IN_PROGRESS' | 'APPROVED' | 'REVIEW_REQUIRED';
 

--- a/plugins/github-pull-requests-board/src/utils/types.tsx
+++ b/plugins/github-pull-requests-board/src/utils/types.tsx
@@ -100,7 +100,12 @@ export type PullRequestsColumn = {
   content: PullRequests;
 };
 
-export type PRCardFormating = 'compacted' | 'fullscreen' | 'draft' | 'team' | 'archivedRepo';
+export type PRCardFormating =
+  | 'compacted'
+  | 'fullscreen'
+  | 'draft'
+  | 'team'
+  | 'archivedRepo';
 
 export type ReviewDecision = 'IN_PROGRESS' | 'APPROVED' | 'REVIEW_REQUIRED';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This work is a continuation of https://github.com/backstage/backstage/pull/13829. Solves https://github.com/RoadieHQ/roadie-backstage-plugins/issues/668

Adds a new "Archived" Filter Options to the Github Pull Requests Dashboard. When toggling this option on, the dashboard will display PRs from archived repositories. These PRs will not be displayed in the default filter.

Unit tests have been added to cover the functionality of the filter options component, proper filtering of the pull requests cards, and new icons added to the pull requests cards to indicate their state and make it more clear which filters are currently applied.

### Previous plugin-github-pull-requests-board UI

PRs on archived repositories are shown by default.

![Screen Shot 2023-04-06 at 11 49 18 PM](https://user-images.githubusercontent.com/89806876/230557200-20ffc994-efe8-4352-8849-87382b14a06e.png)

Draft PRs are indicated by the addition of "🔧 DRAFT - " to the PR title.

![Screen Shot 2023-04-06 at 11 53 14 PM](https://user-images.githubusercontent.com/89806876/230558623-bdc684f9-0790-4ffd-a2f2-b38fbef37da9.png)

### New plugin-github-pull-requests-board UI

PRs on archived repositories are not shown by default and are only rendered when the "Repository is archived" filter option is selected. This new filter applies additively to the existing filters. PRs in archived repositories are indicated by an icon on the card which matches the filter selection icon. Similarly, draft PRs are now indicated by an icon on the card, again matching the filter selection icon.

![Screen Shot 2023-04-07 at 12 01 47 AM](https://user-images.githubusercontent.com/89806876/230559110-c972427a-8060-4cc6-9da6-d3f1d378ab30.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
