### PR TITLE
authentication providers page to reflect status

### DIFF
--- a/.changeset/beige-zebras-walk.md
+++ b/.changeset/beige-zebras-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Reflect the updated sign on status for a provider after signing out.

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -37,6 +37,8 @@ import {
 } from '@backstage/core-plugin-api';
 import { ProviderSettingsAvatar } from './ProviderSettingsAvatar';
 
+const emptyProfile: ProfileInfo = {};
+
 /** @public */
 export const ProviderSettingsItem = (props: {
   title: string;
@@ -49,8 +51,7 @@ export const ProviderSettingsItem = (props: {
   const api = useApi(apiRef);
   const errorApi = useApi(errorApiRef);
   const [signedIn, setSignedIn] = useState(false);
-  const emptyProfile: ProfileInfo = {};
-  const [profile, setProfile] = useState(emptyProfile);
+  const [profile, setProfile] = useState<ProfileInfo>(emptyProfile);
 
   useEffect(() => {
     let didCancel = false;
@@ -58,6 +59,10 @@ export const ProviderSettingsItem = (props: {
     const subscription = api
       .sessionState$()
       .subscribe((sessionState: SessionState) => {
+        if (sessionState !== SessionState.SignedIn) {
+          setProfile(emptyProfile);
+          setSignedIn(false);
+        }
         if (!didCancel) {
           api
             .getProfile({ optional: true })


### PR DESCRIPTION
## Hey, I just made a Pull Request!

authentication providers page to reflect status

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
