### PR TITLE
Expose devtools plugin permissions through the metadata endpoint

### DIFF
--- a/.changeset/fast-zebras-watch.md
+++ b/.changeset/fast-zebras-watch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-devtools-backend': patch
+'@backstage/plugin-devtools-common': patch
+---
+
+Expose permissions through the metadata endpoint.

--- a/.changeset/fast-zebras-watch.md
+++ b/.changeset/fast-zebras-watch.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-devtools-backend': patch
-'@backstage/plugin-devtools-common': patch
 ---
 
 Expose permissions through the metadata endpoint.

--- a/.changeset/plenty-roses-raise.md
+++ b/.changeset/plenty-roses-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools-common': patch
+---
+
+Export the list of permissions

--- a/plugins/devtools-backend/src/service/router.ts
+++ b/plugins/devtools-backend/src/service/router.ts
@@ -21,6 +21,7 @@ import {
   devToolsConfigReadPermission,
   devToolsExternalDependenciesReadPermission,
   devToolsInfoReadPermission,
+  devToolsPermissions,
 } from '@backstage/plugin-devtools-common';
 
 import { Config } from '@backstage/config';
@@ -31,6 +32,7 @@ import Router from 'express-promise-router';
 import { errorHandler } from '@backstage/backend-common';
 import express from 'express';
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 
 /** @public */
 export interface RouterOptions {
@@ -51,6 +53,11 @@ export async function createRouter(
 
   const router = Router();
   router.use(express.json());
+  router.use(
+    createPermissionIntegrationRouter({
+      permissions: devToolsPermissions,
+    }),
+  );
 
   router.get('/health', (_req, res) => {
     res.status(200).json({ status: 'ok' });

--- a/plugins/devtools-common/api-report.md
+++ b/plugins/devtools-common/api-report.md
@@ -40,6 +40,9 @@ export type DevToolsInfo = {
 // @public (undocumented)
 export const devToolsInfoReadPermission: BasicPermission;
 
+// @public
+export const devToolsPermissions: BasicPermission[];
+
 // @public (undocumented)
 export type Endpoint = {
   name: string;

--- a/plugins/devtools-common/src/permissions.ts
+++ b/plugins/devtools-common/src/permissions.ts
@@ -47,3 +47,15 @@ export const devToolsExternalDependenciesReadPermission = createPermission({
   name: 'devtools.external-dependencies',
   attributes: { action: 'read' },
 });
+
+/**
+ * List of all Devtools permissions
+ *
+ * @public
+ */
+export const devToolsPermissions = [
+  devToolsAdministerPermission,
+  devToolsInfoReadPermission,
+  devToolsConfigReadPermission,
+  devToolsExternalDependenciesReadPermission,
+];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add missing permissions to be exposed in metadata endpoint for devtools plugin

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
