### PR TITLE
test apps should have a fetch api by default

### DIFF
--- a/.changeset/plenty-weeks-boil.md
+++ b/.changeset/plenty-weeks-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Add a `fetchApiRef` implementation by default

--- a/packages/test-utils/src/testUtils/mockApis.ts
+++ b/packages/test-utils/src/testUtils/mockApis.ts
@@ -15,13 +15,15 @@
  */
 
 import {
-  storageApiRef,
-  errorApiRef,
   createApiFactory,
+  errorApiRef,
+  fetchApiRef,
+  storageApiRef,
 } from '@backstage/core-plugin-api';
-import { MockErrorApi, MockStorageApi } from './apis';
+import { MockErrorApi, MockFetchApi, MockStorageApi } from './apis';
 
 export const mockApis = [
   createApiFactory(errorApiRef, new MockErrorApi()),
+  createApiFactory(fetchApiRef, new MockFetchApi()),
   createApiFactory(storageApiRef, MockStorageApi.create()),
 ];


### PR DESCRIPTION
By default it does actual fetches, which works well with our standard msw usage.