### PR TITLE
Update dice-roller for k8s 1.22+

### DIFF
--- a/plugins/kubernetes-backend/examples/dice-roller/dice-roller-manifests.yaml
+++ b/plugins/kubernetes-backend/examples/dice-roller/dice-roller-manifests.yaml
@@ -230,7 +230,7 @@ spec:
           restartPolicy: OnFailure
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dice-roller


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Just changing the dev example to work with the latest k8s. The networking.k8s.io/v1beta1 API version of Ingress is no longer served as of v1.22:

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
