### PR TITLE
Adding info on entities selected to catalog table title

### DIFF
--- a/.changeset/tiny-shrimps-beam.md
+++ b/.changeset/tiny-shrimps-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Adding in type and kind entity details to catalog table title for user clarity

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.test.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.test.tsx
@@ -168,7 +168,7 @@ describe('DefaultApiExplorerPage', () => {
     const { findByTitle, findByText } = await renderWrapped(
       <DefaultApiExplorerPage />,
     );
-    expect(await findByText(/All \(1\)/)).toBeInTheDocument();
+    expect(await findByText(/All apis \(1\)/)).toBeInTheDocument();
     expect(await findByTitle(/View/)).toBeInTheDocument();
     expect(await findByTitle(/View/)).toBeInTheDocument();
     expect(await findByTitle(/Edit/)).toBeInTheDocument();
@@ -198,7 +198,7 @@ describe('DefaultApiExplorerPage', () => {
     const { findByTitle, findByText } = await renderWrapped(
       <DefaultApiExplorerPage actions={actions} />,
     );
-    expect(await findByText(/All \(1\)/)).toBeInTheDocument();
+    expect(await findByText(/All apis \(1\)/)).toBeInTheDocument();
     expect(await findByTitle(/Foo Action/)).toBeInTheDocument();
     expect(await findByTitle(/Bar Action/)).toBeInTheDocument();
     expect((await findByTitle(/Bar Action/)).firstChild).toBeDisabled();

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -205,7 +205,9 @@ describe('DefaultCatalogPage', () => {
   it('should render the default actions of an item in the grid', async () => {
     await renderWrapped(<DefaultCatalogPage />);
     fireEvent.click(screen.getByTestId('user-picker-owned'));
-    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/Owned components \(1\)/),
+    ).resolves.toBeInTheDocument();
     await expect(screen.findByTitle(/View/)).resolves.toBeInTheDocument();
     await expect(screen.findByTitle(/Edit/)).resolves.toBeInTheDocument();
     await expect(
@@ -235,7 +237,9 @@ describe('DefaultCatalogPage', () => {
 
     await renderWrapped(<DefaultCatalogPage actions={actions} />);
     fireEvent.click(screen.getByTestId('user-picker-owned'));
-    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/Owned components \(1\)/),
+    ).resolves.toBeInTheDocument();
     await expect(screen.findByTitle(/Foo Action/)).resolves.toBeInTheDocument();
     await expect(screen.findByTitle(/Bar Action/)).resolves.toBeInTheDocument();
     await expect(
@@ -249,14 +253,20 @@ describe('DefaultCatalogPage', () => {
   it('should render', async () => {
     await renderWrapped(<DefaultCatalogPage />);
     fireEvent.click(screen.getByTestId('user-picker-owned'));
-    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/Owned components \(1\)/),
+    ).resolves.toBeInTheDocument();
     fireEvent.click(screen.getByTestId('user-picker-all'));
-    await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/All components \(2\)/),
+    ).resolves.toBeInTheDocument();
   }, 20_000);
 
   it('should set initial filter correctly', async () => {
     await renderWrapped(<DefaultCatalogPage initiallySelectedFilter="all" />);
-    await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/All components \(2\)/),
+    ).resolves.toBeInTheDocument();
   }, 20_000);
 
   // this test is for fixing the bug after favoriting an entity, the matching
@@ -264,7 +274,9 @@ describe('DefaultCatalogPage', () => {
   it('should render the correct entities filtered on the selected filter', async () => {
     await renderWrapped(<DefaultCatalogPage />);
     fireEvent.click(screen.getByTestId('user-picker-owned'));
-    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/Owned components \(1\)/),
+    ).resolves.toBeInTheDocument();
     // The "Starred" menu option should initially be disabled, since there
     // aren't any starred entities.
     expect(screen.getByTestId('user-picker-starred')).toHaveAttribute(
@@ -272,11 +284,15 @@ describe('DefaultCatalogPage', () => {
       'true',
     );
     fireEvent.click(screen.getByTestId('user-picker-all'));
-    await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/All components \(2\)/),
+    ).resolves.toBeInTheDocument();
 
     const starredIcons = await screen.findAllByTitle('Add to favorites');
     fireEvent.click(starredIcons[0]);
-    await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/All components \(2\)/),
+    ).resolves.toBeInTheDocument();
 
     // Now that we've starred an entity, the "Starred" menu option should be
     // enabled.
@@ -286,7 +302,7 @@ describe('DefaultCatalogPage', () => {
     );
     fireEvent.click(screen.getByTestId('user-picker-starred'));
     await expect(
-      screen.findByText(/Starred \(1\)/),
+      screen.findByText(/Starred components \(1\)/),
     ).resolves.toBeInTheDocument();
   }, 20_000);
 

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -95,6 +95,11 @@ describe('CatalogTable component', () => {
                 () => false,
                 () => false,
               ),
+              kind: {
+                value: 'component',
+                getCatalogFilters: () => ({ kind: 'component' }),
+                toQueryValue: () => 'component',
+              },
             },
           }}
         >
@@ -107,7 +112,7 @@ describe('CatalogTable component', () => {
         },
       },
     );
