### PR TITLE
EntityOwnerPicker: add owners-only and all modes

### DIFF
--- a/.changeset/little-boats-think.md
+++ b/.changeset/little-boats-think.md
@@ -3,6 +3,10 @@
 ---
 
 The `EntityOwnerPicker` component has undergone improvements to enhance its performance.
-
-The component now loads entities asynchronously, resulting in improved performance and responsiveness. Instead of loading all entities upfront, they are now loaded in batches as the user scrolls.
 The previous implementation inferred users and groups displayed by the `EntityOwnerPicker` component based on the entities available in the `EntityListContext`. The updated version no longer relies on the `EntityListContext` for inference, allowing for better decoupling and improved performance.
+
+The component now loads entities asynchronously, resulting in improved performance and responsiveness. A new `mode` prop has been introduced which provides two different behaviours:
+
+- `<EntityOwnerPicker mode="owners-only" />`: loads the owners data asynchronously using the facets endpoint. The data is kept in memory and rendered asynchronously as the user scrolls. This is the default mode and is supposed to be retro-compatible with the previous implementation.
+
+- `<EntityOwnerPicker mode="all" />` loads all users and groups present in the catalog asynchronously. The data is loaded in batches as the user scrolls. This is more efficient than `owners-only`, but has the drowback of displaying users and groups who aren't owner of any entity.

--- a/.changeset/unlucky-feet-smell.md
+++ b/.changeset/unlucky-feet-smell.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+`CatalogIndexPage` now accepts an optional `ownerPickerMode` for toggling the behavior of the `EntityOwnerPicker`,
+exposing a new mode `<CatalogIndexPage ownerPickerMode="all" />` particularly suitable for larger catalogs. In this new mode, `EntityOwnerPicker` will display all the users and groups present in the catalog.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -266,7 +266,14 @@ export class EntityOwnerFilter implements EntityFilter {
 }
 
 // @public (undocumented)
