### PR TITLE
feat: add ability to view the labels/tags added to each PR in github-pull-requests-plugin

### DIFF
--- a/plugins/github-pull-requests-board/src/api/useGetPullRequestDetails.ts
+++ b/plugins/github-pull-requests-board/src/api/useGetPullRequestDetails.ts
@@ -59,6 +59,12 @@ export const useGetPullRequestDetails = () => {
                 mergeable
                 state
                 reviewDecision
+                labels(first: 10) {
+                  nodes {
+                    id
+                    name
+                  }
+                }
                 isDraft
                 createdAt
                 author {

--- a/plugins/github-pull-requests-board/src/components/Card/Card.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/Card.tsx
@@ -16,6 +16,7 @@
 import React, { PropsWithChildren, FunctionComponent } from 'react';
 import { Box, Paper, CardActionArea } from '@material-ui/core';
 import CardHeader from './CardHeader';
+import { Labels } from '../../utils/types';
 
 type Props = {
   title: string;
@@ -25,6 +26,7 @@ type Props = {
   authorName: string;
   authorAvatar?: string;
   repositoryName: string;
+  labels?: Labels[];
 };
 
 const Card: FunctionComponent<Props> = (props: PropsWithChildren<Props>) => {
@@ -36,6 +38,7 @@ const Card: FunctionComponent<Props> = (props: PropsWithChildren<Props>) => {
     authorName,
     authorAvatar,
     repositoryName,
+    labels,
     children,
   } = props;
 
@@ -51,6 +54,7 @@ const Card: FunctionComponent<Props> = (props: PropsWithChildren<Props>) => {
               authorName={authorName}
               authorAvatar={authorAvatar}
               repositoryName={repositoryName}
+              labels={labels}
             />
             {children}
           </Box>

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 import React, { FunctionComponent } from 'react';
-import { Typography, Box } from '@material-ui/core';
+import { Typography, Box, Chip } from '@material-ui/core';
 import { getElapsedTime } from '../../utils/functions';
 import { UserHeader } from '../UserHeader';
+import { Labels } from '../../utils/types';
+import { useFormClasses } from './styles';
 
 type Props = {
   title: string;
@@ -25,9 +27,12 @@ type Props = {
   authorName: string;
   authorAvatar?: string;
   repositoryName: string;
+  labels?: Labels[];
 };
 
 const CardHeader: FunctionComponent<Props> = (props: Props) => {
+  const classes = useFormClasses();
+
   const {
     title,
     createdAt,
@@ -35,6 +40,7 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
     authorName,
     authorAvatar,
     repositoryName,
+    labels,
   } = props;
 
   return (
@@ -57,6 +63,15 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
             Last update: <strong>{getElapsedTime(updatedAt)}</strong>
           </Typography>
         )}
+      </Box>
+      <Box display="flex" alignItems="center" flexWrap="wrap" paddingTop={1}>
+        {labels?.map(data => {
+          return (
+            <li key={data.id} className={classes.labelItem}>
+              <Chip color="primary" label={data.name} size="small" />
+            </li>
+          );
+        })}
       </Box>
     </>
   );

--- a/plugins/github-pull-requests-board/src/components/Card/styles.ts
+++ b/plugins/github-pull-requests-board/src/components/Card/styles.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles } from '@material-ui/core';
+
+export const useFormClasses = makeStyles(() => ({
+  labelItem: {
+    display: 'flex',
+    position: 'relative',
+    boxSizing: 'border-box',
+    textAlign: 'left',
+    alignItems: 'center',
+    paddingTop: 2,
+    paddingBottom: 2,
+    justifyContent: 'flex-start',
+    textDecoration: 'none',
+    paddingLeft: 2,
+    paddingRight: 2,
+  },
+  tagBox: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    maxWidth: 750,
+  },
+}));

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -107,6 +107,7 @@ const EntityTeamPullRequestsCard = (props: EntityTeamPullRequestsCardProps) => {
                     latestReviews,
                     repository,
                     isDraft,
+                    labels,
                   },
                   index,
                 ) =>
@@ -128,6 +129,7 @@ const EntityTeamPullRequestsCard = (props: EntityTeamPullRequestsCardProps) => {
                       reviews={latestReviews.nodes}
                       repositoryName={repository.name}
                       isDraft={isDraft}
+                      labels={labels.nodes}
                     />
                   ),
               )}

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -99,6 +99,7 @@ const EntityTeamPullRequestsContent = (
                     latestReviews,
                     repository,
                     isDraft,
+                    labels,
                   },
                   index,
                 ) =>
@@ -120,6 +121,7 @@ const EntityTeamPullRequestsContent = (
                       reviews={latestReviews.nodes}
                       repositoryName={repository.name}
                       isDraft={isDraft}
+                      labels={labels.nodes}
                     />
                   ),
               )}

--- a/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
@@ -19,7 +19,7 @@ import {
   getChangeRequests,
   getCommentedReviews,
 } from '../../utils/functions';
-import { Reviews, Author } from '../../utils/types';
+import { Reviews, Author, Labels } from '../../utils/types';
 import { Card } from '../Card';
 import { UserHeaderList } from '../UserHeaderList';
 
@@ -32,6 +32,7 @@ type Props = {
   reviews: Reviews;
   repositoryName: string;
   isDraft: boolean;
+  labels?: Labels[];
 };
 
 const PullRequestCard: FunctionComponent<Props> = (props: Props) => {
@@ -44,6 +45,7 @@ const PullRequestCard: FunctionComponent<Props> = (props: Props) => {
     reviews,
     repositoryName,
     isDraft,
+    labels,
   } = props;
 
   const approvedReviews = getApprovedReviews(reviews);
@@ -61,6 +63,7 @@ const PullRequestCard: FunctionComponent<Props> = (props: Props) => {
       authorAvatar={author.avatarUrl}
       repositoryName={repositoryName}
       prUrl={url}
+      labels={labels}
     >
       {!!approvedReviews.length && (
         <UserHeaderList

--- a/plugins/github-pull-requests-board/src/utils/types.tsx
+++ b/plugins/github-pull-requests-board/src/utils/types.tsx
@@ -75,6 +75,11 @@ export type Repository = {
   };
 };
 
+export type Labels = {
+  id: string;
+  name: string;
+};
+
 export type PullRequest = {
   id: string;
   repository: Repository;
@@ -83,6 +88,9 @@ export type PullRequest = {
   lastEditedAt: string;
   latestReviews: {
     nodes: Reviews;
+  };
+  labels: {
+    nodes: Labels[];
   };
   mergeable: boolean;
   state: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added view of labels belonging to PRs to the PR card

<img width="971" alt="image" src="https://user-images.githubusercontent.com/55829559/231584285-87e6607a-09cb-4ab8-9015-c76c6e68805d.png">
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
