### PR TITLE
Update typing for usage of scaffolder TemplateAction

### DIFF
--- a/.changeset/thick-parents-pump.md
+++ b/.changeset/thick-parents-pump.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Update typing for `RouterOptions::actions` and `ScaffolderActionsExtensionPoint::addActions` to allow any kind of action being assigned to it.

--- a/plugins/scaffolder-backend/alpha-api-report.md
+++ b/plugins/scaffolder-backend/alpha-api-report.md
@@ -91,7 +91,7 @@ export const scaffolderPlugin: (
 
 // @alpha
 export type ScaffolderPluginOptions = {
-  actions?: TemplateAction<any>[];
+  actions?: TemplateAction<any, any>[];
   taskWorkers?: number;
   taskBroker?: TaskBroker;
   additionalTemplateFilters?: Record<string, TemplateFilter>;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -746,7 +746,7 @@ export type OctokitWithPullRequestPluginClient = Octokit & {
 // @public
 export interface RouterOptions {
   // (undocumented)
-  actions?: TemplateAction_2<any>[];
+  actions?: TemplateAction_2<any, any>[];
   // (undocumented)
   additionalTemplateFilters?: Record<string, TemplateFilter>;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -40,7 +40,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export type ScaffolderPluginOptions = {
-  actions?: TemplateAction<any>[];
+  actions?: TemplateAction<any, any>[];
   taskWorkers?: number;
   taskBroker?: TaskBroker;
   additionalTemplateFilters?: Record<string, TemplateFilter>;
@@ -50,7 +50,7 @@ export type ScaffolderPluginOptions = {
 class ScaffolderActionsExtensionPointImpl
   implements ScaffolderActionsExtensionPoint
 {
-  #actions = new Array<TemplateAction<any>>();
+  #actions = new Array<TemplateAction<any, any>>();
 
   addActions(...actions: TemplateAction<any>[]): void {
     this.#actions.push(...actions);

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -98,7 +98,7 @@ export interface RouterOptions {
   database: PluginDatabaseManager;
   catalogClient: CatalogApi;
   scheduler?: PluginTaskScheduler;
-  actions?: TemplateAction<any>[];
+  actions?: TemplateAction<any, any>[];
   /**
    * @deprecated taskWorkers is deprecated in favor of concurrentTasksLimit option with a single TaskWorker
    * @defaultValue 1

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -70,7 +70,7 @@ export const createTemplateAction: <
 // @alpha
 export interface ScaffolderActionsExtensionPoint {
   // (undocumented)
-  addActions(...actions: TemplateAction<any>[]): void;
+  addActions(...actions: TemplateAction<any, any>[]): void;
 }
 
 // @alpha

--- a/plugins/scaffolder-node/src/extensions.ts
+++ b/plugins/scaffolder-node/src/extensions.ts
@@ -23,7 +23,7 @@ import { TemplateAction } from './actions';
  * @alpha
  */
 export interface ScaffolderActionsExtensionPoint {
-  addActions(...actions: TemplateAction<any>[]): void;
+  addActions(...actions: TemplateAction<any, any>[]): void;
 }
 
 /**


### PR DESCRIPTION
Update typing for `RouterOptions::actions` and `ScaffolderActionsExtesionPoint::addActions` to allow any kind of action being assigned to it.

with the changes of #16910 a second type parameter was introduced to `TemplateAction`.
With this the following two methods were producing type errors, when an action was passed with a typed output value:

* RouterOptions::actions
* ScaffolderActionsExtesionPoint::addActions

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