-export const EntityOwnerPicker: () => JSX.Element | null;
+export const EntityOwnerPicker: (
+  props?: EntityOwnerPickerProps,
+) => JSX.Element | null;
+
+// @public (undocumented)
+export type EntityOwnerPickerProps = {
+  mode?: 'owners-only' | 'all';
+};
 
 // @public
 export const EntityPeekAheadPopover: (

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -121,7 +121,7 @@ const mockCatalogApi: Partial<CatalogApi> = {
 
 const mockErrorApi = new MockErrorApi();
 
-describe('<EntityOwnerPicker/>', () => {
+describe('<EntityOwnerPicker mode="all" />', () => {
   const mockApis = TestApiRegistry.from(
     [catalogApiRef, mockCatalogApi],
     [errorApiRef, mockErrorApi],
@@ -154,7 +154,7 @@ describe('<EntityOwnerPicker/>', () => {
     await renderWithEffects(
       <ApiProvider apis={mockApis}>
         <MockEntityListContextProvider value={{}}>
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
@@ -205,7 +205,7 @@ describe('<EntityOwnerPicker/>', () => {
             queryParameters,
           }}
         >
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
@@ -243,7 +243,7 @@ describe('<EntityOwnerPicker/>', () => {
             queryParameters,
           }}
         >
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
@@ -284,7 +284,7 @@ describe('<EntityOwnerPicker/>', () => {
             updateFilters,
           }}
         >
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
@@ -312,7 +312,7 @@ describe('<EntityOwnerPicker/>', () => {
             filters: { owners: new EntityOwnerFilter(['some-owner']) },
           }}
         >
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
@@ -344,7 +344,7 @@ describe('<EntityOwnerPicker/>', () => {
             queryParameters: { owners: ['team-a'] },
           }}
         >
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
@@ -362,7 +362,7 @@ describe('<EntityOwnerPicker/>', () => {
             queryParameters: { owners: ['team-b'] },
           }}
         >
-          <EntityOwnerPicker />
+          <EntityOwnerPicker mode="all" />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -55,6 +55,9 @@ const useStyles = makeStyles(
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
+/**
+ * @public
+ */
 export type EntityOwnerPickerProps = {
   mode?: 'owners-only' | 'all';
 };

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -83,11 +83,10 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
     queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
   );
 
-  const [{ value, loading }, handleFetch, { getEntity, setEntity }] =
-    useFetchEntities({
-      mode,
-      initialSelectedOwnersRefs: selectedOwners,
-    });
+  const [{ value, loading }, handleFetch, cache] = useFetchEntities({
+    mode,
+    initialSelectedOwnersRefs: selectedOwners,
+  });
   useDebouncedEffect(() => handleFetch({ text }), [text, handleFetch], 250);
 
   const availableOwners = value?.items || [];
@@ -136,7 +135,7 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
           getOptionLabel={o => {
             const entity =
               typeof o === 'string'
-                ? getEntity(o) ||
+                ? cache.getEntity(o) ||
                   parseEntityRef(o, {
                     defaultKind: 'group',
                     defaultNamespace: 'default',
@@ -152,7 +151,7 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
                   typeof e === 'string' ? e : stringifyEntityRef(e);
 
                 if (typeof e !== 'string') {
-                  setEntity(e);
+                  cache.setEntity(e);
                 }
 
                 return entityRef;

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EntityOwnerPicker } from './EntityOwnerPicker';
-export type { CatalogReactEntityOwnerPickerClassKey } from './EntityOwnerPicker';
+export type {
+  CatalogReactEntityOwnerPickerClassKey,
+  EntityOwnerPickerProps,
+} from './EntityOwnerPicker';

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { useFacetsEntities } from './useFacetsEntities';
+import { CatalogApi } from '@backstage/catalog-client';
+
+const mockedGetEntityFacets: jest.MockedFn<CatalogApi['getEntityFacets']> =
+  jest.fn();
+
+const mockCatalogApi: Partial<CatalogApi> = {
+  getEntityFacets: mockedGetEntityFacets,
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: () => mockCatalogApi,
+}));
+
+describe('useFacetsEntities', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`should return empty items when facets are loading`, () => {
+    mockedGetEntityFacets.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    expect(result.current[0]).toEqual({ value: { items: [] }, loading: true });
+  });
+
+  it(`should return the owners`, async () => {
+    mockedGetEntityFacets.mockResolvedValue({
+      facets: {
+        'relations.ownedBy': [
+          { count: 1, value: 'component:default/e2' },
+          { count: 1, value: 'component:default/e1' },
+        ],
+      },
+    });
+
+    const { result, waitFor } = renderHook(() =>
+      useFacetsEntities({ enabled: true }),
+    );
+
+    result.current[1]({ text: '' });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: {
+          items: [
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'e1', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'e2', namespace: 'default' },
+            },
+          ],
+        },
+        loading: false,
+      });
+    });
+  });
+
+  it(`should return the owners sorted by namespace, name and kind`, async () => {
+    const entityRefs = [
+      'group:namespace/team-b',
+      'component:default/c',
+      'group:default/a',
+      'component:default/a',
+      'component:default/b',
+    ];
+
+    mockedGetEntityFacets.mockResolvedValue({
+      facets: {
+        'relations.ownedBy': entityRefs.map(value => ({ count: 1, value })),
+      },
+    });
+
+    const { result, waitFor } = renderHook(() =>
+      useFacetsEntities({ enabled: true }),
+    );
+
+    result.current[1]({ text: '' });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: {
+          items: [
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'b', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'c', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'team-b', namespace: 'namespace' },
+            },
+          ],
+        },
+        loading: false,
+      });
+    });
+  });
+
+  it(`should paginate the data accordingly`, async () => {
+    const entityRefs = [
+      'group:namespace/team-b',
+      'component:default/c',
+      'group:default/a',
+      'component:default/a',
+      'component:default/b',
+    ];
+
+    mockedGetEntityFacets.mockResolvedValue({
+      facets: {
+        'relations.ownedBy': entityRefs.map(value => ({ count: 1, value })),
+      },
+    });
+
+    const { result, waitFor } = renderHook(() =>
+      useFacetsEntities({ enabled: true }),
+    );
+
+    result.current[1]({ text: '' }, { limit: 2 });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: {
+          items: [
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+          ],
+          cursor: 'eyJ0ZXh0IjoiIiwic3RhcnQiOjJ9',
+        },
+        loading: false,
+      });
+    });
+
+    result.current[1](result.current[0].value!, { limit: 2 });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: {
+          items: [
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'b', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'c', namespace: 'default' },
+            },
+          ],
+          cursor: 'eyJ0ZXh0IjoiIiwic3RhcnQiOjR9',
+        },
+        loading: false,
+      });
+    });
+
+    result.current[1](result.current[0].value!, { limit: 2 });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: {
+          items: [
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'b', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'c', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'team-b', namespace: 'namespace' },
+            },
+          ],
+        },
+        loading: false,
+      });
+    });
+  });
+});

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
@@ -241,4 +241,59 @@ describe('useFacetsEntities', () => {
       });
     });
   });
