### PR TITLE
improvement(core-components): `MissingAnnotationEmptyState` copy code button

### DIFF
--- a/.changeset/lazy-boxes-chew.md
+++ b/.changeset/lazy-boxes-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+This PR adds a copy code button to MissingAnnotationEmptyState by setting showCopyCodeButton=true. This improves the catalog user experience because now they can easily copy required annotations without having to highlight, ctrl+c etc.

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -116,6 +116,7 @@ export function MissingAnnotationEmptyState(props: Props) {
               text={generateComponentYaml(annotations)}
               language="yaml"
               showLineNumbers
+              showCopyCodeButton
               highlightedNumbers={generateLineNumbers(annotations.length)}
               customStyle={{ background: 'inherit', fontSize: '115%' }}
             />


### PR DESCRIPTION
This PR adds a copy code button to  `MissingAnnotationEmptyState` by setting `showCopyCodeButton=true`. This improves the catalog user experience because now they can easily copy required annotations without having to highlight, ctrl+c etc.

### Before
![image](https://github.com/backstage/backstage/assets/13325146/728cb1db-6e4f-4c35-8eab-96ecfed16619)


### After
![image](https://github.com/backstage/backstage/assets/13325146/ba40ee9e-ed80-48ee-a46e-d901299fbe71)


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
