### PR TITLE
fix(microsite): Bold text for NEW ribbon in Plugins

### DIFF
--- a/microsite/src/pages/plugins/plugins.module.scss
+++ b/microsite/src/pages/plugins/plugins.module.scss
@@ -31,6 +31,7 @@
       padding: 0 var(--paddingX);
       position: absolute;
       text-align: center;
+      font-weight: bold;
 
       transform: translateY(var(--translateY)) translateX(var(--translateX))
         rotate(var(--rotation));


### PR DESCRIPTION
## Bold text for NEW ribbon in Plugins

Bold font for the `NEW` ribbon on plugins card on microsite.

Relates to #17877 

![Screenshot 2023-05-30 at 4 37 31 PM](https://github.com/backstage/backstage/assets/9698639/ff38a4a0-12dd-4bf4-b410-de2c5d6a9f8c)
![Screenshot 2023-05-30 at 4 38 11 PM](https://github.com/backstage/backstage/assets/9698639/06cb8d93-de19-437d-9caf-3dc0104ce0b5)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
