### PR TITLE
feat(github): support commit hashes at GithubUrlReader.readTree/search

### DIFF
--- a/.changeset/brave-forks-pull.md
+++ b/.changeset/brave-forks-pull.md
@@ -1,0 +1,9 @@
+---
+'@backstage/backend-common': patch
+---
+
+Support commit hashes at `GithubUrlReader.readTree/search` additionally to branch names.
+
+Additionally, this will reduce the number of API calls from 2 to 1 for retrieving the "repo details"
+for all cases besides when the default branch has to be resolved and used
+(e.g., repo URL without any branch or commit hash).

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -30,7 +30,7 @@ import path from 'path';
 import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import {
   GhBlobResponse,
-  GhBranchResponse,
+  GhCombinedCommitStatusResponse,
   GhRepoResponse,
   GhTreeResponse,
   GithubUrlReader,
@@ -309,12 +309,15 @@ describe('GithubUrlReader', () => {
         'https://ghe.github.com/api/v3/repos/backstage/mock/{archive_format}{/ref}',
     } as Partial<GhRepoResponse>;
 
-    const branchesApiResponse = {
-      name: 'main',
-      commit: {
-        sha: 'etag123abc',
-      },
-    } as Partial<GhBranchResponse>;
+    const commitStatusGithubResponse = {
+      sha: 'etag123abc',
+      repository: reposGithubApiResponse,
+    } as Partial<GhCombinedCommitStatusResponse>;
+
+    const commitStatusGheResponse = {
+      sha: 'etag123abc',
+      repository: reposGheApiResponse,
+    } as Partial<GhCombinedCommitStatusResponse>;
 
     beforeEach(() => {
       worker.use(
@@ -326,13 +329,18 @@ describe('GithubUrlReader', () => {
           ),
         ),
         rest.get(
-          'https://api.github.com/repos/backstage/mock/branches/main',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(branchesApiResponse),
-            ),
+          'https://api.github.com/repos/backstage/mock/commits/main/status',
+          (req, res, ctx) => {
+            if (req.url.searchParams.get('per_page') === '0') {
+              return res(
+                ctx.status(200),
+                ctx.set('Content-Type', 'application/json'),
+                ctx.json(commitStatusGithubResponse),
+              );
+            }
+
+            return res(ctx.status(500));
+          },
         ),
         rest.get(
           'https://api.github.com/repos/backstage/mock/tarball/etag123abc',
@@ -348,7 +356,7 @@ describe('GithubUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://api.github.com/repos/backstage/mock/branches/branchDoesNotExist',
+          'https://api.github.com/repos/backstage/mock/commits/branchDoesNotExist/status',
           (_, res, ctx) => res(ctx.status(404)),
         ),
         rest.get(
@@ -374,13 +382,18 @@ describe('GithubUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://ghe.github.com/api/v3/repos/backstage/mock/branches/main',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(branchesApiResponse),
-            ),
+          'https://ghe.github.com/api/v3/repos/backstage/mock/commits/main/status',
+          (req, res, ctx) => {
+            if (req.url.searchParams.get('per_page') === '0') {
+              return res(
+                ctx.status(200),
+                ctx.set('Content-Type', 'application/json'),
+                ctx.json(commitStatusGheResponse),
+              );
+            }
+
+            return res(ctx.status(500));
+          },
         ),
       );
     });
@@ -684,36 +697,69 @@ describe('GithubUrlReader', () => {
       );
     });
 
-    // Branch details
+    // commit status for branch details
     beforeEach(() => {
-      const response = {
-        name: 'main',
-        commit: {
-          sha: 'etag123abc',
+      const githubResponse = {
+        sha: 'etag123abc',
+        repository: {
+          id: 123,
+          full_name: 'backstage/mock',
+          default_branch: 'main',
+          branches_url:
+            'https://api.github.com/repos/backstage/mock/branches{/branch}',
+          archive_url:
+            'https://api.github.com/repos/backstage/mock/{archive_format}{/ref}',
+          trees_url:
+            'https://api.github.com/repos/backstage/mock/git/trees{/sha}',
         },
-      } as Partial<GhBranchResponse>;
+      } as Partial<GhCombinedCommitStatusResponse>;
+
+      const gheResponse = {
+        sha: 'etag123abc',
+        repository: {
+          id: 123,
+          full_name: 'backstage/mock',
+          default_branch: 'main',
+          branches_url:
+            'https://ghe.github.com/api/v3/repos/backstage/mock/branches{/branch}',
+          archive_url:
+            'https://ghe.github.com/api/v3/repos/backstage/mock/{archive_format}{/ref}',
+          trees_url:
+            'https://ghe.github.com/api/v3/repos/backstage/mock/git/trees{/sha}',
+        },
+      } as Partial<GhCombinedCommitStatusResponse>;
 
       worker.use(
         rest.get(
-          'https://api.github.com/repos/backstage/mock/branches/main',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(response),
-            ),
+          'https://api.github.com/repos/backstage/mock/commits/main/status',
+          (req, res, ctx) => {
+            if (req.url.searchParams.get('per_page') === '0') {
+              return res(
+                ctx.status(200),
+                ctx.set('Content-Type', 'application/json'),
+                ctx.json(githubResponse),
+              );
+            }
+
+            return res(ctx.status(500));
+          },
         ),
         rest.get(
-          'https://ghe.github.com/api/v3/repos/backstage/mock/branches/main',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(response),
-            ),
+          'https://ghe.github.com/api/v3/repos/backstage/mock/commits/main/status',
+          (req, res, ctx) => {
+            if (req.url.searchParams.get('per_page') === '0') {
+              return res(
+                ctx.status(200),
+                ctx.set('Content-Type', 'application/json'),
+                ctx.json(gheResponse),
+              );
+            }
+
+            return res(ctx.status(500));
+          },
         ),
         rest.get(
-          'https://api.github.com/repos/backstage/mock/branches/branchDoesNotExist',
+          'https://api.github.com/repos/backstage/mock/commits/branchDoesNotExist/status',
           (_, res, ctx) => res(ctx.status(404)),
         ),
       );


### PR DESCRIPTION
Support commit hashes additionally to branch names at the `GithubUrlReader`'s `readTree` and `search`.

This is achieved by using the "combined commit status" API instead of the branch API which works with commit hashes and branch names.
When used with branch names, it will return the result for the HEAD of the branch which is what the branch API was used for before.
We are not really interested in commit statuses, though, and can ignore them.

The "combined commit status" API support branch names with slashes as well, like `branch/name`.

Additionally, this will reduce the number of API calls from 2 to 1 for retrieving the "repo details" for all cases besides when the default branch has to be resolved and used (e.g., repo URL without any branch or commit hash).

Relates-to: PR #16721

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
