### PR TITLE
[cli] Add `--alwaysYarnPack` flag to build-workspace command

### DIFF
--- a/.changeset/cli-packs-a-punch.md
+++ b/.changeset/cli-packs-a-punch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/cli': patch
+---
+
+Introduced the `--alwaysYarnPack` flag on `backstage-cli build-workspace`, which can be passed in cases where accuracy of workspace contents is more important than the
+speed with which the workspace is built. Useful in rare situations where `yarn pack` and `npm pack` produce different results.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -24,7 +24,7 @@ Commands:
   versions:bump [options]
   versions:check [options]
   clean
-  build-workspace <workspace-dir> [packages...]
+  build-workspace [options] <workspace-dir> [packages...]
   create-github-app <github-org>
   info
   help [command]
@@ -36,6 +36,7 @@ Commands:
 Usage: backstage-cli build-workspace [options] <workspace-dir> [packages...]
 
 Options:
+  --alwaysYarnPack
   -h, --help
 ```
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -402,6 +402,10 @@ export function registerCommands(program: Command) {
 
   program
     .command('build-workspace <workspace-dir> [packages...]')
+    .option(
+      '--alwaysYarnPack',
+      'Force workspace output to be a result of running `yarn pack` on each package (warning: very slow)',
+    )
     .description('Builds a temporary dist workspace from the provided packages')
     .action(lazy(() => import('./buildWorkspace').then(m => m.default)));
 


### PR DESCRIPTION
## What / Why

Turns out there's a discrepancy in the way `npm pack` and `yarn pack` determine which files to include in a package.  Specifically: if a pattern listed in a `package.json`'s `files` property is a sub-directory, `npm` will include the contents of the subdirectory, while `yarn` will ignore it.  Upstream bug report for that here: https://github.com/yarnpkg/berry/issues/5032

This PR proposes adding a flag `--alwaysYarnPack` to `backstage-cli build-workspace`, which allows folks who pack/publish plugins using yarn to build workspaces in a way consistent with their chosen packing/publishing mechanisms (at the expense of workspace creation performance).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
