### PR TITLE
kubernetes-backend proxy endpoint only adds auth header with nonempty token

### DIFF
--- a/.changeset/shiny-meals-chew.md
+++ b/.changeset/shiny-meals-chew.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fixed a bug where the proxy endpoint would error when used in combination with
+a local kubectl proxy process and a token-based auth strategy on-cluster.

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -548,15 +548,17 @@ describe('KubernetesProxy', () => {
     });
 
     worker.use(
-      rest.get('http://localhost:8001/api/v1/namespaces', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json({
-            kind: 'NamespaceList',
-            apiVersion: 'v1',
-            items: [],
-          }),
-        );
+      rest.get('http://localhost:8001/api/v1/namespaces', (req, res, ctx) => {
+        return req.headers.get('Authorization')
+          ? res(ctx.status(401))
+          : res(
+              ctx.status(200),
+              ctx.json({
+                kind: 'NamespaceList',
+                apiVersion: 'v1',
+                items: [],
+              }),
+            );
       }),
     );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #18140. 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
