### PR TITLE
Allow for customizing theme typography

### DIFF
--- a/.changeset/nervous-llamas-tan.md
+++ b/.changeset/nervous-llamas-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Removed themed example from `OwnershipCard` Storybook entry

--- a/.changeset/nervous-llamas-tan.md
+++ b/.changeset/nervous-llamas-tan.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-org': patch
----
-
-Removed themed example from `OwnershipCard` Storybook entry

--- a/.changeset/serious-carrots-applaud.md
+++ b/.changeset/serious-carrots-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+You can now customize the typography of your theme by passing in your own custom typography defaults

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -124,6 +124,8 @@ export interface BaseThemeOptionsInput<PaletteOptions> {
   pageTheme?: Record<string, PageTheme>;
   // (undocumented)
   palette: PaletteOptions;
+  // (undocumented)
+  typography?: Typography;
 }
 
 // @public
@@ -134,40 +136,7 @@ export function createBaseThemeOptions<PaletteOptions>(
   options: BaseThemeOptionsInput<PaletteOptions>,
 ): {
   palette: PaletteOptions;
-  typography: {
-    htmlFontSize: number;
-    fontFamily: string;
-    h1: {
-      fontSize: number;
-      fontWeight: number;
-      marginBottom: number;
-    };
-    h2: {
-      fontSize: number;
-      fontWeight: number;
-      marginBottom: number;
-    };
-    h3: {
-      fontSize: number;
-      fontWeight: number;
-      marginBottom: number;
-    };
-    h4: {
-      fontWeight: number;
-      fontSize: number;
-      marginBottom: number;
-    };
-    h5: {
-      fontWeight: number;
-      fontSize: number;
-      marginBottom: number;
-    };
-    h6: {
-      fontWeight: number;
-      fontSize: number;
-      marginBottom: number;
-    };
-  };
+  typography: Typography;
   page: PageTheme;
   getPageTheme: ({ themeId }: PageThemeSelector) => PageTheme;
 };
@@ -379,6 +348,7 @@ export type SimpleThemeOptions = {
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
   htmlFontSize?: number;
+  typography?: Typography;
 };
 
 // @public
@@ -403,6 +373,42 @@ export function transformV5ComponentThemesToV4(
 };
 
 // @public
