### PR TITLE
cli: deprecate use of react 16

### DIFF
--- a/.changeset/tiny-crews-pull.md
+++ b/.changeset/tiny-crews-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Deprecated the use of React 16

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -45,7 +45,7 @@ function checkReactVersion() {
           `
 ⚠️                                                                           ⚠️
 ⚠️ You are using React version 16, which is deprecated for use in Backstage. ⚠️
-⚠️ Please upgrade to at React 17 by updating your packages/app dependencies. ⚠️
+⚠️ Please upgrade to React 17 by updating your packages/app dependencies.    ⚠️
 ⚠️                                                                           ⚠️
 `,
         ),

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -32,6 +32,30 @@ interface StartAppOptions {
   configPaths: string[];
 }
 
+function checkReactVersion() {
+  try {
+    // Make sure we're looking at the root of the target repo
+    const reactPkgPath = require.resolve('react/package.json', {
+      paths: [paths.targetRoot],
+    });
+    const reactPkg = require(reactPkgPath);
+    if (reactPkg.version.startsWith('16.')) {
+      console.log(
+        chalk.yellow(
+          `
+⚠️                                                                           ⚠️
+⚠️ You are using React version 16, which is deprecated for use in Backstage. ⚠️
+⚠️ Please upgrade to at React 17 by updating your packages/app dependencies. ⚠️
+⚠️                                                                           ⚠️
+`,
+        ),
+      );
+    }
+  } catch {
+    /* ignored */
+  }
+}
+
 export async function startFrontend(options: StartAppOptions) {
   if (options.verifyVersions) {
     const lockfile = await Lockfile.load(paths.resolveTargetRoot('yarn.lock'));
@@ -64,6 +88,8 @@ export async function startFrontend(options: StartAppOptions) {
       );
     }
   }
+
+  checkReactVersion();
 
   const { name } = await fs.readJson(paths.resolveTarget('package.json'));
   const config = await loadCliConfig({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In order to move #17414 and #7094 forward we'll be deprecating usage of React 16 in the 1.14 release. The goal is then to move to supporting both and only React 17 and React 18 in the 1.15 release in June.

If the `node_modules/react/packages.json` is at v16, the following warning will be printed when running `yarn start`:

![image](https://github.com/backstage/backstage/assets/4984472/3357b34c-e6a9-4dbe-b460-a3ebe79dba74)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
