### PR TITLE
backend-app-api: parallelize plugin startup, introduce startup hook and middleware

### DIFF
--- a/.changeset/ninety-jeans-scream.md
+++ b/.changeset/ninety-jeans-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': minor
+---
+
+Added `ServiceUnavailableError`

--- a/.changeset/ninety-turkeys-knock.md
+++ b/.changeset/ninety-turkeys-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Switched startup strategy to initialize all plugins in parallel, as well as hook into the new startup lifecycle hooks.

--- a/.changeset/olive-carpets-explode.md
+++ b/.changeset/olive-carpets-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Added startup hooks to the lifecycle services.

--- a/.changeset/selfish-olives-end.md
+++ b/.changeset/selfish-olives-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Introduced built-in middleware into the default `HttpService` implementation that throws a `ServiceNotAvailable` error when plugins aren't able to serve request. Also introduced a request stalling mechanism that pauses incoming request until plugins have been fully initialized.

--- a/.changeset/tasty-oranges-sleep.md
+++ b/.changeset/tasty-oranges-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Added handling of `ServiceUnavailableError` to error handling middleware.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -18,6 +18,7 @@ import { Handler } from 'express';
 import { HelmetOptions } from 'helmet';
 import * as http from 'http';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
+import { HumanDuration } from '@backstage/types';
 import { IdentityService } from '@backstage/backend-plugin-api';
 import { JsonObject } from '@backstage/types';
 import { LifecycleService } from '@backstage/backend-plugin-api';
@@ -179,8 +180,7 @@ export const identityServiceFactory: (
 export interface LifecycleMiddlewareOptions {
   // (undocumented)
   lifecycle: LifecycleService;
-  // (undocumented)
-  timeoutMs?: number;
+  startupRequestPauseTimeout?: HumanDuration;
 }
 
 // @public

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -78,6 +78,11 @@ export function createHttpServer(
   },
 ): Promise<ExtendedHttpServer>;
 
