### PR TITLE
Fix missing "migrations" for plugin-badges-backend

### DIFF
--- a/.changeset/hungry-lies-drop.md
+++ b/.changeset/hungry-lies-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges-backend': patch
+---
+
+Adding migrations to the packages.json

--- a/plugins/badges-backend/package.json
+++ b/plugins/badges-backend/package.json
@@ -59,6 +59,7 @@
     "cross-fetch": "^3.1.5"
   },
   "files": [
-    "dist"
+    "dist",
+    "migrations/**/*.{js,d.ts}"
   ]
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing https://github.com/backstage/backstage/issues/18065

Backstage backend is unable to start without the migration if using the new version of  `"@backstage/plugin-badges-backend": "^0.2.0"`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
