### PR TITLE
Ensure that entity cache state is only written to the database when actually changed

### DIFF
--- a/.changeset/chilled-queens-wonder.md
+++ b/.changeset/chilled-queens-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Ensure that entity cache state is only written to the database when actually changed

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -150,7 +150,10 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
           track.markProcessorsCompleted(result);
 
           if (result.ok) {
-            if (stableStringify(state) !== stableStringify(result.state)) {
+            const { ttl: _, ...stateWithoutTtl } = state ?? {};
+            if (
+              stableStringify(stateWithoutTtl) !== stableStringify(result.state)
+            ) {
               await this.processingDatabase.transaction(async tx => {
                 await this.processingDatabase.updateEntityCache(tx, {
                   id,


### PR DESCRIPTION
The ttl key was always in one side of the equality but never in the other, making the comparison always lead to a write.