### PR TITLE
introduce the concept of deferred stitching

### DIFF
--- a/.changeset/loud-ghosts-deny.md
+++ b/.changeset/loud-ghosts-deny.md
@@ -1,0 +1,16 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Introduce a new optional config parameter `catalog.stitchingStrategy.mode`,
+which can have the values `'immediate'` (default) and `'deferred'`. The default
+is for stitching to work as it did before this change, which means that it
+happens "in-band" (blocking) immediately when each processing task finishes.
+When set to `'deferred'`, stitching is instead deferred to happen on a separate
+asynchronous worker queue just like processing.
+
+Deferred stitching should make performance smoother when ingesting large amounts
+of entities, and reduce p99 processing times and repeated over-stitching of
+hot spot entities when fan-out/fan-in in terms of relations is very large. It
+does however also come with some performance cost due to the queuing with how
+much wall-clock time some types of task take.

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -146,6 +146,19 @@ export interface Config {
     orphanStrategy?: 'keep' | 'delete';
 
     /**
+     * The strategy to use when stitching together the final entities.
+     */
+    stitchingStrategy?:
+      | {
+          /** Perform stitching in-band immediately when needed */
+          mode: 'immediate';
+        }
+      | {
+          /** Defer stitching to be performed asynchronously */
+          mode: 'deferred';
+        };
+
+    /**
      * The interval at which the catalog should process its entities.
      *
      * @remarks

--- a/plugins/catalog-backend/migrations/20230525141717_stitch_queue.js
+++ b/plugins/catalog-backend/migrations/20230525141717_stitch_queue.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('refresh_state', table => {
+    table
+      .dateTime('next_stitch_at')
+      .nullable()
+      .comment('Timestamp of when entity should be stitched');
+    table
+      .string('next_stitch_ticket')
+      .nullable()
+      .comment('Random value distinguishing stitch requests');
+    table.index('next_stitch_at', 'refresh_state_next_stitch_at_idx', {
+      predicate: knex.whereNotNull('next_stitch_at'),
+    });
+  });
+
+  // Look for things that are due for stitching, and move them over to the new
+  // system. An explanation on the length based ones: Before adding the new
+  // system, stitching was triggered by setting hashes to various hard coded
+  // strings - and we leverage the fact that those strings were always shorter
+  // than a real hash would be. There's also the case where we have not yet
+  // created the final_entities row corresponding to the refresh_state one. This
+  // is split into two statements because MySQL doesn't allow you to write to
+  // tables you're reading from.
+  const candidates = await knex
+    .select({ entityId: 'refresh_state.entity_id' })
+    .from('refresh_state')
+    .leftOuterJoin(
+      'final_entities',
+      'final_entities.entity_id',
+      'refresh_state.entity_id',
+    )
+    // no final entities at all
+    .orWhereNull('final_entities.entity_id')
+    // the final entity hash was forcibly set to something short
+    .orWhere(knex.raw('LENGTH(??) < 15', ['final_entities.hash']))
+    // there used to be an ongoing stitch (possibly unfinished and aborted)
+    .orWhere(knex.raw('LENGTH(??) > 0', ['final_entities.stitch_ticket']))
+    // the processing output entity hash was forcibly set to something short
+    .orWhere(knex.raw('LENGTH(??) < 15', ['refresh_state.result_hash']));
+  if (candidates.length) {
+    for (let i = 0; i < candidates.length; i += 1000) {
+      await knex('refresh_state')
+        .update({
+          next_stitch_at: knex.fn.now(),
+          next_stitch_ticket: 'initial',
+        })
+        .whereIn(
+          'entity_id',
+          candidates.slice(i, i + 1000).map(c => c.entityId),
+        );
+    }
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('refresh_state', table => {
+    table.dropIndex([], 'refresh_state_next_stitch_at_idx');
+    table.dropColumn('next_stitch_at');
+    table.dropColumn('next_stitch_ticket');
+  });
+};

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases } from '@backstage/backend-test-utils';
+import { applyDatabaseMigrations } from '../../migrations';
+import { getDeferredStitchableEntities } from './getDeferredStitchableEntities';
+
+jest.setTimeout(60_000);
+
+describe('getDeferredStitchableEntities', () => {
+  const databases = TestDatabases.create({
+    ids: ['MYSQL_8', 'POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
+  });
+
+  it.each(databases.eachSupportedId())(
+    'selects the right rows %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await applyDatabaseMigrations(knex);
+
+      await knex
+        .insert([
+          {
+            entity_id: '1',
+            entity_ref: 'k:ns/no_stitch_time',
+            unprocessed_entity: '{}',
+            processed_entity: '{}',
+            errors: '[]',
+            next_update_at: knex.fn.now(),
+            last_discovery_at: knex.fn.now(),
+            next_stitch_at: null,
+            next_stitch_ticket: null,
+          },
+          {
+            entity_id: '2',
+            entity_ref: 'k:ns/future_stitch_time',
+            unprocessed_entity: '{}',
+            processed_entity: '{}',
+            errors: '[]',
+            next_update_at: knex.fn.now(),
+            last_discovery_at: knex.fn.now(),
+            next_stitch_at: '2037-01-01T00:00:00.000',
+            next_stitch_ticket: 't1',
+          },
+          {
+            entity_id: '3',
+            entity_ref: 'k:ns/past_stitch_time',
+            unprocessed_entity: '{}',
+            processed_entity: '{}',
+            errors: '[]',
+            next_update_at: knex.fn.now(),
+            last_discovery_at: knex.fn.now(),
+            next_stitch_at: '1971-01-01T00:00:00.000',
+            next_stitch_ticket: 't3',
+          },
+          {
+            entity_id: '4',
+            entity_ref: 'k:ns/past_stitch_time_again',
+            unprocessed_entity: '{}',
+            processed_entity: '{}',
+            errors: '[]',
+            next_update_at: knex.fn.now(),
+            last_discovery_at: knex.fn.now(),
+            next_stitch_at: '1972-01-01T00:00:00.000',
+            next_stitch_ticket: 't4',
+          },
+        ])
+        .into('refresh_state');
+
+      const rowsBefore = await knex('refresh_state');
+
+      const items = await getDeferredStitchableEntities({
+        knex,
+        batchSize: 1,
+        stitchTimeout: { seconds: 2 },
+      });
+
+      const rowsAfter = await knex('refresh_state');
+
+      expect(items).toEqual([
+        {
+          entityRef: 'k:ns/past_stitch_time',
+          stitchTicket: 't3',
+          stitchRequestedAt: expect.anything(),
+        },
+      ]);
+
+      const hitRowBefore = rowsBefore.filter(r => r.entity_id === '3')[0]
+        .next_stitch_at;
+      const hitRowAfter = rowsAfter.filter(r => r.entity_id === '3')[0]
+        .next_stitch_at;
+      const missRowBefore = rowsBefore.filter(r => r.entity_id === '4')[0]
+        .next_stitch_at;
+      const missRowAfter = rowsAfter.filter(r => r.entity_id === '4')[0]
+        .next_stitch_at;
+
+      expect(+new Date(hitRowAfter)).toBeGreaterThan(+new Date(hitRowBefore));
+      expect(+new Date(missRowAfter)).toEqual(+new Date(missRowBefore));
+    },
+  );
+});

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { durationToMilliseconds, HumanDuration } from '@backstage/types';
+import { Knex } from 'knex';
+import { DateTime } from 'luxon';
+import { timestampToDateTime } from '../../conversion';
+import { DbRefreshStateRow } from '../../tables';
+
+// TODO(freben): There is no retry counter or similar. If items start
+// perpetually crashing during stitching, they'll just get silently retried over
+// and over again, for better or worse. This will be visible in metrics though.
+
+/**
+ * Finds entities that are marked for deferred stitching.
+ *
+ * @remarks
+ *
+ * This assumes that the stitching strategy is set to deferred.
+ *
+ * They are expected to already have the next_stitch_ticket set (by
+ * markForStitching) so that their tickets can be returned with each item.
+ *
+ * All returned items have their next_stitch_at updated to be moved forward by
+ * the given timeout duration. This has the effect that they will be picked up
+ * for stitching again in the future, if it hasn't completed by that point for
+ * some reason (restarts, crashes, etc).
+ */
+export async function getDeferredStitchableEntities(options: {
+  knex: Knex | Knex.Transaction;
+  batchSize: number;
+  stitchTimeout: HumanDuration;
+}): Promise<
+  Array<{
+    entityRef: string;
+    stitchTicket: string;
+    stitchRequestedAt: DateTime; // the time BEFORE moving it forward by the timeout
+  }>
+> {
+  const { knex, batchSize, stitchTimeout } = options;
+
+  let itemsQuery = knex<DbRefreshStateRow>('refresh_state').select(
+    'entity_ref',
+    'next_stitch_at',
+    'next_stitch_ticket',
+  );
+
+  // This avoids duplication of work because of race conditions and is
+  // also fast because locked rows are ignored rather than blocking.
+  // It's only available in MySQL and PostgreSQL
+  if (['mysql', 'mysql2', 'pg'].includes(knex.client.config.client)) {
+    itemsQuery = itemsQuery.forUpdate().skipLocked();
+  }
+
+  const items = await itemsQuery
+    .whereNotNull('next_stitch_at')
+    .whereNotNull('next_stitch_ticket')
+    .where('next_stitch_at', '<=', knex.fn.now())
+    .orderBy('next_stitch_at', 'asc')
+    .limit(batchSize);
+
+  if (!items.length) {
+    return [];
+  }
+
+  await knex<DbRefreshStateRow>('refresh_state')
+    .whereIn(
+      'entity_ref',
+      items.map(i => i.entity_ref),
+    )
+    // avoid race condition where someone completes a stitch right between these statements
+    .whereNotNull('next_stitch_ticket')
+    .update({
+      next_stitch_at: nowPlus(knex, stitchTimeout),
+    });
+
+  return items.map(i => ({
+    entityRef: i.entity_ref,
+    stitchTicket: i.next_stitch_ticket!,
+    stitchRequestedAt: timestampToDateTime(i.next_stitch_at!),
+  }));
+}
+
+function nowPlus(knex: Knex, duration: HumanDuration): Knex.Raw {
+  const seconds = durationToMilliseconds(duration) / 1000;
+  if (knex.client.config.client.includes('sqlite3')) {
+    return knex.raw(`datetime('now', ?)`, [`${seconds} seconds`]);
+  } else if (knex.client.config.client.includes('mysql')) {
+    return knex.raw(`now() + interval ${seconds} second`);
+  }
+  return knex.raw(`now() + interval '${seconds} seconds'`);
+}

--- a/plugins/catalog-backend/src/database/operations/stitcher/markDeferredStitchCompleted.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/markDeferredStitchCompleted.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases } from '@backstage/backend-test-utils';
+import { applyDatabaseMigrations } from '../../migrations';
+import { markDeferredStitchCompleted } from './markDeferredStitchCompleted';
+import { DbRefreshStateRow } from '../../tables';
+
+jest.setTimeout(60_000);
+
+describe('markDeferredStitchCompleted', () => {
+  const databases = TestDatabases.create({
+    ids: ['MYSQL_8', 'POSTGRES_13', 'POSTGRES_9', 'SQLITE_3'],
+  });
+
+  it.each(databases.eachSupportedId())(
+    'completes only if unchanged %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await applyDatabaseMigrations(knex);
+
+      await knex<DbRefreshStateRow>('refresh_state').insert([
+        {
+          entity_id: '1',
+          entity_ref: 'k:ns/n',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: knex.fn.now(),
+          last_discovery_at: knex.fn.now(),
+          next_stitch_at: '1971-01-01T00:00:00.000',
+          next_stitch_ticket: 'the-ticket',
+        },
+      ]);
+
+      async function result() {
+        return knex<DbRefreshStateRow>('refresh_state').select(
+          'next_stitch_at',
+          'next_stitch_ticket',
+        );
+      }
+
+      await markDeferredStitchCompleted({
+        knex,
+        entityRef: 'k:ns/n',
+        stitchTicket: 'the-wrong-ticket',
+      });
+      await expect(result()).resolves.toEqual([
+        { next_stitch_at: expect.anything(), next_stitch_ticket: 'the-ticket' },
+      ]);
+
+      await markDeferredStitchCompleted({
+        knex,
+        entityRef: 'k:ns/n',
+        stitchTicket: 'the-ticket',
+      });
+      await expect(result()).resolves.toEqual([
+        { next_stitch_at: null, next_stitch_ticket: null },
+      ]);
+    },
+  );
+});

