### PR TITLE
Fixes the example config in HostDiscovery.ts.

### DIFF
--- a/.changeset/nice-readers-heal.md
+++ b/.changeset/nice-readers-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fixed typo in HostDiscovery's JSDoc

--- a/packages/backend-common/src/discovery/HostDiscovery.ts
+++ b/packages/backend-common/src/discovery/HostDiscovery.ts
@@ -45,7 +45,7 @@ export class HostDiscovery implements PluginEndpointDiscovery {
    *    - target: https://internal.example.com/internal-catalog
    *      plugins: [catalog]
    *    - target: https://internal.example.com/secure/api/{{pluginId}}
-   *      plugins: [auth, permissions]
+   *      plugins: [auth, permission]
    *    - target:
    *        internal: https://internal.example.com/search
    *        external: https://example.com/search


### PR DESCRIPTION
The permission plugin was referenced as 'permissions' when the plugin id is 'permission'.

## Hey, I just made a Pull Request!

In HostDiscovery.ts there's documentation showing how to set the baseUrls for different plugins in app-config.yaml. In the example configuration the permission plugin was referenced as 'permissions' when the plugin id is 'permission'.

This is a code-comment change and has no impact on run-time functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
