### PR TITLE
fix(dynatrace): fix "View Entity in Dynatrace" button in Dynatrace plugin

### DIFF
--- a/.changeset/mighty-shoes-refuse.md
+++ b/.changeset/mighty-shoes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-dynatrace': patch
+---
+
+updated the link that the "View Entity in Dynatrace" redirects the user to.

--- a/plugins/dynatrace/src/components/Problems/ProblemsList/ProblemsList.tsx
+++ b/plugins/dynatrace/src/components/Problems/ProblemsList/ProblemsList.tsx
@@ -43,6 +43,31 @@ const cardContents = (
   );
 };
 
+const dynatraceEntityPrefixes = (idPrefix: string): string => {
+  switch (idPrefix) {
+    case 'APPLICATION':
+      return '#uemapplications/uemappmetrics;uemapplicationId=';
+
+    case 'SERVICE':
+      return '#services/serviceOverview;id=';
+
+    case `MOBILE_APPLICATION`:
+      return '#mobileappoverview;appID=';
+
+    case 'SYNTHETIC_TEST':
+      return 'ui/browser-monitor/';
+
+    case 'KUBERNETES_CLUSTER':
+      return 'ui/kubernetes/';
+
+    case 'PROCESS_GROUP_INSTANCE':
+      return '#processdetails;id=';
+
+    default:
+      return 'ui/entity/';
+  }
+};
+
 export const ProblemsList = (props: ProblemsListProps) => {
   const { dynatraceEntityId } = props;
   const configApi = useApi(configApiRef);
@@ -53,6 +78,10 @@ export const ProblemsList = (props: ProblemsListProps) => {
     return dynatraceApi.getDynatraceProblems(dynatraceEntityId);
   }, [dynatraceApi, dynatraceEntityId]);
   const problems = value?.problems;
+
+  const deepLinkPrefix = dynatraceEntityPrefixes(
+    `${dynatraceEntityId.split('-')[0]}`,
+  );
 
   if (loading) {
     return <Progress />;
@@ -65,7 +94,7 @@ export const ProblemsList = (props: ProblemsListProps) => {
       subheader={`Last 2 hours - ${dynatraceEntityId}`}
       deepLink={{
         title: 'View Entity in Dynatrace',
-        link: `${dynatraceBaseUrl}/#serviceOverview;id=${dynatraceEntityId}`,
+        link: `${dynatraceBaseUrl}/${deepLinkPrefix}${dynatraceEntityId}`,
       }}
     >
       {cardContents(problems || [], dynatraceBaseUrl)}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Fixes #18310 
Updated the link that the "View Entity in Dynatrace" button (in the `DynatraceTab` component) the user gets redirected to.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
