### PR TITLE
[search] Extend InputProps on <SearchBar/>

### DIFF
--- a/.changeset/ninety-mugs-sin.md
+++ b/.changeset/ninety-mugs-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': minor
+---
+
+<SearchBar/> accepts InputProp property that can override keys from default

--- a/plugins/search-react/src/components/SearchBar/SearchBar.stories.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.stories.tsx
@@ -92,13 +92,18 @@ const useStyles = makeStyles({
     borderRadius: '50px',
     margin: 'auto',
   },
+  notchedOutline: {
+    borderStyle: 'none',
+  },
 });
 
 export const CustomStyles = () => {
   const classes = useStyles();
   return (
     <Paper className={classes.search}>
-      <SearchBar />
+      <SearchBar
+        InputProps={{ classes: { notchedOutline: classes.notchedOutline } }}
+      />
     </Paper>
   );
 };

--- a/plugins/search-react/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.tsx
@@ -80,7 +80,8 @@ export const SearchBarBase: ForwardRefExoticComponent<SearchBarBaseProps> =
         value: defaultValue,
         label,
         placeholder,
-        inputProps: defaultInputProps = {},
+        inputProps = {},
+        InputProps = {},
         endAdornment,
         ...rest
       } = props;
@@ -168,10 +169,11 @@ export const SearchBarBase: ForwardRefExoticComponent<SearchBarBaseProps> =
               endAdornment: clearButton
                 ? clearButtonEndAdornment
                 : endAdornment,
+              ...InputProps,
             }}
             inputProps={{
               'aria-label': ariaLabel,
-              ...defaultInputProps,
+              ...inputProps,
             }}
             fullWidth={fullWidth}
             onChange={handleChange}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the current implementation of `<SearchBar/>` it is possible to overwrite the default `<TextField/>` `InputProps` by passing a prop of the same name. But sometimes is necessary to extend only, for example when one is interested on changing the clear button only.
The clear button is supplied in the `endAdornment`, part of the `InputProps`, but at the same time the `startAdornment` is also on it. To be able to replace the clear button implementation without affecting the rest, this patch proposes a change where `InputProps` is exposed in the same manner as `inputProps` (notice the change from capital I to i). Where the received object may overwrite keys using the spread operator.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
