### PR TITLE
[cli] Fix --alwaysYarnPack flag

### DIFF
--- a/.changeset/cli-always-yarn-pack-freal.md
+++ b/.changeset/cli-always-yarn-pack-freal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed the `--alwaysYarnPack` flag on the`backstage-cli build-workspace` command.

--- a/packages/cli/src/commands/buildWorkspace.ts
+++ b/packages/cli/src/commands/buildWorkspace.ts
@@ -17,12 +17,17 @@
 import fs from 'fs-extra';
 import { createDistWorkspace } from '../lib/packager';
 
-export default async (dir: string, packages: string[]) => {
+type Options = {
+  alwaysYarnPack?: boolean;
+};
+
+export default async (dir: string, packages: string[], options: Options) => {
   if (!(await fs.pathExists(dir))) {
     throw new Error(`Target workspace directory doesn't exist, '${dir}'`);
   }
 
   await createDistWorkspace(packages, {
     targetDir: dir,
+    alwaysYarnPack: options.alwaysYarnPack,
   });
 };


### PR DESCRIPTION
## What / Why

Turns out the command function and definition are in different places and the flag has to be passed down one more layer. 😐 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
