### PR TITLE
feat(config-loader): Make children of `secret` visibility parents `secret` themselves.

### DIFF
--- a/.changeset/selfish-coats-shout.md
+++ b/.changeset/selfish-coats-shout.md
@@ -1,0 +1,55 @@
+---
+'@backstage/config-loader': minor
+---
+
+Adds a new `deepVisibility` schema keyword that sets child visibility recursively to the defined value, respecting preexisting values or child `deepVisibility`.
+
+Example usage:
+
+```ts
+export interface Config {
+  /**
+   * Enforces a default of `secret` instead of `backend` for this object.
+   * @deepVisibility secret
+   */
+  mySecretProperty: {
+    type: 'object';
+    properties: {
+      secretValue: {
+        type: 'string';
+      };
+
+      verySecretProperty: {
+        type: 'string';
+      };
+    };
+  };
+}
+```
+
+Example of a schema that would not be allowed:
+
+```ts
+export interface Config {
+  /**
+   * Set the top level property to secret, enforcing a default of `secret` instead of `backend` for this object.
+   * @deepVisibility secret
+   */
+  mySecretProperty: {
+    type: 'object';
+    properties: {
+      frontendUrl: {
+        /**
+         * We can NOT override the visibility to reveal a property to the front end.
+         * @visibility frontend
+         */
+        type: 'string';
+      };
+
+      verySecretProperty: {
+        type: 'string';
+      };
+    };
+  };
+}
+```

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -190,7 +190,7 @@ async function compileTsSchemas(paths: string[]) {
         // This enables the use of these tags in TSDoc comments
         {
           required: true,
-          validationKeywords: ['visibility', 'deprecated'],
+          validationKeywords: ['visibility', 'deepVisibility', 'deprecated'],
         },
         [path.split(sep).join('/')], // Unix paths are expected for all OSes here
       ) as JsonObject | null;

--- a/packages/config-loader/src/schema/compile.test.ts
+++ b/packages/config-loader/src/schema/compile.test.ts
@@ -70,7 +70,7 @@ describe('compileConfigSchemas', () => {
             c: { type: 'string' },
             d: {
               type: 'array',
-              visibility: 'secret',
+              visibility: 'frontend',
               items: { type: 'string', visibility: 'frontend' },
             },
           },
@@ -86,7 +86,7 @@ describe('compileConfigSchemas', () => {
             c: { type: 'string', visibility: 'backend' },
             d: {
               type: 'array',
-              visibility: 'secret',
+              visibility: 'frontend',
               items: { type: 'string' },
             },
           },
@@ -102,7 +102,7 @@ describe('compileConfigSchemas', () => {
         Object.entries({
           '/a': 'frontend',
           '/b': 'secret',
-          '/d': 'secret',
+          '/d': 'frontend',
           '/d/0': 'frontend',
         }),
       ),
@@ -110,7 +110,7 @@ describe('compileConfigSchemas', () => {
         Object.entries({
           '/properties/a': 'frontend',
           '/properties/b': 'secret',
-          '/properties/d': 'secret',
+          '/properties/d': 'frontend',
           '/properties/d/items': 'frontend',
         }),
       ),
@@ -229,5 +229,211 @@ describe('compileConfigSchemas', () => {
       ),
       deprecationByDataPath: new Map(),
     });
+  });
+});
+
+describe('deepVisibility', () => {
+  it('should pass secret visibility to children, but respect existing backend/secret visibility', () => {
+    const validate = compileConfigSchemas([
+      {
+        path: 'a1',
+        value: {
+          type: 'object',
+          properties: {
+            a: { type: 'string', visibility: 'backend' },
+            b: { type: 'string', visibility: 'backend' },
+            c: { type: 'string' },
+            d: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+      {
+        path: 'a2',
+        value: {
+          type: 'object',
+          deepVisibility: 'secret',
+          properties: {
+            a: { type: 'string' },
+            b: { type: 'string', visibility: 'secret' },
+            c: { type: 'string', visibility: 'backend' },
+            d: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+        },
+      },
+    ]);
+    expect(
+      validate([
+        {
+          data: { a: 'a', b: 'b', c: 'c', d: ['d'] },
+          context: 'test',
+        },
+      ]),
+    ).toEqual({
+      visibilityByDataPath: new Map(
+        Object.entries({
+          '': 'secret',
+          '/b': 'secret',
+          '/d': 'secret',
+          '/d/0': 'secret',
+        }),
+      ),
+      visibilityBySchemaPath: new Map(
+        Object.entries({
+          '': 'secret',
+          '/properties/b': 'secret',
+          '/properties/d': 'secret',
+          '/properties/d/items': 'secret',
+        }),
+      ),
+      deprecationByDataPath: new Map(),
+    });
+  });
+
+  it('should pass secret visibility to children, but throws when overriding with frontend visibility', () => {
+    expect(() =>
+      compileConfigSchemas([
+        {
+          path: 'a1',
+          value: {
+            type: 'object',
+            properties: {
+              a: { type: 'string', visibility: 'frontend' },
+              b: { type: 'string', visibility: 'backend' },
+              c: { type: 'string' },
+              d: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+          },
+        },
+        {
+          path: 'a2',
+          value: {
+            type: 'object',
+            deepVisibility: 'secret',
+            visibility: 'secret',
+            properties: {
+              a: { type: 'string' },
+              b: { type: 'string', visibility: 'secret' },
+              c: { type: 'string', visibility: 'frontend' },
+              d: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(
+      "Config schema visibility is both 'frontend' and 'secret' for /properties/a",
+    );
+  });
+
+  it('should throw when children have a different deepVisibility', () => {
+    expect(() =>
+      compileConfigSchemas([
+        {
+          path: 'a1',
+          value: {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+              b: { type: 'string', visibility: 'backend' },
+              c: { type: 'string' },
+              d: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+          },
+        },
+        {
+          path: 'a2',
+          value: {
+            type: 'object',
+            deepVisibility: 'secret',
+            properties: {
+              a: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string', visibility: 'frontend' },
+                },
+              },
+              b: { type: 'string', visibility: 'secret' },
+              c: { type: 'string', visibility: 'backend' },
+              d: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(
+      `Config schema visibility is both 'frontend' and 'secret' for /properties/a`,
+    );
+  });
+
+  it('should throw when ancestor and children have a different deepVisibility', () => {
+    expect(() =>
+      compileConfigSchemas([
+        {
+          path: 'a1',
+          value: {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+              b: { type: 'string', visibility: 'backend' },
+              c: { type: 'string' },
+              d: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+          },
+        },
+        {
+          path: 'a2',
+          value: {
+            type: 'object',
+            deepVisibility: 'secret',
+            properties: {
+              a: {
+                type: 'object',
+                deepVisibility: 'frontend',
+                properties: {
+                  a: { type: 'string', visibility: 'frontend' },
+                },
+              },
+              b: { type: 'string', visibility: 'secret' },
+              c: { type: 'string', visibility: 'backend' },
+              d: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(
+      `Config schema visibility is both 'frontend' and 'secret' for /properties/a`,
+    );
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #18006. Sets the visibility of child elements to `secret` if the parent visibility is set to `secret`.

👀 @benjdlambert , @awanlin 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
