### PR TITLE
Omit ManagedFields from the Kubernetes resource YAML display.

### DIFF
--- a/.changeset/fifty-laws-count.md
+++ b/.changeset/fifty-laws-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Omit managed fields in the Kubernetes resource YAML display.

--- a/plugins/kubernetes/src/components/KubernetesDrawer/KubernetesDrawer.tsx
+++ b/plugins/kubernetes/src/components/KubernetesDrawer/KubernetesDrawer.tsx
@@ -222,7 +222,16 @@ const KubernetesDrawerContent = <T extends KubernetesDrawerable>({
         />
       </div>
       <div className={classes.content}>
-        {isYaml && <CodeSnippet language="yaml" text={jsYaml.dump(object)} />}
+        {isYaml && (
+          <CodeSnippet
+            language="yaml"
+            text={jsYaml.dump(object, {
+              replacer: (key: string, value: string): any => {
+                return key === 'managedFields' ? undefined : value;
+              },
+            })}
+          />
+        )}
         {!isYaml && (
           <StructuredMetadataTable
             metadata={renderObject(replaceNullsWithUndefined(object))}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The default for the Kubernetes CLI tooling is to omit the managed fields by default, since these are only present for internal machinery. For the Kubernetes resource YAML display, the managed fields take up a ton of space, but are never useful to operators who are interested in the details of their Kubernetes resources.

<img width="481" alt="Screen Shot 2023-04-25 at 10 36 24 am" src="https://user-images.githubusercontent.com/9917/234147079-852b223f-59bf-4bad-8ea6-189d4fe24727.png">

This fixes #14177.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
