### PR TITLE
chore(kubernetes-backend): Replace reference to deprecated import

### DIFF
--- a/.changeset/beige-actors-melt.md
+++ b/.changeset/beige-actors-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Replace reference to deprecated import

--- a/plugins/kubernetes-backend/src/service/standaloneApplication.ts
+++ b/plugins/kubernetes-backend/src/service/standaloneApplication.ts
@@ -18,7 +18,7 @@ import {
   errorHandler,
   notFoundHandler,
   requestLoggingHandler,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import compression from 'compression';
 import cors from 'cors';
@@ -40,12 +40,12 @@ export async function createStandaloneApplication(
 ): Promise<express.Application> {
   const { enableCors, logger } = options;
   const config = new ConfigReader({});
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
 
   const app = express();
 
   const catalogApi = new CatalogClient({
-    discoveryApi: SingleHostDiscovery.fromConfig(config),
+    discoveryApi: HostDiscovery.fromConfig(config),
   });
 
   const permissions = {} as PermissionEvaluator;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Replace the deprecated import of `SingleHostDiscovery` with its go-forward alias `HostDiscovery`.

<img width="887" alt="image" src="https://github.com/backstage/backstage/assets/33203301/67fe55ce-31fe-4302-8a72-a8d57c0a35c4">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
