### PR TITLE
Update NGINX default.conf.template - adding MIME types support

### DIFF
--- a/contrib/docker/frontend-with-nginx/docker/default.conf.template
+++ b/contrib/docker/frontend-with-nginx/docker/default.conf.template
@@ -6,6 +6,7 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
+        include /etc/nginx/mime.types;
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri /index.html;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Without MIME types enabled Nginx services files as text/plain. This is not supported eg. in the Firefox - it does not load CSS files with wrong Content-Type header. This caused stopped to work GraphQL plugin.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
