### PR TITLE
(catalog-module-unprocessed): Align knex dependency

### DIFF
--- a/.changeset/mean-games-play.md
+++ b/.changeset/mean-games-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-unprocessed': patch
+---
+
+Downgrade `knex` dependency to version `^2.0.0`. With the newest version the usage of this plugin is causing the `yarn tsc` command to complain due to incompatible types

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -32,6 +32,6 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "express-promise-router": "^4.1.1",
-    "knex": "^2.4.2"
+    "knex": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5510,7 +5510,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     express-promise-router: ^4.1.1
-    knex: ^2.4.2
+    knex: ^2.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Otherwise, the types are mismatching and backstage cannot build in certain cases

## Hey, I just made a Pull Request!

After upgrading backstage to 1.15.0, we tried to integrate this module into our catalog. But this doesn't work properly due to type errors. Since all the internal packages are setting the version `^2.0.0` in the `package.json` but this module uses the latest (`2.4.2`), it seems that something is incorrect and the type complains.

When setting this lines in our `catalog.ts` file:

```ts
const unprocessed = new UnprocessedEntitesModule(
  await env.database.getClient(),
  router,
);
```

The output is the following:

```sh
$ yarn tsc
yarn run v1.22.19
$ tsc
packages/backend/src/plugins/catalog.ts:391:5 - error TS2345: Argument of type 'import("/home/ivgo/backstage/backstage/node_modules/knex/types/index").Knex<any, any[]>' is not assignable to parameter of type 'import("/home/ivgo/backstage/backstage/plugins/catalog-backend-module-unprocessed/node_modules/knex/types/index").Knex<any, any[]>'.

391     await env.database.getClient(),
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

plugins/catalog-backend-module-unprocessed/src/module.ts:40:11 - error TS2345: Argument of type 'import("/home/ivgo/backstage/backstage/node_modules/knex/types/index").Knex<any, any[]>' is not assignable to parameter of type 'import("/home/ivgo/backstage/backstage/plugins/catalog-backend-module-unprocessed/node_modules/knex/types/index").Knex<any, any[]>'.
  The types of 'raw(...).transacting' are incompatible between these types.
    Type '(trx: import("/home/ivgo/backstage/backstage/node_modules/knex/types/index").Knex.Transaction<any, any[]>) => import("/home/ivgo/backstage/backstage/node_modules/knex/types/index").Knex.Raw<any>' is not assignable to type '(trx: import("/home/ivgo/backstage/backstage/plugins/catalog-backend-module-unprocessed/node_modules/knex/types/index").Knex.Transaction<any, any[]>) => import("/home/ivgo/backstage/backstage/plugins/catalog-backend-module-unprocessed/node_modules/knex/types/index").Knex.Raw<any>'.
      Types of parameters 'trx' and 'trx' are incompatible.
        Type 'import("/home/ivgo/backstage/backstage/plugins/catalog-backend-module-unprocessed/node_modules/knex/types/index").Knex.Transaction<any, any[]>' is not assignable to type 'import("/home/ivgo/backstage/backstage/node_modules/knex/types/index").Knex.Transaction<any, any[]>'.
          The types of 'query(...).client.config.client' are incompatible between these types.
            Type 'string | typeof import("/home/ivgo/backstage/backstage/plugins/catalog-backend-module-unprocessed/node_modules/knex/types/index").Knex.Client | undefined' is not assignable to type 'string | typeof import("/home/ivgo/backstage/backstage/node_modules/knex/types/index").Knex.Client | undefined'.
              Type 'typeof Client' is not assignable to type 'string | typeof Client | undefined'.

40           await database.getClient(),
             ~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  packages/backend/src/plugins/catalog.ts:391
     1  plugins/catalog-backend-module-unprocessed/src/module.ts:40
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After this change, the command is not failing anymore.

This is blocking us to start using this plugin, since the `yarn tsc` is required to build our backstage image.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
