### PR TITLE
Upgrade @azure/identity version

### DIFF
--- a/.changeset/friendly-rivers-hammer.md
+++ b/.changeset/friendly-rivers-hammer.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-azure-sites-backend': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Upgrade `@azure/identity` to support using Workload Identity to authenticate against Azure.

--- a/plugins/azure-sites-backend/package.json
+++ b/plugins/azure-sites-backend/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@azure/arm-appservice": "^13.0.1",
     "@azure/arm-resourcegraph": "^4.2.1",
-    "@azure/identity": "^2.1.0",
+    "@azure/identity": "^3.2.1",
     "@backstage/backend-common": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/plugin-azure-sites-common": "workspace:^",

--- a/plugins/catalog-backend-module-msgraph/package.json
+++ b/plugins/catalog-backend-module-msgraph/package.json
@@ -45,7 +45,7 @@
     "clean": "backstage-cli package clean"
   },
   "dependencies": {
-    "@azure/identity": "^2.1.0",
+    "@azure/identity": "^3.2.1",
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -52,7 +52,7 @@
     "@aws-crypto/sha256-js": "^3.0.0",
     "@aws-sdk/credential-providers": "^3.350.0",
     "@aws-sdk/signature-v4": "^3.347.0",
-    "@azure/identity": "^2.0.4",
+    "@azure/identity": "^3.2.1",
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-client": "workspace:^",

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/lib-storage": "^3.350.0",
     "@aws-sdk/node-http-handler": "^3.350.0",
     "@aws-sdk/types": "^3.347.0",
-    "@azure/identity": "^2.1.0",
+    "@azure/identity": "^3.2.1",
     "@azure/storage-blob": "^12.5.0",
     "@backstage/backend-common": "workspace:^",
     "@backstage/catalog-model": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,30 +1974,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/identity@npm:^2.0.4, @azure/identity@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@azure/identity@npm:2.1.0"
-  dependencies:
-    "@azure/abort-controller": ^1.0.0
-    "@azure/core-auth": ^1.3.0
-    "@azure/core-client": ^1.4.0
-    "@azure/core-rest-pipeline": ^1.1.0
-    "@azure/core-tracing": ^1.0.0
-    "@azure/core-util": ^1.0.0
-    "@azure/logger": ^1.0.0
-    "@azure/msal-browser": ^2.26.0
-    "@azure/msal-common": ^7.0.0
-    "@azure/msal-node": ^1.10.0
-    events: ^3.0.0
-    jws: ^4.0.0
-    open: ^8.0.0
-    stoppable: ^1.1.0
-    tslib: ^2.2.0
-    uuid: ^8.3.0
-  checksum: 1f29f1fd46c51f226da06e6e70f113d50f5ef0dd163e2ba1b8bc35cadcf98ccd829bff3d2bf4d90641c369e5d6b74b344f17abec10f2ae9469a74aeb9415d6d4
-  languageName: node
-  linkType: hard
-
 "@azure/identity@npm:^3.2.1":
   version: 3.2.2
   resolution: "@azure/identity@npm:3.2.2"
@@ -2059,7 +2035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/msal-browser@npm:^2.26.0, @azure/msal-browser@npm:^2.32.2":
+"@azure/msal-browser@npm:^2.32.2":
   version: 2.37.0
   resolution: "@azure/msal-browser@npm:2.37.0"
   dependencies:
@@ -2075,13 +2051,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/msal-common@npm:^7.0.0":
-  version: 7.1.0
-  resolution: "@azure/msal-common@npm:7.1.0"
-  checksum: 761a8b9363c7b620d831aba7d7e7a66e341685e306034b027b57dc31dae11abdf86c3187c08fc8008448c845ffdcbbc42c767c75355625cf87aba25ba7e2832e
-  languageName: node
-  linkType: hard
-
 "@azure/msal-common@npm:^9.0.2":
   version: 9.0.2
   resolution: "@azure/msal-common@npm:9.0.2"
@@ -2089,7 +2058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/msal-node@npm:^1.10.0, @azure/msal-node@npm:^1.14.6":
+"@azure/msal-node@npm:^1.14.6":
   version: 1.17.2
   resolution: "@azure/msal-node@npm:1.17.2"
   dependencies:
@@ -5125,7 +5094,7 @@ __metadata:
   dependencies:
     "@azure/arm-appservice": ^13.0.1
     "@azure/arm-resourcegraph": ^4.2.1
-    "@azure/identity": ^2.1.0
+    "@azure/identity": ^3.2.1
     "@backstage/backend-common": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
@@ -5612,7 +5581,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-catalog-backend-module-msgraph@workspace:plugins/catalog-backend-module-msgraph"
   dependencies:
-    "@azure/identity": ^2.1.0
+    "@azure/identity": ^3.2.1
     "@backstage/backend-common": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-tasks": "workspace:^"
@@ -7613,7 +7582,7 @@ __metadata:
     "@aws-crypto/sha256-js": ^3.0.0
     "@aws-sdk/credential-providers": ^3.350.0
     "@aws-sdk/signature-v4": ^3.347.0
-    "@azure/identity": ^2.0.4
+    "@azure/identity": ^3.2.1
     "@backstage/backend-common": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
@@ -9623,7 +9592,7 @@ __metadata:
     "@aws-sdk/lib-storage": ^3.350.0
     "@aws-sdk/node-http-handler": ^3.350.0
     "@aws-sdk/types": ^3.347.0
-    "@azure/identity": ^2.1.0
+    "@azure/identity": ^3.2.1
     "@azure/storage-blob": ^12.5.0
     "@backstage/backend-common": "workspace:^"
     "@backstage/catalog-model": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Consolidated `@azure/identity` uses onto the 3.2.1 version used by the integration plugin.

Version 3.2 and above unlocks support for [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) which allows backstage pods running in Kubernetes to authenticate with Azure without needing to manage secrets.  (+ for all practical purposes, it was probably the version ultimatley being sued as the 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
