### PR TITLE
feat(scaffolder/next): Markdown text output

### DIFF
--- a/.changeset/heavy-penguins-burn.md
+++ b/.changeset/heavy-penguins-burn.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-common': patch
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Add support for Markdown text blob outputs from templates

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -510,10 +510,8 @@ take a look at, or you can
 
 Each individual step can output some variables that can be used in the
 scaffolder frontend for after the job is finished. This is useful for things
-like linking to the entity that has been created with the backend, and also
-linking to the created repository.
-
-The main two that are used are the following:
+like linking to the entity that has been created with the backend, linking
+to the created repository, or showing Markdown text blobs.
 
 ```yaml
 output:
@@ -523,6 +521,10 @@ output:
     - title: Open in catalog
       icon: catalog
       entityRef: ${{ steps['register'].output.entityRef }} # link to the entity that has been ingested to the catalog
+  text:
+    - title: More data
+      data: |
+        Access the [remote repository](${{ steps['publish'].output.remoteUrl }}).
 ```
 
 ## The templating syntax

--- a/plugins/scaffolder-common/src/Template.v1beta3.schema.json
+++ b/plugins/scaffolder-common/src/Template.v1beta3.schema.json
@@ -218,6 +218,33 @@
                       }
                     }
                   }
+                },
+                "text": {
+                  "type": "array",
+                  "description": "A list of text blobs, like output data from the template.",
+                  "items": {
+                    "type": "object",
+                    "required": [],
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                        "description": "A user friendly display name for the text blob.",
+                        "examples": ["Output Data"],
+                        "minLength": 1
+                      },
+                      "icon": {
+                        "type": "string",
+                        "description": "A key representing a visual icon to be displayed in the UI.",
+                        "examples": ["dashboard"],
+                        "minLength": 1
+                      },
+                      "data": {
+                        "type": "string",
+                        "description": "The text blob to display in the UI.",
+                        "examples": ["{}"]
+                      }
+                    }
+                  }
                 }
               },
               "additionalProperties": {

--- a/plugins/scaffolder-react/src/api/types.ts
+++ b/plugins/scaffolder-react/src/api/types.ts
@@ -85,8 +85,16 @@ export type ScaffolderOutputLink = {
 };
 
 /** @public */
+export type ScaffolderOutputText = {
+  title?: string;
+  icon?: string;
+  data?: string;
+};
+
+/** @public */
 export type ScaffolderTaskOutput = {
   links?: ScaffolderOutputLink[];
+  text?: ScaffolderOutputText[];
 } & {
   [key: string]: unknown;
 };

--- a/plugins/scaffolder-react/src/next/components/TemplateOutputs/DefaultTemplateOutputs.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateOutputs/DefaultTemplateOutputs.tsx
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { Box, Paper } from '@material-ui/core';
-import { LinkOutputs } from './LinkOutputs';
+import { InfoCard, MarkdownContent } from '@backstage/core-components';
 import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';
+import { Box, Paper } from '@material-ui/core';
+import React, { useMemo, useState } from 'react';
+import { LinkOutputs } from './LinkOutputs';
+import { TextOutputs } from './TextOutputs';
 
 /**
  * The DefaultOutputs renderer for the scaffolder task output
@@ -26,17 +28,47 @@ import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';
 export const DefaultTemplateOutputs = (props: {
   output?: ScaffolderTaskOutput;
 }) => {
-  if (!props.output?.links) {
+  const [textOutputIndex, setTextOutputIndex] = useState<number | undefined>();
+
+  const textOutput = useMemo(
+    () =>
+      textOutputIndex !== undefined
+        ? props.output?.text?.[textOutputIndex]
+        : null,
+    [props.output, textOutputIndex],
+  );
+
+  if (!props.output) {
     return null;
   }
 
   return (
-    <Box paddingBottom={2}>
-      <Paper>
-        <Box padding={2} justifyContent="center" display="flex" gridGap={16}>
-          <LinkOutputs output={props.output} />
+    <>
+      <Box paddingBottom={2}>
+        <Paper>
+          <Box padding={2} justifyContent="center" display="flex" gridGap={16}>
+            <TextOutputs
+              output={props.output}
+              index={textOutputIndex}
+              setIndex={setTextOutputIndex}
+            />
+            <LinkOutputs output={props.output} />
+          </Box>
+        </Paper>
+      </Box>
+      {textOutput ? (
+        <Box paddingBottom={2}>
+          <InfoCard
+            title={textOutput.title ?? 'Text Output'}
+            noPadding
+            titleTypographyProps={{ component: 'h2' }}
+          >
+            <Box padding={2} height="100%">
+              <MarkdownContent content={textOutput.data ?? ''} />
+            </Box>
+          </InfoCard>
         </Box>
-      </Paper>
-    </Box>
+      ) : null}
+    </>
   );
 };

--- a/plugins/scaffolder-react/src/next/components/TemplateOutputs/TextOutputs.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateOutputs/TextOutputs.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IconComponent, useApp } from '@backstage/core-plugin-api';
+import { Button } from '@material-ui/core';
+import WebIcon from '@material-ui/icons/Web';
+import React from 'react';
+import { ScaffolderTaskOutput } from '../../../api';
+
+export const TextOutputs = (props: {
+  output: ScaffolderTaskOutput;
+  index?: number;
+  setIndex?: (index: number | undefined) => void;
+}) => {
+  const {
+    output: { text = [] },
+    index,
+    setIndex,
+  } = props;
+
+  const app = useApp();
+
+  const iconResolver = (key?: string): IconComponent =>
+    app.getSystemIcon(key!) ?? WebIcon;
+
+  return (
+    <>
+      {text
+        .filter(({ data }) => data)
+        .map(({ title, icon }, i) => {
+          const Icon = iconResolver(icon);
+          return (
+            <Button
+              startIcon={<Icon />}
+              component="div"
+              color="primary"
+              onClick={() => setIndex?.(index !== i ? i : undefined)}
+              variant={index === i ? 'outlined' : undefined}
+            >
+              {title}
+            </Button>
+          );
+        })}
+    </>
+  );
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for `text` outputs on templates in `scaffolder/next`.

```yaml
output:
  text:
    - title: Test Text
      data: |
        Hello, world! This is some markdown!

        ```
        console.log("Hello, world!");
        ```
```

![image](https://user-images.githubusercontent.com/11506439/236067199-50711a89-b76a-4784-9c32-7443f73eb95f.png)

They appear like `link` outputs, but can be clicked to reveal a box that renders their `data` as Markdown.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
  - No tests are done on existing scaffolder output, so this was skipped
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
