### PR TITLE
(bugfix): Make sure the configuration for the custom HomePage is always present

### DIFF
--- a/.changeset/silver-icons-work.md
+++ b/.changeset/silver-icons-work.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Make sure the function `handleLayoutChange` only updates the widgets if the
+layout has changed.
+
+In some cases, if the settings are not stored in the browser and the user
+clicks on the "Edit" button, this function could be triggered in a loop and cause
+the browser to freeze.

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -67,6 +67,7 @@
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "^16.11.26",
     "@types/react-grid-layout": "^1.3.2",

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { MockStorageApi, TestApiProvider } from '@backstage/test-utils';
+import { featureFlagsApiRef, storageApiRef } from '@backstage/core-plugin-api';
+import { useHomeStorage } from './CustomHomepageGrid';
+import { GridWidget } from './types';
+import { LocalStorageFeatureFlags } from '@backstage/core-app-api';
+
+describe('CustomHomepageGrid', () => {
+  describe('useHomeStorage', () => {
+    const storageApi = MockStorageApi.create();
+
+    const Wrapper = (props: { children?: React.ReactNode }) => (
+      <TestApiProvider
+        apis={[
+          [storageApiRef, storageApi],
+          [featureFlagsApiRef, new LocalStorageFeatureFlags()],
+        ]}
+      >
+        {props.children}
+      </TestApiProvider>
+    );
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should change widgets', async () => {
+      const { result } = renderHook(() => useHomeStorage([]), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current[0]).toStrictEqual([]);
+
+      const settings: GridWidget[] = [
+        {
+          id: 'test',
+          layout: { i: 'id', h: 3, w: 3, x: 0, y: 0 },
+          settings: {},
+        },
+      ];
+      act(() => {
+        result.current[1](settings);
+      });
+      expect(result.current[0]).toStrictEqual(settings);
+    });
+  });
+});

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -86,7 +86,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function useHomeStorage(
+export function useHomeStorage(
   defaultWidgets: GridWidget[],
 ): [GridWidget[], (value: GridWidget[]) => void] {
   const key = 'home';
@@ -365,7 +365,10 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
           layout: l,
         } as GridWidget;
       });
-      setWidgets(newWidgets);
+      // Only update if the old and new GridWidget are different
+      if (JSON.stringify(newWidgets) !== JSON.stringify(widgets)) {
+        setWidgets(newWidgets);
+      }
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7158,6 +7158,7 @@ __metadata:
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
+    "@testing-library/react-hooks": ^8.0.1
     "@testing-library/user-event": ^14.0.0
     "@types/node": ^16.11.26
     "@types/react": ^16.13.1 || ^17.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While trying to integrate the custom HomePage, we noticed that sometimes when we wanted to edit the view, the frontend would block due a huge amount of requests executed in a loop, but only if a `defaultConfig` was set. After some investigation, we discovered that all the components which were included in the default view were re-rendered in an infinite loop, and since some of them were making requests to the catalog, this also created a huge amount of traffic.

The way to reproduce it is the following:
1. Create the custom homepage adding the `RandomJoke` component including default settings for the random joke, like in the following:
    ```ts
    const defaultConfig: LayoutConfiguration[] = [
     {
       component: <HomePageRandomJoke />,
       x: 2,
       y: 0,
       height: 2,
       width: 8,
     },
   ];

    <CustomHomepageGrid config={defaultConfig}>
            <HomePageRandomJoke />
    </CustomHomepageGrid>
    ```
2. Open your home page in `http://localhost:3000` or `http://localhost:3000/home`
3. Then right click, open the `Inspector` and go to the `Local Storage` section.
4. If you see an entry `/home`, remove it (this should be the initial state if the user never used the custom homepage before)
5. Now, refresh the page. You'll still see the default view, as expected. But in the inspector there's no entry anymore
6. With the inspector open, go to the "Network" tab, and click in the "Edit" button in your HomePage
7. Suddenly, it should freeze and you''ll see a lot of requests to the API to get a joke

How was this solved? After more deep investigation, we discovered the following:

When the `changeEditMode` is triggered (if the user click in Edit), the widgets are updated, and the `ResponsiveGrid` gets updated as well with the new children (basically with the option to move and resize them).

However, this also seems to be triggering in some cases the method `handleLayoutChange`. Which then updates the widgets again. The "funny" part is that the old and new `GridWidget` items are exactly the same. Therefore, adding a check before updating this is more than enough. Since they are complex objects, it's easier to just compare them as strings.

Also, I left a tiny test to check if the `widgets` and `setWidgets` hooks are working as they should.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
