### PR TITLE
config-loader: rename AsyncConfigSourceIterator -> AsyncConfigSourceGenerator

### DIFF
--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -11,11 +11,13 @@ import { JSONSchema7 } from 'json-schema';
 import { Observable } from '@backstage/types';
 
 // @public
-export interface AsyncConfigSourceIterator
-  extends AsyncIterator<ConfigSourceIteratorItem, void, void> {
-  // (undocumented)
-  [Symbol.asyncIterator](): AsyncIterator<ConfigSourceIteratorItem, void, void>;
-}
+export type AsyncConfigSourceGenerator = AsyncGenerator<
+  {
+    configs: ConfigSourceData[];
+  },
+  void,
+  void
+>;
 
 // @public
 export interface BaseConfigSourcesOptions {
@@ -53,18 +55,12 @@ export type ConfigSchemaProcessingOptions = {
 // @public
 export interface ConfigSource {
   // (undocumented)
-  readConfigData(options?: ReadConfigDataOptions): AsyncConfigSourceIterator;
+  readConfigData(options?: ReadConfigDataOptions): AsyncConfigSourceGenerator;
 }
 
 // @public
 export interface ConfigSourceData extends AppConfig {
   path?: string;
-}
-
-// @public
-export interface ConfigSourceIteratorItem {
-  // (undocumented)
-  configs: ConfigSourceData[];
 }
 
 // @public
@@ -120,7 +116,7 @@ export type ConfigVisibility = 'frontend' | 'backend' | 'secret';
 export class EnvConfigSource implements ConfigSource {
   static create(options: EnvConfigSourceOptions): ConfigSource;
   // (undocumented)
-  readConfigData(): AsyncConfigSourceIterator;
+  readConfigData(): AsyncConfigSourceGenerator;
   // (undocumented)
   toString(): string;
 }
@@ -137,7 +133,7 @@ export type EnvFunc = (name: string) => Promise<string | undefined>;
 export class FileConfigSource implements ConfigSource {
   static create(options: FileConfigSourceOptions): ConfigSource;
   // (undocumented)
-  readConfigData(options?: ReadConfigDataOptions): AsyncConfigSourceIterator;
+  readConfigData(options?: ReadConfigDataOptions): AsyncConfigSourceGenerator;
   // (undocumented)
   toString(): string;
 }
@@ -203,7 +199,7 @@ export class MutableConfigSource implements ConfigSource {
   // (undocumented)
   readConfigData(
     options?: ReadConfigDataOptions | undefined,
-  ): AsyncConfigSourceIterator;
+  ): AsyncConfigSourceGenerator;
   setData(data: JsonObject): void;
   // (undocumented)
   toString(): string;
@@ -234,7 +230,7 @@ export class RemoteConfigSource implements ConfigSource {
   // (undocumented)
   readConfigData(
     options?: ReadConfigDataOptions | undefined,
-  ): AsyncConfigSourceIterator;
+  ): AsyncConfigSourceGenerator;
   // (undocumented)
   toString(): string;
 }
@@ -250,7 +246,7 @@ export interface RemoteConfigSourceOptions {
 export class StaticConfigSource implements ConfigSource {
   static create(options: StaticConfigSourceOptions): ConfigSource;
   // (undocumented)
-  readConfigData(): AsyncConfigSourceIterator;
+  readConfigData(): AsyncConfigSourceGenerator;
   // (undocumented)
   toString(): string;
 }

--- a/packages/config-loader/src/sources/EnvConfigSource.ts
+++ b/packages/config-loader/src/sources/EnvConfigSource.ts
@@ -17,7 +17,7 @@
 import { AppConfig } from '@backstage/config';
 import { assertError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
-import { AsyncConfigSourceIterator, ConfigSource } from './types';
+import { AsyncConfigSourceGenerator, ConfigSource } from './types';
 
 /**
  * Options for {@link EnvConfigSource.create}.
@@ -68,7 +68,7 @@ export class EnvConfigSource implements ConfigSource {
     private readonly env: { [name: string]: string | undefined },
   ) {}
 
-  async *readConfigData(): AsyncConfigSourceIterator {
+  async *readConfigData(): AsyncConfigSourceGenerator {
     const configs = readEnvConfig(this.env);
     yield { configs };
     return;

--- a/packages/config-loader/src/sources/FileConfigSource.ts
+++ b/packages/config-loader/src/sources/FileConfigSource.ts
@@ -19,7 +19,7 @@ import fs from 'fs-extra';
 import { basename, dirname, isAbsolute, resolve as resolvePath } from 'path';
 import yaml from 'yaml';
 import {
-  AsyncConfigSourceIterator,
+  AsyncConfigSourceGenerator,
   ConfigSource,
   ConfigSourceData,
   SubstitutionFunc,
@@ -92,7 +92,7 @@ export class FileConfigSource implements ConfigSource {
   // changes it might be worth refactoring this to avoid duplicate work.
   async *readConfigData(
     options?: ReadConfigDataOptions,
-  ): AsyncConfigSourceIterator {
+  ): AsyncConfigSourceGenerator {
     const signal = options?.signal;
     const configFileName = basename(this.#path);
 

--- a/packages/config-loader/src/sources/MergedConfigSource.ts
+++ b/packages/config-loader/src/sources/MergedConfigSource.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  AsyncConfigSourceIterator,
+  AsyncConfigSourceGenerator,
   ConfigSource,
   ConfigSourceData,
   ReadConfigDataOptions,
@@ -54,7 +54,7 @@ export class MergedConfigSource implements ConfigSource {
 
   async *readConfigData(
     options?: ReadConfigDataOptions,
-  ): AsyncConfigSourceIterator {
+  ): AsyncConfigSourceGenerator {
     const its = this.sources.map(source => source.readConfigData(options));
     const initialResults = await Promise.all(its.map(it => it.next()));
     const configs = initialResults.map((result, i) => {

--- a/packages/config-loader/src/sources/MutableConfigSource.ts
+++ b/packages/config-loader/src/sources/MutableConfigSource.ts
@@ -16,7 +16,7 @@
 
 import { JsonObject } from '@backstage/types';
 import {
-  AsyncConfigSourceIterator,
+  AsyncConfigSourceGenerator,
   ConfigSource,
   ReadConfigDataOptions,
 } from './types';
@@ -64,7 +64,7 @@ export class MutableConfigSource implements ConfigSource {
 
   async *readConfigData(
     options?: ReadConfigDataOptions | undefined,
-  ): AsyncConfigSourceIterator {
+  ): AsyncConfigSourceGenerator {
     let deferredPromise = this.#deferred.promise;
 
     if (this.#currentData !== undefined) {

--- a/packages/config-loader/src/sources/RemoteConfigSource.ts
+++ b/packages/config-loader/src/sources/RemoteConfigSource.ts
@@ -21,7 +21,7 @@ import fetch from 'node-fetch';
 import yaml from 'yaml';
 import { ConfigTransformer, createConfigTransformer } from './transform';
 import {
-  AsyncConfigSourceIterator,
+  AsyncConfigSourceGenerator,
   ConfigSource,
   SubstitutionFunc,
   ReadConfigDataOptions,
@@ -114,7 +114,7 @@ export class RemoteConfigSource implements ConfigSource {
 
   async *readConfigData(
     options?: ReadConfigDataOptions | undefined,
-  ): AsyncConfigSourceIterator {
+  ): AsyncConfigSourceGenerator {
     let data = await this.#load();
 
     yield { configs: [{ data, context: this.#url }] };

--- a/packages/config-loader/src/sources/StaticConfigSource.ts
+++ b/packages/config-loader/src/sources/StaticConfigSource.ts
@@ -16,7 +16,7 @@
 
 import { JsonObject, Observable } from '@backstage/types';
 import {
-  AsyncConfigSourceIterator,
+  AsyncConfigSourceGenerator,
   ConfigSource,
   ReadConfigDataOptions,
 } from './types';
@@ -45,7 +45,7 @@ class StaticObservableConfigSource implements ConfigSource {
 
   async *readConfigData(
     options?: ReadConfigDataOptions | undefined,
-  ): AsyncConfigSourceIterator {
+  ): AsyncConfigSourceGenerator {
     const queue = new Array<JsonObject>();
     let deferred = simpleDefer<void>();
 
@@ -108,7 +108,7 @@ export class StaticConfigSource implements ConfigSource {
     const { data, context = 'static-config' } = options;
     if (!data) {
       return {
-        async *readConfigData(): AsyncConfigSourceIterator {
+        async *readConfigData(): AsyncConfigSourceGenerator {
           yield { configs: [] };
           return;
         },
@@ -121,7 +121,7 @@ export class StaticConfigSource implements ConfigSource {
 
     if (isAsyncIterable(data)) {
       return {
-        async *readConfigData(): AsyncConfigSourceIterator {
+        async *readConfigData(): AsyncConfigSourceGenerator {
           for await (const value of data) {
             yield { configs: [{ data: value, context }] };
           }
@@ -137,7 +137,7 @@ export class StaticConfigSource implements ConfigSource {
     private readonly context: string,
   ) {}
 
-  async *readConfigData(): AsyncConfigSourceIterator {
+  async *readConfigData(): AsyncConfigSourceGenerator {
     yield { configs: [{ data: await this.promise, context: this.context }] };
     return;
   }

--- a/packages/config-loader/src/sources/index.ts
+++ b/packages/config-loader/src/sources/index.ts
@@ -37,6 +37,5 @@ export type {
   ConfigSource,
   ConfigSourceData,
   ReadConfigDataOptions,
-  AsyncConfigSourceIterator,
-  ConfigSourceIteratorItem,
+  AsyncConfigSourceGenerator,
 } from './types';

--- a/packages/config-loader/src/sources/types.ts
+++ b/packages/config-loader/src/sources/types.ts
@@ -38,23 +38,15 @@ export interface ReadConfigDataOptions {
 }
 
 /**
- * The type of the iterator returned by {@link ConfigSource.readConfigData}.
+ * The the generator returned by {@link ConfigSource.readConfigData}.
  *
  * @public
  */
-export interface AsyncConfigSourceIterator
-  extends AsyncIterator<ConfigSourceIteratorItem, void, void> {
-  [Symbol.asyncIterator](): AsyncIterator<ConfigSourceIteratorItem, void, void>;
-}
-
-/**
- * An item returned by {@link AsyncConfigSourceIterator}.
- *
- * @public
- */
-export interface ConfigSourceIteratorItem {
-  configs: ConfigSourceData[];
-}
+export type AsyncConfigSourceGenerator = AsyncGenerator<
+  { configs: ConfigSourceData[] },
+  void,
+  void
+>;
 
 /**
  * A source of configuration data.
@@ -81,7 +73,7 @@ export interface ConfigSourceIteratorItem {
  * @public
  */
 export interface ConfigSource {
-  readConfigData(options?: ReadConfigDataOptions): AsyncConfigSourceIterator;
+  readConfigData(options?: ReadConfigDataOptions): AsyncConfigSourceGenerator;
 }
 
 /**


### PR DESCRIPTION
Yet another followup for #17209 and #17505 😁 

Turns out the existing `AsyncGenerator` type is the smoothest way to declare this.