### PR TITLE
Track sidebar item clicks by default

### DIFF
--- a/.changeset/unlucky-plants-give.md
+++ b/.changeset/unlucky-plants-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Start capturing sidebar click events in analytics by default.

--- a/packages/core-components/src/layout/Sidebar/Items.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.test.tsx
@@ -15,7 +15,11 @@
  */
 
 import React from 'react';
-import { renderInTestApp } from '@backstage/test-utils';
+import {
+  MockAnalyticsApi,
+  TestApiProvider,
+  renderInTestApp,
+} from '@backstage/test-utils';
 import { createEvent, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import HomeIcon from '@material-ui/icons/Home';
@@ -24,6 +28,7 @@ import { Sidebar } from './Bar';
 import { SidebarItem, SidebarSearchField, SidebarExpandButton } from './Items';
 import { renderHook } from '@testing-library/react-hooks';
 import { makeStyles } from '@material-ui/core/styles';
+import { analyticsApiRef } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles({
   spotlight: {
@@ -31,27 +36,50 @@ const useStyles = makeStyles({
   },
 });
 
+let analyticsApiMock: MockAnalyticsApi;
+
+const handleSidebarItemClick = jest.fn();
+
 async function renderSidebar() {
   const { result } = renderHook(() => useStyles());
 
   await renderInTestApp(
-    <Sidebar>
-      <SidebarSearchField onSearch={() => {}} to="/search" />
-      <SidebarItem text="Home" icon={HomeIcon} to="./" />
-      <SidebarItem
-        icon={CreateComponentIcon}
-        onClick={() => {}}
-        text="Create..."
-        className={result.current.spotlight}
-      />
-      <SidebarExpandButton />
-    </Sidebar>,
+    <TestApiProvider apis={[[analyticsApiRef, analyticsApiMock]]}>
+      <Sidebar>
+        <SidebarSearchField onSearch={() => {}} to="/search" />
+        <SidebarItem text="Home" icon={HomeIcon} to="./" />
+        <SidebarItem
+          icon={CreateComponentIcon}
+          onClick={handleSidebarItemClick}
+          text="Create..."
+          className={result.current.spotlight}
+        />
+        <SidebarItem
+          icon={CreateComponentIcon}
+          to="/docs"
+          onClick={handleSidebarItemClick}
+          text="Docs"
+          className={result.current.spotlight}
+        />
+        <SidebarItem
+          icon={CreateComponentIcon}
+          to="/explore"
+          onClick={handleSidebarItemClick}
+          text="Explore"
+          className={result.current.spotlight}
+          noTrack
+        />
+        <SidebarExpandButton />
+      </Sidebar>
+    </TestApiProvider>,
   );
   await userEvent.hover(screen.getByTestId('sidebar-root'));
 }
 
 describe('Items', () => {
   beforeEach(async () => {
+    jest.clearAllMocks();
+    analyticsApiMock = new MockAnalyticsApi();
     await renderSidebar();
   });
 
@@ -72,6 +100,40 @@ describe('Items', () => {
       expect(
         await screen.findByRole('button', { name: /create/i }),
       ).toHaveStyle(`background-color: transparent`);
+    });
+
+    it('should send button clicks to analytics', async () => {
+      await userEvent.click(
+        await screen.findByRole('button', { name: /create/i }),
+      );
+      expect(handleSidebarItemClick).toHaveBeenCalledTimes(1);
+      expect(analyticsApiMock.getEvents()).toHaveLength(1);
+      expect(analyticsApiMock.getEvents()[0]).toMatchObject({
+        action: 'click',
+        subject: 'Create...',
+        context: { routeRef: 'unknown', pluginId: 'root', extension: 'App' },
+        attributes: { to: '/' },
+      });
+    });
+
+    it('should send link clicks to analytics', async () => {
+      await userEvent.click(await screen.findByRole('link', { name: /docs/i }));
+      expect(handleSidebarItemClick).toHaveBeenCalledTimes(1);
+      expect(analyticsApiMock.getEvents()).toHaveLength(1);
+      expect(analyticsApiMock.getEvents()[0]).toMatchObject({
+        action: 'click',
+        subject: 'Docs',
+        context: { routeRef: 'unknown', pluginId: 'root', extension: 'App' },
+        attributes: { to: '/docs' },
+      });
+    });
+
+    it('should not send clicks to analytics when tracking is disabled', async () => {
+      await userEvent.click(
+        await screen.findByRole('link', { name: /explore/i }),
+      );
+      expect(handleSidebarItemClick).toHaveBeenCalledTimes(1);
+      expect(analyticsApiMock.getEvents()).toHaveLength(0);
     });
   });
   describe('SidebarSearchField', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Capture `SidebarItem` click events into analytics by default, similarly to what we do in the `Link` component.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
