### PR TITLE
chore(kubernetes): Make Pod Drawer headings consistent

### DIFF
--- a/.changeset/red-cherries-draw.md
+++ b/.changeset/red-cherries-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Make pod drawer headings consistent

--- a/plugins/kubernetes/src/components/Pods/PodDrawer/PodDrawer.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodDrawer/PodDrawer.tsx
@@ -173,7 +173,7 @@ export const PodDrawer = ({ podAndErrors, open }: PodDrawerProps) => {
             </Grid>
             {podAndErrors.errors.length > 0 && (
               <Grid item xs={12}>
-                <Typography variant="h5">Errors:</Typography>
+                <Typography variant="h5">Errors</Typography>
               </Grid>
             )}
             {podAndErrors.errors.length > 0 && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
In the Kubernetes plug-in, On the pod drawer pop up, there's a "Containers" section and if there are errors, the "Errors" section below it. It's a heading, and so doesn't visually need a trailing colon (IMHO), and this will keep it consistent with the "Containers" heading (which does not use a trailing colon).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
