### PR TITLE
Feature/group leaders

### DIFF
--- a/.changeset/clean-wolves-dream.md
+++ b/.changeset/clean-wolves-dream.md
@@ -4,9 +4,9 @@
 '@backstage/plugin-org': minor
 ---
 
-Added the ability to optionally define leaders of groups in the catalog.
-
-A "leader" here is a manager, a chairperson, a spokesperson, etc.
-
-A group can have zero-or-one user defined as the leader, and users can be leaders of
-zero-or-more groups. The leader is not required to be a member of the group.
+- Added the ability to optionally define leaders of groups in the catalog
+  - A "leader" here is a manager, a chairperson, a spokesperson, etc.
+  - A group can have zero-or-one user defined as the leader, and users can be leaders of zero-or-more groups. The leader is not required to be a member of the group
+- Display the leader of a group (if any) on the Group Profile Card
+- Display the group(s) a user leads (if any) on the User Profile Card
+  - Also adds labels to the fields being displayed on the User Profile Card

--- a/.changeset/clean-wolves-dream.md
+++ b/.changeset/clean-wolves-dream.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/catalog-model': minor
+'@backstage/plugin-org': minor
+---
+
+Added the ability to optionally define leaders of groups in the catalog.
+
+A "leader" here is a manager, a chairperson, a spokesperson, etc.
+
+A group can have zero-or-one user defined as the leader, and users can be leaders of
+zero-or-more groups. The leader is not required to be a member of the group.

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -924,6 +924,7 @@ spec:
   parent: ops
   children: [backstage, other]
   members: [jdoe]
