### PR TITLE
(feat): Allow hiding card title in custom homepage cards

### DIFF
--- a/.changeset/mean-squids-relax.md
+++ b/.changeset/mean-squids-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home-react': patch
+---
+
+Make `title` optional when defining the `createCardExtension`

--- a/.changeset/stupid-berries-run.md
+++ b/.changeset/stupid-berries-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Make sure the widget name is never empty in the `AddWidgetDialog`. If the title was set to "", the entry would contain an empty string. Use the name as a fallback

--- a/plugins/home-react/api-report.md
+++ b/plugins/home-react/api-report.md
@@ -55,7 +55,7 @@ export type ComponentRenderer = {
 
 // @public
 export function createCardExtension<T>(options: {
-  title: string;
+  title?: string;
   components: () => Promise<ComponentParts>;
   name?: string;
   description?: string;
@@ -65,14 +65,14 @@ export function createCardExtension<T>(options: {
 
 // @public (undocumented)
 export type RendererProps = {
-  title: string;
+  title?: string;
 } & ComponentParts;
 
 // @public (undocumented)
 export const SettingsModal: (props: {
   open: boolean;
   close: Function;
-  componentName: string;
+  componentName?: string;
   children: JSX.Element;
 }) => JSX.Element;
 ```

--- a/plugins/home-react/src/components/SettingsModal.tsx
+++ b/plugins/home-react/src/components/SettingsModal.tsx
@@ -27,14 +27,16 @@ import {
 export const SettingsModal = (props: {
   open: boolean;
   close: Function;
-  componentName: string;
+  componentName?: string;
   children: JSX.Element;
 }) => {
   const { open, close, componentName, children } = props;
 
   return (
     <Dialog open={open} onClose={() => close()}>
-      <DialogTitle>Settings - {componentName}</DialogTitle>
+      <DialogTitle>
+        {componentName ? `Settings - ${componentName}` : 'Settings'}
+      </DialogTitle>
       <DialogContent>{children}</DialogContent>
       <DialogActions>
         <Button onClick={() => close()} color="primary" variant="contained">

--- a/plugins/home-react/src/extensions.tsx
+++ b/plugins/home-react/src/extensions.tsx
@@ -42,7 +42,7 @@ export type ComponentParts = {
 /**
  * @public
  */
-export type RendererProps = { title: string } & ComponentParts;
+export type RendererProps = { title?: string } & ComponentParts;
 
 /**
  * @public
@@ -79,7 +79,7 @@ export type CardConfig = {
  * @public
  */
 export function createCardExtension<T>(options: {
-  title: string;
+  title?: string;
   components: () => Promise<ComponentParts>;
   name?: string;
   description?: string;
@@ -113,7 +113,6 @@ export function createCardExtension<T>(options: {
 
 type CardExtensionComponentProps<T> = CardExtensionProps<T> &
   ComponentParts & {
-    title: string;
     isCustomizable?: boolean;
     overrideTitle?: string;
   };
@@ -137,7 +136,7 @@ function CardExtension<T>(props: CardExtensionComponentProps<T>) {
     return (
       <Suspense fallback={<Progress />}>
         <Renderer
-          title={title}
+          {...(title && { title })}
           {...{
             Content,
             ...(Actions ? { Actions } : {}),
@@ -151,7 +150,7 @@ function CardExtension<T>(props: CardExtensionComponentProps<T>) {
   }
 
   const cardProps = {
-    title: title,
+    ...(title && { title }),
     ...(Settings && !isCustomizable
       ? {
           action: (

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -176,6 +176,8 @@ properties. The `settings.schema` object should follow
 must be `object`. As well, the `uiSchema` can be defined if a certain UI style needs to be applied fo any of the defined
 properties. More documentation [here](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema).
 
+If you want to hide the card title, you can do it by setting a `name` and leaving the `title` empty.
+
 ```tsx
 import { createCardExtension } from '@backstage/plugin-home-react';
 

--- a/plugins/home/api-report.md
+++ b/plugins/home/api-report.md
@@ -42,7 +42,7 @@ export type ClockConfig = {
 
 // @public (undocumented)
 export const ComponentAccordion: (props: {
-  title: string;
+  title?: string | undefined;
   expanded?: boolean | undefined;
   Content: () => JSX.Element;
   Actions?: (() => JSX.Element) | undefined;
@@ -156,7 +156,7 @@ export type RendererProps = RendererProps_2;
 export const SettingsModal: (props: {
   open: boolean;
   close: Function;
-  componentName: string;
+  componentName?: string | undefined;
   children: JSX.Element;
 }) => JSX.Element;
 

--- a/plugins/home/src/componentRenderers/ComponentAccordion.tsx
+++ b/plugins/home/src/componentRenderers/ComponentAccordion.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export const ComponentAccordion = (props: {
-  title: string;
+  title?: string;
   expanded?: boolean;
   Content: () => JSX.Element;
   Actions?: () => JSX.Element;

--- a/plugins/home/src/components/CustomHomepage/AddWidgetDialog.tsx
+++ b/plugins/home/src/components/CustomHomepage/AddWidgetDialog.tsx
@@ -29,7 +29,7 @@ interface AddWidgetDialogProps {
 }
 
 const getTitle = (widget: Widget) => {
-  return widget.title ?? widget.name;
+  return widget.title || widget.name;
 };
 
 export const AddWidgetDialog = (props: AddWidgetDialogProps) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In some cases, the Card header is not really important, since it just occupies space that might be used by other things. With this change both the custom cards that a person creates as well as the built-in ones (or others provided by external plugins) can hide that text.

There are 2 options to do it:

1. Inside the `CustomHomePageGrid`:
    ```ts
      <CustomHomepageGrid>
        <HomePageStarredEntities hideTitle />
      </CustomHomepageGrid>
    ```
2. As part of the `createCardExtension`:
    ```ts
    export const TestHomePageComponent = homePlugin.provide(
      createCardExtension({
        name: 'Test',
        title: 'Test',
        hideTitle: true,
        components: () => import('./homePageComponents/Test'),
      }),
    );
    ```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
