### PR TITLE
Allow Stepper components to be overriden from the NextScaffolderPage

### DIFF
--- a/.changeset/proud-books-grin.md
+++ b/.changeset/proud-books-grin.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Allow `Stepper` components to be overriden from the `NextScaffolderPage`
+Allow `Stepper` components to be overridden from the `NextScaffolderPage`

--- a/.changeset/proud-books-grin.md
+++ b/.changeset/proud-books-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Allow `Stepper` components to be overriden from the `NextScaffolderPage`

--- a/plugins/scaffolder/alpha-api-report.md
+++ b/plugins/scaffolder/alpha-api-report.md
@@ -14,6 +14,7 @@ import { default as React_2 } from 'react';
 import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateGroupFilter } from '@backstage/plugin-scaffolder-react/alpha';
+import { WorkflowProps } from '@backstage/plugin-scaffolder-react/alpha';
 
 // @alpha @deprecated
 export type FormProps = Pick<
@@ -33,7 +34,7 @@ export type NextRouterProps = {
     }>;
     TemplateListPageComponent?: React_2.ComponentType<TemplateListPageProps>;
     TemplateWizardPageComponent?: React_2.ComponentType<TemplateWizardPageProps>;
-  };
+  } & Pick<WorkflowProps, 'components'>['components'];
   groups?: TemplateGroupFilter[];
   templateFilter?: (entity: TemplateEntityV1beta3) => boolean;
   FormProps?: FormProps_2;
@@ -68,7 +69,7 @@ export type TemplateWizardPageProps = {
   customFieldExtensions: NextFieldExtensionOptions<any, any>[];
   layouts?: LayoutOptions[];
   FormProps?: FormProps_2;
-};
+} & Pick<WorkflowProps, 'components'>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/scaffolder/src/next/Router/Router.test.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.test.tsx
@@ -88,14 +88,21 @@ describe('Router', () => {
       expect(TemplateWizardPage).not.toHaveBeenCalled();
     });
 
-    it('should pass through the FormProps property', async () => {
+    it('should pass through the FormProps and components properties', async () => {
       const transformErrorsMock = jest.fn();
+
+      const MockReviewComponent = jest.fn();
 
       await renderInTestApp(
         <Router
           FormProps={{
             transformErrors: transformErrorsMock,
             noHtml5Validate: true,
+          }}
+          components={{
+            ReviewStateComponent: MockReviewComponent,
+            createButtonText: 'new create',
+            reviewButtonText: 'new review',
           }}
         />,
         {
@@ -105,11 +112,17 @@ describe('Router', () => {
 
       const mock = TemplateWizardPage as jest.Mock;
 
-      const [{ FormProps }] = mock.mock.calls[0];
+      const [{ FormProps, components }] = mock.mock.calls[0];
 
       expect(FormProps).toEqual({
         transformErrors: transformErrorsMock,
         noHtml5Validate: true,
+      });
+
+      expect(components).toEqual({
+        ReviewStateComponent: MockReviewComponent,
+        createButtonText: 'new create',
+        reviewButtonText: 'new review',
       });
     });
 

--- a/plugins/scaffolder/src/next/Router/Router.tsx
+++ b/plugins/scaffolder/src/next/Router/Router.tsx
@@ -21,9 +21,11 @@ import {
   TemplateWizardPageProps,
 } from '../TemplateWizardPage';
 import {
-  NextFieldExtensionOptions,
-  FormProps,
+  type NextFieldExtensionOptions,
+  type FormProps,
   TemplateGroupFilter,
+  type WorkflowProps,
+  ReviewState,
 } from '@backstage/plugin-scaffolder-react/alpha';
 import {
   ScaffolderTaskOutput,
@@ -64,7 +66,7 @@ export type NextRouterProps = {
     }>;
     TemplateListPageComponent?: React.ComponentType<TemplateListPageProps>;
     TemplateWizardPageComponent?: React.ComponentType<TemplateWizardPageProps>;
-  };
+  } & Pick<WorkflowProps, 'components'>['components'];
   groups?: TemplateGroupFilter[];
   templateFilter?: (entity: TemplateEntityV1beta3) => boolean;
   // todo(blam): rename this to formProps
@@ -92,6 +94,9 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
       TaskPageComponent = OngoingTask,
       TemplateListPageComponent = TemplateListPage,
       TemplateWizardPageComponent = TemplateWizardPage,
+      ReviewStateComponent = ReviewState,
+      createButtonText = 'Create',
+      reviewButtonText = 'Review',
     } = {},
   } = props;
   const outlet = useOutlet() || props.children;
@@ -131,6 +136,11 @@ export const Router = (props: PropsWithChildren<NextRouterProps>) => {
               customFieldExtensions={fieldExtensions}
               layouts={customLayouts}
               FormProps={props.FormProps}
+              components={{
+                ReviewStateComponent: ReviewStateComponent,
+                createButtonText: createButtonText,
+                reviewButtonText: reviewButtonText,
+              }}
             />
           </SecretsContextProvider>
         }

--- a/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateWizardPage/TemplateWizardPage.tsx
@@ -31,6 +31,7 @@ import {
   FormProps,
   Workflow,
   NextFieldExtensionOptions,
+  type WorkflowProps,
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { JsonValue } from '@backstage/types';
 import { Header, Page } from '@backstage/core-components';
@@ -48,7 +49,7 @@ export type TemplateWizardPageProps = {
   customFieldExtensions: NextFieldExtensionOptions<any, any>[];
   layouts?: LayoutOptions[];
   FormProps?: FormProps;
-};
+} & Pick<WorkflowProps, 'components'>;
 
 export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
   const rootRef = useRouteRef(rootRouteRef);
@@ -78,6 +79,8 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
 
   const onError = () => <Navigate to={rootRef()} />;
 
+  const { customFieldExtensions, ...rest } = props;
+
   return (
     <AnalyticsContext attributes={{ entityRef: templateRef }}>
       <Page themeId="website">
@@ -91,9 +94,8 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
           templateName={templateName}
           onCreate={onCreate}
           onError={onError}
-          extensions={props.customFieldExtensions}
-          FormProps={props.FormProps}
-          layouts={props.layouts}
+          extensions={customFieldExtensions}
+          {...rest}
         />
       </Page>
     </AnalyticsContext>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Prior to this PR, it is only possible to pass in your own `ReviewState` component by creating your own `Workflow` component.

This PR allows you to override the same components from `Workflow` but via the `NextScaffolderPage`

```ts
<SecretsContextProvider>
  <TemplateWizardPageComponent
    customFieldExtensions={fieldExtensions}
    layouts={customLayouts}
    FormProps={props.FormProps}
    components={{
      ReviewStateComponent: ReviewStateComponent,
      createButtonText: createButtonText,
      reviewButtonText: reviewButtonText,
    }}
  />
</SecretsContextProvider>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
