### PR TITLE
Updated azure-sites-backend health URL and fixed typos in README

### DIFF
--- a/.changeset/nine-planes-carry.md
+++ b/.changeset/nine-planes-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-sites-backend': patch
+---
+
+Updated URL to `/health` and corrected typos in the `README.md`

--- a/plugins/azure-sites-backend/README.md
+++ b/plugins/azure-sites-backend/README.md
@@ -2,7 +2,7 @@
 
 Simple plugin that proxies requests to the Azure Portal API through Azure SDK JavaScript libraries.
 
-_Inspired by [roadie.io AWS Lamda plugin](https://roadie.io/backstage/plugins/aws-lambda/)_
+_Inspired by [roadie.io AWS Lambda plugin](https://roadie.io/backstage/plugins/aws-lambda/)_
 
 ## Setup
 
@@ -65,7 +65,7 @@ Here's how to get the backend plugin up and running:
    ```ts
    import azure from './plugins/azure';
 
-   // Removed for clairty...
+   // Removed for clarity...
 
    async function main() {
      // ...
@@ -82,4 +82,4 @@ Here's how to get the backend plugin up and running:
 
 4. Now run `yarn start-backend` from the repo root.
 
-5. Finally, open `http://localhost:7007/api/azure/health` in a browser, it should return `{"status":"ok"}`.
+5. Finally, open `http://localhost:7007/api/azure-sites/health` in a browser, it should return `{"status":"ok"}`.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated URL to `/health` and corrected typos in the `README.md`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
