### PR TITLE
Add missing createPermissionIntegrationRouter call

### DIFF
--- a/.changeset/sour-bulldogs-bow.md
+++ b/.changeset/sour-bulldogs-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-playlist-backend': minor
+---
+
+Exposes the announcements plugin's permissions in a metadata endpoint.

--- a/plugins/playlist-backend/src/service/router.ts
+++ b/plugins/playlist-backend/src/service/router.ts
@@ -112,6 +112,7 @@ export async function createRouter(
   };
 
   const permissionIntegrationRouter = createPermissionIntegrationRouter({
+    permissions: Object.values(permissions),
     getResources: resourceRefs =>
       Promise.all(resourceRefs.map(ref => dbHandler.getPlaylist(ref))),
     resourceType: PLAYLIST_LIST_RESOURCE_TYPE,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We (the permission framework maintainers) updated the correct usage of createPermissionIntegrationRouter, but the docs remained outdated. As part of fixing the docs (https://github.com/backstage/backstage/pull/17388) we're making PRs to help fix the issue in community plugins as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
