### PR TITLE
Add name parameter to CustomErrorBase class

### DIFF
--- a/.changeset/dirty-wasps-draw.md
+++ b/.changeset/dirty-wasps-draw.md
@@ -2,4 +2,4 @@
 '@backstage/errors': patch
 ---
 
-Added a new parameter "name" to "CustomErrorBase" and updated all the existing extensions to use it
+Set `this.name` in all error classes that extend `CustomErrorBase` class to their actual name

--- a/.changeset/dirty-wasps-draw.md
+++ b/.changeset/dirty-wasps-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': patch
+---
+
+Added a new parameter "name" to "CustomErrorBase" and updated all the existing extensions to use it

--- a/packages/errors/api-report.md
+++ b/packages/errors/api-report.md
@@ -11,13 +11,13 @@ export function assertError(value: unknown): asserts value is ErrorLike;
 // @public
 export class AuthenticationError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'AuthenticationError';
 }
 
 // @public
 export class ConflictError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'ConflictError';
 }
 
 // @public
@@ -81,7 +81,7 @@ export class ForwardedError extends CustomErrorBase {
 // @public
 export class InputError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'InputError';
 }
 
 // @public
@@ -90,25 +90,25 @@ export function isError(value: unknown): value is ErrorLike;
 // @public
 export class NotAllowedError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'NotAllowedError';
 }
 
 // @public
 export class NotFoundError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'NotFoundError';
 }
 
 // @public
 export class NotImplementedError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'NotImplementedError';
 }
 
 // @public
 export class NotModifiedError extends CustomErrorBase {
   // (undocumented)
-  name: string;
+  name: 'NotModifiedError';
 }
 
 // @public

--- a/packages/errors/api-report.md
+++ b/packages/errors/api-report.md
@@ -9,10 +9,16 @@ import { JsonObject } from '@backstage/types';
 export function assertError(value: unknown): asserts value is ErrorLike;
 
 // @public
