### PR TITLE
EntityOwnerPicker infinite scrolling

### DIFF
--- a/.changeset/little-boats-think.md
+++ b/.changeset/little-boats-think.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+`EntityOwnerPicker` now loads entities asynchronously
+
+**BREAKING**: In order to improve the performance of the component, the users and groups displayed by `EntityOwnerPicker` aren't inferred
+anymore by the entities available in the `EntityListContext` and are not affected by the filters applied to the `EntityListContext`.
+Instead, the entities are displayed in batches, loaded asynchronously on scroll and filtered server side.

--- a/.changeset/little-boats-think.md
+++ b/.changeset/little-boats-think.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog-react': minor
 ---
 
 The `EntityOwnerPicker` component has undergone improvements to enhance its performance.

--- a/.changeset/little-boats-think.md
+++ b/.changeset/little-boats-think.md
@@ -5,5 +5,5 @@
 `EntityOwnerPicker` now loads entities asynchronously
 
 **BREAKING**: In order to improve the performance of the component, the users and groups displayed by `EntityOwnerPicker` aren't inferred
-anymore by the entities available in the `EntityListContext` and are not affected by the filters applied to the `EntityListContext`.
+anymore by the entities available in the `EntityListContext` and will no longer react to changes in the filters of `EntityListContext`.
 Instead, the entities are displayed in batches, loaded asynchronously on scroll and filtered server side.

--- a/.changeset/little-boats-think.md
+++ b/.changeset/little-boats-think.md
@@ -1,9 +1,8 @@
 ---
-'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog-react': patch
 ---
 
-`EntityOwnerPicker` now loads entities asynchronously
+The `EntityOwnerPicker` component has undergone improvements to enhance its performance.
 
-**BREAKING**: In order to improve the performance of the component, the users and groups displayed by `EntityOwnerPicker` aren't inferred
-anymore by the entities available in the `EntityListContext` and will no longer react to changes in the filters of `EntityListContext`.
-Instead, the entities are displayed in batches, loaded asynchronously on scroll and filtered server side.
+The component now loads entities asynchronously, resulting in improved performance and responsiveness. Instead of loading all entities upfront, they are now loaded in batches as the user scrolls.
+The previous implementation inferred users and groups displayed by the `EntityOwnerPicker` component based on the entities available in the `EntityListContext`. The updated version no longer relies on the `EntityListContext` for inference, allowing for better decoupling and improved performance.

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -60,6 +60,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@react-hookz/web": "^23.0.0",
     "@types/react": "^16.13.1 || ^17.0.0",
     "classnames": "^2.2.6",
     "jwt-decode": "^3.1.0",

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
-import { fireEvent, screen } from '@testing-library/react';
+import { Entity } from '@backstage/catalog-model';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
 import { EntityOwnerFilter } from '../../filters';
@@ -28,8 +28,9 @@ import {
 } from '@backstage/test-utils';
 import { catalogApiRef, CatalogApi } from '../..';
 import { errorApiRef } from '@backstage/core-plugin-api';
+import { QueryEntitiesCursorRequest } from '@backstage/catalog-client';
 
