### PR TITLE
Refactored MuiChip overrides

### DIFF
--- a/.changeset/smooth-badgers-sell.md
+++ b/.changeset/smooth-badgers-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Removed the hard coded color and background color in the `MuiChip` overrides so that they work better with custom themes

--- a/packages/theme/src/v5/defaultComponentThemes.ts
+++ b/packages/theme/src/v5/defaultComponentThemes.ts
@@ -168,14 +168,9 @@ export const defaultComponentThemes: ThemeOptions['components'] = {
   MuiChip: {
     styleOverrides: {
       root: ({ theme }) => ({
-        backgroundColor: '#D9D9D9',
         // By default there's no margin, but it's usually wanted, so we add some trailing margin
         marginRight: theme.spacing(1),
         marginBottom: theme.spacing(1),
-        color: theme.palette.grey[900],
-      }),
-      outlined: ({ theme }) => ({
-        color: theme.palette.text.primary,
       }),
       label: ({ theme }) => ({
         lineHeight: theme.spacing(2.5),
@@ -186,7 +181,6 @@ export const defaultComponentThemes: ThemeOptions['components'] = {
         fontSize: theme.spacing(1.5),
       }),
       deleteIcon: ({ theme }) => ({
-        color: theme.palette.grey[500],
         width: theme.spacing(3),
         height: theme.spacing(3),
         margin: `0 ${theme.spacing(0.75)} 0 -${theme.spacing(0.75)}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Removed the hard coded color and background color in the `MuiChip` overrides so that they work better with custom themes

|  Before | After  |  
|---|---|
|  ![Screenshot 2023-07-11 at 6 57 53 AM](https://github.com/backstage/backstage/assets/67169551/1ea07d68-7242-431f-b043-365d1293c3e0) |  ![Screenshot 2023-07-11 at 7 08 00 AM](https://github.com/backstage/backstage/assets/67169551/b2293911-b58c-405a-a104-8bf760243e62) | 
|  ![Screenshot 2023-07-11 at 6 58 00 AM](https://github.com/backstage/backstage/assets/67169551/e3b3e60d-4457-4b57-aa6d-0e4c3a7632d4) | ![Screenshot 2023-07-11 at 7 08 09 AM](https://github.com/backstage/backstage/assets/67169551/d26615c6-c10c-4049-b370-df36631263ce)  | 

(First row uses the default variant, second row uses the outline variant)

As you can see there is a slight background color difference for the default using the light and dark themes after this change



Closes #18428 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
