### PR TITLE
Fix Issue 17893 - Use Concurrency for Microsite Deploy

### DIFF
--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -13,6 +13,10 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
       DOCUSAURUS_SSR_CONCURRENCY: 5
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Modify GitHub workflow to use concurrency during Microsite deploy to cancel in-progress runs of the same workflow.

The only thing being changed is a GitHub workflow file and the code itself is not being changed at all.  Didn't produce a changeset for this reason.

See Issue #17893 - Use Concurrency for Microsite Deploy

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

