### PR TITLE
Fix a broken image url in docs/features/software-catalog/

### DIFF
--- a/docs/features/software-catalog/index.md
+++ b/docs/features/software-catalog/index.md
@@ -130,7 +130,7 @@ infrastructure UIs (and incurring additional cognitive overhead each time they
 make a context switch), most of these tools can be organized around the entities
 in the catalog.
 
-![tools](https://backstage.io/blog/assets/20-05-20/tabs.png)
+![tools](https://backstage.io/assets/images/tabs-abfdf72185d3ceb1d92c4237f7f78809.png)
 
 The Backstage platform can be customized by incorporating
 [existing open source plugins](https://github.com/backstage/backstage/tree/master/plugins),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

See https://backstage.io/docs/features/software-catalog/#integrated-tooling-through-plugins

I found the exact same picture in a [blogpost](https://backstage.io/blog/2020/05/22/phase-2-service-catalog#so-what-is-phase-2) and used the image from there.

I couldn't really figure out why the existing URL doesn't work as I am not familiar with how Backstage.io is setup.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