-const ownerEntities: Entity[] = [
+const ownerEntitiesBatch1: Entity[] = [
   {
     apiVersion: '1',
     kind: 'Group',
@@ -68,64 +69,52 @@ const ownerEntities: Entity[] = [
   },
 ];
 
-const sampleEntities: Entity[] = [
+const ownerEntitiesBatch2: Entity[] = [
   {
     apiVersion: '1',
-    kind: 'Component',
+    kind: 'Group',
     metadata: {
-      name: 'component-1',
+      name: 'some-owner-batch-2',
     },
-    relations: [
-      {
-        type: 'ownedBy',
-        targetRef: 'group:default/some-owner',
-      },
-      {
-        type: 'ownedBy',
-        targetRef: 'group:default/some-owner-2',
-      },
-    ],
   },
   {
     apiVersion: '1',
-    kind: 'Component',
+    kind: 'Group',
     metadata: {
-      name: 'component-2',
+      name: 'some-owner-2-batch-2',
     },
-    relations: [
-      {
-        type: 'ownedBy',
-        targetRef: 'group:default/another-owner',
+    spec: {
+      profile: {
+        displayName: 'Some Owner Batch 2',
       },
-      {
-        type: 'ownedBy',
-        targetRef: 'group:test-namespace/another-owner-2',
-      },
-    ],
+    },
   },
   {
     apiVersion: '1',
-    kind: 'Component',
+    kind: 'Group',
     metadata: {
-      name: 'component-3',
+      name: 'another-owner-batch-2',
+      title: 'Another Owner Batch 2',
     },
-    relations: [
-      {
-        type: 'ownedBy',
-        targetRef: 'group:default/some-owner',
-      },
-    ],
+  },
+  {
+    apiVersion: '1',
+    kind: 'Group',
+    metadata: {
+      namespace: 'test-namespace',
+      name: 'another-owner-2-batch-2',
+      title: 'Another Owner in Another Namespace Batch 2',
+    },
   },
 ];
 
-const getEntitiesByRefs = jest.fn(async ({ entityRefs }) => ({
-  items: entityRefs.map((e: string) =>
-    ownerEntities.find(f => stringifyEntityRef(f) === e),
-  ),
-}));
+const mockedQueryEntities: jest.MockedFn<CatalogApi['queryEntities']> =
+  jest.fn();
+
 const mockCatalogApi: Partial<CatalogApi> = {
-  getEntitiesByRefs,
+  queryEntities: mockedQueryEntities,
 };
+
 const mockErrorApi = new MockErrorApi();
 
 describe('<EntityOwnerPicker/>', () => {
@@ -134,12 +123,33 @@ describe('<EntityOwnerPicker/>', () => {
     [errorApiRef, mockErrorApi],
   );
 
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockedQueryEntities.mockImplementation(async request => {
+      const totalItems =
+        ownerEntitiesBatch1.length + ownerEntitiesBatch2.length;
+      if ((request as QueryEntitiesCursorRequest).cursor) {
+        return {
+          items: ownerEntitiesBatch2,
+          pageInfo: {},
+          totalItems,
+        };
+      }
+      return {
+        items: ownerEntitiesBatch1,
+        pageInfo: {
+          nextCursor: 'nextCursor',
+        },
+        totalItems,
+      };
+    });
+  });
+
   it('renders all owners', async () => {
     await renderWithEffects(
       <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider
-          value={{ entities: sampleEntities, backendEntities: sampleEntities }}
-        >
+        <MockEntityListContextProvider value={{}}>
           <EntityOwnerPicker />
         </MockEntityListContextProvider>
       </ApiProvider>,
@@ -147,36 +157,36 @@ describe('<EntityOwnerPicker/>', () => {
     expect(screen.getByText('Owner')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
+
+    await waitFor(() =>
+      expect(screen.getByText('Another Owner')).toBeInTheDocument(),
+    );
+
     [
-      'Another Owner',
       'some-owner',
       'Some Owner 2',
       'Another Owner in Another Namespace',
     ].forEach(owner => {
       expect(screen.getByText(owner)).toBeInTheDocument();
     });
-  });
 
-  it('renders unique owners in alphabetical order', async () => {
-    await renderWithEffects(
-      <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider
-          value={{ entities: sampleEntities, backendEntities: sampleEntities }}
-        >
-          <EntityOwnerPicker />
-        </MockEntityListContextProvider>
-      </ApiProvider>,
+    expect(mockedQueryEntities).toHaveBeenCalledTimes(1);
+
+    fireEvent.scroll(screen.getByTestId('owner-picker-listbox'));
+
+    await waitFor(() =>
+      expect(screen.getByText('some-owner-batch-2')).toBeInTheDocument(),
     );
-    expect(screen.getByText('Owner')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('owner-picker-expand'));
+    [
+      'some-owner-batch-2',
+      'Some Owner Batch 2',
+      'Another Owner in Another Namespace Batch 2',
+    ].forEach(owner => {
+      expect(screen.getByText(owner)).toBeInTheDocument();
+    });
 
-    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
-      'Another Owner',
-      'Another Owner in Another Namespace',
-      'some-owner',
-      'Some Owner 2',
-    ]);
+    expect(mockedQueryEntities).toHaveBeenCalledTimes(2);
   });
 
   it('respects the query parameter filter value', async () => {
@@ -186,8 +196,6 @@ describe('<EntityOwnerPicker/>', () => {
       <ApiProvider apis={mockApis}>
         <MockEntityListContextProvider
           value={{
-            entities: sampleEntities,
-            backendEntities: sampleEntities,
             updateFilters,
             queryParameters,
           }}
@@ -208,8 +216,6 @@ describe('<EntityOwnerPicker/>', () => {
       <ApiProvider apis={mockApis}>
         <MockEntityListContextProvider
           value={{
-            entities: sampleEntities,
-            backendEntities: sampleEntities,
             updateFilters,
           }}
         >
@@ -222,6 +228,8 @@ describe('<EntityOwnerPicker/>', () => {
     });
 
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
+    await waitFor(() => screen.getByText('some-owner'));
+
     fireEvent.click(screen.getByText('some-owner'));
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/some-owner']),
@@ -234,8 +242,6 @@ describe('<EntityOwnerPicker/>', () => {
       <ApiProvider apis={mockApis}>
         <MockEntityListContextProvider
           value={{
-            entities: sampleEntities,
-            backendEntities: sampleEntities,
             updateFilters,
             filters: { owners: new EntityOwnerFilter(['some-owner']) },
           }}
@@ -249,7 +255,9 @@ describe('<EntityOwnerPicker/>', () => {
     });
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
 
-    expect(screen.getByLabelText('some-owner')).toBeChecked();
+    await waitFor(() =>
+      expect(screen.getByLabelText('some-owner')).toBeChecked(),
+    );
 
     fireEvent.click(screen.getByLabelText('some-owner'));
     expect(updateFilters).toHaveBeenLastCalledWith({
@@ -265,7 +273,6 @@ describe('<EntityOwnerPicker/>', () => {
           value={{
             updateFilters,
             queryParameters: { owners: ['team-a'] },
-            backendEntities: sampleEntities,
           }}
         >
           <EntityOwnerPicker />
@@ -281,7 +288,6 @@ describe('<EntityOwnerPicker/>', () => {
           value={{
             updateFilters,
             queryParameters: { owners: ['team-b'] },
-            backendEntities: sampleEntities,
           }}
         >
           <EntityOwnerPicker />
@@ -290,25 +296,6 @@ describe('<EntityOwnerPicker/>', () => {
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/team-b']),
-    });
-  });
-  it('removes owners from filters if there are none available', async () => {
-    const updateFilters = jest.fn();
-    await renderWithEffects(
-      <ApiProvider apis={mockApis}>
-        <MockEntityListContextProvider
-          value={{
-            updateFilters,
-            queryParameters: { owners: ['team-a'] },
-            backendEntities: [],
-          }}
-        >
-          <EntityOwnerPicker />
-        </MockEntityListContextProvider>
-      </ApiProvider>,
-    );
-    expect(updateFilters).toHaveBeenLastCalledWith({
-      owners: undefined,
     });
   });
 });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -119,6 +119,14 @@ export const EntityOwnerPicker = () => {
     });
   }, [selectedOwners, updateFilters]);
 
+  if (
+    ['user', 'group'].includes(
+      filters.kind?.value.toLocaleLowerCase('en-US') || '',
+    )
+  ) {
+    return null;
+  }
+
   return (
     <Box pb={1} pt={1}>
       <Typography variant="button" component="label">

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -21,6 +21,7 @@ import {
   FormControlLabel,
   TextField,
   Typography,
+  makeStyles,
 } from '@material-ui/core';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
@@ -41,11 +42,21 @@ import { humanizeEntity } from '../EntityRefLink/humanize';
 /** @public */
 export type CatalogReactEntityOwnerPickerClassKey = 'input';
 
+const useStyles = makeStyles(
+  {
+    input: {},
+  },
+  {
+    name: 'CatalogReactEntityOwnerPicker',
+  },
+);
+
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 /** @public */
 export const EntityOwnerPicker = () => {
+  const classes = useStyles();
   const {
     updateFilters,
     filters,
@@ -201,6 +212,7 @@ export const EntityOwnerPicker = () => {
           renderInput={params => (
             <TextField
               {...params}
+              className={classes.input}
               onChange={e => {
                 setText(e.currentTarget.value);
               }}

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.test.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.test.ts
@@ -215,9 +215,12 @@ describe('humanizeEntityRef', () => {
 describe('humanizeEntity', () => {
   it('gives a readable name when one is provided at metadata.title', () => {
     expect(
-      humanizeEntity({
-        metadata: { name: 'my-entity', title: 'My Title' },
-      } as Entity),
+      humanizeEntity(
+        {
+          metadata: { name: 'my-entity', title: 'My Title' },
+        } as Entity,
+        'default',
+      ),
     ).toBe('My Title');
   });
 
@@ -257,13 +260,16 @@ describe('humanizeEntity', () => {
   ])(
     'gives a readable name for kind %s when one is provided at spec.profile.displayName',
     (_, entity: Entity, expected) => {
-      expect(humanizeEntity(entity)).toBe(expected);
+      expect(humanizeEntity(entity, 'default')).toBe(expected);
     },
   );
 
   it('should pass through to humanizeEntityRef when nothing matches', () => {
     expect(
-      humanizeEntity({ kind: 'Group', metadata: { name: 'test' } } as Entity),
-    ).toBe('group:test');
+      humanizeEntity(
+        { kind: 'Group', metadata: { name: 'test' } } as Entity,
+        'default',
+      ),
+    ).toBe('default');
   });
 });

--- a/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
+++ b/plugins/catalog-react/src/components/EntityRefLink/humanize.ts
@@ -25,7 +25,8 @@ import get from 'lodash/get';
  * @param defaultNamespace - if set to false then namespace is never omitted,
  * if set to string which matches namespace of entity then omitted
  *
- * @public */
+ * @public
+ **/
 export function humanizeEntityRef(
   entityRef: Entity | CompoundEntityRef,
   opts?: {
@@ -73,27 +74,19 @@ export function humanizeEntityRef(
  * If an entity is either User or Group, this will be its `spec.profile.displayName`.
  * Otherwise, this is `metadata.title`.
  *
- * If neither of those are found or populated, fallback to `humanizeEntityRef`.
+ * If neither of those are found or populated, fallback to `defaultName`.
  *
  * @param entity - Entity to convert.
- * @param opts - If entity readable name is not available, opts will be used to specify humanizeEntityRef options.
- * @returns Readable name, defaults to unique identifier.
+ * @param defaultName - If entity readable name is not available, `defaultName` will be returned.
+ * @returns Readable name, defaults to `defaultName`.
  *
- * @public
  */
-export function humanizeEntity(
-  entity: Entity,
-  opts?: {
-    defaultKind?: string;
-    defaultNamespace?: string | false;
-  },
-) {
+export function humanizeEntity(entity: Entity, defaultName: string) {
   for (const path of ['spec.profile.displayName', 'metadata.title']) {
     const value = get(entity, path);
     if (value && typeof value === 'string') {
       return value;
     }
   }
-
-  return humanizeEntityRef(entity, opts);
+  return defaultName;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5823,6 +5823,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^23.0.0
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
@@ -13860,6 +13861,22 @@ __metadata:
     js-cookie:
       optional: true
   checksum: bb393f892c2c81deff37d5f18faf8ec17431a24994d72d88ec390dcc1579b27318a7c8c6260070c87b66e8c635e4daec4436c33abf2622f842d1567235ed457d
+  languageName: node
+  linkType: hard
+
+"@react-hookz/web@npm:^23.0.0":
+  version: 23.0.0
+  resolution: "@react-hookz/web@npm:23.0.0"
+  dependencies:
+    "@react-hookz/deep-equal": ^1.0.4
+  peerDependencies:
+    js-cookie: ^3.0.1
+    react: ^16.8 || ^17 || ^18
+    react-dom: ^16.8 || ^17 || ^18
+  peerDependenciesMeta:
+    js-cookie:
+      optional: true
+  checksum: 230bff62291bcafa65e0b9adcc3f0769fd63fabc226c77149e7797d1ea67362e9ad581ceff3cdfe2949698798d2deefb223c05bdfed1e465b5d92298d48cf3e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Alò,
The `EntityOwnerPicker` component has been notoriously slow in case of large catalog, due to the fact that the entities aren't virtualized or paginated.
Lately a new feature has been merged which caused #17499.

This PR changes how users and groups are displayed in `EntityOwnerPicker`. Instead of relying on the entities stored in `EntityListContext` and on the `kind` filter applied in `EntityListContext`, all the users and groups available in the catalog are now displayed. Users and groups are now filtered server side and loaded in batches using an infinite scrolling approach.

This new approach fixes the issue with large catalog, closes #17499 and makes another step toward #12247.
 
https://user-images.githubusercontent.com/8433119/234408465-b8fe9337-0f6c-4c5e-8fcc-c267de07237c.mov
 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
