### PR TITLE
[Test Utils] Add PG 11 and 12 as supported test database targets

### DIFF
--- a/.changeset/backend-like-a-tattoo.md
+++ b/.changeset/backend-like-a-tattoo.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Added `POSTGRES_11` and `POSTGRES_12` as supported test database IDs.

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -169,6 +169,8 @@ export interface TestBackendOptions<
 // @public
 export type TestDatabaseId =
   | 'POSTGRES_13'
+  | 'POSTGRES_12'
+  | 'POSTGRES_11'
   | 'POSTGRES_9'
   | 'MYSQL_8'
   | 'SQLITE_3';

--- a/packages/backend-test-utils/src/database/TestDatabases.test.ts
+++ b/packages/backend-test-utils/src/database/TestDatabases.test.ts
@@ -36,7 +36,7 @@ describe('TestDatabases', () => {
     process.env = OLD_ENV;
   });
 
-  describe('each', () => {
+  describe('each create', () => {
     const dbs = TestDatabases.create();
 
     it.each(dbs.eachSupportedId())(
@@ -56,81 +56,160 @@ describe('TestDatabases', () => {
     );
   });
 
-  itIfDocker('obeys a provided connection string for postgres 13', async () => {
+  describe('each connect', () => {
     const dbs = TestDatabases.create();
-    const { host, port, user, password, stop } = await startPostgresContainer(
-      'postgres:13',
+
+    itIfDocker(
+      'obeys a provided connection string for postgres 13',
+      async () => {
+        const { host, port, user, password, stop } =
+          await startPostgresContainer('postgres:13');
+
+        try {
+          // Leave a mark
+          process.env.BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
+          const input = await dbs.init('POSTGRES_13');
+          await input.schema.createTable('a', table =>
+            table.string('x').primary(),
+          );
+          await input.insert({ x: 'y' }).into('a');
+
+          // Look for the mark
+          const database = input.client.config.connection.database;
+          const output = knexFactory({
+            client: 'pg',
+            connection: { host, port, user, password, database },
+          });
+          // eslint-disable-next-line jest/no-standalone-expect
+          await expect(output.select('x').from('a')).resolves.toEqual([
+            { x: 'y' },
+          ]);
+        } finally {
+          await stop();
+        }
+      },
     );
 
-    try {
-      // Leave a mark
-      process.env.BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
-      const input = await dbs.init('POSTGRES_13');
-      await input.schema.createTable('a', table => table.string('x').primary());
-      await input.insert({ x: 'y' }).into('a');
+    itIfDocker(
+      'obeys a provided connection string for postgres 12',
+      async () => {
+        const { host, port, user, password, stop } =
+          await startPostgresContainer('postgres:12');
 
-      // Look for the mark
-      const database = input.client.config.connection.database;
-      const output = knexFactory({
-        client: 'pg',
-        connection: { host, port, user, password, database },
-      });
-      // eslint-disable-next-line jest/no-standalone-expect
-      await expect(output.select('x').from('a')).resolves.toEqual([{ x: 'y' }]);
-    } finally {
-      await stop();
-    }
-  });
+        try {
+          // Leave a mark
+          process.env.BACKSTAGE_TEST_DATABASE_POSTGRES12_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
+          const input = await dbs.init('POSTGRES_12');
+          await input.schema.createTable('a', table =>
+            table.string('x').primary(),
+          );
+          await input.insert({ x: 'y' }).into('a');
 
-  itIfDocker('obeys a provided connection string for postgres 9', async () => {
-    const dbs = TestDatabases.create();
-    const { host, port, user, password, stop } = await startPostgresContainer(
-      'postgres:9',
+          // Look for the mark
+          const database = input.client.config.connection.database;
+          const output = knexFactory({
+            client: 'pg',
+            connection: { host, port, user, password, database },
+          });
+          // eslint-disable-next-line jest/no-standalone-expect
+          await expect(output.select('x').from('a')).resolves.toEqual([
+            { x: 'y' },
+          ]);
+        } finally {
+          await stop();
+        }
+      },
     );
 
-    try {
-      // Leave a mark
-      process.env.BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
-      const input = await dbs.init('POSTGRES_9');
-      await input.schema.createTable('a', table => table.string('x').primary());
-      await input.insert({ x: 'y' }).into('a');
+    itIfDocker(
+      'obeys a provided connection string for postgres 11',
+      async () => {
+        const { host, port, user, password, stop } =
+          await startPostgresContainer('postgres:11');
 
-      // Look for the mark
-      const database = input.client.config.connection.database;
-      const output = knexFactory({
-        client: 'pg',
-        connection: { host, port, user, password, database },
-      });
-      // eslint-disable-next-line jest/no-standalone-expect
-      await expect(output.select('x').from('a')).resolves.toEqual([{ x: 'y' }]);
-    } finally {
-      await stop();
-    }
-  });
+        try {
+          // Leave a mark
+          process.env.BACKSTAGE_TEST_DATABASE_POSTGRES11_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
+          const input = await dbs.init('POSTGRES_11');
+          await input.schema.createTable('a', table =>
+            table.string('x').primary(),
+          );
+          await input.insert({ x: 'y' }).into('a');
 
-  itIfDocker('obeys a provided connection string for mysql 8', async () => {
-    const dbs = TestDatabases.create();
-    const { host, port, user, password, stop } = await startMysqlContainer(
-      'mysql:8',
+          // Look for the mark
+          const database = input.client.config.connection.database;
+          const output = knexFactory({
+            client: 'pg',
+            connection: { host, port, user, password, database },
+          });
+          // eslint-disable-next-line jest/no-standalone-expect
+          await expect(output.select('x').from('a')).resolves.toEqual([
+            { x: 'y' },
+          ]);
+        } finally {
+          await stop();
+        }
+      },
     );
 
-    try {
-      // Leave a mark
-      process.env.BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING = `mysql://${user}:${password}@${host}:${port}/ignored`;
-      const input = await dbs.init('MYSQL_8');
-      await input.schema.createTable('a', table => table.string('x').primary());
-      await input.insert({ x: 'y' }).into('a');
+    itIfDocker(
+      'obeys a provided connection string for postgres 9',
+      async () => {
+        const { host, port, user, password, stop } =
+          await startPostgresContainer('postgres:9');
 
-      // Look for the mark
-      const database = input.client.config.connection.database;
-      const output = knexFactory({
-        client: 'mysql2',
-        connection: { host, port, user, password, database },
-      });
-      // eslint-disable-next-line jest/no-standalone-expect
-      await expect(output.select('x').from('a')).resolves.toEqual([{ x: 'y' }]);
-    } finally {
-      await stop();
-    }
+        try {
+          // Leave a mark
+          process.env.BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING = `postgresql://${user}:${password}@${host}:${port}`;
+          const input = await dbs.init('POSTGRES_9');
+          await input.schema.createTable('a', table =>
+            table.string('x').primary(),
+          );
+          await input.insert({ x: 'y' }).into('a');
+
+          // Look for the mark
+          const database = input.client.config.connection.database;
+          const output = knexFactory({
+            client: 'pg',
+            connection: { host, port, user, password, database },
+          });
+          // eslint-disable-next-line jest/no-standalone-expect
+          await expect(output.select('x').from('a')).resolves.toEqual([
+            { x: 'y' },
+          ]);
+        } finally {
+          await stop();
+        }
+      },
+    );
+
+    itIfDocker('obeys a provided connection string for mysql 8', async () => {
+      const { host, port, user, password, stop } = await startMysqlContainer(
+        'mysql:8',
+      );
+
+      try {
+        // Leave a mark
+        process.env.BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING = `mysql://${user}:${password}@${host}:${port}/ignored`;
+        const input = await dbs.init('MYSQL_8');
+        await input.schema.createTable('a', table =>
+          table.string('x').primary(),
+        );
+        await input.insert({ x: 'y' }).into('a');
+
+        // Look for the mark
+        const database = input.client.config.connection.database;
+        const output = knexFactory({
+          client: 'mysql2',
+          connection: { host, port, user, password, database },
+        });
+        // eslint-disable-next-line jest/no-standalone-expect
+        await expect(output.select('x').from('a')).resolves.toEqual([
+          { x: 'y' },
+        ]);
+      } finally {
+        await stop();
+      }
+    });
   });
 });

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -24,6 +24,8 @@ import { Knex } from 'knex';
  */
 export type TestDatabaseId =
   | 'POSTGRES_13'
+  | 'POSTGRES_12'
+  | 'POSTGRES_11'
   | 'POSTGRES_9'
   | 'MYSQL_8'
   | 'SQLITE_3';
@@ -49,6 +51,20 @@ export const allDatabases: Record<TestDatabaseId, TestDatabaseProperties> =
       dockerImageName: 'postgres:13',
       connectionStringEnvironmentVariableName:
         'BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING',
+    },
+    POSTGRES_12: {
+      name: 'Postgres 12.x',
+      driver: 'pg',
+      dockerImageName: 'postgres:12',
+      connectionStringEnvironmentVariableName:
+        'BACKSTAGE_TEST_DATABASE_POSTGRES12_CONNECTION_STRING',
+    },
+    POSTGRES_11: {
+      name: 'Postgres 11.x',
+      driver: 'pg',
+      dockerImageName: 'postgres:11',
+      connectionStringEnvironmentVariableName:
+        'BACKSTAGE_TEST_DATABASE_POSTGRES11_CONNECTION_STRING',
     },
     POSTGRES_9: {
       name: 'Postgres 9.x',


### PR DESCRIPTION
## What / Why

Postgres dropped [support](https://www.postgresql.org/support/versioning/) for PG `9.x` in November of 2021.  Currently, the lowest supported version is `11` (although support ends in November of this year).  For those reasons, I'm proposing we add support for at least versions `11` and `12` in backend test utils, so that others can target them for support in their own tests.

_Maybe_ we should consider a formal policy of database support in core plugins, but that's outside the scope of this PR.  ...For that reason, I also did not update any existing `POSTGRES_9` tests to use `11`.  I also did not introduce any deprecations / warnings.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
