### PR TITLE
Allow using external templates in `create-app`

### DIFF
--- a/.changeset/six-camels-perform.md
+++ b/.changeset/six-camels-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Enable specifying an external application template when using the `create-app` CLI command.

--- a/.changeset/six-camels-perform.md
+++ b/.changeset/six-camels-perform.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/create-app': minor
+'@backstage/create-app': patch
 ---
 
 Enable specifying an external application template when using the `create-app` CLI command.

--- a/packages/create-app/cli-report.md
+++ b/packages/create-app/cli-report.md
@@ -11,5 +11,6 @@ Options:
   -V, --version
   --path [directory]
   --skip-install
+  --template-path [directory]
   -h, --help
 ```

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -66,7 +66,7 @@ export default async (opts: OptionValues): Promise<void> => {
   ]);
 
   const templateDir = opts.templatePath
-    ? resolvePath(paths.targetDir, opts.templatePath)
+    ? paths.resolveTarget(opts.templatePath)
     : paths.resolveOwn('templates/default-app');
   const tempDir = resolvePath(os.tmpdir(), answers.name);
 

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -65,7 +65,9 @@ export default async (opts: OptionValues): Promise<void> => {
     },
   ]);
 
-  const templateDir = paths.resolveOwn('templates/default-app');
+  const templateDir = opts.templatePath
+    ? resolvePath(paths.targetDir, opts.templatePath)
+    : paths.resolveOwn('templates/default-app');
   const tempDir = resolvePath(os.tmpdir(), answers.name);
 
   // Use `--path` argument as application directory when specified, otherwise
@@ -132,11 +134,15 @@ export default async (opts: OptionValues): Promise<void> => {
     if (!opts.skipInstall) {
       Task.log(
         `  Install the dependencies: ${chalk.cyan(
-          `cd ${answers.name} && yarn install`,
+          `cd ${opts.path ?? answers.name} && yarn install`,
         )}`,
       );
     }
-    Task.log(`  Run the app: ${chalk.cyan(`cd ${answers.name} && yarn dev`)}`);
+    Task.log(
+      `  Run the app: ${chalk.cyan(
+        `cd ${opts.path ?? answers.name} && yarn dev`,
+      )}`,
+    );
     Task.log(
       '  Set up the software catalog: https://backstage.io/docs/features/software-catalog/configuration',
     );

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -39,6 +39,10 @@ const main = (argv: string[]) => {
       '--skip-install',
       'Skip the install and builds steps after creating the app',
     )
+    .option(
+      '--template-path [directory]',
+      'Use an external application template instead of the default template',
+    )
     .action(cmd => createApp(cmd));
 
   program.parse(argv);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a new CLI option to the `create-app` CLI command that allows using an external application template in the `create-app` command: `template-path`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
