### PR TITLE
Fix import paths and examples in catalog-backend-module-puppetdb

### DIFF
--- a/.changeset/rare-elephants-arrive.md
+++ b/.changeset/rare-elephants-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-puppetdb': patch
+---
+
+Fixes import paths and updates documentation

--- a/microsite/data/plugins/catalog-backend-module-puppetdb.yaml
+++ b/microsite/data/plugins/catalog-backend-module-puppetdb.yaml
@@ -5,7 +5,7 @@ authorUrl: https://github.com/tdabasinskas
 category: Configuration Management
 description: Import nodes from PuppetDB into Backstage as Resource Entities
 documentation: https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-puppetdb/README.md
-iconUrl: https://avatars.githubusercontent.com/u/234268?s=200&v=4
+iconUrl: /img/puppet.png
 npmPackageName: '@backstage/plugin-catalog-backend-module-puppetdb'
 tags:
   - puppet

--- a/plugins/catalog-backend-module-puppetdb/README.md
+++ b/plugins/catalog-backend-module-puppetdb/README.md
@@ -31,9 +31,9 @@ Update the catalog plugin initialization in your backend to add the provider and
 +      schedule: env.scheduler.createScheduledTaskRunner({
 +        frequency: { minutes: 10 },
 +        timeout: { minutes: 50 },
-+        initialDelay: { seconds: 15}
++        initialDelay: { seconds: 15 }
 +      }),
-+    });
++    })
 +  );
 ```
 
@@ -67,7 +67,7 @@ of overriding the default transformer.
 export const customResourceTransformer: ResourceTransformer = async (
   node,
   config,
-): Promise<GroupEntity | undefined> => {
+): Promise<ResourceEntity | undefined> => {
   // Transformations may change namespace, owner, change entity naming pattern, add labels, annotations, etc.
 
   // Create the Resource Entity on your own, or wrap the default transformer
@@ -77,14 +77,16 @@ export const customResourceTransformer: ResourceTransformer = async (
 
 2. Configure the provider with the transformer:
 
-```ts
-const puppetDbEntityProvider = PuppetDbEntityProvider.fromConfig(env.config, {
-  logger: env.logger,
-  schedule: env.scheduler.createScheduledTaskRunner({
-    frequency: { minutes: 10 },
-    timeout: { minutes: 50 },
-    initialDelay: { seconds: 15 },
-  }),
-  transformer: customResourceTransformer,
-});
+```diff
+  builder.addEntityProvider(
+    PuppetDbEntityProvider.fromConfig(env.config, {
+      logger: env.logger,
++     transformer: customResourceTransformer,
+      schedule: env.scheduler.createScheduledTaskRunner({
+        frequency: { minutes: 10 },
+        timeout: { minutes: 50 },
+        initialDelay: { seconds: 15 }
+      }),
+    })
+  );
 ```

--- a/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProvider.test.ts
@@ -28,7 +28,7 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   ResourceEntity,
-} from '@backstage/catalog-model/';
+} from '@backstage/catalog-model';
 import { DEFAULT_ENTITY_OWNER, ENDPOINT_NODES } from '../puppet/constants';
 
 jest.mock('../puppet/read', () => {

--- a/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProvider.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProvider.ts
@@ -31,7 +31,7 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   Entity,
-} from '@backstage/catalog-model/';
+} from '@backstage/catalog-model';
 import { merge } from 'lodash';
 import { readPuppetNodes } from '../puppet/read';
 import { ENDPOINT_NODES } from '../puppet/constants';

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/read.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/read.ts
@@ -16,7 +16,7 @@
 
 import { PuppetDbEntityProviderConfig } from '../providers';
 import { PuppetNode, ResourceTransformer } from './types';
-import { ResourceEntity } from '@backstage/catalog-model/';
+import { ResourceEntity } from '@backstage/catalog-model';
 import { defaultResourceTransformer } from './transformers';
 import fetch from 'node-fetch';
 import { ResponseError } from '@backstage/errors';


### PR DESCRIPTION
The PR includes fixes for some issues that were missed in #16183:

- The import path for `@backstage/catalog-model` contained an extra trailing slash, which causes issues importing the plugin.
- There were some typos on the examples provided in README.

Also, as per the [recommendation](https://github.com/backstage/backstage/pull/17260#discussion_r1160107602) on #17260, I'm adding the logo on the microsite statically not to rely on external URL.

### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
