### PR TITLE
Removed database required for Badges createRouter

### DIFF
--- a/.changeset/extragavent-fast-fly.md
+++ b/.changeset/extragavent-fast-fly.md
@@ -7,4 +7,4 @@ Fixing badges-backend plugin to get a token from the TokenManager instead of par
 
 Implementing an obfuscation feature to protect an open badges endpoint from being enumerated. The feature is disabled by default and the change is compatible with the previous version.
 
-**BREAKING**: `createRouter` now require that `tokenManager`, `logger`, `identityApi` and `database`, are passed in as options.
+**BREAKING**: `createRouter` now require that `tokenManager`, `logger`, and `identityApi`, are passed in as options.

--- a/docs/releases/v1.14.0-next.2-changelog.md
+++ b/docs/releases/v1.14.0-next.2-changelog.md
@@ -32,7 +32,7 @@
 
   Implementing an obfuscation feature to protect an open badges endpoint from being enumerated. The feature is disabled by default and the change is compatible with the previous version.
 
-  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, `identityApi` and `database`, are passed in as options.
+  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, and `identityApi`, are passed in as options.
 
 ### Patch Changes
 
@@ -335,7 +335,7 @@
 
   Implementing an obfuscation feature to protect an open badges endpoint from being enumerated. The feature is disabled by default and the change is compatible with the previous version.
 
-  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, `identityApi` and `database`, are passed in as options.
+  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, and `identityApi`, are passed in as options.
 
 - Updated dependencies
   - @backstage/theme@0.3.0-next.0

--- a/plugins/badges-backend/CHANGELOG.md
+++ b/plugins/badges-backend/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   Implementing an obfuscation feature to protect an open badges endpoint from being enumerated. The feature is disabled by default and the change is compatible with the previous version.
 
-  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, `identityApi` and `database`, are passed in as options.
+  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, and `identityApi`, are passed in as options.
 
 ### Patch Changes
 

--- a/plugins/badges/CHANGELOG.md
+++ b/plugins/badges/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   Implementing an obfuscation feature to protect an open badges endpoint from being enumerated. The feature is disabled by default and the change is compatible with the previous version.
 
-  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, `identityApi` and `database`, are passed in as options.
+  **BREAKING**: `createRouter` now require that `tokenManager`, `logger`, and `identityApi`, are passed in as options.
 
 - Updated dependencies
   - @backstage/theme@0.3.0-next.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The just removes `database` as a required item being passed to the `createRouter` for the Badges plugin in the changeset, CHANGELOG, and the release changelog.

I'm not sure if this is the right way to do this but it for sure tripped me up when I did the upgrade.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
