### PR TITLE
EntityProcessingStatusPicker: remove mocked backendEntities from tests

### DIFF
--- a/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.test.tsx
@@ -14,48 +14,16 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { EntityErrorFilter, EntityOrphanFilter } from '../../filters';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
 import { EntityProcessingStatusPicker } from './EntityProcessingStatusPicker';
 
-const orphanAnnotation: Record<string, string> = {};
-orphanAnnotation['backstage.io/orphan'] = 'true';
-
-const sampleEntities: Entity[] = [
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'valid-component',
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'orphan-component',
-      annotations: orphanAnnotation,
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'error-component',
-      tags: ['Invalid Tag'],
-    },
-  },
-];
-
 describe('<EntityProcessingStatusPicker/>', () => {
   it('renders all processing status options', () => {
     render(
-      <MockEntityListContextProvider
-        value={{ entities: sampleEntities, backendEntities: sampleEntities }}
-      >
+      <MockEntityListContextProvider value={{}}>
         <EntityProcessingStatusPicker />
       </MockEntityListContextProvider>,
     );
@@ -71,8 +39,6 @@ describe('<EntityProcessingStatusPicker/>', () => {
     render(
       <MockEntityListContextProvider
         value={{
-          entities: sampleEntities,
-          backendEntities: sampleEntities,
           updateFilters,
         }}
       >
@@ -92,8 +58,6 @@ describe('<EntityProcessingStatusPicker/>', () => {
     render(
       <MockEntityListContextProvider
         value={{
-          entities: sampleEntities,
-          backendEntities: sampleEntities,
           updateFilters,
         }}
       >
@@ -113,8 +77,6 @@ describe('<EntityProcessingStatusPicker/>', () => {
     render(
       <MockEntityListContextProvider
         value={{
-          entities: sampleEntities,
-          backendEntities: sampleEntities,
           updateFilters,
         }}
       >
@@ -134,8 +96,6 @@ describe('<EntityProcessingStatusPicker/>', () => {
     render(
       <MockEntityListContextProvider
         value={{
-          entities: sampleEntities,
-          backendEntities: sampleEntities,
           updateFilters,
         }}
       >


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Refactor the `EntityProcessingStatusPicker`'s tests since don't depend on the entities stored in the `EntityListContext`.
Part of https://github.com/backstage/backstage/issues/12247

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
