### PR TITLE
[repo-tools] Command to create/update `catalog-info.yaml` files for Backstage Packages

### DIFF
--- a/.changeset/repo-tools-yo-dawg.md
+++ b/.changeset/repo-tools-yo-dawg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Introducing a new, experimental command `backstage-repo-tools generate-catalog-info`, which can be used to create standardized `catalog-info.yaml` files for each Backstage package in a Backstage monorepo. It can also be used to automatically fix existing `catalog-info.yaml` files with the correct metadata (including `metadata.name`, `metadata.title`, and `metadata.description` introspected from the package's `package.json`, as well as `spec.owner` introspected from `CODEOWNERS`), e.g. in a post-commit hook.

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -14,6 +14,7 @@ Options:
 Commands:
   api-reports [options] [paths...]
   type-deps
+  generate-catalog-info [options]
   schema [command]
   help [command]
 ```
@@ -33,6 +34,16 @@ Options:
   --allow-all-warnings
   -o, --omit-messages <messageCodes>
   --validate-release-tags
+  -h, --help
+```
+
+### `backstage-repo-tools generate-catalog-info`
+
+```
+Usage: backstage-repo-tools generate-catalog-info [options]
+
+Options:
+  --dry-run
   -h, --help
 ```
 

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@apisyouwonthate/style-guide": "^1.4.0",
+    "@backstage/catalog-model": "workspace:^",
     "@backstage/cli-common": "workspace:^",
     "@backstage/cli-node": "workspace:^",
     "@backstage/errors": "workspace:^",
@@ -46,6 +47,7 @@
     "@stoplight/spectral-runtime": "^1.1.2",
     "@stoplight/types": "^13.14.0",
     "chalk": "^4.0.0",
+    "codeowners-utils": "^1.0.2",
     "commander": "^9.1.0",
     "fs-extra": "10.1.0",
     "glob": "^8.0.3",
@@ -54,7 +56,8 @@
     "lodash": "^4.17.21",
     "minimatch": "^5.1.1",
     "p-limit": "^3.0.2",
-    "ts-node": "^10.0.0"
+    "ts-node": "^10.0.0",
+    "yaml-diff-patch": "^2.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/packages/repo-tools/src/commands/generate-catalog-info/codeowners.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/codeowners.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  CodeOwnersEntry,
+  CODEOWNERS_PATHS,
+  matchFile as matchCodeowner,
+  parse as parseCodeowners,
+} from 'codeowners-utils';
+import { relative as relativePath, resolve as resolvePath } from 'path';
+import { readFile } from './utils';
+
+export async function loadCodeowners(): Promise<CodeOwnersEntry[]> {
+  const maybeFiles = await Promise.allSettled(
+    CODEOWNERS_PATHS.map(async path =>
+      readFile(resolvePath('.', path), { encoding: 'utf-8' }),
+    ),
+  );
+  const file = maybeFiles.find(
+    maybeFile => maybeFile.status === 'fulfilled',
+  ) as PromiseFulfilledResult<string> | undefined;
+
+  if (!file) {
+    throw new Error(
+      'This utility expects a CODEOWNERS file, but no such file was found.',
+    );
+  }
+
+  return parseCodeowners(file.value);
+}
+
+export function getPossibleCodeowners(
+  codeowners: CodeOwnersEntry[],
+  relPath: string,
+): string[] {
+  const codeownerMaybe = matchCodeowner(relPath, codeowners);
+  return codeownerMaybe
+    ? codeownerMaybe.owners.map(
+        owner => (owner.match(/(?:\@[^\/]+\/)?([^\@\/]*)$/) || [])[1],
+      )
+    : [];
+}
+
+export function getOwnerFromCodeowners(
+  codeowners: CodeOwnersEntry[],
+  absPath: string,
+): string {
+  const relPath = relativePath('.', absPath);
+  const possibleOwners = getPossibleCodeowners(codeowners, relPath);
+  const owner = possibleOwners.slice(-1)[0];
+
+  if (!owner) {
+    throw new Error(`${relPath} isn't owned by anyone in CODEOWNERS`);
+  }
+
+  return owner;
+}

