### PR TITLE
[Analytics Plugin] Export withAnalyticsContext

### DIFF
--- a/.changeset/nasty-ways-fail.md
+++ b/.changeset/nasty-ways-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Export withAnalyticsContext high order component

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -769,6 +769,15 @@ export function useRouteRefParams<Params extends AnyParams>(
 ): Params;
 
 // @public
+export function withAnalyticsContext<TProps extends {} = any>(
+  Component: React_2.ComponentType<TProps>,
+  attributes: Partial<AnalyticsContextValue>,
+): {
+  (props: TProps): JSX.Element;
+  displayName: string;
+};
+
+// @public
 export function withApis<T extends {}>(
   apis: TypesToApiRefs<T>,
 ): <TProps extends T>(

--- a/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
+++ b/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
@@ -85,19 +85,19 @@ export const AnalyticsContext = (options: {
 
 /**
  * Returns an HOC wrapping the provided component in an Analytics context with
- * the given values.
+ * the given attributes.
  *
  * @param Component - Component to be wrapped with analytics context attributes
- * @param values - Analytics context key/value pairs.
+ * @param attributes - Analytics context key/value pairs.
  * @public
  */
 export function withAnalyticsContext<TProps extends {} = any>(
   Component: React.ComponentType<TProps>,
-  values: Partial<AnalyticsContextValue>,
+  attributes: Partial<AnalyticsContextValue>,
 ) {
   const ComponentWithAnalyticsContext = (props: TProps) => {
     return (
-      <AnalyticsContext attributes={values}>
+      <AnalyticsContext attributes={attributes}>
         <Component {...props} />
       </AnalyticsContext>
     );

--- a/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
+++ b/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
@@ -89,11 +89,11 @@ export const AnalyticsContext = (options: {
  *
  * @param Component - Component to be wrapped with analytics context attributes
  * @param values - Analytics context key/value pairs.
- * @internal
+ * @public
  */
-export function withAnalyticsContext<TProps extends {}>(
+export function withAnalyticsContext<TProps extends {} = any>(
   Component: React.ComponentType<TProps>,
-  values: AnalyticsContextValue,
+  values: Partial<AnalyticsContextValue>,
 ) {
   const ComponentWithAnalyticsContext = (props: TProps) => {
     return (

--- a/packages/core-plugin-api/src/analytics/index.ts
+++ b/packages/core-plugin-api/src/analytics/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { AnalyticsContext } from './AnalyticsContext';
+export { AnalyticsContext, withAnalyticsContext } from './AnalyticsContext';
 export type { AnalyticsContextValue, CommonAnalyticsContext } from './types';
 export { useAnalytics } from './useAnalytics';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `withAnalyticsContext` function exists in the `@backstage/core-plugin-api` package without being exported. This patch intends to put it to use and expose this alternative to use the analytics plugin.

The function had to me altered a bit and because of data it was covered with tests in the same fashion as the `AnalyticsContext` component.

### Design choice

The `withAnalyticsContext` function has a `TProps extends {} = any` to allow receiving components that the type signature cannot be inferred.

```js
export function withAnalyticsContext<TProps extends {} = any>(
  Component: React.ComponentType<TProps>,
  attributes: Partial<AnalyticsContextValue>,
) {
'...'
}
```
This would allow, for example:
```js
withAnalyticsContext(
  ({ prop }) => <div data-testid="prop">{prop}</div>,
  { extension: 'test' },
);
```

But if type analysis needs to be always enforced, the alternative with:
```js
export function withAnalyticsContext<TProps extends {}>(
  Component: React.ComponentType<TProps>,
  attributes: Partial<AnalyticsContextValue>,
) {
'...'
}
```
Would force the function user to write code like, for example:
```js
withAnalyticsContext(
  ({ prop }: { prop: string }) => <div data-testid="prop">{prop}</div>,
  { extension: 'test' },
);
```

The former was chosen just for the ease of usage. If the type error on the typescript compiler was clear I wouldn't see this as an issue but it is not as straight forward as it could be.

I'm not sure what is the Backstage code base policy in this kind of issue and I appreciate a nudge in the right direction =].

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
