### PR TITLE
fix(catalog): Add Screen Reader notice Edit Metadata Link opens in new tab

### DIFF
--- a/.changeset/three-tools-pump.md
+++ b/.changeset/three-tools-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix accessibility issue with Edit Metadata Link on screen readers missing notice about opening in a new tab.

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -188,6 +188,9 @@ export const Link = React.forwardRef<any, LinkProps>(
       <MaterialLink
         {...(newWindow ? { target: '_blank', rel: 'noopener' } : {})}
         {...props}
+        {...(props['aria-label']
+          ? { 'aria-label': `${props['aria-label']}, Opens in a new window` }
+          : {})}
         ref={ref}
         href={to}
         onClick={handleClick}


### PR DESCRIPTION
## Catalog: Screen Reader notice Edit Metadata Link opens in new tab

The issue is that in the Catalog's About page, when using a Screen Reader, the `Edit Metadata` link doesn't tell the user it will open in a new tab, which is an accessibility issue.

The issue happens when you mix a Backstage's Link and an `aria-label`, our Link checks whether the link is an external one with a Regex, and adds a hidden label to the content of the link, however when `aria-label` is present, the reader uses that without looking at the content, this is very common when we use an IconButton as a Link.

![Screenshot 2023-05-10 at 3 55 32 PM](https://github.com/backstage/backstage/assets/9698639/474df318-2367-41ba-bf48-cd0bd2e2bd22)

To fix this we check if the link received an `aria-label` and concatenate the `, Opens in a new window` text.

### Steps to reproduce:

1. Open Url: https://demo.backstage.io/ and enter valid login credentials.
2. Navigate to the Kind combo box. Make sure `Component` is selected.
3. Select a link from the name column (For example playback-order). A new page of component opens up.
4. Launch NVDA or VoiceOver and navigate to `Edit Metadata` link.
5. Screen reader will not mention the link will open in a new tab.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