--- a/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import YAML from 'js-yaml';
+import pLimit from 'p-limit';
+import { relative as relativePath, resolve as resolvePath } from 'path';
+import { yamlOverwrite } from 'yaml-diff-patch';
+import chalk from 'chalk';
+import { PackageGraph, PackageRole } from '@backstage/cli-node';
+import { Entity } from '@backstage/catalog-model';
+import {
+  getOwnerFromCodeowners,
+  getPossibleCodeowners,
+  loadCodeowners,
+} from './codeowners';
+import {
+  BackstagePackageJson,
+  isBackstagePackage,
+  readFile,
+  writeFile,
+} from './utils';
+import { CodeOwnersEntry } from 'codeowners-utils';
+
+type CreateFixPackageInfoYamlsOptions = {
+  dryRun?: boolean;
+};
+
+export default async (opts: CreateFixPackageInfoYamlsOptions) => {
+  const { dryRun = false } = opts;
+  const packages = await PackageGraph.listTargetPackages();
+  const codeowners = await loadCodeowners();
+  const limit = pLimit(10);
+
+  const results = await Promise.allSettled<void>(
+    packages.map(({ packageJson, dir }) =>
+      limit(async () => {
+        if (!isBackstagePackage(packageJson)) {
+          return;
+        }
+
+        // Check if there is already a corresponding catalog-info.yaml
+        const infoYamlPath = resolvePath(dir, 'catalog-info.yaml');
+        let yamlString = '';
+
+        try {
+          yamlString = await readFile(infoYamlPath, { encoding: 'utf-8' });
+        } catch (e) {
+          if (e.code === 'ENOENT') {
+            await createCatalogInfoYaml({
+              yamlPath: infoYamlPath,
+              packageJson,
+              codeowners,
+              dryRun,
+            });
+            return;
+          }
+
+          throw e;
+        }
+
+        fixCatalogInfoYaml({
+          yamlPath: infoYamlPath,
+          packageJson,
+          codeowners,
+          yamlString,
+          dryRun,
+        });
+      }),
+    ),
+  );
+
+  const rejects = results.filter(
+    r => r.status === 'rejected',
+  ) as PromiseRejectedResult[];
+  if (rejects.length > 0) {
+    // Problems encountered. Print details here.
+    console.error(
+      chalk.red('Unable to create or fix catalog-info.yaml files\n'),
+    );
+    rejects.forEach(reject => console.error(`  ${reject.reason}`));
+    console.error();
+    process.exit(1);
+  }
+};
+
+type CreateOptions = {
+  yamlPath: string;
+  packageJson: BackstagePackageJson;
+  codeowners: CodeOwnersEntry[];
+  dryRun: boolean;
+};
+
+type FixOptions = CreateOptions & {
+  yamlString: string;
+};
+
+type BackstagePackageEntity = Entity & {
+  spec: {
+    type: 'backstage-package';
+    backstageRole: PackageRole;
+    lifecycle: string;
+    owner: string;
+    [key: string]: any;
+  };
+};
+
+function createCatalogInfoYaml(options: CreateOptions) {
+  const { codeowners, dryRun, packageJson, yamlPath } = options;
+  const owner = getOwnerFromCodeowners(codeowners, yamlPath);
+  const entity = createOrMergeEntity(packageJson, owner);
+
+  return dryRun
+    ? Promise.resolve(console.error(`Create ${relativePath('.', yamlPath)}`))
+    : writeFile(yamlPath, YAML.dump(entity));
+}
+
+function fixCatalogInfoYaml(options: FixOptions) {
+  const { codeowners, dryRun, packageJson, yamlPath, yamlString } = options;
+  const possibleOwners = getPossibleCodeowners(
+    codeowners,
+    relativePath('.', yamlPath),
+  );
+  const safeName = packageJson.name
+    .replace(/[^a-z0-9_\-\.]+/g, '-')
+    .replace(/^[^a-z0-9]|[^a-z0-9]$/g, '');
+  let yamlJson: BackstagePackageEntity;
+
+  try {
+    yamlJson = YAML.load(yamlString) as BackstagePackageEntity;
+  } catch (e) {
+    throw new Error(`Unable to parse ${relativePath('.', yamlPath)}: ${e}`);
+  }
+
+  const badOwner = !possibleOwners.includes(yamlJson.spec?.owner);
+  const badTitle = yamlJson.metadata.title !== packageJson.name;
+  const badName = yamlJson.metadata.name !== safeName;
+  const badType =
+    yamlJson.spec?.type !== `backstage-${packageJson.backstage.role}`;
+  const badDesc = yamlJson.metadata.description !== packageJson.description;
+
+  if (badOwner || badTitle || badName || badType || badDesc) {
+    const owner = badOwner
+      ? getOwnerFromCodeowners(codeowners, yamlPath)
+      : yamlJson.spec?.owner;
+    const newJson = createOrMergeEntity(packageJson, owner, yamlJson);
+    return dryRun
+      ? Promise.resolve(console.error(`Update ${relativePath('.', yamlPath)}`))
+      : writeFile(yamlPath, yamlOverwrite(yamlString, newJson));
+  }
+
+  return Promise.resolve();
+}
+
+/**
+ * Canonical representation on how to create (or update) a backstage-package
+ * component.
+ */
+function createOrMergeEntity(
+  packageJson: BackstagePackageJson,
+  owner: string,
+  existingEntity: BackstagePackageEntity | Record<string, any> = {},
+): BackstagePackageEntity {
+  const safeEntityName = packageJson.name
+    .replace(/[^a-z0-9_\-\.]+/g, '-')
+    .replace(/^[^a-z0-9]|[^a-z0-9]$/g, '');
+
+  return {
+    ...existingEntity,
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      ...existingEntity.metadata,
+      // Provide default name/title/description values.
+      name: safeEntityName,
+      title: packageJson.name,
+      ...(packageJson.description
+        ? { description: packageJson.description }
+        : undefined),
+    },
+    spec: {
+      lifecycle: 'experimental',
+      ...existingEntity.spec,
+      type: `backstage-${packageJson.backstage.role}`,
+      owner,
+    },
+  };
+}

