### PR TITLE
workflows: remove matrices and switch to 18

### DIFF
--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -8,10 +8,6 @@ jobs:
   deploy-microsite-and-storybook:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     env:
       CI: true
       NODE_OPTIONS: --max-old-space-size=8192
@@ -20,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: use node.js ${{ matrix.node-version }}
+      - name: use node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       # We avoid caching in this workflow, as we're running an install of both the top-level

--- a/.github/workflows/deploy_nightly.yml
+++ b/.github/workflows/deploy_nightly.yml
@@ -9,10 +9,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     env:
       CI: true
       NODE_OPTIONS: --max-old-space-size=4096
@@ -20,15 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: use node.js ${{ matrix.node-version }}
+      - name: use node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: yarn install
         uses: backstage/actions/yarn-install@v0.6.3
         with:
-          cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
+          cache-prefix: ${{ runner.os }}-v18.x
 
       # No verification done here, only build & publish. If the master branch
       # is broken we will see that from those builds, but we still want to push nightly

--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -10,22 +10,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - uses: actions/checkout@v3
 
-      - name: use node.js ${{ matrix.node-version }}
+      - name: use node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: yarn install
         uses: backstage/actions/yarn-install@v0.6.3
         with:
-          cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
+          cache-prefix: ${{ runner.os }}-v18.x
 
       - name: Create Snyk report
         uses: snyk/actions/node@master

--- a/.github/workflows/verify_microsite-noop.yml
+++ b/.github/workflows/verify_microsite-noop.yml
@@ -13,10 +13,6 @@ jobs:
   noop:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     name: Microsite
     steps:
       - run: echo NOOP

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -11,10 +11,6 @@ jobs:
   build-microsite:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     env:
       CI: true
       NODE_OPTIONS: --max-old-space-size=8192
@@ -24,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: use node.js ${{ matrix.node-version }}
+      - name: use node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
 
         # Skip caching of microsite dependencies, it keeps the global cache size
         # smaller, which make Windows builds a lot faster for the rest of the project.

--- a/.github/workflows/verify_storybook-noop.yml
+++ b/.github/workflows/verify_storybook-noop.yml
@@ -22,10 +22,6 @@ jobs:
   noop:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     name: Storybook
     steps:
       - run: echo NOOP


### PR DESCRIPTION
Getting rid of the matrix strategy for workflows that we'll never want to run towards multiple node versions. That way we'll have for example "Microsite" rather than "Microsite (16.x)".

Also bumped up to 18 since it's not too long until we'll drop 16