### PR TITLE
fix(circleci): Avoid trailing "took" in table row for in progress builds

### DIFF
--- a/.changeset/lazy-keys-work.md
+++ b/.changeset/lazy-keys-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-circleci': patch
+---
+
+Fixes row display for in progress jobs to not display trailing "took"

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -211,7 +211,9 @@ const generatedColumns: TableColumn[] = [
           run {relativeTimeTo(row?.startTime)}
         </Typography>
         <Typography variant="body2">
-          took {durationHumanized(row?.startTime, row?.stopTime)}
+          {row?.stopTime
+            ? `took ${durationHumanized(row?.startTime, row?.stopTime)}`
+            : ''}
         </Typography>
       </>
     ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #17093 

This PR fixes the row display for in progress builds so that they don't end with a trailing "took" because there's not yet a way to calculate a duration for a job which hasn't finished.

<img width="989" alt="image" src="https://user-images.githubusercontent.com/33203301/231029771-890420ad-c00a-4724-9dfb-6386adf53c08.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
