### PR TITLE
Support wildcards in GitHub provider organizations

### DIFF
--- a/.changeset/wicked-kangaroos-pull.md
+++ b/.changeset/wicked-kangaroos-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Added support for wildcards in GitHub provider organization names

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -206,7 +206,7 @@ This provider supports multiple organizations via unique provider IDs.
   The hostname of your GitHub Enterprise instance. It must match a host defined in [integrations.github](locations.md).
 - **`organization`**:
   Name of your organization account/workspace.
-  If you want to add multiple organizations, you need to add one provider config each.
+  If you want to add multiple organizations you can either you use wildcards - `*` or add one provider config each.
 - **`validateLocationsExist`** _(optional)_:
   Whether to validate locations that exist before emitting them.
   This option avoids generating locations for catalog info files that do not exist in the source repository.

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -26,7 +26,7 @@ the OAuth apps and their respective scopes.
 - The created GitHub App is private by default, this is most likely what you
   want for github.com but it's recommended to make your application public for
   GitHub Enterprise in order to share application across your GHE organizations.
-- Widcards (`*`) in `organization` are not supported when using GitHub discovery with GitHub App.
+- Wildcards (`*`) in `organization` are not supported when using GitHub discovery with GitHub App.
 
 A GitHub app created with the cli will have read
 access by default. You have to manually update the GitHub App settings in GitHub

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -26,6 +26,7 @@ the OAuth apps and their respective scopes.
 - The created GitHub App is private by default, this is most likely what you
   want for github.com but it's recommended to make your application public for
   GitHub Enterprise in order to share application across your GHE organizations.
+- Widcards (`*`) in `organization` are not supported when using GitHub discovery with GitHub App.
 
 A GitHub app created with the cli will have read
 access by default. You have to manually update the GitHub App settings in GitHub

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -63,6 +63,7 @@ export interface Config {
             host?: string;
             /**
              * (Required) Name of your organization account/workspace.
+             * You can use wildcards - `*` - to automatically search for organizations.
              */
             organization: string;
             /**
@@ -128,6 +129,7 @@ export interface Config {
               host?: string;
               /**
                * (Required) Name of your organization account/workspace.
+               * You can use wildcards - `*` - to automatically search for organizations.
                */
               organization: string;
               /**

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -31,6 +31,7 @@ import {
   createAddEntitiesOperation,
   createRemoveEntitiesOperation,
   createReplaceEntitiesOperation,
+  getOrganizations,
 } from './github';
 import fetch from 'node-fetch';
 
@@ -472,6 +473,47 @@ describe('github', () => {
       );
 
       await expect(getTeamMembers(graphql, 'a', 'b')).resolves.toEqual(output);
+    });
+  });
+
+  describe('getOrganizations', () => {
+    it('read organizations', async () => {
+      const input: QueryResponse = {
+        viewer: {
+          organizations: {
+            nodes: [
+              {
+                login: 'org1',
+              },
+              {
+                login: 'org2',
+              },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+            },
+          },
+        },
+      };
+
+      const output = {
+        organizations: [
+          {
+            login: 'org1',
+          },
+          {
+            login: 'org2',
+          },
+        ],
+      };
+
+      server.use(
+        graphqlMsw.query('organizations', (_req, res, ctx) =>
+          res(ctx.data(input)),
+        ),
+      );
+
+      await expect(getOrganizations(graphql)).resolves.toEqual(output);
     });
   });
 

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -457,6 +457,7 @@ export async function getOrganizationRepositories(
   const query = `
     query repositories($org: String!, $catalogPathRef: String!, $cursor: String) {
       repositoryOwner(login: $org) {
+        login
         repositories(first: 100, after: $cursor) {
           nodes {
             name

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -45,7 +45,7 @@ type RepositoryOwnerResponse = {
 };
 
 export type OrganizationResponse = {
-  login: string;
+  login?: string;
   membersWithRole?: Connection<GithubUser>;
   team?: GithubTeamResponse;
   teams?: Connection<GithubTeamResponse>;
@@ -140,7 +140,6 @@ export async function getOrganizationUsers(
   const query = `
     query users($org: String!, $email: Boolean!, $cursor: String) {
       organization(login: $org) {
-        login
         membersWithRole(first: 100, after: $cursor) {
           pageInfo { hasNextPage, endCursor }
           nodes {
@@ -191,7 +190,6 @@ export async function getOrganizationTeams(
   const query = `
     query teams($org: String!, $cursor: String) {
       organization(login: $org) {
-        login
         teams(first: 100, after: $cursor) {
           pageInfo { hasNextPage, endCursor }
           nodes {
@@ -269,7 +267,6 @@ export async function getOrganizationTeamsFromUsers(
   const query = `
    query teams($org: String!, $cursor: String, $userLogins: [String!] = "") {
   organization(login: $org) {
-    login
     teams(first: 100, after: $cursor, userLogins: $userLogins) {
       pageInfo {
         hasNextPage
@@ -354,7 +351,6 @@ export async function getOrganizationTeam(
   const query = `
   query teams($org: String!, $teamSlug: String!) {
       organization(login: $org) {
-        login
         team(slug:$teamSlug) {
             slug
             combinedSlug
@@ -461,7 +457,6 @@ export async function getOrganizationRepositories(
   const query = `
     query repositories($org: String!, $catalogPathRef: String!, $cursor: String) {
       repositoryOwner(login: $org) {
-        login
         repositories(first: 100, after: $cursor) {
           nodes {
             name

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -39,18 +39,16 @@ import {
   readProviderConfigs,
   GithubEntityProviderConfig,
 } from './GithubEntityProviderConfig';
-import { getOrganizationRepositories } from '../lib/github';
-import {
-  satisfiesTopicFilter,
-  satisfiesForkFilter,
-  satisfiesVisibilityFilter,
-} from '../lib/util';
 import {
   getOrganizationRepositories,
   getOrganizations,
   RepositoryResponse,
 } from '../lib/github';
-import { satisfiesTopicFilter, satisfiesForkFilter } from '../lib/util';
+import {
+  satisfiesTopicFilter,
+  satisfiesForkFilter,
+  satisfiesVisibilityFilter,
+} from '../lib/util';
 
 import { EventParams, EventSubscriber } from '@backstage/plugin-events-node';
 import { PushEvent, Commit } from '@octokit/webhooks-types';


### PR DESCRIPTION
The Pull Request fixes #16932 by allowing to discover manifest files across multiple GitHub organizations. As per the mentioned issue, that's a quite crucial feature for GHES installations to avoid the need to maintain organization lists manually.

There's one caveat that I couldn't find a way to retrieve the organizations list when using the GitHub App – the organizations query always results in `This endpoint requires you to be authenticated`. That might be related to the fact that the authentication actually requires  `owner` (organization) when creating a token. To avoid introducing breaking changes, we need to initialize a separate client so that it at least works when using static organization name same as before.

I'm open for any suggestions on how to improve the code, so we could have this support for autodiscovery for organizations.

### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
