### PR TITLE
Fix handling of `optional` property in `catalog:register` scaffolder action

### DIFF
--- a/.changeset/angry-jobs-ring.md
+++ b/.changeset/angry-jobs-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Updated API docs

--- a/.changeset/few-oranges-complain.md
+++ b/.changeset/few-oranges-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix handling of `optional` property in `catalog:register` scaffolder action

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -353,6 +353,10 @@ export type Location = {
 export type AddLocationRequest = {
   type?: string;
   target: string;
+  /**
+   * If set to true, the location will not be added, but the response will
+   * contain the entities that match the given location.
+   */
   dryRun?: boolean;
 };
 
@@ -363,8 +367,13 @@ export type AddLocationRequest = {
  */
 export type AddLocationResponse = {
   location: Location;
+  /**
+   * The entities matching this location. Will only be filled in dryRun mode
+   */
   entities: Entity[];
-  // Only set in dryRun mode.
+  /**
+   * True, if the location exists. Will only be filled in dryRun mode
+   */
   exists?: boolean;
 };
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.ts
@@ -17,7 +17,7 @@
 import { InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
 import { CatalogApi } from '@backstage/catalog-client';
-import { stringifyEntityRef } from '@backstage/catalog-model';
+import { stringifyEntityRef, Entity } from '@backstage/catalog-model';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import yaml from 'yaml';
 
@@ -144,17 +144,26 @@ export function createCatalogRegisterAction(options: {
 
       ctx.logger.info(`Registering ${catalogInfoUrl} in the catalog`);
 
-      await catalogClient.addLocation(
-        {
-          type: 'url',
-          target: catalogInfoUrl,
-        },
-        ctx.secrets?.backstageToken
-          ? { token: ctx.secrets.backstageToken }
-          : {},
-      );
+      try {
+        // 1st try to register the location, this will throw an error if the location already exists (see catch)
+        await catalogClient.addLocation(
+          {
+            type: 'url',
+            target: catalogInfoUrl,
+          },
+          ctx.secrets?.backstageToken
+            ? { token: ctx.secrets.backstageToken }
+            : {},
+        );
+      } catch (e) {
+        if (!input.optional) {
+          // if optional is false or unset, it is not allowed to register the same location twice, we rethrow the error
+          throw e;
+        }
+      }
 
       try {
+        // 2nd retry the registration as a dry run, this will not throw an error if the location already exists
         const result = await catalogClient.addLocation(
           {
             dryRun: true,
@@ -166,18 +175,18 @@ export function createCatalogRegisterAction(options: {
             : {},
         );
 
-        if (result.entities.length > 0) {
+        if (result.entities.length) {
           const { entities } = result;
-          let entity: any;
+          let entity: Entity | undefined;
           // prioritise 'Component' type as it is the most central kind of entity
           entity = entities.find(
-            (e: any) =>
+            e =>
               !e.metadata.name.startsWith('generated-') &&
               e.kind === 'Component',
           );
           if (!entity) {
             entity = entities.find(
-              (e: any) => !e.metadata.name.startsWith('generated-'),
+              e => !e.metadata.name.startsWith('generated-'),
             );
           }
           if (!entity) {


### PR DESCRIPTION
This PR fixes an issue in the scaffolder `catalog:register` action, where the `optional` input property is set to `true`.

In the previous implementation an error was thrown, if the URL to be registered was already exiting.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
