### PR TITLE
Added note about how secrets are displayed

### DIFF
--- a/.changeset/smart-berries-wash.md
+++ b/.changeset/smart-berries-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Added note to README about how secrets are displayed in the Config tab of the DevTools plugin

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -16,7 +16,7 @@ Lists helpful information about your current running Backstage instance such as:
 
 Lists the configuration being used by your current running Backstage instance.
 
-**Note:** The Config tab uses the configuration schema [defined by each plugin](https://backstage.io/docs/conf/defining) to be able to mask secrets. It does this by checking that the [visibility](https://backstage.io/docs/conf/defining#visibility) has been marked as `secret`. If this is not set then the secret will appear in clear text. To avoid this it is highly recommended that you enable the [permission framework](https://backstage.io/docs/permissions/overview) and [apply the proper permissions](#permissions)).
+**Note:** The Config tab uses the configuration schema [defined by each plugin](https://backstage.io/docs/conf/defining) to be able to mask secrets. It does this by checking that the [visibility](https://backstage.io/docs/conf/defining#visibility) has been marked as `secret`. If this is not set then the secret will appear in clear text. To mitigate this it is highly recommended that you enable the [permission framework](https://backstage.io/docs/permissions/overview) and [apply the proper permissions](#permissions)). If you do see secrets in clear text please contact the plugin's author to get the visibility set to secret for the applicable property.
 
 ![Example of Config tab](./docs/devtools-config-tab.png)
 

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -16,6 +16,8 @@ Lists helpful information about your current running Backstage instance such as:
 
 Lists the configuration being used by your current running Backstage instance.
 
+**Note:** The Config tab uses the configuration schema [defined by each plugin](https://backstage.io/docs/conf/defining) to be able to mask secrets. It does this by checking that the [visibility](https://backstage.io/docs/conf/defining#visibility) has been marked as `secret`. If this is not set then the secret will appear in clear text. To avoid this it is highly recommended that you enable the [permission framework](https://backstage.io/docs/permissions/overview) and [apply the proper permissions](#permissions)).
+
 ![Example of Config tab](./docs/devtools-config-tab.png)
 
 ## Optional Features


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added note to README about how secrets are displayed in the Config tab of the DevTools plugin

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
