### PR TITLE
Allow injecting MemberComponent into MembersListCard

### DIFF
--- a/.changeset/sour-points-repeat.md
+++ b/.changeset/sour-points-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Allowing MemberComponent to be injected into MembersListCard

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -9,6 +9,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
+import { UserEntity } from '@backstage/catalog-model';
 
 // @public (undocumented)
 export const EntityGroupProfileCard: (props: {
@@ -21,6 +22,7 @@ export const EntityMembersListCard: (props: {
   memberDisplayTitle?: string | undefined;
   pageSize?: number | undefined;
   showAggregateMembersToggle?: boolean | undefined;
+  MemberComponent?: ((props: { member: UserEntity }) => any) | undefined;
 }) => JSX.Element;
 
 // @public (undocumented)
@@ -46,9 +48,10 @@ export const GroupProfileCard: (props: {
 
 // @public (undocumented)
 export const MembersListCard: (props: {
-  memberDisplayTitle?: string;
-  pageSize?: number;
-  showAggregateMembersToggle?: boolean;
+  memberDisplayTitle?: string | undefined;
+  pageSize?: number | undefined;
+  showAggregateMembersToggle?: boolean | undefined;
+  MemberComponent?: ((props: { member: UserEntity }) => any) | undefined;
 }) => JSX.Element;
 
 // @public

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const MemberComponent = (props: { member: UserEntity }) => {
+const DefaultMemberComponent = (props: { member: UserEntity }) => {
   const classes = useStyles();
   const {
     metadata: { name: metaName, description },
@@ -132,11 +132,13 @@ export const MembersListCard = (props: {
   memberDisplayTitle?: string;
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
+  MemberComponent?: (props: { member: UserEntity }) => any;
 }) => {
   const {
     memberDisplayTitle = 'Members',
     pageSize = 50,
     showAggregateMembersToggle,
+    MemberComponent = DefaultMemberComponent,
   } = props;
 
   const { entity: groupEntity } = useEntity<GroupEntity>();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

[Issue](https://github.com/backstage/backstage/issues/18646):
Allow for MemberComponent to be injected into MembersListCard with current MemberComponent remaining default component used.

Context: 
We are working on customizing Member cards in the MemberListCard. However, to get to the MemberComponent, we would need to fully rewrite the MembersListCard.

There was a similar case in Discord ([link](https://discord.com/channels/687207715902193673/687207715902193679/1029296086646525992)) but it wasn't resolved.

This change will allow creation of custom member cards more easily.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
