### PR TITLE
workflows: add placeholder workflows to be able to require status checks

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,0 +1,22 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: CI Void
+on:
+  pull_request:
+    paths:
+      - 'microsite/**'
+
+jobs:
+  # The verify jobs runs all the verification that doesn't require a
+  # diff towards master, since it takes some time to fetch that.
+  noop:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    name: Verify ${{ matrix.node-version }}
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  # NOTE: If you change these you must update ci-noop.yml as well
   pull_request:
     paths-ignore:
       - 'microsite/**'
@@ -23,6 +24,7 @@ jobs:
       CI: true
       NODE_OPTIONS: --max-old-space-size=4096
 
+    name: Verify ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/verify_accessibility-noop.yml
+++ b/.github/workflows/verify_accessibility-noop.yml
@@ -1,0 +1,21 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: Accessibility
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - 'lighthouserc.js'
+      - '.github/workflows/verify_accessibility_core.yml'
+      - 'plugins/catalog/**'
+      - 'plugins/techdocs/**'
+      - 'plugins/scaffolder/**'
+      - 'plugins/search/**'
+
+jobs:
+  noop:
+    name: Accessibility
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/verify_accessibility.yml
+++ b/.github/workflows/verify_accessibility.yml
@@ -1,5 +1,6 @@
-name: Verify Accessibility Core features
+name: Accessibility
 on:
+  # NOTE: If you change these you must update verify_accessibility_core-noop.yml as well
   pull_request:
     branches: [master]
     paths:
@@ -12,7 +13,7 @@ on:
 
 jobs:
   lhci:
-    name: Lighthouse
+    name: Accessibility
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/verify_e2e-kubernetes-noop.yml
+++ b/.github/workflows/verify_e2e-kubernetes-noop.yml
@@ -1,0 +1,22 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: E2E Kubernetes Void
+on:
+  pull_request:
+    paths-ignore:
+      - 'yarn.lock'
+      - '.github/workflows/verify_kubernetes.yml'
+      - 'packages/backend-common/src/**'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    name: Kubernetes ${{ matrix.node-version }}
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/verify_e2e-kubernetes.yml
+++ b/.github/workflows/verify_e2e-kubernetes.yml
@@ -1,5 +1,6 @@
-name: E2E Test Kubernetes
+name: E2E Kubernetes
 on:
+  # NOTE: If you change these you must update verify_kubernetes-noop.yml as well
   pull_request:
     paths:
       - 'yarn.lock'
@@ -18,6 +19,7 @@ jobs:
       CI: true
       KUBERNETES_TESTS: true
 
+    name: Kubernetes ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/verify_e2e-linux-noop.yml
+++ b/.github/workflows/verify_e2e-linux-noop.yml
@@ -1,0 +1,27 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: E2E Linux Void
+on:
+  pull_request:
+    paths:
+      - '.changeset/**'
+      - 'contrib/**'
+      - 'docs/**'
+      - 'microsite/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    name: E2E Linux ${{ matrix.node-version }}
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -1,5 +1,6 @@
-name: E2E Test Linux
+name: E2E Linux
 on:
+  # NOTE: If you change these you must update verify_e2e-linux-noop.yml as well
   pull_request:
     paths-ignore:
       - '.changeset/**'
@@ -13,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -30,14 +31,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         node-version: [16.x, 18.x]
 
     env:
       CI: true
       NODE_OPTIONS: --max-old-space-size=4096
 
-    name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: E2E Linux ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -1,4 +1,4 @@
-name: E2E Test Techdocs
+name: E2E Techdocs
 on:
   pull_request:
     paths:
@@ -24,6 +24,7 @@ jobs:
       CI: true
       NODE_OPTIONS: --max-old-space-size=4096
 
+    name: Techdocs
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/verify_e2e-windows-noop.yml
+++ b/.github/workflows/verify_e2e-windows-noop.yml
@@ -1,0 +1,24 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: E2E Windows Void
+on:
+  pull_request:
+    paths-ignore:
+      - 'yarn.lock'
+      - '.github/workflows/verify_e2e-windows.yml'
+      - 'packages/cli/**'
+      - 'packages/e2e-test/**'
+      - 'packages/create-app/**'
+
+jobs:
+  noop:
+    runs-on: windows-2019
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    name: E2E Windows ${{ matrix.node-version }}
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -1,8 +1,9 @@
 # Building on windows is really slow, so this workflow is separate from e2e.yml and only builds on changes
 # to the cli itself. They're more likely to introduce issues on windows, compared to changes to core and yarn.lock.
 
-name: E2E Test Windows
+name: E2E Windows
 on:
+  # NOTE: If you change these you must update verify_e2e-windows-noop.yml as well
   pull_request:
     paths:
       - 'yarn.lock'
@@ -17,18 +18,17 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2019
 
     strategy:
       matrix:
-        os: [windows-2019]
         node-version: [16.x, 18.x]
 
     env:
       CI: true
       NODE_OPTIONS: --max-old-space-size=8192
 
-    name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: E2E Windows ${{ matrix.node-version }}
     steps:
       # In order to have the create-app template function as if it was downloaded from NPM
       # we need to make sure we checkout files with LF line endings only

--- a/.github/workflows/verify_microsite-noop.yml
+++ b/.github/workflows/verify_microsite-noop.yml
@@ -1,0 +1,22 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: Microsite Void
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/verify_microsite-next.yml'
+      - 'microsite/**'
+      - 'docs/**'
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    name: Microsite
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -1,5 +1,6 @@
-name: Verify Microsite Next
+name: Microsite
 on:
+  # NOTE: If you change these you must update verify_microsite-noop.yml as well
   pull_request:
     paths:
       - '.github/workflows/verify_microsite-next.yml'
@@ -19,6 +20,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
       DOCUSAURUS_SSR_CONCURRENCY: 5
 
+    name: Microsite
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/verify_storybook-noop.yml
+++ b/.github/workflows/verify_storybook-noop.yml
@@ -1,0 +1,31 @@
+# NO-OP placeholder that always passes for other paths
+# This is here so that we're able to set the status check as required
+
+name: Storybook Void
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/verify_storybook.yml'
+      - 'storybook/**'
+      - 'packages/config/src/**'
+      - 'packages/theme/src/**'
+      - 'packages/types/src/**'
+      - 'packages/errors/src/**'
+      - 'packages/version-bridge/src/**'
+      - 'packages/test-utils/src/**'
+      - 'packages/core-app-api/src/**'
+      - 'packages/core-plugin-api/src/**'
+      - 'packages/core-components/src/**'
+      - '**/*.stories.tsx'
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    name: Storybook
+    steps:
+      - run: echo NOOP

--- a/.github/workflows/verify_storybook.yml
+++ b/.github/workflows/verify_storybook.yml
@@ -1,5 +1,6 @@
-name: Verify Storybook
+name: Storybook
 on:
+  # NOTE: If you change these you must update verify_storybook-noop.yml as well
   pull_request:
     paths:
       - '.github/workflows/verify_storybook.yml'
@@ -24,6 +25,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: [16.x]
 
+    name: Storybook
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This adds no-op workflows for the most important verification flows. By adding this we can mark these status checks as required in GitHub, and use auto-merge in a safer way.

The no-op flows use path filters that are the inverse of the actual workflow, which we need to keep in sync manually ._.

This is far from optimal ofc, but haven't found any other way to do this for now and would really like to make these status checks required.