### PR TITLE
Updating techdocs-cli to fully facilitate a Backstage like environment using the `--preview-app-bundle-path` flag

### DIFF
--- a/.changeset/slow-terms-clean.md
+++ b/.changeset/slow-terms-clean.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-techdocs-node': minor
 ---
 
-Made changes to faciliate using the --preview-app-bundle-path flag with techdocs-cli
+Made changes to facilitate using the --preview-app-bundle-path flag with techdocs-cli

--- a/.changeset/slow-terms-clean.md
+++ b/.changeset/slow-terms-clean.md
@@ -1,0 +1,6 @@
+---
+'@techdocs/cli': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Made changes to faciliate using the --preview-app-bundle-path flag with techdocs-cli

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -86,16 +86,17 @@ Usage: techdocs-cli serve [options]
 Serve a documentation project locally in a Backstage app-like environment
 
 Options:
-  -i, --docker-image <DOCKER_IMAGE>           The mkdocs docker container to use (default: "spotify/techdocs")
+  -i, --docker-image <DOCKER_IMAGE>           The mkdocs docker container to use (default: "spotify/techdocs:v1.2.0")
   --docker-entrypoint <DOCKER_ENTRYPOINT>     Override the image entrypoint
-  --docker-option <DOCKER_OPTION...>          Extra options to pass to the docker run command, e.g. "--add-host=internal.host:192.168.11.12"
-                                              (can be added multiple times).
+  --docker-option <DOCKER_OPTION...>          Extra options to pass to the docker run command, e.g. "--add-host=internal.host:192.168.11.12" (can be added
+                                              multiple times).
   --no-docker                                 Do not use Docker, use MkDocs executable in current user environment.
+  --site-name                                 Name for site when using default MkDocs config
+  --site-dir <PATH>                           Directory containing generated TechDocs site. (default: "./site/")
   --mkdocs-port <PORT>                        Port for MkDocs server to use (default: "8000")
-  --preview-app-bundle-path <PATH_TO_BUNDLE>  Preview documentation using a web app other than the included one.
-  --preview-app-port <PORT>                   Port where the preview will be served.
-                                              Can only be used with "--preview-app-bundle-path". (default: "3000")
   -v --verbose                                Enable verbose output. (default: false)
+  --preview-app-bundle-path <PATH_TO_BUNDLE>  Preview documentation using another web app
+  --preview-app-port <PORT>                   Port for the preview app to be served on (default: "3000")
   -h, --help                                  display help for command
 ```
 
@@ -122,7 +123,6 @@ sure all the dependencies are installed. But it can be disabled using
 Command reference:
 
 ```bash
-techdocs-cli generate --help
 Usage: techdocs-cli generate|build [options]
 
 Generate TechDocs documentation site using MkDocs.
@@ -130,22 +130,20 @@ Generate TechDocs documentation site using MkDocs.
 Options:
   --source-dir <PATH>             Source directory containing mkdocs.yml and docs/ directory. (default: ".")
   --output-dir <PATH>             Output directory containing generated TechDocs site. (default: "./site/")
-  --docker-image <DOCKER_IMAGE>   The mkdocs docker container to use (default: "spotify/techdocs:v1.0.3")
+  --docker-image <DOCKER_IMAGE>   The mkdocs docker container to use (default: "spotify/techdocs:v1.2.0")
   --no-pull                       Do not pull the latest docker image
   --no-docker                     Do not use Docker, use MkDocs executable and plugins in current user environment.
-  --techdocs-ref <HOST_TYPE:URL>  The repository hosting documentation source files e.g.
-                                  url:https://ghe.mycompany.net.com/org/repo.
-                                  This value is same as the backstage.io/techdocs-ref annotation of the corresponding
-                                  Backstage entity.
-                                  It is completely fine to skip this as it is only being used to set repo_url in mkdocs.yml
-                                  if not found.
-  --etag <ETAG>                   A unique identifier for the prepared tree e.g. commit SHA. If provided it will be stored
-                                  in techdocs_metadata.json.
-  --omitTechdocsCoreMkdocsPlugin  An option to disable automatic addition of techdocs-core plugin to the mkdocs.yaml files.
-                                  Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
-  --legacyCopyReadmeMdToIndexMd   Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md
-                                  in case a default <docs-dir>/index.md is not provided. (default: false)
+  --techdocs-ref <HOST_TYPE:URL>  The repository hosting documentation source files e.g. url:https://ghe.mycompany.net.com/org/repo.
+                                  This value is same as the backstage.io/techdocs-ref annotation of the corresponding Backstage entity.
+                                  It is completely fine to skip this as it is only being used to set repo_url in mkdocs.yml if not found.
+  --etag <ETAG>                   A unique identifier for the prepared tree e.g. commit SHA. If provided it will be stored in techdocs_metadata.json.
+  --site-name                     Name for site when using default MkDocs config
+  --catalog-file <PATH>           Path to the backstage catalog file. This optional and will only be used if serving using the --preview-app-bundle-path
+                                  flag
   -v --verbose                    Enable verbose output. (default: false)
