### PR TITLE
feat: support disable get outside font links

### DIFF
--- a/.changeset/modern-yaks-taste.md
+++ b/.changeset/modern-yaks-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': major
+---
+
+Add disableOutsideFonts option to app-config.yaml to support disable get outside font links

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -528,6 +528,16 @@ techdocs:
 This way, all iframes where the host of src attribute is in the
 `sanitizer.allowedIframeHosts` list will be displayed.
 
+It's possible to disable outside font links when your network env is not support to getting those font links. To do this, set the `techdocs.sanitizer.disableOutsideFonts` to be `true` in configuration of your `app-config.yaml`
+
+E.g.
+
+```yaml
+techdocs:
+  sanitizer:
+    disableOutsideFonts: true
+```
+
 ## How to add Mermaid support in TechDocs
 
 To add `Mermaid` support in Techdocs, you can use [`kroki`](https://kroki.io)

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -42,6 +42,12 @@ export interface Config {
        * @visibility frontend
        */
       allowedIframeHosts?: string[];
+
+      /**
+       * Disable outside font links
+       * @visibility frontend
+       */
+      disableOutsideFonts?: boolean;
     };
   };
 }

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
@@ -54,6 +54,7 @@ export const addBaseUrl = ({
       for (const elem of list) {
         if (elem.hasAttribute(attributeName)) {
           const elemAttribute = elem.getAttribute(attributeName);
+
           if (!elemAttribute) return;
 
           // Special handling for SVG images.

--- a/plugins/techdocs/src/reader/transformers/html/hooks/links.ts
+++ b/plugins/techdocs/src/reader/transformers/html/hooks/links.ts
@@ -17,6 +17,7 @@
 const MKDOCS_CSS = /main\.[A-Fa-f0-9]{8}\.min\.css$/;
 const GOOGLE_FONTS = /^https:\/\/fonts\.googleapis\.com/;
 const GSTATIC_FONTS = /^https:\/\/fonts\.gstatic\.com/;
+const OUTSIDE_FONTS = /^https:\/\/fonts\./;
 
 /**
  * Checks whether a node is link or not.
@@ -39,13 +40,29 @@ const isSafe = (node: Element) => {
 };
 
 /**
- * Function that removes unsafe link nodes.
- * @param node - can be any element.
- * @param hosts - list of allowed hosts.
+ * Checks whether a font link is outside or not.
+ * @param node - is an link element.
+ * @returns true when link is google fonts or gstatic fonts.
  */
-export const removeUnsafeLinks = (node: Element) => {
-  if (isLink(node) && !isSafe(node)) {
-    node.remove();
-  }
-  return node;
+const isOutside = (node: Element) => {
+  const href = node?.getAttribute('href') || '';
+  return href.match(OUTSIDE_FONTS);
 };
+
+/**
+ * Function that removes link nodes which (1 or 2)
+ * 1. disableOutsideFonts is set true and link is outside that match OUTSIDE_FONTS
+ * 2. is unsafe links
+ * @param disableOutsideFonts - if disable outside fonts.
+ * @param node - can be any element.
+ */
+export const removeUnsafeLinks =
+  (disableOutsideFonts?: boolean) => (node: Element) => {
+    if (
+      isLink(node) &&
+      ((disableOutsideFonts && isOutside(node)) || !isSafe(node))
+    ) {
+      node.remove();
+    }
+    return node;
+  };

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -42,8 +42,14 @@ export const useSanitizerTransformer = (): Transformer => {
   return useCallback(
     async (dom: Element) => {
       const hosts = config?.getOptionalStringArray('allowedIframeHosts');
+      const disableOutsideFonts = config?.getOptionalBoolean(
+        'disableOutsideFonts',
+      );
 
-      DOMPurify.addHook('beforeSanitizeElements', removeUnsafeLinks);
+      DOMPurify.addHook(
+        'beforeSanitizeElements',
+        removeUnsafeLinks(disableOutsideFonts),
+      );
       const tags = ['link'];
 
       if (hosts) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add `disableOutsideFonts` option to `app-config.yaml` to support disable get outside font links. Some network env can not get google font link such as china

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


<img width="1214" alt="image" src="https://user-images.githubusercontent.com/7720722/234154100-1e4c89a7-e012-4c1e-b8b3-585e58be7aec.png">

