### PR TITLE
docs(analytics-module-ga4): fix CSP documentation

### DIFF
--- a/plugins/analytics-module-ga4/README.md
+++ b/plugins/analytics-module-ga4/README.md
@@ -56,8 +56,8 @@ backend:
   csp:
     connect-src: ["'self'", 'http:', 'https:']
     # Add these two lines below
-    script-src: ["'self'", "'unsafe-eval'", 'https://www.google-analytics.com']
-    img-src: ["'self'", 'data:', 'https://www.google-analytics.com']
+    script-src: ["'self'", "'unsafe-eval'", 'https://www.googletagmanager.com']
+    img-src: ["'self'", 'data:', 'https://https://www.googletagmanager.com']
 ```
 
 ## Configuration


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The documentation for recently merged GA4 plugin seems to be copied over from the old GA plugin, however that won't wok out of the box. This PR fixes the documentation to include GA4 url in CSP.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentatio
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
