### PR TITLE
Add selectedBackground color to SidebarSubmenuItem

### DIFF
--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles<BackstageTheme>(
     },
     selected: {
       background:
-          theme.palette.navigation.navItem?.selectedBackground? || '#6f6f6f',
+          theme.palette.navigation.navItem?.selectedBackground || '#6f6f6f',
       color: theme.palette.common.white,
     },
     label: {

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles<BackstageTheme>(
       width: '100%',
     },
     selected: {
-      background: '#6f6f6f',
+      theme.palette.navigation.navItem?.selectedBackground || '#6f6f6f',
       color: theme.palette.common.white,
     },
     label: {

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles<BackstageTheme>(
     },
     selected: {
       background:
-          theme.palette.navigation.navItem?.selectedBackground || '#6f6f6f',
+          theme.palette.navigation.navItem?.selectedBackground? || '#6f6f6f',
       color: theme.palette.common.white,
     },
     label: {

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -52,7 +52,8 @@ const useStyles = makeStyles<BackstageTheme>(
       width: '100%',
     },
     selected: {
-      theme.palette.navigation.navItem?.selectedBackground || '#6f6f6f',
+      background:
+          theme.palette.navigation.navItem?.selectedBackground || '#6f6f6f',
       color: theme.palette.common.white,
     },
     label: {

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -55,7 +55,7 @@ export type BackstagePaletteAdditions = {
     selectedColor: string;
     navItem?: {
       hoverBackground: string;
-      selectBackground: string;
+      selectedBackground: string;
     };
     submenu?: {
       background: string;

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -55,7 +55,7 @@ export type BackstagePaletteAdditions = {
     selectedColor: string;
     navItem?: {
       hoverBackground: string;
-      selectedBackground: string;
+      selectedBackground?: string;
     };
     submenu?: {
       background: string;

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -55,6 +55,7 @@ export type BackstagePaletteAdditions = {
     selectedColor: string;
     navItem?: {
       hoverBackground: string;
+      selectBackground: string;
     };
     submenu?: {
       background: string;


### PR DESCRIPTION
This pull request adds support for a `selectedBackground` color to the SidebarSubmenuItem component in order to provide a visual indication of the selected navigation item. The changes include:

- In `SidebarSubmenuItem.tsx`, the `background` property of the `selected` style object has been updated to use the `selectedBackground` color defined in the `theme.palette.navigation.navItem` object, or a fallback color of '#6f6f6f' if it is not defined.
- In `types.ts`, the `BackstagePaletteAdditions` type has been updated to include an optional `selectedBackground` color in the `navItem` object.

This change should help users to easily select the proper color for selected items in the SidebarSubmenuItem.

Changes:
- Add `selectedBackground` color to SidebarSubmenuItem component
- Update `BackstagePaletteAdditions` type to include `selectedBackground` color

Before submitting this pull request, I have:
- [x] Verified that the changes work as intended by testing them locally.
- [x] Made sure that the changes follow the project's coding standards.
- [x] Checked that there are no existing open pull requests that address the same changes.