+// @public
+export function createLifecycleMiddleware(
+  options: LifecycleMiddlewareOptions,
+): RequestHandler;
+
 // @public (undocumented)
 export function createSpecializedBackend(
   options: CreateSpecializedBackendOptions,
@@ -169,6 +174,14 @@ export type IdentityFactoryOptions = {
 export const identityServiceFactory: (
   options?: IdentityFactoryOptions | undefined,
 ) => ServiceFactory<IdentityService, 'plugin'>;
+
+// @public
+export interface LifecycleMiddlewareOptions {
+  // (undocumented)
+  lifecycle: LifecycleService;
+  // (undocumented)
+  timeoutMs?: number;
+}
 
 // @public
 export const lifecycleServiceFactory: () => ServiceFactory<

--- a/packages/backend-app-api/src/http/MiddlewareFactory.test.ts
+++ b/packages/backend-app-api/src/http/MiddlewareFactory.test.ts
@@ -21,6 +21,7 @@ import {
   NotAllowedError,
   NotFoundError,
   NotModifiedError,
+  ServiceUnavailableError,
 } from '@backstage/errors';
 import express from 'express';
 import createError from 'http-errors';
@@ -143,6 +144,9 @@ describe('MiddlewareFactory', () => {
       app.use('/ConflictError', () => {
         throw new ConflictError();
       });
+      app.use('/ServiceUnavailableError', () => {
+        throw new ServiceUnavailableError();
+      });
       app.use(middleware.error());
 
       const r = request(app);
@@ -164,6 +168,10 @@ describe('MiddlewareFactory', () => {
       expect((await r.get('/ConflictError')).status).toBe(409);
       expect((await r.get('/ConflictError')).body.error.name).toBe(
         'ConflictError',
+      );
+      expect((await r.get('/ServiceUnavailableError')).status).toBe(503);
+      expect((await r.get('/ServiceUnavailableError')).body.error.name).toBe(
+        'ServiceUnavailableError',
       );
     });
 

--- a/packages/backend-app-api/src/http/MiddlewareFactory.ts
+++ b/packages/backend-app-api/src/http/MiddlewareFactory.ts
@@ -36,6 +36,7 @@ import {
   NotAllowedError,
   NotFoundError,
   NotModifiedError,
+  ServiceUnavailableError,
   serializeError,
 } from '@backstage/errors';
 import { NotImplementedError } from '@backstage/errors';
@@ -260,6 +261,8 @@ function getStatusCode(error: Error): number {
       return 409;
     case NotImplementedError.name:
       return 501;
+    case ServiceUnavailableError.name:
+      return 503;
     default:
       break;
   }

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createLifecycleMiddleware } from './createLifecycleMiddleware';
+import { BackendLifecycleImpl } from '../rootLifecycle/rootLifecycleServiceFactory';
+import { mockServices } from '@backstage/backend-test-utils';
+import { ServiceUnavailableError } from '@backstage/errors';
+
+describe('createLifecycleMiddleware', () => {
+  it('should pause requests when plugin is not ready', async () => {
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+
+    const middleware = createLifecycleMiddleware({ lifecycle });
+
+    const next = jest.fn();
+    middleware({} as any, {} as any, next);
+    expect(next).not.toHaveBeenCalled();
+    await lifecycle.startup();
+
+    // pending call
+    expect(next).toHaveBeenCalledWith();
+
+    // new call
+    const next2 = jest.fn();
+    middleware({} as any, {} as any, next2);
+    expect(next2).toHaveBeenCalledWith();
+  });
+
+  it('should throw ServiceUnavailableError after shutdown', async () => {
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+    const middleware = createLifecycleMiddleware({ lifecycle });
+
+    const next = jest.fn();
+    middleware({} as any, {} as any, next);
+    expect(next).not.toHaveBeenCalled();
+    await lifecycle.shutdown();
+
+    // pending call
+    expect(next).toHaveBeenCalledWith(
+      new ServiceUnavailableError('Service is shutting down'),
+    );
+
+    // new call
+    const next2 = jest.fn();
+    middleware({} as any, {} as any, next2);
+    expect(next2).toHaveBeenCalledWith(
+      new ServiceUnavailableError('Service is shutting down'),
+    );
+  });
+
+  it('should throw ServiceUnavailableError after timeout', async () => {
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+    const middleware = createLifecycleMiddleware({ lifecycle, timeoutMs: 1 });
+
+    const next = jest.fn();
+    middleware({} as any, {} as any, next);
+    expect(next).not.toHaveBeenCalled();
+
+    await new Promise(r => setTimeout(r, 2));
+
+    expect(next).toHaveBeenCalledWith(
+      new ServiceUnavailableError('Service has not started up yet'),
+    );
+  });
+});

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.test.ts
@@ -63,7 +63,10 @@ describe('createLifecycleMiddleware', () => {
 
   it('should throw ServiceUnavailableError after timeout', async () => {
     const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
-    const middleware = createLifecycleMiddleware({ lifecycle, timeoutMs: 1 });
+    const middleware = createLifecycleMiddleware({
+      lifecycle,
+      startupRequestPauseTimeout: { milliseconds: 1 },
+    });
 
     const next = jest.fn();
     middleware({} as any, {} as any, next);

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.ts
@@ -50,6 +50,8 @@ export interface LifecycleMiddlewareOptions {
   lifecycle: LifecycleService;
   /**
    * The maximum time that paused requests will wait for the service to start, before returning an error.
+   *
+   * Defaults to 5 seconds.
    */
   startupRequestPauseTimeout?: HumanDuration;
 }

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createLifecycleMiddleware.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LifecycleService } from '@backstage/backend-plugin-api';
+import { ServiceUnavailableError } from '@backstage/errors';
+import { RequestHandler } from 'express';
+
+export const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Options for {@link createLifecycleMiddleware}.
+ * @public
+ */
+export interface LifecycleMiddlewareOptions {
+  lifecycle: LifecycleService;
+  timeoutMs?: number;
+}
+
+/**
+ * Creates a middleware that pauses requests until the service has started.
+ *
+ * @remarks
+ *
+ * Requests that arrive before the service has started will be paused until startup is complete.
+ * If the service does not start within the provided timeout, the request will be rejected with a
+ * {@link @backstage/errors#ServiceUnavailableError}.
+ *
+ * If the service is shutting down, all requests will be rejected with a
+ * {@link @backstage/errors#ServiceUnavailableError}.
+ *
+ * @public
+ */
+export function createLifecycleMiddleware(
+  options: LifecycleMiddlewareOptions,
+): RequestHandler {
+  const { lifecycle, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+
+  let state: 'init' | 'up' | 'down' = 'init';
+  const waiting = new Set<{
+    next: (err?: Error) => void;
+    timeout: NodeJS.Timeout;
+  }>();
+
+  lifecycle.addStartupHook(async () => {
+    if (state === 'init') {
+      state = 'up';
+      for (const item of waiting) {
+        clearTimeout(item.timeout);
+        item.next();
+      }
+      waiting.clear();
+    }
+  });
+
+  lifecycle.addShutdownHook(async () => {
+    state = 'down';
+
+    for (const item of waiting) {
+      clearTimeout(item.timeout);
+      item.next(new ServiceUnavailableError('Service is shutting down'));
+    }
+    waiting.clear();
+  });
+
+  return (_req, _res, next) => {
+    if (state === 'up') {
+      next();
+      return;
+    } else if (state === 'down') {
+      next(new ServiceUnavailableError('Service is shutting down'));
+      return;
+    }
+
+    const item = {
+      next,
+      timeout: setTimeout(() => {
+        if (waiting.delete(item)) {
+          next(new ServiceUnavailableError('Service has not started up yet'));
+        }
+      }, timeoutMs),
+    };
+
+    waiting.add(item);
+  };
+}

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.test.ts
@@ -26,24 +26,32 @@ describe('httpRouterFactory', () => {
       {
         rootHttpRouter,
         plugin: { getId: () => 'test1' },
+        lifecycle: { addStartupHook() {}, addShutdownHook() {} },
       },
       undefined,
     );
     router1.use(handler1);
     expect(rootHttpRouter.use).toHaveBeenCalledTimes(1);
-    expect(rootHttpRouter.use).toHaveBeenCalledWith('/api/test1', handler1);
+    expect(rootHttpRouter.use).toHaveBeenCalledWith(
+      '/api/test1',
+      expect.any(Function),
+    );
 
     const handler2 = () => {};
     const router2 = await factory.factory(
       {
         rootHttpRouter,
         plugin: { getId: () => 'test2' },
+        lifecycle: { addStartupHook() {}, addShutdownHook() {} },
       },
       undefined,
     );
     router2.use(handler2);
     expect(rootHttpRouter.use).toHaveBeenCalledTimes(2);
-    expect(rootHttpRouter.use).toHaveBeenCalledWith('/api/test2', handler2);
+    expect(rootHttpRouter.use).toHaveBeenCalledWith(
+      '/api/test2',
+      expect.any(Function),
+    );
   });
 
   it('should use custom path generator', async () => {
@@ -57,6 +65,7 @@ describe('httpRouterFactory', () => {
       {
         rootHttpRouter,
         plugin: { getId: () => 'test1' },
+        lifecycle: { addStartupHook() {}, addShutdownHook() {} },
       },
       undefined,
     );
@@ -64,7 +73,7 @@ describe('httpRouterFactory', () => {
     expect(rootHttpRouter.use).toHaveBeenCalledTimes(1);
     expect(rootHttpRouter.use).toHaveBeenCalledWith(
       '/some/test1/path',
-      handler1,
+      expect.any(Function),
     );
 
     const handler2 = () => {};
@@ -72,6 +81,7 @@ describe('httpRouterFactory', () => {
       {
         rootHttpRouter,
         plugin: { getId: () => 'test2' },
+        lifecycle: { addStartupHook() {}, addShutdownHook() {} },
       },
       undefined,
     );
@@ -79,7 +89,7 @@ describe('httpRouterFactory', () => {
     expect(rootHttpRouter.use).toHaveBeenCalledTimes(2);
     expect(rootHttpRouter.use).toHaveBeenCalledWith(
       '/some/test2/path',
-      handler2,
+      expect.any(Function),
     );
   });
 });

--- a/packages/backend-app-api/src/services/implementations/httpRouter/index.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/index.ts
@@ -16,3 +16,5 @@
 
 export { httpRouterServiceFactory } from './httpRouterServiceFactory';
 export type { HttpRouterFactoryOptions } from './httpRouterServiceFactory';
+export { createLifecycleMiddleware } from './createLifecycleMiddleware';
+export type { LifecycleMiddlewareOptions } from './createLifecycleMiddleware';

--- a/packages/backend-app-api/src/services/implementations/lifecycle/lifecycleServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/lifecycle/lifecycleServiceFactory.ts
@@ -44,6 +44,9 @@ export class BackendPluginLifecycleImpl implements LifecycleService {
     hook: LifecycleServiceStartupHook,
     options?: LifecycleServiceStartupOptions,
   ): void {
+    if (this.#hasStarted) {
+      throw new Error('Attempted to add startup hook after startup');
+    }
     this.#startupTasks.push({ hook, options });
   }
 

--- a/packages/backend-app-api/src/services/implementations/rootLifecycle/rootLifecycleServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLifecycle/rootLifecycleServiceFactory.test.ts
@@ -44,4 +44,17 @@ describe('lifecycleService', () => {
     });
     await expect(service.shutdown()).resolves.toBeUndefined();
   });
+
+  it('should reject hooks after trigger', async () => {
+    const service = new BackendLifecycleImpl(getVoidLogger());
+    await service.startup();
+    expect(() => {
+      service.addStartupHook(() => {});
+    }).toThrow('Attempted to add startup hook after startup');
+
+    await service.shutdown();
+    expect(() => {
+      service.addShutdownHook(() => {});
+    }).toThrow('Attempted to add shutdown hook after shutdown');
+  });
 });

--- a/packages/backend-app-api/src/services/implementations/rootLifecycle/rootLifecycleServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLifecycle/rootLifecycleServiceFactory.ts
@@ -39,6 +39,9 @@ export class BackendLifecycleImpl implements RootLifecycleService {
     hook: LifecycleServiceStartupHook,
     options?: LifecycleServiceStartupOptions,
   ): void {
+    if (this.#hasStarted) {
+      throw new Error('Attempted to add startup hook after startup');
+    }
     this.#startupTasks.push({ hook, options });
   }
 
@@ -72,6 +75,9 @@ export class BackendLifecycleImpl implements RootLifecycleService {
     hook: LifecycleServiceShutdownHook,
     options?: LifecycleServiceShutdownOptions,
   ): void {
+    if (this.#hasShutdown) {
+      throw new Error('Attempted to add shutdown hook after shutdown');
+    }
     this.#shutdownTasks.push({ hook, options });
   }
 

--- a/packages/backend-app-api/src/services/implementations/rootLifecycle/rootLifecycleServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLifecycle/rootLifecycleServiceFactory.ts
@@ -48,13 +48,13 @@ export class BackendLifecycleImpl implements RootLifecycleService {
     }
     this.#hasStarted = true;
 
-    this.logger.info(`Running ${this.#startupTasks.length} startup tasks...`);
+    this.logger.debug(`Running ${this.#startupTasks.length} startup tasks...`);
     await Promise.all(
       this.#startupTasks.map(async ({ hook, options }) => {
         const logger = options?.logger ?? this.logger;
         try {
           await hook();
-          logger.info(`Startup hook succeeded`);
+          logger.debug(`Startup hook succeeded`);
         } catch (error) {
           logger.error(`Startup hook failed, ${error}`);
         }
@@ -81,13 +81,15 @@ export class BackendLifecycleImpl implements RootLifecycleService {
     }
     this.#hasShutdown = true;
 
-    this.logger.info(`Running ${this.#shutdownTasks.length} shutdown tasks...`);
+    this.logger.debug(
+      `Running ${this.#shutdownTasks.length} shutdown tasks...`,
+    );
     await Promise.all(
       this.#shutdownTasks.map(async ({ hook, options }) => {
         const logger = options?.logger ?? this.logger;
         try {
           await hook();
-          logger.info(`Shutdown hook succeeded`);
+          logger.debug(`Shutdown hook succeeded`);
         } catch (error) {
           logger.error(`Shutdown hook failed, ${error}`);
         }

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -17,9 +17,11 @@
 import {
   createServiceRef,
   createServiceFactory,
+  coreServices,
 } from '@backstage/backend-plugin-api';
 import { BackendInitializer } from './BackendInitializer';
 import { ServiceRegistry } from './ServiceRegistry';
+import { rootLifecycleServiceFactory } from '../services/implementations';
 
 const rootRef = createServiceRef<{ x: number }>({
   id: '1',
@@ -29,6 +31,16 @@ const rootRef = createServiceRef<{ x: number }>({
 const pluginRef = createServiceRef<{ x: number }>({
   id: '2',
 });
+
+class MockLogger {
+  debug() {}
+  info() {}
+  warn() {}
+  error() {}
+  child() {
+    return this;
+  }
+}
 
 describe('BackendInitializer', () => {
   it('should initialize root scoped services', async () => {
@@ -45,6 +57,12 @@ describe('BackendInitializer', () => {
         service: pluginRef,
         deps: {},
         factory: pluginFactory,
+      })(),
+      rootLifecycleServiceFactory(),
+      createServiceFactory({
+        service: coreServices.rootLogger,
+        deps: {},
+        factory: () => new MockLogger(),
       })(),
     ]);
 

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -115,4 +115,64 @@ describe('BackendInitializer', () => {
       "Module 'mod' for plugin 'test' startup failed; caused by Error: NOPE",
     );
   });
+
+  it('should reject duplicate plugins', async () => {
+    const init = new BackendInitializer(new ServiceRegistry([]));
+    init.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      })(),
+    );
+    init.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      })(),
+    );
+    await expect(init.start()).rejects.toThrow(
+      "Plugin 'test' is already registered",
+    );
+  });
+
+  it('should reject duplicate modules', async () => {
+    const init = new BackendInitializer(new ServiceRegistry([]));
+    init.add(
+      createBackendModule({
+        pluginId: 'test',
+        moduleId: 'mod',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      })(),
+    );
+    init.add(
+      createBackendModule({
+        pluginId: 'test',
+        moduleId: 'mod',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      })(),
+    );
+    await expect(init.start()).rejects.toThrow(
+      "Module 'mod' for plugin 'test' is already registered",
+    );
+  });
 });

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
@@ -32,12 +32,18 @@ describe('createSpecializedBackend', () => {
           createServiceFactory({
             service: coreServices.rootLifecycle,
             deps: {},
-            factory: async () => ({ addShutdownHook: () => {} }),
+            factory: async () => ({
+              addStartupHook: () => {},
+              addShutdownHook: () => {},
+            }),
           }),
           createServiceFactory({
             service: coreServices.rootLifecycle,
             deps: {},
-            factory: async () => ({ addShutdownHook: () => {} }),
+            factory: async () => ({
+              addStartupHook: () => {},
+              addShutdownHook: () => {},
+            }),
           }),
         ],
       }),

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -30,16 +30,6 @@ export interface Backend {
   stop(): Promise<void>;
 }
 
-export interface BackendRegisterInit {
-  id: string;
-  consumes: Set<ServiceOrExtensionPoint>;
-  provides: Set<ServiceOrExtensionPoint>;
-  init: {
-    deps: { [name: string]: ServiceOrExtensionPoint };
-    func: (deps: { [name: string]: unknown }) => Promise<void>;
-  };
-}
-
 /**
  * @public
  */

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -35,7 +35,10 @@ describe('createBackend', () => {
           createServiceFactory({
             service: coreServices.rootLifecycle,
             deps: {},
-            factory: async () => ({ addShutdownHook: () => {} }),
+            factory: async () => ({
+              addStartupHook: () => {},
+              addShutdownHook: () => {},
+            }),
           }),
         ],
       }),
@@ -49,12 +52,18 @@ describe('createBackend', () => {
           createServiceFactory({
             service: coreServices.rootLifecycle,
             deps: {},
-            factory: async () => ({ addShutdownHook: () => {} }),
+            factory: async () => ({
+              addStartupHook: () => {},
+              addShutdownHook: () => {},
+            }),
           }),
           createServiceFactory({
             service: coreServices.rootLifecycle,
             deps: {},
-            factory: async () => ({ addShutdownHook: () => {} }),
+            factory: async () => ({
+              addStartupHook: () => {},
+              addShutdownHook: () => {},
+            }),
           }),
         ],
       }),

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -273,6 +273,10 @@ export interface LifecycleService {
     hook: LifecycleServiceShutdownHook,
     options?: LifecycleServiceShutdownOptions,
   ): void;
+  addStartupHook(
+    hook: LifecycleServiceStartupHook,
+    options?: LifecycleServiceStartupOptions,
+  ): void;
 }
 
 // @public (undocumented)
@@ -280,6 +284,14 @@ export type LifecycleServiceShutdownHook = () => void | Promise<void>;
 
 // @public (undocumented)
 export interface LifecycleServiceShutdownOptions {
+  logger?: LoggerService;
+}
+
+// @public (undocumented)
+export type LifecycleServiceStartupHook = () => void | Promise<void>;
+
+// @public (undocumented)
+export interface LifecycleServiceStartupOptions {
   logger?: LoggerService;
 }
 

--- a/packages/backend-plugin-api/src/services/definitions/LifecycleService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/LifecycleService.ts
@@ -19,6 +19,21 @@ import { LoggerService } from './LoggerService';
 /**
  * @public
  */
+export type LifecycleServiceStartupHook = () => void | Promise<void>;
+
+/**
+ * @public
+ */
+export interface LifecycleServiceStartupOptions {
+  /**
+   * Optional {@link LoggerService} that will be used for logging instead of the default logger.
+   */
+  logger?: LoggerService;
+}
+
+/**
+ * @public
+ */
 export type LifecycleServiceShutdownHook = () => void | Promise<void>;
 
 /**
@@ -35,6 +50,20 @@ export interface LifecycleServiceShutdownOptions {
  * @public
  */
 export interface LifecycleService {
+  /**
+   * Register a function to be called when the backend has been initialized.
+   *
+   * @remarks
+   *
+   * When used with plugin scope it will wait for the plugin itself to have been initialized.
+   *
+   * When used with root scope it will wait for all plugins to have been initialized.
+   */
+  addStartupHook(
+    hook: LifecycleServiceStartupHook,
+    options?: LifecycleServiceStartupOptions,
+  ): void;
+
   /**
    * Register a function to be called when the backend is shutting down.
    */

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -26,6 +26,8 @@ export type { DiscoveryService } from './DiscoveryService';
 export type { HttpRouterService } from './HttpRouterService';
 export type {
   LifecycleService,
+  LifecycleServiceStartupHook,
+  LifecycleServiceStartupOptions,
   LifecycleServiceShutdownHook,
   LifecycleServiceShutdownOptions,
 } from './LifecycleService';

--- a/packages/errors/api-report.md
+++ b/packages/errors/api-report.md
@@ -126,5 +126,8 @@ export function serializeError(
 ): SerializedError;
 
 // @public
+export class ServiceUnavailableError extends CustomErrorBase {}
+
+// @public
 export function stringifyError(error: unknown): string;
 ```

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -82,6 +82,13 @@ export class NotModifiedError extends CustomErrorBase {}
 export class NotImplementedError extends CustomErrorBase {}
 
 /**
+ * The server is not ready to handle the request.
+ *
+ * @public
+ */
+export class ServiceUnavailableError extends CustomErrorBase {}
+
+/**
  * An error that forwards an underlying cause with additional context in the message.
  *
  * The `name` property of the error will be inherited from the `cause` if

--- a/packages/errors/src/errors/index.ts
+++ b/packages/errors/src/errors/index.ts
@@ -25,6 +25,7 @@ export {
   NotFoundError,
   NotModifiedError,
   NotImplementedError,
+  ServiceUnavailableError,
 } from './common';
 export { CustomErrorBase } from './CustomErrorBase';
 export { ResponseError } from './ResponseError';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It's quite common to run into issues when calling other plugins at startup, because the target plugin has not been started up yet. This fixes that problem in two ways: if a plugin is not available to respond to a request, we will now respond with a 503, rather than a 404. We also pause incoming requests for up to 5s by default, waiting for the plugin to start up before we resume the request.

In order to implement this I've parallelized the plugin and module initialization, as well as added a startup hook to the lifecycle services.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
