### PR TITLE
Properly pass on `loadBackendConfig`'s `additionalConfig` option

### DIFF
--- a/.changeset/sour-cooks-repeat.md
+++ b/.changeset/sour-cooks-repeat.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-common': patch
+---
+
+Renamed the `loadBackendConfig` option `additionalConfig` to `additionalConfigs` as an array, and ensured that they get passed on properly.
+
+This is technically breaking, but the [original addition](https://github.com/backstage/backstage/pull/16643) hasn't been released in mainline yet so we are taking this step now as a `patch` change.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -534,7 +534,7 @@ export const legacyPlugin: (
 export function loadBackendConfig(options: {
   logger: LoggerService;
   remote?: LoadConfigOptionsRemote;
-  additionalConfig?: AppConfig;
+  additionalConfigs?: AppConfig[];
   argv: string[];
 }): Promise<Config>;
 

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -34,7 +34,7 @@ export async function loadBackendConfig(options: {
   logger: LoggerService;
   // process.argv or any other overrides
   remote?: LoadConfigOptionsRemote;
-  additionalConfig?: AppConfig;
+  additionalConfigs?: AppConfig[];
   argv: string[];
 }): Promise<Config> {
   const secretEnumerator = await createConfigSecretEnumerator({


### PR DESCRIPTION
Fixes #17380
