### PR TITLE
MADR v3 Front Matter parsing/display

### DIFF
--- a/.changeset/nine-bags-dream.md
+++ b/.changeset/nine-bags-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+Render table of front matter metadata when displaying MADR v3 formatted ADR

--- a/.changeset/real-donuts-brush.md
+++ b/.changeset/real-donuts-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr-backend': patch
+---
+
+Use front matter parser for MADR v3 formatted ADRs when indexing status/date

--- a/.changeset/strange-geese-argue.md
+++ b/.changeset/strange-geese-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr-common': patch
+---
+
+Add utility function for parsing MADR front matter

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -274,6 +274,9 @@ catalog:
     # Example component for TechDocs
     - type: file
       target: ../../plugins/techdocs-backend/examples/documented-component/catalog-info.yaml
+    # Example component for ADRs
+    - type: file
+      target: ../../plugins/adr/examples/component/catalog-info.yaml
     # Backstage example templates
     - type: file
       target: ../../plugins/scaffolder-backend/sample-templates/all-templates.yaml

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/integration-react": "workspace:^",
+    "@backstage/plugin-adr": "workspace:^",
     "@backstage/plugin-airbrake": "workspace:^",
     "@backstage/plugin-apache-airflow": "workspace:^",
     "@backstage/plugin-api-docs": "workspace:^",

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -26,6 +26,7 @@ import {
   RELATION_PROVIDES_API,
 } from '@backstage/catalog-model';
 import { EmptyState, InfoCard } from '@backstage/core-components';