-export class AuthenticationError extends CustomErrorBase {}
+export class AuthenticationError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
-export class ConflictError extends CustomErrorBase {}
+export class ConflictError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
 export type ConsumedResponse = {
@@ -73,22 +79,37 @@ export class ForwardedError extends CustomErrorBase {
 }
 
 // @public
-export class InputError extends CustomErrorBase {}
+export class InputError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
 export function isError(value: unknown): value is ErrorLike;
 
 // @public
-export class NotAllowedError extends CustomErrorBase {}
+export class NotAllowedError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
-export class NotFoundError extends CustomErrorBase {}
+export class NotFoundError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
-export class NotImplementedError extends CustomErrorBase {}
+export class NotImplementedError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
-export class NotModifiedError extends CustomErrorBase {}
+export class NotModifiedError extends CustomErrorBase {
+  // (undocumented)
+  name: string;
+}
 
 // @public
 export function parseErrorResponseBody(

--- a/packages/errors/src/errors/CustomErrorBase.ts
+++ b/packages/errors/src/errors/CustomErrorBase.ts
@@ -53,7 +53,10 @@ export class CustomErrorBase extends Error {
 
     Error.captureStackTrace?.(this, this.constructor);
 
-    this.name = 'CustomErrorBase';
+    if (!this.name) {
+      this.name = this.constructor.name;
+    }
+
     this.cause = isError(cause) ? cause : undefined;
   }
 }

--- a/packages/errors/src/errors/CustomErrorBase.ts
+++ b/packages/errors/src/errors/CustomErrorBase.ts
@@ -19,6 +19,7 @@ import { isError } from './assertion';
 
 /**
  * A base class that custom Error classes can inherit from.
+ * @param name This is useful when you extend this base class to pass a custom name that will be included in the error message
  *
  * @public
  * @example
@@ -38,7 +39,7 @@ export class CustomErrorBase extends Error {
    */
   readonly cause?: Error | undefined;
 
-  constructor(message?: string, cause?: Error | unknown) {
+  constructor(message?: string, cause?: Error | unknown, name?: string) {
     let fullMessage = message;
     if (cause !== undefined) {
       const causeStr = stringifyError(cause);
@@ -53,7 +54,7 @@ export class CustomErrorBase extends Error {
 
     Error.captureStackTrace?.(this, this.constructor);
 
-    this.name = this.constructor.name;
+    this.name = name || 'CustomErrorBase';
     this.cause = isError(cause) ? cause : undefined;
   }
 }

--- a/packages/errors/src/errors/CustomErrorBase.ts
+++ b/packages/errors/src/errors/CustomErrorBase.ts
@@ -19,7 +19,6 @@ import { isError } from './assertion';
 
 /**
  * A base class that custom Error classes can inherit from.
- * @param name This is useful when you extend this base class to pass a custom name that will be included in the error message
  *
  * @public
  * @example
@@ -39,7 +38,7 @@ export class CustomErrorBase extends Error {
    */
   readonly cause?: Error | undefined;
 
-  constructor(message?: string, cause?: Error | unknown, name?: string) {
+  constructor(message?: string, cause?: Error | unknown) {
     let fullMessage = message;
     if (cause !== undefined) {
       const causeStr = stringifyError(cause);
@@ -54,7 +53,7 @@ export class CustomErrorBase extends Error {
 
     Error.captureStackTrace?.(this, this.constructor);
 
-    this.name = name || 'CustomErrorBase';
+    this.name = 'CustomErrorBase';
     this.cause = isError(cause) ? cause : undefined;
   }
 }

--- a/packages/errors/src/errors/CustomErrorBase.ts
+++ b/packages/errors/src/errors/CustomErrorBase.ts
@@ -22,8 +22,11 @@ import { isError } from './assertion';
  *
  * @public
  * @example
- *```ts
- * class MyCustomError extends CustomErrorBase {}
+ *
+ * ```ts
+ * class MyCustomError extends CustomErrorBase {
+ *  name = 'MyCustomError' as const;
+ * }
  *
  * const e = new MyCustomError('Some message', cause);
  * // e.name === 'MyCustomError'
@@ -53,8 +56,11 @@ export class CustomErrorBase extends Error {
 
     Error.captureStackTrace?.(this, this.constructor);
 
-    if (!this.name) {
-      this.name = this.constructor.name;
+    if (!this.name || this.name === 'Error') {
+      const baseName = this.constructor.name;
+      if (baseName !== 'Error') {
+        this.name = this.constructor.name;
+      }
     }
 
     this.cause = isError(cause) ? cause : undefined;

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -34,7 +34,7 @@ import { CustomErrorBase } from './CustomErrorBase';
  * @public
  */
 export class InputError extends CustomErrorBase {
-  name = 'InputError';
+  name = 'InputError' as const;
 }
 
 /**
@@ -43,7 +43,7 @@ export class InputError extends CustomErrorBase {
  * @public
  */
 export class AuthenticationError extends CustomErrorBase {
-  name = 'AuthenticationError';
+  name = 'AuthenticationError' as const;
 }
 
 /**
@@ -52,7 +52,7 @@ export class AuthenticationError extends CustomErrorBase {
  * @public
  */
 export class NotAllowedError extends CustomErrorBase {
-  name = 'NotAllowedError';
+  name = 'NotAllowedError' as const;
 }
 
 /**
@@ -64,7 +64,7 @@ export class NotAllowedError extends CustomErrorBase {
  * @public
  */
 export class NotFoundError extends CustomErrorBase {
-  name = 'NotFoundError';
+  name = 'NotFoundError' as const;
 }
 
 /**
@@ -74,7 +74,7 @@ export class NotFoundError extends CustomErrorBase {
  * @public
  */
 export class ConflictError extends CustomErrorBase {
-  name = 'ConflictError';
+  name = 'ConflictError' as const;
 }
 
 /**
@@ -83,7 +83,7 @@ export class ConflictError extends CustomErrorBase {
  * @public
  */
 export class NotModifiedError extends CustomErrorBase {
-  name = 'NotModifiedError';
+  name = 'NotModifiedError' as const;
 }
 
 /**
@@ -92,7 +92,7 @@ export class NotModifiedError extends CustomErrorBase {
  * @public
  */
 export class NotImplementedError extends CustomErrorBase {
-  name = 'NotImplementedError';
+  name = 'NotImplementedError' as const;
 }
 
 /**

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -34,10 +34,7 @@ import { CustomErrorBase } from './CustomErrorBase';
  * @public
  */
 export class InputError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'InputError';
-  }
+  name = 'InputError';
 }
 
 /**
@@ -46,10 +43,7 @@ export class InputError extends CustomErrorBase {
  * @public
  */
 export class AuthenticationError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'AuthenticationError';
-  }
+  name = 'AuthenticationError';
 }
 
 /**
@@ -58,10 +52,7 @@ export class AuthenticationError extends CustomErrorBase {
  * @public
  */
 export class NotAllowedError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'NotAllowedError';
-  }
+  name = 'NotAllowedError';
 }
 
 /**
@@ -73,10 +64,7 @@ export class NotAllowedError extends CustomErrorBase {
  * @public
  */
 export class NotFoundError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'NotFoundError';
-  }
+  name = 'NotFoundError';
 }
 
 /**
@@ -86,10 +74,7 @@ export class NotFoundError extends CustomErrorBase {
  * @public
  */
 export class ConflictError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'ConflictError';
-  }
+  name = 'ConflictError';
 }
 
 /**
@@ -98,10 +83,7 @@ export class ConflictError extends CustomErrorBase {
  * @public
  */
 export class NotModifiedError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'NotModifiedError';
