### PR TITLE
feat(catalog-backend): Add observability for catalog processing

### DIFF
--- a/.changeset/slimy-kids-jam.md
+++ b/.changeset/slimy-kids-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added OpenTelemetry spans for catalog processing

--- a/.changeset/slimy-kids-jam.md
+++ b/.changeset/slimy-kids-jam.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-backend': minor
 ---
 
 Added OpenTelemetry spans for catalog processing

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -140,7 +140,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
       processTask: async item => {
         await withActiveSpan(tracer, 'ProcessingRun', async span => {
           const track = this.tracker.processStart(item, this.logger);
-          addEntityAttributes(span, item.entityRef);
+          addEntityAttributes(span, item.unprocessedEntity);
 
           try {
             const {

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -194,10 +194,12 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
 
     it('runs all processor validations when asked to', async () => {
       const validate = jest.fn(async () => true);
-      const processor1: Partial<CatalogProcessor> = {
+      const processor1: CatalogProcessor = {
+        getProcessorName: () => 'processor1',
         validateEntityKind: validate,
       };
-      const processor2: Partial<CatalogProcessor> = {
+      const processor2: CatalogProcessor = {
+        getProcessorName: () => 'processor2',
         validateEntityKind: validate,
       };
 

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import { Span, trace } from '@opentelemetry/api';
 import {
   Entity,
   EntityPolicy,
@@ -311,7 +311,7 @@ export class DefaultCatalogProcessingOrchestrator
               async span => {
                 addEntityAttributes(span, context.entityRef);
                 addProcessorAttributes(span, 'postProcessEntity', processor);
-                return await processor.validateEntityKind(entity);
+                return await processor.validateEntityKind!(entity);
               },
             );
             if (thisValid) {
@@ -387,7 +387,7 @@ export class DefaultCatalogProcessingOrchestrator
                 async span => {
                   addEntityAttributes(span, context.entityRef);
                   addProcessorAttributes(span, 'readLocationEntity', processor);
-                  return await processor.readLocation(
+                  return await processor.readLocation!(
                     {
                       type,
                       target,

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -201,10 +201,7 @@ export class DefaultCatalogProcessingOrchestrator
   ): Promise<Entity> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
       addEntityAttributes(stageSpan, context.entityRef);
-      stageSpan.setAttribute(
-        'backstage.catalog.processor.stage',
-        'preProcessEntity',
-      );
+      stageSpan.setAttribute('backstage.catalog.processor.stage', 'preProcess');
       let res = entity;
 
       for (const processor of this.options.processors) {
@@ -244,7 +241,7 @@ export class DefaultCatalogProcessingOrchestrator
       addEntityAttributes(stageSpan, stringifyEntityRef(entity));
       stageSpan.setAttribute(
         'backstage.catalog.processor.stage',
-        'enforcePolicyEntity',
+        'enforcePolicy',
       );
       let policyEnforcedEntity: Entity | undefined;
 
@@ -278,10 +275,7 @@ export class DefaultCatalogProcessingOrchestrator
   ): Promise<void> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
       addEntityAttributes(stageSpan, context.entityRef);
-      stageSpan.setAttribute(
-        'backstage.catalog.processor.stage',
-        'validateEntity',
-      );
+      stageSpan.setAttribute('backstage.catalog.processor.stage', 'validate');
       // Double check that none of the previous steps tried to change something
       // related to the entity ref, which would break downstream
       if (stringifyEntityRef(entity) !== context.entityRef) {
@@ -310,7 +304,7 @@ export class DefaultCatalogProcessingOrchestrator
               'ProcessingStep',
               async span => {
                 addEntityAttributes(span, context.entityRef);
-                addProcessorAttributes(span, 'postProcessEntity', processor);
+                addProcessorAttributes(span, 'validateEntityKind', processor);
                 return await processor.validateEntityKind!(entity);
               },
             );
@@ -348,7 +342,7 @@ export class DefaultCatalogProcessingOrchestrator
       addEntityAttributes(stageSpan, context.entityRef);
       stageSpan.setAttribute(
         'backstage.catalog.processor.stage',
-        'readLocationEntity',
+        'readLocation',
       );
       const { type = context.location.type, presence = 'required' } =
         entity.spec;
@@ -386,7 +380,7 @@ export class DefaultCatalogProcessingOrchestrator
                 'ProcessingStep',
                 async span => {
                   addEntityAttributes(span, context.entityRef);
-                  addProcessorAttributes(span, 'readLocationEntity', processor);
+                  addProcessorAttributes(span, 'readLocation', processor);
                   return await processor.readLocation!(
                     {
                       type,

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -200,7 +200,7 @@ export class DefaultCatalogProcessingOrchestrator
     context: Context,
   ): Promise<Entity> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
-      addEntityAttributes(stageSpan, context.entityRef);
+      addEntityAttributes(stageSpan, entity);
       stageSpan.setAttribute('backstage.catalog.processor.stage', 'preProcess');
       let res = entity;
 
@@ -208,7 +208,7 @@ export class DefaultCatalogProcessingOrchestrator
         if (processor.preProcessEntity) {
           let innerRes = res;
           res = await withActiveSpan(tracer, 'ProcessingStep', async span => {
-            addEntityAttributes(span, context.entityRef);
+            addEntityAttributes(span, entity);
             addProcessorAttributes(span, 'preProcessEntity', processor);
             try {
               innerRes = await processor.preProcessEntity!(
@@ -238,7 +238,7 @@ export class DefaultCatalogProcessingOrchestrator
    */
   private async runPolicyStep(entity: Entity): Promise<Entity> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
-      addEntityAttributes(stageSpan, stringifyEntityRef(entity));
+      addEntityAttributes(stageSpan, entity);
       stageSpan.setAttribute(
         'backstage.catalog.processor.stage',
         'enforcePolicy',
@@ -274,7 +274,7 @@ export class DefaultCatalogProcessingOrchestrator
     context: Context,
   ): Promise<void> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
-      addEntityAttributes(stageSpan, context.entityRef);
+      addEntityAttributes(stageSpan, entity);
       stageSpan.setAttribute('backstage.catalog.processor.stage', 'validate');
       // Double check that none of the previous steps tried to change something
       // related to the entity ref, which would break downstream
@@ -303,7 +303,7 @@ export class DefaultCatalogProcessingOrchestrator
               tracer,
               'ProcessingStep',
               async span => {
-                addEntityAttributes(span, context.entityRef);
+                addEntityAttributes(span, entity);
                 addProcessorAttributes(span, 'validateEntityKind', processor);
                 return await processor.validateEntityKind!(entity);
               },
@@ -339,7 +339,7 @@ export class DefaultCatalogProcessingOrchestrator
     context: Context,
   ): Promise<void> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
-      addEntityAttributes(stageSpan, context.entityRef);
+      addEntityAttributes(stageSpan, entity);
       stageSpan.setAttribute(
         'backstage.catalog.processor.stage',
         'readLocation',
@@ -379,7 +379,7 @@ export class DefaultCatalogProcessingOrchestrator
                 tracer,
                 'ProcessingStep',
                 async span => {
-                  addEntityAttributes(span, context.entityRef);
+                  addEntityAttributes(span, entity);
                   addProcessorAttributes(span, 'readLocation', processor);
                   return await processor.readLocation!(
                     {
@@ -423,7 +423,7 @@ export class DefaultCatalogProcessingOrchestrator
     context: Context,
   ): Promise<Entity> {
     return await withActiveSpan(tracer, 'ProcessingStage', async stageSpan => {
-      addEntityAttributes(stageSpan, context.entityRef);
+      addEntityAttributes(stageSpan, entity);
       stageSpan.setAttribute(
         'backstage.catalog.processor.stage',
         'postProcessEntity',
@@ -434,7 +434,7 @@ export class DefaultCatalogProcessingOrchestrator
         if (processor.postProcessEntity) {
           let innerRes = res;
           res = await withActiveSpan(tracer, 'ProcessingStep', async span => {
-            addEntityAttributes(span, context.entityRef);
+            addEntityAttributes(span, entity);
             addProcessorAttributes(span, 'postProcessEntity', processor);
             try {
               innerRes = await processor.postProcessEntity!(

--- a/plugins/catalog-backend/src/util/opentelemetry.ts
+++ b/plugins/catalog-backend/src/util/opentelemetry.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Span, SpanStatusCode } from '@opentelemetry/api';
+import { parseEntityRef } from '@backstage/catalog-model';
+
+export const TRACER_ID = 'backstage-plugin-catalog-backend';
+
+export function addEntityAttributes(span: Span, entityRef: string) {
+  try {
+    const fields = parseEntityRef(entityRef);
+    span.setAttribute('backstage.entity.kind', fields.kind);
+    span.setAttribute('backstage.entity.namespace', fields.namespace);
+    span.setAttribute('backstage.entity.name', fields.name);
+  } catch (err) {
+    span.recordException(err);
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+}

--- a/plugins/catalog-backend/src/util/opentelemetry.ts
+++ b/plugins/catalog-backend/src/util/opentelemetry.ts
@@ -15,20 +15,29 @@
  */
 
 import { Span, SpanOptions, SpanStatusCode, Tracer } from '@opentelemetry/api';
-import { parseEntityRef } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 
 export const TRACER_ID = 'backstage-plugin-catalog-backend';
 
-export function addEntityAttributes(span: Span, entityRef: string) {
-  try {
-    const fields = parseEntityRef(entityRef);
-    span.setAttribute('backstage.entity.kind', fields.kind);
-    span.setAttribute('backstage.entity.namespace', fields.namespace);
-    span.setAttribute('backstage.entity.name', fields.name);
-  } catch (err) {
-    span.recordException(err);
-    span.setStatus({ code: SpanStatusCode.ERROR });
+function setAttributeIfDefined(span: Span, attribute: string, value?: string) {
+  if (value !== null && value !== undefined) {
+    span.setAttribute(attribute, value);
   }
+}
+
+export function addEntityAttributes(span: Span, entity: Entity) {
+  setAttributeIfDefined(span, 'backstage.entity.apiVersion', entity.apiVersion);
+  setAttributeIfDefined(span, 'backstage.entity.kind', entity.kind);
+  setAttributeIfDefined(
+    span,
+    'backstage.entity.metadata.namespace',
+    entity.metadata?.namespace,
+  );
+  setAttributeIfDefined(
+    span,
+    'backstage.entity.metadata.name',
+    entity.metadata?.name,
+  );
 }
 
 // Adapted from https://github.com/open-telemetry/opentelemetry-js/blob/359fbcc40a859057a02b14e84599eac399b8dba7/api/src/trace/SugaredTracer.ts


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Add some spans inside the catalog processing.

When [instrumenting an instance of Backstage using OpenTelemetry](https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/) it works fine for things coming from the frontend - all spans are rooted under the auto-instrumented http server span, but for scheduled tasks on the backend everything's missing parents.

With these spans, each individual instance of catalog processing is visible as a trace. This seems like the sensible place for this to be rooted - a parent span encompassing the task processing would lead to all processing forever being under a single trace, which isn't advisable.

![Screenshot 2023-04-26 at 19 56 25](https://user-images.githubusercontent.com/1478103/234675520-2dbb67b7-42e8-4125-8666-4f0f506860c6.png)

I'm sure this could be improved - I'm not sure what the span names should really be, for one thing, so would welcome feedback


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
