### PR TITLE
Remove the direct dependency on deprecated "request" library

### DIFF
--- a/.changeset/chilly-fireants-type.md
+++ b/.changeset/chilly-fireants-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Remove the direct dependency on deprecated "request" library

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -96,7 +96,6 @@
     "node-forge": "^1.3.1",
     "pg": "^8.3.0",
     "raw-body": "^2.4.1",
-    "request": "^2.88.2",
     "selfsigned": "^2.0.0",
     "stoppable": "^1.1.0",
     "tar": "^6.1.12",

--- a/packages/backend-common/src/util/KubernetesContainerRunner.ts
+++ b/packages/backend-common/src/util/KubernetesContainerRunner.ts
@@ -30,7 +30,6 @@ import {
   Watch,
 } from '@kubernetes/client-node';
 import { v4 as uuid } from 'uuid';
-import { Request } from 'request';
 
 /**
  * An existing Kubernetes volume that will be used as base for mounts.
@@ -228,7 +227,7 @@ export class KubernetesContainerRunner implements ContainerRunner {
     taskId: string,
     callback: (pod: V1Pod) => void,
     errorCallback: (reason: any) => void,
-  ): Promise<Request> {
+  ): Promise<{ abort: () => void }> {
     const watch = new Watch(this.kubeConfig);
     const labelSelector = `task=${taskId}`;
     return watch.watch(
@@ -251,8 +250,8 @@ export class KubernetesContainerRunner implements ContainerRunner {
     taskId: string,
     logStream: Writable,
   ): { promise: Promise<void>; close: () => Promise<void> } {
-    let log: Promise<Request>;
-    let req: Promise<Request>;
+    let log: Promise<{ abort: () => void }>;
+    let req: Promise<{ abort: () => void }>;
     const watchPromise = new Promise<void>((_, reject) => {
       req = this.watchPod(
         taskId,
@@ -299,7 +298,7 @@ export class KubernetesContainerRunner implements ContainerRunner {
     promise: Promise<void>;
     close: () => Promise<void>;
   } {
-    let req: Promise<Request>;
+    let req: Promise<{ abort: () => void }>;
     const promise = new Promise<void>(async (resolve, reject) => {
       req = this.watchPod(
         taskId,

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -298,6 +298,7 @@ export interface KubernetesFetcher {
   fetchPodMetricsByNamespaces(
     clusterDetails: ClusterDetails,
     namespaces: Set<string>,
+    labelSelector?: string,
   ): Promise<FetchResponseWrapper>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3585,7 +3585,6 @@ __metadata:
     pg: ^8.3.0
     raw-body: ^2.4.1
     recursive-readdir: ^2.2.2
-    request: ^2.88.2
     selfsigned: ^2.0.0
     stoppable: ^1.1.0
     supertest: ^6.1.3
@@ -35650,7 +35649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"request@npm:^2.88.0, request@npm:^2.88.2":
+"request@npm:^2.88.0":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
   dependencies:


### PR DESCRIPTION
See [the comment about this concern](https://github.com/backstage/backstage/pull/12839/files#r942564337) when it was originally added, and [the support question about it now](https://discord.com/channels/687207715902193673/1100982528736755744/1100982528736755744). The library is disowned and deprecated and has vulnerabilities.

We will not fully get rid of that package as long as the kubernetes client isn't replaced or receives an update, but it's a small step forward at least.