### PR TITLE
Fix/get credentials for multiple GitHub apps

### DIFF
--- a/.changeset/good-lions-approve.md
+++ b/.changeset/good-lions-approve.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Bug fix for multiples github apps integration
+Fixed a bug where the wrong credentials would be selected when using multiple GitHub app integrations.

--- a/.changeset/good-lions-approve.md
+++ b/.changeset/good-lions-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Bug fix for multiples github apps integration

--- a/.changeset/sweet-chairs-draw.md
+++ b/.changeset/sweet-chairs-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Bump integration package

--- a/.changeset/sweet-chairs-draw.md
+++ b/.changeset/sweet-chairs-draw.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-github': patch
----
-
-Bump integration package to solve bug on multiple Github Apps credentials.

--- a/.changeset/sweet-chairs-draw.md
+++ b/.changeset/sweet-chairs-draw.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-Bump integration package
+Bump integration package to solve bug on multiple Github Apps credentials.

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -232,13 +232,15 @@ export class GithubAppCredentialsMux {
       ),
     );
 
-    const result = results.find(resultItem => resultItem.credentials);
+    const result = results.find(
+      resultItem => resultItem.credentials?.accessToken,
+    );
     if (result) {
       return result.credentials!.accessToken;
     }
 
     const errors = results.map(r => r.error);
-    const notNotFoundError = errors.find(err => err.name !== 'NotFoundError');
+    const notNotFoundError = errors.find(err => err?.name !== 'NotFoundError');
     if (notNotFoundError) {
       throw notNotFoundError;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When multiples Github Apps was configured for integrations, only the first credential was returned due a mistake on find logic.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