+  leader: mmanager
 ```
 
 In addition to the [common envelope metadata](#common-to-all-kinds-the-metadata)
@@ -993,6 +994,19 @@ The entries of this array are
 | --------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
 | [`User`](#kind-user) (default)          | Same as this entity, typically `default`   | [`hasMember`, and reverse `memberOf`](well-known-relations.md#memberof-and-hasmember) |
 
+### `spec.leader` [optional]
+
+The user who is the leader (manager, chairperson, etc) of the group, if any. Not all groups must have a
+leader, and groups may not have
+more than one parent. A given User can be the leader of multiple groups.
+
+This field is an
+[entity reference](https://backstage.io/docs/features/software-catalog/references).
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                    |
+| --------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| [`User`](#kind-user) (default)          | Same as this entity, typically `default`   | [`hasLeader`, and reverse `leaderOf`](well-known-relations.md#leaderof-and-hasleader) |
+
 ## Kind: User
 
 Describes the following entity kind:
@@ -1022,6 +1036,7 @@ spec:
     email: jenny-doe@example.com
     picture: https://example.com/staff/jenny-with-party-hat.jpeg
   memberOf: [team-b, employees]
+  leaderOf: [team-b]
 ```
 
 In addition to the [common envelope metadata](#common-to-all-kinds-the-metadata)
@@ -1052,6 +1067,20 @@ The entries of this array are
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                    |
 | --------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
 | [`Group`](#kind-group) (default)        | Same as this entity, typically `default`   | [`memberOf`, and reverse `hasMember`](well-known-relations.md#memberof-and-hasmember) |
+
+### `spec.leaderOf` [optional]
+
+The list of groups that the user is the direct leader of (i.e., no transitive
+leaderships are listed here). "Leader" may mean manager, chairperson, etc. The list is optional, and may be empty if the
+user is not the leader of any groups. The items are not guaranteed to be ordered in
+any particular way. The user is not required to be a [member of](#specmemberof-required) the group.
+
+The entries of this array are
+[entity references](https://backstage.io/docs/features/software-catalog/references).
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                    |
+| --------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| [`Group`](#kind-group) (default)        | Same as this entity, typically `default`   | [`leaderOf`, and reverse `hasLeader`](well-known-relations.md#leaderof-and-hasleader) |
 
 ## Kind: Resource
 

--- a/docs/features/software-catalog/well-known-relations.md
+++ b/docs/features/software-catalog/well-known-relations.md
@@ -107,3 +107,10 @@ component, API or resource belongs to a system; or that a system is grouped
 under a domain.
 
 This relation is commonly based on `spec.system` or `spec.domain`.
+
+### `leaderOf` and `hasLeader`
+
+A relationship describing a [User](descriptor-format.md#kind-user) as the leader of a [Group](descriptor-format.md#kind-group). A User can be the leader of many Groups, but a Group can have zero-or-one leader. The leader
+does not need to be a member of the group.
+
+This relation is commonly based on `spec.leader` on the Group entity.

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -243,6 +243,7 @@ interface GroupEntityV1alpha1 extends Entity {
     parent?: string;
     children: string[];
     members?: string[];
+    leader?: string;
   };
 }
 export { GroupEntityV1alpha1 as GroupEntity };
@@ -376,10 +377,16 @@ export const RELATION_DEPENDENCY_OF = 'dependencyOf';
 export const RELATION_DEPENDS_ON = 'dependsOn';
 
 // @public
+export const RELATION_HAS_LEADER = 'hasLeader';
+
+// @public
 export const RELATION_HAS_MEMBER = 'hasMember';
 
 // @public
 export const RELATION_HAS_PART = 'hasPart';
+
+// @public
+export const RELATION_LEADER_OF = 'leaderOf';
 
 // @public
 export const RELATION_MEMBER_OF = 'memberOf';
@@ -475,6 +482,7 @@ interface UserEntityV1alpha1 extends Entity {
       picture?: string;
     };
     memberOf?: string[];
+    leaderOf?: string[];
   };
 }
 export { UserEntityV1alpha1 as UserEntity };

--- a/packages/catalog-model/examples/acme/team-a-group.yaml
+++ b/packages/catalog-model/examples/acme/team-a-group.yaml
@@ -11,6 +11,7 @@ spec:
     picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
   parent: backstage
   children: []
+  leader: breanna.davison
 ---
 apiVersion: backstage.io/v1alpha1
 kind: User

--- a/packages/catalog-model/examples/acme/team-c-group.yaml
+++ b/packages/catalog-model/examples/acme/team-c-group.yaml
@@ -11,6 +11,7 @@ spec:
     picture: https://avatars.dicebear.com/api/identicon/team-c@example.com.svg?background=%23fff&margin=25
   parent: boxoffice
   children: []
+  leader: sarah.gilroy
 ---
 apiVersion: backstage.io/v1alpha1
 kind: User

--- a/packages/catalog-model/examples/acme/team-d-group.yaml
+++ b/packages/catalog-model/examples/acme/team-d-group.yaml
@@ -11,6 +11,7 @@ spec:
     picture: https://avatars.dicebear.com/api/identicon/team-d@example.com.svg?background=%23fff&margin=25
   parent: boxoffice
   children: []
+  leader: eva.macdowell
 ---
 apiVersion: backstage.io/v1alpha1
 kind: User

--- a/packages/catalog-model/src/kinds/GroupEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/GroupEntityV1alpha1.test.ts
@@ -40,6 +40,7 @@ describe('GroupV1alpha1Validator', () => {
         parent: 'group-a',
         children: ['child-a', 'child-b'],
         members: ['jdoe'],
+        leader: 'manager-a',
       },
     };
   });
@@ -194,5 +195,17 @@ describe('GroupV1alpha1Validator', () => {
   it('accepts no members', async () => {
     (entity as any).spec.members = [];
     await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  // leaders
+
+  it('accepts missing leader', async () => {
+    delete (entity as any).spec.leader;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty leader', async () => {
+    (entity as any).spec.leader = '';
+    await expect(validator.check(entity)).rejects.toThrow(/leader/);
   });
 });

--- a/packages/catalog-model/src/kinds/GroupEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/GroupEntityV1alpha1.ts
@@ -36,6 +36,7 @@ export interface GroupEntityV1alpha1 extends Entity {
     parent?: string;
     children: string[];
     members?: string[];
+    leader?: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/UserEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/UserEntityV1alpha1.test.ts
@@ -36,6 +36,7 @@ describe('userEntityV1alpha1Validator', () => {
           picture: 'https://doe.org/john.jpeg',
         },
         memberOf: ['team-a', 'developers'],
+        leaderOf: ['team-a', 'team-b'],
       },
     };
   });
@@ -153,5 +154,32 @@ describe('userEntityV1alpha1Validator', () => {
   it('rejects null memberOf', async () => {
     (entity as any).spec.memberOf = null;
     await expect(validator.check(entity)).rejects.toThrow(/memberOf/);
+  });
+
+  // leaderOf
+
+  it('allows missing leaderOf', async () => {
+    delete (entity as any).spec.leaderOf;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects wrong leaderOf', async () => {
+    (entity as any).spec.leaderOf = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/leaderOf/);
+  });
+
+  it('rejects wrong leaderOf item', async () => {
+    (entity as any).spec.leaderOf[0] = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/leaderOf/);
+  });
+
+  it('accepts empty leaderOf', async () => {
+    (entity as any).spec.leaderOf = [];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects null leaderOf', async () => {
+    (entity as any).spec.leaderOf = null;
+    await expect(validator.check(entity)).rejects.toThrow(/leaderOf/);
   });
 });

