### PR TITLE
fix(confluence-to-markdown): update config struture

### DIFF
--- a/.changeset/cool-beans-tap.md
+++ b/.changeset/cool-beans-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': minor
+---
+
+This change updates the configuration structure of the action so that it does not conflict with other plugins.

--- a/.changeset/cool-beans-tap.md
+++ b/.changeset/cool-beans-tap.md
@@ -2,4 +2,75 @@
 '@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': minor
 ---
 
-This change updates the configuration structure of the action so that it does not conflict with other plugins.
+**BREAKING**
+
+This change updates the configuration of the confluence-to-markdown action so that it does not conflict with other confluence plguins. Currently many plugins make use of the `confluence.auth` configuration. However, only the confluence-to-markdown action uses the `confluence.auth` as a string. This change updates it so that `confluence.auth` is an object.
+
+## Required Changes
+
+Below are examples for updating `bearer`, `basic`, and `userpass` implementations.
+
+For `bearer`:
+Before:
+
+```yaml
+confluence:
+  baseUrl: 'https://confluence.example.com'
+  auth: 'bearer'
+  token: '${CONFLUENCE_TOKEN}'
+```
+
+After:
+
+```yaml
+confluence:
+  baseUrl: 'https://confluence.example.com'
+  auth:
+    type: 'bearer'
+    token: '${CONFLUENCE_TOKEN}'
+```
+
+For `basic`:
+
+Before:
+
+```yaml
+confluence:
+  baseUrl: 'https://confluence.example.com'
+  auth: 'basic'
+  token: '${CONFLUENCE_TOKEN}'
+  email: 'example@company.org'
+```
+
+After:
+
+```yaml
+confluence:
+  baseUrl: 'https://confluence.example.com'
+  auth:
+    type: 'basic'
+    token: '${CONFLUENCE_TOKEN}'
+    email: 'example@company.org'
+```
+
+For `userpass`
+Before:
+
+```yaml
+confluence:
+  baseUrl: 'https://confluence.example.com'
+  auth: 'userpass'
+  username: 'your-username'
+  password: 'your-password'
+```
+
+After:
+
+```yaml
+confluence:
+  baseUrl: 'https://confluence.example.com'
+  auth:
+    type: 'userpass'
+    username: 'your-username'
+    password: 'your-password'
+```

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/README.md
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/README.md
@@ -65,7 +65,8 @@ There is some configuration that needs to be setup to use this action, these are
 ```yaml
 confluence:
   baseUrl: 'https://confluence.example.com'
-  token: '${CONFLUENCE_TOKEN}'
+  auth:
+    token: '${CONFLUENCE_TOKEN}'
 ```
 
 The sections below will go into more details about the Base URL and Auth Methods.
@@ -85,8 +86,9 @@ For `bearer`:
 ```yaml
 confluence:
   baseUrl: 'https://confluence.example.com'
-  auth: 'bearer'
-  token: '${CONFLUENCE_TOKEN}'
+  auth:
+    type: 'bearer'
+    token: '${CONFLUENCE_TOKEN}'
 ```
 
 For `basic`:
@@ -94,9 +96,10 @@ For `basic`:
 ```yaml
 confluence:
   baseUrl: 'https://confluence.example.com'
-  auth: 'basic'
-  token: '${CONFLUENCE_TOKEN}'
-  email: 'example@company.org'
+  auth:
+    type: 'basic'
+    token: '${CONFLUENCE_TOKEN}'
+    email: 'example@company.org'
 ```
 
 For `userpass`
