### PR TITLE
fix(deps): Add missing @rjsf/core in plugin-home

### DIFF
--- a/.changeset/pretty-gifts-greet.md
+++ b/.changeset/pretty-gifts-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Add missing @rjsf/core dependency

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -42,6 +42,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@rjsf/core": "^3.2.1",
     "@rjsf/material-ui": "^3.2.1",
     "@rjsf/utils": "5.6.0",
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6868,6 +6868,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
+    "@rjsf/core": ^3.2.1
     "@rjsf/material-ui": ^3.2.1
     "@rjsf/utils": 5.6.0
     "@testing-library/dom": ^8.0.0


### PR DESCRIPTION
After rolling to v1.13 and #16744 using plugin-home throws the following error:

```console
$ yarn dev
(...)
[0] ERROR in ../../node_modules/@rjsf/material-ui/dist/material-ui.esm.js 1:0-46
[0] Module not found: Error: Can't resolve '@rjsf/core' in '/Users/example/dev/backstage-rm/node_modules/@rjsf/material-ui/dist'
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
