### PR TITLE
Fix example code in Explore plugin README

### DIFF
--- a/.changeset/two-gorillas-drop.md
+++ b/.changeset/two-gorillas-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Updated the example code in the "Customization" section of the Readme to make the imports match the components used.

--- a/.changeset/two-gorillas-drop.md
+++ b/.changeset/two-gorillas-drop.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-explore': patch
 ---
 
-Updated the example code in the "Customization" section of the Readme to make the imports match the components used.
+Updated the example code in the "Customization" section of the README to make the imports match the components used.

--- a/plugins/explore/README.md
+++ b/plugins/explore/README.md
@@ -104,11 +104,11 @@ Create a custom explore page in
 
 ```tsx
 import {
-  DomainExplorerContent,
+  CatalogKindExplorerContent,
   ExploreLayout,
 } from '@backstage/plugin-explore';
 import React from 'react';
-import { InnserSourceExplorerContent } from './InnserSourceExplorerContent';
+import { AcmeInnserSourceExploreContent } from './InnserSourceExplorerContent';
 
 export const ExplorePage = () => {
   return (
@@ -123,7 +123,7 @@ export const ExplorePage = () => {
         <CatalogKindExploreContent kind="system" />
       </ExploreLayout.Route>
       <ExploreLayout.Route path="inner-source" title="InnerSource">
-        <AcmeInnserSourceExplorerContent />
+        <AcmeInnserSourceExploreContent />
       </ExploreLayout.Route>
     </ExploreLayout>
   );

--- a/plugins/explore/README.md
+++ b/plugins/explore/README.md
@@ -104,11 +104,11 @@ Create a custom explore page in
 
 ```tsx
 import {
-  CatalogKindExplorerContent,
+  CatalogKindExploreContent,
   ExploreLayout,
 } from '@backstage/plugin-explore';
 import React from 'react';
-import { AcmeInnserSourceExploreContent } from './InnserSourceExplorerContent';
+import { InnerSourceExploreContent } from './InnerSourceExploreContent';
 
 export const ExplorePage = () => {
   return (
@@ -123,7 +123,7 @@ export const ExplorePage = () => {
         <CatalogKindExploreContent kind="system" />
       </ExploreLayout.Route>
       <ExploreLayout.Route path="inner-source" title="InnerSource">
-        <AcmeInnserSourceExploreContent />
+        <InnerSourceExploreContent />
       </ExploreLayout.Route>
     </ExploreLayout>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I was setting up the Explore plugin and realized that the example code in the customization section was not valid. Updated to fix the errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
