### PR TITLE
feat(plugins/adr): render SupportButton only if config is set

### DIFF
--- a/.changeset/twelve-birds-boil.md
+++ b/.changeset/twelve-birds-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': minor
+---
+
+render SupportButton only if config is set

--- a/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
+++ b/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
@@ -29,7 +29,7 @@ import {
   SupportButton,
   WarningPanel,
 } from '@backstage/core-components';
-import { useApi, useRouteRef } from '@backstage/core-plugin-api';
+import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import {
   AdrFilePathFilterFn,
@@ -170,6 +170,9 @@ export const EntityAdrContent = (props: {
   const adrApi = useApi(adrApiRef);
   const entityHasAdrs = isAdrAvailable(entity);
 
+  const config = useApi(configApiRef);
+  const appSupportConfigured = config?.getOptionalConfig('app.support');
+
   const { value, loading, error } = useAsync(async () => {
     const url = getAdrLocationUrl(entity, scmIntegrations);
     return adrApi.listAdrs(url);
@@ -212,7 +215,7 @@ export const EntityAdrContent = (props: {
   return (
     <Content>
       <ContentHeader title="Architecture Decision Records">
-        <SupportButton />
+        {appSupportConfigured && <SupportButton />}
       </ContentHeader>
 
       {!entityHasAdrs && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change will render the `SupportButton` for ADRs only if `app.support` config is set.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
