### PR TITLE
feat(core-components): Add a link to denote opening a new window.

### DIFF
--- a/.changeset/poor-cameras-protect.md
+++ b/.changeset/poor-cameras-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add an external link icon to the `Link` component.

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -29,6 +29,7 @@ import {
   LinkProps as RouterLinkProps,
   Route,
 } from 'react-router-dom';
+import LaunchIcon from '@material-ui/icons/Launch';
 
 export function isReactRouterBeta(): boolean {
   const [obj] = createRoutesFromChildren(<Route index element={<div />} />);
@@ -48,6 +49,14 @@ const useStyles = makeStyles(
     },
     externalLink: {
       position: 'relative',
+      display: 'inline-flex',
+      alignItems: 'center',
+    },
+    externalLinkWrapper: {
+      flexShrink: 1,
+    },
+    externalLinkIcon: {
+      marginLeft: '.25rem',
     },
   },
   { name: 'Link' },
@@ -197,6 +206,7 @@ export const Link = React.forwardRef<any, LinkProps>(
         <Typography component="span" className={classes.visuallyHidden}>
           , Opens in a new window
         </Typography>
+        <LaunchIcon fontSize="inherit" className={classes.externalLinkIcon} />
       </MaterialLink>
     ) : (
       // Interact with React Router for internal links

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -203,10 +203,17 @@ export const Link = React.forwardRef<any, LinkProps>(
         className={classnames(classes.externalLink, props.className)}
       >
         {props.children}
-        <Typography component="span" className={classes.visuallyHidden}>
-          , Opens in a new window
-        </Typography>
-        <LaunchIcon fontSize="inherit" className={classes.externalLinkIcon} />
+        {newWindow && (
+          <>
+            <Typography component="span" className={classes.visuallyHidden}>
+              , Opens in a new window
+            </Typography>
+            <LaunchIcon
+              fontSize="inherit"
+              className={classes.externalLinkIcon}
+            />
+          </>
+        )}
       </MaterialLink>
     ) : (
       // Interact with React Router for internal links

--- a/plugins/git-release-manager/src/features/Features.test.tsx
+++ b/plugins/git-release-manager/src/features/Features.test.tsx
@@ -84,6 +84,16 @@ describe('Features', () => {
             >
               , Opens in a new window
             </span>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root Link-externalLinkIcon-15 MuiSvgIcon-fontSizeInherit"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+              />
+            </svg>
           </a>
           .
         </p>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #17143. Adds the LaunchIcon SVG to all external links and adds a MUI style class for control by the theme. 

<img width="515" alt="Screen Shot 2023-05-05 at 3 35 16 PM" src="https://user-images.githubusercontent.com/34432188/236554708-491737a0-d210-4ec9-b5bf-55365e3124e0.png">
<img width="515" alt="Screen Shot 2023-05-05 at 4 13 50 PM" src="https://user-images.githubusercontent.com/34432188/236560062-6b563867-5e53-4462-9c2b-76975f042609.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
