### PR TITLE
fix api base url usage in gitlab integration

### DIFF
--- a/.changeset/dry-jobs-smash.md
+++ b/.changeset/dry-jobs-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+Fixed bug in Gitlab Integration where even if `apiBaseUrl` was specified some requests used the `baseUrl` instead in API calls

--- a/docs/integrations/gitlab/locations.md
+++ b/docs/integrations/gitlab/locations.md
@@ -30,9 +30,7 @@ structure with up to four elements:
 - `host`: The host of the GitLab instance, e.g. `gitlab.company.com`.
 - `token` (optional): An authentication token as expected by GitLab. The token need at least `api`, `read_repository` and `write_repository` scopes. If this is
   not supplied, anonymous access will be used.
-- `apiBaseUrl` (optional): The URL of the GitLab API. For self-hosted
-  installations, it is commonly at `https://<host>/api/v4`. For gitlab.com, this
-  configuration is not needed as it can be inferred.
 - `baseUrl` (optional): The base URL for this provider, e.g.
   `https://gitlab.com`. If this is not provided, it is assumed to be
   `https://{host}`.
+- `apiBaseUrl` (optional): The URL of the GitLab API. If this is not provided, it is assumed to be `https://{baseUrl}/api/v4`.

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -99,10 +99,18 @@ describe('GitlabUrlReader', () => {
       );
     });
 
-    const createConfig = (token?: string) =>
+    const createGitlabComConfig = (token?: string) =>
       new ConfigReader(
         {
           integrations: { gitlab: [{ host: 'gitlab.com', token }] },
+        },
+        'test-config',
+      );
+
+    const createPrivateGitlabConfig = (token?: string) =>
+      new ConfigReader(
+        {
+          integrations: { gitlab: [{ host: 'gitlab.example.com', token }] },
         },
         'test-config',
       );
