### PR TITLE
fix: fix description links when clicking entry in radar

### DIFF
--- a/.changeset/fair-suits-warn.md
+++ b/.changeset/fair-suits-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Fix description links when clicking entry in radar.

--- a/plugins/tech-radar/src/components/RadarEntry/RadarEntry.tsx
+++ b/plugins/tech-radar/src/components/RadarEntry/RadarEntry.tsx
@@ -26,6 +26,7 @@ export type Props = {
   value: number;
   color: string;
   url?: string;
+  links?: Array<{ title: string; url: string }>;
   moved?: number;
   description?: string;
   timeline?: EntrySnapshot[];
@@ -73,6 +74,7 @@ const RadarEntry = (props: Props): JSX.Element => {
     title,
     color,
     url,
+    links,
     value,
     x,
     y,
@@ -112,6 +114,7 @@ const RadarEntry = (props: Props): JSX.Element => {
           description={description ? description : 'no description'}
           timeline={timeline ? timeline : []}
           url={url}
+          links={links}
         />
       )}
       {description ? (

--- a/plugins/tech-radar/src/components/RadarPlot/RadarPlot.tsx
+++ b/plugins/tech-radar/src/components/RadarPlot/RadarPlot.tsx
@@ -73,6 +73,7 @@ const RadarPlot = (props: Props): JSX.Element => {
             color={entry.color || ''}
             value={(entry?.index || 0) + 1}
             url={entry.url}
+            links={entry.links}
             description={entry.description}
             moved={entry.moved}
             title={entry.title}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After this PR links are show again, when clicking an entry on the radar. This was only working for entries in the legend.
<img width="620" alt="CleanShot 2023-05-07 at 16 06 08@2x" src="https://user-images.githubusercontent.com/1021324/236682460-8fb381e1-3808-494a-b811-adbf85044d0a.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
