### PR TITLE
Use consistent names for cursor and context

### DIFF
--- a/.changeset/curvy-trainers-hide.md
+++ b/.changeset/curvy-trainers-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Update installation guide to fix inconsistency in type names

--- a/plugins/catalog-backend-module-incremental-ingestion/README.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/README.md
@@ -121,7 +121,7 @@ To create an Incremental Entity Provider, you need to know how to retrieve a sin
 Here is the type definition for an Incremental Entity Provider.
 
 ```ts
-interface IncrementalEntityProvider<TCursor, TContext> {
+interface IncrementalEntityProvider<Cursor, Context> {
   /**
    * This name must be unique between all of the entity providers
    * operating in the catalog.
@@ -137,9 +137,9 @@ interface IncrementalEntityProvider<TCursor, TContext> {
    * the next page after this one.
    */
   next(
-    context: TContext,
-    cursor?: TCursor,
-  ): Promise<EntityIteratorResult<TCursor>>;
+    context: Context,
+    cursor?: Cursor,
+  ): Promise<EntityIteratorResult<Cursor>>;
   /**
    * Do any setup and teardown necessary in order to provide the
    * context for fetching pages. This should always invoke `burst` in
@@ -147,7 +147,7 @@ interface IncrementalEntityProvider<TCursor, TContext> {
    *
    * @param burst - a function which performs a series of iterations
    */
-  around(burst: (context: TContext) => Promise<void>): Promise<void>;
+  around(burst: (context: Context) => Promise<void>): Promise<void>;
 }
 ```
 
@@ -175,17 +175,17 @@ import { IncrementalEntityProvider } from '@backstage/plugin-catalog-backend-mod
 
 // This will include your pagination information, let's say our API accepts a `page` parameter.
 // In this case, the cursor will include `page`
-interface MyApiCursor {
+interface Cursor {
   page: number;
 }
 
 // This interface describes the type of data that will be passed to your burst function.
-interface MyContext {
+interface Context {
   apiClient: MyApiClient;
 }
 
 export class MyIncrementalEntityProvider
-  implements IncrementalEntityProvider<MyApiCursor, MyContext>
+  implements IncrementalEntityProvider<Cursor, Context>
 {
   getProviderName() {
     return `MyIncrementalEntityProvider`;
@@ -203,7 +203,7 @@ export class MyIncrementalEntityProvider
     return `MyIncrementalEntityProvider`;
   }
 
-  async around(burst: (context: MyContext) => Promise<void>): Promise<void> {
+  async around(burst: (context: Context) => Promise<void>): Promise<void> {
     const apiClient = new MyApiClient();
 
     await burst({ apiClient });
@@ -229,7 +229,7 @@ export class MyIncrementalEntityProvider
     return `MyIncrementalEntityProvider`;
   }
 
-  async around(burst: (context: MyContext) => Promise<void>): Promise<void> {
+  async around(burst: (context: Context) => Promise<void>): Promise<void> {
     const apiClient = new MyApiClient(this.token);
 
     await burst({ apiClient });
@@ -240,7 +240,7 @@ export class MyIncrementalEntityProvider
 The last step is to implement the actual `next` method that will accept the cursor, call the API, process the result and return the result.
 
 ```ts
-export class MyIncrementalEntityProvider implements IncrementalEntityProvider<MyApiCursor, MyContext> {
+export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cursor, Context> {
 
   token: string;
 
@@ -253,14 +253,14 @@ export class MyIncrementalEntityProvider implements IncrementalEntityProvider<My
   }
 
 
-  async around(burst: (context: MyContext) => Promise<void>): Promise<void> {
+  async around(burst: (context: Context) => Promise<void>): Promise<void> {
 
     const apiClient = new MyApiClient(this.token)
 
     await burst({ apiClient })
   }
 
-  async next(context: MyContext, cursor?: MyApiCursor = { page: 1 }): Promise<EntityIteratorResult<MyApiCursor>> {
+  async next(context: Context, cursor?: Cursor = { page: 1 }): Promise<EntityIteratorResult<Cursor>> {
     const { apiClient } = context;
 
     // call your API with the current cursor

--- a/plugins/catalog-backend-module-incremental-ingestion/README.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/README.md
@@ -175,17 +175,17 @@ import { IncrementalEntityProvider } from '@backstage/plugin-catalog-backend-mod
 
 // This will include your pagination information, let's say our API accepts a `page` parameter.
 // In this case, the cursor will include `page`
-interface TCursor {
+interface Cursor {
   page: number;
 }
 
 // This interface describes the type of data that will be passed to your burst function.
-interface TContext {
+interface Context {
   apiClient: MyApiClient;
 }
 
 export class MyIncrementalEntityProvider
-  implements IncrementalEntityProvider<TCursor, TContext>
+  implements IncrementalEntityProvider<Cursor, Context>
 {
   getProviderName() {
     return `MyIncrementalEntityProvider`;
@@ -197,13 +197,13 @@ export class MyIncrementalEntityProvider
 
 ```ts
 export class MyIncrementalEntityProvider
-  implements IncrementalEntityProvider<TCursor, TContext>
+  implements IncrementalEntityProvider<Cursor, Context>
 {
   getProviderName() {
     return `MyIncrementalEntityProvider`;
   }
 
-  async around(burst: (context: TContext) => Promise<void>): Promise<void> {
+  async around(burst: (context: Context) => Promise<void>): Promise<void> {
     const apiClient = new MyApiClient();
 
     await burst({ apiClient });
@@ -217,7 +217,7 @@ If you need to pass a token to your API, then you can create a constructor that 
 
 ```ts
 export class MyIncrementalEntityProvider
-  implements IncrementalEntityProvider<TCursor, TContext>
+  implements IncrementalEntityProvider<Cursor, Context>
 {
   token: string;
 
@@ -229,7 +229,7 @@ export class MyIncrementalEntityProvider
     return `MyIncrementalEntityProvider`;
   }
 
-  async around(burst: (context: TContext) => Promise<void>): Promise<void> {
+  async around(burst: (context: Context) => Promise<void>): Promise<void> {
     const apiClient = new MyApiClient(this.token);
 
     await burst({ apiClient });
@@ -240,7 +240,7 @@ export class MyIncrementalEntityProvider
 The last step is to implement the actual `next` method that will accept the cursor, call the API, process the result and return the result.
 
 ```ts
-export class MyIncrementalEntityProvider implements IncrementalEntityProvider<TCursor, TContext> {
+export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cursor, Context> {
 
   token: string;
 
@@ -253,14 +253,14 @@ export class MyIncrementalEntityProvider implements IncrementalEntityProvider<TC
   }
 
 
-  async around(burst: (context: TContext) => Promise<void>): Promise<void> {
+  async around(burst: (context: Context) => Promise<void>): Promise<void> {
 
     const apiClient = new MyApiClient(this.token)
 
     await burst({ apiClient })
   }
 
-  async next(context: TContext, cursor?: TCursor = { page: 1 }): Promise<EntityIteratorResult<TCursor>> {
+  async next(context: Context, cursor?: Cursor = { page: 1 }): Promise<EntityIteratorResult<Cursor>> {
     const { apiClient } = context;
 
     // call your API with the current cursor


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The type names for cursor and context were inconsistent, e.g. `MyApiCursor`, `TCursor`, `Cursor`. I made them consistent so as to avoid confusion. Decided on `TCursor` and `TContext` as they are the most generic and would make it easier to reuse without having to replace them when developers copy the examples.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
