### PR TITLE
fix: Fix Fix wrong gitlabUrl format in repoUrl input description

### DIFF
--- a/.changeset/modern-dancers-sit.md
+++ b/.changeset/modern-dancers-sit.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Fix wrong gitlabUrl format in repoUrl input description

--- a/.changeset/modern-dancers-sit.md
+++ b/.changeset/modern-dancers-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Fix wrong gitlabUrl format in repoUrl input description

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -57,6 +57,7 @@ export function createPublishGitlabAction(options: {
           repoUrl: {
             title: 'Repository Location',
             type: 'string',
+            description: `Accepts the format 'gitlab.com?repo=project_name&owner=group_name' where 'project_name' is the repository name and 'group_name' is a group or username`,
           },
           repoVisibility: {
             title: 'Repository Visibility',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -57,7 +57,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
           repoUrl: {
             type: 'string',
             title: 'Repository Location',
-            description: `Accepts the format 'gitlab.com/group_name/project_name' where 'project_name' is the repository name and 'group_name' is a group or username`,
+            description: `Accepts the format 'gitlab.com?repo=project_name&owner=group_name' where 'project_name' is the repository name and 'group_name' is a group or username`,
           },
           /** @deprecated projectID is passed as query parameters in the repoUrl */
           projectid: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixed gitlab repoUrl format in publishing actions. Currently, the format described in the `publish:gitlab:merge-request` input is wrong and confusing. Spend a lot of time debugging until read a source code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
