### PR TITLE
[reading] Fix `unexpected end of file`

### DIFF
--- a/.changeset/many-ants-poke.md
+++ b/.changeset/many-ants-poke.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': patch
 ---
 
-use `Readable.from` to convert the buffer to explicitly convert the buffer to a `Readable` stream
+use `Readable.from` to explicitly convert the `buffer` from `node-fetch` to a `Readable` stream

--- a/.changeset/many-ants-poke.md
+++ b/.changeset/many-ants-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+use `Readable.from` to convert the buffer to explicitly convert the buffer to a `Readable` stream

--- a/packages/backend-common/src/reading/AzureUrlReader.ts
+++ b/packages/backend-common/src/reading/AzureUrlReader.ts
@@ -158,7 +158,7 @@ export class AzureUrlReader implements UrlReader {
     }
 
     return await this.deps.treeResponseFactory.fromZipArchive({
-      stream: archiveAzureResponse.body as unknown as Readable,
+      stream: Readable.from(archiveAzureResponse.body),
       etag: commitSha,
       filter,
       subpath,

--- a/packages/backend-common/src/reading/BitbucketCloudUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketCloudUrlReader.ts
@@ -160,7 +160,7 @@ export class BitbucketCloudUrlReader implements UrlReader {
     }
 
     return await this.deps.treeResponseFactory.fromTarArchive({
-      stream: archiveResponse.body as unknown as Readable,
+      stream: Readable.from(archiveResponse.body),
       subpath: filepath,
       etag: lastCommitShortHash,
       filter: options?.filter,

--- a/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketServerUrlReader.ts
@@ -151,7 +151,7 @@ export class BitbucketServerUrlReader implements UrlReader {
     }
 
     return await this.deps.treeResponseFactory.fromTarArchive({
-      stream: archiveResponse.body as unknown as Readable,
+      stream: Readable.from(archiveResponse.body),
       subpath: filepath,
       etag: lastCommitShortHash,
       filter: options?.filter,

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -171,7 +171,7 @@ export class BitbucketUrlReader implements UrlReader {
     }
 
     return await this.deps.treeResponseFactory.fromTarArchive({
-      stream: archiveBitbucketResponse.body as unknown as Readable,
+      stream: Readable.from(archiveBitbucketResponse.body),
       subpath: filepath,
       etag: lastCommitShortHash,
       filter: options?.filter,

--- a/packages/backend-common/src/reading/GerritUrlReader.ts
+++ b/packages/backend-common/src/reading/GerritUrlReader.ts
@@ -204,7 +204,7 @@ export class GerritUrlReader implements UrlReader {
       });
       const tarArchive = Readable.from(data);
       return await this.deps.treeResponseFactory.fromTarArchive({
-        stream: tarArchive as unknown as Readable,
+        stream: Readable.from(tarArchive),
         subpath: filePath === '/' ? undefined : filePath,
         etag: branchInfo.revision,
         filter: options?.filter,

--- a/packages/backend-common/src/reading/GerritUrlReader.ts
+++ b/packages/backend-common/src/reading/GerritUrlReader.ts
@@ -204,7 +204,7 @@ export class GerritUrlReader implements UrlReader {
       });
       const tarArchive = Readable.from(data);
       return await this.deps.treeResponseFactory.fromTarArchive({
-        stream: Readable.from(tarArchive),
+        stream: tarArchive,
         subpath: filePath === '/' ? undefined : filePath,
         etag: branchInfo.revision,
         filter: options?.filter,

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -238,7 +238,7 @@ export class GithubUrlReader implements UrlReader {
     return await this.deps.treeResponseFactory.fromTarArchive({
       // TODO(Rugvip): Underlying implementation of fetch will be node-fetch, we probably want
       //               to stick to using that in exclusively backend code.
-      stream: archive.body as unknown as Readable,
+      stream: Readable.from(archive.body),
       subpath,
       etag: sha,
       filter: options?.filter,
@@ -347,7 +347,6 @@ export class GithubUrlReader implements UrlReader {
     init: RequestInit,
   ): Promise<Response> {
     const urlAsString = url.toString();
-
     const response = await fetch(urlAsString, init);
 
     if (!response.ok) {

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -229,7 +229,7 @@ export class GitlabUrlReader implements UrlReader {
     }
 
     return await this.deps.treeResponseFactory.fromTarArchive({
-      stream: archiveGitLabResponse.body as unknown as Readable,
+      stream: Readable.from(archiveGitLabResponse.body),
       subpath: filepath,
       etag: commitSha,
       filter: options?.filter,

--- a/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
@@ -151,7 +151,9 @@ export class TarArchiveResponse implements ReadTreeResponse {
     const strip = this.subPath ? this.subPath.split('/').length : 1;
 
     let filterError: Error | undefined = undefined;
-
+    this.stream.on('error', console.error);
+    this.stream.on('close', console.error);
+    console.log('we are here!');
     await pipeline(
       this.stream,
       tar.extract({

--- a/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
@@ -151,9 +151,6 @@ export class TarArchiveResponse implements ReadTreeResponse {
     const strip = this.subPath ? this.subPath.split('/').length : 1;
 
     let filterError: Error | undefined = undefined;
-    this.stream.on('error', console.error);
-    this.stream.on('close', console.error);
-    console.log('we are here!');
     await pipeline(
       this.stream,
       tar.extract({


### PR DESCRIPTION
Fixes #18002 

Not sure why this works yet, and why it differs between node versions.

I think that the underlying cause is how `Buffers` are treated with `node-tar`, but I can't be certain. Seems to work consistently with a `Readable` stream instead.