### PR TITLE
Fixed a bug in `gitlab:group:ensureExists` where `repos` was always set as the root group

### DIFF
--- a/.changeset/wicked-ears-scream.md
+++ b/.changeset/wicked-ears-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Fixed a bug in `gitlab:group:ensureExists` where `repos` was always set as the root group.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.test.ts
@@ -51,17 +51,17 @@ describe('gitlab:group:ensureExists', () => {
     mockGitlabClient.Groups.search.mockResolvedValue([
       {
         id: 1,
-        full_path: 'repos/bar',
+        full_path: 'bar',
       },
       {
         id: 2,
-        full_path: 'repos/foo',
+        full_path: 'foo',
       },
     ]);
 
     mockGitlabClient.Groups.create.mockResolvedValue({
       id: 3,
-      full_path: 'repos/foo/bar',
+      full_path: 'foo/bar',
     });
 
     const config = new ConfigReader({
@@ -98,15 +98,15 @@ describe('gitlab:group:ensureExists', () => {
     mockGitlabClient.Groups.search.mockResolvedValue([
       {
         id: 1,
-        full_path: 'repos/bar',
+        full_path: 'bar',
       },
       {
         id: 2,
-        full_path: 'repos/foo',
+        full_path: 'foo',
       },
       {
         id: 42,
-        full_path: 'repos/foo/bar',
+        full_path: 'foo/bar',
       },
     ]);
 

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabGroupEnsureExistsAction.ts
@@ -66,10 +66,12 @@ export const createGitlabGroupEnsureExistsAction = (options: {
         token: token,
       });
 
-      let currentPath: string = 'repos';
+      let currentPath: string | null = null;
       let parent: GroupSchema | null = null;
       for (const pathElement of path) {
-        const fullPath = `${currentPath}/${pathElement}`;
+        const fullPath: string = currentPath
+          ? `${currentPath}/${pathElement}`
+          : pathElement;
         const result = (await api.Groups.search(
           fullPath,
         )) as unknown as Array<GroupSchema>; // recast since the return type for search is wrong in the gitbeaker typings


### PR DESCRIPTION
This PR fixes a bug found by @albibanushi  (see https://github.com/backstage/backstage/pull/17750#issuecomment-1622778494)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
