### PR TITLE
Fix #18524 - add instruction to install deps when run with --skip-ins…

### DIFF
--- a/.changeset/cold-hounds-cheat.md
+++ b/.changeset/cold-hounds-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Post-create message - added instruction to run `yarn install` when app was created with `--skip-install`

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -129,6 +129,13 @@ export default async (opts: OptionValues): Promise<void> => {
     );
     Task.log();
     Task.section('All set! Now you might want to');
+    if (!opts.skipInstall) {
+      Task.log(
+        `  Install the dependencies: ${chalk.cyan(
+          `cd ${answers.name} && yarn install`,
+        )}`,
+      );
+    }
     Task.log(`  Run the app: ${chalk.cyan(`cd ${answers.name} && yarn dev`)}`);
     Task.log(
       '  Set up the software catalog: https://backstage.io/docs/features/software-catalog/configuration',


### PR DESCRIPTION
…tall

## Hey, I just made a Pull Request!

A fix for #18524 - add instruction to run `yarn install` when app was created with `--skip-install`

#### :heavy_check_mark: Checklist

- [*] All your commits have a `Signed-off-by` line in the message. 