### PR TITLE
Fix broken link for kubernetes documentation

### DIFF
--- a/.changeset/tough-flowers-suffer.md
+++ b/.changeset/tough-flowers-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Update readme with a valid link to k8s documentation

--- a/microsite/docusaurus.config.js
+++ b/microsite/docusaurus.config.js
@@ -130,7 +130,7 @@ module.exports = {
           {
             from: '/docs/features/kubernetes/overview',
             to: '/docs/features/kubernetes/',
-          },          
+          },
           {
             from: '/docs/features/search/search-overview',
             to: '/docs/features/search/',

--- a/microsite/docusaurus.config.js
+++ b/microsite/docusaurus.config.js
@@ -128,6 +128,10 @@ module.exports = {
             to: '/docs/features/techdocs/',
           },
           {
+            from: '/docs/features/kubernetes/overview',
+            to: '/docs/features/kubernetes/',
+          },          
+          {
             from: '/docs/features/search/search-overview',
             to: '/docs/features/search/',
           },

--- a/plugins/kubernetes-backend/README.md
+++ b/plugins/kubernetes-backend/README.md
@@ -16,4 +16,4 @@ The plugin requires configuration in the Backstage `app-config.yaml` to connect 
 
 In addition, configuration of an entity's `catalog-info.yaml` helps identify which specific Kubernetes object(s) should be presented on a specific entity catalog page.
 
-For more information, see the [formal documentation about the Kubernetes feature in Backstage](https://backstage.io/docs/features/kubernetes/overview).
+For more information, see the [formal documentation about the Kubernetes feature in Backstage](https://backstage.io/docs/features/kubernetes/).


### PR DESCRIPTION
The current k8s documentation is broken. updating it to point to the correct URL

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
 I have added the link to the broken kubernetes documentation. This PR resolves the issue #18421
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
