### PR TITLE
fix: Use themeable styling for markdown in `DescriptionFieldTemplate`

### DIFF
--- a/.changeset/fluffy-frogs-change.md
+++ b/.changeset/fluffy-frogs-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Made markdown description theme-able

--- a/plugins/scaffolder-react/src/next/components/Form/DescriptionFieldTemplate.tsx
+++ b/plugins/scaffolder-react/src/next/components/Form/DescriptionFieldTemplate.tsx
@@ -24,17 +24,17 @@ import {
   StrictRJSFSchema,
 } from '@rjsf/utils';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   markdownDescription: {
-    fontSize: '0.75rem',
+    fontSize: theme.typography.caption.fontSize,
     margin: 0,
-    marginTop: '5px',
-    color: 'rgba(0, 0, 0, 0.54)',
-    '& p:first-child': {
+    color: theme.palette.text.secondary,
+    '& :first-child': {
       margin: 0,
+      marginTop: '3px', // to keep the standard browser padding
     },
   },
-});
+}));
 
 /** The `DescriptionField` is the template to use to render the description of a field
  * @alpha


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Lack of themeing support in markdown content makes it very difficult to see this text, especially on a dark theme.

Added themed support, used the same config as in the component `ScaffolderField`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
