### PR TITLE
microsite: add GA4 tracking ID

### DIFF
--- a/microsite/docusaurus.config.js
+++ b/microsite/docusaurus.config.js
@@ -63,7 +63,7 @@ module.exports = {
           customCss: 'src/theme/customTheme.scss',
         },
         gtag: {
-          trackingID: 'G-KSEVGGNCJW',
+          trackingID: ['G-KSEVGGNCJW', 'UA-163836834-5'],
         },
       },
     ],


### PR DESCRIPTION
Using multiple tracking IDs should let us collect both GA3 and GA4 data until GA3 is disabled. See https://github.com/facebook/docusaurus/issues/7221