### PR TITLE
fixing the SonarQube case in backend plugin readme

### DIFF
--- a/.changeset/flat-mangos-grow.md
+++ b/.changeset/flat-mangos-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube-backend': patch
+---
+
+Updated installation instructions

--- a/plugins/sonarqube-backend/README.md
+++ b/plugins/sonarqube-backend/README.md
@@ -80,7 +80,7 @@ Allows configuration of either a single or multiple global Sonarqube instances a
 ##### Config
 
 ```yaml
-sonarqube:
+sonarQube:
   baseUrl: https://sonarqube.example.com
   apiKey: 123456789abcdef0123456789abcedf012
 ```
@@ -103,7 +103,7 @@ The following will look for findings at `https://special-project-sonarqube.examp
 ##### Config
 
 ```yaml
-sonarqube:
+sonarQube:
   instances:
     - name: default
       baseUrl: https://default-sonarqube.example.com
@@ -124,12 +124,12 @@ metadata:
     sonarqube.org/project-key: specialProject/YOUR_PROJECT_KEY
 ```
 
-If the `specialProject/` part is omitted (or replaced with `default/`), the Sonarqube instance of name `default` will be used.
+If the `specialProject/` part is omitted (or replaced with `default/`), the SonarQube instance of name `default` will be used.
 
 The following config is an equivalent (but less clear) version of the above:
 
 ```yaml
-sonarqube:
+sonarQube:
   baseUrl: https://default-sonarqube.example.com
   apiKey: 123456789abcdef0123456789abcedf012
   instances:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The SonarQube backend plugin config https://github.com/backstage/backstage/blob/bc51b8b7a0f3074bcf1cff5f8479e132727a71f6/plugins/sonarqube-backend/config.d.ts#L19 states that the SonarQube case is 'sonarQube' but the README suggests the case as 'sonarqube'. Using either of the cases didn't error out but when we tried to run the config-check with --strict it errors out for the case.

This PR is to fix the case in the README to reflect the same case from the config file. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
