### PR TITLE
Support for multiple order-by parameters in the by-query endpoint.

### DIFF
--- a/.changeset/tame-camels-provide.md
+++ b/.changeset/tame-camels-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Support for multiple `orderFields` query parameters in the `entities/by-query` endpoint.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary
Support multiple order by parameters in the by-query endpoint. Setting up possibility of then-by queries in dynamic pickers, dropdowns, tables, etc. Closes #17560 

### Cursor Pagination
I had some trouble implementing the full pagination. It works in it's current form and the basic idea is that we check if each order-by column's value is either greater than or less than (if we're in reverse) the previous value. There should be no issues with this approach, but please verify that's the case.

### Risks
We're adding an additional `n` leftOuterJoins to this query, this may cause a significant slow down from the base cursor pagination base approach.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
