### PR TITLE
Allow endpoint to be configured for sqs event publisher

### DIFF
--- a/.changeset/cold-laws-turn.md
+++ b/.changeset/cold-laws-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend-module-aws-sqs': minor
+---
+
+Allow endpoint configuration for sqs, enabling use of localstack for testing.

--- a/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.ts
@@ -68,7 +68,11 @@ export class AwsSqsConsumingEventPublisher implements EventPublisher {
       VisibilityTimeout: config.visibilityTimeout?.as('seconds'),
       WaitTimeSeconds: config.pollingWaitTime.as('seconds'),
     };
-    this.sqs = new SQSClient({ region: config.region });
+
+    this.sqs = new SQSClient({
+      region: config.region,
+      endpoint: config.endpoint,
+    });
     this.queueUrl = config.queueUrl;
 
     this.taskTimeoutSeconds = config.timeout.as('seconds');

--- a/plugins/events-backend-module-aws-sqs/src/publisher/config.test.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/config.test.ts
@@ -79,6 +79,7 @@ describe('readConfig', () => {
                     url: 'https://fake1.queue.url',
                     visibilityTimeout: { minutes: 5 },
                     waitTime: { seconds: 10 },
+                    endpoint: 'https://fake.endpoint.url',
                   },
                   timeout: { minutes: 5 },
                   waitTimeAfterEmptyReceive: { seconds: 30 },
@@ -97,6 +98,7 @@ describe('readConfig', () => {
     expect(publisherConfigs[0].topic).toEqual('fake1');
     expect(publisherConfigs[0].region).toEqual('eu-west-1');
     expect(publisherConfigs[0].queueUrl).toEqual('https://fake1.queue.url');
+    expect(publisherConfigs[0].endpoint).toEqual('https://fake.endpoint.url');
     expect(publisherConfigs[0].pollingWaitTime.as('seconds')).toBe(10);
     expect(publisherConfigs[0].timeout.as('seconds')).toBe(300);
     expect(publisherConfigs[0].waitTimeAfterEmptyReceive.as('seconds')).toBe(

--- a/plugins/events-backend-module-aws-sqs/src/publisher/config.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/config.ts
@@ -31,6 +31,7 @@ export interface AwsSqsEventSourceConfig {
   topic: string;
   visibilityTimeout?: Duration;
   waitTimeAfterEmptyReceive: Duration;
+  endpoint?: string;
 }
 
 // TODO(pjungermann): validation could be improved similar to `convertToHumanDuration` at @backstage/backend-tasks

--- a/plugins/events-backend-module-aws-sqs/src/publisher/config.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/config.ts
@@ -75,6 +75,7 @@ export function readConfig(config: Config): AwsSqsEventSourceConfig[] {
       }
       const queueUrl = topicConfig.getString('queue.url');
       const region = topicConfig.getString('queue.region');
+      const endpoint = topicConfig.getOptionalString('queue.endpoint');
       const visibilityTimeout = readOptionalDuration(
         topicConfig,
         'queue.visibilityTimeout',
@@ -107,6 +108,7 @@ export function readConfig(config: Config): AwsSqsEventSourceConfig[] {
       return {
         pollingWaitTime,
         queueUrl,
+        endpoint,
         region,
         timeout,
         topic,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For dev/tes is is useful to be able to use tools like localstack to emulate sqs. This change allows you to set the endpoint to configure tools such as localstack.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
