### PR TITLE
await response errors

### DIFF
--- a/.changeset/eleven-taxis-notice.md
+++ b/.changeset/eleven-taxis-notice.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': patch
+'@backstage/config-loader': patch
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed the way that some request errors are thrown

--- a/packages/config-loader/src/sources/RemoteConfigSource.ts
+++ b/packages/config-loader/src/sources/RemoteConfigSource.ts
@@ -149,7 +149,7 @@ export class RemoteConfigSource implements ConfigSource {
       signal: signal as import('node-fetch').RequestInit['signal'],
     });
     if (!res.ok) {
-      throw ResponseError.fromResponse(res);
+      throw await ResponseError.fromResponse(res);
     }
 
     const content = await res.text();

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
@@ -227,7 +227,7 @@ export class CloudflareAccessAuthProvider implements AuthProviderRouteHandlers {
         { headers },
       );
       if (!res.ok) {
-        throw ResponseError.fromResponse(res);
+        throw await ResponseError.fromResponse(res);
       }
       const cfIdentity = await res.json();
       return cfIdentity as unknown as CloudflareAccessIdentityProfile;

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -88,7 +88,7 @@ export const getAndWriteAttachments = async (
         },
       });
       if (!res.ok) {
-        throw ResponseError.fromResponse(res);
+        throw await ResponseError.fromResponse(res);
       } else if (res.body !== null) {
         fs.openSync(`${workspace}/${mkdocsDir}docs/img/${downloadTitle}`, 'w');
         const writeStream = fs.createWriteStream(


### PR DESCRIPTION
It may be the case that the default error middleware could be rebuilt to support promises too. Don't have time for that right now though