### PR TITLE
Fix text falling off Catalog and Component pages when too long #17863

### DIFF
--- a/.changeset/nine-mayflies-joke.md
+++ b/.changeset/nine-mayflies-joke.md
@@ -3,7 +3,7 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Updated EntityRefLink and AboutField components to handle long values by using the OverflowTooltip core backstage component to truncate when needed.
+Updated `EntityRefLink` and `AboutField` components to handle long values by using the `OverflowTooltip` component to truncate when needed.
 
 Changes to EntityRefLink.tsx:
 

--- a/.changeset/nine-mayflies-joke.md
+++ b/.changeset/nine-mayflies-joke.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-catalog-react': major
-'@backstage/plugin-catalog': major
+'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog': minor
 ---
 
 Updated EntityRefLink and AboutField components to handle long values by using the OverflowTooltip core backstage component to truncate when needed.

--- a/.changeset/nine-mayflies-joke.md
+++ b/.changeset/nine-mayflies-joke.md
@@ -1,0 +1,36 @@
+---
+'@backstage/plugin-catalog-react': major
+'@backstage/plugin-catalog': major
+---
+
+Updated EntityRefLink and AboutField components to handle long values by using the OverflowTooltip core backstage component to truncate when needed.
+
+Changes to EntityRefLink.tsx:
+
+```diff
+-import { Tooltip } from '@material-ui/core';
++import { Tooltip, Box } from '@material-ui/core';
++import { OverflowTooltip } from '@backstage/core-components';
+
+-        {!children && (title ?? formattedEntityRefTitle)}
++        {!children &&
++          (title ?? (
++            <Box maxWidth="200px">
++              <OverflowTooltip text={formattedEntityRefTitle} />
++            </Box>
++          ))}
+
+```
+
+Changes to AboutField.tsx:
+
+```diff
+-import { Grid, makeStyles, Typography } from '@material-ui/core';
++import { Grid, makeStyles, Typography, Box } from '@material-ui/core';
++import { OverflowTooltip } from '@backstage/core-components';
+
+-        {value || `unknown`}
++        <Box maxWidth="200px">
++          <OverflowTooltip text={value || `unknown`} />
++        </Box>
+```

--- a/.changeset/nine-mayflies-joke.md
+++ b/.changeset/nine-mayflies-joke.md
@@ -5,32 +5,3 @@
 
 Updated `EntityRefLink` and `AboutField` components to handle long values by using the `OverflowTooltip` component to truncate when needed.
 
-Changes to EntityRefLink.tsx:
-
-```diff
--import { Tooltip } from '@material-ui/core';
-+import { Tooltip, Box } from '@material-ui/core';
-+import { OverflowTooltip } from '@backstage/core-components';
-
--        {!children && (title ?? formattedEntityRefTitle)}
-+        {!children &&
-+          (title ?? (
-+            <Box maxWidth="200px">
-+              <OverflowTooltip text={formattedEntityRefTitle} />
-+            </Box>
-+          ))}
-
-```
-
-Changes to AboutField.tsx:
-
-```diff
--import { Grid, makeStyles, Typography } from '@material-ui/core';
-+import { Grid, makeStyles, Typography, Box } from '@material-ui/core';
-+import { OverflowTooltip } from '@backstage/core-components';
-
--        {value || `unknown`}
-+        <Box maxWidth="200px">
-+          <OverflowTooltip text={value || `unknown`} />
-+        </Box>
-```

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -25,7 +25,8 @@ import { entityRouteRef } from '../../routes';
 import { humanizeEntityRef } from './humanize';
 import { Link, LinkProps } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
-import { Tooltip } from '@material-ui/core';
+import { Tooltip, Box } from '@material-ui/core';
+import { OverflowTooltip } from '@backstage/core-components';
 
 /**
  * Props for {@link EntityRefLink}.
@@ -80,7 +81,12 @@ export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
     const link = (
       <Link {...linkProps} ref={ref} to={entityRoute(routeParams)}>
         {children}
-        {!children && (title ?? formattedEntityRefTitle)}
+        {!children &&
+          (title ?? (
+            <Box maxWidth="200px">
+              <OverflowTooltip text={formattedEntityRefTitle} />
+            </Box>
+          ))}
       </Link>
     );
 

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLinks.test.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLinks.test.tsx
@@ -34,7 +34,10 @@ describe('<EntityRefLinks />', () => {
         '/catalog/:namespace/:kind/:name/*': entityRouteRef,
       },
     });
-    expect(screen.getByText('component:software')).toHaveAttribute(
+
+    const entityLink = screen.getByRole('link');
+
+    expect(entityLink).toHaveAttribute(
       'href',
       '/catalog/default/component/software',
     );
@@ -58,12 +61,17 @@ describe('<EntityRefLinks />', () => {
         '/catalog/:namespace/:kind/:name/*': entityRouteRef,
       },
     });
+
     expect(screen.getByText(',')).toBeInTheDocument();
-    expect(screen.getByText('component:software')).toHaveAttribute(
+
+    const entityLinks = screen.getAllByRole('link');
+
+    expect(entityLinks[0]).toHaveAttribute(
       'href',
       '/catalog/default/component/software',
     );
-    expect(screen.getByText('api:interface')).toHaveAttribute(
+
+    expect(entityLinks[1]).toHaveAttribute(
       'href',
       '/catalog/default/api/interface',
     );

--- a/plugins/catalog/src/components/AboutCard/AboutField.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutField.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useElementFilter } from '@backstage/core-plugin-api';
-import { Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography, Box } from '@material-ui/core';
+import { OverflowTooltip } from '@backstage/core-components';
 import React from 'react';
 
 const useStyles = makeStyles(theme => ({
@@ -61,7 +62,9 @@ export function AboutField(props: AboutFieldProps) {
       childElements
     ) : (
       <Typography variant="body2" className={classes.value}>
-        {value || `unknown`}
+        <Box maxWidth="200px">
+          <OverflowTooltip text={value || `unknown`} />
+        </Box>
       </Typography>
     );
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a bug (#17863) in the **EntityRefLink and AboutField** components that allowed text to fall off screen if too long. This fix uses the OverflowTooltip core component to truncate EntityRefLinks when too long. (screenshots shown below).

It should be noted that with this fix, both the **Box** styled component from **@material-ui/core** and **OverflowTooltip** from **@backstage/core-components** are now being imported in both files.

All relevant tests have been updated.

Catalog Page:
![CatalogPage](https://github.com/backstage/backstage/assets/66703548/46212b37-6667-440f-93ea-b7a6e75d349e)

Component Page:
![ComponentPage](https://github.com/backstage/backstage/assets/66703548/0d5897d4-ea30-4407-b35a-841a05184132)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
