### PR TITLE
fix(core-components): Fix accessibility issue with Table headers

### DIFF
--- a/.changeset/ninety-eggs-lie.md
+++ b/.changeset/ninety-eggs-lie.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/theme': patch
+---
+
+Fix accessibility issue with Backstage Table's header style

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -105,7 +105,6 @@ const StyledMTableHeader = withStyles(
       borderTop: `1px solid ${theme.palette.grey.A100}`,
       borderBottom: `1px solid ${theme.palette.grey.A100}`,
       // withStyles hasn't a generic overload for theme
-      color: (theme as BackstageTheme).palette.textSubtle,
       fontWeight: theme.typography.fontWeightBold,
       position: 'static',
       wordBreak: 'normal',

--- a/packages/theme/src/baseTheme.ts
+++ b/packages/theme/src/baseTheme.ts
@@ -159,7 +159,6 @@ export function createThemeOverrides(theme: BackstageTheme): Overrides {
       head: {
         wordBreak: 'break-word',
         overflow: 'hidden',
-        color: theme.palette.textSubtle,
         fontWeight: 'normal',
         lineHeight: '1',
       },
@@ -198,14 +197,10 @@ export function createThemeOverrides(theme: BackstageTheme): Overrides {
         '&:hover': {
           color: 'inherit',
         },
-        '&:focus': {
-          color: 'inherit',
-        },
       },
       // Bold font for highlighting selected column
       active: {
         fontWeight: 'bold',
-        color: 'inherit',
       },
     },
     MuiListItemText: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Backsage's Table has an issue where navigating through keyboard to a table's header will not highlight correctly, the first item highlighted is the Drag & Drop `div` (with space & arrow keys or mouse drag you move it), the second item to receive focus but not highlighted at all is the `MuiTableSortLabel`.

It's worth noting the table is made with `@material-table/core` library that uses `MUI` under the hood, this is the one that adds the extra draggable div to the header to allow for column dragging, the draggable component uses a white border highlight, but the `MuiTableSortLabel` uses a darker font color, not sure if this is the best solution but would argue it's a problem with the respective libraries...

![Screenshot 2023-05-08 at 12 58 33 PM](https://user-images.githubusercontent.com/9698639/236940138-9209589c-e9b6-4f35-9023-f6db15274a79.png)
![Screenshot 2023-05-08 at 12 55 40 PM](https://user-images.githubusercontent.com/9698639/236940144-d0a51661-a405-4d50-b2bd-ba723ec5562d.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
