### PR TITLE
feat(catalog): Link launch template in Entity's AboutCard

### DIFF
--- a/.changeset/chatty-seals-tap.md
+++ b/.changeset/chatty-seals-tap.md
@@ -1,4 +1,5 @@
 ---
+'@backstage/create-app': patch
 '@backstage/plugin-catalog': patch
 ---
 

--- a/.changeset/chatty-seals-tap.md
+++ b/.changeset/chatty-seals-tap.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+'example-app': patch
+---
+
+Add link from Template entity to the scaffolder launch page for the template in the AboutCard.

--- a/.changeset/chatty-seals-tap.md
+++ b/.changeset/chatty-seals-tap.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-catalog': patch
-'example-app': patch
 ---
 
 Add link from Template entity to the scaffolder launch page for the template in the AboutCard.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -142,6 +142,7 @@ const app = createApp({
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
       viewTechDoc: techdocsPlugin.routes.docRoot,
+      selectedTemplateRoute: scaffolderPlugin.routes.selectedTemplate,
     });
     bind(apiDocsPlugin.externalRoutes, {
       registerApi: catalogImportPlugin.routes.importPage,

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -142,7 +142,7 @@ const app = createApp({
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
       viewTechDoc: techdocsPlugin.routes.docRoot,
-      selectedTemplateRoute: scaffolderPlugin.routes.selectedTemplate,
+      createFromTemplate: scaffolderPlugin.routes.selectedTemplate,
     });
     bind(apiDocsPlugin.externalRoutes, {
       registerApi: catalogImportPlugin.routes.importPage,

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -40,12 +40,14 @@ const app = createApp({
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
       viewTechDoc: techdocsPlugin.routes.docRoot,
+      selectedTemplateRoute: scaffolderPlugin.routes.selectedTemplate,
     });
     bind(apiDocsPlugin.externalRoutes, {
       registerApi: catalogImportPlugin.routes.importPage,
     });
     bind(scaffolderPlugin.externalRoutes, {
       registerComponent: catalogImportPlugin.routes.importPage,
+      viewTechDoc: techdocsPlugin.routes.docRoot,
     });
     bind(orgPlugin.externalRoutes, {
       catalogIndex: catalogPlugin.routes.catalogIndex,

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -40,7 +40,7 @@ const app = createApp({
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
       viewTechDoc: techdocsPlugin.routes.docRoot,
-      selectedTemplateRoute: scaffolderPlugin.routes.selectedTemplate,
+      createFromTemplate: scaffolderPlugin.routes.selectedTemplate,
     });
     bind(apiDocsPlugin.externalRoutes, {
       registerApi: catalogImportPlugin.routes.importPage,

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -105,6 +105,13 @@ export const catalogPlugin: BackstagePlugin<
       },
       true
     >;
+    selectedTemplateRoute: ExternalRouteRef<
+      {
+        namespace: string;
+        templateName: string;
+      },
+      true
+    >;
   },
   CatalogInputPluginOptions
 >;

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -105,7 +105,7 @@ export const catalogPlugin: BackstagePlugin<
       },
       true
     >;
-    selectedTemplateRoute: ExternalRouteRef<
+    createFromTemplate: ExternalRouteRef<
       {
         namespace: string;
         templateName: string;

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -40,6 +40,7 @@
     "@backstage/integration-react": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
+    "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-search-react": "workspace:^",
     "@backstage/theme": "workspace:^",

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -30,7 +30,7 @@ import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { selectedTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
+import { createFromTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
 import { AboutCard } from './AboutCard';
 
 describe('<AboutCard />', () => {
@@ -545,7 +545,7 @@ describe('<AboutCard />', () => {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
           '/create/templates/:namespace/:templateName':
-            selectedTemplateRouteRef,
+            createFromTemplateRouteRef,
         },
       },
     );
@@ -612,7 +612,7 @@ describe('<AboutCard />', () => {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
             '/create/templates/:namespace/:templateName':
-              selectedTemplateRouteRef,
+              createFromTemplateRouteRef,
           },
         },
       );

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -30,6 +30,7 @@ import {
   alertApiRef,
   errorApiRef,
   useApi,
+  useApp,
   useRouteRef,
 } from '@backstage/core-plugin-api';
 import {
@@ -90,8 +91,8 @@ export interface AboutCardProps {
 /**
  * Exported publicly via the EntityAboutCard
  */
-export function AboutCard(props: AboutCardProps) {
-  const { variant } = props;
+export function AboutCard({ variant }: AboutCardProps) {
+  const app = useApp();
   const classes = useStyles();
   const { entity } = useEntity();
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
@@ -132,9 +133,12 @@ export function AboutCard(props: AboutCardProps) {
   const subHeaderLinks = [viewInSource, viewInTechDocs];
 
   if (isTemplateEntityV1beta3(entity)) {
+    const Icon = app.getSystemIcon('scaffolder') ?? AddIcon;
+
     const launchTemplate: IconLinkVerticalProps = {
       label: 'Launch Template',
-      icon: <AddIcon />,
+      icon: <Icon />,
+      disabled: !templateRoute,
       href:
         templateRoute &&
         templateRoute({

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {
   ANNOTATION_EDIT_URL,
   ANNOTATION_LOCATION,
@@ -42,6 +41,7 @@ import {
   getEntitySourceLocation,
   useEntity,
 } from '@backstage/plugin-catalog-react';
+import { isTemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import {
   Card,
   CardContent,
@@ -50,14 +50,14 @@ import {
   IconButton,
   makeStyles,
 } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import CachedIcon from '@material-ui/icons/Cached';
 import DocsIcon from '@material-ui/icons/Description';
 import EditIcon from '@material-ui/icons/Edit';
 import React, { useCallback } from 'react';
-import { selectedTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
+
+import { createFromTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
 import { AboutContent } from './AboutContent';
-import { isTemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 
 const useStyles = makeStyles({
   gridItemCard: {
@@ -91,7 +91,8 @@ export interface AboutCardProps {
 /**
  * Exported publicly via the EntityAboutCard
  */
-export function AboutCard({ variant }: AboutCardProps) {
+export function AboutCard(props: AboutCardProps) {
+  const { variant } = props;
   const app = useApp();
   const classes = useStyles();
   const { entity } = useEntity();
@@ -100,7 +101,7 @@ export function AboutCard({ variant }: AboutCardProps) {
   const alertApi = useApi(alertApiRef);
   const errorApi = useApi(errorApiRef);
   const viewTechdocLink = useRouteRef(viewTechDocRouteRef);
-  const templateRoute = useRouteRef(selectedTemplateRouteRef);
+  const templateRoute = useRouteRef(createFromTemplateRouteRef);
 
   const entitySourceLocation = getEntitySourceLocation(
     entity,
@@ -133,7 +134,7 @@ export function AboutCard({ variant }: AboutCardProps) {
   const subHeaderLinks = [viewInSource, viewInTechDocs];
 
   if (isTemplateEntityV1beta3(entity)) {
-    const Icon = app.getSystemIcon('scaffolder') ?? AddIcon;
+    const Icon = app.getSystemIcon('scaffolder') ?? CreateComponentIcon;
 
     const launchTemplate: IconLinkVerticalProps = {
       label: 'Launch Template',

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -49,12 +49,14 @@ import {
   IconButton,
   makeStyles,
 } from '@material-ui/core';
+import AddIcon from '@material-ui/icons/Add';
 import CachedIcon from '@material-ui/icons/Cached';
 import DocsIcon from '@material-ui/icons/Description';
 import EditIcon from '@material-ui/icons/Edit';
 import React, { useCallback } from 'react';
-import { viewTechDocRouteRef } from '../../routes';
+import { selectedTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
 import { AboutContent } from './AboutContent';
+import { isTemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 
 const useStyles = makeStyles({
   gridItemCard: {
@@ -97,6 +99,7 @@ export function AboutCard(props: AboutCardProps) {
   const alertApi = useApi(alertApiRef);
   const errorApi = useApi(errorApiRef);
   const viewTechdocLink = useRouteRef(viewTechDocRouteRef);
+  const templateRoute = useRouteRef(selectedTemplateRouteRef);
 
   const entitySourceLocation = getEntitySourceLocation(
     entity,
@@ -125,6 +128,23 @@ export function AboutCard(props: AboutCardProps) {
         name: entity.metadata.name,
       }),
   };
+
+  const subHeaderLinks = [viewInSource, viewInTechDocs];
+
+  if (isTemplateEntityV1beta3(entity)) {
+    const launchTemplate: IconLinkVerticalProps = {
+      label: 'Launch Template',
+      icon: <AddIcon />,
+      href:
+        templateRoute &&
+        templateRoute({
+          templateName: entity.metadata.name,
+          namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
+        }),
+    };
+
+    subHeaderLinks.push(launchTemplate);
+  }
 
   let cardClass = '';
   if (variant === 'gridItem') {
@@ -179,7 +199,7 @@ export function AboutCard(props: AboutCardProps) {
             </IconButton>
           </>
         }
-        subheader={<HeaderIconLinkRow links={[viewInSource, viewInTechDocs]} />}
+        subheader={<HeaderIconLinkRow links={subHeaderLinks} />}
       />
       <Divider />
       <CardContent className={cardContentClass}>

--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -23,7 +23,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import {
   createComponentRouteRef,
-  selectedTemplateRouteRef,
+  createFromTemplateRouteRef,
   viewTechDocRouteRef,
 } from './routes';
 import {
@@ -81,7 +81,7 @@ export const catalogPlugin = createPlugin({
   externalRoutes: {
     createComponent: createComponentRouteRef,
     viewTechDoc: viewTechDocRouteRef,
-    selectedTemplateRoute: selectedTemplateRouteRef,
+    createFromTemplate: createFromTemplateRouteRef,
   },
   __experimentalConfigure(
     options?: CatalogInputPluginOptions,

--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -21,7 +21,11 @@ import {
   entityRouteRef,
   starredEntitiesApiRef,
 } from '@backstage/plugin-catalog-react';
-import { createComponentRouteRef, viewTechDocRouteRef } from './routes';
+import {
+  createComponentRouteRef,
+  selectedTemplateRouteRef,
+  viewTechDocRouteRef,
+} from './routes';
 import {
   createApiFactory,
   createComponentExtension,
@@ -77,6 +81,7 @@ export const catalogPlugin = createPlugin({
   externalRoutes: {
     createComponent: createComponentRouteRef,
     viewTechDoc: viewTechDocRouteRef,
+    selectedTemplateRoute: selectedTemplateRouteRef,
   },
   __experimentalConfigure(
     options?: CatalogInputPluginOptions,

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -30,6 +30,12 @@ export const viewTechDocRouteRef = createExternalRouteRef({
   params: ['namespace', 'kind', 'name'],
 });
 
+export const selectedTemplateRouteRef = createExternalRouteRef({
+  id: 'selected-template',
+  optional: true,
+  params: ['namespace', 'templateName'],
+});
+
 export const rootRouteRef = createRouteRef({
   id: 'catalog',
 });

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -30,8 +30,8 @@ export const viewTechDocRouteRef = createExternalRouteRef({
   params: ['namespace', 'kind', 'name'],
 });
 
-export const selectedTemplateRouteRef = createExternalRouteRef({
-  id: 'selected-template',
+export const createFromTemplateRouteRef = createExternalRouteRef({
+  id: 'create-from-template',
   optional: true,
   params: ['namespace', 'templateName'],
 });

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -26,8 +26,8 @@ export const createGitlabProjectAccessTokenAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    projectId: string | number;
     repoUrl: string;
+    projectId: string | number;
     token?: string | undefined;
     name?: string | undefined;
     accessLevel?: number | undefined;
@@ -44,8 +44,8 @@ export const createGitlabProjectDeployTokenAction: (options: {
 }) => TemplateAction<
   {
     name: string;
-    projectId: string | number;
     repoUrl: string;
+    projectId: string | number;
     token?: string | undefined;
     username?: string | undefined;
     scopes?: string[] | undefined;
@@ -63,8 +63,8 @@ export const createGitlabProjectVariableAction: (options: {
   {
     key: string;
     value: string;
-    projectId: string | number;
     repoUrl: string;
+    projectId: string | number;
     variableType: string;
     token?: string | undefined;
     variableProtected?: boolean | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5739,6 +5739,7 @@ __metadata:
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
+    "@backstage/plugin-scaffolder-common": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding a Link to the Entity's AboutCard subHeader row to allow launching an ScafolderPlugin Template from the CatalogEntityPage, conditionally checking if it's a template with `isTemplateEntityV1beta3`.

Closes #17434

![Screenshot 2023-05-19 at 1 07 26 PM](https://github.com/backstage/backstage/assets/9698639/77bbe738-7bd7-4745-9864-949e93fb0ce7)

![Screenshot 2023-05-19 at 1 05 50 PM](https://github.com/backstage/backstage/assets/9698639/1812ebb8-956a-4dfa-b1e8-ce7e526f0d59)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
