### PR TITLE
adjust change logs to show enableExperimentalRedirectFlow at root

### DIFF
--- a/docs/releases/v1.13.0-changelog.md
+++ b/docs/releases/v1.13.0-changelog.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 
 ### Patch Changes
 
@@ -61,7 +61,7 @@
 
 ### Minor Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 - c15e0cedbe1: The `AuthConnector` interface now supports specifying a set of scopes when
   refreshing a session. The `DefaultAuthConnector` implementation passes the
   `scope` query parameter to the auth-backend plugin appropriately. The
@@ -106,7 +106,7 @@
 - 67140d9f96f: Upgrade `react-virtualized-auto-sizer´ to version `^1.0.11\`
 - 6e0b71493df: Switched internal declaration of `DependencyGraphTypes` to use `namespace`.
 - c8779cc1d09: Updated `LogLine` component, which is used by the `LogViewer`, to turn URLs into clickable links. This feature is on by default
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 - 1e4f5e91b8e: Bump `zod` and `zod-to-json-schema` dependencies.
 - 29ba8267d69: Updated dependency `@material-ui/lab` to `4.0.0-alpha.61`.
 - 8e00acb28db: Small tweaks to remove warnings in the console during development (mainly focusing on techdocs)
@@ -170,7 +170,7 @@
 
 ### Minor Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 
 ### Patch Changes
 
@@ -1245,7 +1245,7 @@
 
 - d8f774c30df: Enforce the secret visibility of certificates and client secrets in the auth backend. Also, document all known options for each auth plugin.
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 
 - 475abd1dc3f: The `microsoft` (i.e. Azure) auth provider now supports negotiating tokens for
   Azure resources besides Microsoft Graph (e.g. AKS, Virtual Machines, Machine

--- a/docs/releases/v1.13.0-next.0-changelog.md
+++ b/docs/releases/v1.13.0-next.0-changelog.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 
 ### Patch Changes
 
@@ -19,7 +19,7 @@
 
 ### Minor Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 
 ### Patch Changes
 
@@ -33,7 +33,7 @@
 
 ### Minor Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 
 ### Patch Changes
 
@@ -336,7 +336,7 @@
 
 ### Patch Changes
 
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 - 8e00acb28db: Small tweaks to remove warnings in the console during development (mainly focusing on techdocs)
 - 7245e744ab1: Fixed the font color on `BackstageHeaderLabel` to respect the active page theme.
 - Updated dependencies
@@ -530,7 +530,7 @@
 ### Patch Changes
 
 - d8f774c30df: Enforce the secret visibility of certificates and client secrets in the auth backend. Also, document all known options for each auth plugin.
-- 7908d72e033: Introduce a new global config parameter, `auth.enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
+- 7908d72e033: Introduce a new global config parameter, `enableExperimentalRedirectFlow`. When enabled, auth will happen with an in-window redirect flow rather than through a popup window.
 - Updated dependencies
   - @backstage/backend-common@0.18.4-next.0
   - @backstage/config@1.0.7

--- a/docs/releases/v1.13.0.md
+++ b/docs/releases/v1.13.0.md
@@ -86,7 +86,7 @@ Contributed by [@sennyeya](https://github.com/sennyeya) in [#15667](https://gith
 
 ### Experimental inline auth flows
 
-There’s new support for running auth flows inline in the current page instead of in a separate popup window, enabled via the `auth.enableExperimentalRedirectFlow` app-config parameter. This will allow the use of some providers that do not support popup flows. It’s still an experimental feature, but do try it out if this applies to you!
+There’s new support for running auth flows inline in the current page instead of in a separate popup window, enabled via the `enableExperimentalRedirectFlow` app-config parameter. This will allow the use of some providers that do not support popup flows. It’s still an experimental feature, but do try it out if this applies to you!
 
 Contributed by [@headphonejames](https://github.com/headphonejames) in [#15841](https://github.com/backstage/backstage/pull/15841)
 

--- a/packages/core-app-api/config.d.ts
+++ b/packages/core-app-api/config.d.ts
@@ -117,8 +117,8 @@ export interface Config {
   };
 
   /**
-   $ Enable redirect authentication flow type, instead of a popup for authentication
-   * default value: 'false'
+   * Enable redirect authentication flow type, instead of a popup for authentication.
+   * @defaultValue false
    * @visibility frontend
    */
   enableExperimentalRedirectFlow?: boolean;


### PR DESCRIPTION
The config key [is actually at the root](https://github.com/backstage/backstage/blob/8b45bc7c122d6ec931d592373896518438864ffb/packages/core-app-api/config.d.ts#L124).

Intentionally skipped the changeset for core. It's not that important, and am happy to have that covered by some other change under the radar