### PR TITLE
Bugfix/pass missing `templateName` prop to `Stepper` in `Workflow` (GA4 event tracking bug fix)

### DIFF
--- a/.changeset/ten-otters-appear.md
+++ b/.changeset/ten-otters-appear.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder-react': patch
 ---
 
 Fixed bug in Workflow component by passing a prop `templateName` down to Stepper component.

--- a/.changeset/ten-otters-appear.md
+++ b/.changeset/ten-otters-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+---
+
+Fixed bug in Workflow component by passing a prop `templateName` down to Stepper component.

--- a/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
+++ b/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
@@ -102,7 +102,7 @@ export const Workflow = (workflowProps: WorkflowProps): JSX.Element | null => {
           noPadding
           titleTypographyProps={{ component: 'h2' }}
         >
-          <Stepper manifest={manifest} {...props} />
+          <Stepper manifest={manifest} templateName={templateName} {...props} />
         </InfoCard>
       )}
     </Content>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I noticed that `templateName` prop is not passed down from `Workflow` component to `Stepper` component. I caught this bug when I captured `create` event with Google Analytics 4 event tracking (`analytics.captureEvent`). As a result, the template name is getting retuned as `unknown` on the GA4 dashboard. This change should fix it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
