### PR TITLE
Small-nit for incorrect capitalisation of circle-token

### DIFF
--- a/plugins/circleci/README.md
+++ b/plugins/circleci/README.md
@@ -42,7 +42,7 @@ proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1
     headers:
-      Circle-Token: ${CIRCLECI_AUTH_TOKEN}
+      circle-Token: ${CIRCLECI_AUTH_TOKEN}
 ```
 
 5. Get and provide a `CIRCLECI_AUTH_TOKEN` as an environment variable (see the [CircleCI docs](https://circleci.com/docs/api/#add-an-api-token)).


### PR DESCRIPTION
In the above mentioned example of proxy, under headers it's mentioned as `Circle-token` but the api call look for `circle-token` hence resulting in 401 error.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
