### PR TITLE
scaffolder/next: Added loading indicator for `AsyncValidation`

### DIFF
--- a/.changeset/poor-horses-approve.md
+++ b/.changeset/poor-horses-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Add indication that the validators are running

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
@@ -22,7 +22,6 @@ import type { RJSFValidationError } from '@rjsf/utils';
 import { JsonValue } from '@backstage/types';
 import { NextFieldExtensionComponentProps } from '../../extensions';
 import { LayoutTemplate } from '../../../layouts';
-import { AsyncDependenciesBlock } from 'webpack';
 
 describe('Stepper', () => {
   it('should render the step titles for each step of the manifest', async () => {

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -21,6 +21,7 @@ import {
   StepLabel as MuiStepLabel,
   Button,
   makeStyles,
+  LinearProgress,
 } from '@material-ui/core';
 import { type IChangeEvent } from '@rjsf/core-v5';
 import { ErrorSchema } from '@rjsf/utils';
@@ -93,6 +94,7 @@ export const Stepper = (stepperProps: StepperProps) => {
   const { steps } = useTemplateSchema(props.manifest);
   const apiHolder = useApiHolder();
   const [activeStep, setActiveStep] = useState(0);
+  const [isValidating, setIsValidating] = useState(false);
   const [formState, setFormState] = useFormDataFromQuery(props.initialState);
 
   const [errors, setErrors] = useState<undefined | FormValidation>();
@@ -133,11 +135,12 @@ export const Stepper = (stepperProps: StepperProps) => {
   }: {
     formData?: Record<string, JsonValue>;
   }) => {
-    // TODO(blam): What do we do about loading states, does each field extension get a chance
-    // to display it's own loading? Or should we grey out the entire form.
     setErrors(undefined);
+    setIsValidating(true);
 
     const returnedValidation = await validation(formData);
+
+    setIsValidating(false);
 
     if (hasErrors(returnedValidation)) {
       setErrors(returnedValidation);
@@ -154,6 +157,7 @@ export const Stepper = (stepperProps: StepperProps) => {
 
   return (
     <>
+      {isValidating && <LinearProgress variant="indeterminate" />}
       <MuiStepper activeStep={activeStep} alternativeLabel variant="elevation">
         {steps.map((step, index) => (
           <MuiStep key={index}>
@@ -183,11 +187,16 @@ export const Stepper = (stepperProps: StepperProps) => {
               <Button
                 onClick={handleBack}
                 className={styles.backButton}
-                disabled={activeStep < 1}
+                disabled={activeStep < 1 || isValidating}
               >
                 Back
               </Button>
-              <Button variant="contained" color="primary" type="submit">
+              <Button
+                variant="contained"
+                color="primary"
+                type="submit"
+                disabled={isValidating}
+              >
                 {activeStep === steps.length - 1 ? reviewButtonText : 'Next'}
               </Button>
             </div>


### PR DESCRIPTION
- feat: added progress bar and disable buttons when async validation is running
- chore: added changeset

![Screen Recording 2023-04-11 at 14 19 48](https://user-images.githubusercontent.com/3645856/231167303-9d21b439-1928-4688-aa6c-fd133771518d.gif)
