### PR TITLE
Keyboard navigation to EntityContextMenu now focus-visible the first element.

### DIFF
--- a/.changeset/warm-hornets-fetch.md
+++ b/.changeset/warm-hornets-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Keyboard navigation to open EntityContextMenu now focus visible the first element.

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -142,7 +142,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         aria-labelledby="long-menu"
       >
-        <MenuList>
+        <MenuList autoFocusItem={Boolean(anchorEl)}>
           {extraItems}
           <UnregisterEntity
             unregisterEntityOptions={UNSTABLE_contextMenuOptions}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For accessibility, keyboard navigation to open EntityContextMenu should `focus-visible` the first element.

![Screenshot 2023-06-01 at 7 27 29 PM](https://github.com/backstage/backstage/assets/9698639/8c9ef125-1b0c-4986-b330-6d66bbb81279)
![Screenshot 2023-06-01 at 7 48 08 PM](https://github.com/backstage/backstage/assets/9698639/b93c7826-1b2a-4d08-bce5-04dcf240d275)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
