### PR TITLE
fix(catalog-backend): db query

### DIFF
--- a/.changeset/fifty-grapes-explode.md
+++ b/.changeset/fifty-grapes-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix a bug in an SQL query where the AND and OR logic is incorrect.

--- a/.changeset/fifty-grapes-explode.md
+++ b/.changeset/fifty-grapes-explode.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Fix a bug in an SQL query where the AND and OR logic is incorrect.
+Fixed a bug in the `queryEntities` endpoint that was causing filtered entities to be included in cursor requests.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -413,17 +413,18 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const isOrderingDescending = sortField.order === 'desc';
 
     if (prevItemOrderFieldValue) {
-      dbQuery.andWhere(
-        'value',
-        isFetchingBackwards !== isOrderingDescending ? '<' : '>',
-        prevItemOrderFieldValue,
-      );
-      dbQuery.orWhere(function nested() {
-        this.where('value', '=', prevItemOrderFieldValue).andWhere(
-          'search.entity_id',
+      dbQuery.andWhere(function nested() {
+        this.where(
+          'value',
           isFetchingBackwards !== isOrderingDescending ? '<' : '>',
-          prevItemUid,
-        );
+          prevItemOrderFieldValue,
+        )
+          .orWhere('value', '=', prevItemOrderFieldValue)
+          .andWhere(
+            'search.entity_id',
+            isFetchingBackwards !== isOrderingDescending ? '<' : '>',
+            prevItemUid,
+          );
       });
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Background
I am working on the paginated catalog table by using the new queryEntities api, I noticed a issue that the api returns entities which are not belong to the Kind I specify, and also I noticed it also returns some duplicated entities as well. So I looked into the source code, and found some suspicious code which probably related to the issue.

### What I found

After I investigated the source code, I found the following sql code which is generated for fetching the cursor based paginated data.

```sql
select *
from  search  inner join  final_entities 
on  search . entity_id  =  final_entities . entity_id 
where  search . key  = 'metadata.name'
  and ((((( search . entity_id  in (select  search . entity_id  from  search  where  key  = 'kind'
  and ( value  = 'documentation')))))))
  and value 
    > 'something'
   or  ( value  = 'something' -- parentheses here might be wrong
  and  search . entity_id 
    > '70661536-64fd-8466-9640-a5485126a63a')
order by  value  asc,  search . entity_id  asc
limit 11
```

so this part looks wired: 
```sql
and value 
    > 'something'
   or  ( value  = 'something' -- parentheses here might be wrong
  and  search . entity_id 
    > '70661536-64fd-8466-9640-a5485126a63a')
```

I don't fully understand the whole logic of this dbQuery, but I feel the parentheses is placed in a wrong place, it probably should be: 
```sql
and ( value  -- parentheses probably should be here
    > 'something'
   or  value  = 'something'
  and  search . entity_id 
    > '70661536-64fd-8466-9640-a5485126a63a')
```

So the full sql should be: 
```sql
select *
from  search  inner join  final_entities 
on  search . entity_id  =  final_entities . entity_id 
where  search . key  = 'metadata.name'
  and ((((( search . entity_id  in (select  search . entity_id  from  search  where  key  = 'kind'
  and ( value  = 'documentation')))))))
  and ( value  -- parentheses probably should be here
    > 'something'
   or  value  = 'something'
  and  search . entity_id 
    > '70661536-64fd-8466-9640-a5485126a63a')
order by  value  asc,  search . entity_id  asc
limit 11
```

After this fix, at least the issue I found was fixed.

### Conclusion
Please note I don't really understand the whole logic of the dbQuery, so it would be great if you guys can verify and test in your side.



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
