### PR TITLE
scaffolder: Fix GitLab repo picker in case workspace is nested subgroup

### DIFF
--- a/.changeset/beige-tigers-matter.md
+++ b/.changeset/beige-tigers-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix case GitLab workspace is a nested subgroup

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -196,7 +196,7 @@ describe('RepoUrlPicker', () => {
           <div data-testid="current-secrets">{JSON.stringify({ secrets })}</div>
         );
       };
-      const { getAllByRole, getByTestId } = await renderInTestApp(
+      const { getAllByRole } = await renderInTestApp(
         <TestApiProvider
           apis={[
             [scmIntegrationsApiRef, mockIntegrationsApi],

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -43,6 +43,11 @@ describe('RepoUrlPicker', () => {
           type: 'bitbucketServer',
           title: 'server.bitbucket.org',
         },
+        {
+          host: 'gitlab.example.com',
+          type: 'gitlab',
+          title: 'gitlab.example.com',
+        },
       ],
     }),
   };
@@ -182,6 +187,59 @@ describe('RepoUrlPicker', () => {
 
       expect(currentSecrets).toEqual({
         secrets: { testKey: 'abc123' },
+      });
+    });
+    it('should call the scmAuthApi with the correct params if workspace is nested', async () => {
+      const SecretsComponent = () => {
+        const { secrets } = useTemplateSecrets();
+        return (
+          <div data-testid="current-secrets">{JSON.stringify({ secrets })}</div>
+        );
+      };
+      const { getAllByRole, getByTestId } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scmIntegrationsApiRef, mockIntegrationsApi],
+            [scmAuthApiRef, mockScmAuthApi],
+            [scaffolderApiRef, mockScaffolderApi],
+          ]}
+        >
+          <SecretsContextProvider>
+            <Form
+              schema={{ type: 'string' }}
+              uiSchema={{
+                'ui:field': 'RepoUrlPicker',
+                'ui:options': {
+                  allowedHosts: ['gitlab.example.com'],
+                  requestUserCredentials: {
+                    secretsKey: 'testKey',
+                  },
+                },
+              }}
+              fields={{ RepoUrlPicker: RepoUrlPicker }}
+            />
+            <SecretsComponent />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+      );
+
+      const [projectInput, repoInput] = getAllByRole('textbox');
+
+      await act(async () => {
+        fireEvent.change(projectInput, {
+          target: { value: 'backstage/mysubgroup' },
+        });
+        fireEvent.change(repoInput, { target: { value: 'repo123' } });
+
+        // need to wait for the debounce to finish
+        await new Promise(resolve => setTimeout(resolve, 600));
+      });
+
+      expect(mockScmAuthApi.getCredentials).toHaveBeenCalledWith({
+        url: 'https://gitlab.example.com/backstage/mysubgroup/repo123',
+        additionalScope: {
+          repoWrite: true,
+        },
       });
     });
     it('should call the scmAuthApi with the correct params if only a project is set', async () => {

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -132,15 +132,15 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
       // That created an issue where GitLab workspace can be nested like groupA/subgroupB
       // when we encodeURi separately and then join, the URL will be malformed and
       // resulting in 400 request error from GitLab API
-      const url = encodeURIComponent(
-        [state.host, workspace, state.repoName].join(),
+      const [encodedHost, encodedRepoName] = [state.host, state.repoName].map(
+        encodeURIComponent,
       );
 
       // user has requested that we use the users credentials
       // so lets grab them using the scmAuthApi and pass through
       // any additional scopes from the ui:options
       const { token } = await scmAuthApi.getCredentials({
-        url,
+        url: `https://${encodedHost}/${workspace}/${encodedRepoName}`,
         additionalScope: {
           repoWrite: true,
           customScopes: requestUserCredentials.additionalScopes,

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -128,17 +128,19 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
         return;
       }
 
-      const [encodedHost, encodedWorkspace, encodedRepoName] = [
-        state.host,
-        workspace,
-        state.repoName,
-      ].map(encodeURIComponent);
+      // previously, we were encodeURI for state.host, workspace and state.repoName separately.
+      // That created an issue where GitLab workspace can be nested like groupA/subgroupB
+      // when we encodeURi separately and then join, the URL will be malformed and
+      // resulting in 400 request error from GitLab API
+      const url = encodeURIComponent(
+        [state.host, workspace, state.repoName].join(),
+      );
 
       // user has requested that we use the users credentials
       // so lets grab them using the scmAuthApi and pass through
       // any additional scopes from the ui:options
       const { token } = await scmAuthApi.getCredentials({
-        url: `https://${encodedHost}/${encodedWorkspace}/${encodedRepoName}`,
+        url,
         additionalScope: {
           repoWrite: true,
           customScopes: requestUserCredentials.additionalScopes,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, we're encodeURI host, workspace and repoName separately and it's fine if the workspace is single level.

however, if it's a nested group like groupA/subgroupB, encoding separately like that before re-creating the URL will make GitLab API unhappy and return 400 error.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
