### PR TITLE
[MUI v5] Suggestion to remove PaletteOptions & ThemeOptions override

### DIFF
--- a/packages/theme/src/v4/types.ts
+++ b/packages/theme/src/v4/types.ts
@@ -93,12 +93,8 @@ export type SimpleThemeOptions = {
 
 declare module '@material-ui/core/styles/createPalette' {
   interface Palette extends BackstagePaletteAdditions {}
-
-  interface PaletteOptions extends BackstagePaletteAdditions {}
 }
 
 declare module '@material-ui/core/styles/createTheme' {
   interface Theme extends BackstageThemeAdditions {}
-
-  interface ThemeOptions extends BackstageThemeAdditions {}
 }

--- a/packages/theme/src/v5/types.ts
+++ b/packages/theme/src/v5/types.ts
@@ -22,14 +22,10 @@ import {
 
 declare module '@mui/material/styles' {
   interface Palette extends BackstagePaletteAdditions {}
-
-  interface PaletteOptions extends BackstagePaletteAdditions {}
 }
 
 declare module '@mui/material/styles' {
   interface Theme extends BackstageThemeAdditions {}
-
-  interface ThemeOptions extends BackstageThemeAdditions {}
 }
 
 declare module '@mui/private-theming/defaultTheme' {


### PR DESCRIPTION
> This is a suggestion - not super sure I'm on point with this thought

## What

Remove override of `PaletteOptions` & `ThemeOptions` types in `@backstage/theme`.

## Why 

The `...Options` type indicate the optionality of all nested parameters. The TypeScript Guide to Customisation also highlights that for adding new variables to the palette (https://mui.com/material-ui/customization/palette/#typescript) 

MUI uses those types to allow overriding certain values in the theme/palette through deep-merging the Options with the Palette/Theme (https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/createPalette.js#L272-L313). With overwriting those types we will prevent this usage of e.g. `createTheme(...)` with `ThemeOptions` **without** the `BackstageThemeAdditions`.

On the other hand - the only usage of those `PaletteOptions`/`ThemeOptions` & `createTheme/createPalette` should be to create nested palettes/themes as their will always be a top level `ThemeProvider`. Inner `ThemeProvider` will then override outer `ThemeProvider` if they don't use a functions (https://mui.com/system/styles/advanced/#theme-nesting). So this actually could be an opportunity to avoid overrides of themes with static defaults & encourage the consumption on outer themes when creating inner themes.

## Action

Removing those types now would allow a usage of the current Material UI behaviour - but without the capability of overriding Backstage Variables without passing a full theme in.

Alternatives:
- Keep it as it is, making it a bit harder to create inner themes & maybe have a higher consciousness around what is overwritten
- Add `BackstageThemeAdditionOptions` types and making all Backstage additions to the theme optional for `createTheme`/`createPalette`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
