### PR TITLE
feat: support k8s proxy working fine with cluster url has subpath

### DIFF
--- a/.changeset/polite-shrimps-confess.md
+++ b/.changeset/polite-shrimps-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Proxy endpoint supports cluster URLs with subpath

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -638,4 +638,46 @@ describe('KubernetesProxy', () => {
 
     expect(response.status).toEqual(500);
   });
+
+  it('should get res through proxy with cluster url has sub path', async () => {
+    worker.use(
+      rest.get(
+        'http://localhost:9999/subpath/api/v1/namespaces',
+        (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              kind: 'NamespaceList',
+              apiVersion: 'v1',
+              items: [],
+            }),
+          );
+        },
+      ),
+    );
+    permissionApi.authorize.mockResolvedValue([
+      { result: AuthorizeResult.ALLOW },
+    ]);
+    clusterSupplier.getClusters.mockResolvedValue([
+      {
+        name: 'cluster1',
+        url: 'http://localhost:9999/subpath',
+        authProvider: '',
+      },
+    ]);
+    authTranslator.decorateClusterDetailsWithAuth.mockImplementation(
+      async x => x,
+    );
+    const app = express().use(
+      Router().use('/mountpath', proxy.createRequestHandler({ permissionApi })),
+    );
+
+    const requestPromise = request(app)
+      .get('/mountpath/api/v1/namespaces')
+      .set(HEADER_KUBERNETES_CLUSTER, 'cluster1');
+    worker.use(rest.all(requestPromise.url, (req: any) => req.passthrough()));
+    const response = await requestPromise;
+
+    expect(response.status).toEqual(200);
+  });
 });

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -143,7 +143,7 @@ export class KubernetesProxy {
           const cluster = await this.getClusterForRequest(req);
           const url = new URL(cluster.url);
           return path.replace(
-            new RegExp(`^${originalReq.baseUrl}`),
+            new RegExp(`^${req.baseUrl}`),
             url.pathname || '',
           );
         },

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -138,7 +138,15 @@ export class KubernetesProxy {
         ws: true,
         secure: !originalCluster.skipTLSVerify,
         changeOrigin: true,
-        pathRewrite: { [`^${originalReq.baseUrl}`]: '' },
+        pathRewrite: async (path, req) => {
+          // Re-evaluate the cluster on each request, in case it has changed
+          const cluster = await this.getClusterForRequest(req);
+          const url = new URL(cluster.url);
+          return path.replace(
+            new RegExp(`^${originalReq.baseUrl}`),
+            url.pathname || '',
+          );
+        },
         router: async req => {
           // Re-evaluate the cluster on each request, in case it has changed
           const cluster = await this.getClusterForRequest(req);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When I build my own clusterSupplier and return clusters with cluster.url having subpath, for instance

```
{
    name: 'cluster1',
    url: 'http://localhost:9999/subpath',
    authProvider: '',
  }
```

using `api/kubernetes/proxy` api will return 404

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
