### PR TITLE
ci(uffizzi): provide git ref to uffizzi preview-action

### DIFF
--- a/.github/workflows/uffizzi-preview.yaml
+++ b/.github/workflows/uffizzi-preview.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Read Git Ref From Event Object
         id: ref
-        run: echo "GIT_REF=${{ fromJSON(env.EVENT_JSON).head.sha }}" >> $GITHUB_ENV
+        run: echo "GIT_REF=${{ fromJSON(env.EVENT_JSON).pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: DEBUG - Print Job Outputs
         if: ${{ runner.debug }}


### PR DESCRIPTION
Fixes 6ec1b61a37b9aab9e64bec17dbdcae701cff3b28

The JSON path at the previous PR was wrong
and should have been `$.pull_request.head.sha` instead.

Relates-to: PR #16721
Relates-to: PR #17299

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
