### PR TITLE
repo-tools: include, exclude, and better path handling

### DIFF
--- a/.changeset/eight-needles-swim.md
+++ b/.changeset/eight-needles-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Package paths provided to `api-reports` and OpenAPI commands will now match any path within the target package.

--- a/.changeset/happy-cycles-retire.md
+++ b/.changeset/happy-cycles-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Added `--include <patterns>` and `--exclude <patterns>` options for `api-reports` command that work based on package names.

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -28,6 +28,8 @@ Options:
   --ci
   --tsc
   --docs
+  --include <pattern>
+  --exclude <pattern>
   -a, --allow-warnings <allowWarningsPaths>
   --allow-all-warnings
   -o, --omit-messages <messageCodes>

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@backstage/cli-common": "workspace:^",
+    "@backstage/cli-node": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.19.27",

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -1161,7 +1161,7 @@ export async function buildDocs({
   documenter.generateFiles();
 }
 
-export async function categorizePackageDirs(packageDirs: any[]) {
+export async function categorizePackageDirs(packageDirs: string[]) {
   const dirs = packageDirs.slice();
   const tsPackageDirs = new Array<string>();
   const cliPackageDirs = new Array<string>();

--- a/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
@@ -27,6 +27,7 @@ import {
 
 import { buildApiReports } from './api-reports';
 import { generateTypeDeclarations } from './generateTypeDeclarations';
+import { PackageGraph } from '@backstage/cli-node';
 
 jest.mock('./generateTypeDeclarations');
 // create mocks for the dependencies of the `buildApiReports` function
@@ -52,6 +53,28 @@ jest
 jest.spyOn(projectPaths, 'resolveTargetRoot').mockImplementation((...path) => {
   return resolvePath(normalize('/root'), ...path);
 });
+jest.spyOn(PackageGraph, 'listTargetPackages').mockResolvedValue([
+  {
+    dir: '/root/packages/package-a',
+    packageJson: { name: 'package-a', version: '0.0.0' },
+  },
+  {
+    dir: '/root/packages/package-b',
+    packageJson: { name: 'package-b', version: '0.0.0' },
+  },
+  {
+    dir: '/root/plugins/plugin-a',
+    packageJson: { name: 'plugin-a', version: '0.0.0' },
+  },
+  {
+    dir: '/root/plugins/plugin-b',
+    packageJson: { name: 'plugin-b', version: '0.0.0' },
+  },
+  {
+    dir: '/root/plugins/plugin-c',
+    packageJson: { name: 'plugin-c', version: '0.0.0' },
+  },
+]);
 
 describe('buildApiReports', () => {
   beforeEach(() => {

--- a/packages/repo-tools/src/commands/api-reports/api-reports.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.ts
@@ -22,7 +22,7 @@ import {
   runCliExtraction,
   buildDocs,
 } from './api-extractor';
-import { getMatchingWorkspacePaths, paths as cliPaths } from '../../lib/paths';
+import { paths as cliPaths, resolvePackagePaths } from '../../lib/paths';
 import { generateTypeDeclarations } from './generateTypeDeclarations';
 
 type Options = {
@@ -48,7 +48,11 @@ export const buildApiReports = async (paths: string[] = [], opts: Options) => {
   const omitMessages = parseArrayOption(opts.omitMessages);
 
   const isAllPackages = !paths?.length;
-  const selectedPackageDirs = await getMatchingWorkspacePaths(paths);
+  const selectedPackageDirs = await resolvePackagePaths({
+    paths,
+    include: opts.include,
+    exclude: opts.exclude,
+  });
 
   if (isAllPackages && !isCiBuild && !isDocsBuild) {
     console.log('');

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -25,6 +25,16 @@ export function registerCommands(program: Command) {
     .option('--tsc', 'executes the tsc compilation before extracting the APIs')
     .option('--docs', 'generates the api documentation')
     .option(
+      '--include <pattern>',
+      'Only include packages matching the provided patterns',
+      (opt: string, opts: string[] = []) => [...opts, ...opt.split(',')],
+    )
+    .option(
+      '--exclude <pattern>',
+      'Exclude package matching the provided patterns',
+      (opt: string, opts: string[] = []) => [...opts, ...opt.split(',')],
+    )
+    .option(
       '-a, --allow-warnings <allowWarningsPaths>',
       'continue processing packages after getting errors on selected packages Allows glob patterns and comma separated values (i.e. packages/core,plugins/core-*)',
     )

--- a/packages/repo-tools/src/commands/openapi/runner.ts
+++ b/packages/repo-tools/src/commands/openapi/runner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getMatchingWorkspacePaths } from '../../lib/paths';
+import { resolvePackagePaths } from '../../lib/paths';
 import pLimit from 'p-limit';
 import { relative as relativePath } from 'path';
 import { paths as cliPaths } from '../../lib/paths';
@@ -23,7 +23,7 @@ export async function runner(
   paths: string[],
   command: (dir: string) => Promise<void>,
 ) {
-  const packages = await getMatchingWorkspacePaths(paths);
+  const packages = await resolvePackagePaths({ paths });
   const limit = pLimit(5);
 
   const resultsList = await Promise.all(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9472,6 +9472,7 @@ __metadata:
     "@apidevtools/swagger-parser": ^10.1.0
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
+    "@backstage/cli-node": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     "@manypkg/get-packages": ^1.1.3


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #16903

This introduces both `--include` and `--exclude` flags for the `api-reports` command. For all commands that accept path options it is now also possible to provide a path deeper in the package, for example `packages/cli/package.json` will build the report for `packages/cli`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
