### PR TITLE
queryEntities: fix filters clashing with pagination clause

### DIFF
--- a/.changeset/fifty-grapes-explode.md
+++ b/.changeset/fifty-grapes-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix a bug in an SQL query where the AND and OR logic is incorrect.

--- a/.changeset/fifty-grapes-explode.md
+++ b/.changeset/fifty-grapes-explode.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Fix a bug in an SQL query where the AND and OR logic is incorrect.
+Fixed a bug in the `queryEntities` endpoint that was causing filtered entities to be included in cursor requests.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -1424,7 +1424,7 @@ describe('DefaultEntitiesCatalog', () => {
         await createDatabase(databaseId);
 
         await Promise.all([
-          addEntityToSearch(entityFrom('AA', { uid: '1' })),
+          addEntityToSearch(entityFrom('AA', { uid: '1', kind: 'included' })),
           addEntityToSearch(
             entityFrom('AA', {
               namespace: 'namespace2',
@@ -1476,8 +1476,8 @@ describe('DefaultEntitiesCatalog', () => {
         };
         const response1 = await catalog.queryEntities(request1);
         expect(response1.items).toMatchObject([
-          entityFrom('AA', { uid: '1' }),
-          entityFrom('AA', { uid: '2' }),
+          entityFrom('AA', { uid: '1', kind: 'included' }),
+          entityFrom('AA', { uid: '2', kind: 'included' }),
         ]);
         expect(response1.pageInfo.nextCursor).toBeDefined();
         expect(response1.pageInfo.prevCursor).toBeUndefined();
@@ -1490,8 +1490,8 @@ describe('DefaultEntitiesCatalog', () => {
         };
         const response2 = await catalog.queryEntities(request2);
         expect(response2.items).toMatchObject([
-          entityFrom('AA', { uid: '4' }),
-          entityFrom('AA', { uid: '5' }),
+          entityFrom('AA', { uid: '4', kind: 'included' }),
+          entityFrom('AA', { uid: '5', kind: 'included' }),
         ]);
         expect(response2.pageInfo.nextCursor).toBeDefined();
         expect(response2.pageInfo.prevCursor).toBeDefined();

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -413,17 +413,18 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const isOrderingDescending = sortField.order === 'desc';
 
     if (prevItemOrderFieldValue) {
-      dbQuery.andWhere(
-        'value',
-        isFetchingBackwards !== isOrderingDescending ? '<' : '>',
-        prevItemOrderFieldValue,
-      );
-      dbQuery.orWhere(function nested() {
-        this.where('value', '=', prevItemOrderFieldValue).andWhere(
-          'search.entity_id',
+      dbQuery.andWhere(function nested() {
+        this.where(
+          'value',
           isFetchingBackwards !== isOrderingDescending ? '<' : '>',
-          prevItemUid,
-        );
+          prevItemOrderFieldValue,
+        )
+          .orWhere('value', '=', prevItemOrderFieldValue)
+          .andWhere(
+            'search.entity_id',
+            isFetchingBackwards !== isOrderingDescending ? '<' : '>',
+            prevItemUid,
+          );
       });
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes the issue described in https://github.com/backstage/backstage/pull/17503 adding some tests on top of it

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
