### PR TITLE
feat: support for overriding MissingAnnotationEmptyState component links via context

### DIFF
--- a/.changeset/mean-toys-return.md
+++ b/.changeset/mean-toys-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Support for overriding `MissingAnnotationEmptyState` component links via context.

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.test.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  MissingAnnotationEmptyState,
+  LinkContext,
+} from './MissingAnnotationEmptyState';
+
+describe('MissingAnnotationEmptyState', () => {
+  const contextLinks = { test: 'http://test.link' };
+  it('renders the component with special readMoreUrl', () => {
+    const annotation = 'backstage.io/test';
+    const readMoreUrl = 'https://example.com';
+    const { getByText } = render(
+      <LinkContext.Provider value={contextLinks}>
+        <MissingAnnotationEmptyState
+          annotation={annotation}
+          readMoreUrl={readMoreUrl}
+        />
+      </LinkContext.Provider>,
+    );
+    expect(getByText('Missing Annotation')).toBeInTheDocument();
+    expect(getByText('Read more').parentElement).toHaveAttribute(
+      'href',
+      readMoreUrl,
+    );
+  });
+
+  it('renders the component with special readMoreUrlKey which not existed in context', () => {
+    const annotation = 'backstage.io/test';
+    const readMoreUrl = 'https://example.com';
+    const { getByText } = render(
+      <LinkContext.Provider value={contextLinks}>
+        <MissingAnnotationEmptyState
+          annotation={annotation}
+          readMoreUrl={readMoreUrl}
+          readMoreUrlKey="not-exist"
+        />
+      </LinkContext.Provider>,
+    );
+
+    expect(getByText('Missing Annotation')).toBeInTheDocument();
+    expect(getByText('Read more').parentElement).toHaveAttribute(
+      'href',
+      readMoreUrl,
+    );
+  });
+
+  it('renders the component with special readMoreUrlKey which existed in context', () => {
+    const annotation = 'backstage.io/test';
+    const readMoreUrl = 'https://example.com';
+    const { getByText } = render(
+      <LinkContext.Provider value={contextLinks}>
+        <MissingAnnotationEmptyState
+          annotation={annotation}
+          readMoreUrl={readMoreUrl}
+          readMoreUrlKey="test"
+        />
+      </LinkContext.Provider>,
+    );
+
+    expect(getByText('Missing Annotation')).toBeInTheDocument();
+    expect(getByText('Read more').parentElement).toHaveAttribute(
+      'href',
+      contextLinks.test,
+    );
+  });
+});

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -18,7 +18,7 @@ import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import React from 'react';
+import React, { createContext, useContext } from 'react';
 
 import { CodeSnippet } from '../CodeSnippet';
 import { Link } from '../Link';
@@ -42,9 +42,14 @@ const ANNOTATION_LINE = COMPONENT_YAML_TEMPLATE.split('\n').findIndex(line =>
   ANNOTATION_REGEXP.test(line),
 );
 
+export type LinkData = Record<string, string>;
+
+export const LinkContext = createContext<LinkData>({});
+
 type Props = {
   annotation: string | string[];
   readMoreUrl?: string;
+  readMoreUrlKey?: string;
 };
 
 export type MissingAnnotationEmptyStateClassKey = 'code';
@@ -93,9 +98,11 @@ function generateDescription(annotations: string[]) {
 }
 
 export function MissingAnnotationEmptyState(props: Props) {
+  const contextLinks = useContext(LinkContext);
   const { annotation, readMoreUrl } = props;
   const annotations = Array.isArray(annotation) ? annotation : [annotation];
   const url =
+    contextLinks[props.readMoreUrlKey || ''] ||
     readMoreUrl ||
     'https://backstage.io/docs/features/software-catalog/well-known-annotations';
   const classes = useStyles();


### PR DESCRIPTION
Signed-off-by: mingfu <mingfu@alauda.io>

## Hey, I just made a Pull Request!

In this pr, supports setting readMoreLink via context for the MissingAnnotationEmptyState component.

**Scenario**: Some community plugins set the `readMoreLink`, which is inaccessible within our company as we don't have access to the public network. So the expectation is that there is a way to override readMoreLink.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
