### PR TITLE
feat(kubernetes-backend): Add WebSocket support to `kubernetes-backend` Proxy

### DIFF
--- a/.changeset/khaki-rocks-do.md
+++ b/.changeset/khaki-rocks-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Add WebSocket support to `kubernetes-backend` proxy.

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -54,6 +54,10 @@ describe('KubernetesProxy', () => {
       params: {
         path,
       },
+      headers: {
+        'content-type': 'application/json',
+        [HEADER_KUBERNETES_CLUSTER.toLowerCase()]: clusterName,
+      },
       header: jest.fn((key: string) => {
         switch (key) {
           case 'Content-Type': {


### PR DESCRIPTION
## Add WebSocket support to `kubernetes-backend` Proxy

Add support for WebSocket requests through `kubernetes-backend`'s `KuberentesProxy`, fixing an issue with WS requests that do not posses the `header` function since those are instances of `http.IncomingMessage`.

Closes #18099 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
