### PR TITLE
Add ability to use `defaultNamespace` and `defaultKind` for scaffolder action `catalog:fetch`

### DIFF
--- a/.changeset/giant-students-lie.md
+++ b/.changeset/giant-students-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add ability to use `defaultNamespace` and `defaultKind` for scaffolder action `catalog:fetch`

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -119,6 +119,8 @@ export function createFetchCatalogEntityAction(options: {
     entityRef?: string | undefined;
     entityRefs?: string[] | undefined;
     optional?: boolean | undefined;
+    defaultKind?: string | undefined;
+    defaultNamespace?: string | undefined;
   },
   {
     entity?: any;


### PR DESCRIPTION
Add ability to use `defaultNamespace` and `defaultKind` for scaffolder action `catalog:fetch`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
