### PR TITLE
feat: allow processing placeholders in same directory

### DIFF
--- a/.changeset/many-buckets-kiss.md
+++ b/.changeset/many-buckets-kiss.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow resolving placeholders from the same directory
+
+This change allows to resolve YAML placeholders that are located in the same
+directory as the source is. This enables to split entity files, especially
+very long templates, to multiple parts inside the same directory.

--- a/plugins/catalog-backend/src/modules/util/urls.test.ts
+++ b/plugins/catalog-backend/src/modules/util/urls.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isHttpUrl } from './urls';
+
+describe('isValidUrl', () => {
+  it('should return true for url', () => {
+    const validUrl = isHttpUrl('http://some.valid.url');
+    expect(validUrl).toBe(true);
+  });
+
+  it('should return false for absolute path', () => {
+    const validUrl = isHttpUrl('/some/absolute/path');
+    expect(validUrl).toBe(false);
+  });
+
+  it('should return false for relative path', () => {
+    const validUrl = isHttpUrl('../some/relative/path');
+    expect(validUrl).toBe(false);
+  });
+});

--- a/plugins/catalog-backend/src/modules/util/urls.ts
+++ b/plugins/catalog-backend/src/modules/util/urls.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function isHttpUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return ['http:', 'https:'].includes(url.protocol);
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change allows to resolve YAML placeholders that are located in the same directory as the source is. This enables to split entity files, especially very long templates, to multiple parts inside the same directory.

For example in #15241 the $yaml includes can now be done now in local filesystem instead fetching them from the remote. Only limitation is that the included files must be in the same directory (or subdirectory) as the file including those is.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
