### PR TITLE
Correct Code of Conduct reference to refer to CNCF not Spotify

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ For those contributors who have earned write access to the repository, when a pu
 
 ## Code of Conduct
 
-This project adheres to the [Spotify FOSS Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
+This project adheres to the [CNCF Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
 
 [code-of-conduct]: https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Correct code of conduct reference in CONTRIBUTING.md to refer to CNCF's code of conduct, not Spotify's FOSS code of conduct.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
