### PR TITLE
Unprocessed Entities: Fix spacing for success message

### DIFF
--- a/.changeset/silver-balloons-sniff.md
+++ b/.changeset/silver-balloons-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+---
+
+Fixed spacing for success message

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -23,15 +23,14 @@ import {
   TableColumn,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { BackstageThemeOptions } from '@backstage/theme';
-import { Box, Typography, makeStyles } from '@material-ui/core';
+import { Box, Theme, Typography, makeStyles } from '@material-ui/core';
 
 import { UnprocessedEntity } from '../types';
 import { EntityDialog } from './EntityDialog';
 import { catalogUnprocessedEntitiesApiRef } from '../api';
 import useAsync from 'react-use/lib/useAsync';
 
-const useStyles = makeStyles((theme: BackstageThemeOptions) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   errorBox: {
     color: theme.palette.status.error,
     backgroundColor: theme.palette.errorBackground,
@@ -46,6 +45,7 @@ const useStyles = makeStyles((theme: BackstageThemeOptions) => ({
   successMessage: {
     background: theme.palette.infoBackground,
     color: theme.palette.infoText,
+    padding: theme.spacing(2),
   },
 }));
 

--- a/plugins/catalog-unprocessed-entities/src/components/PendingEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/PendingEntities.tsx
@@ -21,7 +21,7 @@ import {
   TableColumn,
   Table,
 } from '@backstage/core-components';
-import { Typography, makeStyles } from '@material-ui/core';
+import { Theme, Typography, makeStyles } from '@material-ui/core';
 
 import { UnprocessedEntity } from '../types';
 
@@ -29,9 +29,8 @@ import { EntityDialog } from './EntityDialog';
 import { useApi } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/lib/useAsync';
 import { catalogUnprocessedEntitiesApiRef } from '../api';
-import { BackstageTheme } from '@backstage/theme';
 
-const useStyles = makeStyles((theme: BackstageTheme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   successMessage: {
     background: theme.palette.infoBackground,
     color: theme.palette.infoText,


### PR DESCRIPTION
Compare Failed & Pending messages:

[castasdf.webm](https://github.com/backstage/backstage/assets/300900/eada1321-1a0e-4bea-8884-8c62fda55b25)

This change fixes the broken spacing on "Failed Entities".


Signed-off-by: Gustaf Lundh <gustaf.lundh@axis.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ x ] Added or updated documentation
- [ x ] Screenshots attached (for UI changes)
- [ x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
