### PR TITLE
fix: microsoftAuth accessToken allow multiple scopes for a single resource

### DIFF
--- a/.changeset/hungry-countries-enjoy.md
+++ b/.changeset/hungry-countries-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed bug in microsoftAuth preventing access tokens with multiple scopes for one resource

--- a/.changeset/hungry-countries-enjoy.md
+++ b/.changeset/hungry-countries-enjoy.md
@@ -2,4 +2,4 @@
 '@backstage/core-app-api': patch
 ---
 
-Fixed bug in microsoftAuth preventing access tokens with multiple scopes for one resource
+Fixed a bug in the Azure auth provider which prevented getting access tokens with multiple scopes for one resource

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -79,6 +79,16 @@ describe('MicrosoftAuth', () => {
         'Requested access token with scopes from multiple Azure resources: one-resource, other-resource. Access tokens can only have a single audience.',
       );
     });
+
+    it('succeeds when requesting multiple scopes for the same resource', async () => {
+      const accessTokenPromise = microsoftAuth.getAccessToken(
+        'same-resource/one-scope same-resource/other-scope',
+      );
+
+      await expect(accessTokenPromise).resolves.toEqual(
+        'tokenForOtherResource',
+      );
+    });
   });
 
   describe('without a refresh token', () => {

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts
@@ -91,10 +91,15 @@ export default class MicrosoftAuth {
   }
 
   private static resourceForScopes(scope: string): Promise<string> {
-    const audiences = scope
-      .split(' ')
-      .map(MicrosoftAuth.resourceForScope)
-      .filter(aud => aud !== 'openid');
+    const audiences = [
+      ...new Set(
+        scope
+          .split(' ')
+          .map(MicrosoftAuth.resourceForScope)
+          .filter(aud => aud !== 'openid'),
+      ),
+    ];
+
     if (audiences.length > 1) {
       return Promise.reject(
         new Error(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves https://github.com/backstage/backstage/issues/17784

Fixes an issue where the microsoftAuth getAccessToken would throw an error when multiple scopes were requested, even if all scopes were for the same resource.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
