### PR TITLE
Fixed search 404 caused by URL encoding change

### DIFF
--- a/.changeset/calm-wolves-taste.md
+++ b/.changeset/calm-wolves-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fixed 404 Error when fetching search results due to URL encoding changes

--- a/plugins/search/src/apis.test.ts
+++ b/plugins/search/src/apis.test.ts
@@ -51,8 +51,8 @@ describe('apis', () => {
 
   it('Fetch is called with expected URL (including stringified Q params)', async () => {
     await client.query(query);
-    expect(getBaseUrl).toHaveBeenLastCalledWith('search/query');
-    expect(fetch).toHaveBeenLastCalledWith(`${baseUrl}?term=`, {
+    expect(getBaseUrl).toHaveBeenLastCalledWith('search');
+    expect(fetch).toHaveBeenLastCalledWith(`${baseUrl}/query?term=`, {
       headers: {},
     });
   });
@@ -63,8 +63,8 @@ describe('apis', () => {
       identityApi: createIdentityApiMock(withToken),
     });
     await authedClient.query(query);
-    expect(getBaseUrl).toHaveBeenLastCalledWith('search/query');
-    expect(fetch).toHaveBeenLastCalledWith(`${baseUrl}?term=`, {
+    expect(getBaseUrl).toHaveBeenLastCalledWith('search');
+    expect(fetch).toHaveBeenLastCalledWith(`${baseUrl}/query?term=`, {
       headers: { Authorization: `Bearer ${token}` },
     });
   });

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -37,8 +37,8 @@ export class SearchClient implements SearchApi {
     const { token } = await this.identityApi.getCredentials();
     const queryString = qs.stringify(query);
     const url = `${await this.discoveryApi.getBaseUrl(
-      'search/query',
-    )}?${queryString}`;
+      'search',
+    )}/query?${queryString}`;
     const response = await fetch(url, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the 404 error you would get when trying to search. This was due to #17152 which added `encodeURIComponent` to `getBaseUrl`. But also it was probably bad form to use `getBaseUrl` the way it was. I did a search for other cases like this but did not find any.

Error before this fix: 

![image](https://user-images.githubusercontent.com/67169551/234938200-19a9235f-c7c3-4c9c-85d0-5ecbbeb66146.png)

In the console you would then see attempts to use: `api/search%2Fquery?term=`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
