### PR TITLE
Fix wrong `pluginID` in the `kubernetes` alpha backend support

### DIFF
--- a/.changeset/tame-buttons-smell.md
+++ b/.changeset/tame-buttons-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fixed wrong `pluginID` in the `kubernetes` alpha backend support, that made the `kubernetes` plugin fail with the new experimental backend.

--- a/plugins/kubernetes-backend/src/plugin.ts
+++ b/plugins/kubernetes-backend/src/plugin.ts
@@ -28,7 +28,7 @@ import { KubernetesBuilder } from '@backstage/plugin-kubernetes-backend';
  * @alpha
  */
 export const kubernetesPlugin = createBackendPlugin({
-  pluginId: 'kubernetes-backend',
+  pluginId: 'kubernetes',
   register(env) {
     env.registerInit({
       deps: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the alpha backend entrypoint of the `kubernetes-backend` plugin, the `pluginID` passed when creating the router is wrong. If we compare with the legacy backend, it should be `kubernetes`, and *not* `kubernetes-backend`.
This prevents the `kubernetes` to work properly with the new aplha backend, because the backend `kubernetes` endpoint cannot be reached correctly.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