@@ -104,9 +107,10 @@ For `userpass`
 ```yaml
 confluence:
   baseUrl: 'https://confluence.example.com'
-  auth: 'userpass'
-  username: 'your-username'
-  password: 'your-password'
+  auth:
+    type: 'userpass'
+    username: 'your-username'
+    password: 'your-password'
 ```
 
 **Note:** For `basic` and `bearer` authorization methods you will need an access token for authorization with `Read` permissions. You can create a Personal Access Token (PAT) in Confluence. The value used should be the raw token as it will be encoded for you by the action.

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/config.d.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/config.d.ts
@@ -21,29 +21,31 @@ export interface Config {
      * The base URL for accessing the Confluence API
      */
     baseUrl: string;
-    /**
-     * Authentication method - basic, bearer, username/password
-     */
-    auth: 'basic' | 'bearer' | 'userpass';
-    /**
-     * Token used for the basic and bearer auth methods
-     * @visibility secret
-     */
-    token?: string;
-    /**
-     * Email used with the token for the basic auth method
-     * @visibility secret
-     */
-    email?: string;
-    /**
-     * Username used with the Username/Password auth method
-     * @visibility secret
-     */
-    username?: string;
-    /**
-     * Password used with the Username/Password auth method
-     * @visibility secret
-     */
-    password?: string;
+    auth: {
+      /**
+       * Authentication method - basic, bearer, username/password
+       */
+      type: 'basic' | 'bearer' | 'userpass';
+      /**
+       * Token used for the basic and bearer auth methods
+       * @visibility secret
+       */
+      token?: string;
+      /**
+       * Email used with the token for the basic auth method
+       * @visibility secret
+       */
+      email?: string;
+      /**
+       * Username used with the Username/Password auth method
+       * @visibility secret
+       */
+      username?: string;
+      /**
+       * Password used with the Username/Password auth method
+       * @visibility secret
+       */
+      password?: string;
+    };
   };
 }

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
@@ -47,7 +47,9 @@ describe('confluence:transform:markdown', () => {
   const config = new ConfigReader({
     confluence: {
       baseUrl: baseUrl,
-      token: 'fake_token',
+      auth: {
+        token: 'fake_token',
+      },
     },
   });
 

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.test.ts
@@ -57,8 +57,10 @@ describe('getConfluenceConfig', () => {
     const config = new ConfigReader({
       confluence: {
         baseUrl: 'https://example.atlassian.net',
-        auth: 'bearer',
-        token: 'fake_token',
+        auth: {
+          type: 'bearer',
+          token: 'fake_token',
+        },
       },
     });
 
@@ -78,9 +80,11 @@ describe('getConfluenceConfig', () => {
     const config = new ConfigReader({
       confluence: {
         baseUrl: 'https://example.atlassian.net',
-        auth: 'basic',
-        token: 'fake_token',
-        email: 'example@example.atlassian.net',
+        auth: {
+          type: 'basic',
+          token: 'fake_token',
+          email: 'example@example.atlassian.net',
+        },
       },
     });
 
@@ -100,9 +104,11 @@ describe('getConfluenceConfig', () => {
     const config = new ConfigReader({
       confluence: {
         baseUrl: 'https://example.atlassian.net',
-        auth: 'userpass',
-        username: 'fake_user',
-        password: 'fake_password',
+        auth: {
+          type: 'userpass',
+          username: 'fake_user',
+          password: 'fake_password',
+        },
       },
     });
 

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -43,7 +43,7 @@ export interface Results {
   results: Result[];
 }
 
-export type ConfluenceConfig = {
+export type LocalConfluenceConfig = {
   baseUrl: string;
   auth: string;
   token?: string;
@@ -53,13 +53,13 @@ export type ConfluenceConfig = {
 };
 
 export const getConfluenceConfig = (config: Config) => {
-  const confluenceConfig: ConfluenceConfig = {
+  const confluenceConfig = {
     baseUrl: config.getString('confluence.baseUrl'),
-    auth: config.getOptionalString('confluence.auth') ?? 'bearer',
-    token: config.getOptionalString('confluence.token'),
-    email: config.getOptionalString('confluence.email'),
-    username: config.getOptionalString('confluence.username'),
-    password: config.getOptionalString('confluence.password'),
+    auth: config.getOptionalString('confluence.auth.type') ?? 'bearer',
+    token: config.getOptionalString('confluence.auth.token'),
+    email: config.getOptionalString('confluence.auth.email'),
+    username: config.getOptionalString('confluence.auth.username'),
+    password: config.getOptionalString('confluence.auth.password'),
   };
 
   if (
@@ -89,7 +89,7 @@ export const getConfluenceConfig = (config: Config) => {
   return confluenceConfig;
 };
 
-export const getAuthorizationHeaderValue = (config: ConfluenceConfig) => {
+export const getAuthorizationHeaderValue = (config: LocalConfluenceConfig) => {
   switch (config.auth) {
     case 'bearer':
       return `Bearer ${config.token}`;
@@ -116,7 +116,7 @@ export const readFileAsString = async (fileDir: string) => {
 
 export const fetchConfluence = async (
   relativeUrl: string,
-  config: ConfluenceConfig,
+  config: LocalConfluenceConfig,
 ) => {
   const baseUrl = config.baseUrl;
   const authHeaderValue = getAuthorizationHeaderValue(config);
@@ -137,7 +137,7 @@ export const fetchConfluence = async (
 export const getAndWriteAttachments = async (
   arr: Results,
   workspace: string,
-  config: ConfluenceConfig,
+  config: LocalConfluenceConfig,
   mkdocsDir: string,
 ) => {
   const productArr: string[][] = [];


### PR DESCRIPTION
This change is being implemented so there is not a conflict between confluence-to-markdown and the confluence search plugin. Both items make use of `confluence.auth`. The confluence-to-markdown expects `auth` to be a string where as within the search plugin it is an object. Similarly both items expect a username and password or a token. In order to eliminate the duplicate code, this action is being updated to make use of the `auth` object and all items moving under this object.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
