### PR TITLE
fix(catalog-import): Fix stepper component order for accessibility

### DIFF
--- a/.changeset/cold-pillows-mix.md
+++ b/.changeset/cold-pillows-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Swap `ImportStepper` and `InfoCard` order to fix tab order in `catalog-import`.

--- a/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
+++ b/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
@@ -47,13 +47,13 @@ export const DefaultImportPage = () => {
           </SupportButton>
         </ContentHeader>
 
-        <Grid container spacing={2} direction="row-reverse">
-          <Grid item xs={12} md={4} lg={6} xl={8}>
-            <ImportInfoCard />
-          </Grid>
-
+        <Grid container spacing={2}>
           <Grid item xs={12} md={8} lg={6} xl={4}>
             <ImportStepper />
+          </Grid>
+
+          <Grid item xs={12} md={4} lg={6} xl={8}>
+            <ImportInfoCard />
           </Grid>
         </Grid>
       </Content>


### PR DESCRIPTION
## Catalog Import's stepper tab order first

In the Catalog Import page there's a grid with a `ImportStepper` and an `InfoCard`, for some reason the stepper is below & the grid inverts the order to position it to the left, this causes an issue with the tab order as it goes like this `SupportButton` > `InfoCard` > `ImportStepper`.

Given the way it's rendered the `InfoCard` should go after, this PR fixes this by swapping the Html order & removing the `Grid`'s direction property.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
