### PR TITLE
chore: Remove deprecated imports

### DIFF
--- a/.changeset/orange-frogs-exist.md
+++ b/.changeset/orange-frogs-exist.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-test-utils': patch
+'@backstage/backend-app-api': patch
+'@techdocs/cli': patch
+'@backstage/create-app': patch
+---
+
+Remove reference to deprecated import

--- a/packages/backend-app-api/src/services/implementations/discovery/discoveryServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/discovery/discoveryServiceFactory.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SingleHostDiscovery } from '@backstage/backend-common';
+import { HostDiscovery } from '@backstage/backend-common';
 import {
   coreServices,
   createServiceFactory,
@@ -27,6 +27,6 @@ export const discoveryServiceFactory = createServiceFactory({
     config: coreServices.config,
   },
   async factory({ config }) {
-    return SingleHostDiscovery.fromConfig(config);
+    return HostDiscovery.fromConfig(config);
   },
 });

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -22,7 +22,7 @@ import {
   ExtendedHttpServer,
   DefaultRootHttpRouter,
 } from '@backstage/backend-app-api';
-import { SingleHostDiscovery } from '@backstage/backend-common';
+import { HostDiscovery } from '@backstage/backend-common';
 import {
   ServiceFactory,
   ServiceRef,
@@ -148,7 +148,7 @@ export async function startTestBackend<
         throw new Error('Test server not started yet');
       }
       const port = server.port();
-      const discovery = SingleHostDiscovery.fromConfig(
+      const discovery = HostDiscovery.fromConfig(
         new ConfigReader({
           backend: { baseUrl: `http://localhost:${port}`, listen: { port } },
         }),

--- a/packages/create-app/templates/default-app/packages/backend/src/index.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/index.ts
@@ -15,7 +15,7 @@ import {
   notFoundHandler,
   CacheManager,
   DatabaseManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   UrlReaders,
   ServerTokenManager,
 } from '@backstage/backend-common';
@@ -35,7 +35,7 @@ import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 function makeCreateEnv(config: Config) {
   const root = getRootLogger();
   const reader = UrlReaders.default({ logger: root, config });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const cacheManager = CacheManager.fromConfig(config);
   const databaseManager = DatabaseManager.fromConfig(config, { logger: root });
   const tokenManager = ServerTokenManager.noop();

--- a/packages/techdocs-cli/src/commands/migrate/migrate.ts
+++ b/packages/techdocs-cli/src/commands/migrate/migrate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SingleHostDiscovery } from '@backstage/backend-common';
+import { HostDiscovery } from '@backstage/backend-common';
 import { Publisher } from '@backstage/plugin-techdocs-node';
 import { OptionValues } from 'commander';
 import { createLogger } from '../../lib/utility';
@@ -24,7 +24,7 @@ export default async function migrate(opts: OptionValues) {
   const logger = createLogger({ verbose: opts.verbose });
 
   const config = PublisherConfig.getValidConfig(opts);
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const publisher = await Publisher.fromConfig(config, { logger, discovery });
 
   if (!publisher.migrateDocsCase) {

--- a/packages/techdocs-cli/src/commands/publish/publish.ts
+++ b/packages/techdocs-cli/src/commands/publish/publish.ts
@@ -17,7 +17,7 @@
 import { resolve } from 'path';
 import { OptionValues } from 'commander';
 import { createLogger } from '../../lib/utility';
-import { SingleHostDiscovery } from '@backstage/backend-common';
+import { HostDiscovery } from '@backstage/backend-common';
 import { Publisher } from '@backstage/plugin-techdocs-node';
 import { Entity } from '@backstage/catalog-model';
 import { PublisherConfig } from '../../lib/PublisherConfig';
@@ -26,7 +26,7 @@ export default async function publish(opts: OptionValues): Promise<any> {
   const logger = createLogger({ verbose: opts.verbose });
 
   const config = PublisherConfig.getValidConfig(opts);
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const publisher = await Publisher.fromConfig(config, { logger, discovery });
 
   // Check that the publisher's underlying storage is ready and available.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Maintenance PR to replace all legacy references of `SingleHostDiscovery` with the more simple `HostDiscovery` throughout core Backstage packages.

The legacy reference is now a reference to the new one, so functionally this is identical.

Lots more plugins referencing it, but this should help take care of just those in `packages/`.

https://github.com/backstage/backstage/blob/9f9b8ef2f082379b7d44dafdaabfee018058e74c/packages/backend-common/src/discovery/HostDiscovery.ts#L132C1-L143

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
