### PR TITLE
Add fetch polyfill to app tests

### DIFF
--- a/.changeset/dull-sheep-tie.md
+++ b/.changeset/dull-sheep-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Fix test failures caused by missing fetch library

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -106,6 +106,7 @@
     "@types/react-dom": "*",
     "@types/zen-observable": "^0.8.0",
     "cross-env": "^7.0.0",
+    "cross-fetch": "^3.1.6",
     "cypress": "^10.0.0",
     "eslint-plugin-cypress": "^2.10.3",
     "start-server-and-test": "^1.10.11"

--- a/packages/app/src/setupTests.ts
+++ b/packages/app/src/setupTests.ts
@@ -19,4 +19,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
-import 'cross-fetch';
+import 'cross-fetch/polyfill';

--- a/packages/app/src/setupTests.ts
+++ b/packages/app/src/setupTests.ts
@@ -19,3 +19,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import 'cross-fetch';

--- a/packages/create-app/templates/default-app/packages/app/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/app/package.json.hbs
@@ -61,6 +61,7 @@
     "@types/node": "^16.11.26",
     "@types/react-dom": "*",
     "cross-env": "^7.0.0",
+    "cross-fetch": "^3.1.6",
     "cypress": "^9.7.0",
     "eslint-plugin-cypress": "^2.10.3",
     "start-server-and-test": "^1.10.11"

--- a/packages/create-app/templates/default-app/packages/app/src/setupTests.ts
+++ b/packages/create-app/templates/default-app/packages/app/src/setupTests.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import 'cross-fetch/polyfill';

--- a/yarn.lock
+++ b/yarn.lock
@@ -21791,7 +21791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.1.3, cross-fetch@npm:^3.1.5":
+"cross-fetch@npm:^3.1.3, cross-fetch@npm:^3.1.5, cross-fetch@npm:^3.1.6":
   version: 3.1.6
   resolution: "cross-fetch@npm:3.1.6"
   dependencies:
@@ -24623,6 +24623,7 @@ __metadata:
     "@types/react-dom": "*"
     "@types/zen-observable": ^0.8.0
     cross-env: ^7.0.0
+    cross-fetch: ^3.1.6
     cypress: ^10.0.0
     eslint-plugin-cypress: ^2.10.3
     history: ^5.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix for an issue causing E2E tests to fail:

```
● App › should render

    ReferenceError: Request is not defined

      at Object.fetch (../../../node_modules/@backstage/core-app-api/dist/index.esm.js:1723:23)
      at CatalogClient.requestOptional (../../../node_modules/@backstage/catalog-client/src/CatalogClient.ts:514:42)
      at CatalogClient.getEntityFacets (../../../node_modules/@backstage/catalog-client/src/CatalogClient.ts:341:12)
```

The issue seems to be related to the missing fetch library in the global scope.

here `Request` is missing -> https://github.com/backstage/backstage/blob/2197872a97b755b86ddde153733894fa77b8a864/packages/core-app-api/src/apis/implementations/FetchApi/PluginProtocolResolverFetchMiddleware.ts#L37

here `global.fetch` is missing -> https://github.com/backstage/backstage/blob/2197872a97b755b86ddde153733894fa77b8a864/packages/core-app-api/src/apis/implementations/FetchApi/createFetchApi.ts#L36

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
