### PR TITLE
Set private-token header as secret

### DIFF
--- a/.changeset/cuddly-tigers-burn.md
+++ b/.changeset/cuddly-tigers-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Set PRIVATE-TOKEN that is used by GitLab to secret

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -40,6 +40,8 @@ export interface Config {
             'X-Api-Key': string;
             /** @visibility secret */
             'x-api-key': string;
+            /** @visibility secret */
+            'PRIVATE-TOKEN': string;
             [key: string]: string;
           }>;
           /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `PRIVATE-TOKEN` that is used by GitLab as a secret in `proxy-backend`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
