### PR TITLE
fix certificate issues in KubernetesProxy

### DIFF
--- a/.changeset/good-rabbits-exist.md
+++ b/.changeset/good-rabbits-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fixed bug in KubernetesProxy where Host header was not propagated, leading to certificate issues

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -155,6 +155,44 @@ describe('KubernetesProxy', () => {
     expect(response.body).toStrictEqual(apiResponse);
   });
 
+  it('sets host header to support clusters behind name-based virtual hosts', async () => {
+    worker.use(
+      rest.get(
+        'http://localhost:9999/api/v1/namespaces',
+        (req: any, res: any, ctx: any) => {
+          const host = req.headers.get('Host');
+          return host === 'localhost:9999'
+            ? res(ctx.status(200))
+            : res.networkError(`Host '${host}' is not in the cert's altnames`);
+        },
+      ),
+    );
+    permissionApi.authorize.mockResolvedValue([
+      { result: AuthorizeResult.ALLOW },
+    ]);
+    clusterSupplier.getClusters.mockResolvedValue([
+      {
+        name: 'cluster1',
+        url: 'http://localhost:9999',
+        authProvider: '',
+      },
+    ]);
+    authTranslator.decorateClusterDetailsWithAuth.mockImplementation(
+      async x => x,
+    );
+    const app = express().use(
+      Router().use('/mountpath', proxy.createRequestHandler({ permissionApi })),
+    );
+
+    const requestPromise = request(app)
+      .get('/mountpath/api/v1/namespaces')
+      .set(HEADER_KUBERNETES_CLUSTER, 'cluster1');
+    worker.use(rest.all(requestPromise.url, (req: any) => req.passthrough()));
+    const response = await requestPromise;
+
+    expect(response.status).toEqual(200);
+  });
+
   it('should default to using a authTranslator provided serviceAccountToken as authorization headers to kubeapi when backstage-kubernetes-auth field is not provided', async () => {
     worker.use(
       rest.get(

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -137,6 +137,7 @@ export class KubernetesProxy {
       middleware = createProxyMiddleware({
         logProvider: () => logger,
         secure: !originalCluster.skipTLSVerify,
+        changeOrigin: true,
         router: async req => {
           // Re-evaluate the cluster on each request, in case it has changed
           const cluster = await this.getClusterForRequest(req);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Kubernetes Proxy does not propagate the Host header, leading to certificate issues that prevent pod logs from displaying. This adds the [`changeOrigin`](https://github.com/chimurai/http-proxy-middleware/blob/cd58f962aec22c925b7df5140502978da8f87d5f/recipes/virtual-hosts.md) option to fix this.

Fixes: https://github.com/backstage/backstage/issues/18036

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] (N/A) Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
   - I'm not sure how to test this; I can figure it out if needed. Pointers would be helpful, though.
- [ ] (N/A) Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
