### PR TITLE
chore(docs): Replace deprecated imports

### DIFF
--- a/docs/features/search/how-to-guides.md
+++ b/docs/features/search/how-to-guides.md
@@ -51,7 +51,7 @@ The TechDocs plugin has supported integrations to Search, meaning that it
 provides a default collator factory ready to be used.
 
 The purpose of this guide is to walk you through how to register the
-[DefaultTechDocsCollatorFactory](https://github.com/backstage/backstage/blob/de294ce5c410c9eb56da6870a1fab795268f60e3/plugins/techdocs-backend/src/search/DefaultTechDocsCollatorFactory.ts)
+[DefaultTechDocsCollatorFactory](https://github.com/backstage/backstage/blob/1adc2c7/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts)
 in your App, so that you can get TechDocs documents indexed.
 
 If you have been through the
@@ -61,10 +61,10 @@ so, you can go ahead and follow this guide - if not, start by going through the
 getting started guide.
 
 1. Import the `DefaultTechDocsCollatorFactory` from
-   `@backstage/plugin-techdocs-backend`.
+   `@backstage/plugin-search-backend-module-techdocs`.
 
    ```typescript
-   import { DefaultTechDocsCollatorFactory } from '@backstage/plugin-techdocs-backend';
+   import { DefaultTechDocsCollatorFactory } from '@backstage/plugin-search-backend-module-techdocs';
    ```
 
 2. If there isn't an existing schedule you'd like to run the collator on, be


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
One of my colleagues @tcnaganath noticed that we still had collators imported from deprecated imports, and at first we had some challenges figuring that out.  This fixes the Search TechDocs How To which currently suggests users to use the same deprecated imports, and replaces them with the new imports. (turns out the deprecated imports anyway just export the new ones)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
