### PR TITLE
feat(plugins/azure-devops): support for multiple builds-definitions

### DIFF
--- a/.changeset/quiet-stingrays-fly.md
+++ b/.changeset/quiet-stingrays-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops': minor
+---
+
+The getBuildRuns function now checks contains multiple comma-separated builds and splits them to send multiple requests for each and concatenates the results.

--- a/plugins/azure-devops/README.md
+++ b/plugins/azure-devops/README.md
@@ -70,7 +70,7 @@ dev.azure.com/project: <project-name>
 dev.azure.com/build-definition: <build-definition-name>
 ```
 
-In this case `<project-name>` will be the name of your Team Project and `<build-definition-name>` will be the name of the Build Definition you would like to see Builds for. If the Build Definition name has spaces in it make sure to put quotes around it
+In this case `<project-name>` will be the name of your Team Project and `<build-definition-name>` will be the name of the Build Definition you would like to see Builds for, and it's possible to add more Builds separated by a comma. If the Build Definition name has spaces in it make sure to put quotes around it.
 
 ### Azure Pipelines Component
 

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -120,7 +120,23 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
       queryString.append('repoName', repoName);
     }
     if (definitionName) {
-      queryString.append('definitionName', definitionName);
+      const definitionNames = definitionName.split(',');
+      if (definitionNames.length > 1) {
+        const buildRuns: BuildRun[] = [];
+        for (const name of definitionNames) {
+          queryString.set('definitionName', name.trim());
+          if (options?.top) {
+            queryString.set('top', options.top.toString());
+          }
+          const urlSegment = `builds/${encodeURIComponent(
+            projectName,
+          )}?${queryString}`;
+          const items = await this.get<BuildRun[]>(urlSegment);
+          buildRuns.push(...items);
+        }
+        return { items: buildRuns };
+      }
+      queryString.append('definitionName', definitionName.trim());
     }
     if (options?.top) {
       queryString.append('top', options.top.toString());


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The plugin was only prepared to work with a single build definition, since annotations only allow strings and not arrays, I decided to use a string separating by commas each build-definition and inside the plugin split them and make a request to Azure DevOps API for each one, then returning a combined list with the builds.

![image](https://user-images.githubusercontent.com/20321160/236235627-481632f9-9a30-4fd0-ace3-5b93d78ee2ef.png)
(two different builds are shown in the same listing)

![api](https://user-images.githubusercontent.com/20321160/236241215-20515d7e-ba98-4ff5-bffa-bb72c805c045.png)


It's not a breaking change, if a single build-definition is received it still works the same way.
Maybe in the future if annotations would allow arrays, we could modify it to a list of strings instead of separating them by comma :)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
