### PR TITLE
chore(azure devops): rename azure credential types

### DIFF
--- a/.changeset/silly-jeans-wonder.md
+++ b/.changeset/silly-jeans-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Renamed ClientSecret to AzureClientSecretCredential and ManagedIdentity to AzureManagedIdentityCredential

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -39,7 +39,16 @@ export type AwsS3IntegrationConfig = {
 };
 
 // @public
-export type AzureCredential = ClientSecret | ManagedIdentity;
+export type AzureClientSecretCredential = {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+};
+
+// @public
+export type AzureCredential =
+  | AzureClientSecretCredential
+  | AzureManagedIdentityCredential;
 
 // @public
 export class AzureIntegration implements ScmIntegration {
@@ -67,6 +76,11 @@ export type AzureIntegrationConfig = {
   host: string;
   token?: string;
   credential?: AzureCredential;
+};
+
+// @public
+export type AzureManagedIdentityCredential = {
+  clientId: string;
 };
 
 // @public
@@ -156,13 +170,6 @@ export type BitbucketServerIntegrationConfig = {
   token?: string;
   username?: string;
   password?: string;
-};
-
-// @public
-export type ClientSecret = {
-  tenantId: string;
-  clientId: string;
-  clientSecret: string;
 };
 
 // @public
@@ -571,11 +578,6 @@ export interface IntegrationsByType {
   // (undocumented)
   gitlab: ScmIntegrationsGroup<GitLabIntegration>;
 }
-
-// @public
-export type ManagedIdentity = {
-  clientId: string;
-};
 
 // @public
 export function parseGerritGitilesUrl(

--- a/packages/integration/src/azure/config.ts
+++ b/packages/integration/src/azure/config.ts
@@ -51,7 +51,7 @@ export type AzureIntegrationConfig = {
  * Authenticate using a client secret that was generated for an App Registration.
  * @public
  */
-export type ClientSecret = {
+export type AzureClientSecretCredential = {
   /**
    * The Azure Active Directory tenant
    */
@@ -71,7 +71,7 @@ export type ClientSecret = {
  * Authenticate using a managed identity available at the deployment environment.
  * @public
  */
-export type ManagedIdentity = {
+export type AzureManagedIdentityCredential = {
   /**
    * The clientId
    */
@@ -82,11 +82,13 @@ export type ManagedIdentity = {
  * Credential used to authenticate to Azure Active Directory.
  * @public
  */
-export type AzureCredential = ClientSecret | ManagedIdentity;
-export const isServicePrincipal = (
+export type AzureCredential =
+  | AzureClientSecretCredential
+  | AzureManagedIdentityCredential;
+export const isAzureClientSecretCredential = (
   credential: Partial<AzureCredential>,
-): credential is ClientSecret => {
-  const clientSecretCredential = credential as ClientSecret;
+): credential is AzureClientSecretCredential => {
+  const clientSecretCredential = credential as AzureClientSecretCredential;
 
   return (
     Object.keys(credential).length === 3 &&
@@ -96,12 +98,12 @@ export const isServicePrincipal = (
   );
 };
 
-export const isManagedIdentity = (
+export const isAzureManagedIdentityCredential = (
   credential: Partial<AzureCredential>,
-): credential is ManagedIdentity => {
+): credential is AzureManagedIdentityCredential => {
   return (
     Object.keys(credential).length === 1 &&
-    (credential as ManagedIdentity).clientId !== undefined
+    (credential as AzureManagedIdentityCredential).clientId !== undefined
   );
 };
 
@@ -133,8 +135,8 @@ export function readAzureIntegrationConfig(
 
   if (
     credential &&
-    !isServicePrincipal(credential) &&
-    !isManagedIdentity(credential)
+    !isAzureClientSecretCredential(credential) &&
+    !isAzureManagedIdentityCredential(credential)
   ) {
     throw new Error(
       `Invalid Azure integration config, credential is not valid`,

--- a/packages/integration/src/azure/core.ts
+++ b/packages/integration/src/azure/core.ts
@@ -17,8 +17,8 @@
 import { AzureUrl } from './AzureUrl';
 import {
   AzureIntegrationConfig,
-  isManagedIdentity,
-  isServicePrincipal,
+  isAzureManagedIdentityCredential,
+  isAzureClientSecretCredential,
 } from './config';
 import {
   ClientSecretCredential,
@@ -81,7 +81,7 @@ export async function getAzureRequestOptions(
 
   const { token, credential } = config;
   if (credential) {
-    if (isServicePrincipal(credential)) {
+    if (isAzureClientSecretCredential(credential)) {
       const servicePrincipal = new ClientSecretCredential(
         credential.tenantId,
         credential.clientId,
@@ -90,7 +90,7 @@ export async function getAzureRequestOptions(
 
       const accessToken = await servicePrincipal.getToken(azureDevOpsScope);
       headers.Authorization = `Bearer ${accessToken.token}`;
-    } else if (isManagedIdentity(credential)) {
+    } else if (isAzureManagedIdentityCredential(credential)) {
       const managedIdentity = new ManagedIdentityCredential(
         credential.clientId,
       );

--- a/packages/integration/src/azure/index.ts
+++ b/packages/integration/src/azure/index.ts
@@ -22,8 +22,8 @@ export {
 export type {
   AzureIntegrationConfig,
   AzureCredential,
-  ManagedIdentity,
-  ClientSecret,
+  AzureManagedIdentityCredential,
+  AzureClientSecretCredential,
 } from './config';
 export {
   getAzureCommitsUrl,


### PR DESCRIPTION


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Renamed `ClientSecret` to `AzureClientSecretCredential` and renamed `ManagedIdentity` to `AzureManagedIdentityCredential`. This makes it more explicit that these are Azure-based credentials.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] ~Added or updated documentation~
- [x] ~Tests for new functionality and regression tests for bug fixes~
- [x] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
