### PR TITLE
fix: Fix pathRewrite in k8s Proxy for WebSocket requests

### DIFF
--- a/.changeset/chatty-seahorses-juggle.md
+++ b/.changeset/chatty-seahorses-juggle.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-WebSocket requests path were not being rewritten by the proxy properly, now they do.
+Fixed a bug where the proxy was not rewriting WebSocket request paths properly.

--- a/.changeset/chatty-seahorses-juggle.md
+++ b/.changeset/chatty-seahorses-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+WebSocket requests path were not being rewritten by the proxy properly, now they do.

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -90,9 +90,11 @@
     "@backstage/cli": "workspace:^",
     "@types/aws4": "^1.5.1",
     "@types/http-proxy-middleware": "^0.19.3",
+    "cross-fetch": "^3.1.5",
     "mock-fs": "^5.2.0",
     "msw": "^1.0.0",
-    "supertest": "^6.1.3"
+    "supertest": "^6.1.3",
+    "ws": "^8.13.0"
   },
   "files": [
     "dist",

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -695,7 +695,6 @@ describe('KubernetesProxy', () => {
       wsServer = new WebSocketServer({ port: wsPort, path: wsPath });
 
       wsServer.on('connection', (ws: WebSocket) => {
-        // send immediatly a feedback to the incoming connection
         ws.send('connected');
 
         // Echo message handling

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -693,7 +693,6 @@ describe('KubernetesProxy', () => {
       });
 
       wsEchoServer = new WebSocketServer({
-        // server: expressServer,
         port: 0,
         path: wsPath,
       });

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -749,8 +749,7 @@ describe('KubernetesProxy', () => {
 
       const connectMessagePromise = eventPromiseFactory(webSocket, 'message');
 
-      const openPromise = eventPromiseFactory(webSocket, 'open');
-      await openPromise;
+      await eventPromiseFactory(webSocket, 'open');
 
       const connectMessage = await connectMessagePromise;
       expect(connectMessage).toBe('connected');

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -712,7 +712,6 @@ describe('KubernetesProxy', () => {
       expressServer.close();
     });
 
-    // eslint-disable-next-line jest/no-done-callback
     it('should proxy websocket connections', async () => {
       clusterSupplier.getClusters.mockResolvedValue([
         {

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -731,7 +731,7 @@ describe('KubernetesProxy', () => {
         authProvider: 'serviceAccount',
       } as ClusterDetails);
 
-      const wsProxyAddress = `ws://localhost:${proxyPort}${proxyPath}${wsPath}`;
+      const wsProxyAddress = `ws://127.0.0.1:${proxyPort}${proxyPath}${wsPath}`;
       const wsAddress = `ws://localhost:${wsPort}${wsPath}`;
       console.log('Ports: ', wsProxyAddress, wsAddress);
 

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -126,8 +126,8 @@ describe('KubernetesProxy', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     proxy = new KubernetesProxy({ logger, clusterSupplier, authTranslator });
-    permissionApi.authorize.mockReturnValue(
-      Promise.resolve([{ result: AuthorizeResult.ALLOW }]),
+    permissionApi.authorize.mockResolvedValue(
+      [{ result: AuthorizeResult.ALLOW }],
     );
   });
 

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -145,7 +145,7 @@ export class KubernetesProxy {
           const cluster = await this.getClusterForRequest(req);
           const url = new URL(cluster.url);
           return path.replace(
-            new RegExp(`^${req.baseUrl}`),
+            new RegExp(`^${originalReq.baseUrl}`),
             url.pathname || '',
           );
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7334,6 +7334,7 @@ __metadata:
     "@types/luxon": ^3.0.0
     compression: ^1.7.4
     cors: ^2.8.5
+    cross-fetch: ^3.1.5
     express: ^4.17.1
     express-promise-router: ^4.1.0
     fs-extra: 10.1.0
@@ -7348,6 +7349,7 @@ __metadata:
     stream-buffers: ^3.0.2
     supertest: ^6.1.3
     winston: ^3.2.1
+    ws: ^8.13.0
     yn: ^4.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

WebSocket requests path were not being rewritten by the proxy properly, now they do.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
