### PR TITLE
feat(shortcuts): Added export of AddShortcut & EditShortuct

### DIFF
--- a/.changeset/purple-timers-jog.md
+++ b/.changeset/purple-timers-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+Added EditShortcut and AddShortcut to the export list of components for external use

--- a/plugins/shortcuts/api-report.md
+++ b/plugins/shortcuts/api-report.md
@@ -13,6 +13,49 @@ import { Shortcut as Shortcut_2 } from '@backstage/plugin-shortcuts';
 import { ShortcutApi as ShortcutApi_2 } from '@backstage/plugin-shortcuts';
 import type { StorageApi } from '@backstage/core-plugin-api';
 
+// @public (undocumented)
+export const AddShortcut: ({
+  onClose,
+  anchorEl,
+  api,
+  allowExternalLinks,
+}: AddShortcutProps) => JSX.Element;
+
+// @public
+export interface AddShortcutProps {
+  // (undocumented)
+  allowExternalLinks?: boolean;
+  // (undocumented)
+  anchorEl?: Element;
+  // (undocumented)
+  api: ShortcutApi;
+  // (undocumented)
+  onClose: () => void;
+}
+
+// @public (undocumented)
+export const EditShortcut: ({
+  shortcut,
+  onClose,
+  anchorEl,
+  api,
+  allowExternalLinks,
+}: EditShortcutProps) => JSX.Element;
+
+// @public
+export interface EditShortcutProps {
+  // (undocumented)
+  allowExternalLinks?: boolean;
+  // (undocumented)
+  anchorEl?: Element;
+  // (undocumented)
+  api: ShortcutApi;
+  // (undocumented)
+  onClose: () => void;
+  // (undocumented)
+  shortcut: Shortcut;
+}
+
 // @public
 export class LocalStoredShortcuts implements ShortcutApi_2 {
   constructor(storageApi: StorageApi);

--- a/plugins/shortcuts/src/AddShortcut.tsx
+++ b/plugins/shortcuts/src/AddShortcut.tsx
@@ -41,20 +41,25 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-type Props = {
+/**
+ * AddShortcutProps
+ * Props for the {@link AddShortcut} component.
+ * @public
+ */
+export interface AddShortcutProps {
   onClose: () => void;
   anchorEl?: Element;
   api: ShortcutApi;
 
   allowExternalLinks?: boolean;
-};
+}
 
 export const AddShortcut = ({
   onClose,
   anchorEl,
   api,
   allowExternalLinks,
-}: Props) => {
+}: AddShortcutProps) => {
   const classes = useStyles();
   const alertApi = useApi(alertApiRef);
   const { pathname } = useLocation();

--- a/plugins/shortcuts/src/EditShortcut.tsx
+++ b/plugins/shortcuts/src/EditShortcut.tsx
@@ -41,13 +41,18 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-type Props = {
+/**
+ * EditShortcutProps
+ * Props for the {@link EditShortcut} component.
+ * @public
+ */
+export interface EditShortcutProps {
   shortcut: Shortcut;
   onClose: () => void;
   anchorEl?: Element;
   api: ShortcutApi;
   allowExternalLinks?: boolean;
-};
+}
 
 export const EditShortcut = ({
   shortcut,
@@ -55,7 +60,7 @@ export const EditShortcut = ({
   anchorEl,
   api,
   allowExternalLinks,
-}: Props) => {
+}: EditShortcutProps) => {
   const classes = useStyles();
   const alertApi = useApi(alertApiRef);
   const open = Boolean(anchorEl);

--- a/plugins/shortcuts/src/index.ts
+++ b/plugins/shortcuts/src/index.ts
@@ -20,7 +20,14 @@
  * @packageDocumentation
  */
 
-export { shortcutsPlugin, Shortcuts } from './plugin';
+export {
+  shortcutsPlugin,
+  Shortcuts,
+  AddShortcut,
+  EditShortcut,
+} from './plugin';
 export * from './api';
 export type { Shortcut } from './types';
 export type { ShortcutsProps } from './Shortcuts';
+export type { AddShortcutProps } from './AddShortcut';
+export type { EditShortcutProps } from './EditShortcut';

--- a/plugins/shortcuts/src/plugin.ts
+++ b/plugins/shortcuts/src/plugin.ts
@@ -42,3 +42,21 @@ export const Shortcuts = shortcutsPlugin.provide(
     component: { lazy: () => import('./Shortcuts').then(m => m.Shortcuts) },
   }),
 );
+
+/** @public */
+export const AddShortcut = shortcutsPlugin.provide(
+  createComponentExtension({
+    name: 'AddShortcut',
+    component: { lazy: () => import('./AddShortcut').then(m => m.AddShortcut) },
+  }),
+);
+
+/** @public */
+export const EditShortcut = shortcutsPlugin.provide(
+  createComponentExtension({
+    name: 'EditShortcut',
+    component: {
+      lazy: () => import('./EditShortcut').then(m => m.EditShortcut),
+    },
+  }),
+);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I think was really cool if AddShortcut And EditShortcut Modals and his logic could be available to import from external sources.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
