### PR TITLE
remove zooming in restrictions in the graph

### DIFF
--- a/.changeset/sweet-pots-rescue.md
+++ b/.changeset/sweet-pots-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Remove zooming in restrictions in the catalog graph

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -241,7 +241,7 @@ export function DependencyGraph<NodeData, EdgeData>(
           container.call(
             d3Zoom
               .zoom<SVGSVGElement, null>()
-              .scaleExtent([1, 10])
+              .scaleExtent([1, Infinity])
               .on('zoom', event => {
                 event.transform.x = Math.min(
                   0,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When dealing with large node graphs it is not possible to zoom in deep enough to see the node content.

With this change, zooming in is no longer restricted. Closes #18527

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
