### PR TITLE
fix(front-matter parsing): resolve issue with markdown header dates

### DIFF
--- a/.changeset/quiet-drinks-share.md
+++ b/.changeset/quiet-drinks-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+This change addresses an issue where the front-matter parsing of date strings resulted in the date not appearing in the rendered output. The fix ensures that the date is correctly parsed and rendered in the expected format.

--- a/plugins/adr/examples/component/catalog-info.yaml
+++ b/plugins/adr/examples/component/catalog-info.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
@@ -6,7 +5,7 @@ metadata:
   title: Component With ADRs
   description: A Service with ADRs registerd
   annotations:
-    backstage.io/adr-location: https://github.com/adr/madr/tree/develop/docs/decisions
+    backstage.io/adr-location: https://github.com/Nidafjoll/pastebin/blob/main/decisions
 spec:
   type: service
   lifecycle: experimental


### PR DESCRIPTION
Closes #18413

This PR fixes front-matter parsing for markdown header dates. The issue introduced as a consequence of PR #17954 causing front-matter to parse the date string as a date object, resulting in the date not appearing in the rendered output. 

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
