### PR TITLE
Support for configuring Token Endpoint Auth Method for OIDC Provider

### DIFF
--- a/.changeset/tender-clouds-promise.md
+++ b/.changeset/tender-clouds-promise.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-auth-backend': patch
 ---
 
 Support for Token Endpoint Auth Method for OIDC Provider

--- a/.changeset/tender-clouds-promise.md
+++ b/.changeset/tender-clouds-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Support for Token Endpoint Auth Method for OIDC Provider

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -354,6 +354,7 @@ auth:
         clientSecret: ${AUTH_OIDC_CLIENT_SECRET}
         authorizationUrl: ${AUTH_OIDC_AUTH_URL}
         tokenUrl: ${AUTH_OIDC_TOKEN_URL}
+        tokenEndpointAuthMethod: ${AUTH_OIDC_TOKEN_ENDPOINT_AUTH_METHOD} # default='client_secret_basic'
         tokenSignedResponseAlg: ${AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG} # default='RS256'
         scope: ${AUTH_OIDC_SCOPE} # default='openid profile email'
         prompt: ${AUTH_OIDC_PROMPT} # default=none (allowed values: auto, none, consent, login)

--- a/docs/auth/oidc.md
+++ b/docs/auth/oidc.md
@@ -237,7 +237,8 @@ check the App Registration you created:
 - `metadataUrl`: In Overview > Endpoints tab, grab OpenID Connect metadata document URL.
 - `authorizationUrl` and `tokenUrl`: Open the `metadataUrl` in a browser, that json will
   hold these 2 urls somewhere in there.
-- `tokenEndpointAuthMethod` and `tokenSignedResponseAlg`: Don't define it, use the default unless you know what it does.
+- `tokenEndpointAuthMethod`: Don't define it, use the default unless you know what it does.
+- `tokenSignedResponseAlg`: Don't define it, use the default unless you know what it does.
 - `scope`: Only used if we didn't specify `defaultScopes` in the provider's factory,
   basically the same thing.
 - `prompt`: Recommended to use `auto` so the browser will request login to the IDP if the

--- a/docs/auth/oidc.md
+++ b/docs/auth/oidc.md
@@ -237,7 +237,7 @@ check the App Registration you created:
 - `metadataUrl`: In Overview > Endpoints tab, grab OpenID Connect metadata document URL.
 - `authorizationUrl` and `tokenUrl`: Open the `metadataUrl` in a browser, that json will
   hold these 2 urls somewhere in there.
-- `tokenSignedResponseAlg`: Don't define it, use the default unless you know what it does.
+- `tokenEndpointAuthMethod` and `tokenSignedResponseAlg`: Don't define it, use the default unless you know what it does.
 - `scope`: Only used if we didn't specify `defaultScopes` in the provider's factory,
   basically the same thing.
 - `prompt`: Recommended to use `auto` so the browser will request login to the IDP if the

--- a/plugins/auth-backend/src/providers/oidc/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.test.ts
@@ -53,6 +53,7 @@ const clientMetadata: Options = {
   clientId: 'testclientid',
   clientSecret: 'testclientsecret',
   metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
+  tokenEndpointAuthMethod: 'none',
   tokenSignedResponseAlg: 'none',
 };
 

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -1,4 +1,4 @@
-/*
+z/*
  * Copyright 2020 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -236,9 +236,9 @@ export const oidc = createAuthProviderIntegration({
           customCallbackUrl ||
           `${globalConfig.baseUrl}/${providerId}/handler/frame`;
         const metadataUrl = envConfig.getString('metadataUrl');
-        const tokenEndpointAuthMethod = envConfig.getOptionalString<ClientAuthMethod>(
+        const tokenEndpointAuthMethod = envConfig.getOptionalString(
           'tokenEndpointAuthMethod',
-        );
+        ) as ClientAuthMethod;
         const tokenSignedResponseAlg = envConfig.getOptionalString(
           'tokenSignedResponseAlg',
         );

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -236,7 +236,7 @@ export const oidc = createAuthProviderIntegration({
           customCallbackUrl ||
           `${globalConfig.baseUrl}/${providerId}/handler/frame`;
         const metadataUrl = envConfig.getString('metadataUrl');
-        const tokenEndpointAuthMethod = envConfig.getOptional<ClientAuthMethod>(
+        const tokenEndpointAuthMethod = envConfig.getOptionalString<ClientAuthMethod>(
           'tokenEndpointAuthMethod',
         );
         const tokenSignedResponseAlg = envConfig.getOptionalString(

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -17,6 +17,7 @@
 import express from 'express';
 import {
   Client,
+  ClientAuthMethod,
   Issuer,
   Strategy as OidcStrategy,
   TokenSet,
@@ -72,6 +73,7 @@ export type Options = OAuthProviderOptions & {
   metadataUrl: string;
   scope?: string;
   prompt?: string;
+  tokenEndpointAuthMethod?: ClientAuthMethod;
   tokenSignedResponseAlg?: string;
   signInResolver?: SignInResolver<OidcAuthResult>;
   authHandler: AuthHandler<OidcAuthResult>;
@@ -144,6 +146,8 @@ export class OidcAuthProvider implements OAuthHandlers {
       client_secret: options.clientSecret,
       redirect_uris: [options.callbackUrl],
       response_types: ['code'],
+      token_endpoint_auth_method:
+        options.tokenEndpointAuthMethod || 'client_secret_basic',
       id_token_signed_response_alg: options.tokenSignedResponseAlg || 'RS256',
       scope: options.scope || '',
     });
@@ -232,6 +236,9 @@ export const oidc = createAuthProviderIntegration({
           customCallbackUrl ||
           `${globalConfig.baseUrl}/${providerId}/handler/frame`;
         const metadataUrl = envConfig.getString('metadataUrl');
+        const tokenEndpointAuthMethod = envConfig.getOptional<ClientAuthMethod>(
+          'tokenEndpointAuthMethod',
+        );
         const tokenSignedResponseAlg = envConfig.getOptionalString(
           'tokenSignedResponseAlg',
         );
@@ -252,6 +259,7 @@ export const oidc = createAuthProviderIntegration({
           clientId,
           clientSecret,
           callbackUrl,
+          tokenEndpointAuthMethod,
           tokenSignedResponseAlg,
           metadataUrl,
           scope,

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -1,4 +1,4 @@
-z/*
+/*
  * Copyright 2020 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for configuring Client Authentication Method for the token endpoint for the OIDC Provider.

With this change, we can now configure the Client Authentication Method by using `tokenEndpointAuthMethod` in the `app-config.yaml` under the configuration - `auth.providers.oidc` to one of the below values in accordance with the [openid-client specification](https://github.com/panva/node-openid-client/blob/main/docs/README.md#client-authentication-methods)
- `none`
- `client_secret_basic` (default)
- `client_secret_post`
- `client_secret_jwt`
- `private_key_jwt`
- `tls_client_auth`
- `self_signed_tls_client_auth`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