+
+  it('should filter the data accordingly', async () => {
+    const entityRefs = [
+      'group:namespace/spiderman',
+      'group:spiders/go',
+      'group:default/go',
+      'component:spiders/a-component',
+      'component:default/a-component',
+      'component:default/spider',
+      'spid:default/lemon',
+      'component:default/lemon',
+      'component:default/nade',
+    ];
+
+    mockedGetEntityFacets.mockResolvedValue({
+      facets: {
+        'relations.ownedBy': entityRefs.map(value => ({ count: 1, value })),
+      },
+    });
+
+    const { result, waitFor } = renderHook(() =>
+      useFacetsEntities({ enabled: true }),
+    );
+
+    result.current[1]({ text: 'der  ' });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: {
+          items: [
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'spider', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'spiderman', namespace: 'namespace' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'component',
+              metadata: { name: 'a-component', namespace: 'spiders' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: { name: 'go', namespace: 'spiders' },
+            },
+          ],
+        },
+        loading: false,
+      });
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useApi } from '@backstage/core-plugin-api';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { catalogApiRef } from '../../api';
+import { useState } from 'react';
+import { Entity, parseEntityRef } from '@backstage/catalog-model';
+
+type FacetsCursor = {
+  start?: number;
+  text: string;
+};
+
+type FacetsEntitiesResponse = {
+  items: Entity[];
+  cursor?: string;
+};
+
+export function useFacetsEntities({ enabled }: { enabled: boolean }) {
+  const catalogApi = useApi(catalogApiRef);
+
+  const [facetsPromise] = useState(() =>
+    Promise.resolve().then(() => {
+      if (!enabled) {
+        return [];
+      }
+      const facet = 'relations.ownedBy';
+      return catalogApi.getEntityFacets({ facets: [facet] }).then(response =>
+        response.facets[facet]
+          .map(e => e.value)
+          .map<Entity>(ref => {
+            const { kind, name, namespace } = parseEntityRef(ref);
+            return {
+              apiVersion: 'backstage.io/v1beta1',
+              kind,
+              metadata: { name, namespace },
+            };
+          })
+          .sort(
+            (a, b) =>
+              (a.metadata.namespace || '').localeCompare(
+                b.metadata.namespace || '',
+                'en-US',
+              ) ||
+              a.metadata.name.localeCompare(b.metadata.name, 'en-US') ||
+              a.kind.localeCompare(b.kind, 'en-US'),
+          ),
+      );
+    }),
+  );
+
+  return useAsyncFn<
+    (
+      request: { text: string } | FacetsEntitiesResponse,
+    ) => Promise<FacetsEntitiesResponse>
+  >(
+    async request => {
+      const facets = await facetsPromise;
+
+      if (!facets) {
+        return {
+          items: [],
+        };
+      }
+      const initialRequest = request as { text: string };
+      const cursorRequest = request as FacetsEntitiesResponse;
+
+      const limit = 20;
+
+      if (cursorRequest.cursor) {
+        const { start, text } = JSON.parse(
+          atob(cursorRequest.cursor),
+        ) as FacetsCursor;
+        const filteredRefs = facets.filter(e => filterEntity(text, e));
+        if (start === undefined) {
+          return request as FacetsEntitiesResponse;
+        }
+        const end = start + limit;
+
+        return {
+          items: filteredRefs.slice(0, end),
+          cursor: btoa(
+            JSON.stringify({
+              text,
+              ...(end < filteredRefs.length && { start: end }),
+            }),
+          ),
+        };
+      }
+
+      return {
+        items: facets
+          .filter(e => filterEntity(initialRequest.text, e))
+          .slice(0, limit),
+        cursor: btoa(
+          JSON.stringify({ text: initialRequest.text, start: limit }),
+        ),
+      };
+    },
+    [],
+    { loading: true },
+  );
+}
+
+function filterEntity(text: string, entity: Entity) {
+  return (
+    entity.kind.includes(text) ||
+    entity.metadata.namespace?.includes(text) ||
+    entity.metadata.name.includes(text)
+  );
+}

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFetchEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFetchEntities.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useRef } from 'react';
+import { useFacetsEntities } from './useFacetsEntities';
+import { useQueryEntities } from './useQueryEntities';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '../../api';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { useMountEffect } from '@react-hookz/web';
+
+export function useFetchEntities({
+  mode,
+  initialSelectedOwnersRefs,
+}: {
+  mode: 'owners-only' | 'all';
+  initialSelectedOwnersRefs: string[];
+}) {
+  const isOwnersOnlyMode = mode === 'owners-only';
+  const queryEntitiesResponse = useQueryEntities();
+  const facetsEntitiesResponse = useFacetsEntities({
+    enabled: isOwnersOnlyMode,
+  });
+
+  const [state, handleFetch] = isOwnersOnlyMode
+    ? facetsEntitiesResponse
+    : queryEntitiesResponse;
+
+  return [
+    state,
+    handleFetch,
+    useSelectedOwners({
+      enabled: !isOwnersOnlyMode,
+      initialSelectedOwnersRefs,
+    }),
+  ] as const;
+}
+
+/**
+ * Hook used for storing the full entity of the specified owners
+ * in order to display users and group using the information contained on each entity.
+ * When a component is rendered for the first time, it loads the content of the entities
+ * specified by `initialSelectedOwnersRefs` and export the `getEntity` and `setEntity`
+ * utilities, used to retrieve and modify the owners.
+ */
+function useSelectedOwners({
+  enabled,
+  initialSelectedOwnersRefs,
+}: {
+  enabled: boolean;
+  initialSelectedOwnersRefs: string[];
+}) {
+  const allEntities = useRef<Record<string, Entity>>({});
+  const catalogApi = useApi(catalogApiRef);
+
+  const [, handleFetch] = useAsyncFn(async () => {
+    const initialSelectedEntities = await catalogApi.getEntitiesByRefs({
+      entityRefs: initialSelectedOwnersRefs,
+    });
+    initialSelectedEntities.items.forEach(e => {
+      if (e) {
+        allEntities.current[stringifyEntityRef(e)] = e;
+      }
+    });
+  }, []);
+
+  useMountEffect(() => {
+    if (enabled && initialSelectedOwnersRefs.length > 0) {
+      handleFetch();
+    }
+  });
+
+  return {
+    getEntity: (entityRef: string) => allEntities.current[entityRef],
+    setEntity: (entity: Entity) => {
+      allEntities.current[stringifyEntityRef(entity)] = entity;
+    },
+  };
+}

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useQueryEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useQueryEntities.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { CatalogApi } from '@backstage/catalog-client';
+import { useQueryEntities } from './useQueryEntities';
+
+const mockedQueryEntities: jest.MockedFn<CatalogApi['queryEntities']> =
+  jest.fn();
+
+const mockCatalogApi: Partial<CatalogApi> = {
+  queryEntities: mockedQueryEntities,
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: () => mockCatalogApi,
+}));
+
+describe('useQueryEntities', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`should not invoke queryEntities on mount`, () => {
+    mockedQueryEntities.mockResolvedValue({
+      items: [],
+      pageInfo: {},
+      totalItems: 0,
+    });
+
+    renderHook(() => useQueryEntities());
+    expect(mockedQueryEntities).not.toHaveBeenCalled();
+  });
+
+  it(`should fetch the data accordingly`, async () => {
+    mockedQueryEntities
+      .mockResolvedValueOnce({
+        items: [
+          { apiVersion: '1', kind: 'kind', metadata: { name: 'name-1' } },
+        ],
+        pageInfo: { nextCursor: 'next' },
+        totalItems: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          { apiVersion: '1', kind: 'kind', metadata: { name: 'name-2' } },
+        ],
+        pageInfo: {},
+        totalItems: 2,
+      });
+
+    const { result, waitFor } = renderHook(() => useQueryEntities());
+    const [, fetch] = result.current!;
+    fetch({ text: 'text' });
+
+    await waitFor(() =>
+      expect(result.current[0].value!).toEqual({
+        items: [
+          { apiVersion: '1', kind: 'kind', metadata: { name: 'name-1' } },
+        ],
+        cursor: 'next',
+      }),
+    );
+    expect(mockedQueryEntities).toHaveBeenCalledWith({
+      filter: { kind: ['User', 'Group'] },
+      fullTextFilter: {
+        fields: [
+          'metadata.name',
+          'kind',
+          'spec.profile.displayname',
+          'metadata.title',
+        ],
+        term: 'text',
+      },
+      limit: 20,
+      orderFields: [{ field: 'metadata.name', order: 'asc' }],
+    });
+
+    fetch(result.current[0].value!);
+    await waitFor(() =>
+      expect(result.current[0].value!).toEqual({
+        items: [
+          { apiVersion: '1', kind: 'kind', metadata: { name: 'name-1' } },
+          { apiVersion: '1', kind: 'kind', metadata: { name: 'name-2' } },
+        ],
+      }),
+    );
+    expect(mockedQueryEntities).toHaveBeenCalledWith({
+      cursor: 'next',
+      limit: 20,
+    });
+  });
+});

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useQueryEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useQueryEntities.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '../../api';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { Entity } from '@backstage/catalog-model';
+
+type QueryEntitiesResponse = {
+  items: Entity[];
+  cursor?: string;
+};
+
+export function useQueryEntities() {
+  const catalogApi = useApi(catalogApiRef);
+  return useAsyncFn(
+    async (
+      request: { text: string } | QueryEntitiesResponse,
+    ): Promise<QueryEntitiesResponse> => {
+      const initialRequest = request as { text: string };
+      const cursorRequest = request as QueryEntitiesResponse;
+      const limit = 20;
+
+      if (cursorRequest.cursor) {
+        const response = await catalogApi.queryEntities({
+          cursor: cursorRequest.cursor,
+          limit,
+        });
+        return {
+          cursor: response.pageInfo.nextCursor,
+          items: [...cursorRequest.items, ...response.items],
+        };
+      }
+
+      const response = await catalogApi.queryEntities({
+        fullTextFilter: {
+          term: initialRequest.text || '',
+          fields: [
+            'metadata.name',
+            'kind',
+            'spec.profile.displayname',
+            'metadata.title',
+          ],
+        },
+        filter: { kind: ['User', 'Group'] },
+        orderFields: [{ field: 'metadata.name', order: 'asc' }],
+        limit,
+      });
+
+      return {
+        cursor: response.pageInfo.nextCursor,
+        items: response.items,
+      };
+    },
+    [],
+    { loading: true },
+  );
+}

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useQueryEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useQueryEntities.ts
@@ -28,10 +28,11 @@ export function useQueryEntities() {
   return useAsyncFn(
     async (
       request: { text: string } | QueryEntitiesResponse,
+      options?: { limit: number },
     ): Promise<QueryEntitiesResponse> => {
       const initialRequest = request as { text: string };
       const cursorRequest = request as QueryEntitiesResponse;
-      const limit = 20;
+      const limit = options?.limit ?? 20;
 
       if (cursorRequest.cursor) {
         const response = await catalogApi.queryEntities({

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ComponentEntity } from '@backstage/catalog-model';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
+import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { IndexableDocument } from '@backstage/plugin-search-common';
@@ -214,6 +215,8 @@ export interface DefaultCatalogPageProps {
   initialKind?: string;
   // (undocumented)
   initiallySelectedFilter?: UserListFilterKind;
+  // (undocumented)
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
   // (undocumented)
   tableOptions?: TableProps<CatalogTableRow>['options'];
 }

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -36,6 +36,7 @@ import {
   UserListPicker,
   EntityKindPicker,
   EntityNamespacePicker,
+  EntityOwnerPickerProps,
 } from '@backstage/plugin-catalog-react';
 import React, { ReactNode } from 'react';
 import { createComponentRouteRef } from '../../routes';
@@ -54,6 +55,7 @@ export interface DefaultCatalogPageProps {
   initialKind?: string;
   tableOptions?: TableProps<CatalogTableRow>['options'];
   emptyContent?: ReactNode;
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
@@ -64,6 +66,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     initialKind = 'component',
     tableOptions = {},
     emptyContent,
+    ownerPickerMode,
   } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
@@ -87,7 +90,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
               <EntityKindPicker initialFilter={initialKind} />
               <EntityTypePicker />
               <UserListPicker initialFilter={initiallySelectedFilter} />
-              <EntityOwnerPicker />
+              <EntityOwnerPicker mode={ownerPickerMode} />
               <EntityLifecyclePicker />
               <EntityTagPicker />
               <EntityProcessingStatusPicker />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix for #18001 
In #17514 we decoupled the `EntityOwnerPicker` from the backend entities of the `EntityListContext`, which introduced the side effect of showing all users and groups present in the catalog, instead of all user and groups listed as owners of entities.
In this PR, we rollback the default functionality of `EntityOwnerPicker`, which now uses the facets endpoint for fetching the list of owners. In default mode, `<EntityOwnerPicker mode="owners-only" />` or `<EntityOwnerPicker />` the data is filtered client side, matching namespace, kind or name of each entity. The data is also sorted client side, by namespace, name and kind.

The functionality introduced in #17514 are still there and can be activated by `<EntityOwnerPicker mode="all" />`. In this mode, the data is fetched using the `queryEntities` endpoint and is more suitable for larger catalogs.

`mode=owners-only` below:


https://github.com/backstage/backstage/assets/8433119/cc4d2d2a-63ce-40f2-ab0c-d693870a21fc

`mode=all` same as in #17514.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
