### PR TITLE
[Search]: Optimize search bar test suite

### DIFF
--- a/plugins/search-react/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { screen, render, waitFor, act } from '@testing-library/react';
+import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { configApiRef, analyticsApiRef } from '@backstage/core-plugin-api';
 import { ConfigReader } from '@backstage/core-app-api';
@@ -41,15 +41,22 @@ const createInitialState = ({
 });
 
 describe('SearchBar', () => {
+  const user = userEvent.setup({ delay: null });
+
   const query = jest.fn().mockResolvedValue({ results: [] });
 
-  const analyticsApiMock = new MockAnalyticsApi();
+  const searchApiMock = { query };
 
   const configApiMock = new ConfigReader({
-    app: { title: 'Mock title' },
+    app: {
+      title: 'Mock title',
+      analytics: {
+        ga: {
+          trackingId: 'xyz123',
+        },
+      },
+    },
   });
-
-  const searchApiMock = { query };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -64,20 +71,20 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider>
-          <SearchBar />
+          <SearchBar debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Search')).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByLabelText('Search')).toBeInTheDocument(),
+    );
   });
 
   it('Renders with custom label', async () => {
     const label = 'label';
 
-    const result = await renderWithEffects(
+    await renderWithEffects(
       <TestApiProvider
         apis={[
           [configApiRef, configApiMock],
@@ -85,14 +92,14 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider>
-          <SearchBar label={label} />
+          <SearchBar label={label} debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    await waitFor(() => {
-      expect(result.getByLabelText(label)).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByLabelText(label)).toBeInTheDocument(),
+    );
   });
 
   it('Renders with custom placeholder', async () => {
@@ -106,20 +113,20 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider>
-          <SearchBar placeholder={placeholder} />
+          <SearchBar placeholder={placeholder} debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument(),
+    );
   });
 
   it('Renders based on initial search', async () => {
     const term = 'term';
 
-    render(
+    await renderWithEffects(
       <TestApiProvider
         apis={[
           [configApiRef, configApiMock],
@@ -127,19 +134,18 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider initialState={createInitialState({ term })}>
-          <SearchBar />
+          <SearchBar debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: 'Search' })).toHaveValue(term);
-    });
+    await waitFor(() =>
+      expect(screen.getByLabelText('Search')).toHaveValue(term),
+    );
   });
 
   it('Updates term state when text is entered', async () => {
     jest.useFakeTimers();
-    const user = userEvent.setup({ delay: null });
 
     await renderWithEffects(
       <TestApiProvider
@@ -154,7 +160,7 @@ describe('SearchBar', () => {
       </TestApiProvider>,
     );
 
-    const textbox = screen.getByRole('textbox', { name: 'Search' });
+    const textbox = screen.getByLabelText('Search');
 
     const value = 'value';
 
@@ -164,14 +170,13 @@ describe('SearchBar', () => {
       jest.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(textbox).toHaveValue(value);
-    });
+    await waitFor(() => expect(textbox).toHaveValue(value));
 
     expect(query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: value }),
     );
 
+    jest.runAllTimers();
     jest.useRealTimers();
   });
 
@@ -186,22 +191,18 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider initialState={createInitialState({ term })}>
-          <SearchBar />
+          <SearchBar debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    const textbox = screen.getByRole('textbox', { name: 'Search' });
+    const textbox = screen.getByLabelText('Search');
 
-    await waitFor(() => {
-      expect(textbox).toHaveValue(term);
-    });
+    await waitFor(() => expect(textbox).toHaveValue(term));
 
-    await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    await user.click(screen.getByLabelText('Clear'));
 
-    await waitFor(() => {
-      expect(textbox).toHaveValue('');
-    });
+    await waitFor(() => expect(textbox).toHaveValue(''));
 
     expect(query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: '' }),
@@ -219,22 +220,20 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider initialState={createInitialState({ term })}>
-          <SearchBar clearButton={false} />
+          <SearchBar clearButton={false} debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: 'Clear' }),
-      ).not.toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Clear')).not.toBeInTheDocument(),
+    );
   });
 
   it('Adheres to provided debounceTime', async () => {
     jest.useFakeTimers();
-    const user = userEvent.setup({ delay: null });
-    const debounceTime = 600;
+
+    const debounceTime = 100;
 
     await renderWithEffects(
       <TestApiProvider
@@ -249,36 +248,34 @@ describe('SearchBar', () => {
       </TestApiProvider>,
     );
 
-    const textbox = await screen.findByRole('textbox', { name: 'Search' });
+    const textbox = screen.getByLabelText('Search');
 
     const value = 'value';
 
     await user.type(textbox, value);
 
-    await waitFor(() => {
+    await waitFor(() =>
       expect(query).not.toHaveBeenLastCalledWith(
         expect.objectContaining({ term: value }),
-      );
-    });
+      ),
+    );
 
     act(() => {
       jest.advanceTimersByTime(debounceTime);
     });
 
-    await waitFor(() => {
-      expect(textbox).toHaveValue(value);
-    });
+    await waitFor(() => expect(textbox).toHaveValue(value));
 
     expect(query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: value }),
     );
 
+    jest.runAllTimers();
     jest.useRealTimers();
   });
 