@@ -111,7 +119,7 @@ describe('GitlabUrlReader', () => {
       // Scoped routes
       {
         url: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
-        config: createConfig(),
+        config: createGitlabComConfig(),
         response: expect.objectContaining({
           url: 'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
           headers: expect.objectContaining({
@@ -121,7 +129,7 @@ describe('GitlabUrlReader', () => {
       },
       {
         url: 'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
-        config: createConfig('0123456789'),
+        config: createPrivateGitlabConfig('0123456789'),
         response: expect.objectContaining({
           url: 'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
           headers: expect.objectContaining({
@@ -131,7 +139,7 @@ describe('GitlabUrlReader', () => {
       },
       {
         url: 'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path/to/file.yaml', // Repo not in subgroup
-        config: createConfig(),
+        config: createGitlabComConfig(),
         response: expect.objectContaining({
           url: 'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
         }),
@@ -140,7 +148,7 @@ describe('GitlabUrlReader', () => {
       // Unscoped route
       {
         url: 'https://gitlab.example.com/a/b/blob/master/c.yaml',
-        config: createConfig(),
+        config: createPrivateGitlabConfig(),
         response: expect.objectContaining({
           url: 'https://gitlab.example.com/api/v4/projects/12345/repository/files/c.yaml/raw?ref=master',
         }),
@@ -161,7 +169,7 @@ describe('GitlabUrlReader', () => {
     it.each([
       {
         url: '',
-        config: createConfig(''),
+        config: createGitlabComConfig(''),
         error:
           "Invalid type in config for key 'integrations.gitlab[0].token' in 'test-config', got empty-string, wanted string",
       },

--- a/packages/integration/src/gitlab/config.test.ts
+++ b/packages/integration/src/gitlab/config.test.ts
@@ -157,4 +157,61 @@ describe('readGitLabIntegrationConfigs', () => {
       },
     ]);
   });
+
+  it('adds a default apiBaseUrl when missing', () => {
+    const output = readGitLabIntegrationConfigs(
+      buildConfig([
+        {
+          host: 'a.com',
+          token: 't',
+        },
+      ]),
+    );
+
+    expect(output).toContainEqual({
+      host: 'a.com',
+      token: 't',
+      apiBaseUrl: 'https://a.com/api/v4',
+      baseUrl: 'https://a.com',
+    });
+  });
+
+  it('adds a default apiBaseUrl based on baseUrl', () => {
+    const output = readGitLabIntegrationConfigs(
+      buildConfig([
+        {
+          host: 'a.com',
+          baseUrl: 'https://a.com/gitlab',
+          token: 't',
+        },
+      ]),
+    );
+
+    expect(output).toContainEqual({
+      host: 'a.com',
+      token: 't',
+      apiBaseUrl: 'https://a.com/gitlab/api/v4',
+      baseUrl: 'https://a.com/gitlab',
+    });
+  });
+
+  it('respects given apiBaseUrl', () => {
+    const output = readGitLabIntegrationConfigs(
+      buildConfig([
+        {
+          host: 'a.com',
+          baseUrl: 'https://a.com/gitlab',
+          apiBaseUrl: 'http://internal.gitlab/api/v4',
+          token: 't',
+        },
+      ]),
+    );
+
+    expect(output).toContainEqual({
+      host: 'a.com',
+      token: 't',
+      apiBaseUrl: 'http://internal.gitlab/api/v4',
+      baseUrl: 'https://a.com/gitlab',
+    });
+  });
 });

--- a/packages/integration/src/gitlab/config.ts
+++ b/packages/integration/src/gitlab/config.ts
@@ -66,12 +66,17 @@ export function readGitLabIntegrationConfig(
   config: Config,
 ): GitLabIntegrationConfig {
   const host = config.getString('host');
-  let apiBaseUrl = config.getOptionalString('apiBaseUrl');
+
+  let baseUrl = config.getOptionalString('baseUrl') || `https://${host}`;
+  let apiBaseUrl =
+    config.getOptionalString('apiBaseUrl') || `${baseUrl}/api/v4`;
   const token = config.getOptionalString('token');
-  let baseUrl = config.getOptionalString('baseUrl');
+
   if (apiBaseUrl) {
     apiBaseUrl = trimEnd(apiBaseUrl, '/');
-  } else if (host === GITLAB_HOST) {
+  }
+
+  if (host === GITLAB_HOST) {
     apiBaseUrl = GITLAB_API_BASE_URL;
   }
 
@@ -134,9 +139,6 @@ export function readGitLabIntegrationConfigs(
 export function getGitLabIntegrationRelativePath(
   config: GitLabIntegrationConfig,
 ): string {
-  let relativePath = '';
-  if (config.host !== GITLAB_HOST) {
-    relativePath = new URL(config.baseUrl).pathname;
-  }
+  const relativePath = new URL(config.baseUrl).pathname;
   return trimEnd(relativePath, '/');
 }

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -78,11 +78,11 @@ export function buildProjectUrl(
       .slice(1)
       .join('/blob/');
     const [branch, ...filePath] = branchAndFilePath.split('/');
-    const relativePath = getGitLabIntegrationRelativePath(config);
+    const apiRelativePath = new URL(config.apiBaseUrl).pathname;
 
     url.pathname = [
-      ...(relativePath ? [relativePath] : []),
-      'api/v4/projects',
+      apiRelativePath,
+      'projects',
       projectID,
       'repository/files',
       encodeURIComponent(decodeURIComponent(filePath.join('/'))),
@@ -90,6 +90,10 @@ export function buildProjectUrl(
     ].join('/');
 
     url.search = `?ref=${branch}`;
+
+    const apiBaseUrl = new URL(config.apiBaseUrl);
+    url.host = apiBaseUrl.host;
+    url.protocol = apiBaseUrl.protocol;
 
     return url;
   } catch (e) {
@@ -124,7 +128,7 @@ export async function getProjectId(
     // Convert
     // to: https://gitlab.com/api/v4/projects/groupA%2Fteams%2FsubgroupA%2FteamA%2Frepo
     const repoIDLookup = new URL(
-      `${url.origin}${relativePath}/api/v4/projects/${encodeURIComponent(
+      `${config.apiBaseUrl}/projects/${encodeURIComponent(
         repo.replace(/^\//, ''),
       )}`,
     );


### PR DESCRIPTION
Signed-off-by: Jefferson Girao <jefferson@girao.net>

## Hey, I just made a Pull Request!

* whenever `apiBaseUrl` is specified then ensure it is used for all API calls.

* make `baseUrl` and `apiBaseUrl` optional in the configuration where a default for `apiBaseUrl` is derived from `baseUrl` and a `baseUrl` can be derived from `host`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
