### PR TITLE
sonarqube: Make default config optional

### DIFF
--- a/.changeset/mighty-pandas-deny.md
+++ b/.changeset/mighty-pandas-deny.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-sonarqube': minor
+'@backstage/plugin-sonarqube-backend': minor
+---
+
+Made default config optional

--- a/.changeset/mighty-pandas-deny.md
+++ b/.changeset/mighty-pandas-deny.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-sonarqube': minor
-'@backstage/plugin-sonarqube-backend': minor
+'@backstage/plugin-sonarqube': patch
+'@backstage/plugin-sonarqube-backend': patch
 ---
 
 Made default config optional

--- a/plugins/sonarqube-backend/config.d.ts
+++ b/plugins/sonarqube-backend/config.d.ts
@@ -21,13 +21,13 @@ export interface Config {
      * The base url of the sonarqube installation. Defaults to https://sonarcloud.io.
      * @visibility frontend
      */
-    baseUrl: string;
+    baseUrl?: string;
 
     /**
      * The api key to access the sonarqube instance under baseUrl.
      * @visibility secret
      */
-    apiKey: string;
+    apiKey?: string;
 
     /**
      * The optional sonarqube instances.

--- a/plugins/sonarqube/config.d.ts
+++ b/plugins/sonarqube/config.d.ts
@@ -21,6 +21,6 @@ export interface Config {
      * The base url of the sonarqube installation. Defaults to https://sonarcloud.io.
      * @visibility frontend
      */
-    baseUrl: string;
+    baseUrl?: string;
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #18477

Sonarqube allows both "default" config and the configuration of list of instances. A recent change in backstage has started to cause errors on startup if you do no specify the default config, even if you are using the isntances. 

This seems to be because the default values in the config are not shown as optional parameters and are so correctly flagged as no being present.

This change will make the default config optional so that you can use only instance based config. The plugin itself checks to see if you are mixing and matching the values in an unexpected way.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
