### PR TITLE
Use transient for info and success alerts

### DIFF
--- a/.changeset/six-dingos-end.md
+++ b/.changeset/six-dingos-end.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-shortcuts': patch
+'@backstage/plugin-playlist': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-jenkins': patch
+'@backstage/plugin-org': patch
+---
+
+Updated `alertApi` usages with severity of `info` or `success` to use `display: transient`

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -172,7 +172,11 @@ export function AboutCard(props: AboutCardProps) {
   const refreshEntity = useCallback(async () => {
     try {
       await catalogApi.refreshEntity(stringifyEntityRef(entity));
-      alertApi.post({ message: 'Refresh scheduled', severity: 'info' });
+      alertApi.post({
+        message: 'Refresh scheduled',
+        severity: 'info',
+        display: 'transient',
+      });
     } catch (e) {
       errorApi.post(e);
     }

--- a/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -191,6 +191,7 @@ const generatedColumns: TableColumn[] = [
               alertApi.post({
                 message: 'Jenkins re-build has successfully executed',
                 severity: 'success',
+                display: 'transient',
               });
             } catch (e) {
               alertApi.post({

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -73,7 +73,11 @@ export const GroupProfileCard = (props: {
 
   const refreshEntity = useCallback(async () => {
     await catalogApi.refreshEntity(stringifyEntityRef(group));
-    alertApi.post({ message: 'Refresh scheduled', severity: 'info' });
+    alertApi.post({
+      message: 'Refresh scheduled',
+      severity: 'info',
+      display: 'transient',
+    });
   }, [catalogApi, alertApi, group]);
 
   if (!group) {

--- a/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.test.tsx
+++ b/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.test.tsx
@@ -167,6 +167,7 @@ describe('EntityPlaylistDialog', () => {
       expect(alertApi.post).toHaveBeenCalledWith({
         message: 'Entity added to playlist-2',
         severity: 'success',
+        display: 'transient',
       });
     });
   });

--- a/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.tsx
+++ b/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.tsx
@@ -159,6 +159,7 @@ export const EntityPlaylistDialog = (props: EntityPlaylistDialogProps) => {
         alertApi.post({
           message: `Entity added to ${playlist.name}`,
           severity: 'success',
+          display: 'transient',
         });
       } catch (e) {
         alertApi.post({

--- a/plugins/shortcuts/src/AddShortcut.tsx
+++ b/plugins/shortcuts/src/AddShortcut.tsx
@@ -71,6 +71,7 @@ export const AddShortcut = ({
       alertApi.post({
         message: `Added shortcut '${title}' to your sidebar`,
         severity: 'success',
+        display: 'transient',
       });
     } catch (error) {
       alertApi.post({

--- a/plugins/shortcuts/src/EditShortcut.tsx
+++ b/plugins/shortcuts/src/EditShortcut.tsx
@@ -74,6 +74,7 @@ export const EditShortcut = ({
       alertApi.post({
         message: `Updated shortcut '${title}'`,
         severity: 'success',
+        display: 'transient',
       });
     } catch (error) {
       alertApi.post({
@@ -91,6 +92,7 @@ export const EditShortcut = ({
       alertApi.post({
         message: `Removed shortcut '${shortcut.title}' from your sidebar`,
         severity: 'success',
+        display: 'transient',
       });
     } catch (error) {
       alertApi.post({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `alertApi` usages with severity of `info` or `success` to use `display: transient` this way these alerts don't stay around forever.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
