### PR TITLE
[Search] Fix SearchModal and HomePageSearchBar debounce

### DIFF
--- a/.changeset/honest-beds-appear.md
+++ b/.changeset/honest-beds-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fixes `SearchModal` and `HomePageSearchBar` components to use search bar reference value when "enter" is pressed, avoiding waiting for query state debounce.

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.test.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { searchApiRef } from '@backstage/plugin-search-react';
+
+import { rootRouteRef } from '../../plugin';
+
+import { HomePageSearchBar } from './HomePageSearchBar';
+
+const navigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => navigate,
+}));
+
+describe('<HomePageSearchBar/>', () => {
+  const searchApiMock = { query: jest.fn().mockResolvedValue({ results: [] }) };
+
+  it("Don't wait query debounce time when enter is pressed", async () => {
+    await renderInTestApp(
+      <TestApiProvider apis={[[searchApiRef, searchApiMock]]}>
+        <HomePageSearchBar />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/search': rootRouteRef,
+        },
+      },
+    );
+
+    expect(searchApiMock.query).toHaveBeenCalledWith(
+      expect.objectContaining({ term: '' }),
+    );
+
+    await userEvent.type(screen.getByLabelText('Search'), 'term{enter}');
+
+    expect(navigate).toHaveBeenCalledWith('/search?query=term');
+  });
+});

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   SearchBarBase,
@@ -47,11 +47,15 @@ export type HomePageSearchBarProps = Partial<
 export const HomePageSearchBar = (props: HomePageSearchBarProps) => {
   const classes = useStyles(props);
   const [query, setQuery] = useState('');
+  const ref = useRef<HTMLInputElement | null>(null);
+
   const handleSearch = useNavigateToQuery();
 
-  const handleSubmit = () => {
-    handleSearch({ query });
-  };
+  // This handler is called when "enter" is pressed
+  const handleSubmit = useCallback(() => {
+    // Using ref to get the current field value without waiting for a query debounce
+    handleSearch({ query: ref.current?.value ?? '' });
+  }, [handleSearch]);
 
   const handleChange = useCallback(
     value => {
@@ -65,6 +69,7 @@ export const HomePageSearchBar = (props: HomePageSearchBarProps) => {
       value={query}
       onSubmit={handleSubmit}
       onChange={handleChange}
+      inputProps={{ ref }}
       InputProps={{
         ...props.InputProps,
         classes: {


### PR DESCRIPTION
Signed-off-by: Camila Belo <camilaibs@gmail.com>

## Hey, I just made a Pull Request!

Closes: https://github.com/backstage/backstage/issues/17675

Fixes `SearchModal` and `HomePageSearchBar` components to use search bar reference value when "enter" is pressed, avoiding waiting for query state debounce.

https://github.com/backstage/backstage/assets/6290749/e4a13a7d-8110-4462-b910-b164faafe779

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
