### PR TITLE
Update light theme colours to meet WCAG

### DIFF
--- a/.changeset/cool-dingos-repair.md
+++ b/.changeset/cool-dingos-repair.md
@@ -2,4 +2,4 @@
 '@backstage/theme': minor
 ---
 
-Updates light theme's primary foreground and `running` status indicator colours to meet WCAG
+Updates light theme's primary foreground and `running` status indicator colours to meet WCAG. Previously #2E77D0 changed to #1F5493.

--- a/.changeset/cool-dingos-repair.md
+++ b/.changeset/cool-dingos-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': minor
+---
+
+Updates light theme's primary foreground and `running` status indicator colours to meet WCAG

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -33,7 +33,7 @@ export const lightTheme = createTheme({
       ok: '#1DB954',
       warning: '#FF9800',
       error: '#E22134',
-      running: '#2E77D0',
+      running: '#1F5493',
       pending: '#FFED51',
       aborted: '#757575',
     },
@@ -48,7 +48,7 @@ export const lightTheme = createTheme({
       },
     },
     primary: {
-      main: '#2E77D0',
+      main: '#1F5493',
     },
     banner: {
       info: '#2E77D0',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The primary colour for the light theme `#2E77D0` fails accessibility tests on both a white and light grey backgrounds (table rows):
<img width="472" alt="image" src="https://user-images.githubusercontent.com/4676275/236817920-4ad2e8d9-05fb-4d35-b669-825f41ae7a8e.png">
<img width="472" alt="image" src="https://user-images.githubusercontent.com/4676275/236817826-485c153c-1ad9-4062-be37-617196af02b7.png">

This same colour hex code is used for the [`running` status indicator](https://backstage.io/storybook/?path=/story/data-display-status--default). The lighthouse tests on this component also fail.

The PR updates the theme's colours from `#2E77D0` to `#1F5493`.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/4676275/236817713-1ce03652-635b-48d2-97e7-ca4355e15408.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