+import { EntityAdrContent, isAdrAvailable } from '@backstage/plugin-adr';
 import {
   EntityApiDefinitionCard,
   EntityConsumedApisCard,
@@ -482,6 +483,10 @@ const serviceEntityPage = (
 
     <EntityLayout.Route path="/docs" title="Docs">
       {techdocsContent}
+    </EntityLayout.Route>
+
+    <EntityLayout.Route if={isAdrAvailable} path="/adrs" title="ADRS">
+      <EntityAdrContent />
     </EntityLayout.Route>
 
     <EntityLayout.Route

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -28,6 +28,7 @@ import {
   catalogApiRef,
   CATALOG_FILTER_EXISTS,
 } from '@backstage/plugin-catalog-react';
+import { AdrSearchResultListItem } from '@backstage/plugin-adr';
 import { SearchType } from '@backstage/plugin-search';
 import {
   SearchBar,
@@ -86,6 +87,11 @@ const SearchPage = () => {
                     name: 'Documentation',
                     icon: <DocsIcon />,
                   },
+                  {
+                    value: 'adr',
+                    name: 'Architecture Decision Records',
+                    icon: <DocsIcon />,
+                  },
                 ]}
               />
               <Paper className={classes.filters}>
@@ -131,6 +137,7 @@ const SearchPage = () => {
               <CatalogSearchResultListItem icon={<CatalogIcon />} />
               <TechDocsSearchResultListItem icon={<DocsIcon />} />
               <ToolSearchResultListItem icon={<BuildIcon />} />
+              <AdrSearchResultListItem icon={<DocsIcon />} />
             </SearchResult>
             <SearchResultPager />
           </Grid>

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -15,6 +15,7 @@
  */
 
 import { useHotCleanup } from '@backstage/backend-common';
+import { DefaultAdrCollatorFactory } from '@backstage/plugin-adr-backend';
 import { DefaultCatalogCollatorFactory } from '@backstage/plugin-catalog-backend';
 import { ToolDocumentCollatorFactory } from '@backstage/plugin-explore-backend';
 import { createRouter } from '@backstage/plugin-search-backend';
@@ -68,6 +69,18 @@ export default async function createPlugin(
 
   // Collators are responsible for gathering documents known to plugins. This
   // particular collator gathers entities from the software catalog.
+  indexBuilder.addCollator({
+    schedule,
+    factory: DefaultAdrCollatorFactory.fromConfig({
+      cache: env.cache,
+      config: env.config,
+      discovery: env.discovery,
+      logger: env.logger,
+      reader: env.reader,
+      tokenManager: env.tokenManager,
+    }),
+  });
+
   indexBuilder.addCollator({
     schedule,
     factory: DefaultCatalogCollatorFactory.fromConfig(env.config, {

--- a/plugins/adr-backend/src/search/madrParser.ts
+++ b/plugins/adr-backend/src/search/madrParser.ts
@@ -16,7 +16,10 @@
 
 import { DateTime } from 'luxon';
 import { marked } from 'marked';
-import { MADR_DATE_FORMAT } from '@backstage/plugin-adr-common';
+import {
+  MADR_DATE_FORMAT,
+  parseMadrWithFrontmatter,
+} from '@backstage/plugin-adr-common';
 
 const getTitle = (tokens: marked.TokensList): string | undefined => {
   return (
@@ -26,22 +29,6 @@ const getTitle = (tokens: marked.TokensList): string | undefined => {
   )?.text;
 };
 
-const getStatusForV3Format = (tokens: marked.TokensList): string | undefined =>
-  (
-    tokens.find(
-      t =>
-        t.type === 'heading' &&
-        t.depth === 2 &&
-        t.text.toLowerCase().includes('status:'),
-    ) as marked.Tokens.Text
-  )?.text
-    .toLowerCase()
-    .split('\n')
-    .find(l => /^status:/.test(l))
-    ?.replace(/^status:/i, '')
-    .trim()
-    .toLocaleLowerCase('en-US');
-
 const getStatusForV2Format = (tokens: marked.TokensList): string | undefined =>
   (tokens.find(t => t.type === 'list') as marked.Tokens.List)?.items
     ?.find(t => /^status:/i.test(t.text))
@@ -49,71 +36,45 @@ const getStatusForV2Format = (tokens: marked.TokensList): string | undefined =>
     .trim()
     .toLocaleLowerCase('en-US');
 
-const getDateForV3Format = (
-  tokens: marked.TokensList,
-  dateFormat: string,
-): string | undefined => {
-  let adrDateTime: DateTime | undefined;
-  const dateLine = (
-    tokens.find(
-      t =>
-        t.type === 'heading' &&
-        t.depth === 2 &&
-        t.text.toLowerCase().includes('date:'),
-    ) as marked.Tokens.Text
-  )?.text
-    .toLowerCase()
-    .split('\n')
-    .find(l => /^date:/.test(l));
-
-  if (dateLine) {
-    adrDateTime = DateTime.fromFormat(
-      dateLine.replace(/^date:/i, '').trim(),
-      dateFormat,
-    );
-  }
-  return adrDateTime?.isValid
-    ? adrDateTime.toFormat(MADR_DATE_FORMAT)
-    : undefined;
-};
-
-const getDateForV2Format = (
-  tokens: marked.TokensList,
-  dateFormat: string,
-): string | undefined => {
+const getDateForV2Format = (tokens: marked.TokensList): string | undefined => {
   const listTokens = (tokens.find(t => t.type === 'list') as marked.Tokens.List)
     ?.items;
-  const adrDateTime = DateTime.fromFormat(
-    listTokens
-      ?.find(t => /^date:/i.test(t.text))
-      ?.text.replace(/^date:/i, '')
-      .trim() ?? '',
-    dateFormat,
-  );
-  return adrDateTime?.isValid
-    ? adrDateTime.toFormat(MADR_DATE_FORMAT)
-    : undefined;
+  const adrDateTime = listTokens
+    ?.find(t => /^date:/i.test(t.text))
+    ?.text.replace(/^date:/i, '')
+    .trim();
+  return adrDateTime;
 };
 
-const getStatus = (tokens: marked.TokensList): string | undefined => {
-  return getStatusForV3Format(tokens) ?? getStatusForV2Format(tokens);
+const getStatus = (
+  tokens: marked.TokensList,
+  frontMatterStatus?: string,
+): string | undefined => {
+  return frontMatterStatus ?? getStatusForV2Format(tokens);
 };
 const getDate = (
   tokens: marked.TokensList,
   dateFormat: string,
-): string | undefined =>
-  getDateForV3Format(tokens, dateFormat) ??
-  getDateForV2Format(tokens, dateFormat);
+  frontMatterDate?: string,
+): string | undefined => {
+  const dateString = frontMatterDate ?? getDateForV2Format(tokens);
+  if (!dateString) {
+    return undefined;
+  }
+  const date = DateTime.fromFormat(dateString, dateFormat);
+  return date?.isValid ? date.toFormat(MADR_DATE_FORMAT) : undefined;
+};
 
 export const madrParser = (content: string, dateFormat = MADR_DATE_FORMAT) => {
-  const tokens = marked.lexer(content);
+  const preparsed = parseMadrWithFrontmatter(content);
+  const tokens = marked.lexer(preparsed.content);
   if (!tokens.length) {
     throw new Error('ADR has no content');
   }
 
   return {
     title: getTitle(tokens),
-    status: getStatus(tokens),
-    date: getDate(tokens, dateFormat),
+    status: getStatus(tokens, preparsed.status),
+    date: getDate(tokens, dateFormat, preparsed.date),
   };
 };

--- a/plugins/adr-common/api-report.md
+++ b/plugins/adr-common/api-report.md
@@ -35,4 +35,15 @@ export const MADR_DATE_FORMAT = 'yyyy-MM-dd';
 
 // @public
 export const madrFilePathFilter: AdrFilePathFilterFn;
+
+// @public
+export interface ParsedMadr {
+  attributes: Record<string, unknown>;
+  content: string;
+  date?: string;
+  status?: string;
+}
+
+// @public
+export const parseMadrWithFrontmatter: (content: string) => ParsedMadr;
 ```

--- a/plugins/adr-common/package.json
+++ b/plugins/adr-common/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@backstage/catalog-model": "workspace:^",
     "@backstage/integration": "workspace:^",
-    "@backstage/plugin-search-common": "workspace:^"
+    "@backstage/plugin-search-common": "workspace:^",
+    "front-matter": "^4.0.2"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^"

--- a/plugins/adr-common/src/index.ts
+++ b/plugins/adr-common/src/index.ts
@@ -20,6 +20,7 @@
 import { Entity, getEntitySourceLocation } from '@backstage/catalog-model';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { ScmIntegrationRegistry } from '@backstage/integration';
+import frontMatter from 'front-matter';
 
 /**
  * ADR plugin annotation.
@@ -101,3 +102,43 @@ export interface AdrDocument extends IndexableDocument {
    */
   date?: string;
 }
+
+/**
+ * Parsed MADR document with front matter (if present) parsed and extracted from the main markdown content.
+ * @public
+ */
+export interface ParsedMadr {
+  /**
+   * Main body of ADR content (with any front matter removed)
+   */
+  content: string;
+  /**
+   * ADR status
+   */
+  status?: string;
+  /**
+   * ADR date
+   */
+  date?: string;
+  /**
+   * All attributes parsed from front matter
+   */
+  attributes: Record<string, unknown>;
+}
+
+/**
+ * Utility function to parse raw markdown content for an ADR and extract any metadata found as "front matter" at the top of the Markdown document.
+ * @param content - Raw markdown content which may (optionally) include front matter
+ * @public
+ */
+export const parseMadrWithFrontmatter = (content: string): ParsedMadr => {
+  const parsed = frontMatter<Record<string, unknown>>(content);
+  const status = parsed.attributes.status;
+  const date = parsed.attributes.date;
+  return {
+    content: parsed.body,
+    status: status ? String(status) : undefined,
+    date: date ? String(date) : undefined,
+    attributes: parsed.attributes,
+  };
+};

--- a/plugins/adr/README.md
+++ b/plugins/adr/README.md
@@ -113,7 +113,7 @@ import { AdrDocument } from '@backstage/plugin-adr-common';
 
 ## Custom ADR formats
 
-By default, this plugin will parse ADRs according to the format specified by the [Markdown Architecture Decision Record (MADR) v2.x template](https://github.com/adr/madr/tree/2.1.2). If your ADRs are written using a different format, you can apply the following customizations to correctly identify and parse your documents:
+By default, this plugin will parse ADRs according to the format specified by the [Markdown Architecture Decision Record (MADR) v2.x template](https://github.com/adr/madr/tree/2.1.2) or the [Markdown Any Decision Record (MADR) 3.x template](https://github.com/adr/madr/tree/3.0.0). If your ADRs are written using a different format, you can apply the following customizations to correctly identify and parse your documents:
 
 ### Custom Filename/Path Format
 
@@ -135,7 +135,7 @@ const myCustomFilterFn: AdrFilePathFilterFn = (path: string): boolean => {
 
 ### Custom Content Decorators
 
-Your ADR Markdown content will typically be rendered in the UI as is with the exception of relative links/embeds being rewritten as absolute URLs so they can be linked correctly (e.g. `./my-diagram.png` => `<ABSOLUTE_ADR_DIR_URL>/my-diagram.png`). Depending on your ADR format, you may want to apply additional transformations to the content (e.g. parsing/ignoring front matter). You can do so by passing in a list of custom content decorators for the optional `contentDecorators` parameter. Note that passing in this parameter will override the default decorators. If you want to include the default ones, make sure to add them as well:
+Your ADR Markdown content will typically be rendered in the UI as is with the exception of relative links/embeds being rewritten as absolute URLs so they can be linked correctly (e.g. `./my-diagram.png` => `<ABSOLUTE_ADR_DIR_URL>/my-diagram.png`). Depending on your ADR format, you may want to apply additional transformations to the content (e.g. hiding or formatting front matter in a different way). You can do so by passing in a list of custom content decorators for the optional `contentDecorators` parameter. Note that passing in this parameter will override the default decorators. If you want to include the default ones, make sure to add them as well:
 
 ```tsx
 import {
@@ -154,6 +154,7 @@ const myCustomDecorator: AdrContentDecorator = ({ content }) => {
 <EntityAdrContent contentDecorators={[
     AdrReader.decorators.createRewriteRelativeLinksDecorator(),
     AdrReader.decorators.createRewriteRelativeEmbedsDecorator(),
+    AdrReader.decorators.createFrontMatterFormatterDecorator(),
     myCustomDecorator,
   ]}
 />

--- a/plugins/adr/api-report.md
+++ b/plugins/adr/api-report.md
@@ -80,6 +80,7 @@ export const AdrReader: {
   decorators: Readonly<{
     createRewriteRelativeLinksDecorator(): AdrContentDecorator;
     createRewriteRelativeEmbedsDecorator(): AdrContentDecorator;
+    createFrontMatterFormatterDecorator(): AdrContentDecorator;
   }>;
 };
 

--- a/plugins/adr/examples/component/catalog-info.yaml
+++ b/plugins/adr/examples/component/catalog-info.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: component-with-adrs
+  title: Component With ADRs
+  description: A Service with ADRs registerd
+  annotations:
+    backstage.io/adr-location: https://github.com/adr/madr/tree/develop/docs/decisions
+spec:
+  type: service
+  lifecycle: experimental
+  owner: user:guest

--- a/plugins/adr/src/components/AdrReader/AdrReader.tsx
+++ b/plugins/adr/src/components/AdrReader/AdrReader.tsx
@@ -59,6 +59,7 @@ export const AdrReader = (props: {
     const adrDecorators = decorators ?? [
       adrDecoratorFactories.createRewriteRelativeLinksDecorator(),
       adrDecoratorFactories.createRewriteRelativeEmbedsDecorator(),
+      adrDecoratorFactories.createFrontMatterFormatterDecorator(),
     ];
 
     return adrDecorators.reduce(

--- a/plugins/adr/src/components/AdrReader/decorators.ts
+++ b/plugins/adr/src/components/AdrReader/decorators.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { parseMadrWithFrontmatter } from '@backstage/plugin-adr-common';
 import { AdrContentDecorator } from './types';
 
 /**
@@ -43,5 +44,24 @@ export const adrDecoratorFactories = Object.freeze({
         `![$1](${baseUrl}/$2$3$4)`,
       ),
     });
+  },
+  /**
+   * Formats YAML front-matter into a table format (if any exists in the markdown document)
+   */
+  createFrontMatterFormatterDecorator(): AdrContentDecorator {
+    return ({ content }) => {
+      const parsedFrontmatter = parseMadrWithFrontmatter(content);
+      let table = '';
+      const attrs = parsedFrontmatter.attributes;
+      if (Object.keys(attrs).length > 0) {
+        const stripNewLines = (val: unknown) =>
+          String(val).replaceAll('\n', '<br/>');
+        const row = (vals: string[]) => `|${vals.join('|')}|\n`;
+        table = `${row(Object.keys(attrs))}`;
+        table += `${row(Object.keys(attrs).map(() => '---'))}`;
+        table += `${row(Object.values(attrs).map(stripNewLines))}\n\n`;
+      }
+      return { content: table + parsedFrontmatter.content };
+    };
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4521,6 +4521,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
+    front-matter: ^4.0.2
   languageName: unknown
   linkType: soft
 
@@ -25384,6 +25385,15 @@ __metadata:
   version: 1.3.2
   resolution: "fromentries@npm:1.3.2"
   checksum: 33729c529ce19f5494f846f0dd4945078f4e37f4e8955f4ae8cc7385c218f600e9d93a7d225d17636c20d1889106fd87061f911550861b7072f53bf891e6b341
+  languageName: node
+  linkType: hard
+
+"front-matter@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "front-matter@npm:4.0.2"
+  dependencies:
+    js-yaml: ^3.13.1
+  checksum: a5b4c36d75a820301ebf31db0f677332d189c4561903ab6853eaa0504b43634f98557dbf87752e09043dbd2c9dcc14b4bcf9151cb319c8ad7e26edb203c0cd23
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,7 +4525,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-adr@workspace:plugins/adr":
+"@backstage/plugin-adr@workspace:^, @backstage/plugin-adr@workspace:plugins/adr":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-adr@workspace:plugins/adr"
   dependencies:
@@ -24254,6 +24254,7 @@ __metadata:
     "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/integration-react": "workspace:^"
+    "@backstage/plugin-adr": "workspace:^"
     "@backstage/plugin-airbrake": "workspace:^"
     "@backstage/plugin-apache-airflow": "workspace:^"
     "@backstage/plugin-api-docs": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The ADR plugins previously added (partial, it turns out, see #16491) support for MADR v3. The code used the markdown parser to extract the status/date from the YAML front matter for indexing purposes but did not adjust the display of the ADR at all resulting in any YAML front matter (which is part of the MADR v3 standard template) to be rendered without appropriate formatting. This pull request uses the [front-matter NPM library](https://www.npmjs.com/package/front-matter) to parse the front matter which is then used for indexing purposes as well as displaying as a table at the top of the ADR when rendered in the browser.

I also added the ADR plugin to the example app.

:warning: I was unable to get ADRs from a local directory to load (the ScmIntegration wouldn't cooperate) so I pointed it at the MADR repo's directory of ADRs on GitHub for now. Happy to rip that out or change to something else if preferred.

Here is [an example of how a v3 MADR](https://github.com/adr/madr/blob/develop/docs/decisions/0003-provide-own-madr-tools.md) is displayed previous to this PR in Backstage:

![image](https://github.com/backstage/backstage/assets/28457/072713ec-ae79-4957-91a6-f9c6e20a69c7)

With this PR, the front matter is rendered as a table at the top, similar to how GitHub renders the same markdown:

![image](https://github.com/backstage/backstage/assets/28457/e0d8f643-87b0-41c2-8cf8-1fdb7de89495)

This fixes #17929 as well as addresses questions raised in a couple of discussions (#16644 and #16421).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
