### PR TITLE
Update ProxiedSignInPage.tsx with generic imports

### DIFF
--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -21,8 +21,7 @@ import {
 } from '@backstage/core-plugin-api';
 import React from 'react';
 import { useAsync, useMountEffect } from '@react-hookz/web';
-import { ErrorPanel } from '../../components/ErrorPanel';
-import { Progress } from '../../components/Progress';
+import { ErrorPanel, Progress } from '@backstage/core-components';
 import { ProxiedSignInIdentity } from './ProxiedSignInIdentity';
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I changed ProxiedSignInPage imports to use `@backstage/core-components` refs instead of relative `../../` paths.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
