### PR TITLE
Fixed bug on OwnedEntityPicker not populating the catalog filter to child EntityPicker

### DIFF
--- a/.changeset/cyan-hornets-deliver.md
+++ b/.changeset/cyan-hornets-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Fixed the OwnedEntityPicker to correctly populate the catalog filter property on the internal EntityPicker

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.test.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type EntityFilterQuery } from '@backstage/catalog-client';
+import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { FieldProps } from '@rjsf/core';
+import React from 'react';
+import { OwnedEntityPicker } from './OwnedEntityPicker';
+import {
+  BackstageUserIdentity,
+  IdentityApi,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+
+const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
+  apiVersion: 'backstage.io/v1beta1',
+  kind,
+  metadata: { namespace, name },
+});
+
+const makeIdentity = (
+  userEntityRef: string,
+  ownershipEntityRefs: string[],
+  type: 'user',
+) => ({
+  type,
+  userEntityRef,
+  ownershipEntityRefs,
+});
+
+describe('<OwnedEntityPicker />', () => {
+  let entities: Entity[];
+  let identity: BackstageUserIdentity;
+  const onChange = jest.fn();
+  const schema = {};
+  const required = false;
+  let uiSchema: {
+    'ui:options': {
+      allowedKinds?: string[];
+      defaultKind?: string;
+      allowArbitraryValues?: boolean;
+      defaultNamespace?: string | false;
+      catalogFilter?: EntityFilterQuery;
+    };
+  };
+  const rawErrors: string[] = [];
+  const formData = undefined;
+
+  let props: FieldProps;
+
+  const catalogApi: jest.Mocked<CatalogApi> = {
+    getLocationById: jest.fn(),
+    getEntityByName: jest.fn(),
+    getEntities: jest.fn(async () => ({ items: entities })),
+    addLocation: jest.fn(),
+    getLocationByRef: jest.fn(),
+    removeEntityByUid: jest.fn(),
+  } as any;
+  const identityApi: jest.Mocked<IdentityApi> = {
+    getProfileInfo: jest.fn(),
+    getBackstageIdentity: jest.fn(async () => ({ items: entities })),
+    getCredentials: jest.fn(),
+    signOut: jest.fn(),
+  } as any;
+  let Wrapper: React.ComponentType<React.PropsWithChildren<{}>>;
+
+  beforeEach(() => {
+    entities = [
+      makeEntity('Group', 'default', 'team-a'),
+      makeEntity('Group', 'default', 'squad-b'),
+    ];
+    identity = makeIdentity('', [''], 'user');
+
+    Wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <TestApiProvider
+        apis={[
+          [identityApiRef, identityApi],
+          [catalogApiRef, catalogApi],
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe('without catalogFilter and allowedKinds', () => {
+    beforeEach(() => {
+      uiSchema = { 'ui:options': {} };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps<any>;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      identityApi.getBackstageIdentity.mockResolvedValue(identity);
+    });
+
+    it('searches for all owned entities', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <OwnedEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(identityApi.getBackstageIdentity).toHaveBeenCalled();
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        filter: {
+          [`relations.${RELATION_OWNED_BY}`]: identity.ownershipEntityRefs,
+        },
+      });
+    });
+  });
+
+  describe('with allowedKinds', () => {
+    beforeEach(() => {
+      uiSchema = { 'ui:options': { allowedKinds: ['User'] } };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps<any>;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      identityApi.getBackstageIdentity.mockResolvedValue(identity);
+    });
+
+    it('searches for users', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <OwnedEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(identityApi.getBackstageIdentity).toHaveBeenCalled();
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        filter: {
+          kind: ['User'],
+          [`relations.${RELATION_OWNED_BY}`]: identity.ownershipEntityRefs,
+        },
+      });
+    });
+  });
+
+  describe('with catalogFilter', () => {
+    beforeEach(() => {
+      uiSchema = {
+        'ui:options': {
+          catalogFilter: {
+            kind: ['Group'],
+            'spec.type': 'team',
+          },
+        },
+      };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps<any>;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      identityApi.getBackstageIdentity.mockResolvedValue(identity);
+    });
+
+    it('searches for group entities of type team', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <OwnedEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(identityApi.getBackstageIdentity).toHaveBeenCalled();
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        filter: {
+          kind: ['Group'],
+          'spec.type': 'team',
+          [`relations.${RELATION_OWNED_BY}`]: identity.ownershipEntityRefs,
+        },
+      });
+    });
+  });
+
+  describe('catalogFilter should take precedence over allowedKinds', () => {
+    beforeEach(() => {
+      uiSchema = {
+        'ui:options': {
+          allowedKinds: ['system'],
+          catalogFilter: {
+            kind: ['Group', 'User'],
+            'spec.type': ['team', 'business-unit'],
+          },
+        },
+      };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps<any>;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      identityApi.getBackstageIdentity.mockResolvedValue(identity);
+    });
+
+    it('searches for users and groups or teams and business units', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <OwnedEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(identityApi.getBackstageIdentity).toHaveBeenCalled();
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        filter: {
+          kind: ['Group', 'User'],
+          [`relations.${RELATION_OWNED_BY}`]: identity.ownershipEntityRefs,
+          'spec.type': ['team', 'business-unit'],
+        },
+      });
+    });
+  });
+});

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -36,6 +36,7 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
     schema: { title = 'Entity', description = 'An entity from the catalog' },
     uiSchema,
     required,
