### PR TITLE
Fix Status a11y concerns

### DIFF
--- a/.changeset/four-humans-applaud.md
+++ b/.changeset/four-humans-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Updates the Status component to fix use of color and voice over accessibility issues.

--- a/packages/core-components/src/components/Status/Status.test.tsx
+++ b/packages/core-components/src/components/Status/Status.test.tsx
@@ -28,42 +28,52 @@ import {
 
 describe('<StatusOK />', () => {
   it('renders without exploding', async () => {
-    const { getByLabelText } = await renderInTestApp(<StatusOK />);
-    expect(getByLabelText('Status ok')).toBeInTheDocument();
+    const { getByText } = await renderInTestApp(<StatusOK>OK</StatusOK>);
+    expect(getByText('OK')).toBeInTheDocument();
   });
 });
 
 describe('<StatusWarning />', () => {
   it('renders without exploding', async () => {
-    const { getByLabelText } = await renderInTestApp(<StatusWarning />);
-    expect(getByLabelText('Status warning')).toBeInTheDocument();
+    const { getByText } = await renderInTestApp(
+      <StatusWarning>Warning</StatusWarning>,
+    );
+    expect(getByText('Warning')).toBeInTheDocument();
   });
 });
 
 describe('<StatusError />', () => {
   it('renders without exploding', async () => {
-    const { getByLabelText } = await renderInTestApp(<StatusError />);
-    expect(getByLabelText('Status error')).toBeInTheDocument();
+    const { getByText } = await renderInTestApp(
+      <StatusError>Error</StatusError>,
+    );
+    expect(getByText('Error')).toBeInTheDocument();
   });
 });
 
 describe('<StatusPending />', () => {
   it('renders without exploding', async () => {
-    const { getByLabelText } = await renderInTestApp(<StatusPending />);
-    expect(getByLabelText('Status pending')).toBeInTheDocument();
+    const { getByText } = await renderInTestApp(
+      <StatusPending>Pending</StatusPending>,
+    );
+    expect(getByText('Pending')).toBeInTheDocument();
   });
 });
 
 describe('<StatusRunning />', () => {
   it('renders without exploding', async () => {
-    const { getByLabelText } = await renderInTestApp(<StatusRunning />);
-    expect(getByLabelText('Status running')).toBeInTheDocument();
+    const { getByText } = await renderInTestApp(
+      <StatusRunning>Running</StatusRunning>,
+    );
+    expect(getByText('Running')).toBeInTheDocument();
   });
 });
 
 describe('<StatusAborted />', () => {
   it('renders without exploding', async () => {
-    const { getByLabelText } = await renderInTestApp(<StatusAborted />);
-    expect(getByLabelText('Status aborted')).toBeInTheDocument();
+    const { getByText } = await renderInTestApp(
+      <StatusAborted>Aborted</StatusAborted>,
+    );
+    expect(getByText('Aborted')).toBeInTheDocument();
   });
 });

--- a/packages/core-components/src/components/Status/Status.tsx
+++ b/packages/core-components/src/components/Status/Status.tsx
@@ -19,11 +19,11 @@ import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
 import React, { PropsWithChildren } from 'react';
 
-import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CheckIcon from '@material-ui/icons/Check';
 import WarningIcon from '@material-ui/icons/Warning';
 import ErrorIcon from '@material-ui/icons/Error';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
-import WatchLaterIcon from '@material-ui/icons/WatchLater';
+import ScheduleIcon from '@material-ui/icons/Schedule';
 import DirectionsRunIcon from '@material-ui/icons/DirectionsRun';
 
 export type StatusClassKey =
@@ -90,7 +90,7 @@ export function StatusOK(props: PropsWithChildren<{}>) {
       aria-label={!props.children ? 'Ok' : undefined}
       role={!props.children ? 'img' : undefined}
     >
-      <CheckCircleIcon style={{ fontSize: '1rem' }} />
+      <CheckIcon style={{ fontSize: '1rem' }} />
       <Typography component="span" {...props} />
     </div>
   );
@@ -132,7 +132,7 @@ export function StatusPending(props: PropsWithChildren<{}>) {
       aria-label={!props.children ? 'Pending' : undefined}
       role={!props.children ? 'img' : undefined}
     >
-      <WatchLaterIcon style={{ fontSize: '1rem' }} />
+      <ScheduleIcon style={{ fontSize: '1rem' }} />
       <Typography component="span" {...props} />
     </div>
   );

--- a/packages/core-components/src/components/Status/Status.tsx
+++ b/packages/core-components/src/components/Status/Status.tsx
@@ -19,6 +19,13 @@ import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
 import React, { PropsWithChildren } from 'react';
 
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import WarningIcon from '@material-ui/icons/Warning';
+import ErrorIcon from '@material-ui/icons/Error';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import WatchLaterIcon from '@material-ui/icons/WatchLater';
+import DirectionsRunIcon from '@material-ui/icons/DirectionsRun';
+
 export type StatusClassKey =
   | 'status'
   | 'ok'
@@ -31,44 +38,43 @@ export type StatusClassKey =
 const useStyles = makeStyles<BackstageTheme>(
   theme => ({
     status: {
+      alignItems: 'center',
+      display: 'flex',
+      flexFlow: 'row wrap',
       fontWeight: theme.typography.fontWeightMedium,
-      '&::before': {
-        width: '0.7em',
-        height: '0.7em',
-        display: 'inline-block',
+
+      '& > svg': {
         marginRight: theme.spacing(1),
-        borderRadius: '50%',
-        content: '""',
       },
     },
     ok: {
-      '&::before': {
-        backgroundColor: theme.palette.status.ok,
+      '& > svg': {
+        fill: theme.palette.status.ok,
       },
     },
     warning: {
-      '&::before': {
-        backgroundColor: theme.palette.status.warning,
+      '& > svg': {
+        fill: theme.palette.status.warning,
       },
     },
     error: {
-      '&::before': {
-        backgroundColor: theme.palette.status.error,
+      '& > svg': {
+        fill: theme.palette.status.error,
       },
     },
     pending: {
-      '&::before': {
-        backgroundColor: theme.palette.status.pending,
+      '& > svg': {
+        fill: theme.palette.status.pending,
       },
     },
     running: {
-      '&::before': {
-        backgroundColor: theme.palette.status.running,
+      '& > svg': {
+        fill: theme.palette.status.running,
       },
     },
     aborted: {
-      '&::before': {
-        backgroundColor: theme.palette.status.aborted,
+      '& > svg': {
+        fill: theme.palette.status.aborted,
       },
     },
   }),
@@ -77,78 +83,85 @@ const useStyles = makeStyles<BackstageTheme>(
 
 export function StatusOK(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);
+
   return (
-    <Typography
-      component="span"
+    <div
       className={classNames(classes.status, classes.ok)}
-      aria-label="Status ok"
-      aria-hidden="true"
-      {...props}
-    />
+      aria-label={!props.children ? 'Ok' : undefined}
+      role={!props.children ? 'img' : undefined}
+    >
+      <CheckCircleIcon style={{ fontSize: '1rem' }} />
+      <Typography component="span" {...props} />
+    </div>
   );
 }
 
 export function StatusWarning(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);
   return (
-    <Typography
-      component="span"
+    <div
       className={classNames(classes.status, classes.warning)}
-      aria-label="Status warning"
-      aria-hidden="true"
-      {...props}
-    />
+      aria-label={!props.children ? 'Warning' : undefined}
+      role={!props.children ? 'img' : undefined}
+    >
+      <WarningIcon style={{ fontSize: '1rem' }} />
+      <Typography component="span" {...props} />
+    </div>
   );
 }
 
 export function StatusError(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);
   return (
-    <Typography
-      component="span"
+    <div
       className={classNames(classes.status, classes.error)}
-      aria-label="Status error"
-      aria-hidden="true"
-      {...props}
-    />
+      aria-label={!props.children ? 'Error' : undefined}
+      role={!props.children ? 'img' : undefined}
+    >
+      <ErrorIcon style={{ fontSize: '1rem' }} />
+      <Typography component="span" {...props} />
+    </div>
   );
 }
 
 export function StatusPending(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);
   return (
-    <Typography
-      component="span"
+    <div
       className={classNames(classes.status, classes.pending)}
-      aria-label="Status pending"
-      aria-hidden="true"
-      {...props}
-    />
+      aria-label={!props.children ? 'Pending' : undefined}
+      role={!props.children ? 'img' : undefined}
+    >
+      <WatchLaterIcon style={{ fontSize: '1rem' }} />
+      <Typography component="span" {...props} />
+    </div>
   );
 }
 
 export function StatusRunning(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);
   return (
-    <Typography
-      component="span"
+    <div
       className={classNames(classes.status, classes.running)}
-      aria-label="Status running"
-      aria-hidden="true"
-      {...props}
-    />
+      aria-label={!props.children ? 'Running' : undefined}
+      role={!props.children ? 'img' : undefined}
+    >
+      <DirectionsRunIcon style={{ fontSize: '1rem' }} />
+      <Typography component="span" {...props} />
+    </div>
   );
 }
 
 export function StatusAborted(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);
   return (
-    <Typography
-      component="span"
+    <div
       className={classNames(classes.status, classes.aborted)}
-      aria-label="Status aborted"
-      aria-hidden="true"
-      {...props}
-    />
+      aria-label={!props.children ? 'Aborted' : undefined}
+      role={!props.children ? 'img' : undefined}
+    >
+      <HighlightOffIcon style={{ fontSize: '1rem' }} />
+      <Typography component="span" {...props} />
+    </div>
   );
 }

--- a/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.test.tsx
@@ -24,19 +24,19 @@ describe('StatusIcon', () => {
     let rendered = await renderInTestApp(
       <StatusIcon buildStatus="succeeded" />,
     );
-    expect(rendered.getByLabelText('Status ok')).toBeInTheDocument();
+    expect(rendered.getByLabelText('Ok')).toBeInTheDocument();
 
     rendered = await renderInTestApp(<StatusIcon buildStatus="failed" />);
-    expect(rendered.getByLabelText('Status error')).toBeInTheDocument();
+    expect(rendered.getByLabelText('Error')).toBeInTheDocument();
 
     rendered = await renderInTestApp(<StatusIcon buildStatus="stopped" />);
-    expect(rendered.getByLabelText('Status warning')).toBeInTheDocument();
+    expect(rendered.getByLabelText('Warning')).toBeInTheDocument();
   });
 
   it('should render invalid statuses', async () => {
     const rendered = await renderInTestApp(
       <StatusIcon buildStatus={'invalid' as BuildStatus} />,
     );
-    expect(rendered.getByLabelText('Status aborted')).toBeInTheDocument();
+    expect(rendered.getByLabelText('Aborted')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR seeks to fix several accessibility issues with the `Select` component.

The current `Status` component includes `aria-hidden='true'` which hides it from assistive technologies. This causes important information to be lost when using, for example, a screen reader. Using the [Backstage Storybook](https://backstage.io/storybook/?path=/story/data-display-status--default) as an example, a screen reader will announce the example 'Status' cells as "Blank".

![Screenshot 2023-06-29 at 10 14 51 AM](https://github.com/backstage/backstage/assets/2529208/e63f8e93-61f4-453a-8387-07cad1083416)

This fix allows the `Status` component to be properly announced:

![Screenshot 2023-06-30 at 8 41 31 PM](https://github.com/backstage/backstage/assets/2529208/26890aa9-429b-4262-8eec-1f41ef3ff9e7)

Additionally this PR replaces the colored dots with colored icons, so color is not used as the only visual means of conveying information (https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Although including text as a child to the `Status` component (e.g., `<StatusOK>Foo</StatusOK>`) provides context to the colored dot, the text is not required; the component can be rendered without text (e.g., `<StatusOK />`).

Lastly, for situations where the component is rendered without text (e.g., `<StatusOK />`) and `aria-label` and `role` are added to the component to allow it to be properly announced by voice over. The `role` is necessary for assistive technology to properly handle the `aria-label` on the `div`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
