### PR TITLE
fixes #18172: manifest type can now be undefined as well

### DIFF
--- a/.changeset/strong-crabs-flow.md
+++ b/.changeset/strong-crabs-flow.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-react': major
+'@backstage/plugin-scaffolder-react': minor
 ---
 
 Fixed typescript casting bug for useTemplateParameterSchema hook

--- a/.changeset/strong-crabs-flow.md
+++ b/.changeset/strong-crabs-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': major
+---
+
+Fixed typescript casting bug for useTemplateParameterSchema hook

--- a/plugins/home/api-report.md
+++ b/plugins/home/api-report.md
@@ -44,7 +44,7 @@ export type ClockConfig = {
 export const ComponentAccordion: (props: {
   title: string;
   expanded?: boolean | undefined;
-  Content: () => JSX.Element;
+  Content: () => JSX.Element /** @public */;
   Actions?: (() => JSX.Element) | undefined;
   Settings?: (() => JSX.Element) | undefined;
   ContextProvider?: ((props: any) => JSX.Element) | undefined;

--- a/plugins/home/api-report.md
+++ b/plugins/home/api-report.md
@@ -44,7 +44,7 @@ export type ClockConfig = {
 export const ComponentAccordion: (props: {
   title: string;
   expanded?: boolean | undefined;
-  Content: () => JSX.Element /** @public */;
+  Content: () => JSX.Element;
   Actions?: (() => JSX.Element) | undefined;
   Settings?: (() => JSX.Element) | undefined;
   ContextProvider?: ((props: any) => JSX.Element) | undefined;

--- a/plugins/scaffolder-react/alpha-api-report.md
+++ b/plugins/scaffolder-react/alpha-api-report.md
@@ -289,7 +289,7 @@ export const useFormDataFromQuery: (
 
 // @alpha (undocumented)
 export const useTemplateParameterSchema: (templateRef: string) => {
-  manifest: TemplateParameterSchema;
+  manifest: TemplateParameterSchema | undefined;
   loading: boolean;
   error: Error | undefined;
 };

--- a/plugins/scaffolder-react/src/next/hooks/useTemplateParameterSchema.ts
+++ b/plugins/scaffolder-react/src/next/hooks/useTemplateParameterSchema.ts
@@ -29,5 +29,9 @@ export const useTemplateParameterSchema = (templateRef: string) => {
     [scaffolderApi, templateRef],
   );
 
-  return { manifest: value as TemplateParameterSchema, loading, error };
+  return {
+    manifest: value as TemplateParameterSchema | undefined,
+    loading,
+    error,
+  };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes 18172
Casting manifest as TemplateParameterSchema could previously cause issues when its loading and type is undefined.
![image](https://github.com/backstage/backstage/assets/38109596/87e7d2cf-312d-442b-8e55-56866bab2d84)

The type can now be undefined as well preventing failures.
![image](https://github.com/backstage/backstage/assets/38109596/e34d8e96-1d31-4365-b640-5a002b84a421)

NOTE: 
* There was another way to fix this by not casting the manifest at all. A similar hook is seen in "/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx" at line 54 where the schema is not casted at all which could be reported as another issue if necessary or can be fixed within this PR with another commit.
* ESLint fixed the formatting as well automatically.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
