### PR TITLE
fix(bitbucketCloud,events): handle missing slug in event payload

### DIFF
--- a/.changeset/sixty-icons-brush.md
+++ b/.changeset/sixty-icons-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+---
+
+Fix missing repo slug in `repo:push` events.

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
@@ -101,7 +101,7 @@ describe('BitbucketCloudEntityProvider', () => {
     },
     repository: {
       type: 'repository',
-      slug: 'test-repo',
+      full_name: 'test-ws/test-repo',
       links: {
         html: {
           href: 'https://bitbucket.org/test-ws/test-repo',
@@ -627,7 +627,7 @@ describe('BitbucketCloudEntityProvider', () => {
         ...repoPushEventParams.eventPayload,
         repository: {
           ...repoPushEventParams.eventPayload.repository,
-          slug: 'not-matching',
+          full_name: `${repoPushEventParams.eventPayload.repository.workspace.slug}/not-matching`,
         },
       },
     });


### PR DESCRIPTION
The current handling for `repo:push` events assumed that the repo slug is provided as part of the event.

However, this is not the case which led to a few issues:

- repo slug filter was always positive as it was checked against `undefined`
- the `repo:` filter at the code search query was never applied which led to the same result as at the full refresh
  - all additionally discovered catalog files were categorized as "added"
  - this may not have caused additional API requests (not verified)

This change will enhance the event by adding the missing slug, extracted from the `full_name`
(format: `{workspace-slug}/{repo-slug}`).

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
