### PR TITLE
chore(docs): Add local debugging with logs page

### DIFF
--- a/docs/local-dev/debugging.md
+++ b/docs/local-dev/debugging.md
@@ -1,0 +1,49 @@
+---
+id: debugging
+title: Debugging Backstage
+description: How logging works and how to configure it
+---
+
+When configuring Backstage for the first time locally, or contributing new code changes,
+it can be helpful to change the logging levels to better understand how the system is functioning.
+
+Backstage uses the [Winston logging library](https://github.com/winstonjs/winston) and supports
+[the `npm` logging levels](https://github.com/winstonjs/winston#logging-levels) such as
+`warn`, `info` (the default), or `debug`.
+
+The logging instance is also passed to plugins for them to expose information about
+their processing as well.
+
+Changing the level can be done by setting the `LOG_LEVEL` environment variable.
+
+For example, to turn on debug logs when running the app locally, you can run:
+
+```shell
+LOG_LEVEL=debug yarn dev
+```
+
+The resulting log should now have more information available for debugging:
+
+```text
+[1] 2023-04-12T00:51:42.468Z catalog debug Skipped stitching of domain:default/artists, no changes type=plugin
+[1] 2023-04-12T00:51:42.469Z catalog debug Skipped stitching of domain:default/playback, no changes type=plugin
+[1] 2023-04-12T00:51:42.470Z catalog debug Processing system:default/podcast type=plugin
+[1] 2023-04-12T00:51:42.470Z catalog debug Processing group:default/infrastructure type=plugin
+[1] 2023-04-12T00:51:42.470Z catalog debug Processing group:default/boxoffice type=plugin
+[1] 2023-04-12T00:51:42.470Z catalog debug Processing group:default/backstage type=plugin
+[1] 2023-04-12T00:51:42.470Z catalog debug Processing group:default/team-a type=plugin
+[1] 2023-04-12T00:51:42.519Z catalog debug Skipped stitching of group:default/acme-corp, no changes type=plugin
+[1] 2023-04-12T00:51:42.520Z catalog debug Skipped stitching of group:default/backstage, no changes type=plugin
+[1] 2023-04-12T00:51:42.521Z catalog debug Skipped stitching of group:default/boxoffice, no changes type=plugin
+[1] 2023-04-12T00:51:42.523Z catalog debug Processing user:default/breanna.davison type=plugin
+[1] 2023-04-12T00:51:42.524Z catalog debug Processing user:default/janelle.dawe type=plugin
+[1] 2023-04-12T00:51:42.524Z catalog debug Processing user:default/nigel.manning type=plugin
+[1] 2023-04-12T00:51:42.524Z catalog debug Processing user:default/guest type=plugin
+[1] 2023-04-12T00:51:42.525Z catalog debug Processing group:default/team-b type=plugin
+[1] 2023-04-12T00:51:44.057Z search info Starting collation of explore tools type=plugin
+[1] 2023-04-12T00:51:44.095Z backstage info ::1 - - [12/Apr/2023:00:51:44 +0000] "GET /api/explore/tools HTTP/1.1" 200 - "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" type=incomingRequest
+[1] 2023-04-12T00:51:44.100Z backstage info ::1 - - [12/Apr/2023:00:51:44 +0000] "GET /api/catalog/entities?filter=metadata.annotations.backstage.io%2Ftechdocs-ref&fields=kind,namespace,metadata.annotations,metadata.name,metadata.title,metadata.namespace,spec.type,spec.lifecycle,relations&offset=0&limit=500 HTTP/1.1" 200 - "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" type=incomingRequest
+[1] 2023-04-12T00:51:44.104Z search info Finished collation of explore tools type=plugin
+[1] 2023-04-12T00:51:44.118Z search info Collating documents for tools succeeded type=plugin documentType=tools
+[1] 2023-04-12T00:51:44.119Z backstage debug task: search_index_tools will next occur around 2023-04-11T21:01:44.118-04:00 type=taskManager task=search_index_tools
+```

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -60,7 +60,8 @@
           "local-dev/cli-commands"
         ]
       },
-      "local-dev/linking-local-packages"
+      "local-dev/linking-local-packages",
+      "local-dev/debugging"
     ],
     "Core Features": [
       {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

There was a [question in Discord this week](https://discord.com/channels/687207715902193673/1095132282433589400) with a user asking how to adjust the log levels. I too remember this wasn't immediately apparent to me at first, but once you know how to do it, it seems very simple.

This PR adds a debugging page to the Local Development section of the microsite, with just some brief info to new users to help bootstrap. It has minor overlap with the observability page which also refers to Winston logger, but is intended for a less "Backstage experienced" audience. The key words "debugging", logs, etc, should also help if users search for that on the docs.

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/33203301/231320200-a2145174-fe4b-4ee0-8ad5-b821f2ca9f6e.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
