### PR TITLE
Remove requirement that deprecated property 'target' is provided

### DIFF
--- a/.changeset/rich-owls-smell.md
+++ b/.changeset/rich-owls-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Remove requirement for 'target' property of EntityRelation

--- a/packages/catalog-model/src/schema/shared/common.schema.json
+++ b/packages/catalog-model/src/schema/shared/common.schema.json
@@ -32,7 +32,7 @@
       "$id": "#relation",
       "type": "object",
       "description": "A directed relation from one entity to another.",
-      "required": ["type", "target", "targetRef"],
+      "required": ["type", "targetRef"],
       "additionalProperties": false,
       "properties": {
         "type": {

--- a/packages/catalog-model/src/validation/entitySchemaValidator.test.ts
+++ b/packages/catalog-model/src/validation/entitySchemaValidator.test.ts
@@ -365,11 +365,6 @@ describe('entitySchemaValidator', () => {
     expect(() => validator(entity)).toThrow(/relations/);
   });
 
-  it('does reject missing relations.target', () => {
-    delete entity.relations[0].target;
-    expect(() => validator(entity)).toThrow(/relations/);
-  });
-
   it('does reject missing relations.targetRef', () => {
     delete entity.relations[0].targetRef;
     expect(() => validator(entity)).toThrow(/relations/);


### PR DESCRIPTION
The target property has been deprecated for a long time on an EntityRelation, but is still required in the spec. This fix removes that requirement, but keeps it around for now.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
