### PR TITLE
Allow trailing slash in Techdocs navigation

### DIFF
--- a/.changeset/curvy-months-appear.md
+++ b/.changeset/curvy-months-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Re-add the possibility to have trailing slashes in Techdocs navigation.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/useNavigateUrl.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/useNavigateUrl.test.tsx
@@ -40,12 +40,6 @@ describe('resolveUrlToRelative', () => {
     const baseUrl = 'http://localhost:3000/instance';
     expect(resolveUrlToRelative(url, baseUrl)).toBe('/test');
   });
-
-  it('removes trailing slashes on the URL when present', () => {
-    const url = 'http://localhost:3000/test//';
-    const baseUrl = 'http://localhost:3000';
-    expect(resolveUrlToRelative(url, baseUrl)).toBe('/test');
-  });
 });
 
 const Component = ({ to }: { to: string }) => {

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/useNavigateUrl.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/useNavigateUrl.tsx
@@ -32,8 +32,7 @@ export function resolveUrlToRelative(url: string, baseUrl: string) {
 
   const relativeUrl = url
     .replace(appUrlPath, '')
-    // Remove any leading and trailing slashes.
-    .replace(/\/+$/, '')
+    // Remove any leading slashes.
     .replace(/^\/+/, '');
   const parsedUrl = new URL(`http://localhost/${relativeUrl}`);
   return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Closes #17481 

This PR re-adds the possibility to have trailing slashes in Techdocs navigation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
