### PR TITLE
Update deprecated packages in ImmediateEntityProvider.ts

### DIFF
--- a/contrib/catalog/ImmediateEntityProvider.ts
+++ b/contrib/catalog/ImmediateEntityProvider.ts
@@ -9,8 +9,8 @@ import {
   DeferredEntity,
   EntityProvider,
   EntityProviderConnection,
-  parseEntityYaml,
-} from '@backstage/plugin-catalog-backend';
+} from '@backstage/plugin-catalog-node';
+import { parseEntityYaml } from '@backstage/plugin-catalog-backend';
 import bodyParser from 'body-parser';
 import express from 'express';
 import Router from 'express-promise-router';


### PR DESCRIPTION
Imports have been updated to reflect that `DeferredEntity`, `EntityProvider`, and `EntityProviderConnection` now reside in `@backstage/plugin-catalog-node`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