-    expect(screen.getByText(/Owned \(3\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Owned components \(3\)/)).toBeInTheDocument();
     expect(screen.getByText(/component1/)).toBeInTheDocument();
     expect(screen.getByText(/component2/)).toBeInTheDocument();
     expect(screen.getByText(/component3/)).toBeInTheDocument();

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -226,7 +226,8 @@ export const CatalogTable = (props: CatalogTableProps) => {
     typeColumn.hidden = !showTypeColumn;
   }
   const showPagination = rows.length > 20;
-
+  const currentKind = filters.kind?.value || '';
+  const currentType = filters.type?.value || '';
   return (
     <Table<CatalogTableRow>
       isLoading={loading}
@@ -241,7 +242,9 @@ export const CatalogTable = (props: CatalogTableProps) => {
         pageSizeOptions: [20, 50, 100],
         ...tableOptions,
       }}
-      title={`${titlePreamble} (${entities.length})`}
+      title={`${titlePreamble} ${currentType} ${currentKind}${
+        currentKind ? 's' : ''
+      } (${entities.length})`}
       data={rows}
       actions={actions || defaultActions}
       subtitle={subtitle}

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -43,6 +43,7 @@ import { capitalize } from 'lodash';
 import React, { ReactNode, useMemo } from 'react';
 import { columnFactories } from './columns';
 import { CatalogTableRow } from './types';
+import pluralize from 'pluralize';
 
 /**
  * Props for {@link CatalogTable}.
@@ -228,7 +229,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const showPagination = rows.length > 20;
   const currentKind = filters.kind?.value || '';
   const currentType = filters.type?.value || '';
-  const titleDisplay = [titlePreamble, currentType, currentKind]
+  const titleDisplay = [titlePreamble, currentType, pluralize(currentKind)]
     .filter(s => s)
     .join(' ');
 
@@ -246,7 +247,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         pageSizeOptions: [20, 50, 100],
         ...tableOptions,
       }}
-      title={`${titleDisplay}${currentKind ? 's' : ''} (${entities.length})`}
+      title={`${titleDisplay} (${entities.length})`}
       data={rows}
       actions={actions || defaultActions}
       subtitle={subtitle}

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -228,6 +228,10 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const showPagination = rows.length > 20;
   const currentKind = filters.kind?.value || '';
   const currentType = filters.type?.value || '';
+  const titleDisplay = [titlePreamble, currentType, currentKind]
+    .filter(s => s)
+    .join(' ');
+
   return (
     <Table<CatalogTableRow>
       isLoading={loading}
@@ -242,9 +246,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         pageSizeOptions: [20, 50, 100],
         ...tableOptions,
       }}
-      title={`${titlePreamble} ${currentType} ${currentKind}${
-        currentKind ? 's' : ''
-      } (${entities.length})`}
+      title={`${titleDisplay}${currentKind ? 's' : ''} (${entities.length})`}
       data={rows}
       actions={actions || defaultActions}
       subtitle={subtitle}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

In prep for user research, we realized this page can cause confusion on what is currently selected. This makes the title on the table more descriptive for the user.
<img width="871" alt="Screenshot 2023-05-17 at 10 52 01 AM" src="https://github.com/backstage/backstage/assets/7171310/88245385-7594-45f4-9029-c5cdad689b24">

<img width="913" alt="Screenshot 2023-05-17 at 10 51 42 AM" src="https://github.com/backstage/backstage/assets/7171310/e2dc650f-54f9-4e3a-bd90-e9ac4e419fde">
<img width="890" alt="Screenshot 2023-05-17 at 10 51 54 AM" src="https://github.com/backstage/backstage/assets/7171310/1bf89a0a-1d92-4a55-ba5e-666eb3bf28e9">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
