### PR TITLE
feat: show k8sgpt results in kubernetes plugin

### DIFF
--- a/plugins/kubernetes/src/components/CustomResources/CustomResources.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/CustomResources.tsx
@@ -42,13 +42,7 @@ export const CustomResources = ({}: CustomResourcesProps) => {
           case 'Rollout':
             return <RolloutAccordions key={i} rollouts={resources} />;
           case 'Result':
-            return (
-              <K8sGPTResultAccordions
-                key={i}
-                customResources={resources}
-                customResourceName={kind}
-              />
-            );
+            return <K8sGPTResultAccordions key={i} results={resources} />;
           default:
             return (
               <DefaultCustomResourceAccordions

--- a/plugins/kubernetes/src/components/CustomResources/CustomResources.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/CustomResources.tsx
@@ -17,6 +17,7 @@
 import React, { useContext } from 'react';
 import lodash, { Dictionary } from 'lodash';
 import { RolloutAccordions } from './ArgoRollouts';
+import { K8sGPTResultAccordions } from './K8sGPTResults';
 import { DefaultCustomResourceAccordions } from './DefaultCustomResource';
 import { GroupedResponsesContext } from '../../hooks';
 
@@ -40,6 +41,14 @@ export const CustomResources = ({}: CustomResourcesProps) => {
         switch (kind) {
           case 'Rollout':
             return <RolloutAccordions key={i} rollouts={resources} />;
+          case 'Result':
+            return (
+              <K8sGPTResultAccordions
+                key={i}
+                customResources={resources}
+                customResourceName={kind}
+              />
+            );
           default:
             return (
               <DefaultCustomResourceAccordions

--- a/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResult.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResult.tsx
@@ -27,29 +27,23 @@ import { StructuredMetadataTable } from '@backstage/core-components';
 import { Typography } from '@material-ui/core';
 
 type K8sGPTResultAccordionsProps = {
-  customResources: any[];
-  customResourceName: string;
+  results: any[];
   defaultExpanded?: boolean;
   children?: React.ReactNode;
 };
 
 type K8sGPTResultAccordionProps = {
-  customResource: any;
-  customResourceName: string;
+  result: any;
   defaultExpanded?: boolean;
   children?: React.ReactNode;
 };
 
 type K8sGPTResultSummaryProps = {
-  customResource: any;
-  customResourceName: string;
+  result: any;
   children?: React.ReactNode;
 };
 
-const K8sGPTResultSummary = ({
-  customResource,
-  customResourceName,
-}: K8sGPTResultSummaryProps) => {
+const K8sGPTResultSummary = ({ result }: K8sGPTResultSummaryProps) => {
   return (
     <Grid
       container
@@ -59,18 +53,14 @@ const K8sGPTResultSummary = ({
       spacing={0}
     >
       <Grid xs={12} item>
-        <K8sGPTResultDrawer
-          customResource={customResource}
-          customResourceName={customResourceName}
-        />
+        <K8sGPTResultDrawer result={result} />
       </Grid>
     </Grid>
   );
 };
 
 const K8sGPTResultAccordion = ({
-  customResource,
-  customResourceName,
+  result,
   defaultExpanded,
 }: K8sGPTResultAccordionProps) => {
   return (
@@ -80,14 +70,11 @@ const K8sGPTResultAccordion = ({
       variant="outlined"
     >
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <K8sGPTResultSummary
-          customResource={customResource}
-          customResourceName={customResourceName}
-        />
+        <K8sGPTResultSummary result={result} />
       </AccordionSummary>
       <AccordionDetails>
         <Typography variant="body2">
-          K8sGPT found this issue: {customResource.spec.details}
+          K8sGPT found this issue: {result.spec.details}
         </Typography>
       </AccordionDetails>
     </Accordion>
@@ -95,8 +82,7 @@ const K8sGPTResultAccordion = ({
 };
 
 export const K8sGPTResultAccordions = ({
-  customResources,
-  customResourceName,
+  results,
   defaultExpanded = false,
 }: K8sGPTResultAccordionsProps) => {
   return (
@@ -106,13 +92,12 @@ export const K8sGPTResultAccordions = ({
       justifyContent="flex-start"
       alignItems="flex-start"
     >
-      {customResources.map((cr, i) => (
+      {results.map((result, i) => (
         <Grid container item key={i} xs>
           <Grid item xs>
             <K8sGPTResultAccordion
               defaultExpanded={defaultExpanded}
-              customResource={cr}
-              customResourceName={customResourceName}
+              result={result}
             />
           </Grid>
         </Grid>

--- a/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResult.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResult.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Grid,
+} from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { K8sGPTResultDrawer } from './K8sGPTResultsDrawer';
+import { StructuredMetadataTable } from '@backstage/core-components';
+import { Typography } from '@material-ui/core';
+
+type K8sGPTResultAccordionsProps = {
+  customResources: any[];
+  customResourceName: string;
+  defaultExpanded?: boolean;
+  children?: React.ReactNode;
+};
+
+type K8sGPTResultAccordionProps = {
+  customResource: any;
+  customResourceName: string;
+  defaultExpanded?: boolean;
+  children?: React.ReactNode;
+};
+
+type K8sGPTResultSummaryProps = {
+  customResource: any;
+  customResourceName: string;
+  children?: React.ReactNode;
+};
+
+const K8sGPTResultSummary = ({
+  customResource,
+  customResourceName,
+}: K8sGPTResultSummaryProps) => {
+  return (
+    <Grid
+      container
+      direction="row"
+      justifyContent="space-between"
+      alignItems="center"
+      spacing={0}
+    >
+      <Grid xs={12} item>
+        <K8sGPTResultDrawer
+          customResource={customResource}
+          customResourceName={customResourceName}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+const K8sGPTResultAccordion = ({
+  customResource,
+  customResourceName,
+  defaultExpanded,
+}: K8sGPTResultAccordionProps) => {
+  return (
+    <Accordion
+      defaultExpanded={defaultExpanded}
+      TransitionProps={{ unmountOnExit: true }}
+      variant="outlined"
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <K8sGPTResultSummary
+          customResource={customResource}
+          customResourceName={customResourceName}
+        />
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography variant="body2">
+          K8sGPT found this issue: {customResource.spec.details}
+        </Typography>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export const K8sGPTResultAccordions = ({
+  customResources,
+  customResourceName,
+  defaultExpanded = false,
+}: K8sGPTResultAccordionsProps) => {
+  return (
+    <Grid
+      container
+      direction="column"
+      justifyContent="flex-start"
+      alignItems="flex-start"
+    >
+      {customResources.map((cr, i) => (
+        <Grid container item key={i} xs>
+          <Grid item xs>
+            <K8sGPTResultAccordion
+              defaultExpanded={defaultExpanded}
+              customResource={cr}
+              customResourceName={customResourceName}
+            />
+          </Grid>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};

--- a/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResultsDrawer.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResultsDrawer.tsx
@@ -22,22 +22,19 @@ const capitalize = (str: string) =>
   str.charAt(0).toLocaleUpperCase('en-US') + str.slice(1);
 
 export const K8sGPTResultDrawer = ({
-  customResource,
-  customResourceName,
+  result,
   expanded,
 }: {
-  customResource: any;
-  customResourceName: string;
+  result: any;
   expanded?: boolean;
 }) => {
-  const capitalizedName = capitalize(customResourceName);
-  const name = customResource.spec?.name.split('/').pop();
-  const namespace = customResource.spec?.name.split('/').shift();
+  const name = result.spec?.name.split('/').pop();
+  const namespace = result.spec?.name.split('/').shift();
   return (
     <KubernetesStructuredMetadataTableDrawer
-      object={customResource}
+      object={result}
       expanded={expanded}
-      kind={capitalizedName}
+      kind="Result"
       renderObject={cr => cr}
     >
       <Grid
@@ -49,7 +46,7 @@ export const K8sGPTResultDrawer = ({
       >
         <Grid item>
           <Typography variant="body1">
-            {customResource.spec?.name ?? 'unknown object'}
+            {result.spec?.name ?? 'unknown object'}
           </Typography>
         </Grid>
         <Grid item>

--- a/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResultsDrawer.tsx
+++ b/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/K8sGPTResultsDrawer.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { KubernetesStructuredMetadataTableDrawer } from '../../KubernetesDrawer';
+import { Typography, Grid, Chip } from '@material-ui/core';
+
+const capitalize = (str: string) =>
+  str.charAt(0).toLocaleUpperCase('en-US') + str.slice(1);
+
+export const K8sGPTResultDrawer = ({
+  customResource,
+  customResourceName,
+  expanded,
+}: {
+  customResource: any;
+  customResourceName: string;
+  expanded?: boolean;
+}) => {
+  const capitalizedName = capitalize(customResourceName);
+  const name = customResource.spec?.name.split('/').pop();
+  const namespace = customResource.spec?.name.split('/').shift();
+  return (
+    <KubernetesStructuredMetadataTableDrawer
+      object={customResource}
+      expanded={expanded}
+      kind={capitalizedName}
+      renderObject={cr => cr}
+    >
+      <Grid
+        container
+        direction="column"
+        justifyContent="flex-start"
+        alignItems="flex-start"
+        spacing={0}
+      >
+        <Grid item>
+          <Typography variant="body1">
+            {customResource.spec?.name ?? 'unknown object'}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography color="textSecondary" variant="subtitle1">
+            K8sGPT Result
+          </Typography>
+        </Grid>
+        {namespace && (
+          <Grid item>
+            <Chip size="small" label={`namespace: ${namespace}`} />
+          </Grid>
+        )}
+      </Grid>
+    </KubernetesStructuredMetadataTableDrawer>
+  );
+};

--- a/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/index.ts
+++ b/plugins/kubernetes/src/components/CustomResources/K8sGPTResults/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './K8sGPTResult';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We want to show result objects of the k8sgpt operator in the kubernetes frontend plugin.

Our first approach would be to show it like other special custom resources:

![image](https://github.com/backstage/backstage/assets/11465610/bf69aac2-55d5-4663-bcf6-8a6629ae59e3)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
