### PR TITLE
docs: Add error handling instructions for 'No token available' error

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -242,7 +242,8 @@ integrations:
     - host: github.com
       token: ${GITHUB_TOKEN} # this will use the environment variable GITHUB_TOKEN
 ```
-> If you encounter the error `No token available for host: github.com, with owner , and repo from-backstage`, try resolving it by restarting Backstage. First, stop the running instance by pressing `Control-C` in the terminal. Then, restart it by running the command `yarn dev`. Once Backstage is up and running, click the **START OVER** button."
+
+> Note: If you encounter the error `No token available for host: github.com, with owner , and repo from-backstage`, try resolving it by restarting Backstage. First, stop the running instance by pressing `Control-C` in the terminal. Then, restart it by running the command `yarn dev`. Once Backstage is up and running, click the **START OVER** button."
 
 Some helpful links, for if you want to learn more about:
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -242,6 +242,7 @@ integrations:
     - host: github.com
       token: ${GITHUB_TOKEN} # this will use the environment variable GITHUB_TOKEN
 ```
+> If you encounter the error `No token available for host: github.com, with owner , and repo from-backstage`, try resolving it by restarting Backstage. First, stop the running instance by pressing `Control-C` in the terminal. Then, restart it by running the command `yarn dev`. Once Backstage is up and running, click the **START OVER** button."
 
 Some helpful links, for if you want to learn more about:
 


### PR DESCRIPTION
This commit adds instructions to the Backstage documentation on how to handle the `No token available for host: github.com, with owner , and repo from-backstage' error`. The instructions guide the user to restart Backstage using `Control-C` and `yarn dev` commands in the terminal, followed by clicking on the **START OVER** button.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
- Added or updated documentation
- All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
