### PR TITLE
(catalog-unprocessed-entities) Export more types and functions for customization

### DIFF
--- a/.changeset/green-otters-wait.md
+++ b/.changeset/green-otters-wait.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+---
+
+Export some types and API items. This allows people to call the API from different places with the ApiRef, as well
+as completely customize the client if required. Check the [README.md](../plugins/catalog-unprocessed-entities/README.md) to
+note what needs to be added in order to use the new `catalogUnprocessedEntitiesApiRef` exported function.

--- a/plugins/catalog-unprocessed-entities/README.md
+++ b/plugins/catalog-unprocessed-entities/README.md
@@ -40,6 +40,30 @@ import { CatalogUnprocessedEntitiesPage } from '@backstage/plugin-catalog-unproc
 />;
 ```
 
+## Customization
+
+If you want to use the provided endpoints in a different way, you can use the ApiRef doing the following:
+
+```typescript
+import { catalogUnprocessedEntitiesApiRef } from '@backstage/plugin-catalog-unprocessed-entities';
+import { useApi } from '@backstage/core-plugin-api';
+
+const catalogUnprocessedEntitiesApi = useApi(catalogUnprocessedEntitiesApiRef);
+```
+
+Note that you will need to add the API implementation to avoid your instance to crash due to "missing implementation for apiRef". To do so, add the following lines:
+
+```typescript
+// In packages/app/src/apis.ts
+import { catalogUnprocessedEntitiesPlugin } from '@backstage/plugin-catalog-unprocessed-entities';
+
+export const apis: AnyApiFactory[] = [
+  // ...other API implementations
+
+  ...catalogUnprocessedEntitiesPlugin.getApis(),
+];
+```
+
 ## Getting started
 
 Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/catalog-unprocessed-entities](http://localhost:3000/catalog-unprocessed-entities).

--- a/plugins/catalog-unprocessed-entities/README.md
+++ b/plugins/catalog-unprocessed-entities/README.md
@@ -51,17 +51,12 @@ import { useApi } from '@backstage/core-plugin-api';
 const catalogUnprocessedEntitiesApi = useApi(catalogUnprocessedEntitiesApiRef);
 ```
 
-Note that you will need to add the API implementation to avoid your instance to crash due to "missing implementation for apiRef". To do so, add the following lines:
+Note that if you are not rendering the `CatalogUnprocessedEntitiesPage` in the `App.tsx` tree, you will need to export the `catalogUnproccessedEntitiesPlugin` from your `plugins.ts` file to setup the plugin otherwise you will receive an error like `No implementation available for apiRef{plugin.catalog-unprocessed-entities.service}`
 
 ```typescript
-// In packages/app/src/apis.ts
-import { catalogUnprocessedEntitiesPlugin } from '@backstage/plugin-catalog-unprocessed-entities';
-
-export const apis: AnyApiFactory[] = [
-  // ...other API implementations
-
-  ...catalogUnprocessedEntitiesPlugin.getApis(),
-];
+// In packages/app/src/plugins.ts
+...
+export { catalogUnprocessedEntitiesPlugin } from '@backstage/plugin-catalog-unprocessed-entities';
 ```
 
 ## Getting started

--- a/plugins/catalog-unprocessed-entities/README.md
+++ b/plugins/catalog-unprocessed-entities/README.md
@@ -59,6 +59,20 @@ Note that if you are not rendering the `CatalogUnprocessedEntitiesPage` in the `
 export { catalogUnprocessedEntitiesPlugin } from '@backstage/plugin-catalog-unprocessed-entities';
 ```
 
+If you don't have a `plugins.ts` file, you can create it with the path `packages/app/src/plugins.ts` and then import it into your `App.tsx`:
+
+```diff
++ import * as plugins from './plugins';
+
+const app = createApp({
+  apis,
++   plugins: Object.values(plugins),
+  bindRoutes({ bind }) {
+    /* ... */
+  },
+});
+```
+
 ## Getting started
 
 Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/catalog-unprocessed-entities](http://localhost:3000/catalog-unprocessed-entities).

--- a/plugins/catalog-unprocessed-entities/api-report.md
+++ b/plugins/catalog-unprocessed-entities/api-report.md
@@ -5,8 +5,24 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
+
+// @public
+export interface CatalogUnprocessedEntitiesApi {
+  failed(): Promise<CatalogUnprocessedEntitiesApiResponse>;
+  pending(): Promise<CatalogUnprocessedEntitiesApiResponse>;
+}
+
+// @public
+export const catalogUnprocessedEntitiesApiRef: ApiRef<CatalogUnprocessedEntitiesApi>;
+
+// @public
+export type CatalogUnprocessedEntitiesApiResponse = {
+  entities: UnprocessedEntity[];
+};
 
 // @public
 export const CatalogUnprocessedEntitiesPage: () => JSX.Element;
@@ -22,6 +38,38 @@ export const catalogUnprocessedEntitiesPlugin: BackstagePlugin<
 
 // @public (undocumented)
 export const UnprocessedEntitiesContent: () => JSX.Element;
+
+// @public
+export type UnprocessedEntity = {
+  entity_id: string;
+  entity_ref: string;
+  unprocessed_entity: Entity;
+  unprocessed_hash?: string;
+  processed_entity?: Entity;
+  result_hash?: string;
+  cache?: UnprocessedEntityCache;
+  next_update_at: string | Date;
+  last_discovery_at: string | Date;
+  errors?: UnprocessedEntityError[];
+  location_key?: string;
+};
+
+// @public
+export type UnprocessedEntityCache = {
+  ttl: number;
+  cache: object;
+};
+
+// @public
+export type UnprocessedEntityError = {
+  name: string;
+  message: string;
+  cause: {
+    name: string;
+    message: string;
+    stack: string;
+  };
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-unprocessed-entities/src/api/index.ts
+++ b/plugins/catalog-unprocessed-entities/src/api/index.ts
@@ -32,20 +32,43 @@ export const catalogUnprocessedEntitiesApiRef =
   });
 
 /**
- * API client for the Catalog Unprocessed Entities plugin
+ * Response expected by the {@link CatalogUnprocessedEntitiesApi}
  *
  * @public
  */
