### PR TITLE
[Analytics] Avoid erroneously attributing `navigate` events to home plugin 

### DIFF
--- a/.changeset/analytics-millenial-whoop.md
+++ b/.changeset/analytics-millenial-whoop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed a bug that could cause `navigate` analytics events to be misattributed to the plugin mounted on the root route (e.g. the `home` plugin at `/`) when the route that was navigated to wasn't associated with a routable extension.

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -213,6 +213,7 @@ middleware
 minikube
 Minikube
 Minio
+misattributed
 misconfiguration
 misconfigured
 mkdocs

--- a/packages/core-app-api/src/routing/RouteTracker.test.tsx
+++ b/packages/core-app-api/src/routing/RouteTracker.test.tsx
@@ -25,23 +25,37 @@ import {
   createPlugin,
   createRouteRef,
 } from '@backstage/core-plugin-api';
+import { MATCH_ALL_ROUTE } from './collectors';
 
 describe('RouteTracker', () => {
+  const routeRef0 = createRouteRef({
+    id: 'home:root',
+  });
   const routeRef1 = createRouteRef({
     id: 'route1',
   });
   const routeRef2 = createRouteRef({
     id: 'route2',
   });
+  const plugin0 = createPlugin({ id: 'home' });
   const plugin1 = createPlugin({ id: 'plugin1' });
 
   const routeObjects: BackstageRouteObject[] = [
+    {
+      path: '',
+      element: <div>home page</div>,
+      routeRefs: new Set([routeRef0]),
+      plugins: new Set([plugin0]),
+      caseSensitive: false,
+      children: [MATCH_ALL_ROUTE],
+    },
     {
       path: '/path/:p1/:p2',
       element: <Link to="/path2/hello">go</Link>,
       routeRefs: new Set([routeRef1]),
       plugins: new Set([plugin1]),
       caseSensitive: false,
+      children: [MATCH_ALL_ROUTE],
     },
     {
       path: '/path2/:param',
@@ -49,6 +63,7 @@ describe('RouteTracker', () => {
       routeRefs: new Set([routeRef2]),
       plugins: new Set(),
       caseSensitive: false,
+      children: [MATCH_ALL_ROUTE],
     },
   ];
 
@@ -92,8 +107,8 @@ describe('RouteTracker', () => {
           <RouteTracker routeObjects={routeObjects} />
 
           <Routes>
-            {routeObjects.map(({ routeRefs, ...props }) => (
-              <Route {...props} key={props.path} />
+            {routeObjects.map(({ path, element }) => (
+              <Route key={path} path={path || '/'} element={element} />
             ))}
           </Routes>
         </TestApiProvider>
@@ -113,6 +128,81 @@ describe('RouteTracker', () => {
         routeRef: 'route2',
       },
       subject: '/path2/hello',
+      value: undefined,
+    });
+  });
+
+  it('should capture path query and hash', async () => {
+    render(
+      <MemoryRouter initialEntries={['/path/foo/bar?q=1#header-1']}>
+        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
+          <RouteTracker routeObjects={routeObjects} />
+        </TestApiProvider>
+      </MemoryRouter>,
+    );
+
+    expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
+      action: 'navigate',
+      attributes: {
+        p1: 'foo',
+        p2: 'bar',
+      },
+      context: {
+        extension: 'App',
+        pluginId: 'plugin1',
+        routeRef: 'route1',
+      },
+      subject: '/path/foo/bar?q=1#header-1',
+      value: undefined,
+    });
+  });
+
+  it('should match the root path and send relevant context', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
+          <RouteTracker routeObjects={routeObjects} />
+        </TestApiProvider>
+      </MemoryRouter>,
+    );
+
+    expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
+      action: 'navigate',
+      attributes: {},
+      context: {
+        extension: 'App',
+        pluginId: 'home',
+        routeRef: 'home:root',
+      },
+      subject: '/',
+      value: undefined,
+    });
+  });
+
+  it('should return default context when no plugin/routeRef is on the route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/not-routable-extension']}>
+        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
+          <RouteTracker routeObjects={routeObjects} />
+          <Routes>
+            <Route
+              path="/not-routable-extension"
+              element={<>Non-extension</>}
+            />
+          </Routes>
+        </TestApiProvider>
+      </MemoryRouter>,
+    );
+
+    expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
+      action: 'navigate',
+      attributes: {},
+      context: {
+        extension: 'App',
+        pluginId: 'root',
+        routeRef: 'unknown',
+      },
+      subject: '/not-routable-extension',
       value: undefined,
     });
   });

--- a/packages/core-app-api/src/routing/RouteTracker.tsx
+++ b/packages/core-app-api/src/routing/RouteTracker.tsx
@@ -39,10 +39,7 @@ const getExtensionContext = (
 
     // Of the matching routes, get the last (e.g. most specific) instance of
     // the BackstageRouteObject.
-
-    const routeMatch = matches
-      ?.filter(match => match?.route.routeRefs?.size > 0)
-      .pop();
+    const routeMatch = matches?.pop();
 
     const routeObject = routeMatch?.route;
 
@@ -66,7 +63,7 @@ const getExtensionContext = (
     const params = Object.entries(
       routeMatch?.params || {},
     ).reduce<AnalyticsEventAttributes>((acc, [key, value]) => {
-      if (value !== undefined) {
+      if (value !== undefined && key !== '*') {
         acc[key] = value;
       }
       return acc;


### PR DESCRIPTION
## What / Why

We happen to have a number of routes wired up into our Backstage app that are not associated with routable extensions.  We also happen to use the `home` plugin.  It turns out that, under those circumstances, navigations to those non-routable extension routes would be attributed to the `home` plugin, because the route tracker was filtering down to route matches that had `routeRefs` associated with them.

This PR removes that unnecessary filtering logic, adds test coverage to validate the fix, and adds additional test coverage for the route tracker.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
