### PR TITLE
HEADER_KUBERNETES_CLUSTER optional in single cluster setup

### DIFF
--- a/.changeset/fuzzy-pots-worry.md
+++ b/.changeset/fuzzy-pots-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+K8s proxy HEADER_KUBERNETES_CLUSTER is now optional in single-cluster setups.

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -17,7 +17,6 @@
 import {
   ErrorResponseBody,
   ForwardedError,
-  InputError,
   NotAllowedError,
   NotFoundError,
   serializeError,
@@ -175,13 +174,23 @@ export class KubernetesProxy {
 
   private async getClusterForRequest(req: Request): Promise<ClusterDetails> {
     const clusterName = req.header(HEADER_KUBERNETES_CLUSTER);
-    if (!clusterName) {
-      throw new InputError(`Missing '${HEADER_KUBERNETES_CLUSTER}' header.`);
+    const clusters = await this.clusterSupplier.getClusters();
+
+    if (!clusters || clusters.length <= 0) {
+      throw new NotFoundError(`No Clusters configured`);
     }
 
-    const cluster = await this.clusterSupplier
-      .getClusters()
-      .then(clusters => clusters.find(c => c.name === clusterName));
+    const hasClusterNameHeader =
+      typeof clusterName === 'string' && clusterName.length > 0;
+
+    let cluster: ClusterDetails | undefined;
+
+    if (hasClusterNameHeader) {
+      cluster = clusters.find(c => c.name === clusterName);
+    } else if (clusters.length === 1) {
+      cluster = clusters.at(0);
+    }
+
     if (!cluster) {
       throw new NotFoundError(`Cluster '${clusterName}' not found`);
     }


### PR DESCRIPTION
## Feature

K8s proxy HEADER_KUBERNETES_CLUSTER is now optional in single-cluster setups. Resolves #18097

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
