### PR TITLE
Expose both types of scaffolder permissions in metadata endpoint

### DIFF
--- a/.changeset/big-days-press.md
+++ b/.changeset/big-days-press.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Expose both types of scaffolder permissions and rules through the metadata endpoint.

--- a/.changeset/big-days-press.md
+++ b/.changeset/big-days-press.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Expose both types of scaffolder permissions and rules through the metadata endpoint.
+
+The metadata endpoint now correctly exposes both types of scaffolder permissions and rules (for both the template and action resource types) through the metadata endpoint.

--- a/.changeset/spicy-spies-warn.md
+++ b/.changeset/spicy-spies-warn.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-common': patch
+'@backstage/plugin-scaffolder-common': minor
 ---
 
 Expose scaffolder permissions in new sub-aggregations.

--- a/.changeset/spicy-spies-warn.md
+++ b/.changeset/spicy-spies-warn.md
@@ -4,4 +4,4 @@
 
 Expose scaffolder permissions in new sub-aggregations.
 
-In addition to exporting a list of all scaffolder permissions in `scaffolderPermissions`, scaffolder-common now exports `scaffolderTemplatePermissions` and `scaffolderActionPermissions`, which contain subsets of the scaffolder permissions separated by resoure type.
+In addition to exporting a list of all scaffolder permissions in `scaffolderPermissions`, scaffolder-common now exports `scaffolderTemplatePermissions` and `scaffolderActionPermissions`, which contain subsets of the scaffolder permissions separated by resource type.

--- a/.changeset/spicy-spies-warn.md
+++ b/.changeset/spicy-spies-warn.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-common': patch
+---
+
+Expose scaffolder permissions in new sub-aggregations.
+
+In addition to exporting a list of all scaffolder permissions in `scaffolderPermissions`, scaffolder-common now exports `scaffolderTemplatePermissions` and `scaffolderActionPermissions`, which contain subsets of the scaffolder permissions separated by resoure type.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -29,6 +29,7 @@ import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
+import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
 import { RESOURCE_TYPE_SCAFFOLDER_TEMPLATE } from '@backstage/plugin-scaffolder-common/alpha';
 import { Schema } from 'jsonschema';
 import { ScmIntegrationRegistry } from '@backstage/integration';
@@ -48,6 +49,16 @@ import { ZodTypeDef } from 'zod';
 
 // @public @deprecated (undocumented)
 export type ActionContext<TInput extends JsonObject> = ActionContext_2<TInput>;
+
+// @public (undocumented)
+export type ActionPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<
+  TemplateEntityStepV1beta3 | TemplateParametersV1beta3,
+  {},
+  typeof RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  TParams
+>;
 
 // @public
 export const createBuiltinActions: (
@@ -763,7 +774,9 @@ export interface RouterOptions {
   // (undocumented)
   logger: Logger;
   // (undocumented)
-  permissionRules?: TemplatePermissionRuleInput[];
+  permissionRules?: Array<
+    TemplatePermissionRuleInput | ActionPermissionRuleInput
+  >;
   // (undocumented)
   permissions?: PermissionEvaluator;
   // (undocumented)

--- a/plugins/scaffolder-common/alpha-api-report.md
+++ b/plugins/scaffolder-common/alpha-api-report.md
@@ -15,10 +15,16 @@ export const RESOURCE_TYPE_SCAFFOLDER_ACTION = 'scaffolder-action';
 export const RESOURCE_TYPE_SCAFFOLDER_TEMPLATE = 'scaffolder-template';
 
 // @alpha
+export const scaffolderActionPermissions: ResourcePermission<'scaffolder-action'>[];
+
+// @alpha
 export const scaffolderPermissions: (
   | ResourcePermission<'scaffolder-action'>
   | ResourcePermission<'scaffolder-template'>
 )[];
+
+// @alpha
+export const scaffolderTemplatePermissions: ResourcePermission<'scaffolder-template'>[];
 
 // @alpha
 export const templateParameterReadPermission: ResourcePermission<'scaffolder-template'>;

--- a/plugins/scaffolder-common/src/permissions.ts
+++ b/plugins/scaffolder-common/src/permissions.ts
@@ -87,3 +87,18 @@ export const scaffolderPermissions = [
   templateParameterReadPermission,
   templateStepReadPermission,
 ];
+
+/**
+ * List of the scaffolder permissions that are associated with template steps and parameters.
+ * @alpha
+ */
+export const scaffolderTemplatePermissions = [
+  templateParameterReadPermission,
+  templateStepReadPermission,
+];
+
+/**
+ * List of the scaffolder permissions that are associated with scaffolder actions.
+ * @alpha
+ */
+export const scaffolderActionPermissions = [actionExecutePermission];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Now that #17077 is in, we can correctly provide both types of scaffolder permissions and rules to `createPermissionIntegrationRouter`, which will expose those permissions and rules in the metadata endpoint.

This is now what is returned when querying `scaffolder/.well-known/backstage/permissions/metadata`:
![Screenshot 2023-05-08 at 18 11 36](https://user-images.githubusercontent.com/7915735/236910818-6b882637-8e74-4026-a1bf-128a749fe538.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
