### PR TITLE
fix(plugin-gcalendar): Add userinfo email scope for gcalendar plugin auth refresh to resolve 401

### DIFF
--- a/.changeset/funny-cups-count.md
+++ b/.changeset/funny-cups-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gcalendar': patch
+---
+
+Pass user info email scope on auth refresh to resolve invalid credentials error

--- a/plugins/gcalendar/src/hooks/useSignIn.ts
+++ b/plugins/gcalendar/src/hooks/useSignIn.ts
@@ -25,7 +25,10 @@ export const useSignIn = () => {
   const signIn = useCallback(
     async (optional = false) => {
       const token = await authApi.getAccessToken(
-        'https://www.googleapis.com/auth/calendar.readonly',
+        [
+          'https://www.googleapis.com/auth/calendar.readonly',
+          'https://www.googleapis.com/auth/userinfo.email',
+        ],
         {
           optional,
           instantPopup: !optional,


### PR DESCRIPTION
Signed-off-by: Benjamin <benjamin.mccain@onepeloton.com>

## Hey, I just made a Pull Request!

The google calendar plugin isn't passing all the required scopes in order for the refresh to be completed. It will error out with a 401 due to an additional scope missing, which should be passed. In order to reproduce, you can login, then hard refresh the page in order for the refresh to take place, you will then see a 401 Invalid Credentials error and the user is logged out. This was introduced in the 1.13.0 upgrade when scopes started being passed to the refresh API. With a little digging, it turns out you also have to request the `https://www.googleapis.com/auth/userinfo.email` scope as well as the calendar scope. Google returns the email in the credentials hash and thus, I believe, if you haven't requested access to it you can't read it. I made this change in my local repo and confirmed it resolves the issue.

Specifically for this issue created
https://github.com/backstage/backstage/issues/17703

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
