### PR TITLE
Add `TargetBranchName` variable and output for the `publish:gitlab:merge-request` and `publish:github:pull-request` s'cascaffolder actions.

### DIFF
--- a/.changeset/fifty-shirts-brush.md
+++ b/.changeset/fifty-shirts-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add `TargetBranchName` variable and output for the `publish:gitlab:merge-request` and `publish:github:pull-request` s'cascaffolder actions.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -584,6 +584,7 @@ export const createPublishGithubPullRequestAction: (
   {
     title: string;
     branchName: string;
+    targetBranchName?: string | undefined;
     description: string;
     repoUrl: string;
     draft?: boolean | undefined;
@@ -626,6 +627,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     title: string;
     description: string;
     branchName: string;
+    targetBranchName?: string | undefined;
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
@@ -772,6 +774,9 @@ export type OctokitWithPullRequestPluginClient = Octokit & {
     data: {
       html_url: string;
       number: number;
+      base: {
+        ref: string;
+      };
     };
   } | null>;
 };


### PR DESCRIPTION
…tlab:merge-request` and `publish:github:pull-request` s'cascaffolder actions.

## Hey, I just made a Pull Request!

In this pr, add `TargetBranchName` variable and output for the `publish:gitlab:merge-request` and `publish:github:pull-request` s'cascaffolder actions. So you can specify the target branch when you create pr, and you can get the name of the target branch through output, which is useful for generating `catalogInfo` URLs

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
