### PR TITLE
Fix input schema validation issue for gitlab actions.

### DIFF
--- a/.changeset/gold-vans-sin.md
+++ b/.changeset/gold-vans-sin.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Fix input schema validation issue for gitlab actions:
+
+- gitlab:group:ensureExists
+- gitlab:projectAccessToken:create
+- gitlab:projectDeployToken:create
+- gitlab:projectVariable:create

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -12,10 +12,9 @@ export const createGitlabGroupEnsureExistsAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
+    path: string[];
     repoUrl: string;
     token?: string | undefined;
-  } & {
-    path: string[];
   },
   {
     groupId?: number | undefined;
@@ -27,10 +26,9 @@ export const createGitlabProjectAccessTokenAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
+    projectId: string | number;
     repoUrl: string;
     token?: string | undefined;
-  } & {
-    projectId: string | number;
     name?: string | undefined;
     accessLevel?: number | undefined;
     scopes?: string[] | undefined;
@@ -45,11 +43,10 @@ export const createGitlabProjectDeployTokenAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    repoUrl: string;
-    token?: string | undefined;
-  } & {
     name: string;
     projectId: string | number;
+    repoUrl: string;
+    token?: string | undefined;
     username?: string | undefined;
     scopes?: string[] | undefined;
   },
@@ -64,13 +61,12 @@ export const createGitlabProjectVariableAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    repoUrl: string;
-    token?: string | undefined;
-  } & {
     key: string;
     value: string;
     projectId: string | number;
+    repoUrl: string;
     variableType: string;
+    token?: string | undefined;
     variableProtected?: boolean | undefined;
     masked?: boolean | undefined;
     raw?: boolean | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
@@ -36,7 +36,7 @@ export const createGitlabGroupEnsureExistsAction = (options: {
     id: 'gitlab:group:ensureExists',
     description: 'Ensures a Gitlab group exists',
     schema: {
-      input: commonGitlabConfig.and(
+      input: commonGitlabConfig.merge(
         z.object({
           path: z
             .array(z.string(), {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectAccessTokenAction.ts
@@ -33,7 +33,7 @@ export const createGitlabProjectAccessTokenAction = (options: {
   return createTemplateAction({
     id: 'gitlab:projectAccessToken:create',
     schema: {
-      input: commonGitlabConfig.and(
+      input: commonGitlabConfig.merge(
         z.object({
           projectId: z.union([z.number(), z.string()], {
             description: 'Project ID',

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectDeployTokenAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectDeployTokenAction.ts
@@ -36,7 +36,7 @@ export const createGitlabProjectDeployTokenAction = (options: {
   return createTemplateAction({
     id: 'gitlab:projectDeployToken:create',
     schema: {
-      input: commonGitlabConfig.and(
+      input: commonGitlabConfig.merge(
         z.object({
           projectId: z.union([z.number(), z.string()], {
             description: 'Project ID',

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectVariableAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabProjectVariableAction.ts
@@ -34,7 +34,7 @@ export const createGitlabProjectVariableAction = (options: {
   return createTemplateAction({
     id: 'gitlab:projectVariable:create',
     schema: {
-      input: commonGitlabConfig.and(
+      input: commonGitlabConfig.merge(
         z.object({
           projectId: z.union([z.number(), z.string()], {
             description: 'Project ID',


### PR DESCRIPTION
Using zod intersections results in an invalid JsonSchema. The issue has been reported at https://github.com/StefanTerdell/zod-to-json-schema/issues/64.

The following actions has been fixed:

- gitlab:group:ensureExists
- gitlab:projectAccessToken:create
- gitlab:projectDeployToken:create
- gitlab:projectVariable:create

resolves #17721

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
