### PR TITLE
Add option to pass kinds to AnnotateScmSlugEntityProcessor, eg ['Component', 'Template'] (#17351)

### DIFF
--- a/.changeset/moody-apricots-hear.md
+++ b/.changeset/moody-apricots-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add option to pass kinds to AnnotateScmSlugEntityProcessor, e.g. ['Component', 'Template']

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -91,9 +91,15 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor_2 {
 
 // @public (undocumented)
 export class AnnotateScmSlugEntityProcessor implements CatalogProcessor_2 {
-  constructor(opts: { scmIntegrationRegistry: ScmIntegrationRegistry });
+  constructor(opts: {
+    scmIntegrationRegistry: ScmIntegrationRegistry;
+    kinds: string[];
+  });
   // (undocumented)
-  static fromConfig(config: Config): AnnotateScmSlugEntityProcessor;
+  static fromConfig(
+    config: Config,
+    kinds?: string[],
+  ): AnnotateScmSlugEntityProcessor;
   // (undocumented)
   getProcessorName(): string;
   // (undocumented)

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -93,7 +93,7 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor_2 {
 export class AnnotateScmSlugEntityProcessor implements CatalogProcessor_2 {
   constructor(opts: {
     scmIntegrationRegistry: ScmIntegrationRegistry;
-    kinds: string[];
+    kinds: Set<string>;
   });
   // (undocumented)
   static fromConfig(

--- a/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.test.ts
@@ -83,6 +83,64 @@ describe('AnnotateScmSlugEntityProcessor', () => {
       });
     });
 
+    it('does not add annotation to unknown kind', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+      };
+
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+      );
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+        },
+      });
+    });
+
+    it('adds annotation to added kind', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+      };
+
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+        ['Component', 'Template'],
+      );
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'github.com/project-slug': 'backstage/backstage',
+          },
+        },
+      });
+    });
+
     it('should not add annotation for other providers', async () => {
       const entity: Entity = {
         apiVersion: 'backstage.io/v1alpha1',
@@ -174,6 +232,63 @@ describe('AnnotateScmSlugEntityProcessor', () => {
       });
     });
 
+    it('does not add annotation to unknown kind', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://gitlab.com/group/subgroup/project/-/blob/master/catalog-info.yaml',
+      };
+
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+      );
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+        },
+      });
+    });
+
+    it('adds annotation to added kind', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://gitlab.com/group/subgroup/project/-/blob/master/catalog-info.yaml',
+      };
+
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+        ['Component', 'Template'],
+      );
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'gitlab.com/project-slug': 'group/subgroup/project',
+          },
+        },
+      });
+    });
     it('should not add annotation for other providers', async () => {
       const entity: Entity = {
         apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.ts
@@ -31,16 +31,23 @@ const GITLAB_ACTIONS_ANNOTATION = 'gitlab.com/project-slug';
 /** @public */
 export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   constructor(
-    private readonly opts: { scmIntegrationRegistry: ScmIntegrationRegistry },
+    private readonly opts: {
+      scmIntegrationRegistry: ScmIntegrationRegistry;
+      kinds: string[];
+    },
   ) {}
 
   getProcessorName(): string {
     return 'AnnotateScmSlugEntityProcessor';
   }
 
-  static fromConfig(config: Config): AnnotateScmSlugEntityProcessor {
+  static fromConfig(
+    config: Config,
+    kinds?: string[],
+  ): AnnotateScmSlugEntityProcessor {
     return new AnnotateScmSlugEntityProcessor({
       scmIntegrationRegistry: ScmIntegrations.fromConfig(config),
+      kinds: kinds || ['Component'],
     });
   }
 
@@ -48,7 +55,7 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
     entity: Entity,
     location: LocationSpec,
   ): Promise<Entity> {
-    if (entity.kind !== 'Component' || location.type !== 'url') {
+    if (!this.opts.kinds.includes(entity.kind) || location.type !== 'url') {
       return entity;
     }
 

--- a/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateScmSlugEntityProcessor.ts
@@ -33,7 +33,7 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   constructor(
     private readonly opts: {
       scmIntegrationRegistry: ScmIntegrationRegistry;
-      kinds: string[];
+      kinds: Set<string>;
     },
   ) {}
 
@@ -45,9 +45,17 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
     config: Config,
     kinds?: string[],
   ): AnnotateScmSlugEntityProcessor {
+    const uniqueKinds = new Set<string>();
+    if (kinds) {
+      kinds.forEach(kind => {
+        uniqueKinds.add(kind.toLowerCase());
+      });
+    } else {
+      uniqueKinds.add('component');
+    }
     return new AnnotateScmSlugEntityProcessor({
       scmIntegrationRegistry: ScmIntegrations.fromConfig(config),
-      kinds: kinds || ['Component'],
+      kinds: uniqueKinds,
     });
   }
 
@@ -55,7 +63,10 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
     entity: Entity,
     location: LocationSpec,
   ): Promise<Entity> {
-    if (!this.opts.kinds.includes(entity.kind) || location.type !== 'url') {
+    if (
+      !this.opts.kinds.has(entity.kind.toLowerCase()) ||
+      location.type !== 'url'
+    ) {
       return entity;
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add option to pass kinds to AnnotateScmSlugEntityProcessor, like discussed in #17351 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
