### PR TITLE
catalog-unprocessed-entities: use FetchApi instead of native fetch

### DIFF
--- a/.changeset/tender-clouds-run.md
+++ b/.changeset/tender-clouds-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+---
+
+Use FetchApi instead of native fetch

--- a/plugins/catalog-unprocessed-entities/src/api/index.ts
+++ b/plugins/catalog-unprocessed-entities/src/api/index.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DiscoveryApi, createApiRef } from '@backstage/core-plugin-api';
+import {
+  DiscoveryApi,
+  createApiRef,
+  FetchApi,
+} from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { UnprocessedEntity } from '../types';
 
@@ -35,13 +39,13 @@ export const catalogUnprocessedEntitiesApiRef =
 export class CatalogUnprocessedEntitiesApi {
   url: string = '';
 
-  constructor(public discovery: DiscoveryApi) {}
+  constructor(public discovery: DiscoveryApi, public fetchApi: FetchApi) {}
 
   private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
     if (!this.url) {
       this.url = await this.discovery.getBaseUrl('catalog');
     }
-    const resp = await fetch(`${this.url}/${path}`, init);
+    const resp = await this.fetchApi.fetch(`${this.url}/${path}`, init);
     if (!resp.ok) {
       throw await ResponseError.fromResponse(resp);
     }

--- a/plugins/catalog-unprocessed-entities/src/plugin.ts
+++ b/plugins/catalog-unprocessed-entities/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 import { rootRouteRef } from './routes';
@@ -39,9 +40,9 @@ export const catalogUnprocessedEntitiesPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: catalogUnprocessedEntitiesApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) =>
-        new CatalogUnprocessedEntitiesApi(discoveryApi),
+      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new CatalogUnprocessedEntitiesApi(discoveryApi, fetchApi),
     }),
   ],
 });


### PR DESCRIPTION
Token auth fails if native fetch is used.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