-export class CatalogUnprocessedEntitiesApi {
-  url: string = '';
+export type CatalogUnprocessedEntitiesApiResponse = {
+  entities: UnprocessedEntity[];
+};
 
+/**
+ * Interface for the CatalogUnprocessedEntitiesApi.
+ *
+ * @public
+ */
+export interface CatalogUnprocessedEntitiesApi {
+  /**
+   * Returns a list of entities with state 'pending'
+   */
+  pending(): Promise<CatalogUnprocessedEntitiesApiResponse>;
+  /**
+   * Returns a list of entities with state 'failed'
+   */
+  failed(): Promise<CatalogUnprocessedEntitiesApiResponse>;
+}
+
+/**
+ * Default API implementation for the Catalog Unprocessed Entities plugin
+ *
+ * @public
+ */
+export class CatalogUnprocessedEntitiesClient
+  implements CatalogUnprocessedEntitiesApi
+{
   constructor(public discovery: DiscoveryApi, public fetchApi: FetchApi) {}
 
   private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
-    if (!this.url) {
-      this.url = await this.discovery.getBaseUrl('catalog');
-    }
-    const resp = await this.fetchApi.fetch(`${this.url}/${path}`, init);
+    const url = await this.discovery.getBaseUrl('catalog');
+    const resp = await this.fetchApi.fetch(`${url}/${path}`, init);
     if (!resp.ok) {
       throw await ResponseError.fromResponse(resp);
     }
@@ -53,11 +76,11 @@ export class CatalogUnprocessedEntitiesApi {
     return await resp.json();
   }
 
-  async pending(): Promise<{ entities: UnprocessedEntity[] }> {
+  async pending(): Promise<CatalogUnprocessedEntitiesApiResponse> {
     return await this.fetch('entities/unprocessed/pending');
   }
 
-  async failed(): Promise<{ entities: UnprocessedEntity[] }> {
+  async failed(): Promise<CatalogUnprocessedEntitiesApiResponse> {
     return await this.fetch('entities/unprocessed/failed');
   }
 }

--- a/plugins/catalog-unprocessed-entities/src/index.ts
+++ b/plugins/catalog-unprocessed-entities/src/index.ts
@@ -18,3 +18,13 @@ export {
   CatalogUnprocessedEntitiesPage,
 } from './plugin';
 export { UnprocessedEntitiesContent } from './components/UnprocessedEntities';
+export {
+  type CatalogUnprocessedEntitiesApiResponse,
+  type CatalogUnprocessedEntitiesApi,
+  catalogUnprocessedEntitiesApiRef,
+} from './api';
+export type {
+  UnprocessedEntity,
+  UnprocessedEntityCache,
+  UnprocessedEntityError,
+} from './types';

--- a/plugins/catalog-unprocessed-entities/src/plugin.ts
+++ b/plugins/catalog-unprocessed-entities/src/plugin.ts
@@ -23,7 +23,7 @@ import {
 
 import { rootRouteRef } from './routes';
 import {
-  CatalogUnprocessedEntitiesApi,
+  CatalogUnprocessedEntitiesClient,
   catalogUnprocessedEntitiesApiRef,
 } from './api';
 
@@ -42,7 +42,7 @@ export const catalogUnprocessedEntitiesPlugin = createPlugin({
       api: catalogUnprocessedEntitiesApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
-        new CatalogUnprocessedEntitiesApi(discoveryApi, fetchApi),
+        new CatalogUnprocessedEntitiesClient(discoveryApi, fetchApi),
     }),
   ],
 });

--- a/plugins/catalog-unprocessed-entities/src/types.ts
+++ b/plugins/catalog-unprocessed-entities/src/types.ts
@@ -15,6 +15,10 @@
  */
 import { Entity } from '@backstage/catalog-model';
 
+/**
+ * Unprocessed entity data stored in the database.
+ * @public
+ */
 export type UnprocessedEntity = {
   entity_id: string;
   entity_ref: string;
@@ -29,11 +33,19 @@ export type UnprocessedEntity = {
   location_key?: string;
 };
 
+/**
+ * Unprocessed entity cache stored in the database.
+ * @public
+ */
 export type UnprocessedEntityCache = {
   ttl: number;
   cache: object;
 };
 
+/**
+ * Unprocessed entity error information stored in the database.
+ * @public
+ */
 export type UnprocessedEntityError = {
   name: string;
   message: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In our company we wanted to use this plugin, but not the provided Page, since it doesn't match our idea. So we wanted to use the ApiRef directly, but this is unfortunately not possible at the moment. The only way is copy-pasting the API client, and also the types, which are not exported either.

In this PR I'm just extending the list of types and functions that are exported, as well as adding a new block in the documentation, since using the ApiRef requires us to add the ApiFactory in the `apis.ts` file.

I think this is a nice feature, which is avoiding people to have such ugly workarounds if they want to create a custom component with the output of this new API endpoints.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
