### PR TITLE
Watching app config changes via frontend dev server

### DIFF
--- a/.changeset/loud-garlics-press.md
+++ b/.changeset/loud-garlics-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Reload the frontend when app config changes

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -29,6 +29,7 @@ export async function startFrontend(options: StartAppOptions) {
     entry: options.entry,
     checksEnabled: options.checksEnabled,
     configPaths: options.configPaths,
+    verifyVersions: options.verifyVersions,
   });
 
   await waitForExit();

--- a/packages/cli/src/commands/start/startFrontend.ts
+++ b/packages/cli/src/commands/start/startFrontend.ts
@@ -91,11 +91,16 @@ export async function startFrontend(options: StartAppOptions) {
 
   checkReactVersion();
 
+  const configChannel = new MessageChannel();
+
   const { name } = await fs.readJson(paths.resolveTarget('package.json'));
   const config = await loadCliConfig({
     args: options.configPaths,
     fromPackage: name,
     withFilteredKeys: true,
+    watch(appConfigs) {
+      configChannel.port1.postMessage(appConfigs);
+    },
   });
 
   const appBaseUrl = config.frontendConfig.getString('app.baseUrl');
@@ -119,6 +124,7 @@ export async function startFrontend(options: StartAppOptions) {
   const waitForExit = await serveBundle({
     entry: options.entry,
     checksEnabled: options.checksEnabled,
+    configChannel,
     ...config,
   });
 

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -45,6 +45,7 @@ export async function buildBundle(options: BuildOptions) {
     checksEnabled: false,
     isDev: false,
     baseUrl: resolveBaseUrl(options.frontendConfig),
+    getFrontendAppConfigs: () => options.frontendAppConfigs,
   });
 
   const isCi = yn(process.env.CI, { default: false });

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -118,12 +118,6 @@ export async function createConfig(
   );
 
   plugins.push(
-    new webpack.EnvironmentPlugin({
-      APP_CONFIG: options.frontendAppConfigs,
-    }),
-  );
-
-  plugins.push(
     new HtmlWebpackPlugin({
       template: paths.targetHtml,
       templateParameters: {
@@ -137,6 +131,10 @@ export async function createConfig(
   plugins.push(
     new webpack.DefinePlugin({
       'process.env.BUILD_INFO': JSON.stringify(buildInfo),
+      'process.env.APP_CONFIG': webpack.DefinePlugin.runtimeValue(
+        () => JSON.stringify(options.getFrontendAppConfigs()),
+        true,
+      ),
     }),
   );
 

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -21,27 +21,64 @@ import openBrowser from 'react-dev-utils/openBrowser';
 import { createConfig, resolveBaseUrl } from './config';
 import { ServeOptions } from './types';
 import { resolveBundlingPaths } from './paths';
+import { paths as libPaths } from '../../lib/paths';
+import { loadCliConfig } from '../config';
+import chalk from 'chalk';
 import { AppConfig } from '@backstage/config';
 
 export async function serveBundle(options: ServeOptions) {
-  const url = resolveBaseUrl(options.frontendConfig);
+  const { name } = await fs.readJson(libPaths.resolveTarget('package.json'));
+
+  let server: WebpackDevServer | undefined = undefined;
+  let latestFrontendAppConfigs: AppConfig[] = [];
+
+  const cliConfig = await loadCliConfig({
+    args: options.configPaths,
+    fromPackage: name,
+    withFilteredKeys: true,
+    watch(appConfigs) {
+      latestFrontendAppConfigs = appConfigs;
+      server?.invalidate();
+    },
+  });
+  latestFrontendAppConfigs = cliConfig.frontendAppConfigs;
+
+  const appBaseUrl = cliConfig.frontendConfig.getString('app.baseUrl');
+  const backendBaseUrl = cliConfig.frontendConfig.getString('backend.baseUrl');
+  if (appBaseUrl === backendBaseUrl) {
+    console.log(
+      chalk.yellow(
+        `⚠️   Conflict between app baseUrl and backend baseUrl:
+
+    app.baseUrl:     ${appBaseUrl}
+    backend.baseUrl: ${backendBaseUrl}
+
+    Must have unique hostname and/or ports.
+
+    This can be resolved by changing app.baseUrl and backend.baseUrl to point to their respective local development ports.
+`,
+      ),
+    );
+  }
+
+  const { frontendConfig, fullConfig } = cliConfig;
+  const url = resolveBaseUrl(frontendConfig);
 
   const host =
-    options.frontendConfig.getOptionalString('app.listen.host') || url.hostname;
+    frontendConfig.getOptionalString('app.listen.host') || url.hostname;
   const port =
-    options.frontendConfig.getOptionalNumber('app.listen.port') ||
+    frontendConfig.getOptionalNumber('app.listen.port') ||
     Number(url.port) ||
     (url.protocol === 'https:' ? 443 : 80);
-
-  let latestFrontendAppConfigs = options.frontendAppConfigs;
 
   const paths = resolveBundlingPaths(options);
   const pkgPath = paths.targetPackageJson;
   const pkg = await fs.readJson(pkgPath);
   const config = await createConfig(paths, {
-    ...options,
+    checksEnabled: options.checksEnabled,
     isDev: true,
     baseUrl: url,
+    frontendConfig,
     getFrontendAppConfigs: () => {
       return latestFrontendAppConfigs;
     },
@@ -49,7 +86,7 @@ export async function serveBundle(options: ServeOptions) {
 
   const compiler = webpack(config);
 
-  const server = new WebpackDevServer(
+  server = new WebpackDevServer(
     {
       hot: !process.env.CI,
       devMiddleware: {
@@ -73,8 +110,8 @@ export async function serveBundle(options: ServeOptions) {
       https:
         url.protocol === 'https:'
           ? {
-              cert: options.fullConfig.getString('app.https.certificate.cert'),
-              key: options.fullConfig.getString('app.https.certificate.key'),
+              cert: fullConfig.getString('app.https.certificate.cert'),
+              key: fullConfig.getString('app.https.certificate.key'),
             }
           : false,
       host,
@@ -90,7 +127,7 @@ export async function serveBundle(options: ServeOptions) {
   );
 
   await new Promise<void>((resolve, reject) => {
-    server.startCallback((err?: Error) => {
+    server?.startCallback((err?: Error) => {
       if (err) {
         reject(err);
         return;
@@ -101,17 +138,10 @@ export async function serveBundle(options: ServeOptions) {
     });
   });
 
-  options.configChannel.port2.onmessage = ({
-    data,
-  }: MessageEvent<AppConfig[]>) => {
-    latestFrontendAppConfigs = data;
-    server.invalidate();
-  };
-
   const waitForExit = async () => {
     for (const signal of ['SIGINT', 'SIGTERM'] as const) {
       process.on(signal, () => {
-        server.close();
+        server?.close();
         // exit instead of resolve. The process is shutting down and resolving a promise here logs an error
         process.exit();
       });

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -18,6 +18,8 @@ import fs from 'fs-extra';
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import openBrowser from 'react-dev-utils/openBrowser';
+import uniq from 'lodash/uniq';
+
 import { createConfig, resolveBaseUrl } from './config';
 import { ServeOptions } from './types';
 import { resolveBundlingPaths } from './paths';
@@ -25,8 +27,50 @@ import { paths as libPaths } from '../../lib/paths';
 import { loadCliConfig } from '../config';
 import chalk from 'chalk';
 import { AppConfig } from '@backstage/config';
+import { PackageGraph } from '@backstage/cli-node';
+import { Lockfile } from '../versioning';
+import {
+  forbiddenDuplicatesFilter,
+  includedFilter,
+} from '../../commands/versions/lint';
 
 export async function serveBundle(options: ServeOptions) {
+  if (options.verifyVersions) {
+    const lockfile = await Lockfile.load(
+      libPaths.resolveTargetRoot('yarn.lock'),
+    );
+    const result = lockfile.analyze({
+      filter: includedFilter,
+      localPackages: PackageGraph.fromPackages(
+        await PackageGraph.listTargetPackages(),
+      ),
+    });
+    const problemPackages = [...result.newVersions, ...result.newRanges]
+      .map(({ name }) => name)
+      .filter(forbiddenDuplicatesFilter);
+
+    if (problemPackages.length > 1) {
+      console.log(
+        chalk.yellow(
+          `⚠️   Some of the following packages may be outdated or have duplicate installations:
+
+          ${uniq(problemPackages).join(', ')}
+        `,
+        ),
+      );
+      console.log(
+        chalk.yellow(
+          `⚠️   This can be resolved using the following command:
+
+          yarn backstage-cli versions:check --fix
+      `,
+        ),
+      );
+    }
+  }
+
+  checkReactVersion();
+
   const { name } = await fs.readJson(libPaths.resolveTarget('package.json'));
 
   let server: WebpackDevServer | undefined = undefined;
@@ -152,4 +196,28 @@ export async function serveBundle(options: ServeOptions) {
   };
 
   return waitForExit;
+}
+
+function checkReactVersion() {
+  try {
+    // Make sure we're looking at the root of the target repo
+    const reactPkgPath = require.resolve('react/package.json', {
+      paths: [libPaths.targetRoot],
+    });
+    const reactPkg = require(reactPkgPath);
+    if (reactPkg.version.startsWith('16.')) {
+      console.log(
+        chalk.yellow(
+          `
+⚠️                                                                           ⚠️
+⚠️ You are using React version 16, which is deprecated for use in Backstage. ⚠️
+⚠️ Please upgrade to React 17 by updating your packages/app dependencies.    ⚠️
+⚠️                                                                           ⚠️
+`,
+        ),
+      );
+    }
+  } catch {
+    /* ignored */
+  }
 }

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -29,10 +29,7 @@ export type BundlingOptions = {
 
 export type ServeOptions = BundlingPathsOptions & {
   checksEnabled: boolean;
-  frontendConfig: Config;
-  frontendAppConfigs: AppConfig[];
-  fullConfig: Config;
-  configChannel: MessageChannel;
+  configPaths: string[];
 };
 
 export type BuildOptions = BundlingPathsOptions & {

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -30,6 +30,7 @@ export type BundlingOptions = {
 export type ServeOptions = BundlingPathsOptions & {
   checksEnabled: boolean;
   configPaths: string[];
+  verifyVersions?: boolean;
 };
 
 export type BuildOptions = BundlingPathsOptions & {

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -22,7 +22,7 @@ export type BundlingOptions = {
   checksEnabled: boolean;
   isDev: boolean;
   frontendConfig: Config;
-  frontendAppConfigs: AppConfig[];
+  getFrontendAppConfigs(): AppConfig[];
   baseUrl: URL;
   parallelism?: number;
 };
@@ -32,6 +32,7 @@ export type ServeOptions = BundlingPathsOptions & {
   frontendConfig: Config;
   frontendAppConfigs: AppConfig[];
   fullConfig: Config;
+  configChannel: MessageChannel;
 };
 
 export type BuildOptions = BundlingPathsOptions & {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -91,7 +91,7 @@ export async function loadCliConfig(options: Options) {
           withDeprecatedKeys: options.withDeprecatedKeys,
           ignoreSchemaErrors: !options.strict,
         });
-        options.watch!(newFrontendAppConfigs);
+        options.watch?.(newFrontendAppConfigs);
       },
     },
   });


### PR DESCRIPTION
## Why

Watching config changes in development will allow a smoother development flow & developers are not required to restart the dev server after every config change. This PR is working towards #18372 as it will allow changes in the declarative configuration to cause an update in the frontend dev server.

## How

The important change in the webpack customisation is, that we move the `loadCliConfig` call from `startFrontend` in to the `serveBundle` function and include a `watch` property allowing to [_"manually invalidate the current compiling round [on config changed], without stopping the watch process"_](https://webpack.js.org/api/node/#invalidate-watching)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
