### PR TITLE
Use permission integration router in jenkins plugin to expose permissions

### DIFF
--- a/.changeset/long-lobsters-brake.md
+++ b/.changeset/long-lobsters-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-common': patch
+---
+
+Export list of permissions

--- a/.changeset/lucky-keys-behave.md
+++ b/.changeset/lucky-keys-behave.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-jenkins-backend': patch
-'@backstage/plugin-jenkins-common': patch
 ---
 
 Expose permissions through the metadata endpoint.

--- a/.changeset/lucky-keys-behave.md
+++ b/.changeset/lucky-keys-behave.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+'@backstage/plugin-jenkins-common': patch
+---
+
+Expose permissions through the metadata endpoint.

--- a/plugins/jenkins-backend/package.json
+++ b/plugins/jenkins-backend/package.json
@@ -32,6 +32,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-jenkins-common": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
+    "@backstage/plugin-permission-node": "workspace:^",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -29,7 +29,7 @@ import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-no
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { stringifyError } from '@backstage/errors';
 import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
-import { jenkinsExecutePermission } from '@backstage/plugin-jenkins-common';
+import { jenkinsPermissions } from '@backstage/plugin-jenkins-common';
 
 /** @public */
 export interface RouterOptions {
@@ -62,7 +62,7 @@ export async function createRouter(
   router.use(express.json());
   router.use(
     createPermissionIntegrationRouter({
-      permissions: [jenkinsExecutePermission],
+      permissions: jenkinsPermissions,
     }),
   );
 

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -28,6 +28,8 @@ import {
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { stringifyError } from '@backstage/errors';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
+import { jenkinsExecutePermission } from '@backstage/plugin-jenkins-common';
 
 /** @public */
 export interface RouterOptions {
@@ -58,6 +60,11 @@ export async function createRouter(
 
   const router = Router();
   router.use(express.json());
+  router.use(
+    createPermissionIntegrationRouter({
+      permissions: [jenkinsExecutePermission],
+    }),
+  );
 
   router.get(
     '/v1/entity/:namespace/:kind/:name/projects',

--- a/plugins/jenkins-common/api-report.md
+++ b/plugins/jenkins-common/api-report.md
@@ -8,5 +8,8 @@ import { ResourcePermission } from '@backstage/plugin-permission-common';
 // @public
 export const jenkinsExecutePermission: ResourcePermission<'catalog-entity'>;
 
+// @public
+export const jenkinsPermissions: ResourcePermission<'catalog-entity'>[];
+
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/jenkins-common/src/permissions.ts
+++ b/plugins/jenkins-common/src/permissions.ts
@@ -28,3 +28,10 @@ export const jenkinsExecutePermission = createPermission({
   },
   resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
 });
+
+/**
+ * List of all Jenkins permissions
+ *
+ * @public
+ */
+export const jenkinsPermissions = [jenkinsExecutePermission];

--- a/yarn.lock
+++ b/yarn.lock
@@ -7161,6 +7161,7 @@ __metadata:
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-jenkins-common": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
+    "@backstage/plugin-permission-node": "workspace:^"
     "@types/express": ^4.17.6
     "@types/jenkins": ^0.23.1
     "@types/supertest": ^2.0.8


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In order to properly support permissions within the RBAC UI, plugins that support permissions need to expose those permissions in their router using the `createPermissionIntegrationRouter` helper method exposed by the `@backstage/plugin-permission-node` module. This PR adds this router to the Jenkins plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
