### PR TITLE
chore(docs): Refresh CLI command details

### DIFF
--- a/docs/local-dev/cli-commands.md
+++ b/docs/local-dev/cli-commands.md
@@ -10,55 +10,64 @@ and where to use them.
 ## help
 
 This command displays a help summary or detailed help screens for each command.
-Below is a cleaned up output of `yarn backstage-cli --help`
+Below is a cleaned up output of `yarn backstage-cli --help`:
 
 ```text
-repo [command]        Command that run across an entire Backstage project
-package [command]     Lifecycle scripts for individual packages
-migrate [command]     Migration utilities
-
-create                Open up an interactive guide to creating new things in your app
-
-config:docs           Browse the configuration reference documentation
-config:print          Print the app configuration for the current package
-config:check          Validate that the given configuration loads and matches schema
-config:schema         Dump the app configuration schema
-
-versions:bump         Bump Backstage packages to the latest versions
-versions:check        Check Backstage package versioning
-
-build-workspace       Builds a temporary dist workspace from the provided packages
-create-github-app     Create new GitHub App in your organization (experimental)
-
-info                  Show helpful information for debugging and reporting bugs
-help [command]        display help for command
+new [options]                                  Open up an interactive guide to creating new things in
+                                                your app
+test                                           Run tests, forwarding args to Jest, defaulting to watch
+                                                mode [DEPRECATED]
+config:docs [options]                          Browse the configuration reference documentation
+config:print [options]                         Print the app configuration for the current package
+config:check [options]                         Validate that the given configuration loads and matches
+                                                schema
+config:schema [options]                        Print configuration schema
+repo [command]                                 Command that run across an entire Backstage project
+package [command]                              Lifecycle scripts for individual packages
+migrate [command]                              Migration utilities
+versions:bump [options]                        Bump Backstage packages to the latest versions
+versions:check [options]                       Check Backstage package versioning
+clean                                          Delete cache directories [DEPRECATED]
+build-workspace <workspace-dir> [packages...]  Builds a temporary dist workspace from the provided
+                                                packages
+create-github-app <github-org>                 Create new GitHub App in your organization.
+info                                           Show helpful information for debugging and reporting bugs
+help [command]                                 display help for command
 ```
 
-The `package` command category, `yarn backstage-cli package --help`
+The `package` command category, `yarn backstage-cli package --help`:
 
 ```text
-start [options]       Start a package for local development
-build [options]       Build a package for production deployment or publishing
-lint [options]        Lint a package
-test                  Run tests, forwarding args to Jest, defaulting to watch mode
-clean                 Delete cache directories
-prepack               Prepares a package for packaging before publishing
-postpack              Restores the changes made by the prepack command
+start [options]                  Start a package for local development
+build [options]                  Build a package for production deployment or publishing
+lint [options] [directories...]  Lint a package
+test                             Run tests, forwarding args to Jest, defaulting to watch mode
+clean                            Delete cache directories
+prepack                          Prepares a package for packaging before publishing
+postpack                         Restores the changes made by the prepack command
+help [command]                   display help for command
 ```
 
-The `repo` command category, `yarn backstage-cli repo --help`
+The `repo` command category, `yarn backstage-cli repo --help`:
 
 ```text
-build [options]       Build packages in the project, excluding bundled app and backend packages.
-lint [options]        Lint all packages in the project
+build [options]              Build packages in the project, excluding bundled app and backend packages.
+lint [options]               Lint all packages in the project
+clean                        Delete cache and output directories
+list-deprecations [options]  List deprecations
+test [options]               Run tests, forwarding args to Jest, defaulting to watch mode
+help [command]               display help for command
 ```
 
-The `migrate` command category, `yarn backstage-cli migrate --help`
+The `migrate` command category, `yarn backstage-cli migrate --help`:
 
 ```text
 package-roles         Add package role field to packages that don't have it
 package-scripts       Set package scripts according to each package role
+package-exports       Synchronize package subpath export definitions
 package-lint-configs  Migrates all packages to use @backstage/cli/config/eslint-factory
+react-router-deps     Migrates the react-router dependencies for all packages to be peer dependencies
+help [command]        display help for command
 ```
 
 ## repo build
@@ -235,7 +244,7 @@ Options:
   -h, --help               display help for command
 ```
 
-## config:docs
+## config\:docs
 
 This commands opens up the reference documentation of your apps local
 configuration schema in the browser. This is useful to get an overview of what
@@ -252,7 +261,7 @@ Options:
   -h, --help        display help for command
 ```
 
-## config:print
+## config\:print
 
 Print the static configuration, defaulting to reading `app-config.yaml` in the
 repo root, using schema collected from all local packages in the repo.
@@ -277,7 +286,7 @@ Options:
   -h, --help         display help for command
 ```
 
-## config:check
+## config\:check
 
 Validate that static configuration loads and matches schema, defaulting to
 reading `app-config.yaml` in the repo root and using schema collected from all
@@ -296,7 +305,7 @@ Options:
   -h, --help        display help for command
 ```
 
-## config:schema
+## config\:schema
 
 Dump the configuration schema that was collected from all local packages in the
 repo.
@@ -315,7 +324,7 @@ Options:
   -h, --help         display help for command
 ```
 
-## versions:bump
+## versions\:bump
 
 Bump all `@backstage` packages to the latest versions. This checks for updates
 in the package registry, and will update entries both in `yarn.lock` and
@@ -330,7 +339,7 @@ Options:
   --release <version|next|main> Bump to a specific Backstage release line or version (default: "main")
 ```
 
-## versions:check
+## versions\:check
 
 Validate `@backstage` dependencies within the repo, making sure that there are
 no duplicates of packages that might lead to breakages.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Recently, @awanlin alerted me to the Backstage CLI list-deprecations feature; I had no idea it exists. https://github.com/backstage/backstage/pull/18094

I discovered a user @iTechSebastianoLaini asked a similar question that went unanswered in https://github.com/backstage/backstage/discussions/17988, so I helped answer it.

But the key point is it was a bit hidden! So this PR does two things,

* Refreshes some of the CLI commands which are missing some newer features. (like list deprecations!)
* Fixes some of the headings where the `:word` was being stripped out.

I think this entire page could use a refactor and a clean think about both a good way to keep it updated, and possibly organizing it better. Maybe more in line with how the API References page auto-generates. I don't have that time at the moment, so this quickly uses the latest Backstage CLI from the repo, and updates the command sections.

I also fixed the duplicate headings where things like `config:print` was being displayed in Docusaurus headings as only `config`, and then listing `config` over and over.

| Before (backstage.io/docs) | After |
| --- | --- |
| <img width="359" alt="image" src="https://github.com/backstage/backstage/assets/33203301/368e7462-5db3-4b78-923e-120c94e8d07b"> |  <img width="285" alt="image" src="https://github.com/backstage/backstage/assets/33203301/c4f1e8b0-efbc-4843-9309-e4ea1a40deea"> |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
