### PR TITLE
fix(plugin-search-react): improve SearchPagination page limit change handling

### DIFF
--- a/.changeset/proud-chairs-sleep.md
+++ b/.changeset/proud-chairs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+`SearchPagination` now automatically resets the page cursor when the page limit is changed

--- a/plugins/search-react/api-report.md
+++ b/plugins/search-react/api-report.md
@@ -260,7 +260,7 @@ export type SearchPaginationLimitText = (params: {
 export type SearchPaginationProps = Omit<
   SearchPaginationBaseProps,
   | 'pageLimit'
-  | 'onPageLimitChange'
+  | 'onLimitChange'
   | 'pageCursor'
   | 'onPageCursorChange'
   | 'hasNextPage'

--- a/plugins/search-react/src/components/SearchPagination/SearchPagination.test.tsx
+++ b/plugins/search-react/src/components/SearchPagination/SearchPagination.test.tsx
@@ -185,4 +185,31 @@ describe('SearchPagination', () => {
       }),
     );
   });
+
+  it('Resets page cursor when page limit changes', async () => {
+    const initialState = {
+      term: '',
+      types: [],
+      filters: {},
+      pageCursor: 'Mg==', // page: 2
+    };
+
+    await renderWithEffects(
+      <TestApiProvider apis={[[searchApiRef, { query }]]}>
+        <SearchContextProvider initialState={initialState}>
+          <SearchPagination />
+        </SearchContextProvider>
+      </TestApiProvider>,
+    );
+
+    await userEvent.click(screen.getByText('25')); // first click to open the options
+    await userEvent.click(screen.getByText('10')); // second click to select the option
+
+    expect(query).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        pageCursor: undefined,
+        pageLimit: 10,
+      }),
+    );
+  });
 });

--- a/plugins/search-react/src/components/SearchPagination/SearchPagination.tsx
+++ b/plugins/search-react/src/components/SearchPagination/SearchPagination.tsx
@@ -191,12 +191,20 @@ export const SearchPagination = (props: SearchPaginationProps) => {
   const { pageLimit, setPageLimit, pageCursor, setPageCursor, fetchNextPage } =
     useSearch();
 
+  const handlePageLimitChange = useCallback(
+    (newPageLimit: number) => {
+      setPageLimit(newPageLimit);
+      setPageCursor(undefined);
+    },
+    [setPageLimit, setPageCursor],
+  );
+
   return (
     <SearchPaginationBase
       {...props}
       hasNextPage={!!fetchNextPage}
       limit={pageLimit}
-      onLimitChange={setPageLimit}
+      onLimitChange={handlePageLimitChange}
       cursor={pageCursor}
       onCursorChange={setPageCursor}
     />

--- a/plugins/search-react/src/components/SearchPagination/SearchPagination.tsx
+++ b/plugins/search-react/src/components/SearchPagination/SearchPagination.tsx
@@ -176,7 +176,7 @@ export const SearchPaginationBase = (props: SearchPaginationBaseProps) => {
 export type SearchPaginationProps = Omit<
   SearchPaginationBaseProps,
   | 'pageLimit'
-  | 'onPageLimitChange'
+  | 'onLimitChange'
   | 'pageCursor'
   | 'onPageCursorChange'
   | 'hasNextPage'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently the `SearchPagination` component:

![image](https://user-images.githubusercontent.com/22593117/236854154-4d4e5176-168f-466d-8dd0-3d9ffbe3378d.png)

does not reset the page cursor when page limit changes. 
This can cause some weird situations, for example:

1. User clicks 4 times on 'next page' with page limit 10
2. user now sees search result `40-50`
3. now the user switches page limit to 100
4. he now sees search results `400-500`  => this is way past what results the user went through

This PR fixes this behavior by resetting the page cursor when the page limit is changed.
Also, this PR fixes typescript typings by replacing the inexistent props omission `onPageLimitChange` prop with the correct `onLimitChange`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
