### PR TITLE
feat(circleci): Hide time column data for queued builds

### DIFF
--- a/.changeset/serious-hornets-remember.md
+++ b/.changeset/serious-hornets-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-circleci': patch
+---
+
+Hide empty time field data for queued builds which haven't started yet

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -205,18 +205,19 @@ const generatedColumns: TableColumn[] = [
   {
     title: 'Time',
     field: 'startTime',
-    render: (row: Partial<CITableBuildInfo>) => (
-      <>
-        <Typography variant="body2">
-          run {relativeTimeTo(row?.startTime)}
-        </Typography>
-        <Typography variant="body2">
-          {row?.stopTime
-            ? `took ${durationHumanized(row?.startTime, row?.stopTime)}`
-            : ''}
-        </Typography>
-      </>
-    ),
+    render: (row: Partial<CITableBuildInfo>) =>
+      row?.startTime ? (
+        <>
+          <Typography variant="body2">
+            run {relativeTimeTo(row?.startTime)}
+          </Typography>
+          <Typography variant="body2">
+            {row?.stopTime
+              ? `took ${durationHumanized(row?.startTime, row?.stopTime)}`
+              : ''}
+          </Typography>
+        </>
+      ) : null,
   },
   {
     title: 'Workflow',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/17601.  When a CircleCI job has been queued, it hasn't been started. In such cases, there's no time data to suggest how long ago a build started. Currently, this resulted in printing out "run took" in the column:

<img width="511" alt="image" src="https://user-images.githubusercontent.com/33203301/235528873-0e6b168c-62ca-4bef-ba82-dfcfe8b0046f.png">

In these situations where the start time data is missing, simply null it out and don't display anything in the time column.

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/33203301/235554743-d6af9218-19b6-4ead-91d5-1fcd9da17f5c.png">
(proof this change doesn't break the display, but NOT proof it 100% works :) )

It's REALLY hard to catch this, esp with CircleCI's cloud service, as you have to wait until the SaaS service itself has a queuing problem. We happened to see one of these today - first time I've noticed it through Backstage - and likely just meant whatever resource class and server combination we had it just needed time to spin up in CircleCI's infra, so this is really difficult to test without a test case to force the data.

SOOO.... really this component needs a test suite, which it still lacks, but haven't added one yet. If we had one we could add these various edge cases to properly. (I know I know, preaching to the choir.)  :)



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
