### PR TITLE
expose discovery.endpoints to frontend

### DIFF
--- a/.changeset/chatty-deers-shop.md
+++ b/.changeset/chatty-deers-shop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Expose discovery.endpoints configuration to use FrontendHostDiscovery

--- a/packages/core-app-api/config.d.ts
+++ b/packages/core-app-api/config.d.ts
@@ -122,4 +122,43 @@ export interface Config {
    * @visibility frontend
    */
   enableExperimentalRedirectFlow?: boolean;
+
+  /**
+   * Discovery options.
+   *
+   * @visibility frontend
+   */
+  discovery?: {
+    /**
+     * Endpoints
+     *
+     * A list of target baseUrls and the associated plugins.
+     *
+     * @visibility frontend
+     */
+    endpoints?: Array<{
+      /**
+       * The target baseUrl to use for the plugin
+       *
+       * Can be either a string or an object with internal and external keys. (Internal is used for the backend, external for the frontend)
+       * Targets with `{{pluginId}}` or `{{ pluginId }} in the url will be replaced with the pluginId.
+       *
+       * @visibility frontend
+       */
+      target:
+        | string
+        | {
+            /**
+             * @visibility frontend
+             */
+            external: string;
+          };
+      /**
+       * Array of plugins which use the target baseUrl.
+       *
+       * @visibility frontend
+       */
+      plugins: Array<string>;
+    }>;
+  };
 }


### PR DESCRIPTION
to use FrontendHostDiscovery, it must be exposed
`discovery.endpoints `configuration.

fix #18291

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

[FrontendHostDiscovery](https://github.com/backstage/backstage/blob/v1.14.2/packages/core-app-api/src/apis/implementations/DiscoveryApi/FrontendHostDiscovery.ts) read `discovery.endpoints` from configuration file, but it does not expose to frontend.
(configuration is defined at backend-common's [config.d.ts](https://github.com/backstage/backstage/blob/v1.14.2/packages/backend-common/config.d.ts))


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
