### PR TITLE
[PRFC] Improvements to the scaffolder/next buttons UX

### DIFF
--- a/.changeset/rotten-chefs-jog.md
+++ b/.changeset/rotten-chefs-jog.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Improvements to the `scaffolder/next` buttons UX:
+
+- Added padding around the "Create" button in the `Stepper` component
+- Added a button bar that includes the "Cancel" and "Start Over" buttons to the `OngoingTask` component. The state of these buttons match their existing counter parts in the Context Menu
+- Added a "Show Button Bar"/"Hide Button Bar" item to the `ContextMenu` component

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'right',
-    padding: theme.spacing(2),
+    marginTop: theme.spacing(2),
   },
   formWrapper: {
     padding: theme.spacing(2),

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -49,11 +49,11 @@ const useStyles = makeStyles(theme => ({
   backButton: {
     marginRight: theme.spacing(1),
   },
-
   footer: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'right',
+    padding: theme.spacing(2),
   },
   formWrapper: {
     padding: theme.spacing(2),
@@ -216,6 +216,7 @@ export const Stepper = (stepperProps: StepperProps) => {
               </Button>
               <Button
                 variant="contained"
+                color="primary"
                 onClick={() => {
                   props.onCreate(formState);
                   const name =

--- a/plugins/scaffolder/src/next/OngoingTask/ContextMenu.tsx
+++ b/plugins/scaffolder/src/next/OngoingTask/ContextMenu.tsx
@@ -28,6 +28,7 @@ import { useAsync } from '@react-hookz/web';
 import Cancel from '@material-ui/icons/Cancel';
 import Retry from '@material-ui/icons/Repeat';
 import Toc from '@material-ui/icons/Toc';
+import ControlPointIcon from '@material-ui/icons/ControlPoint';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
@@ -36,8 +37,10 @@ import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 type ContextMenuProps = {
   cancelEnabled?: boolean;
   logsVisible?: boolean;
+  buttonBarVisible?: boolean;
   onStartOver?: () => void;
   onToggleLogs?: (state: boolean) => void;
+  onToggleButtonBar?: (state: boolean) => void;
   taskId?: string;
 };
 
@@ -48,8 +51,15 @@ const useStyles = makeStyles<BackstageTheme, { fontColor: string }>(() => ({
 }));
 
 export const ContextMenu = (props: ContextMenuProps) => {
-  const { cancelEnabled, logsVisible, onStartOver, onToggleLogs, taskId } =
-    props;
+  const {
+    cancelEnabled,
+    logsVisible,
+    buttonBarVisible,
+    onStartOver,
+    onToggleLogs,
+    onToggleButtonBar,
+    taskId,
+  } = props;
   const { getPageTheme } = useTheme<BackstageTheme>();
   const pageTheme = getPageTheme({ themeId: 'website' });
   const classes = useStyles({ fontColor: pageTheme.fontColor });
@@ -89,6 +99,14 @@ export const ContextMenu = (props: ContextMenuProps) => {
               <Toc fontSize="small" />
             </ListItemIcon>
             <ListItemText primary={logsVisible ? 'Hide Logs' : 'Show Logs'} />
+          </MenuItem>
+          <MenuItem onClick={() => onToggleButtonBar?.(!buttonBarVisible)}>
+            <ListItemIcon>
+              <ControlPointIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary={buttonBarVisible ? 'Hide Button Bar' : 'Show Button Bar'}
+            />
           </MenuItem>
           <MenuItem onClick={onStartOver}>
             <ListItemIcon>

--- a/plugins/scaffolder/src/next/OngoingTask/OngoingTask.test.tsx
+++ b/plugins/scaffolder/src/next/OngoingTask/OngoingTask.test.tsx
@@ -18,7 +18,7 @@ import { OngoingTask } from './OngoingTask';
 import React from 'react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { act, fireEvent, waitFor, within } from '@testing-library/react';
 import { rootRouteRef } from '../../routes';
 
 jest.mock('react-router-dom', () => ({
@@ -61,7 +61,7 @@ describe('OngoingTask', () => {
       </TestApiProvider>,
       { mountedRoutes: { '/': rootRouteRef } },
     );
-    const { getByText, getByTestId } = rendered;
+    const { getByTestId } = rendered;
 
     await act(async () => {
       fireEvent.click(getByTestId('menu-button'));
@@ -69,7 +69,8 @@ describe('OngoingTask', () => {
     expect(getByTestId('cancel-task')).not.toHaveClass('Mui-disabled');
 
     await act(async () => {
-      fireEvent.click(getByText(cancelOptionLabel));
+      const element = getByTestId('cancel-task');
+      fireEvent.click(within(element).getByText(cancelOptionLabel));
     });
 
     expect(mockScaffolderApi.cancelTask).toHaveBeenCalled();
@@ -79,6 +80,36 @@ describe('OngoingTask', () => {
 
     await waitFor(() => {
       expect(getByTestId('cancel-task')).toHaveClass('Mui-disabled');
+    });
+  });
+
+  it('should trigger cancel api on "Cancel" button click', async () => {
+    const cancelOptionLabel = 'Cancel';
+    const rendered = await renderInTestApp(
+      <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+        <OngoingTask />
+      </TestApiProvider>,
+      { mountedRoutes: { '/': rootRouteRef } },
+    );
+    const { getByTestId } = rendered;
+
+    await act(async () => {
+      fireEvent.click(getByTestId('menu-button'));
+    });
+    expect(getByTestId('cancel-button')).not.toHaveClass('Mui-disabled');
+
+    await act(async () => {
+      const element = getByTestId('cancel-button');
+      fireEvent.click(within(element).getByText(cancelOptionLabel));
+    });
+
+    expect(mockScaffolderApi.cancelTask).toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.click(getByTestId('menu-button'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('cancel-button')).toHaveClass('Mui-disabled');
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PRFC is attempting to provide some improvements to the `scaffolder/next` buttons UX by doing the following:

- Added padding around the "Create" button and set the `color` property to `primary` in the `Stepper` component
- Added a button bar that includes the "Cancel" and "Start Over" buttons to the `OngoingTask` component. The state of these buttons match their existing counter parts in the Context Menu. The button bar is visible when the steps are ongoing. When the steps complete with a happy result the button bar is hidden, if this fails then the button bar is visible much like the logs.
- Added a "Show Button Bar"/"Hide Button Bar" item to the `ContextMenu` component

`Stepper` component:

| Before  | After  |
|---|---|
| ![Stepper Before](https://user-images.githubusercontent.com/67169551/232107671-58b602ba-047a-4092-bfdc-f269d7001d8d.png)   |  ![Stepper After](https://user-images.githubusercontent.com/67169551/232608303-86e572ba-e420-4354-b0eb-0a9e793c4f48.png) |

`OngoingTask` component:

|  Happy Path | Unhappy Path  |
|---|---|
|  ![Happy Path](https://user-images.githubusercontent.com/67169551/232108145-702084da-7ccb-4633-8948-fe48a70f17f3.png) |  ![Unhappy Path](https://user-images.githubusercontent.com/67169551/232108444-95c05882-3766-4ebe-9e5a-53215ded515b.png) 
  
Happy Path video:

https://user-images.githubusercontent.com/67169551/232115783-ccc0ed7c-3414-4abd-8cfe-5146467945cc.mp4

Unhappy Path video:

https://user-images.githubusercontent.com/67169551/232116230-75287d87-c47e-403d-9ab3-defa78574394.mp4

`ContextMenu` component

|  Show  | Hide  |
|---|---|
|  ![Show Button Bar](https://user-images.githubusercontent.com/67169551/232111929-890b953a-7a43-42fb-8dd8-f02c41ac98cb.png) | ![Hide Button Bar](https://user-images.githubusercontent.com/67169551/232113227-77d9f278-e6ed-46da-bcb3-642ccc20d078.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
