### PR TITLE
Fix issue with clicking on tech radar items

### DIFF
--- a/.changeset/silver-bags-wonder.md
+++ b/.changeset/silver-bags-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Fixed bug in tech radar plugin causing toLocaleDateString error when clicking an item

--- a/plugins/tech-radar/src/components/RadarTimeline/RadarTimeline.tsx
+++ b/plugins/tech-radar/src/components/RadarTimeline/RadarTimeline.tsx
@@ -80,9 +80,7 @@ const RadarTimeline = (props: Props): JSX.Element => {
                   {timeEntry.ring.name ? timeEntry.ring.name : ''}
                 </TableCell>
                 <TableCell align="left">
-                  {timeEntry.date.toLocaleDateString()
-                    ? timeEntry.date.toLocaleDateString()
-                    : ''}
+                  {timeEntry.date ? timeEntry.date : ''}
                 </TableCell>
                 <TableCell align="left">
                   {timeEntry.description ? timeEntry.description : ''}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Clicking on an item in the tech-radar causes JavaScript error because a string is wrongly used as a date

How it looks today:
![sh](https://github.com/backstage/backstage/assets/44162083/5189cfda-7274-41b7-acb7-ea65e8bf5b93)

How it's supposed to look after fix:
![sh2](https://github.com/backstage/backstage/assets/44162083/8081ec1e-d11b-4177-8fbb-504c7d94031e)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
