### PR TITLE
use undici in place of node-fetch

### DIFF
--- a/.changeset/seven-tables-reply.md
+++ b/.changeset/seven-tables-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Make use of `undici` fetch library in place of `node-fetch`.

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -100,6 +100,7 @@
     "selfsigned": "^2.0.0",
     "stoppable": "^1.1.0",
     "tar": "^6.1.12",
+    "undici": "^5.22.0",
     "uuid": "^8.3.2",
     "winston": "^3.2.1",
     "winston-transport": "^4.5.0",

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -22,7 +22,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import { RestEndpointMethodTypes } from '@octokit/rest';
-import fetch, { RequestInit, Response } from 'node-fetch';
+import { fetch, Response, RequestInit } from 'undici';
 import parseGitUrl from 'git-url-parse';
 import { Minimatch } from 'minimatch';
 import { Readable } from 'stream';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,6 +3590,7 @@ __metadata:
     stoppable: ^1.1.0
     supertest: ^6.1.3
     tar: ^6.1.12
+    undici: ^5.22.0
     uuid: ^8.3.2
     winston: ^3.2.1
     winston-transport: ^4.5.0
@@ -39093,12 +39094,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.12.0, undici@npm:^5.8.0":
-  version: 5.19.1
-  resolution: "undici@npm:5.19.1"
+"undici@npm:^5.12.0, undici@npm:^5.22.0, undici@npm:^5.8.0":
+  version: 5.22.0
+  resolution: "undici@npm:5.22.0"
   dependencies:
     busboy: ^1.6.0
-  checksum: 57ee94ee74d944faa41dbcb2faf4e0c90069708d3aaae860185884e51376b5d457728352a8396d69a3c9cb752b62ff99a19a664c5aacb7ee61cc488af499a01c
+  checksum: 8dc55240a60ae7680798df344e8f46ad0f872ed0fa434fb94cc4fd2b5b2f8053bdf11994d15902999d3880f9bf7cd875a2e90883d2702bf0f366dacd9cbf3fc6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

use undici in place of node-fetch

The purpose of this patch is to attempt to fix an error that is appearing in the scaffolder fetch:plain:file action. It is throwing this error:

`InternalServerError: stream is not readable`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
