### PR TITLE
[Search] Fix Lunr fields highlight parsing

### DIFF
--- a/.changeset/search-donuts-wash.md
+++ b/.changeset/search-donuts-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Fix Lunr search engine highlight by ignoring invalid metadata positions.

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -1145,6 +1145,35 @@ describe('parseHighlightFields', () => {
       bar: 'ghi <>jkl</>',
     });
   });
+
+  it('should filter out non array positions', () => {
+    expect(
+      parseHighlightFields({
+        preTag: '<>',
+        postTag: '</>',
+        doc: { foo: 'abc def', bar: 'ghi jkl' },
+        positionMetadata: {
+          test: {
+            foo: {
+              // invalid position item
+              position: [null as unknown as number[]],
+            },
+          },
+          anotherTest: {
+            foo: {
+              position: [[4, 3]],
+            },
+            bar: {
+              position: [[4, 3]],
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      foo: 'abc <>def</>',
+      bar: 'ghi <>jkl</>',
+    });
+  });
 });
 
 describe('stopword testing', () => {

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -309,8 +309,13 @@ export function parseHighlightFields({
   const highlightFieldPositions = Object.values(positionMetadata).reduce(
     (fieldPositions, metadata) => {
       Object.keys(metadata).map(fieldKey => {
-        fieldPositions[fieldKey] = fieldPositions[fieldKey] ?? [];
-        fieldPositions[fieldKey].push(...metadata[fieldKey].position);
+        const validFieldMetadataPositions = metadata[
+          fieldKey
+        ]?.position?.filter(position => Array.isArray(position));
+        if (validFieldMetadataPositions.length) {
+          fieldPositions[fieldKey] = fieldPositions[fieldKey] ?? [];
+          fieldPositions[fieldKey].push(...validFieldMetadataPositions);
+        }
       });
 
       return fieldPositions;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related: https://github.com/backstage/backstage/issues/18707

Lunr's search engine sometimes returns nullable field metadata positions. In these cases, an error is thrown because we cannot determine where the pre and post-highlight tags should be injected.

This pull request fixes highlight parsing ignoring invalid metadata positions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
