### PR TITLE
Added alphabetical sorting to plugin categories.

### DIFF
--- a/microsite/src/components/pluginsFilter/pluginsFilter.tsx
+++ b/microsite/src/components/pluginsFilter/pluginsFilter.tsx
@@ -7,13 +7,15 @@ type Props = {
 };
 
 const PluginsFilter = ({ categories, handleChipClick }: Props) => {
+  const alphaCategories = categories.sort((a,b) => a.name.localeCompare(b.name))
+
   return (
     <div className="dropdown dropdown--hoverable">
       <button className="button button--info dropdown__toggle">
         Categories Filter
       </button>
       <ul className="dropdown__menu">
-        {categories.map(chip => {
+        {alphaCategories.map(chip => {
           return (
             <li key={chip.name} onClick={() => handleChipClick(chip.name)}>
               <div className="dropdown__item">

--- a/microsite/src/components/pluginsFilter/pluginsFilter.tsx
+++ b/microsite/src/components/pluginsFilter/pluginsFilter.tsx
@@ -7,8 +7,9 @@ type Props = {
 };
 
 const PluginsFilter = ({ categories, handleChipClick }: Props) => {
-  const alphaCategories = categories.sort((a,b) => a.name.localeCompare(b.name))
-
+  const alphaCategories = categories.sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
   return (
     <div className="dropdown dropdown--hoverable">
       <button className="button button--info dropdown__toggle">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Sorted the plugins that are shown on the microsite's plugin filter dropdown in alphabetical order. 

<img width="257" alt="Screen Shot 2023-05-21 at 7 19 36 PM" src="https://github.com/backstage/backstage/assets/91796762/c9a46976-a760-45ac-8d82-524bb5c8d3db">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes

- [x] Screenshots attached (for UI changes)

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
