### PR TITLE
fix: don't expose sensible data in Jenkins

### DIFF
--- a/.changeset/clean-meals-pay.md
+++ b/.changeset/clean-meals-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+Don't expose username and authentication header if configured.

--- a/plugins/jenkins-backend/config.d.ts
+++ b/plugins/jenkins-backend/config.d.ts
@@ -38,11 +38,17 @@ export interface Config {
        * instance.
        */
       name: string;
-
       baseUrl: string;
       username: string;
       /** @visibility secret */
       apiKey: string;
+      extraRequestHeaders?: Partial<{
+        /** @visibility secret */
+        Authorization: string;
+        /** @visibility secret */
+        authorization: string;
+        [key: string]: string;
+      }>;
     }[];
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Don't expose username and authentication header if configured.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
