### PR TITLE
Fix <SidebarItem/> and <ToolsCard/> heading accessibility

### DIFF
--- a/.changeset/good-sloths-pretend.md
+++ b/.changeset/good-sloths-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Enhance the sidebar item accessibility by using appropriate header semantics.

--- a/.changeset/two-cobras-shake.md
+++ b/.changeset/two-cobras-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Enhance the tools card accessibility by using appropriate header semantics.

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -411,7 +411,11 @@ const SidebarItemBase = forwardRef<any, SidebarItemProps>((props, ref) => {
         {itemIcon}
       </Box>
       {text && (
-        <Typography variant="subtitle2" className={classes.label}>
+        <Typography
+          variant="subtitle2"
+          component="span"
+          className={classes.label}
+        >
           {text}
         </Typography>
       )}

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -127,7 +127,7 @@ export const SidebarSubmenu = (props: SidebarSubmenuProps) => {
         [classes.drawerOpen]: isSubmenuOpen,
       })}
     >
-      <Typography variant="h5" className={classes.title}>
+      <Typography variant="h5" component="span" className={classes.title}>
         {props.title}
       </Typography>
       {props.children}

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -172,11 +172,19 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
             )}
           >
             {Icon && <Icon fontSize="small" />}
-            <Typography variant="subtitle1" className={classes.label}>
+            <Typography
+              variant="subtitle1"
+              component="span"
+              className={classes.label}
+            >
               {title}
               <br />
               {subtitle && (
-                <Typography variant="caption" className={classes.subtitle}>
+                <Typography
+                  variant="caption"
+                  component="span"
+                  className={classes.subtitle}
+                >
                   {subtitle}
                 </Typography>
               )}
@@ -204,7 +212,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
                   onClick={closeSubmenu}
                   onTouchStart={e => e.stopPropagation()}
                 >
-                  <Typography className={classes.textContent}>
+                  <Typography component="span" className={classes.textContent}>
                     {object.title}
                   </Typography>
                 </Link>
@@ -230,11 +238,19 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
           onTouchStart={e => e.stopPropagation()}
         >
           {Icon && <Icon fontSize="small" />}
-          <Typography variant="subtitle1" className={classes.label}>
+          <Typography
+            variant="subtitle1"
+            component="span"
+            className={classes.label}
+          >
             {title}
             <br />
             {subtitle && (
-              <Typography variant="caption" className={classes.subtitle}>
+              <Typography
+                variant="caption"
+                component="span"
+                className={classes.subtitle}
+              >
                 {subtitle}
               </Typography>
             )}

--- a/plugins/explore/src/components/ToolCard/ToolCard.test.tsx
+++ b/plugins/explore/src/components/ToolCard/ToolCard.test.tsx
@@ -36,8 +36,12 @@ describe('<ToolCard />', () => {
   });
 
   it('renders props correctly', () => {
-    const { getByText } = render(wrapInTestApp(<ToolCard {...minProps} />));
-    expect(getByText(minProps.card.title)).toBeInTheDocument();
+    const { getByRole, getByText } = render(
+      wrapInTestApp(<ToolCard {...minProps} />),
+    );
+    expect(
+      getByRole('heading', { name: minProps.card.title }),
+    ).toBeInTheDocument();
     expect(getByText(minProps.card.description)).toBeInTheDocument();
   });
 

--- a/plugins/explore/src/components/ToolCard/ToolCard.tsx
+++ b/plugins/explore/src/components/ToolCard/ToolCard.tsx
@@ -74,7 +74,7 @@ export const ToolCard = ({ card, objectFit }: Props) => {
         })}
       />
       <CardContent>
-        <Typography paragraph variant="h5">
+        <Typography variant="h5">
           {title}{' '}
           {lifecycle && lifecycle.toLocaleLowerCase('en-US') !== 'ga' && (
             <Chip


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Refs: https://github.com/backstage/backstage/issues/17991

Enhance the sidebar item and tools card accessibility by using appropriate header semantics on these components.

Sidebar items are not headings anymore:
![image](https://github.com/backstage/backstage/assets/6290749/55455ed0-7b21-423d-90aa-9c1f271cfac1)

Card headers, on the explore tools page are headings now:
![image](https://github.com/backstage/backstage/assets/6290749/aad4b9f3-1b68-45ae-abfd-b1e3356874ca)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
