### PR TITLE
chore: add new QS filters to GET v2/tasks endpoint

### DIFF
--- a/.changeset/gold-snails-bake.md
+++ b/.changeset/gold-snails-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': major
+---
+
+Added new query string parameters to GET v2/tasks endpoint

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -732,7 +732,12 @@ export class DatabaseTaskStore implements TaskStore {
   // (undocumented)
   heartbeatTask(taskId: string): Promise<void>;
   // (undocumented)
-  list(options: { createdBy?: string }): Promise<{
+  list(options: {
+    createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
+  }): Promise<{
     tasks: SerializedTask[];
   }>;
   // (undocumented)
@@ -870,7 +875,12 @@ export interface TaskBroker {
   // (undocumented)
   get(taskId: string): Promise<SerializedTask>;
   // (undocumented)
-  list?(options?: { createdBy?: string }): Promise<{
+  list?(options?: {
+    createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
+  }): Promise<{
     tasks: SerializedTask[];
   }>;
   // (undocumented)
@@ -978,7 +988,12 @@ export interface TaskStore {
   // (undocumented)
   heartbeatTask(taskId: string): Promise<void>;
   // (undocumented)
-  list?(options: { createdBy?: string }): Promise<{
+  list?(options: {
+    createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
+  }): Promise<{
     tasks: SerializedTask[];
   }>;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -141,12 +141,30 @@ export class DatabaseTaskStore implements TaskStore {
 
   async list(options: {
     createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
   }): Promise<{ tasks: SerializedTask[] }> {
     const queryBuilder = this.db<RawDbTaskRow>('tasks');
 
     if (options.createdBy) {
       queryBuilder.where({
         created_by: options.createdBy,
+      });
+    }
+    if (options.lastHeartbeatAt) {
+      queryBuilder.whereRaw('last_heartbeat_at > ?', [
+        new Date(options.lastHeartbeatAt).toISOString(),
+      ]);
+    }
+    if (options.createdAt) {
+      queryBuilder.whereRaw('created_at > ?', [
+        new Date(options.createdAt).toISOString(),
+      ]);
+    }
+    if (options.status) {
+      queryBuilder.where({
+        status: options.status as TaskStatus,
       });
     }
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -153,14 +153,14 @@ export class DatabaseTaskStore implements TaskStore {
       });
     }
     if (options.lastHeartbeatAt) {
-      queryBuilder.whereRaw('last_heartbeat_at > ?', [
-        new Date(options.lastHeartbeatAt).toISOString(),
-      ]);
+      queryBuilder.where(
+        'last_heartbeat_at',
+        '>',
+        new Date(options.lastHeartbeatAt),
+      );
     }
     if (options.createdAt) {
-      queryBuilder.whereRaw('created_at > ?', [
-        new Date(options.createdAt).toISOString(),
-      ]);
+      queryBuilder.where('created_at', '>', new Date(options.createdAt));
     }
     if (options.status) {
       queryBuilder.where({

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -164,13 +164,21 @@ export class StorageTaskBroker implements TaskBroker {
 
   async list(options?: {
     createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
   }): Promise<{ tasks: SerializedTask[] }> {
     if (!this.storage.list) {
       throw new Error(
         'TaskStore does not implement the list method. Please implement the list method to be able to list tasks',
       );
     }
-    return await this.storage.list({ createdBy: options?.createdBy });
+    return await this.storage.list({
+      createdBy: options?.createdBy,
+      lastHeartbeatAt: options?.lastHeartbeatAt,
+      createdAt: options?.createdAt,
+      status: options?.status,
+    });
   }
 
   private deferredDispatch = defer();

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -137,7 +137,12 @@ export interface TaskBroker {
 
   get(taskId: string): Promise<SerializedTask>;
 
-  list?(options?: { createdBy?: string }): Promise<{ tasks: SerializedTask[] }>;
+  list?(options?: {
+    createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
+  }): Promise<{ tasks: SerializedTask[] }>;
 }
 
 /**
@@ -215,7 +220,12 @@ export interface TaskStore {
     tasks: { taskId: string }[];
   }>;
 
-  list?(options: { createdBy?: string }): Promise<{ tasks: SerializedTask[] }>;
+  list?(options: {
+    createdBy?: string;
+    lastHeartbeatAt?: number;
+    createdAt?: number;
+    status?: string;
+  }): Promise<{ tasks: SerializedTask[] }>;
 
   emitLogEvent(options: TaskStoreEmitOptions): Promise<void>;
 

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -457,12 +457,39 @@ export async function createRouter(
     })
     .get('/v2/tasks', async (req, res) => {
       const [userEntityRef] = [req.query.createdBy].flat();
+      const [lastHeartBeatAt] = [req.query.lastHeartbeatAt].flat();
+      const [createdAt] = [req.query.createdAt].flat();
+      const [status] = [req.query.status].flat();
 
       if (
         typeof userEntityRef !== 'string' &&
         typeof userEntityRef !== 'undefined'
       ) {
         throw new InputError('createdBy query parameter must be a string');
+      }
+
+      if (
+        (typeof lastHeartBeatAt !== 'string' &&
+          typeof lastHeartBeatAt !== 'undefined') ||
+        (typeof lastHeartBeatAt === 'string' &&
+          !/^-?\d+$/.test(lastHeartBeatAt))
+      ) {
+        throw new InputError(
+          'lastHeartbeatAt query parameter must be a timestamp (numbers only)',
+        );
+      }
+
+      if (
+        (typeof createdAt !== 'string' && typeof createdAt !== 'undefined') ||
+        (typeof createdAt === 'string' && !/^-?\d+$/.test(createdAt))
+      ) {
+        throw new InputError(
+          'createdAt query parameter must be a timestamp (numbers only)',
+        );
+      }
+
+      if (typeof status !== 'string' && typeof status !== 'undefined') {
+        throw new InputError('status query parameter must be a string');
       }
 
       if (!taskBroker.list) {
@@ -473,6 +500,11 @@ export async function createRouter(
 
       const tasks = await taskBroker.list({
         createdBy: userEntityRef,
+        lastHeartbeatAt: lastHeartBeatAt
+          ? parseInt(lastHeartBeatAt, 10)
+          : undefined,
+        createdAt: createdAt ? parseInt(createdAt, 10) : undefined,
+        status: status,
       });
 
       res.status(200).json(tasks);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the hability to list tasks for three new filters (`createdAt`, `lastHeartbeatAt` and `status`) on query string.
To give more details, the endpoint will search for tasks `createdAt > {param}`, `lastHeaartbeatAt > {param}`or `status = {param}`.
In query string the values for `createdAt` and `lastHeartbeatAt` must be a timestamp.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message.
