### PR TITLE
Bug fix:KubernetesProxy requestHandler interrupted by decorateClusterDetailsWithAuth error

### DIFF
--- a/.changeset/spotty-walls-serve.md
+++ b/.changeset/spotty-walls-serve.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-Fixed a bug in the `KubernetesProxy endpoint` where requests to clusters configured with `client-side auth providers` would always fail with a 500 status.
+Fixed a bug in the Kubernetes proxy endpoint where requests to clusters configured with client-side auth providers would always fail with a 500 status.

--- a/.changeset/spotty-walls-serve.md
+++ b/.changeset/spotty-walls-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fixed a bug in the `KubernetesProxy endpoint` where requests to clusters configured with `client-side auth providers` would always fail with a 500 status.


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Fixes #17604, `KubernetesProxy` bug. 

in the case that the request to the proxy endpoint has a `Backstage-Kubernetes-Authorization` header and the cluster in question has a `client-side authProvider`, the `decorateClusterDetailsWithAuth` method was throwing an error which interrupted the execution of the request handler. Express caught this error and served a 500 response. 

Solution was tested following bug reproduction steps included in the above issue.

The following pod-logs are now available
![Screenshot 2023-05-04 at 11 16 19 AM](https://user-images.githubusercontent.com/55550481/236288572-84fe6f92-f61d-4736-9158-225275ec1fe1.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