-  }
+  name = 'NotModifiedError';
 }
 
 /**
@@ -110,10 +92,7 @@ export class NotModifiedError extends CustomErrorBase {
  * @public
  */
 export class NotImplementedError extends CustomErrorBase {
-  constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause);
-    this.name = 'NotImplementedError';
-  }
+  name = 'NotImplementedError';
 }
 
 /**

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -35,7 +35,8 @@ import { CustomErrorBase } from './CustomErrorBase';
  */
 export class InputError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'InputError');
+    super(message, cause);
+    this.name = 'InputError';
   }
 }
 
@@ -46,7 +47,8 @@ export class InputError extends CustomErrorBase {
  */
 export class AuthenticationError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'AuthenticationError');
+    super(message, cause);
+    this.name = 'AuthenticationError';
   }
 }
 
@@ -57,7 +59,8 @@ export class AuthenticationError extends CustomErrorBase {
  */
 export class NotAllowedError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'NotAllowedError');
+    super(message, cause);
+    this.name = 'NotAllowedError';
   }
 }
 
@@ -71,7 +74,8 @@ export class NotAllowedError extends CustomErrorBase {
  */
 export class NotFoundError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'NotFoundError');
+    super(message, cause);
+    this.name = 'NotFoundError';
   }
 }
 
@@ -83,7 +87,8 @@ export class NotFoundError extends CustomErrorBase {
  */
 export class ConflictError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'ConflictError');
+    super(message, cause);
+    this.name = 'ConflictError';
   }
 }
 
@@ -94,7 +99,8 @@ export class ConflictError extends CustomErrorBase {
  */
 export class NotModifiedError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'NotModifiedError');
+    super(message, cause);
+    this.name = 'NotModifiedError';
   }
 }
 
@@ -105,7 +111,8 @@ export class NotModifiedError extends CustomErrorBase {
  */
 export class NotImplementedError extends CustomErrorBase {
   constructor(message?: string, cause?: Error | unknown) {
-    super(message, cause, 'NotImplementedError');
+    super(message, cause);
+    this.name = 'NotImplementedError';
   }
 }
 
@@ -126,6 +133,8 @@ export class ServiceUnavailableError extends CustomErrorBase {}
  */
 export class ForwardedError extends CustomErrorBase {
   constructor(message: string, cause: Error | unknown) {
-    super(message, cause, isError(cause) ? cause.name : 'Error');
+    super(message, cause);
+
+    this.name = isError(cause) ? cause.name : 'Error';
   }
 }

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -33,21 +33,33 @@ import { CustomErrorBase } from './CustomErrorBase';
  *
  * @public
  */
-export class InputError extends CustomErrorBase {}
+export class InputError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'InputError');
+  }
+}
 
 /**
  * The request requires authentication, which was not properly supplied.
  *
  * @public
  */
-export class AuthenticationError extends CustomErrorBase {}
+export class AuthenticationError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'AuthenticationError');
+  }
+}
 
 /**
  * The authenticated caller is not allowed to perform this request.
  *
  * @public
  */
-export class NotAllowedError extends CustomErrorBase {}
+export class NotAllowedError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'NotAllowedError');
+  }
+}
 
 /**
  * The requested resource could not be found.
@@ -57,7 +69,11 @@ export class NotAllowedError extends CustomErrorBase {}
  *
  * @public
  */
-export class NotFoundError extends CustomErrorBase {}
+export class NotFoundError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'NotFoundError');
+  }
+}
 
 /**
  * The request could not complete due to a conflict in the current state of the
@@ -65,21 +81,33 @@ export class NotFoundError extends CustomErrorBase {}
  *
  * @public
  */
-export class ConflictError extends CustomErrorBase {}
+export class ConflictError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'ConflictError');
+  }
+}
 
 /**
  * The requested resource has not changed since last request.
  *
  * @public
  */
-export class NotModifiedError extends CustomErrorBase {}
+export class NotModifiedError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'NotModifiedError');
+  }
+}
 
 /**
  * The server does not support the functionality required to fulfill the request.
  *
  * @public
  */
-export class NotImplementedError extends CustomErrorBase {}
+export class NotImplementedError extends CustomErrorBase {
+  constructor(message?: string, cause?: Error | unknown) {
+    super(message, cause, 'NotImplementedError');
+  }
+}
 
 /**
  * The server is not ready to handle the request.
@@ -98,8 +126,6 @@ export class ServiceUnavailableError extends CustomErrorBase {}
  */
 export class ForwardedError extends CustomErrorBase {
   constructor(message: string, cause: Error | unknown) {
-    super(message, cause);
-
-    this.name = isError(cause) ? cause.name : 'Error';
+    super(message, cause, isError(cause) ? cause.name : 'Error');
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added the name parameter to the CustomErrorBase class which is extended by multiple Error classes so that the name handling is displayed in a better fashion.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

closes #17718
