### PR TITLE
Fix/ GitHubOrgEntityProvider description was not changing

### DIFF
--- a/.changeset/wet-dolphins-love.md
+++ b/.changeset/wet-dolphins-love.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-github': major
 ---
 
-Adding description in function 'onTeamEditedInOrganization` in event of team.edited
+Updated the `team.edited` event emitted from `GithubOrgEntityProvider` to also include teams description.

--- a/.changeset/wet-dolphins-love.md
+++ b/.changeset/wet-dolphins-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': major
+---
+
+Adding description in function 'onTeamEditedInOrganization` in event of team.edited

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -833,8 +833,8 @@ describe('GithubOrgEntityProvider', () => {
                     'url:https://github.com/orgs/backstage/teams/mygroup-with-spaces',
                 },
                 name: 'mygroup-with-spaces',
+                description: 'description-from-the-new-team',
               },
-              description: 'description-from-the-new-team',
               apiVersion: 'backstage.io/v1alpha1',
               kind: 'Group',
               spec: {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -834,6 +834,7 @@ describe('GithubOrgEntityProvider', () => {
                 },
                 name: 'mygroup-with-spaces',
               },
+              description: 'description-from-the-new-team',
               apiVersion: 'backstage.io/v1alpha1',
               kind: 'Group',
               spec: {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -371,14 +371,21 @@ export class GithubOrgEntityProvider
     assignGroupsToUsers(usersToRebuild, groups);
     buildOrgHierarchy(groups);
 
-    const oldName = event.changes.name?.from || '';
+    const oldName = event.changes.name?.from || event.team.name;
     const oldSlug = oldName.toLowerCase().replaceAll(/\s/gi, '-');
+
+    const oldDescription =
+      event.changes.description?.from || event.team.description;
+    const oldDescriptionSlug = oldDescription
+      ?.toLowerCase()
+      .replaceAll(/\s/gi, '-');
 
     const { removed } = createDeltaOperation(org, [
       {
         ...group,
         metadata: {
           name: oldSlug,
+          description: oldDescriptionSlug,
         },
       },
     ]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Adding description parameter in times change event in github through GithubOrgEntityProvider

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
