### PR TITLE
✨Allow incremental ingestion event handler to be async

### DIFF
--- a/.changeset/rotten-colts-decide.md
+++ b/.changeset/rotten-colts-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': minor
+---
+
+Allow incremental event handlers to be async; Force event handler to indicate if it made a change

--- a/.changeset/rotten-colts-decide.md
+++ b/.changeset/rotten-colts-decide.md
@@ -2,4 +2,37 @@
 '@backstage/plugin-catalog-backend-module-incremental-ingestion': minor
 ---
 
-Allow incremental event handlers to be async; Force event handler to indicate if it made a change
+**BREAKING** Allow incremental event handlers to be async; Force event handler
+to indicate if it made a change. Instead of returning `null` or `undefined` from an event
+handler to indicate no-oop, instead return the value { type: "ignored" }.
+
+**before**
+
+```javascript
+import { createDelta, shouldIgnore } from "./my-delta-creater";
+
+eventHandler: {
+  onEvent(params) {
+    if (shouldIgnore(params)) {
+      return;
+    }
+    return createDelta(params);
+  }
+}
+```
+
+**after**
+
+```javascript
+import { createDelta, shouldIgnore } from "./my-delta-creater";
+
+eventHandler: {
+  async onEvent(params) {
+    if (shouldIgnore(params) {
+      return { type: "ignored" };
+    }
+    // code to create delta can now be async if needed
+    return await createDelta(params);
+  }
+}
+```

--- a/plugins/catalog-backend-module-incremental-ingestion/api-report.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/api-report.md
@@ -49,17 +49,23 @@ export class IncrementalCatalogBuilder {
 }
 
 // @public
+export type IncrementalEntityEventResult =
+  | {
+      type: 'ignored';
+    }
+  | {
+      type: 'delta';
+      added: DeferredEntity[];
+      removed: {
+        entityRef: string;
+      }[];
+    };
+
+// @public
 export interface IncrementalEntityProvider<TCursor, TContext> {
   around(burst: (context: TContext) => Promise<void>): Promise<void>;
   eventHandler?: {
-    onEvent: (params: EventParams) =>
-      | undefined
-      | {
-          added: DeferredEntity[];
-          removed: {
-            entityRef: string;
-          }[];
-        };
+    onEvent: (params: EventParams) => Promise<IncrementalEntityEventResult>;
     supportsEventTopics: () => string[];
   };
   getProviderName(): string;

--- a/plugins/catalog-backend-module-incremental-ingestion/src/index.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/index.ts
@@ -23,6 +23,7 @@
 export * from './service';
 export {
   type EntityIteratorResult,
+  type IncrementalEntityEventResult,
   type IncrementalEntityProvider,
   type IncrementalEntityProviderOptions,
   type PluginEnvironment,

--- a/plugins/catalog-backend-module-incremental-ingestion/src/types.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/types.ts
@@ -91,15 +91,12 @@ export interface IncrementalEntityProvider<TCursor, TContext> {
      * optionally maps the payload to an object containing a delta
      * mutation.
      *
-     * If a valid delta is returned by this method, it will be ingested
-     * automatically by the provider.
+     * If a delta result is returned by this method, it will be ingested
+     * automatically by the provider. Alternatively, if an "ignored" result is
+     * returned, then it is understood that this event should not cause anything
+     * to be ingested.
      */
-    onEvent: (params: EventParams) =>
-      | undefined
-      | {
-          added: DeferredEntity[];
-          removed: { entityRef: string }[];
-        };
+    onEvent: (params: EventParams) => Promise<IncrementalEntityEventResult>;
 
     /**
      * This method returns an array of topics for the IncrementalEntityProvider
@@ -108,6 +105,22 @@ export interface IncrementalEntityProvider<TCursor, TContext> {
     supportsEventTopics: () => string[];
   };
 }
+
+/**
+ * An object returned by event handler to indicate whether to ignore the event
+ * or to apply a delta in response to the event.
+ *
+ * @public
+ */
+export type IncrementalEntityEventResult =
+  | {
+      type: 'ignored';
+    }
+  | {
+      type: 'delta';
+      added: DeferredEntity[];
+      removed: { entityRef: string }[];
+    };
 
 /**
  * Value returned by an {@link IncrementalEntityProvider} to provide a


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The point of the event hook is to map incoming changes into catalog deltas. However, this is not always a synchronous process, and might require accessing other resources to get the actual delta.

This converts the hook into an async function and awaits it on the other end. It is also completely acceptable to drop an event and do nothing, so this makes the return value of the event handler explicit in the case of a drop.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
