### PR TITLE
docs(features/software-templates): update "writing-custom-field-extensions.md".

### DIFF
--- a/docs/features/software-templates/writing-custom-field-extensions.md
+++ b/docs/features/software-templates/writing-custom-field-extensions.md
@@ -89,10 +89,8 @@ export const validateKebabCaseValidation = (
   then please use `scaffolderPlugin.provide` from there instead and export it part of your `plugin.ts` rather than re-using the `scaffolder.plugin`.
 */
 
-import {
-  scaffolderPlugin,
-  createScaffolderFieldExtension,
-} from '@backstage/plugin-scaffolder';
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
 import {
   ValidateKebabCase,
   validateKebabCaseValidation,
@@ -133,7 +131,7 @@ Should look something like this instead:
 
 ```tsx
 import { ValidateKebabCaseFieldExtension } from './scaffolder/ValidateKebabCase';
-import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder';
+import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
 
 const routes = (
   <FlatRoutes>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update "writing-custom-field-extensions.md" after deprecated "createScaffolderFieldExtension" and "ScaffolderFieldExtensions" from  "@backstage/plugin-scaffolder".

The [current documentation](https://backstage.io/docs/features/software-templates/writing-custom-field-extensions) still advises that imports be performed from "@backstage/plugin-scaffolder":

![image](https://github.com/backstage/backstage/assets/72894267/7a593bd6-45fc-4dbc-8f52-71a1f0e65244)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
