### PR TITLE
fix(techdocs): Typo in informational log message

### DIFF
--- a/.changeset/forty-socks-vanish.md
+++ b/.changeset/forty-socks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Fix typo in informational log message

--- a/plugins/techdocs-backend/src/service/DocsSynchronizer.test.ts
+++ b/plugins/techdocs-backend/src/service/DocsSynchronizer.test.ts
@@ -156,7 +156,7 @@ describe('DocsSynchronizer', () => {
 
       expect(mockResponseHandler.log).toHaveBeenCalledWith(
         expect.stringMatching(
-          /info.*The docs building process is taking a little bit longer to process this entity. Please bear with us/,
+          /info.*The docs building process is taking a little bit longer to process this entity. Please bare with us/,
         ),
       );
 

--- a/plugins/techdocs-backend/src/service/DocsSynchronizer.ts
+++ b/plugins/techdocs-backend/src/service/DocsSynchronizer.ts
@@ -130,7 +130,7 @@ export class DocsSynchronizer {
 
       const interval = setInterval(() => {
         taskLogger.info(
-          'The docs building process is taking a little bit longer to process this entity. Please bear with us.',
+          'The docs building process is taking a little bit longer to process this entity. Please bare with us.',
         );
       }, 10000);
       const updated = await this.buildLimiter(() => docsBuilder.build());


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Thought this had been fixed before, but found a new one.  😁 

bare (to uncover) vs. 🐻 (rowr)

https://www.grammarly.com/blog/bear-with-me/

<img width="1353" alt="image" src="https://github.com/backstage/backstage/assets/33203301/5a8ed328-88cf-485d-9b29-6b01dea24133">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
