### PR TITLE
Bazaar plugin: Add docs column to metadata table

### DIFF
--- a/.changeset/clever-plums-decide.md
+++ b/.changeset/clever-plums-decide.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-bazaar-backend': patch
+'@backstage/plugin-bazaar': patch
+---
+
+Added the `docs` parameter (optional) to link the project documentation

--- a/plugins/bazaar-backend/migrations/20230407142544_add_docs_to_metadata.js
+++ b/plugins/bazaar-backend/migrations/20230407142544_add_docs_to_metadata.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('metadata', table => {
+    table.text('docs').comment('The link to the project docs (optional)');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('metadata', table => {
+    table.dropColumn('docs');
+  });
+};

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.test.ts
@@ -29,6 +29,7 @@ const bazaarProject: any = {
   endDate: null,
   size: 'small',
   responsible: 'r',
+  docs: '',
 };
 
 jest.setTimeout(60_000);
@@ -75,6 +76,7 @@ describe('DatabaseHandler', () => {
         end_date: bazaarProject.endDate,
         size: bazaarProject.size,
         responsible: bazaarProject.responsible,
+        docs: bazaarProject.docs,
       });
 
       // Add a member to the project
@@ -94,6 +96,7 @@ describe('DatabaseHandler', () => {
       expect(res[0].end_date).toEqual(null);
       expect(res[0].size).toEqual('small');
       expect(res[0].responsible).toEqual('r');
+      expect(res[0].docs).toEqual('');
       expect(
         res[0].members_count === '1' || res[0].members_count === 1,
       ).toBeTruthy();

--- a/plugins/bazaar-backend/src/service/DatabaseHandler.ts
+++ b/plugins/bazaar-backend/src/service/DatabaseHandler.ts
@@ -61,6 +61,7 @@ export class DatabaseHandler {
     'metadata.start_date',
     'metadata.end_date',
     'metadata.responsible',
+    'metadata.docs',
   ];
 
   async getMembers(id: string) {
@@ -120,6 +121,7 @@ export class DatabaseHandler {
       entityRef,
       community,
       description,
+      docs,
       status,
       size,
       startDate,
@@ -133,6 +135,7 @@ export class DatabaseHandler {
         entity_ref: entityRef,
         community,
         description,
+        docs,
         status,
         updated_at: new Date().toISOString(),
         size,
@@ -150,6 +153,7 @@ export class DatabaseHandler {
       entityRef,
       community,
       description,
+      docs,
       status,
       size,
       startDate,
@@ -162,6 +166,7 @@ export class DatabaseHandler {
       entity_ref: entityRef,
       description,
       community,
+      docs,
       status,
       updated_at: new Date().toISOString(),
       size,

--- a/plugins/bazaar/README.md
+++ b/plugins/bazaar/README.md
@@ -127,6 +127,7 @@ The other fields are:
 
 - project - link Bazaar project to existing entity in the catalog
 - community link - link to where the project members can communicate, e.g. Teams or Discord link
+- docs link - link to visit the documentation of the project
 - start date
 - end date
 

--- a/plugins/bazaar/src/components/AddProjectDialog/AddProjectDialog.tsx
+++ b/plugins/bazaar/src/components/AddProjectDialog/AddProjectDialog.tsx
@@ -45,6 +45,7 @@ export const AddProjectDialog = ({
     title: '',
     community: '',
     description: '',
+    docs: '',
     status: 'proposed' as Status,
     size: 'medium' as Size,
     responsible: '',

--- a/plugins/bazaar/src/components/EntityBazaarInfoContent/EntityBazaarInfoContent.tsx
+++ b/plugins/bazaar/src/components/EntityBazaarInfoContent/EntityBazaarInfoContent.tsx
@@ -133,7 +133,7 @@ export const EntityBazaarInfoContent = ({
       label: 'Docs',
       icon: <Description />,
       href: bazaarProject?.docs,
-      disabled: bazaarProject?.docs === undefined || bazaarProject?.docs === '',
+      disabled: bazaarProject?.docs === null || bazaarProject?.docs === '',
     },
   ];
 

--- a/plugins/bazaar/src/components/EntityBazaarInfoContent/EntityBazaarInfoContent.tsx
+++ b/plugins/bazaar/src/components/EntityBazaarInfoContent/EntityBazaarInfoContent.tsx
@@ -26,6 +26,7 @@ import ChatIcon from '@material-ui/icons/Chat';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import LinkOffIcon from '@material-ui/icons/LinkOff';
+import Description from '@material-ui/icons/Description';
 import { EditProjectDialog } from '../EditProjectDialog';
 import { useApi, identityApiRef } from '@backstage/core-plugin-api';
 import { BazaarProject, Member } from '../../types';
@@ -127,6 +128,12 @@ export const EntityBazaarInfoContent = ({
       icon: <ChatIcon />,
       href: bazaarProject?.community,
       disabled: bazaarProject?.community === '' || !isMember,
+    },
+    {
+      label: 'Docs',
+      icon: <Description />,
+      href: bazaarProject?.docs,
+      disabled: bazaarProject?.docs === null || bazaarProject?.docs === '',
     },
   ];
 

--- a/plugins/bazaar/src/components/EntityBazaarInfoContent/EntityBazaarInfoContent.tsx
+++ b/plugins/bazaar/src/components/EntityBazaarInfoContent/EntityBazaarInfoContent.tsx
@@ -133,7 +133,7 @@ export const EntityBazaarInfoContent = ({
       label: 'Docs',
       icon: <Description />,
       href: bazaarProject?.docs,
-      disabled: bazaarProject?.docs === null || bazaarProject?.docs === '',
+      disabled: bazaarProject?.docs === undefined || bazaarProject?.docs === '',
     },
   ];
 

--- a/plugins/bazaar/src/components/HomePageBazaarInfoCard/HomePageBazaarInfoCard.tsx
+++ b/plugins/bazaar/src/components/HomePageBazaarInfoCard/HomePageBazaarInfoCard.tsx
@@ -34,6 +34,7 @@ import InsertLinkIcon from '@material-ui/icons/InsertLink';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import CloseIcon from '@material-ui/icons/Close';
 import LinkOffIcon from '@material-ui/icons/LinkOff';
+import Description from '@material-ui/icons/Description';
 import { EditProjectDialog } from '../EditProjectDialog';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import {
@@ -196,6 +197,13 @@ export const HomePageBazaarInfoCard = ({
       icon: <ChatIcon />,
       href: bazaarProject.value?.community,
       disabled: !bazaarProject.value?.community || !isMember,
+    },
+    {
+      label: 'Docs',
+      icon: <Description />,
+      href: bazaarProject.value?.docs,
+      disabled:
+        bazaarProject.value?.docs === null || bazaarProject.value?.docs === '',
     },
   ];
 

--- a/plugins/bazaar/src/components/HomePageBazaarInfoCard/HomePageBazaarInfoCard.tsx
+++ b/plugins/bazaar/src/components/HomePageBazaarInfoCard/HomePageBazaarInfoCard.tsx
@@ -203,7 +203,8 @@ export const HomePageBazaarInfoCard = ({
       icon: <Description />,
       href: bazaarProject.value?.docs,
       disabled:
-        bazaarProject.value?.docs === null || bazaarProject.value?.docs === '',
+        bazaarProject.value?.docs === undefined ||
+        bazaarProject.value?.docs === '',
     },
   ];
 

--- a/plugins/bazaar/src/components/HomePageBazaarInfoCard/HomePageBazaarInfoCard.tsx
+++ b/plugins/bazaar/src/components/HomePageBazaarInfoCard/HomePageBazaarInfoCard.tsx
@@ -203,8 +203,7 @@ export const HomePageBazaarInfoCard = ({
       icon: <Description />,
       href: bazaarProject.value?.docs,
       disabled:
-        bazaarProject.value?.docs === undefined ||
-        bazaarProject.value?.docs === '',
+        bazaarProject.value?.docs === null || bazaarProject.value?.docs === '',
     },
   ];
 

--- a/plugins/bazaar/src/components/InputField/InputField.tsx
+++ b/plugins/bazaar/src/components/InputField/InputField.tsx
@@ -30,7 +30,7 @@ type Rules = {
 };
 
 type Props = {
-  inputType: 'description' | 'community' | 'responsible' | 'title';
+  inputType: 'description' | 'community' | 'responsible' | 'title' | 'docs';
   error?: FieldError | undefined;
   control: Control<FormValues, object>;
   helperText?: string;

--- a/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
+++ b/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
@@ -144,6 +144,18 @@ export const ProjectDialog = ({
             placeholder="Community link to e.g. Teams or Discord"
           />
 
+          <InputField
+            error={errors.docs}
+            control={control}
+            rules={{
+              required: false,
+              pattern: RegExp('^(https?)://'),
+            }}
+            inputType="docs"
+            helperText="Please enter a link starting with http/https"
+            placeholder="Project docs link"
+          />
+
           <DoubleDateSelector setValue={setValue} control={control} />
         </DialogContent>
 

--- a/plugins/bazaar/src/types.ts
+++ b/plugins/bazaar/src/types.ts
@@ -39,6 +39,7 @@ export type BazaarProject = {
   startDate?: string | null;
   endDate?: string | null;
   responsible: string;
+  docs: string;
 };
 
 export type FormValues = {
@@ -50,4 +51,5 @@ export type FormValues = {
   startDate?: string | null;
   endDate?: string | null;
   responsible: string;
+  docs: string;
 };

--- a/plugins/bazaar/src/util/parseMethods.ts
+++ b/plugins/bazaar/src/util/parseMethods.ts
@@ -30,6 +30,7 @@ export const parseBazaarProject = (metadata: any): BazaarProject => {
     startDate: metadata.start_date,
     endDate: metadata.end_date,
     responsible: metadata.responsible,
+    docs: metadata.docs,
   } as BazaarProject;
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://github.com/backstage/backstage/issues/17245
This PR adds the `docs` optional field to the Bazaar projects so it can have a reference to a Google Docs, Github Issue, etc.

Form with the new docs field:
<img width="881" alt="Captura de pantalla 2023-04-08 a la(s) 11 53 27" src="https://user-images.githubusercontent.com/17910966/230728351-b0e3fa93-5465-4535-8b6b-3e6da6c245f1.png">

Docs validation:
<img width="489" alt="Captura de pantalla 2023-04-08 a la(s) 11 53 37" src="https://user-images.githubusercontent.com/17910966/230728360-eff9e587-8bed-46e2-a924-5086c20ba971.png">

With docs:
<img width="937" alt="Captura de pantalla 2023-04-08 a la(s) 11 54 36" src="https://user-images.githubusercontent.com/17910966/230728371-f526c8c3-b4c5-4991-9695-9a8823d83c7c.png">

Without docs:
<img width="600" alt="Captura de pantalla 2023-04-08 a la(s) 11 58 43" src="https://user-images.githubusercontent.com/17910966/230728382-41d367c5-85db-4aa1-82e5-f86b2e470905.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
