### PR TITLE
Feature: Profile framework that allows the mapping of Custom Resources to corresponding K8's clusters

### DIFF
--- a/.changeset/shaggy-singers-fry.md
+++ b/.changeset/shaggy-singers-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+`Kubernetes ClusterDetails` type now has an optional `customResourceProfile` field.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -36,6 +36,7 @@ kubernetes:
             - group: 'argoproj.io'
               apiVersion: 'v1alpha1'
               plural: 'rollouts'
+          customResourceProfile: build # matches with collection name provided in kubernetes.customResourceProfiles
         - url: http://127.0.0.2:9999
           name: aws-cluster-1
           authProvider: 'aws'
@@ -45,6 +46,18 @@ kubernetes:
       skipTLSVerify: true
       skipMetricsLookup: true
       exposeDashboard: true
+  customResourceProfiles:
+    build:
+      - group: 'sample.io'
+        apiVersion: 'v1alpha1'
+        plural: 'rollouts'
+      - group: 'sample.io'
+        apiVersion: 'v1alpha1'
+        plural: 'fallouts'
+    run:
+      - group: 'othersample.io'
+        apiVersion: 'v1alpha1'
+        plural: 'tests'
 ```
 
 ### `serviceLocatorMethod`
@@ -275,9 +288,13 @@ that the TLS certificate presented by the API server is signed by this CA. Note
 that only clusters defined in the app-config via the [`config`](#config)
 cluster locator method can be configured in this way.
 
+##### `clusters.\*.customResourceProfile` (optional)
+
+Configures which [`customResources`](#customResourceProfiles-optional) profile name to use when returning an entity's kubernetes resources belonging to the cluster. Expected value is a single string.
+
 ##### `clusters.\*.customResources` (optional)
 
-Configures which [custom resources][3] to look for when returning an entity's
+Configures which [`customResources`][3] to look for when returning an entity's
 Kubernetes resources belonging to the cluster. Same specification as [`customResources`](#customresources-optional)
 
 #### `gke`
@@ -360,6 +377,8 @@ Kubernetes resources.
 
 - The optional `kubernetes.customResources` property is overrode by `customResources` at the [clusters level](#clusterscustomresources-optional).
 
+- THe optional `kubernetes.customResources` property is overrode by 'customResourceProfile' at the [clusters level](#clusterscustomresourceprofile-optional)
+
 Defaults to empty array. Example:
 
 ```yaml
