### PR TITLE
feat(tech-insights) Add option to override description in result renderer

### DIFF
--- a/.changeset/afraid-shirts-train.md
+++ b/.changeset/afraid-shirts-train.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Added the possibility to customize the check description in the scorecard component.
+
+- The `CheckResultRenderer` type now exposes an optional `description` method that allows to overwrite the description with a different string or a React component for a provided check result.
+
+Until now only the `BooleanCheck` element could be overridden, but from now on it's also possible to override the description for a check.
+As an example, the description could change depending on the check result. Refer to the [README](../plugins/tech-insights/README.md#adding-custom-rendering-components) file for more details

--- a/plugins/tech-insights/README.md
+++ b/plugins/tech-insights/README.md
@@ -127,3 +127,26 @@ export const myCustomBooleanRenderer: CheckResultRenderer = {
   ),
 };
 ```
+
+It's also possible to customize the description. Both strings and React components are accepted. As an example, you would like
+to display another information if the check has failed. In such cases, you could do something like the following:
+
+```tsx
+// packages/app/src/components/myCustomBooleanRenderer.tsx
+
+export const myCustomBooleanRenderer: CheckResultRenderer = {
+  type: 'boolean',
+  component: (checkResult: CheckResult) => (
+    <BooleanCheck checkResult={checkResult} />
+  ),
+  description: (checkResult: CheckResult) => (
+    <>
+      {
+        checkResult.result
+          ? checkResult.check.description // In case of success, return the same description
+          : `The check has failed! ${checkResult.check.description}` // Add a prefix text if the check failed
+      }
+    </>
+  ),
+};
+```

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -35,6 +35,7 @@ export type Check = {
 export type CheckResultRenderer = {
   type: string;
   component: (check: CheckResult) => React_2.ReactElement;
+  description?: (check: CheckResult) => string | React_2.ReactElement;
 };
 
 // @public (undocumented)

--- a/plugins/tech-insights/src/components/CheckResultRenderer.tsx
+++ b/plugins/tech-insights/src/components/CheckResultRenderer.tsx
@@ -26,6 +26,7 @@ import { BooleanCheck } from './BooleanCheck';
 export type CheckResultRenderer = {
   type: string;
   component: (check: CheckResult) => React.ReactElement;
+  description?: (check: CheckResult) => string | React.ReactElement;
 };
 
 /**

--- a/plugins/tech-insights/src/components/ScorecardsList/ScorecardsList.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsList/ScorecardsList.tsx
@@ -38,21 +38,29 @@ export const ScorecardsList = (props: { checkResults: CheckResult[] }) => {
 
   return (
     <List>
-      {checkResults.map((result, index) => (
-        <ListItem key={result.check.id}>
-          <ListItemText
-            key={index}
-            primary={result.check.name}
-            secondary={result.check.description}
-            className={classes.listItemText}
-          />
-          {checkResultRenderers
-            .find(({ type }) => type === result.check.type)
-            ?.component(result) ?? (
-            <Alert severity="error">Unknown type.</Alert>
-          )}
-        </ListItem>
-      ))}
+      {checkResults.map((result, index) => {
+        const description = checkResultRenderers.find(
+          renderer => renderer.type === result.check.type,
+        )?.description;
+
+        return (
+          <ListItem key={result.check.id}>
+            <ListItemText
+              key={index}
+              primary={result.check.name}
+              secondary={
+                description ? description(result) : result.check.description
+              }
+              className={classes.listItemText}
+            />
+            {checkResultRenderers
+              .find(({ type }) => type === result.check.type)
+              ?.component(result) ?? (
+              <Alert severity="error">Unknown type.</Alert>
+            )}
+          </ListItem>
+        );
+      })}
     </List>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With this PR I'm adding a new extension for the tech-insights.

Currently, the end users were allowed to override the `BooleanCheck` component with something else. In our case, we were showing some extra information while hovering the component using the metadata information (which would be different depending on the check result).

However, we found it more useful to have the ability to also override the description. So I just extended the `CheckResultRenderer` to define a `description` as well (exactly in the same way as it was done for the `component`). But with the difference that it can be a string or a React component. The default renderer will use the same `.check.description` value and, in case the renderer is not found, the fallback will be also the same `.check.description` (same value as before).

So far, I tried this out in our internal Backstage instance, and we were able to use, for example, the `MarkdownContent` component, which allows us to extend the current description with other links depending on the check result. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
