### PR TITLE
fix(storybook): Set addon-a11y to manual avoiding false positives

### DIFF
--- a/storybook/.storybook/preview.js
+++ b/storybook/.storybook/preview.js
@@ -33,4 +33,10 @@ export const parameters = {
       order: ['Plugins', 'Layout', 'Navigation'],
     },
   },
+  // addon-a11y automatic execution timing is not consistent for all components
+  // to avoid catching an interim rendering state resulting in false positives
+  // this is is set to true.
+  a11y: {
+    manual: true,
+  },
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In storybook, the addon-a11y automatic execution timing is not consistent for some components. This resulted in false positives for some components like `DismissableBanner`. Upon refreshing the page multiple times, it would sometimes pop a [WCAG 2](https://dequeuniversity.com/rules/axe/4.4/color-contrast?application=axeAPI) violation. The behavior was inconsistent, the error would pop only sometimes and with different contrast ratio warnings.

This patch configures the addon-a11y to set the execution as manual thus ensuring the user is aware of the state the report is running against.

![backstage-storybook-a11y](https://github.com/backstage/backstage/assets/187639/dd8b82cb-a350-4bee-a2e8-ea92a02723c2)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