+export type Typography = {
+  htmlFontSize: number;
+  fontFamily: string;
+  h1: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h2: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h3: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h4: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h5: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h6: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+};
+
+// @public
 export interface UnifiedTheme {
   // (undocumented)
   getTheme(version: SupportedVersions): SupportedThemes | undefined;
@@ -422,6 +428,8 @@ export interface UnifiedThemeOptions {
   pageTheme?: Record<string, PageTheme>;
   // (undocumented)
   palette: PaletteOptions & PaletteOptions_2;
+  // (undocumented)
+  typography?: Typography;
 }
 
 // @public

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -113,6 +113,42 @@ export interface BackstageThemeOptions extends ThemeOptions_3 {
 }
 
 // @public
+export type BackstageTypography = {
+  htmlFontSize: number;
+  fontFamily: string;
+  h1: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h2: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h3: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h4: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h5: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h6: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+};
+
+// @public
 export interface BaseThemeOptionsInput<PaletteOptions> {
   // (undocumented)
   defaultPageTheme?: string;
@@ -125,7 +161,7 @@ export interface BaseThemeOptionsInput<PaletteOptions> {
   // (undocumented)
   palette: PaletteOptions;
   // (undocumented)
-  typography?: Typography;
+  typography?: BackstageTypography;
 }
 
 // @public
@@ -136,7 +172,7 @@ export function createBaseThemeOptions<PaletteOptions>(
   options: BaseThemeOptionsInput<PaletteOptions>,
 ): {
   palette: PaletteOptions;
-  typography: Typography;
+  typography: BackstageTypography;
   page: PageTheme;
   getPageTheme: ({ themeId }: PageThemeSelector) => PageTheme;
 };
@@ -348,7 +384,7 @@ export type SimpleThemeOptions = {
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
   htmlFontSize?: number;
-  typography?: Typography;
+  typography?: BackstageTypography;
 };
 
 // @public
@@ -373,42 +409,6 @@ export function transformV5ComponentThemesToV4(
 };
 
 // @public
-export type Typography = {
-  htmlFontSize: number;
-  fontFamily: string;
-  h1: {
-    fontSize: number;
-    fontWeight: number;
-    marginBottom: number;
-  };
-  h2: {
-    fontSize: number;
-    fontWeight: number;
-    marginBottom: number;
-  };
-  h3: {
-    fontSize: number;
-    fontWeight: number;
-    marginBottom: number;
-  };
-  h4: {
-    fontSize: number;
-    fontWeight: number;
-    marginBottom: number;
-  };
-  h5: {
-    fontSize: number;
-    fontWeight: number;
-    marginBottom: number;
-  };
-  h6: {
-    fontSize: number;
-    fontWeight: number;
-    marginBottom: number;
-  };
-};
-
-// @public
 export interface UnifiedTheme {
   // (undocumented)
   getTheme(version: SupportedVersions): SupportedThemes | undefined;
@@ -429,7 +429,7 @@ export interface UnifiedThemeOptions {
   // (undocumented)
   palette: PaletteOptions & PaletteOptions_2;
   // (undocumented)
-  typography?: Typography;
+  typography?: BackstageTypography;
 }
 
 // @public

--- a/packages/theme/src/base/createBaseThemeOptions.ts
+++ b/packages/theme/src/base/createBaseThemeOptions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { PageTheme, PageThemeSelector } from './types';
+import { Typography, PageTheme, PageThemeSelector } from './types';
 import { pageTheme as defaultPageThemes } from './pageTheme';
 
 const DEFAULT_HTML_FONT_SIZE = 16;
@@ -33,6 +33,7 @@ export interface BaseThemeOptionsInput<PaletteOptions> {
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
   htmlFontSize?: number;
+  typography?: Typography;
 }
 
 /**
@@ -49,48 +50,51 @@ export function createBaseThemeOptions<PaletteOptions>(
     fontFamily = DEFAULT_FONT_FAMILY,
     defaultPageTheme = DEFAULT_PAGE_THEME,
     pageTheme = defaultPageThemes,
+    typography,
   } = options;
 
   if (!pageTheme[defaultPageTheme]) {
     throw new Error(`${defaultPageTheme} is not defined in pageTheme.`);
   }
 
+  const defaultTypography = {
+    htmlFontSize,
+    fontFamily,
+    h1: {
+      fontSize: 54,
+      fontWeight: 700,
+      marginBottom: 10,
+    },
+    h2: {
+      fontSize: 40,
+      fontWeight: 700,
+      marginBottom: 8,
+    },
+    h3: {
+      fontSize: 32,
+      fontWeight: 700,
+      marginBottom: 6,
+    },
+    h4: {
+      fontWeight: 700,
+      fontSize: 28,
+      marginBottom: 6,
+    },
+    h5: {
+      fontWeight: 700,
+      fontSize: 24,
+      marginBottom: 4,
+    },
+    h6: {
+      fontWeight: 700,
+      fontSize: 20,
+      marginBottom: 2,
+    },
+  };
+
   return {
     palette,
-    typography: {
-      htmlFontSize,
-      fontFamily,
-      h1: {
-        fontSize: 54,
-        fontWeight: 700,
-        marginBottom: 10,
-      },
-      h2: {
-        fontSize: 40,
-        fontWeight: 700,
-        marginBottom: 8,
-      },
-      h3: {
-        fontSize: 32,
-        fontWeight: 700,
-        marginBottom: 6,
-      },
-      h4: {
-        fontWeight: 700,
-        fontSize: 28,
-        marginBottom: 6,
-      },
-      h5: {
-        fontWeight: 700,
-        fontSize: 24,
-        marginBottom: 4,
-      },
-      h6: {
-        fontWeight: 700,
-        fontSize: 20,
-        marginBottom: 2,
-      },
-    },
+    typography: typography ?? defaultTypography,
     page: pageTheme[defaultPageTheme],
     getPageTheme: ({ themeId }: PageThemeSelector) =>
       pageTheme[themeId] ?? pageTheme[defaultPageTheme],

--- a/packages/theme/src/base/createBaseThemeOptions.ts
+++ b/packages/theme/src/base/createBaseThemeOptions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Typography, PageTheme, PageThemeSelector } from './types';
+import { BackstageTypography, PageTheme, PageThemeSelector } from './types';
 import { pageTheme as defaultPageThemes } from './pageTheme';
 
 const DEFAULT_HTML_FONT_SIZE = 16;
@@ -33,7 +33,7 @@ export interface BaseThemeOptionsInput<PaletteOptions> {
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
   htmlFontSize?: number;
-  typography?: Typography;
+  typography?: BackstageTypography;
 }
 
 /**

--- a/packages/theme/src/base/index.ts
+++ b/packages/theme/src/base/index.ts
@@ -23,4 +23,5 @@ export type {
   BackstagePaletteAdditions,
   PageTheme,
   PageThemeSelector,
+  Typography,
 } from './types';

--- a/packages/theme/src/base/index.ts
+++ b/packages/theme/src/base/index.ts
@@ -23,5 +23,5 @@ export type {
   BackstagePaletteAdditions,
   PageTheme,
   PageThemeSelector,
-  Typography,
+  BackstageTypography,
 } from './types';

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -114,3 +114,43 @@ export type BackstageThemeAdditions = {
   page: PageTheme;
   getPageTheme: (selector: PageThemeSelector) => PageTheme;
 };
+
+/**
+ * Custom Typography
+ *
+ * @public
+ */
+export type Typography = {
+  htmlFontSize: number;
+  fontFamily: string;
+  h1: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h2: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h3: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h4: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h5: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+  h6: {
+    fontSize: number;
+    fontWeight: number;
+    marginBottom: number;
+  };
+};

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -120,7 +120,7 @@ export type BackstageThemeAdditions = {
  *
  * @public
  */
-export type Typography = {
+export type BackstageTypography = {
   htmlFontSize: number;
   fontFamily: string;
   h1: {

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -29,7 +29,7 @@ import {
   createTheme as createV5Theme,
 } from '@mui/material/styles';
 import { createBaseThemeOptions } from '../base/createBaseThemeOptions';
-import { PageTheme } from '../base/types';
+import { Typography, PageTheme } from '../base/types';
 import { defaultComponentThemes } from '../v5';
 import { transformV5ComponentThemesToV4 } from './overrides';
 import { SupportedThemes, SupportedVersions, UnifiedTheme } from './types';
@@ -64,6 +64,7 @@ export interface UnifiedThemeOptions {
   fontFamily?: string;
   htmlFontSize?: number;
   components?: ThemeOptionsV5['components'];
+  typography?: Typography;
 }
 
 /**

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -29,7 +29,7 @@ import {
   createTheme as createV5Theme,
 } from '@mui/material/styles';
 import { createBaseThemeOptions } from '../base/createBaseThemeOptions';
-import { Typography, PageTheme } from '../base/types';
+import { BackstageTypography, PageTheme } from '../base/types';
 import { defaultComponentThemes } from '../v5';
 import { transformV5ComponentThemesToV4 } from './overrides';
 import { SupportedThemes, SupportedVersions, UnifiedTheme } from './types';
@@ -64,7 +64,7 @@ export interface UnifiedThemeOptions {
   fontFamily?: string;
   htmlFontSize?: number;
   components?: ThemeOptionsV5['components'];
-  typography?: Typography;
+  typography?: BackstageTypography;
 }
 
 /**

--- a/packages/theme/src/v4/types.ts
+++ b/packages/theme/src/v4/types.ts
@@ -25,6 +25,7 @@ import type {
 import {
   BackstagePaletteAdditions,
   BackstageThemeAdditions,
+  Typography,
   PageTheme,
   PageThemeSelector,
 } from '../base/types';
@@ -89,6 +90,7 @@ export type SimpleThemeOptions = {
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
   htmlFontSize?: number;
+  typography?: Typography;
 };
 
 declare module '@material-ui/core/styles/createPalette' {

--- a/packages/theme/src/v4/types.ts
+++ b/packages/theme/src/v4/types.ts
@@ -25,7 +25,7 @@ import type {
 import {
   BackstagePaletteAdditions,
   BackstageThemeAdditions,
-  Typography,
+  BackstageTypography,
   PageTheme,
   PageThemeSelector,
 } from '../base/types';
@@ -90,7 +90,7 @@ export type SimpleThemeOptions = {
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
   htmlFontSize?: number;
-  typography?: Typography;
+  typography?: BackstageTypography;
 };
 
 declare module '@material-ui/core/styles/createPalette' {

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
@@ -22,13 +22,7 @@ import {
   EntityProvider,
 } from '@backstage/plugin-catalog-react';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
-import {
-  BackstageTheme,
-  createTheme,
-  genPageTheme,
-  shapes,
-} from '@backstage/theme';
-import { Grid, ThemeProvider } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import React from 'react';
 import { catalogIndexRouteRef } from '../../../routes';
 import { OwnershipCard } from './OwnershipCard';
@@ -110,40 +104,6 @@ export const Default = () =>
         </Grid>
       </EntityProvider>
     </ApiProvider>,
-    {
-      mountedRoutes: { '/catalog': catalogIndexRouteRef },
-    },
-  );
-
-const monochromeTheme = (outer: BackstageTheme) =>
-  createTheme({
-    ...outer,
-    defaultPageTheme: 'home',
-    pageTheme: {
-      home: genPageTheme({ colors: ['#444'], shape: shapes.wave2 }),
-      documentation: genPageTheme({ colors: ['#474747'], shape: shapes.wave2 }),
-      tool: genPageTheme({ colors: ['#222'], shape: shapes.wave2 }),
-      service: genPageTheme({ colors: ['#aaa'], shape: shapes.wave2 }),
-      website: genPageTheme({ colors: ['#0e0e0e'], shape: shapes.wave2 }),
-      library: genPageTheme({ colors: ['#9d9d9d'], shape: shapes.wave2 }),
-      other: genPageTheme({ colors: ['#aaa'], shape: shapes.wave2 }),
-      app: genPageTheme({ colors: ['#666'], shape: shapes.wave2 }),
-    },
-  });
-
-export const Themed = () =>
-  wrapInTestApp(
-    <ThemeProvider theme={monochromeTheme}>
-      <ApiProvider apis={apis}>
-        <EntityProvider entity={defaultEntity}>
-          <Grid container spacing={4}>
-            <Grid item xs={12} md={6}>
-              <OwnershipCard />
-            </Grid>
-          </Grid>
-        </EntityProvider>
-      </ApiProvider>
-    </ThemeProvider>,
     {
       mountedRoutes: { '/catalog': catalogIndexRouteRef },
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

You can now customize the typography of your theme by passing in your own custom typography defaults

This is something that we needed so that we can follow our brand standards. We would have like to be able to just use a MUI v5 Theme but we could not see how we could do that easily. This was where we landed that seemed reasonable but we are open to feedback and refactoring this.

Ideally we would do this: https://mui.com/material-ui/customization/typography/#adding-amp-disabling-variants

If we keep the current implementation should we try and match the MUI v5 Typography object more closely?https://mui.com/material-ui/customization/default-theme/?expand-path=$.typography 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
