### PR TITLE
fix: update plugin home dependence @rjsf/material-ui to @rjsf/materia…

### DIFF
--- a/.changeset/popular-kangaroos-accept.md
+++ b/.changeset/popular-kangaroos-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': minor
+---
+
+fix: update plugin home dependence @rjsf/material-ui to @rjsf/material-ui-v5

--- a/.changeset/popular-kangaroos-accept.md
+++ b/.changeset/popular-kangaroos-accept.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-home': minor
+'@backstage/plugin-home': patch
 ---
 
-fix: update plugin home dependence @rjsf/material-ui to @rjsf/material-ui-v5
+fix: update plugin home dependency for `@rjsf/material-ui` to `@rjsf/material-ui-v5`

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -44,7 +44,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
     "@rjsf/core-v5": "npm:@rjsf/core@5.7.3",
-    "@rjsf/material-ui": "5.7.3",
+    "@rjsf/material-ui-v5": "npm:@rjsf/material-ui@5.7.3",
     "@rjsf/utils": "5.7.3",
     "@rjsf/validator-ajv8": "5.7.3",
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/plugins/home/src/components/CustomHomepage/WidgetSettingsOverlay.tsx
+++ b/plugins/home/src/components/CustomHomepage/WidgetSettingsOverlay.tsx
@@ -30,7 +30,7 @@ import { Widget } from './types';
 import { withTheme } from '@rjsf/core-v5';
 import validator from '@rjsf/validator-ajv8';
 
-const Form = withTheme(require('@rjsf/material-ui').Theme);
+const Form = withTheme(require('@rjsf/material-ui-v5').Theme);
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7139,7 +7139,7 @@ __metadata:
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
     "@rjsf/core-v5": "npm:@rjsf/core@5.7.3"
-    "@rjsf/material-ui": 5.7.3
+    "@rjsf/material-ui-v5": "npm:@rjsf/material-ui@5.7.3"
     "@rjsf/utils": 5.7.3
     "@rjsf/validator-ajv8": 5.7.3
     "@testing-library/dom": ^8.0.0
@@ -14296,7 +14296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rjsf/material-ui-v5@npm:@rjsf/material-ui@5.7.3, @rjsf/material-ui@npm:5.7.3":
+"@rjsf/material-ui-v5@npm:@rjsf/material-ui@5.7.3":
   version: 5.7.3
   resolution: "@rjsf/material-ui@npm:5.7.3"
   peerDependencies:


### PR DESCRIPTION
…l-ui-v5

## Hey, I just made a Pull Request!
when I use `@rjsf/material-ui` in my custom plugin. Home page setting form `@rjsf/material-u` will not load the right version

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
