### PR TITLE
fix: make pages and techdocs nicely printable / export PDF

### DIFF
--- a/.changeset/smart-ads-rush.md
+++ b/.changeset/smart-ads-rush.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Make the documentation pages printable (also handy for exporting to pdf when go-green)
+Make the documentation pages printable (also handy for exporting to PDF)

--- a/.changeset/smart-ads-rush.md
+++ b/.changeset/smart-ads-rush.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/core-components': patch
+'@backstage/plugin-techdocs': patch
 ---
 
 Make the documentation pages printable (also handy for exporting to PDF)

--- a/.changeset/smart-ads-rush.md
+++ b/.changeset/smart-ads-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Make the documentation pages printable (also handy for exporting to pdf when go-green)

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -92,6 +92,10 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
       height: 'calc(100% - 10px)', // for pages without content header
       marginBottom: '10px',
+      breakInside: 'avoid',
+      '@media print': {
+        height: 'auto',
+      },
     },
   },
   cardContent: {

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -92,7 +92,7 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
       height: 'calc(100% - 10px)', // for pages without content header
       marginBottom: '10px',
-      breakInside: 'avoid',
+      breakInside: 'avoid-page',
       '@media print': {
         height: 'auto',
       },

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -33,6 +33,11 @@ const useStyles = makeStyles<BackstageTheme>(
       [theme.breakpoints.down('xs')]: {
         height: '100%',
       },
+      '@media print': {
+        display: 'block',
+        height: 'auto',
+        overflowY: 'inherit',
+      },
     },
   }),
   { name: 'BackstagePage' },

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -63,6 +63,9 @@ const useStyles = makeStyles<BackstageTheme, { sidebarConfig: SidebarConfig }>(
       '&::-webkit-scrollbar': {
         display: 'none',
       },
+      '@media print': {
+        display: 'none',
+      },
     },
     drawerWidth: props => ({
       width: props.sidebarConfig.drawerWidthClosed,

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -72,6 +72,9 @@ const useStyles = makeStyles<BackstageTheme, { sidebarConfig: SidebarConfig }>(
       zIndex: theme.zIndex.snackbar,
       // SidebarDivider color
       borderTop: '1px solid #383838',
+      '@media print': {
+        display: 'none',
+      },
     },
 
     overlay: props => ({

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -51,6 +51,10 @@ const useStyles = makeStyles<
       [theme.breakpoints.down('xs')]: {
         paddingBottom: props => props.sidebarConfig.mobileSidebarHeight,
       },
+      '@media print': {
+        paddingLeft: '0px !important',
+        paddingBottom: '0px !important',
+      },
     },
     content: {
       zIndex: 0,

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -52,8 +52,7 @@ const useStyles = makeStyles<
         paddingBottom: props => props.sidebarConfig.mobileSidebarHeight,
       },
       '@media print': {
-        paddingLeft: '0px !important',
-        paddingBottom: '0px !important',
+        padding: '0px !important',
       },
     },
     content: {

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles({
       width: 'calc(100% - 34.4rem)',
       margin: '0 auto',
     },
+    '@media print': {
+      display: 'none',
+    },
   },
 });
 

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     minHeight: 'auto',
     padding: theme.spacing(3, 3, 0),
+    '@media print': {
+      display: 'none',
+    },
   },
 }));
 

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -227,4 +227,14 @@ export default ({ theme, sidebar }: RuleOptions) => `
     width: 12.1rem;
   }
 }
+
+
+@media print {
+  .md-sidebar {
+    display: none;
+  }
+  .md-content {
+    margin: 0;
+  }
+}
 `;

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -230,11 +230,14 @@ export default ({ theme, sidebar }: RuleOptions) => `
 
 
 @media print {
-  .md-sidebar {
+  .md-sidebar,
+  #toggle-sidebar {
     display: none;
   }
   .md-content {
     margin: 0;
+    width: 100%;
+    max-width: 100%;
   }
 }
 `;

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -234,6 +234,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
   #toggle-sidebar {
     display: none;
   }
+  
   .md-content {
     margin: 0;
     width: 100%;


### PR DESCRIPTION
## Make it printable

fixes #15754 #15239 etc where, because of the page setup, only the first page would be printed. Works for Techdocs and other pages. Bug was caused by the setup of the Layout, which reserved only 100% of the user its view height.

<img width="837" alt="screenshot" src="https://github.com/backstage/backstage/assets/25961356/2f8c6202-554e-4f9d-a6ea-b028ec85c104">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
