### PR TITLE
fix: amend getSecurityHotspotsUrl to conditionally remove project path

### DIFF
--- a/.changeset/lazy-books-design.md
+++ b/.changeset/lazy-books-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+amend getSecurityHotspotsUrl to conditionally remove project path if sonarqube is self hosted

--- a/plugins/sonarqube/src/api/SonarQubeClient.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.ts
@@ -130,9 +130,9 @@ export class SonarQubeClient implements SonarQubeApi {
           'en-US',
         )}&resolved=false&view=list`,
       getSecurityHotspotsUrl: () =>
-        `${baseUrl}project/security_hotspots?id=${encodeURIComponent(
-          componentKey,
-        )}`,
+        `${baseUrl}${
+          baseUrl === 'https://sonarcloud.io/' ? 'project/' : ''
+        }security_hotspots?id=${encodeURIComponent(componentKey)}`,
     };
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #16950 by amending getSecurityHotspotsUrl to conditionally remove project path if sonarqube is self hosted

Tested against both sonarqube and sonarcloud. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
