### PR TITLE
Catalog graph - implement node tooltips

### DIFF
--- a/.changeset/wicked-gifts-check.md
+++ b/.changeset/wicked-gifts-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Add tooltips to nodes based on a callback function. Additionally, provide a default implementation using the entity `spec.type` as node tooltip.

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -8,6 +8,7 @@
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { DependencyGraphTypes } from '@backstage/core-components';
+import { Entity } from '@backstage/catalog-model';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
 import { MouseEvent as MouseEvent_2 } from 'react';
@@ -95,6 +96,7 @@ export type EntityNodeData = {
   focused?: boolean;
   color?: 'primary' | 'secondary' | 'default';
   onClick?: MouseEventHandler<unknown>;
+  tooltipTitle?: string;
 };
 
 // @public
@@ -112,6 +114,7 @@ export type EntityRelationsGraphProps = {
   relations?: string[];
   direction?: Direction;
   onNodeClick?: (value: EntityNode, event: MouseEvent_2<unknown>) => void;
+  onTooltip?: (value: Entity) => string | undefined;
   relationPairs?: RelationPairs;
   className?: string;
   zoom?: 'enabled' | 'disabled' | 'enable-on-click';

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -18,6 +18,7 @@ import {
   getCompoundEntityRef,
   parseEntityRef,
   stringifyEntityRef,
+  Entity,
 } from '@backstage/catalog-model';
 import { InfoCard, InfoCardVariants } from '@backstage/core-components';
 import { useAnalytics, useRouteRef } from '@backstage/core-plugin-api';
@@ -75,6 +76,7 @@ export const CatalogGraphCard = (
     className,
     rootEntityNames,
     onNodeClick,
+    onTooltip,
     title = 'Relations',
     zoom = 'enable-on-click',
   } = props;
@@ -105,6 +107,9 @@ export const CatalogGraphCard = (
     [catalogEntityRoute, navigate, analytics],
   );
 
+  const defaultOnTooltip = (nodeEntity: Entity) =>
+    (nodeEntity.spec?.type as string) || undefined;
+
   const catalogGraphParams = qs.stringify(
     {
       rootEntityRefs: [stringifyEntityRef(entity)],
@@ -133,6 +138,7 @@ export const CatalogGraphCard = (
         {...props}
         rootEntityNames={rootEntityNames || entityName}
         onNodeClick={onNodeClick || defaultOnNodeClick}
+        onTooltip={onTooltip || defaultOnTooltip}
         className={className || classes.graph}
         maxDepth={maxDepth}
         unidirectional={unidirectional}

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.test.tsx
@@ -98,4 +98,23 @@ describe('<CustomNode />', () => {
 
     expect(screen.getByText('Custom Title')).toBeInTheDocument();
   });
+
+  test('renders tooltip', async () => {
+    await renderInTestApp(
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <CustomNode
+          node={{
+            focused: false,
+            kind: 'kind',
+            name: 'name',
+            namespace: 'namespace',
+            id: 'kind:namespace/name',
+            tooltipTitle: 'Custom tooltip',
+          }}
+        />
+      </svg>,
+    );
+
+    expect(screen.getByText('Custom tooltip')).toBeInTheDocument();
+  });
 });

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.tsx
@@ -66,6 +66,7 @@ export function CustomNode({
     color = 'default',
     focused,
     title,
+    tooltipTitle,
     onClick,
   },
 }: DependencyGraphTypes.RenderNodeProps<EntityNodeData>) {
@@ -143,6 +144,7 @@ export function CustomNode({
       >
         {displayTitle}
       </text>
+      {tooltipTitle && <title>{tooltipTitle}</title>}
     </g>
   );
 }

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
@@ -430,4 +430,29 @@ describe('<EntityRelationsGraph/>', () => {
     const labels = await screen.findAllByText('Test-Labelvisible');
     expect(labels[0]).toBeInTheDocument();
   });
+
+  test('renders tooltip', async () => {
+    catalog.getEntityByRef.mockResolvedValue({
+      apiVersion: 'a',
+      kind: 'b',
+      metadata: {
+        name: 'c',
+        namespace: 'd',
+      },
+      relations: [],
+    });
+
+    const onTooltip = jest.fn().mockReturnValue('Custom tooltip');
+    await renderInTestApp(
+      <Wrapper>
+        <EntityRelationsGraph
+          rootEntityNames={{ kind: 'b', namespace: 'd', name: 'c' }}
+          onTooltip={onTooltip}
+        />
+      </Wrapper>,
+    );
+
+    expect(await screen.findByText('Custom tooltip')).toBeInTheDocument();
+    expect(onTooltip).toHaveBeenCalledTimes(1);
+  });
 });

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -17,6 +17,7 @@
 import {
   CompoundEntityRef,
   stringifyEntityRef,
+  Entity,
 } from '@backstage/catalog-model';
 import {
   DependencyGraph,
@@ -78,6 +79,7 @@ export type EntityRelationsGraphProps = {
   relations?: string[];
   direction?: Direction;
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
+  onTooltip?: (value: Entity) => string | undefined;
   relationPairs?: RelationPairs;
   className?: string;
   zoom?: 'enabled' | 'disabled' | 'enable-on-click';
@@ -101,6 +103,7 @@ export const EntityRelationsGraph = (props: EntityRelationsGraphProps) => {
     relations,
     direction = Direction.LEFT_RIGHT,
     onNodeClick,
+    onTooltip,
     relationPairs = ALL_RELATION_PAIRS,
     className,
     zoom = 'enabled',
@@ -128,6 +131,7 @@ export const EntityRelationsGraph = (props: EntityRelationsGraphProps) => {
     kinds,
     relations,
     onNodeClick,
+    onTooltip,
     relationPairs,
   });
 

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/types.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/types.ts
@@ -76,6 +76,10 @@ export type EntityNodeData = {
    * Optional click handler.
    */
   onClick?: MouseEventHandler<unknown>;
+  /**
+   * Optional node tooltip.
+   */
+  tooltipTitle?: string;
 };
 
 /**

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.test.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.test.ts
@@ -702,4 +702,62 @@ describe('useEntityRelationNodesAndEdges', () => {
       },
     ]);
   });
+
+  test('should generate tooltip', async () => {
+    const { result, waitForValueToChange } = renderHook(() =>
+      useEntityRelationNodesAndEdges({
+        rootEntityRefs: ['b:d/c'],
+        unidirectional: true,
+        mergeRelations: true,
+        onTooltip: () => 'Custom tooltip',
+      }),
+    );
+
+    await waitForValueToChange(
+      () => result.current.nodes && result.current.edges,
+    );
+
+    const { nodes, loading, error } = result.current;
+
+    expect(loading).toBe(false);
+    expect(error).toBeUndefined();
+    expect(nodes).toEqual([
+      {
+        color: 'secondary',
+        focused: true,
+        id: 'b:d/c',
+        kind: 'b',
+        name: 'c',
+        namespace: 'd',
+        tooltipTitle: 'Custom tooltip',
+      },
+      {
+        color: 'primary',
+        focused: false,
+        id: 'k:d/a1',
+        kind: 'k',
+        name: 'a1',
+        namespace: 'd',
+        tooltipTitle: 'Custom tooltip',
+      },
+      {
+        color: 'primary',
+        focused: false,
+        id: 'b:d/c1',
+        kind: 'b',
+        name: 'c1',
+        namespace: 'd',
+        tooltipTitle: 'Custom tooltip',
+      },
+      {
+        color: 'primary',
+        focused: false,
+        id: 'b:d/c2',
+        kind: 'b',
+        name: 'c2',
+        namespace: 'd',
+        tooltipTitle: 'Custom tooltip',
+      },
+    ]);
+  });
 });

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
+import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
 import { MouseEvent, useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
 import { RelationPairs, ALL_RELATION_PAIRS } from './relations';
@@ -31,6 +31,7 @@ export function useEntityRelationNodesAndEdges({
   kinds,
   relations,
   onNodeClick,
+  onTooltip,
   relationPairs = ALL_RELATION_PAIRS,
 }: {
   rootEntityRefs: string[];
@@ -40,6 +41,7 @@ export function useEntityRelationNodesAndEdges({
   kinds?: string[];
   relations?: string[];
   onNodeClick?: (value: EntityNode, event: MouseEvent<unknown>) => void;
+  onTooltip?: (value: Entity) => string | undefined;
   relationPairs?: RelationPairs;
 }): {
   loading: boolean;
@@ -81,6 +83,10 @@ export function useEntityRelationNodesAndEdges({
 
         if (onNodeClick) {
           node.onClick = event => onNodeClick(node, event);
+        }
+
+        if (onTooltip) {
+          node.tooltipTitle = onTooltip(entity);
         }
 
         return node;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Sometimes it's hard or even impossible to distinguish between entities in the catalog graph as they can have very similar names, if not the same title and even be of the same kind.
For us this is already the case, as we are ingesting data from a source where we haven't much control over naming.
To help the user and give more context, I implemented configurable tooltips for nodes. The tooltip will show the entities `spec.type` by default if available.

<img width="953" alt="CleanShot 2023-06-23 at 00 30 07@2x" src="https://github.com/backstage/backstage/assets/1021324/53f6c0e7-da4f-4a0a-8dc7-ddd7b95ddd14">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