--- a/packages/catalog-model/src/kinds/UserEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/UserEntityV1alpha1.ts
@@ -33,6 +33,7 @@ export interface UserEntityV1alpha1 extends Entity {
       picture?: string;
     };
     memberOf?: string[];
+    leaderOf?: string[];
   };
 }
 

--- a/packages/catalog-model/src/kinds/relations.ts
+++ b/packages/catalog-model/src/kinds/relations.ts
@@ -136,3 +136,19 @@ export const RELATION_PART_OF = 'partOf';
  * @public
  */
 export const RELATION_HAS_PART = 'hasPart';
+
+/**
+ * An relation defining who the leader (a user) of a group is. Reversed direction of
+ * {@link RELATION_LEADER_OF}
+ *
+ * @public
+ */
+export const RELATION_HAS_LEADER = 'hasLeader';
+
+/**
+ * A relationship from a user to a group that the user leads. Reversed direction of
+ * {@link RELATION_HAS_LEADER}
+ *
+ * @public
+ */
+export const RELATION_LEADER_OF = 'leaderOf';

--- a/packages/catalog-model/src/schema/kinds/Group.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Group.v1alpha1.schema.json
@@ -95,6 +95,12 @@
                 "examples": ["jdoe"],
                 "minLength": 1
               }
+            },
+            "leader": {
+              "type": "string",
+              "description": "The user who is the leader of this group, who may or may not be one of the members. This is an entity reference to a user.",
+              "examples": ["mmonroe"],
+              "minLength": 1
             }
           }
         }

--- a/packages/catalog-model/src/schema/kinds/User.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/User.v1alpha1.schema.json
@@ -71,6 +71,15 @@
                 "examples": ["team-b", "employees"],
                 "minLength": 1
               }
+            },
+            "leaderOf": {
+              "type": "array",
+              "description": "The list of groups that the user is the direct leader of (i.e., no transitive memberships are listed here). The list must be present, but may be empty if the user is not the leader of any groups. The items are not guaranteed to be ordered in any particular way. The entries of this array are entity references to groups.",
+              "items": {
+                "type": "string",
+                "examples": ["team-b", "employees"],
+                "minLength": 1
+              }
             }
           }
         }

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
@@ -41,6 +41,8 @@ import {
   RELATION_PARENT_OF,
   RELATION_PART_OF,
   RELATION_PROVIDES_API,
+  RELATION_HAS_LEADER,
+  RELATION_LEADER_OF,
   ResourceEntity,
   resourceEntityV1alpha1Validator,
   SystemEntity,
@@ -238,6 +240,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_MEMBER_OF,
         RELATION_HAS_MEMBER,
       );
