### PR TITLE
Updated GitHub App Docs to include Commit statuses permission

### DIFF
--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -135,3 +135,4 @@ integration:
   - `Pull requests`: `Read & write`
   - `Issues`: `Read & write`
   - `Workflows`: `Read & write` (if templates include GitHub workflows)
+  - `Commit statuses`: `Read-only`


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the section on GitHub App permission to include that you need `Read-only` permission to `Commit statuses`

This is related to #17465 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