--- a/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
@@ -71,7 +71,7 @@ export default async (opts: CreateFixPackageInfoYamlsOptions) => {
           throw e;
         }
 
-        fixCatalogInfoYaml({
+        await fixCatalogInfoYaml({
           yamlPath: infoYamlPath,
           packageJson,
           codeowners,

--- a/packages/repo-tools/src/commands/generate-catalog-info/utils.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/utils.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import { Package } from '@manypkg/get-packages';
+import {
+  BackstagePackageJson as BackstagePackageJsonActual,
+  PackageRole,
+} from '@backstage/cli-node';
+import { promisify } from 'util';
+
+export const readFile = promisify(fs.readFile);
+export const writeFile = promisify(fs.writeFile);
+
+export type BackstagePackageJson = BackstagePackageJsonActual & {
+  description?: string;
+  backstage: {
+    role: PackageRole;
+  };
+};
+
+export function isBackstagePackage(
+  packageJson: Package['packageJson'],
+): packageJson is BackstagePackageJson {
+  return (
+    packageJson &&
+    packageJson.hasOwnProperty('backstage') &&
+    (packageJson as any)?.backstage?.role !== 'undefined'
+  );
+}

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -96,6 +96,21 @@ export function registerCommands(program: Command) {
     .description('Find inconsistencies in types of all packages and plugins')
     .action(lazy(() => import('./type-deps/type-deps').then(m => m.default)));
 
+  program
+    .command('generate-catalog-info')
+    .option(
+      '--dry-run',
+      'Shows what would happen without actually writing any yaml.',
+    )
+    .description('Create or fix info yaml files for all backstage packages')
+    .action(
+      lazy(() =>
+        import('./generate-catalog-info/generate-catalog-info').then(
+          m => m.default,
+        ),
+      ),
+    );
+
   registerSchemaCommand(program);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9537,6 +9537,7 @@ __metadata:
   dependencies:
     "@apidevtools/swagger-parser": ^10.1.0
     "@apisyouwonthate/style-guide": ^1.4.0
+    "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@backstage/cli-node": "workspace:^"
@@ -9556,6 +9557,7 @@ __metadata:
     "@types/mock-fs": ^4.13.0
     "@types/node": ^16.11.26
     chalk: ^4.0.0
+    codeowners-utils: ^1.0.2
     commander: ^9.1.0
     fs-extra: 10.1.0
     glob: ^8.0.3
@@ -9566,6 +9568,7 @@ __metadata:
     mock-fs: ^5.1.0
     p-limit: ^3.0.2
     ts-node: ^10.0.0
+    yaml-diff-patch: ^2.0.0
   peerDependencies:
     "@microsoft/api-extractor-model": "*"
     "@microsoft/tsdoc": "*"
@@ -25603,7 +25606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-patch@npm:^3.0.0-1":
+"fast-json-patch@npm:^3.0.0-1, fast-json-patch@npm:^3.1.0":
   version: 3.1.1
   resolution: "fast-json-patch@npm:3.1.1"
   checksum: c4525b61b2471df60d4b025b4118b036d99778a93431aa44d1084218182841d82ce93056f0f3bbd731a24e6a8e69820128adf1873eb2199a26c62ef58d137833
@@ -33970,6 +33973,15 @@ __metadata:
     object-hash: ^2.2.0
     oidc-token-hash: ^5.0.3
   checksum: 0e5a126b77dad0320e8f7023ac7ad7f5f1f82ad5f985f7ab0b42a7cf36700dfb78f0bef9b59c1fae915dce0148ef191b49921cd0a01443b64c04f862d9dc03e0
+  languageName: node
+  linkType: hard
+
+"oppa@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "oppa@npm:0.4.0"
+  dependencies:
+    chalk: ^4.1.1
+  checksum: ecc43e63ede05c3ccb10e0f2c3f3020a6d72e1a3b318f3e37b8cc8a1a279e300991c043e5385d560c1eebb54a56c7f9b69bf0db0d1933acf350bcd2980c96055
   languageName: node
   linkType: hard
 
@@ -42833,6 +42845,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml-diff-patch@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "yaml-diff-patch@npm:2.0.0"
+  dependencies:
+    fast-json-patch: ^3.1.0
+    oppa: ^0.4.0
+    yaml: ^2.0.0-10
+  bin:
+    yaml-diff-patch: dist/bin/yaml-patch.js
+    yaml-overwrite: dist/bin/yaml-patch.js
+    yaml-patch: dist/bin/yaml-patch.js
+  checksum: 5207d8523584eb6088fe32a0c6010599260ecfa5f959d120a1bad02f19143d1ddeafe10c37ccf125ac04d079072a5ead92b55c6787fd64d12f5acbb0d172e7ec
+  languageName: node
+  linkType: hard
+
 "yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
@@ -42840,10 +42867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.1.1, yaml@npm:^2.2.1, yaml@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "yaml@npm:2.2.2"
-  checksum: d90c235e099e30094dcff61ba3350437aef53325db4a6bcd04ca96e1bfe7e348b191f6a7a52b5211e2dbc4eeedb22a00b291527da030de7c189728ef3f2b4eb3
+"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.1.1, yaml@npm:^2.2.1, yaml@npm:^2.2.2":
+  version: 2.3.1
+  resolution: "yaml@npm:2.3.1"
+  checksum: 2c7bc9a7cd4c9f40d3b0b0a98e370781b68b8b7c4515720869aced2b00d92f5da1762b4ffa947f9e795d6cd6b19f410bd4d15fdd38aca7bd96df59bd9486fb54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## tl;dr
A new `backstage-repo-tools` command to help maintain `catalog-info.yaml` files representing Backstage plugin packages, including a standard for such components.

The command can be invoked very simply:

```sh
# See what would happen
backstage-repo-tools generate-catalog-info --dry-run

# Actually do the thing
backstage-repo-tools generate-catalog-info
```

## What / Why

<!--
At Spotify, we build and maintain hundreds of Backstage plugins owned by many dozens of teams.  Just as the cobbler's children have no shoes, so too do we have no strategy for tracking Backstage plugins in our Software Catalog.

This PR proposes a strategy!  At its essence:

- **The Model**: A Backstage plugin should be modeled as a `Component` of type `backstage-package`.
- **The Method**: All the metadata necessary to generate a minimum viable entity can be introspected from a plugin's `package.json` in combination with a `CODEOWNERS` file.  We'll introduce a `backstage-repo-tools` command that can automatically create `catalog-info.yaml` files based on this metadata, stored as a sibling of the `package.json` file.
- **Incentives**: Enabling teams to modify and deploy changes to their plugins without the need to interact with the core team is key to our InnerSource strategy; we achieve this through `CODEOWNERS`. Aligning plugin ownership with code ownership ensures both code ownership and catalog metadata is up-to-date. That's why this `backstage-repo-tools` command will not only create, but also transparently _update_ these `catalog-info.yaml` files to stay in sync with any `CODEOWNERS` and `package.json` changes. This allows the command to be used in a pre-commit hook, for example, and used in the same way as `prettier --fix`.
- **Customization close to the code**: Though we can cobble together (😉) a basic entity from a `package.json`, there will inevitably be a need to add customizations (system, tags, links, etc). That's why the update capabilities of this `backstage-repo-tools` command will do its best to leave any fields (and formatting) that are not easily introspected untouched.
- **Customization outside the code too**:  We also have situations where we can't keep that metadata close to the code (e.g. we maintain many of the plugins in this very monorepo!).  This PR does not directly address this need, but we can rely on custom entity processors to handle needs like mapping groups/individuals in `spec.owner` to internal owners or applying custom metadata like internal system names, internal documentation links, etc.
-->

This will create any missing `catalog-info.yaml` files, and update existing `catalog-info.yaml` files so that they conform to a proposed minimum standard:

```yaml
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: backstage-plugin-foo # must always be slugified version of "name" key in package.json
  title: '@backstage/plugin-foo' # must always be the "name" key in package.json
spec:
  type: backstage-frontend-plugin # must always be `backstage-` followed by the "backstage.role" key in package.json
  owner: maintainers # should match a CODEOWNER who owns the file/dir, stripped of any preceding org
```

Any extra metadata beyond the above minimum set of metadata will be maintained when the command is re-run (e.g. `spec.lifecycle`, annotations, etc).

Although this PR does not add generated `catalog-info.yaml` files _yet_, I intend to add them in a follow-up PR, alongside a pre-commit hook and build step that ensures that they remain up-to-date with respect to `package.json` and `CODEOWNER` changes, where the goal would be to experiment with their utility in the monorepo.

This is an update to (and replacement for) #17934

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