+      doEmit(
+        user.spec.leaderOf,
+        { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
+        RELATION_LEADER_OF,
+        RELATION_HAS_LEADER,
+      );
     }
 
     /*
@@ -263,6 +271,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         { defaultKind: 'User', defaultNamespace: selfRef.namespace },
         RELATION_HAS_MEMBER,
         RELATION_MEMBER_OF,
+      );
+      doEmit(
+        group.spec.leader,
+        { defaultKind: 'User', defaultNamespace: selfRef.namespace },
+        RELATION_HAS_LEADER,
+        RELATION_LEADER_OF,
       );
     }
 

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -19,6 +19,7 @@ import {
   ANNOTATION_LOCATION,
   GroupEntity,
   RELATION_CHILD_OF,
+  RELATION_HAS_LEADER,
   RELATION_PARENT_OF,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
@@ -53,6 +54,7 @@ import CachedIcon from '@material-ui/icons/Cached';
 import EditIcon from '@material-ui/icons/Edit';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
+import FaceIcon from '@material-ui/icons/Face';
 import { LinksGroup } from '../../Meta';
 
 const CardTitle = (props: { title: string }) => (
@@ -84,6 +86,10 @@ export const GroupProfileCard = (props: {
     metadata: { name, description, title, annotations, links },
     spec: { profile },
   } = group;
+
+  const leader = getEntityRelations(group, RELATION_HAS_LEADER, {
+    kind: 'User',
+  });
 
   const childRelations = getEntityRelations(group, RELATION_PARENT_OF, {
     kind: 'Group',
@@ -152,6 +158,25 @@ export const GroupProfileCard = (props: {
                 <ListItemText
                   primary={<Link to={emailHref}>{profile.email}</Link>}
                   secondary="Email"
+                />
+              </ListItem>
+            )}
+            {leader?.length === 1 && (
+              <ListItem>
+                <ListItemIcon>
+                  <Tooltip title="Group Leader">
+                    <FaceIcon />
+                  </Tooltip>
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    leader.length ? (
+                      <EntityRefLinks entityRefs={leader} defaultKind="User" />
+                    ) : (
+                      'N/A'
+                    )
+                  }
+                  secondary="Group Leader"
                 />
               </ListItem>
             )}

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -17,6 +17,7 @@
 import {
   ANNOTATION_EDIT_URL,
   RELATION_MEMBER_OF,
+  RELATION_LEADER_OF,
   UserEntity,
 } from '@backstage/catalog-model';
 import {
@@ -47,6 +48,7 @@ import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
 import { LinksGroup } from '../../Meta';
 import PersonIcon from '@material-ui/icons/Person';
+import FaceIcon from '@material-ui/icons/Face';
 import React from 'react';
 
 const CardTitle = (props: { title?: string }) =>
@@ -77,6 +79,9 @@ export const UserProfileCard = (props: {
   const displayName = profile?.displayName ?? metaName;
   const emailHref = profile?.email ? `mailto:${profile.email}` : undefined;
   const memberOfRelations = getEntityRelations(user, RELATION_MEMBER_OF, {
+    kind: 'Group',
+  });
+  const leaderOfRelations = getEntityRelations(user, RELATION_LEADER_OF, {
     kind: 'Group',
   });
 
@@ -114,9 +119,29 @@ export const UserProfileCard = (props: {
                     <EmailIcon />
                   </Tooltip>
                 </ListItemIcon>
-                <ListItemText>
-                  <Link to={emailHref ?? ''}>{profile.email}</Link>
-                </ListItemText>
+                <ListItemText
+                  primary={<Link to={emailHref ?? ''}>{profile.email}</Link>}
+                  secondary="Email"
+                />
+              </ListItem>
+            )}
+
+            {leaderOfRelations?.length > 0 && (
+              <ListItem>
+                <ListItemIcon>
+                  <Tooltip title="Leader of">
+                    <FaceIcon />
+                  </Tooltip>
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <EntityRefLinks
+                      entityRefs={leaderOfRelations}
+                      defaultKind="Group"
+                    />
+                  }
+                  secondary="Leader of"
+                />
               </ListItem>
             )}
 
@@ -126,12 +151,15 @@ export const UserProfileCard = (props: {
                   <GroupIcon />
                 </Tooltip>
               </ListItemIcon>
-              <ListItemText>
-                <EntityRefLinks
-                  entityRefs={memberOfRelations}
-                  defaultKind="Group"
-                />
-              </ListItemText>
+              <ListItemText
+                primary={
+                  <EntityRefLinks
+                    entityRefs={memberOfRelations}
+                    defaultKind="Group"
+                  />
+                }
+                secondary="Member of"
+              />
             </ListItem>
 
             {props?.showLinks && <LinksGroup links={links} />}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added the ability to specify the leader of a group in the YAML files.
- It's completely optional
- I defined the `leaderOf` and `hasLeader` relationship
- The `spec.leader` field in the Group yaml can reference a User entity, or be omitted entirely
- The `spec.leaderOf` field in the User yaml can reference zero or more groups, or be omitted entirely
- The leader of a group may or may not be a member of the group
- The Group Profile Card displays the leader of the group, if any
<img width="767" alt="Group Card" src="https://github.com/backstage/backstage/assets/11984848/ddff3371-45cd-48dd-bb03-1214da94c63a">

- The User Profile Card displays the group(s) the user leads, if any
  - Also adds labels to the fields in the card now that there are more than two, to make it clear what the fields are
<img width="768" alt="User Card" src="https://github.com/backstage/backstage/assets/11984848/39fec291-baeb-4dc7-8da9-556f5d6d9e1e">


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages -- clean-wolves-dream.md
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. 
