### PR TITLE
Add support for dry run for `gitlab:group:ensureExists` action.

### DIFF
--- a/.changeset/five-turtles-play.md
+++ b/.changeset/five-turtles-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Add support for dry run for `gitlab:group:ensureExists` action.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.test.ts
@@ -137,4 +137,35 @@ describe('gitlab:group:ensureExists', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith('groupId', 42);
   });
+
+  it('should not call API on dryRun', async () => {
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            token: 'tokenlols',
+            apiBaseUrl: 'https://api.gitlab.com',
+          },
+        ],
+      },
+    });
+    const integrations = ScmIntegrations.fromConfig(config);
+
+    const action = createGitlabGroupEnsureExistsAction({ integrations });
+
+    await action.handler({
+      ...mockContext,
+      isDryRun: true,
+      input: {
+        repoUrl: 'gitlab.com',
+        path: ['foo', 'bar'],
+      },
+    });
+
+    expect(mockGitlabClient.Groups.search).not.toHaveBeenCalled();
+    expect(mockGitlabClient.Groups.create).not.toHaveBeenCalled();
+
+    expect(mockContext.output).toHaveBeenCalledWith('groupId', 42);
+  });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
@@ -35,6 +35,7 @@ export const createGitlabGroupEnsureExistsAction = (options: {
   return createTemplateAction({
     id: 'gitlab:group:ensureExists',
     description: 'Ensures a Gitlab group exists',
+    supportsDryRun: true,
     schema: {
       input: commonGitlabConfig.and(
         z.object({
@@ -52,6 +53,11 @@ export const createGitlabGroupEnsureExistsAction = (options: {
       }),
     },
     async handler(ctx) {
+      if (ctx.isDryRun) {
+        ctx.output('groupId', 42);
+        return;
+      }
+
       const { path } = ctx.input;
       const { token, integrationConfig } = getToken(ctx.input, integrations);
 
@@ -66,7 +72,7 @@ export const createGitlabGroupEnsureExistsAction = (options: {
         const fullPath = `${currentPath}/${pathElement}`;
         const result = (await api.Groups.search(
           fullPath,
-        )) as any as Array<GroupSchema>; // recast since the return type for search is wrong in the gitbeaker typings
+        )) as unknown as Array<GroupSchema>; // recast since the return type for search is wrong in the gitbeaker typings
         const subGroup = result.find(
           searchPathElem => searchPathElem.full_path === fullPath,
         );


### PR DESCRIPTION
#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