--- a/plugins/catalog-backend/src/database/operations/stitcher/markDeferredStitchCompleted.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/markDeferredStitchCompleted.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+import { DbRefreshStateRow } from '../../tables';
+
+/**
+ * Marks a single entity as having been stitched.
+ *
+ * @remarks
+ *
+ * This assumes that the stitching strategy is set to deferred.
+ *
+ * The timestamp and ticket are only reset if the ticket hasn't changed. If it
+ * has, it means that a new stitch request has been made, and the entity should
+ * be stitched once more some time in the future - or is indeed already being
+ * stitched concurrently with ourselves.
+ */
+export async function markDeferredStitchCompleted(option: {
+  knex: Knex | Knex.Transaction;
+  entityRef: string;
+  stitchTicket: string;
+}): Promise<void> {
+  const { knex, entityRef, stitchTicket } = option;
+
+  await knex<DbRefreshStateRow>('refresh_state')
+    .update({
+      next_stitch_at: null,
+      next_stitch_ticket: null,
+    })
+    .where('entity_ref', '=', entityRef)
+    .andWhere('next_stitch_ticket', '=', stitchTicket);
+}

--- a/plugins/catalog-backend/src/database/operations/stitcher/markForStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/markForStitching.ts
@@ -36,8 +36,9 @@ export async function markForStitching(options: {
   const entityRefs = split(options.entityRefs);
   const entityIds = split(options.entityIds);
   const knex = options.knex;
+  const mode = options.strategy.mode;
 
-  if (options.strategy.mode === 'immediate') {
+  if (mode === 'immediate') {
     for (const chunk of entityRefs) {
       await knex
         .table<DbFinalEntitiesRow>('final_entities')
@@ -74,7 +75,7 @@ export async function markForStitching(options: {
         })
         .whereIn('entity_id', chunk);
     }
-  } else {
+  } else if (mode === 'deferred') {
     // It's OK that this is shared across refresh state rows; it just needs to
     // be uniquely generated for every new stitch request.
     const ticket = uuid();
@@ -96,6 +97,8 @@ export async function markForStitching(options: {
         })
         .whereIn('entity_id', chunk);
     }
+  } else {
+    throw new Error(`Unknown stitching strategy mode ${mode}`);
   }
 }
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
@@ -35,8 +35,9 @@ describe('performStitching', () => {
   });
   const logger = getVoidLogger();
 
+  // NOTE(freben): Testing the deferred path since it's a superset of the immediate one
   it.each(databases.eachSupportedId())(
-    'runs the happy path in immediate mode for %p',
+    'runs the happy path in deferred mode for %p',
     async databaseId => {
       const knex = await databases.init(databaseId);
       await applyDatabaseMigrations(knex);
@@ -87,7 +88,11 @@ describe('performStitching', () => {
       await performStitching({
         knex,
         logger,
-        strategy: { mode: 'immediate' },
+        strategy: {
+          mode: 'deferred',
+          pollingInterval: { seconds: 1 },
+          stitchTimeout: { seconds: 1 },
+        },
         entityRef: 'k:ns/n',
       });
 
@@ -172,7 +177,11 @@ describe('performStitching', () => {
       await performStitching({
         knex,
         logger,
-        strategy: { mode: 'immediate' },
+        strategy: {
+          mode: 'deferred',
+          pollingInterval: { seconds: 1 },
+          stitchTimeout: { seconds: 1 },
+        },
         entityRef: 'k:ns/n',
       });
 
@@ -195,7 +204,11 @@ describe('performStitching', () => {
       await performStitching({
         knex,
         logger,
-        strategy: { mode: 'immediate' },
+        strategy: {
+          mode: 'deferred',
+          pollingInterval: { seconds: 1 },
+          stitchTimeout: { seconds: 1 },
+        },
         entityRef: 'k:ns/n',
       });
 

--- a/plugins/catalog-backend/src/database/tables.ts
+++ b/plugins/catalog-backend/src/database/tables.ts
@@ -82,6 +82,47 @@ export type DbRefreshStateRow = {
    */
   next_update_at: string | Date;
   /**
+   * If a stitch has been requested, this is the point in time that that last
+   * happened.
+   *
+   * @remarks
+   *
+   * Each time that a request is made, this timestamp is updated to the current
+   * time, overwriting the previous value if applicable.
+   *
+   * When the stitch loop runs and picks up an entity, this timestamp is not
+   * immediately reset. It's instead moved forward in time by a certain amount,
+   * which means that if the stitcher for some reason fails (eg if the process
+   * crashes or gets shut down), the entity will be picked up again in the
+   * future.
+   *
+   * Only when a stitch run is completed successfully, AND it's found that the
+   * stitch ticket has not changed since the start (which means that no new
+   * request has been made behind our backs), does the timestamp (and the
+   * ticket) get reset.
+   */
+  next_stitch_at?: string | Date | null;
+  /**
+   * If a stitch has been requested, this is the unique ticket that was chosen
+   * to mark the last request.
+   *
+   * @remarks
+   *
+   * Each time that a request is made, a new random ticket is chosen,
+   * overwriting the previous value if applicable.
+   *
+   * When the stitch loop runs and picks up an entity, this column is left
+   * unchanged. This means that if the stitcher for some reason fails (eg if the
+   * process crashes or gets shut down), the entity will be picked up again in
+   * the future.
+   *
+   * Only when a stitch run is completed successfully, AND it's found that the
+   * stitch ticket has not changed since the start (which means that no new
+   * request has been made behind our backs), does the ticket (and the
+   * timestamp) get reset.
+   */
+  next_stitch_ticket?: string | null;
+  /**
    * The last time that this entity was emitted by somebody (the entity provider
    * or a parent entity).
    *

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -28,7 +28,7 @@ import { metrics, trace } from '@opentelemetry/api';
 import { ProcessingDatabase, RefreshStateItem } from '../database/types';
 import { createCounterMetric, createSummaryMetric } from '../util/metrics';
 import { CatalogProcessingOrchestrator, EntityProcessingResult } from './types';
-import { Stitcher } from '../stitching/types';
+import { Stitcher, stitchingStrategyFromConfig } from '../stitching/types';
 import { startTaskPipeline } from './TaskPipeline';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Config } from '@backstage/config';
@@ -335,11 +335,13 @@ export class DefaultCatalogProcessingEngine {
       return () => {};
     }
 
+    const stitchingStrategy = stitchingStrategyFromConfig(this.config);
+
     const runOnce = async () => {
       try {
         const n = await deleteOrphanedEntities({
           knex: this.knex,
-          strategy: { mode: 'immediate' },
+          strategy: stitchingStrategy,
         });
         if (n > 0) {
           this.logger.info(`Deleted ${n} orphaned entities`);

--- a/plugins/catalog-backend/src/stitching/progressTracker.ts
+++ b/plugins/catalog-backend/src/stitching/progressTracker.ts
@@ -19,10 +19,11 @@ import { metrics } from '@opentelemetry/api';
 import { Knex } from 'knex';
 import { DateTime } from 'luxon';
 import { Logger } from 'winston';
+import { DbRefreshStateRow } from '../database/tables';
 import { createCounterMetric } from '../util/metrics';
 
 // Helps wrap the timing and logging behaviors
-export function progressTracker(_knex: Knex, logger: Logger) {
+export function progressTracker(knex: Knex, logger: Logger) {
   // prom-client metrics are deprecated in favour of OpenTelemetry metrics.
   const promStitchedEntities = createCounterMetric({
     name: 'catalog_stitched_entities_count',
@@ -46,6 +47,26 @@ export function progressTracker(_knex: Knex, logger: Logger) {
     },
   );
 
+  const stitchingQueueCount = meter.createObservableGauge(
+    'catalog.stitching.queue.length',
+    { description: 'Number of entities currently in the stitching queue' },
+  );
+  stitchingQueueCount.addCallback(async result => {
+    const total = await knex<DbRefreshStateRow>('refresh_state')
+      .count({ count: '*' })
+      .whereNotNull('next_stitch_at');
+    result.observe(Number(total[0].count));
+  });
+
+  const stitchingQueueDelay = meter.createHistogram(
+    'catalog.stitching.queue.delay',
+    {
+      description:
+        'The amount of delay between being scheduled for stitching, and the start of actually being stitched',
+      unit: 'seconds',
+    },
+  );
+
   function stitchStart(item: {
     entityRef: string;
     stitchRequestedAt?: DateTime;
@@ -53,6 +74,11 @@ export function progressTracker(_knex: Knex, logger: Logger) {
     logger.debug(`Stitching ${item.entityRef}`);
 
     const startTime = process.hrtime();
+    if (item.stitchRequestedAt) {
+      stitchingQueueDelay.record(
+        -item.stitchRequestedAt.diffNow().as('seconds'),
+      );
+    }
 
     function endTime() {
       const delta = process.hrtime(startTime);

--- a/plugins/catalog-backend/src/stitching/types.ts
+++ b/plugins/catalog-backend/src/stitching/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { Config } from '@backstage/config';
+import { HumanDuration } from '@backstage/types';
+
 /**
  * Performs the act of stitching - to take all of the various outputs from the
  * ingestion process, and stitching them together into the final entity JSON
@@ -33,8 +36,45 @@ export interface Stitcher {
  * @remarks
  *
  * In immediate mode, stitching happens "in-band" (blocking) immediately when
- * each processing task finishes.
+ * each processing task finishes. When set to `'deferred'`, stitching is instead
+ * deferred to happen on a separate asynchronous worker queue just like
+ * processing.
+ *
+ * Deferred stitching should make performance smoother when ingesting large
+ * amounts of entities, and reduce p99 processing times and repeated
+ * over-stitching of hot spot entities when fan-out/fan-in in terms of relations
+ * is very large. It does however also come with some performance cost due to
+ * the queuing with how much wall-clock time some types of task take.
  */
-export type StitchingStrategy = {
-  mode: 'immediate';
-};
+export type StitchingStrategy =
+  | {
+      mode: 'immediate';
+    }
+  | {
+      mode: 'deferred';
+      pollingInterval: HumanDuration;
+      stitchTimeout: HumanDuration;
+    };
+
+export function stitchingStrategyFromConfig(config: Config): StitchingStrategy {
+  const strategyMode = config.getOptionalString(
+    'catalog.stitchingStrategy.mode',
+  );
+
+  if (strategyMode === undefined || strategyMode === 'immediate') {
+    return {
+      mode: 'immediate',
+    };
+  } else if (strategyMode === 'deferred') {
+    // TODO(freben): Make parameters configurable
+    return {
+      mode: 'deferred',
+      pollingInterval: { seconds: 1 },
+      stitchTimeout: { seconds: 60 },
+    };
+  }
+
+  throw new Error(
+    `Invalid stitching strategy mode '${strategyMode}', expected one of 'immediate' or 'deferred'`,
+  );
+}

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -215,6 +215,11 @@ class TestHarness {
             connection: ':memory:',
           },
         },
+        catalog: {
+          stitchingStrategy: {
+            mode: 'immediate',
+          },
+        },
       },
     );
     const logger = options?.logger ?? getVoidLogger();


### PR DESCRIPTION

## From the changeset

Introduce a new optional config parameter `catalog.stitchingStrategy.mode`, which can have the values `'immediate'` (default) and `'deferred'`. The default is for stitching to work as it did before this change, which means that it happens "in-band" (blocking) immediately when each processing task finishes. When set to `'deferred'`, stitching is instead deferred to happen on a separate asynchronous worker queue just like processing.

Deferred stitching should make performance smoother when ingesting large amounts of entities, and reduce p99 processing times and repeated over-stitching of hot spot entities when fan-out/fan-in in terms of relations is very large. It does however also come with some performance cost due to the queuing with how much wall-clock time some types of task take.

## Timing results

First: running the migration on a 250 000 entity database with three relations each, took 11 seconds on my local docker based postgres 13 database.

Below are the results of running both immediate and deferred mode with different synthetic large ingestions. Steady state is not expected to be significantly different - the main impact there is that a lag of up to one second is added between processing and stitching.

* **25000 entities, 0 relations each**

  |  | Immediate (original) | Deferred (this PR) |
  | - | - | - | 
  | Total stitcher runs | 25000 | 25000 | 
  | Wall clock time | 1 min 15 sec | 1 min 48 sec | 
  | Speed |  | 44% slower | 

  Few things have no relations whatsoever, but this case probably shows some form of "maximum slowdown" numbers.

* **5000 entities, 3 relations each**

  |  | Immediate (original) | Deferred (this PR) |
  | - | - | - | 
  | Total stitcher runs | 19994 | 7608 | 
  | Wall clock time | 29 sec | 29 sec | 
  | Speed |  | Same | 

  At this scale the wall clock time is the same, but the number of stitch operations is still much lower which potentially puts less load on your database - with the caveat that the queue mechanism in the deferred mode performs db ops too, of course.

* **25000 entities, 2 relations each**

  |  | Immediate (original) | Deferred (this PR) |
  | - | - | - | 
  | Total stitcher runs | 75000 | 37266 | 
  | Wall clock time | 1 min 59 sec | 2 min 13 sec | 
  | Speed |  | 12% slower | 

  Some time penalty when the number of relations is less than three.

* **5000 entities, all with 1 relation to a single "victim" entity**

  |  | Immediate (original) | Deferred (this PR) |
  | - | - | - | 
  | Total stitcher runs | 10001 | 5002 | 
  | Wall clock time | 2 min 8 sec | 25 sec | 
  | Speed |  | over 5x faster |

  This pathological highly connected case shows the original immediate mode code slowing down more and more until it's at one tenth of its original full speed near the completion of the test, because it becomes completely overburdened with repeatedly re-stitching the same thing over and over again, competing for the exact same rows in the database.

* **25000 entities, all with 1 relation to a single "victim" entity**

  |  | Immediate (original) | Deferred (this PR) |
  | - | - | - | 
  | Total stitcher runs | 50001 | 25002 | 
  | Wall clock time | 50 min | 1 min 44 sec | 
  | Speed |  | over 28x faster |

  Clearly the old solution slows down more and more as the connectivity rises, while the new solution is closer to linear.