+    ...restProps
   } = props;
 
   const identityApi = useApi(identityApiRef);
@@ -44,7 +45,29 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
     return identity.ownershipEntityRefs;
   });
 
+  const defaultNamespace = uiSchema['ui:options']?.defaultNamespace;
   const allowedKinds = uiSchema['ui:options']?.allowedKinds;
+  const defaultKind = uiSchema['ui:options']?.defaultKind;
+
+  const catalogFilter = {
+    ...(allowedKinds !== undefined ? { kind: allowedKinds } : {}),
+    ...(uiSchema['ui:options']?.catalogFilter !== undefined
+      ? uiSchema['ui:options']?.catalogFilter
+      : {}),
+    [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
+  };
+
+  const ownedUiSchema = {
+    ...uiSchema,
+    'ui:options': {
+      catalogFilter,
+      allowArbitraryValues:
+        uiSchema['ui:options']?.allowArbitraryValues ?? true,
+      ...(defaultNamespace !== undefined ? { defaultNamespace } : {}),
+      ...(defaultKind !== undefined ? { defaultKind } : {}),
+    },
+  };
+
   if (loading)
     return (
       <Autocomplete
@@ -67,23 +90,10 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
 
   return (
     <EntityPicker
-      {...props}
+      {...restProps}
       schema={{ title, description }}
-      allowedKinds={allowedKinds}
-      catalogFilter={
-        allowedKinds
-          ? {
-              filter: {
-                kind: allowedKinds,
-                [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
-              },
-            }
-          : {
-              filter: {
-                [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
-              },
-            }
-      }
+      required={required}
+      uiSchema={ownedUiSchema}
     />
   );
 };

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/schema.ts
@@ -15,6 +15,7 @@
  */
 import { z } from 'zod';
 import { makeFieldSchemaFromZod } from '../utils';
+import { entityQueryFilterExpressionSchema } from '../EntityPicker/schema';
 
 /**
  * @public
@@ -22,10 +23,15 @@ import { makeFieldSchemaFromZod } from '../utils';
 export const OwnedEntityPickerFieldSchema = makeFieldSchemaFromZod(
   z.string(),
   z.object({
+    /**
+     * @deprecated Use `catalogFilter` instead.
+     */
     allowedKinds: z
       .array(z.string())
       .optional()
-      .describe('List of kinds of entities to derive options from'),
+      .describe(
+        'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from',
+      ),
     defaultKind: z
       .string()
       .optional()
@@ -42,6 +48,11 @@ export const OwnedEntityPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'The default namespace. Options with this namespace will not be prefixed.',
       ),
+    catalogFilter: z
+      .array(entityQueryFilterExpressionSchema)
+      .or(entityQueryFilterExpressionSchema)
+      .optional()
+      .describe('List of key-value filter expression for entities'),
   }),
 );
 


### PR DESCRIPTION
## Fixed bug on OwnedEntityPicker not populating the catalog filter to child EntityPicker

The component 'OwnedEntityPicker' was populating the property 'catalogFilter' wrongly to the 'EntityPicker' component as a property, instead of populating it under the 'ui:options' in uiSchema.
Also added unit tests to detect and changes to the underlying components

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
