### PR TITLE
scaffolder: extract `ui:*` fields from conditional fields.

### DIFF
--- a/.changeset/silent-kangaroos-pay.md
+++ b/.changeset/silent-kangaroos-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Extract `ui:*` fields from conditional `then` and `else` schema branches.

--- a/plugins/scaffolder-react/src/next/lib/schema.test.ts
+++ b/plugins/scaffolder-react/src/next/lib/schema.test.ts
@@ -411,4 +411,84 @@ describe('extractSchemaFromStep', () => {
       uiSchema: expectedUiSchema,
     });
   });
+
+  it('transforms conditional schema', () => {
+    const inputSchema: JsonObject = {
+      type: 'object',
+      properties: {
+        flag: {
+          type: 'boolean',
+        },
+      },
+      if: {
+        properties: {
+          flag: {
+            const: true,
+          },
+        },
+      },
+      then: {
+        properties: {
+          user: {
+            type: 'string',
+            'ui:field': 'EntityPicker',
+            'ui:options': {
+              catalogFilter: [{ kind: 'User' }],
+            },
+          },
+        },
+      },
+      else: {
+        properties: {
+          email: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const expectedSchema = {
+      type: 'object',
+      properties: {
+        flag: {
+          type: 'boolean',
+        },
+      },
+      if: {
+        properties: {
+          flag: {
+            const: true,
+          },
+        },
+      },
+      then: {
+        properties: {
+          user: {
+            type: 'string',
+          },
+        },
+      },
+      else: {
+        properties: {
+          email: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const expectedUiSchema = {
+      flag: {},
+      user: {
+        'ui:field': 'EntityPicker',
+        'ui:options': {
+          catalogFilter: [{ kind: 'User' }],
+        },
+      },
+      email: {},
+    };
+
+    expect(extractSchemaFromStep(inputSchema)).toEqual({
+      schema: expectedSchema,
+      uiSchema: expectedUiSchema,
+    });
+  });
 });

--- a/plugins/scaffolder-react/src/next/lib/schema.ts
+++ b/plugins/scaffolder-react/src/next/lib/schema.ts
@@ -25,7 +25,16 @@ function extractUiSchema(schema: JsonObject, uiSchema: JsonObject) {
     return;
   }
 
-  const { properties, items, anyOf, oneOf, allOf, dependencies } = schema;
+  const {
+    properties,
+    items,
+    anyOf,
+    oneOf,
+    allOf,
+    dependencies,
+    then,
+    else: _else,
+  } = schema;
 
   for (const propName in schema) {
     if (!schema.hasOwnProperty(propName)) {
@@ -95,6 +104,14 @@ function extractUiSchema(schema: JsonObject, uiSchema: JsonObject) {
       }
       extractUiSchema(schemaNode, uiSchema);
     }
+  }
+
+  if (isObject(then)) {
+    extractUiSchema(then, uiSchema);
+  }
+
+  if (isObject(_else)) {
+    extractUiSchema(_else, uiSchema);
   }
 }
 


### PR DESCRIPTION
With this change the `ui:*` schema config is extracted also for the `then` and `else` branch of a conditional schema.

Example schema:

```yaml
parameters:
  - title: Fill in some steps
    properties:
      useUser:
        title: Use existing User
        type: boolean
    if:
      properties:
        useUser:
          const: true
    then:
      properties:
        user:
          type: string
          ui:field: EntityPicker
          ui:options:
            catalogFilter:
              - kind: User
    else:
      properties:
        name:
          type: string
        email:
          type: string
```

![image](https://github.com/backstage/backstage/assets/4464522/f3a1b002-16bb-4273-bfa4-cc085c8a4d51)



#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
