### PR TITLE
EntityOwnershipCard: Fix color to pick up from page theme for component type

### DIFF
--- a/.changeset/ninety-pandas-provide.md
+++ b/.changeset/ninety-pandas-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+EntityOwnershipCard: Fix color to pick up from page theme for component type

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles((theme: BackstageTheme) =>
       boxShadow: theme.shadows[2],
       borderRadius: '4px',
       padding: theme.spacing(2),
-      color: theme.palette.common.white,
       transition: `${theme.transitions.duration.standard}ms`,
       '&:hover': {
         boxShadow: theme.shadows[4],
@@ -58,6 +57,8 @@ const useStyles = makeStyles((theme: BackstageTheme) =>
     entityTypeBox: {
       background: (props: { type: string }) =>
         theme.getPageTheme({ themeId: props.type }).backgroundImage,
+      color: (props: { type: string }) =>
+        theme.getPageTheme({ themeId: props.type }).fontColor,
     },
   }),
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Another one of those white-text-on-white-background PRs, if your page theme has a white background.

I'm on a roll on those, https://github.com/backstage/backstage/pulls?q=is%3Apr+author%3APike+is%3Aclosed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
