### PR TITLE
Update microsite sidebar for latest release notes

### DIFF
--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -1,6 +1,7 @@
 {
   "releases": {
     "Release Notes": [
+      "releases/v1.15.0",
       "releases/v1.14.0",
       "releases/v1.13.0",
       "releases/v1.12.0",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently when on the microsite's latest release https://backstage.io/docs/releases/v1.15.0/ the sidebar with the previous releases doesn't show up (like it does https://backstage.io/docs/releases/v1.14.0/)

I assume this doesn't need a changeset because it's so trivial (like https://github.com/backstage/backstage/pull/18656 didn't need one), but if so let me know

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
