### PR TITLE
Fix/ GitHubOrgEntityProvider description was not changing

### DIFF
--- a/.changeset/new-rules-kiss.md
+++ b/.changeset/new-rules-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+add description onTeamEditedInOrganization event

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -833,6 +833,7 @@ describe('GithubOrgEntityProvider', () => {
                     'url:https://github.com/orgs/backstage/teams/mygroup-with-spaces',
                 },
                 name: 'mygroup-with-spaces',
+                description: 'description-from-the-new-team',
               },
               apiVersion: 'backstage.io/v1alpha1',
               kind: 'Group',

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -371,14 +371,21 @@ export class GithubOrgEntityProvider
     assignGroupsToUsers(usersToRebuild, groups);
     buildOrgHierarchy(groups);
 
-    const oldName = event.changes.name?.from || '';
+    const oldName = event.changes.name?.from || event.team.name;
     const oldSlug = oldName.toLowerCase().replaceAll(/\s/gi, '-');
+
+    const oldDescription =
+      event.changes.description?.from || event.team.description;
+    const oldDescriptionSlug = oldDescription
+      ?.toLowerCase()
+      .replaceAll(/\s/gi, '-');
 
     const { removed } = createDeltaOperation(org, [
       {
         ...group,
         metadata: {
           name: oldSlug,
+          description: oldDescriptionSlug,
         },
       },
     ]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding description parameter in times change event in github through GithubOrgEntityProvider

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
