### PR TITLE
feat: use entity.metadata.title for DomainCard

### DIFF
--- a/.changeset/early-spiders-play.md
+++ b/.changeset/early-spiders-play.md
@@ -1,5 +1,0 @@
----
-'@backstage/catalog-model': patch
----
-
-Add a entity.metadata.title to an example entity for testing purposes

--- a/.changeset/early-spiders-play.md
+++ b/.changeset/early-spiders-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Add a entity.metadata.title to an example entity for testing purposes

--- a/.changeset/khaki-brooms-kiss.md
+++ b/.changeset/khaki-brooms-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Display the title of the entity on the explore card if present, otherwise stick to the name

--- a/packages/catalog-model/examples/domains/artists-domain.yaml
+++ b/packages/catalog-model/examples/domains/artists-domain.yaml
@@ -3,6 +3,7 @@ kind: Domain
 metadata:
   name: artists
   description: Everything related to artists
+  title: Artists
   links:
     - url: http://example.com/domain/artists/
       title: Domain Readme

--- a/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
@@ -51,4 +51,31 @@ describe('<DomainCard />', () => {
       '/catalog/default/domain/artists',
     );
   });
+
+  it('renders a domain card with custom title', async () => {
+    const entity: DomainEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Domain',
+      metadata: {
+        name: 'artists',
+      },
+      spec: {
+        owner: 'guest',
+      },
+    };
+    const { getByText } = await renderInTestApp(
+      <DomainCard entity={entity} title="my Custom Title" />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(getByText('Explore').parentElement).toHaveAttribute(
+      'href',
+      '/catalog/default/domain/artists',
+    );
+    expect(getByText('my Custom Title')).toBeInTheDocument();
+  });
 });

--- a/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
@@ -17,6 +17,7 @@
 import { DomainEntity } from '@backstage/catalog-model';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import { DomainCard } from './DomainCard';
 
@@ -58,13 +59,14 @@ describe('<DomainCard />', () => {
       kind: 'Domain',
       metadata: {
         name: 'artists',
+        title: 'my Custom Title',
       },
       spec: {
         owner: 'guest',
       },
     };
     const { getByText } = await renderInTestApp(
-      <DomainCard entity={entity} title="my Custom Title" />,
+      <DomainCard entity={entity} />,
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
@@ -77,5 +79,6 @@ describe('<DomainCard />', () => {
       '/catalog/default/domain/artists',
     );
     expect(getByText('my Custom Title')).toBeInTheDocument();
+    expect(screen.queryByText('artists')).not.toBeInTheDocument();
   });
 });

--- a/plugins/explore/src/components/DomainCard/DomainCard.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.tsx
@@ -35,7 +35,7 @@ import { LinkButton, ItemCardHeader } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 
 /** @public */
-export const DomainCard = (props: { entity: DomainEntity; title?: string }) => {
+export const DomainCard = (props: { entity: DomainEntity }) => {
   const { entity } = props;
 
   const catalogEntityRoute = useRouteRef(entityRouteRef);
@@ -54,7 +54,7 @@ export const DomainCard = (props: { entity: DomainEntity; title?: string }) => {
     <Card>
       <CardMedia>
         <ItemCardHeader
-          title={props.title ?? entity.metadata.name}
+          title={entity.metadata.title ?? entity.metadata.name}
           subtitle={owner}
         />
       </CardMedia>

--- a/plugins/explore/src/components/DomainCard/DomainCard.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.tsx
@@ -35,7 +35,7 @@ import { LinkButton, ItemCardHeader } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 
 /** @public */
-export const DomainCard = (props: { entity: DomainEntity }) => {
+export const DomainCard = (props: { entity: DomainEntity; title?: string }) => {
   const { entity } = props;
 
   const catalogEntityRoute = useRouteRef(entityRouteRef);
@@ -53,7 +53,10 @@ export const DomainCard = (props: { entity: DomainEntity }) => {
   return (
     <Card>
       <CardMedia>
-        <ItemCardHeader title={entity.metadata.name} subtitle={owner} />
+        <ItemCardHeader
+          title={props.title ?? entity.metadata.name}
+          subtitle={owner}
+        />
       </CardMedia>
       <CardContent>
         {entity.metadata.tags?.length ? (

--- a/plugins/explore/src/components/EntityCard/EntityCard.test.tsx
+++ b/plugins/explore/src/components/EntityCard/EntityCard.test.tsx
@@ -18,6 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
+import { screen } from '@testing-library/react';
 import { EntityCard } from './EntityCard';
 
 describe('<EntityCard />', () => {
@@ -50,5 +51,30 @@ describe('<EntityCard />', () => {
       'href',
       '/catalog/default/domain/artists',
     );
+  });
+
+  it('renders an entity card with display title', async () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Domain',
+      metadata: {
+        name: 'artists',
+        title: 'New Title',
+      },
+      spec: {
+        owner: 'guest',
+      },
+    };
+    const { getByText } = await renderInTestApp(
+      <EntityCard entity={entity} />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(getByText('New Title')).toBeInTheDocument();
+    expect(screen.queryByText('artists')).not.toBeInTheDocument();
   });
 });

--- a/plugins/explore/src/components/EntityCard/EntityCard.tsx
+++ b/plugins/explore/src/components/EntityCard/EntityCard.tsx
@@ -53,7 +53,10 @@ export const EntityCard = (props: { entity: Entity }) => {
   return (
     <Card>
       <CardMedia>
-        <ItemCardHeader title={entity.metadata.name} subtitle={owner} />
+        <ItemCardHeader
+          title={entity.metadata.title ?? entity.metadata.name}
+          subtitle={owner}
+        />
       </CardMedia>
       <CardContent>
         {entity.metadata.tags?.length ? (


### PR DESCRIPTION
Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Changing the display name used for the cards in the Explore page.
Opted to use the title of the entity, since the documentation states that this is what it is for. Fallback to the entity.metadata.name as it has been before.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Screenshot shows capitalized 'Artists' instead of the entity name that is all lowercase.

![image](https://user-images.githubusercontent.com/5969237/234334158-bc965cfc-9314-44b9-b87a-801be8e48ba5.png)

