### PR TITLE
fix: corrected the disconnection behavior to get stream logs Close #1…

### DIFF
--- a/.changeset/chatty-ads-attack.md
+++ b/.changeset/chatty-ads-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+fixed refresh problem when backstage backend disconnects without any feedback to user. Now we send a generic message and try to reconnect after 15 seconds


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey team, I put a fix for #15002 

The problem is described at the issue but the basic is:
We receive a disconnection (internet issues) and don't get any feedback (or update) after that. So I did two things:
1. Change the empty message to `We cannot connect at the moment, trying again in some seconds... Retrying (3/3 retries)`
![image](https://github.com/backstage/backstage/assets/1574240/a1be8ef2-6ce2-42ab-a694-2ca0893787fc)
2. Put a simple retry after 15s using a timeout. In my case I didn't get the backend running again, so I got a `Failed to fetch` message
3. 
![image](https://user-images.githubusercontent.com/1574240/236581342-64c5a25d-83ba-482f-bb96-093211d19eb5.png)


I tried to change the error behavior from the observable (resulting in the subscriber disconnection). Still, I got a very messy code, so this is a simple enough solution.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [N/A] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
