### PR TITLE
[Home]: Improve world clock accessibility

### DIFF
--- a/.changeset/clever-coins-deny.md
+++ b/.changeset/clever-coins-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Use the semantic time tag for rendering world clocks on homepage headers.

--- a/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.test.tsx
+++ b/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.test.tsx
@@ -103,6 +103,6 @@ describe('HeaderWorldClock with custom Time Format', () => {
       />,
     );
 
-    expect(rendered.getByText('09:10')).toBeInTheDocument();
+    expect(rendered.getByText('09:10')).toHaveAttribute('datetime', '09:10');
   });
 });

--- a/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.tsx
+++ b/plugins/home/src/homePageComponents/HeaderWorldClock/HeaderWorldClock.tsx
@@ -23,8 +23,9 @@ const timeFormat: Intl.DateTimeFormatOptions = {
 };
 
 type TimeObj = {
-  time: string;
   label: string;
+  value: string;
+  dateTime: string;
 };
 
 /** @public */
@@ -65,8 +66,14 @@ function getTimes(
       label = 'GMT';
     }
 
-    const time = d.toLocaleTimeString(lang, options);
-    clocks.push({ time, label });
+    const value = d.toLocaleTimeString(lang, options);
+    const dateTime = d.toLocaleTimeString(lang, {
+      timeZone: options.timeZone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    clocks.push({ label, value, dateTime });
   }
 
   return clocks;
@@ -129,9 +136,9 @@ export const HeaderWorldClock = (props: {
       <>
         {clocks.map(clock => (
           <HeaderLabel
-            label={clock.label}
-            value={clock.time}
             key={clock.label}
+            label={clock.label}
+            value={<time dateTime={clock.dateTime}>{clock.value}</time>}
           />
         ))}
       </>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use the semantic time tag for rendering world clocks on homepage headers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