-  it('does not capture analytics event if not enabled in app', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ delay: null });
+  it('Does not capture analytics event if not enabled in app', async () => {
+    const analyticsApiMock = new MockAnalyticsApi();
 
     await renderWithEffects(
       <TestApiProvider
@@ -288,62 +285,42 @@ describe('SearchBar', () => {
         ]}
       >
         <SearchContextProvider>
-          <SearchBar />
+          <SearchBar debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    const textbox = await screen.findByRole('textbox', { name: 'Search' });
+    const textbox = screen.getByLabelText('Search');
 
     const value = 'value';
 
     await user.type(textbox, value);
 
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
-
-    await waitFor(() => {
-      expect(textbox).toHaveValue(value);
-    });
+    await waitFor(() => expect(textbox).toHaveValue(value));
 
     expect(analyticsApiMock.getEvents()).toHaveLength(0);
-
-    jest.useRealTimers();
   });
 
-  it('captures analytics events if enabled in app', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ delay: null });
+  it('Captures analytics events if enabled in app', async () => {
+    const analyticsApiMock = new MockAnalyticsApi();
+
     const types = ['techdocs', 'software-catalog'];
 
     await renderWithEffects(
       <TestApiProvider
         apis={[
+          [configApiRef, configApiMock],
           [searchApiRef, searchApiMock],
           [analyticsApiRef, analyticsApiMock],
-          [
-            configApiRef,
-            new ConfigReader({
-              app: {
-                title: 'Mock title',
-                analytics: {
-                  ga: {
-                    trackingId: 'xyz123',
-                  },
-                },
-              },
-            }),
-          ],
         ]}
       >
         <SearchContextProvider initialState={createInitialState({ types })}>
-          <SearchBar />
+          <SearchBar debounceTime={0} />
         </SearchContextProvider>
       </TestApiProvider>,
     );
 
-    const textbox = await screen.findByRole('textbox', { name: 'Search' });
+    const textbox = screen.getByLabelText('Search');
 
     let value = 'value';
 
@@ -351,13 +328,9 @@ describe('SearchBar', () => {
 
     expect(analyticsApiMock.getEvents()).toHaveLength(0);
 
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
+    await waitFor(() => expect(analyticsApiMock.getEvents()).toHaveLength(1));
 
-    await waitFor(() => expect(textbox).toHaveValue(value));
-
-    expect(analyticsApiMock.getEvents()).toHaveLength(1);
+    expect(textbox).toHaveValue(value);
     expect(analyticsApiMock.getEvents()[0]).toEqual({
       action: 'search',
       context: {
@@ -376,13 +349,9 @@ describe('SearchBar', () => {
     // make sure new term is captured
     await user.type(textbox, value);
 
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
+    await waitFor(() => expect(analyticsApiMock.getEvents()).toHaveLength(2));
 
-    await waitFor(() => expect(textbox).toHaveValue(value));
-
-    expect(analyticsApiMock.getEvents()).toHaveLength(2);
+    expect(textbox).toHaveValue(value);
     expect(analyticsApiMock.getEvents()[1]).toEqual({
       action: 'search',
       context: {
@@ -393,7 +362,5 @@ describe('SearchBar', () => {
       },
       subject: value,
     });
-
-    jest.useRealTimers();
   });
 });

--- a/plugins/search-react/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.test.tsx
@@ -323,44 +323,39 @@ describe('SearchBar', () => {
     const textbox = screen.getByLabelText('Search');
 
     let value = 'value';
-
     await user.type(textbox, value);
-
-    expect(analyticsApiMock.getEvents()).toHaveLength(0);
-
-    await waitFor(() => expect(analyticsApiMock.getEvents()).toHaveLength(1));
-
-    expect(textbox).toHaveValue(value);
-    expect(analyticsApiMock.getEvents()[0]).toEqual({
-      action: 'search',
-      context: {
-        extension: 'SearchBar',
-        pluginId: 'search',
-        routeRef: 'unknown',
-        searchTypes: types.toString(),
-      },
-      subject: value,
+    await waitFor(() => {
+      expect(analyticsApiMock.getEvents()).toHaveLength(1);
+      expect(textbox).toHaveValue(value);
+      expect(analyticsApiMock.getEvents()[0]).toEqual({
+        action: 'search',
+        context: {
+          extension: 'SearchBar',
+          pluginId: 'search',
+          routeRef: 'unknown',
+          searchTypes: types.toString(),
+        },
+        subject: value,
+      });
     });
 
-    await user.clear(textbox);
-
     value = 'new value';
-
+    await user.clear(textbox);
     // make sure new term is captured
     await user.type(textbox, value);
-
-    await waitFor(() => expect(analyticsApiMock.getEvents()).toHaveLength(2));
-
-    expect(textbox).toHaveValue(value);
-    expect(analyticsApiMock.getEvents()[1]).toEqual({
-      action: 'search',
-      context: {
-        extension: 'SearchBar',
-        pluginId: 'search',
-        routeRef: 'unknown',
-        searchTypes: types.toString(),
-      },
-      subject: value,
+    await waitFor(() => {
+      expect(analyticsApiMock.getEvents()).toHaveLength(2);
+      expect(textbox).toHaveValue(value);
+      expect(analyticsApiMock.getEvents()[1]).toEqual({
+        action: 'search',
+        context: {
+          extension: 'SearchBar',
+          pluginId: 'search',
+          routeRef: 'unknown',
+          searchTypes: types.toString(),
+        },
+        subject: value,
+      });
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In this pull request, we are seeking to make the speed of the SearchBar test more consistent and reduce its instability.

Performing the following test changes reduced the `SearchBar` test run time from `27.501` seconds to `6-9` seconds and could help us to reduce the risk of flakiness:

- Using only render with effects to wait for state changes during the first render
- Running all timers after tests using faking timers and setting debounce time to zero in tests that don't use fake timers
- Returning expects on waitFor calls to [avoid unstable tests](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#passing-an-empty-callback-to-waitfor) that sometimes pass in the next tick sometimes not
- Remove all *byRole queries, because of their [performance issues](https://github.com/testing-library/dom-testing-library/issues/698); although it is [recommended](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-byrole-most-of-the-time), this operation is [expensive](https://github.com/testing-library/dom-testing-library/issues/698#issuecomment-658714611).

**Before optimizations**
| 1st run | 2nd run |
| ------- | -------- |
| ![image](https://github.com/backstage/backstage/assets/6290749/8f8c225f-f7a2-4497-9424-015972080b1e) | ![image](https://github.com/backstage/backstage/assets/6290749/35748f21-d802-46c0-85d8-9f2f0aa4b1aa) |

**After optimizations**

Watch Mode (Local)

| 1st run | 2nd run |
| ------- | -------- |
| ![image](https://github.com/backstage/backstage/assets/6290749/8a54b318-fa1a-4bad-a1af-d3e0d20198af) | ![image](https://github.com/backstage/backstage/assets/6290749/73be6a41-84b4-483c-8d4c-609934b12085) |

In Band Mode (CI)

| 1st run | 2nd run |
| ------- | -------- |
| ![image](https://github.com/backstage/backstage/assets/6290749/13c6b4d2-99db-4bc8-9232-273aab329e03) | ![image](https://github.com/backstage/backstage/assets/6290749/6946c6cf-f9ae-475f-8720-3be0e3edd402) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
