### PR TITLE
Update plugin author permission docs to match correct usage of createPermissionIntegrationRouter

### DIFF
--- a/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
+++ b/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
@@ -98,12 +98,28 @@ import { add, getAll, getTodo, update } from './todos';
 /* highlight-add-next-line */
 import { add, getAll, getTodo, TodoFilter, update } from './todos';
 import {
-  todosListCreate,
-  todosListUpdate,
+  TODO_LIST_RESOURCE_TYPE,
+  todoListCreatePermission,
+  todoListUpdatePermission,
   /* highlight-add-next-line */
   todoListReadPermission,
-  TODO_LIST_RESOURCE_TYPE,
 } from './permissions';
+
+// ...
+
+const permissionIntegrationRouter = createPermissionIntegrationRouter({
+  /* highlight-remove-next-line */
+  permissions: [todoListCreatePermission, todoListUpdatePermission],
+  /* highlight-add-next-line */
+  permissions: [todoListCreatePermission, todoListUpdatePermission, todoListReadPermission],
+  getResources: async resourceRefs => {
+    return resourceRefs.map(getTodo);
+  },
+  resourceType: TODO_LIST_RESOURCE_TYPE,
+  rules: Object.values(rules),
+});
+
+// ...
 
 /* highlight-add-next-line */
 const transformConditions: ConditionTransformer<TodoFilter> = createConditionTransformer(Object.values(rules));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the current version of the permission framework docs, we direct a plugin author to use the createPermissionIntegrationRouter function only when they would like to add support for conditional decisions. We made an update to this when we implemented metadata aggregation in RBAC, so this is no longer correct. We now require every permission-framework-integrating plugin to use createPermissionIntegrationRouter regardless of whether they support any conditional decisions. This PR adjusts the documentation so that this is now correctly reflected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