@@ -402,6 +421,34 @@ For more information on which API versions are supported by your cluster, please
 view the Kubernetes API docs for your Kubernetes version (e.g.
 [API Groups for v1.22](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#-strong-api-groups-strong-)
 )
+
+### `customResourceProfiles` (optional)
+
+Defines a collection of `customResources` under a profile name that can be used at the [clusters level](#clusterscustomresourceprofile-optional)
+
+Example:
+
+```yaml
+kubernetes:
+  customResourceProfiles:
+    build:
+      - group: 'sample.io'
+        apiVersion: 'v1alpha1'
+        plural: 'rollouts'
+      - group: 'sample.io'
+        apiVersion: 'v1alpha1'
+        plural: 'fallouts'
+    run:
+      - group: 'othersample.io'
+        apiVersion: 'v1alpha1'
+        plural: 'tests'
+```
+
+A profile name defined as a string such as 'build' or 'run' in the example above represents a collection with the same specifications as [`customresources`](#customresources-optional)
+
+**Notes:**
+
+- This configuration overrides the optional [`kubernetes.customResources`](#customresources-optional) property
 
 ### `objectTypes` (optional)
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -62,6 +62,7 @@ export interface ClusterDetails {
   caData?: string | undefined;
   // (undocumented)
   caFile?: string | undefined;
+  customResourceProfile?: string;
   customResources?: CustomResourceMatcher[];
   dashboardApp?: string;
   dashboardParameters?: JsonObject;

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -51,6 +51,11 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
         if (c.has('dashboardParameters')) {
           clusterDetails.dashboardParameters = c.get('dashboardParameters');
         }
+        if (c.getOptionalString('customResourceProfile')) {
+          clusterDetails.customResourceProfile = c.getOptionalString(
+            'customResourceProfile',
+          );
+        }
 
         switch (authProvider) {
           case 'google': {

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -95,7 +95,6 @@ const cluster1 = {
       plural: 'some-crd-only-on-this-cluster',
     },
   ],
-  customResourceProfile: 'build',
 };
 
 const cluster2 = {
@@ -108,7 +107,6 @@ const cluster2 = {
       plural: 'crd-two-plural',
     },
   ],
-  customResourceProfile: 'run',
 };
 
 const config = new ConfigReader({
@@ -1010,7 +1008,7 @@ describe('getCustomResourcesByEntity', () => {
       },
     ]);
 
-    await sut.getCustomResourcesByEntity({
+    const response = await sut.getCustomResourcesByEntity({
       entity,
       auth: {},
       customResources: [
@@ -1031,10 +1029,23 @@ describe('getCustomResourcesByEntity', () => {
     ).toBe('parameter-crd.example.com');
   });
 
-  it.skip('retrieves objects for one cluster defined by CRD profiles in the config', async () => {
+  it('prioritizes retrieving objects for one cluster defined by CRD profiles in the config', async () => {
     getClustersByEntity.mockImplementation(() =>
       Promise.resolve({
-        clusters: [cluster1],
+        clusters: [
+          {
+            name: 'profile-cluster-1',
+            authProvider: 'serviceAccount',
+            customResources: [
+              {
+                group: 'some-other-crd.example.com',
+                apiVersion: 'v1alpha1',
+                plural: 'some-crd-only-on-this-cluster',
+              },
+            ],
+            customResourceProfile: 'build',
+          },
+        ],
       }),
     );
 

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -269,12 +269,12 @@ export class KubernetesFanOutHandler {
     const namespace =
       entity.metadata?.annotations?.['backstage.io/kubernetes-namespace'];
 
-    let customResourcesArr = customResources;
+    let customResourcesProfileArr: CustomResource[];
 
     return Promise.all(
       clusterDetailsDecoratedForAuth.map(clusterDetailsItem => {
         if (clusterDetailsItem.customResourceProfile) {
-          const profileCustomResources = this.config
+          customResourcesProfileArr = this.config
             .getConfig(`kubernetes.customResourceProfiles`)
             .getConfigArray(`${clusterDetailsItem.customResourceProfile}`)
             .map(
@@ -285,10 +285,8 @@ export class KubernetesFanOutHandler {
                   plural: c.getString('plural'),
                 } as CustomResource),
             );
-          // cant rename a parameter so need to find another way to prioritize this......
-          customResourcesArr = profileCustomResources;
         }
-        // console.log('im here');
+
         return this.fetcher
           .fetchObjectsForService({
             serviceId: entityName,
@@ -296,8 +294,9 @@ export class KubernetesFanOutHandler {
             objectTypesToFetch: objectTypesToFetch,
             labelSelector,
             customResources: (
-              customResourcesArr ||
+              customResources ||
               clusterDetailsItem.customResources ||
+              customResourcesProfileArr ||
               this.customResources
             ).map(c => ({
               ...c,

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -209,6 +209,12 @@ export interface ClusterDetails {
    * Kubernetes resources.
    */
   customResources?: CustomResourceMatcher[];
+  /**
+   * Specifies which profile name to use when returning an entity's
+   * Kubernetes resources. A profile is a name given to a CustomResourceMatcher[].
+   * @see CustomResourceMatcher
+   */
+  customResourceProfile?: string;
 }
 
 /**
@@ -249,6 +255,7 @@ export interface KubernetesObjectsProviderOptions {
   serviceLocator: KubernetesServiceLocator;
   customResources: CustomResource[];
   objectTypesToFetch?: ObjectToFetch[];
+  config: Config;
 }
 
 /**

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -255,7 +255,6 @@ export interface KubernetesObjectsProviderOptions {
   serviceLocator: KubernetesServiceLocator;
   customResources: CustomResource[];
   objectTypesToFetch?: ObjectToFetch[];
-  config: Config;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!
     
Introducing a first-class notion of `profile` that allows for the mapping of `customResources` defined in the `app-config` to corresponding clusters. This is achieved by defining a `profile name` at the cluster level that is defined alongside `customResourceProfiles` in your `app-config` like in the following example:
```yaml
kubernetes:
  customResourceProfiles:
    build:
      - group: 'argoproj.io'
        apiVersion: 'v1alpha1'
        plural: 'rollouts'
    run:
      - group: 'sample.io'
        apiVersion: 'v1alpha1'
        plural: 'tests'
  serviceLocatorMethod:
    type: 'multiTenant'
  clusterLocatorMethods:
    - type: 'config'
      clusters:
        - url: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
          name: kind
          authProvider: 'serviceAccount'
          skipTLSVerify: true
          skipMetricsLookup: true
          serviceAccountToken: ${KUBERNETES_SERVICE_TOKEN}
          customResourceProfile: build
```
Here the kind cluster has a `customResourceProfile` field that is the profile name `build` that we want to use for this cluster. `Kubernetes.customResourceProfiles` in our config defines which customResources belong to that profile name and is later mapped into the clusters details in the `KubernetesFanOutHandler`

This resolves issue #15994 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
