### PR TITLE
fix: don't expose sensible data in proxy backend

### DIFF
--- a/.changeset/selfish-carrots-sneeze.md
+++ b/.changeset/selfish-carrots-sneeze.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-proxy-backend': patch
 ---
 
-The headers `Authorization` and `X-Api-Key` are sensitive and must be declared a secret.
+Marked headers `Authorization` and `X-Api-Key` as secret in order to not show up in frontend configuration.

--- a/.changeset/selfish-carrots-sneeze.md
+++ b/.changeset/selfish-carrots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+The headers `Authorization` and `X-Api-Key` are sensitive and must be declared a secret.

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -31,7 +31,17 @@ export interface Config {
           /**
            * Object with extra headers to be added to target requests.
            */
-          headers?: { [key: string]: string };
+          headers?: Partial<{
+            /** @visibility secret */
+            Authorization: string;
+            /** @visibility secret */
+            authorization: string;
+            /** @visibility secret */
+            'X-Api-Key': string;
+            /** @visibility secret */
+            'x-api-key': string;
+            [key: string]: string;
+          }>;
           /**
            * Changes the origin of the host header to the target URL. Default: true.
            */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The headers `Authorization` and `X-Api-Key` are sensitive and must be declared a secret.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
