### PR TITLE
config-loader: add ConfigSourceIteratorItem

### DIFF
--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -12,21 +12,9 @@ import { Observable } from '@backstage/types';
 
 // @public
 export interface AsyncConfigSourceIterator
-  extends AsyncIterator<
-    {
-      configs: ConfigSourceData[];
-    },
-    void,
-    void
-  > {
+  extends AsyncIterator<ConfigSourceIteratorItem, void, void> {
   // (undocumented)
-  [Symbol.asyncIterator](): AsyncIterator<
-    {
-      configs: ConfigSourceData[];
-    },
-    void,
-    void
-  >;
+  [Symbol.asyncIterator](): AsyncIterator<ConfigSourceIteratorItem, void, void>;
 }
 
 // @public
@@ -71,6 +59,12 @@ export interface ConfigSource {
 // @public
 export interface ConfigSourceData extends AppConfig {
   path?: string;
+}
+
+// @public
+export interface ConfigSourceIteratorItem {
+  // (undocumented)
+  configs: ConfigSourceData[];
 }
 
 // @public

--- a/packages/config-loader/src/sources/index.ts
+++ b/packages/config-loader/src/sources/index.ts
@@ -38,4 +38,5 @@ export type {
   ConfigSourceData,
   ReadConfigDataOptions,
   AsyncConfigSourceIterator,
+  ConfigSourceIteratorItem,
 } from './types';

--- a/packages/config-loader/src/sources/types.ts
+++ b/packages/config-loader/src/sources/types.ts
@@ -43,12 +43,17 @@ export interface ReadConfigDataOptions {
  * @public
  */
 export interface AsyncConfigSourceIterator
-  extends AsyncIterator<{ configs: ConfigSourceData[] }, void, void> {
-  [Symbol.asyncIterator](): AsyncIterator<
-    { configs: ConfigSourceData[] },
-    void,
-    void
-  >;
+  extends AsyncIterator<ConfigSourceIteratorItem, void, void> {
+  [Symbol.asyncIterator](): AsyncIterator<ConfigSourceIteratorItem, void, void>;
+}
+
+/**
+ * An item returned by {@link AsyncConfigSourceIterator}.
+ *
+ * @public
+ */
+export interface ConfigSourceIteratorItem {
+  configs: ConfigSourceData[];
 }
 
 /**


### PR DESCRIPTION
Cleans up the external types a bit and fixes the microsite build. Skipping changeset since #17209 was just merged.