### PR TITLE
feat(plugin-adr): use fetchApi instead of raw fetch

### DIFF
--- a/.changeset/nice-schools-remember.md
+++ b/.changeset/nice-schools-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+Use `fetchApi` instead of raw `fetch` in order to pass auth header if necessary.

--- a/.changeset/nice-schools-remember.md
+++ b/.changeset/nice-schools-remember.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-adr': patch
+'@backstage/plugin-adr': minor
 ---
 
 Use `fetchApi` instead of raw `fetch` in order to pass auth header if necessary.

--- a/plugins/adr/api-report.md
+++ b/plugins/adr/api-report.md
@@ -10,6 +10,7 @@ import { AdrFilePathFilterFn } from '@backstage/plugin-adr-common';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { FetchApi } from '@backstage/core-plugin-api';
 import { isAdrAvailable } from '@backstage/plugin-adr-common';
 import { ReactNode } from 'react';
 import { ResultHighlight } from '@backstage/plugin-search-common';
@@ -37,6 +38,8 @@ export class AdrClient implements AdrApi {
 export interface AdrClientOptions {
   // (undocumented)
   discoveryApi: DiscoveryApi;
+  // (undocumented)
+  fetchApi: FetchApi;
 }
 
 // @public

--- a/plugins/adr/src/api/AdrClient.ts
+++ b/plugins/adr/src/api/AdrClient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { AdrApi, AdrListResult, AdrReadResult } from './types';
 
 /**
@@ -24,6 +24,7 @@ import { AdrApi, AdrListResult, AdrReadResult } from './types';
  */
 export interface AdrClientOptions {
   discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
 }
 
 const readEndpoint = 'file';
@@ -36,9 +37,11 @@ const listEndpoint = 'list';
  */
 export class AdrClient implements AdrApi {
   private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
 
   constructor(options: AdrClientOptions) {
     this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
   }
 
   private async fetchAdrApi<T>(endpoint: string, fileUrl: string): Promise<T> {
@@ -47,7 +50,7 @@ export class AdrClient implements AdrApi {
       fileUrl,
     )}`;
 
-    const result = await fetch(targetUrl);
+    const result = await this.fetchApi.fetch(targetUrl);
     const data = await result.json();
 
     if (!result.ok) {

--- a/plugins/adr/src/plugin.ts
+++ b/plugins/adr/src/plugin.ts
@@ -20,6 +20,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { createSearchResultListItemExtension } from '@backstage/plugin-search-react';
 import { rootRouteRef } from './routes';
@@ -36,9 +37,10 @@ export const adrPlugin = createPlugin({
       api: adrApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
       },
-      factory({ discoveryApi }) {
-        return new AdrClient({ discoveryApi });
+      factory({ discoveryApi, fetchApi }) {
+        return new AdrClient({ discoveryApi, fetchApi });
       },
     }),
   ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the ADR frontend plugin, use fetchApi instead of raw fetch in order to pass auth header if necessary.
This makes the ADR plugin compatible with the [Authenticate API Requests tutorial](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
