### PR TITLE
Add GitlabYamlFileParser Action

### DIFF
--- a/.changeset/honest-pumpkins-ring.md
+++ b/.changeset/honest-pumpkins-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+Add GitlabYamlFileParser Action, which parses yaml files in gitlab to handle them as parameters in scaffolder

--- a/plugins/scaffolder-backend-module-gitlab/README.md
+++ b/plugins/scaffolder-backend-module-gitlab/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Gitlab Module for Scaffolder.
 
-Here you can find all Gitlab related features to improve your scaffolder:
+Here you can find all Gitlab related features to improve your Scaffolder:
 
 ## Getting started
 
@@ -24,6 +24,7 @@ import {
   createGitlabProjectDeployTokenAction,
   createGitlabProjectVariableAction,
   createGitlabGroupEnsureExistsAction,
+  parseGitlabYamlFilesAction,
 } from '@backstage/plugin-scaffolder-backend-module-gitlab';
 
 // Create BuiltIn Actions
@@ -37,10 +38,18 @@ const builtInActions = createBuiltinActions({
 // Add Gitlab Actions
 const actions = [
   ...builtInActions,
-  createGitlabProjectAccessTokenAction({ integrations: integrations }),
-  createGitlabProjectDeployTokenAction({ integrations: integrations }),
-  createGitlabProjectVariableAction({ integrations: integrations }),
-  createGitlabGroupEnsureExistsAction({ integrations: integrations }),
+  createGitlabProjectAccessTokenAction({
+    integrations: integrations,
+  }),
+  createGitlabProjectVariableAction({
+    integrations: integrations,
+  }),
+  createGitlabProjectDeployTokenAction({
+    integrations: integrations,
+  }),
+  parseGitlabYamlFilesAction({
+    integrations: integrations,
+  }),
 ];
 
 // Create Scaffolder Router
@@ -128,6 +137,16 @@ spec:
         name: ${{ parameters.name }}-secret
         username: ${{ parameters.name }}-secret
         scopes: ['read_registry']
+
+    - id: get-cluster-issuer
+      name: Get Cluster Issuer
+      action: gitlab:yamlFiles:parse
+      input:
+        repoUrl: ${{ parameters.repoUrl }}
+        projectId: "${{ steps['publish'].output.projectId }}"
+        filePath: test-dev-abc1d.kubeconfig
+        propPath: 'clusters[0].cluster.server'
+        split: "split('/')[2].split('.')[0]"
 
     - id: gitlab-access-token
       name: Gitlab Project Access Token

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -74,4 +74,18 @@ export const createGitlabProjectVariableAction: (options: {
   },
   JsonObject
 >;
+
+// @public
+export const parseGitlabYamlFilesAction: (options: {
+  integrations: ScmIntegrationRegistry;
+}) => TemplateAction<
+  {
+    repoUrl: string;
+    projectId: string | number;
+    filePath: string;
+    propPath: string;
+    token?: string | undefined;
+  },
+  JsonObject
+>;
 ```

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -80,13 +80,15 @@ export const parseGitlabYamlFilesAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    repoUrl?: string;
-    projectId: string | number;
     filePath: string;
+    repoUrl: string;
+    projectId: string | number;
     propPath: string;
-    split?: string | undefined;
     token?: string | undefined;
+    split?: string | undefined;
   },
-  JsonObject
+  {
+    value: string;
+  }
 >;
 ```

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -80,10 +80,11 @@ export const parseGitlabYamlFilesAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    repoUrl: string;
+    repoUrl?: string;
     projectId: string | number;
     filePath: string;
     propPath: string;
+    split?: string | undefined;
     token?: string | undefined;
   },
   JsonObject

--- a/plugins/scaffolder-backend-module-gitlab/package.json
+++ b/plugins/scaffolder-backend-module-gitlab/package.json
@@ -36,6 +36,7 @@
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
     "@gitbeaker/node": "^35.8.0",
+    "js-yaml": "^4.1.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/parseGitlabYamlFilesAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/parseGitlabYamlFilesAction.test.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseGitlabYamlFilesAction } from './parseGitlabYamlFilesAction';
+import { ScmIntegrations } from '@backstage/integration';
+import { ConfigReader } from '@backstage/config';
+import { getVoidLogger } from '@backstage/backend-common';
+import { PassThrough } from 'stream';
+
+const mockGitlabClient = {
+  RepositoryFiles: {
+    show: jest.fn(),
+  },
+};
+jest.mock('@gitbeaker/node', () => ({
+  Gitlab: class {
+    constructor() {
+      return mockGitlabClient;
+    }
+  },
+}));
+
+describe('gitlab:projectVariable:get', () => {
+  const config = new ConfigReader({
+    integrations: {
+      gitlab: [
+        {
+          host: 'gitlab.com',
+          token: 'tokentest',
+          apiBaseUrl: 'https://api.gitlab.com',
+        },
+        {
+          host: 'hosted.gitlab.com',
+          apiBaseUrl: 'https://api.hosted.gitlab.com',
+        },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  const action = parseGitlabYamlFilesAction({ integrations });
+  const mockContext = {
+    input: {
+      repoUrl: 'gitlab.com?repo=repo&owner=owner',
+      projectId: '123',
+      filePath: 'path/to/file.yaml',
+      propPath: '.clusters[0].name',
+      split: '',
+    },
+    output: jest.fn(),
+    workspacePath: 'test',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    createTemporaryDirectory: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should retrieve the variable value from a .yaml file', async () => {
+    const fileContent = `
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority-data: 
+          server: https://testoidcnumber.gr.eu-central-x.eks.amazonaws.com
+        name: test-dev-abc1d
+    contexts:
+      - context:
+          cluster: test-dev-abc1d
+          namespace: test-dev
+          user: oidc
+        name: test-dev-abc1d
+    current-context: test-dev-abc1d
+    kind: Config
+    `;
+    mockGitlabClient.RepositoryFiles.show.mockResolvedValue({
+      content: Buffer.from(fileContent),
+    });
+
+    await action.handler(mockContext);
+
+    expect(mockGitlabClient.RepositoryFiles.show).toHaveBeenCalledWith(
+      '123',
+      'path/to/file.yaml',
+      'master',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('value', 'test-dev-abc1d');
+  });
+
+  it('should retrieve the modified variable value from a .yaml file', async () => {
+    const fileContent = `
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority-data: 
+          server: https://testoidcnumber.gr.eu-central-x.eks.amazonaws.com
+        name: test-dev-abc1d
+    contexts:
+      - context:
+          cluster: test-dev-abc1d
+          namespace: test-dev
+          user: oidc
+        name: test-dev-abc1d
+    current-context: test-dev-abc1d
+    kind: Config
+    `;
+
+    mockContext.input.propPath = '.clusters[0].cluster.server';
+    mockContext.input.split = "split('/')[2].split('.')[0]";
+    mockGitlabClient.RepositoryFiles.show.mockResolvedValue({
+      content: Buffer.from(fileContent),
+    });
+    await action.handler(mockContext);
+    expect(mockGitlabClient.RepositoryFiles.show).toHaveBeenCalledWith(
+      '123',
+      'path/to/file.yaml',
+      'master',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('value', 'testoidcnumber');
+  });
+
+  it('should retrieve the yaml file in json format', async () => {
+    const fileContent = `
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority-data:
+          server: https://testoidcnumber.gr.eu-central-x.eks.amazonaws.com
+        name: test-dev-abc1d
+    contexts:
+      - context:
+          cluster: test-dev-abc1d
+          namespace: test-dev
+          user: oidc
+        name: test-dev-abc1d
+    current-context: test-dev-abc1d
+    kind: Config
+    `;
+    mockContext.input.propPath = '';
+    mockContext.input.split = '';
+    mockGitlabClient.RepositoryFiles.show.mockResolvedValue({
+      content: Buffer.from(fileContent),
+    });
+    await action.handler(mockContext);
+    expect(mockGitlabClient.RepositoryFiles.show).toHaveBeenCalledWith(
+      '123',
+      'path/to/file.yaml',
+      'master',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('value', {
+      apiVersion: 'v1',
+      clusters: [
+        {
+          cluster: {
+            'certificate-authority-data': null,
+            server: 'https://testoidcnumber.gr.eu-central-x.eks.amazonaws.com',
+          },
+          name: 'test-dev-abc1d',
+        },
+      ],
+      contexts: [
+        {
+          context: {
+            cluster: 'test-dev-abc1d',
+            namespace: 'test-dev',
+            user: 'oidc',
+          },
+          name: 'test-dev-abc1d',
+        },
+      ],
+      'current-context': 'test-dev-abc1d',
+      kind: 'Config',
+    });
+  });
+
+  it('should throw an error if the .yaml file is not found', async () => {
+    mockGitlabClient.RepositoryFiles.show.mockResolvedValue({
+      content: null,
+    });
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      /File not found: path\/to\/file.yaml/,
+    );
+  });
+
+  it('should throw an error if the key is not found in the .yaml file', async () => {
+    const fileContent = `
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority-data: 
+          server: https://testoidcnumber.gr.eu-central-x.eks.amazonaws.com
+        name: test-dev-abc1d
+    contexts:
+      - context:
+          cluster: test-dev-abc1d
+          namespace: test-dev
+          user: oidc
+        name: test-dev-abc1d
+    current-context: test-dev-abc1d
+    kind: Config
+    `;
+    mockContext.input.propPath = 'none';
+    mockGitlabClient.RepositoryFiles.show.mockResolvedValue({
+      content: Buffer.from(fileContent),
+    });
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      'Key not found: none',
+    );
+  });
+
+  it('should throw an error if theres a wrong split functions', async () => {
+    const fileContent = `
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority-data: 
+          server: https://testoidcnumber.gr.eu-central-x.eks.amazonaws.com
+        name: test-dev-abc1d
+    contexts:
+      - context:
+          cluster: test-dev-abc1d
+          namespace: test-dev
+          user: oidc
+        name: test-dev-abc1d
+    current-context: test-dev-abc1d
+    kind: Config
+    `;
+    mockContext.input.propPath = '.clusters[0]';
+    mockContext.input.split = "split('wrong).test()";
+    mockGitlabClient.RepositoryFiles.show.mockResolvedValue({
+      content: Buffer.from(fileContent),
+    });
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      'Invalid manipulation argument. Only correct split functions are allowed',
+    );
+  });
+});

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/parseGitlabYamlFilesAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/parseGitlabYamlFilesAction.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import { type ScmIntegrationRegistry } from '@backstage/integration';
+import { getToken } from '../util';
+import { Gitlab } from '@gitbeaker/node';
+import YAML from 'js-yaml';
+
+/**
+ * Creates a `gitlab:parseGitlabYamlFiles` Scaffolder action.
+ *
+ * @param options - Templating configuration.
+ * @public
+ */
+export const parseGitlabYamlFilesAction = (options: {
+  integrations: ScmIntegrationRegistry;
+}) => {
+  const { integrations } = options;
+  return createTemplateAction<{
+    repoUrl: string;
+    projectId: string | number;
+    filePath: string;
+    propPath: string;
+    split: string;
+    token?: string;
+  }>({
+    id: 'gitlab:yamlFiles:parse',
+    description: 'Retrieve a value from a .yaml file in a Gitlab repository',
+    schema: {
+      input: {
+        required: ['repoUrl', 'projectId', 'filePath'],
+        type: 'object',
+        properties: {
+          repoUrl: {
+            title: 'Repository Location',
+            type: 'string',
+            description:
+              'The Repository Location to the .yaml file containing the variable',
+          },
+          projectId: {
+            title: 'Project ID',
+            type: ['string', 'number'],
+            description:
+              'The Project ID to the .yaml file containing the variable',
+          },
+          filePath: {
+            title: 'File path',
+            type: 'string',
+            description: 'File path to the .yaml file containing the variable',
+          },
+          propPath: {
+            title: 'Property Path',
+            type: 'string',
+            description: 'The property path of the variable to retrieve',
+          },
+          split: {
+            title: 'Split Manipulation of the retrieved variable',
+            type: 'string',
+            description:
+              'The kind of split manipulation you want to use on your retrieved variable',
+          },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description: 'The token to use for authorization to GitLab',
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          value: {
+            title: 'Value',
+            type: 'string',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const { repoUrl, projectId, filePath, propPath, split } = ctx.input;
+      const { token, integrationConfig } = getToken(ctx.input, integrations);
+
+      const api = new Gitlab({
+        host: integrationConfig.config.baseUrl,
+        token: token,
+      });
+
+      const file = await api.RepositoryFiles.show(
+        projectId,
+        filePath,
+        'master',
+      );
+
+      if (!file.content) {
+        throw new Error(`File not found: ${filePath}`);
+      }
+
+      ctx.logger.info(`Retrieving yaml file from "${ctx.input.projectId}"`);
+      const isYamlFile = /\.(yaml|yml|kubeconfig)$/i.test(filePath);
+
+      if (!isYamlFile) {
+        throw new Error(`Invalid file type: ${filePath} is not a YAML file`);
+      }
+
+      let yamlData;
+
+      try {
+        yamlData = YAML.load(file.content);
+      } catch (err) {
+        throw new Error(`Error parsing YAML file: ${err}`);
+      }
+
+      if (!yamlData) {
+        throw new Error(`YAML file ${filePath} could not be parsed`);
+      }
+      function getPropertyByPath<T extends { [key: string]: any }>(
+        obj: T,
+        path: string,
+      ) {
+        if (typeof path !== 'string') {
+          throw new Error('Invalid path: path must be a string');
+        }
+        let value: any = obj;
+        if (
+          /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/.test(
+            value,
+          )
+        ) {
+          const buff = Buffer.from(value, 'base64');
+          value = YAML.load(buff.toString('utf8'));
+        }
+        const keys = path.split(/[\.\[\]]/).filter(key => key !== '');
+        for (const key of keys) {
+          if (typeof value === 'object' && value !== null && key in value) {
+            value = value[key];
+          } else if (Array.isArray(value) && !isNaN(parseInt(key, 10))) {
+            value = value[parseInt(key, 10)];
+          } else {
+            throw new Error(`Key not found: ${key}`);
+          }
+        }
+        return value;
+      }
+      function parseSplit(stringD: string): [string[], number[]] {
+        const splitArgs: string[] = [];
+        const arrayNums: number[] = [];
+        const regex = /(?:split|slice)\(['"](.+?)['"]\)(?:\[(\d+)\])?/g;
+        let match: RegExpExecArray | null = regex.exec(stringD);
+        while (match !== null) {
+          splitArgs.push(match[1]);
+          arrayNums.push(match[2] ? parseInt(match[2], 10) : 0);
+          match = regex.exec(stringD);
+        }
+        return [splitArgs, arrayNums];
+      }
+      function executeSplitCommands(
+        string: string,
+        splitArgs: string[],
+        arrayNums: number[],
+      ): string {
+        let res: string = string;
+        for (let i = 0; i < splitArgs.length; i++) {
+          const splitArg = splitArgs[i];
+          const arrayNum = arrayNums[i];
+          if (typeof arrayNum === 'number') {
+            res = res.split(splitArg)[arrayNum];
+          } else {
+            throw new Error(
+              `Invalid value ${arrayNum} for arrayNums[${i}]. Expected a number.`,
+            );
+          }
+        }
+        return res;
+      }
+      let result: any = undefined;
+      if (propPath) {
+        result = getPropertyByPath(
+          yamlData as { [key: string]: any },
+          propPath,
+        );
+      }
+      if (split) {
+        if (
+          /split\('.+'\)(?:\[\d+\])?(?:\.(?:split\('.+'\)(?:\[\d+\])?)*)?/.test(
+            split,
+          )
+        ) {
+          const [splitArgs, arrayNums] = parseSplit(split);
+          result = executeSplitCommands(result, splitArgs, arrayNums);
+        } else {
+          throw new Error(
+            'Invalid manipulation argument. Only correct split functions are allowed',
+          );
+        }
+      } else if (!propPath) {
+        result = yamlData;
+      }
+      if (result !== undefined) {
+        ctx.output('value', result as string);
+      }
+    },
+  });
+};

--- a/plugins/scaffolder-backend-module-gitlab/src/index.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/index.ts
@@ -23,3 +23,4 @@ export * from './actions/createGitlabGroupEnsureExistsAction';
 export * from './actions/createGitlabProjectDeployTokenAction';
 export * from './actions/createGitlabProjectAccessTokenAction';
 export * from './actions/createGitlabProjectVariableAction';
+export * from './actions/parseGitlabYamlFilesAction';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8502,6 +8502,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@gitbeaker/node": ^35.8.0
+    js-yaml: ^4.1.0
     zod: ^3.21.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To provide simple application templates, the configuration data for the target repositories is usually already available. But this can change from development team to development team. To avoid having to ask the user for this data each time, I have packaged it in a Scaffolder action. An example might be cluster configuration data(.kubecfg) or complex IAC data from a repository.

Contribution is Signed-off-by: Daniel Meyer (external expert on behalf of DB Netz AG) [daniel.di.meyer-extern@deutschebahn.com](mailto:daniel.di.meyer-extern@deutschebahn.com)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