+  --omitTechdocsCoreMkdocsPlugin  Don't patch MkDocs file automatically with techdocs-core plugin. (default: false)
+  --legacyCopyReadmeMdToIndexMd   Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md in case a default
+                                  <docs-dir>/index.md is not provided. (default: false)
   -h, --help                      display help for command
 ```
 

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -70,10 +70,24 @@ a Backstage app server on port 3000. The Backstage app has a custom TechDocs API
 implementation, which uses the MkDocs preview server as a proxy to fetch the
 generated documentation files and assets.
 
+### Preview TechDocs site locally with a provided Backstage app
+
 Backstage instances might differ from the provided preview app in appearance and
 behavior. To preview documentation with a different app, use
 `--preview-app-bundle-path` with a path to the bundle of the app to use instead.
 Typically, a `dist` or `build` directory.
+
+Firstly, generate the mkdocs site and provide your catalog-info file
+
+```bash
+techdocs-cli generate --catalog-file [CATALOG FILE PATH]
+```
+
+Serve the app. Optionally provide a `--preview-app-port` if your Backstage bundle is hardcoded to issue requests to a backend with a port other than the default (3000)
+
+```bash
+techdocs-cli serve --preview-app-bundle-path [BACKSTAGE APP BUNDLE PATH]
+```
 
 NOTE: When using a custom `techdocs` docker image, make sure the entry point is
 also `ENTRYPOINT ["mkdocs"]` or override with `--docker-entrypoint`.

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -34,6 +34,7 @@ Options:
   --techdocs-ref <HOST_TYPE:URL>
   --etag <ETAG>
   --site-name
+  --catalog-file <PATH>
   -v --verbose
   --omitTechdocsCoreMkdocsPlugin
   --legacyCopyReadmeMdToIndexMd
@@ -101,6 +102,7 @@ Options:
   --docker-option <DOCKER_OPTION...>
   --no-docker
   --site-name
+  --site-dir <PATH>
   --mkdocs-port <PORT>
   -v --verbose
   --preview-app-bundle-path <PATH_TO_BUNDLE>

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -46,6 +46,9 @@ export default async function generate(opts: OptionValues) {
   const omitTechdocsCorePlugin = opts.omitTechdocsCoreMkdocsPlugin;
   const dockerImage = opts.dockerImage;
   const pullImage = opts.pull;
+  const catalogFilePath = opts.catalogFile
+    ? resolve(opts.catalogFile)
+    : undefined;
   const legacyCopyReadmeMdToIndexMd = opts.legacyCopyReadmeMdToIndexMd;
 
   logger.info(`Using source dir ${sourceDir}`);
@@ -108,6 +111,7 @@ export default async function generate(opts: OptionValues) {
           parsedLocationAnnotation,
         }
       : {}),
+    catalogFilePath: catalogFilePath,
     logger,
     etag: opts.etag,
     logStream: getLogStream(logger),

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -59,6 +59,10 @@ export function registerCommands(program: Command) {
       'Name for site when using default MkDocs config',
       'Documentation Site',
     )
+    .option(
+      '--catalog-file <PATH>',
+      'Path to the backstage catalog file. This optional and will only be used if serving using the --preview-app-bundle-path flag',
+    )
     .option('-v --verbose', 'Enable verbose output.', false)
     .option(
       '--omitTechdocsCoreMkdocsPlugin',
@@ -268,6 +272,11 @@ export function registerCommands(program: Command) {
       '--site-name',
       'Name for site when using default MkDocs config',
       'Documentation Site',
+    )
+    .option(
+      '--site-dir <PATH>',
+      'Directory containing generated TechDocs site.',
+      './site/',
     )
     .option('--mkdocs-port <PORT>', 'Port for MkDocs server to use', '8000')
     .option('-v --verbose', 'Enable verbose output.', false)

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -128,6 +128,7 @@ export default async function serve(opts: OptionValues) {
     previewAppPath,
     port,
     mkdocsExpectedDevAddr,
+    opts.siteDir,
     opts.verbose,
   );
 

--- a/packages/techdocs-cli/src/lib/httpServer.ts
+++ b/packages/techdocs-cli/src/lib/httpServer.ts
@@ -17,25 +17,35 @@
 import serveHandler from 'serve-handler';
 import http from 'http';
 import httpProxy from 'http-proxy';
+import fs from 'fs-extra';
 import { createLogger } from './utility';
+import path from 'path';
+
+interface PathContent {
+  content: string;
+  contentType: string;
+}
 
 export default class HTTPServer {
   private readonly proxyEndpoint: string;
   private readonly backstageBundleDir: string;
   private readonly backstagePort: number;
   private readonly mkdocsTargetAddress: string;
+  private readonly siteDir: string;
   private readonly verbose: boolean;
 
   constructor(
     backstageBundleDir: string,
     backstagePort: number,
     mkdocsTargetAddress: string,
+    siteDir: string,
     verbose: boolean,
   ) {
     this.proxyEndpoint = '/api/techdocs/';
     this.backstageBundleDir = backstageBundleDir;
     this.backstagePort = backstagePort;
     this.mkdocsTargetAddress = mkdocsTargetAddress;
+    this.siteDir = siteDir;
     this.verbose = verbose;
   }
 
@@ -48,13 +58,24 @@ export default class HTTPServer {
     return (request: http.IncomingMessage): [httpProxy, string] => {
       // If the request path is prefixed with this.proxyEndpoint, remove it.
       const proxyEndpointPath = new RegExp(`^${this.proxyEndpoint}`, 'i');
-      const forwardPath = request.url?.replace(proxyEndpointPath, '') || '';
+      const forwardPath =
+        request.url
+          ?.replace(proxyEndpointPath, '')
+          .replace('static/docs/default/component/local/', '/') || '';
 
       return [proxy, forwardPath];
     };
   }
 
   public async serve(): Promise<http.Server> {
+    const entityMetadata = await fs.readFile(
+      path.join(this.siteDir, 'entity_metadata.json'),
+      'utf8',
+    );
+    const techdocsMetadata = await fs.readFile(
+      path.join(this.siteDir, 'techdocs_metadata.json'),
+      'utf8',
+    );
     return new Promise<http.Server>((resolve, reject) => {
       const proxyHandler = this.createProxy();
       const server = http.createServer(
@@ -68,6 +89,28 @@ export default class HTTPServer {
 
             response.setHeader('Access-Control-Allow-Origin', '*');
             response.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+
+            const forwardPathExceptionsMap: Record<string, PathContent> = {
+              'metadata/entity/default/component/local': {
+                content: entityMetadata,
+                contentType: 'text/event-stream',
+              },
+              'metadata/techdocs/default/component/local': {
+                content: techdocsMetadata,
+                contentType: 'text/event-stream',
+              },
+              'sync/default/component/local': {
+                content: 'sync',
+                contentType: 'text/plain',
+              },
+            };
+            for (const mappedPath of Object.keys(forwardPathExceptionsMap)) {
+              if (forwardPath.includes(mappedPath)) {
+                response.setHeader('Content-Type', 'text/event-stream');
+                response.end(forwardPathExceptionsMap[mappedPath].content);
+                return;
+              }
+            }
 
             request.url = forwardPath;
             proxy.web(request, response);

--- a/packages/techdocs-cli/src/lib/httpServer.ts
+++ b/packages/techdocs-cli/src/lib/httpServer.ts
@@ -68,13 +68,11 @@ export default class HTTPServer {
   }
 
   public async serve(): Promise<http.Server> {
-    const entityMetadata = await fs.readFile(
+    const entityMetadata = await this.readMetadataFile(
       path.join(this.siteDir, 'entity_metadata.json'),
-      'utf8',
     );
-    const techdocsMetadata = await fs.readFile(
+    const techdocsMetadata = await this.readMetadataFile(
       path.join(this.siteDir, 'techdocs_metadata.json'),
-      'utf8',
     );
     return new Promise<http.Server>((resolve, reject) => {
       const proxyHandler = this.createProxy();
@@ -146,5 +144,14 @@ export default class HTTPServer {
         reject(error);
       });
     });
+  }
+
+  private async readMetadataFile(metadataFilePath: string): Promise<string> {
+    try {
+      return await fs.readFile(metadataFilePath, 'utf8');
+    } catch (error) {
+      // no-op
+    }
+    return '{}';
   }
 }

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -47,6 +47,7 @@ export type GeneratorOptions = {
 export type GeneratorRunOptions = {
   inputDir: string;
   outputDir: string;
+  catalogFilePath?: string;
   parsedLocationAnnotation?: ParsedLocationAnnotation;
   etag?: string;
   logger: Logger;

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -369,6 +369,51 @@ export const createOrUpdateMetadata = async (
 };
 
 /**
+ * Create or update the entity_metadata.json file.
+ * The contents of it will be the contents of catalogFilePath converted to JSON
+ * @param catalogFilePath - File path to the catalog info file
+ * @param entityMetadataPath - File path to entity_metadata.json
+ */
+export const createOrUpdateEntityMetadata = async (
+  catalogFilePath: string,
+  entityMetadataPath: string,
+  logger: Logger,
+): Promise<void> => {
+  // check if file exists, create if it does not.
+  try {
+    await fs.access(entityMetadataPath, fs.constants.F_OK);
+  } catch (err) {
+    // Bootstrap file with empty JSON
+    await fs.writeJson(entityMetadataPath, JSON.parse('{}'));
+  }
+  // check if valid Json
+  let json;
+  try {
+    json = await fs.readJson(entityMetadataPath);
+  } catch (err) {
+    assertError(err);
+    const message = `Invalid JSON at ${entityMetadataPath} with error ${err.message}`;
+    logger.error(message);
+    throw new Error(message);
+  }
+  // check if valid YAML
+  let catalogYaml;
+  try {
+    catalogYaml = yaml.load(await fs.readFile(catalogFilePath, 'utf8'));
+  } catch (err) {
+    assertError(err);
+    const message = `Invalid YAML at ${catalogFilePath} with error ${err.message}`;
+    logger.error(message);
+    throw new Error(message);
+  }
+
+  // catalogYaml is represented in JSON form
+  json = catalogYaml;
+  await fs.writeJson(entityMetadataPath, json);
+  return;
+};
+
+/**
  * Update the techdocs_metadata.json to add etag of the prepared tree (e.g. commit SHA or actual Etag of the resource).
  * This is helpful to check if a TechDocs site in storage has gone outdated, without maintaining an in-memory build info
  * per Backstage instance.

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -23,6 +23,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import {
+  createOrUpdateEntityMetadata,
   createOrUpdateMetadata,
   getMkdocsYml,
   patchIndexPreBuild,
@@ -92,6 +93,7 @@ export class TechdocsGenerator implements GeneratorBase {
     const {
       inputDir,
       outputDir,
+      catalogFilePath,
       parsedLocationAnnotation,
       etag,
       logger: childLogger,
@@ -186,6 +188,14 @@ export class TechdocsGenerator implements GeneratorBase {
     /**
      * Post Generate steps
      */
+
+    if (catalogFilePath) {
+      await createOrUpdateEntityMetadata(
+        catalogFilePath,
+        path.join(outputDir, 'entity_metadata.json'),
+        childLogger,
+      );
+    }
 
     // Add build timestamp and files to techdocs_metadata.json
     // Creates techdocs_metadata.json if file does not exist.

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -58,6 +58,7 @@ export type GeneratorConfig = {
 export type GeneratorRunOptions = {
   inputDir: string;
   outputDir: string;
+  catalogFilePath?: string;
   parsedLocationAnnotation?: ParsedLocationAnnotation;
   etag?: string;
   logger: Logger;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I discovered some issues when running `techdocs-cli serve` and using our Backstage app and the upstream Backstage app using the `--preview-app-bundle-path` flag.
The issues boiled down to a few things:
1. The HttpServer not proxying requests to
    1. `*/static/docs/default/component/local/`
    2. `*/metadata/entity/default/component/local`
    3. `*/metadata/techdocs/default/component/local`
    4. `*/sync/default/component/local`
2. The `entity_metadata.json` file was not created. This is requested by the request to `*/metadata/entity/default/component/local`.
I have added the `--catalog-file` flag to the generate command. It will use the catalog file to generate the `entity_metadata.json` file and place it in the `site` folder

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
