### PR TITLE
backend-common: make HostDiscovery strip trailing slashes in backend.baseUrl

### DIFF
--- a/.changeset/itchy-glasses-smoke.md
+++ b/.changeset/itchy-glasses-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+`HostDiscovery` now strips trailing slashes in the `backend.baseUrl` config.

--- a/packages/backend-common/src/discovery/HostDiscovery.test.ts
+++ b/packages/backend-common/src/discovery/HostDiscovery.test.ts
@@ -36,6 +36,24 @@ describe('HostDiscovery', () => {
     );
   });
 
+  it('strips trailing slashes in config', async () => {
+    const discovery = HostDiscovery.fromConfig(
+      new ConfigReader({
+        backend: {
+          baseUrl: 'http://localhost:40//',
+          listen: { port: 80, host: 'localhost' },
+        },
+      }),
+    );
+
+    await expect(discovery.getBaseUrl('catalog')).resolves.toBe(
+      'http://localhost:80/api/catalog',
+    );
+    await expect(discovery.getExternalBaseUrl('catalog')).resolves.toBe(
+      'http://localhost:40/api/catalog',
+    );
+  });
+
   it('can configure the base path', async () => {
     const discovery = HostDiscovery.fromConfig(
       new ConfigReader({

--- a/packages/backend-common/src/discovery/HostDiscovery.ts
+++ b/packages/backend-common/src/discovery/HostDiscovery.ts
@@ -57,7 +57,9 @@ export class HostDiscovery implements PluginEndpointDiscovery {
    */
   static fromConfig(config: Config, options?: { basePath?: string }) {
     const basePath = options?.basePath ?? '/api';
-    const externalBaseUrl = config.getString('backend.baseUrl');
+    const externalBaseUrl = config
+      .getString('backend.baseUrl')
+      .replace(/\/+$/, '');
 
     const {
       listen: { host: listenHost = '::', port: listenPort },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We typically strip trailing slashes in baseUrls. It's more correct to define it without, but we're trying to be a bit permissive of the input.

Fixes #18271 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
