### PR TITLE
[backend-test-utils]: Don't need this export

### DIFF
--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -26,9 +26,6 @@ import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
-export const getDockerImageForName: (name: string) => string;
-
-// @public (undocumented)
 export function isDockerDisabledForTests(): boolean;
 
 // @public (undocumented)

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -16,7 +16,7 @@
 
 import { DatabaseManager } from '@backstage/backend-common';
 import { Knex } from 'knex';
-import { getDockerImageForName } from '../util';
+import { getDockerImageForName } from '../util/getDockerImageForName';
 
 /**
  * The possible databases to test against.

--- a/packages/backend-test-utils/src/util/getDockerImageForName.ts
+++ b/packages/backend-test-utils/src/util/getDockerImageForName.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/** @public */
 export const getDockerImageForName = (name: string) => {
   return process.env.BACKSTAGE_TEST_DOCKER_REGISTRY
     ? `${process.env.BACKSTAGE_TEST_DOCKER_REGISTRY}/${name}`

--- a/packages/backend-test-utils/src/util/index.ts
+++ b/packages/backend-test-utils/src/util/index.ts
@@ -15,4 +15,3 @@
  */
 
 export { isDockerDisabledForTests } from './isDockerDisabledForTests';
-export { getDockerImageForName } from './getDockerImageForName';


### PR DESCRIPTION
Woops, got a little trigger happy with my finger and merged https://github.com/backstage/backstage/pull/17709 but don't think we should export the method from the package it's not needed.
