### PR TITLE
Allow package prefixes to be customized for DevTools dependency listing

### DIFF
--- a/.changeset/kind-cougars-allow.md
+++ b/.changeset/kind-cougars-allow.md
@@ -2,4 +2,13 @@
 '@backstage/plugin-devtools-backend': patch
 ---
 
-Add DevTools configuration to enable dependency listing to be filtered with custom prefixes
+Add DevTools configuration to enable dependency listing to be filtered with custom prefixes. For instance, in your `app-config.yaml`:
+
+```yaml
+devTools:
+  info:
+    packagePrefixes:
+      - @backstage/
+      - @roadiehq/backstage-
+      - @spotify/backstage-
+```

--- a/.changeset/kind-cougars-allow.md
+++ b/.changeset/kind-cougars-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools-backend': patch
+---
+
+Add DevTools configuration to enable dependency listing to be filtered with custom prefixes

--- a/plugins/devtools-backend/config.d.ts
+++ b/plugins/devtools-backend/config.d.ts
@@ -41,9 +41,14 @@ export interface Config {
       }>;
     };
     /**
-     * A list of package prefixes that DevTools will use for filtering all available dependencies
-     * (default is ["@backstage"])
+     * Info configuration
      */
-    packagePrefixes?: string[];
+    info?: {
+      /**
+       * A list of package prefixes that DevTools will use for filtering all available dependencies
+       * (default is ["@backstage"])
+       */
+      packagePrefixes?: string[];
+    };
   };
 }

--- a/plugins/devtools-backend/config.d.ts
+++ b/plugins/devtools-backend/config.d.ts
@@ -40,5 +40,10 @@ export interface Config {
         target: string;
       }>;
     };
+    /**
+     * A list of package prefixes that DevTools will use for filtering all available dependencies
+     * (default is ["@backstage"])
+     */
+    packagePrefixes?: string[];
   };
 }

--- a/plugins/devtools-backend/src/api/DevToolsBackendApi.ts
+++ b/plugins/devtools-backend/src/api/DevToolsBackendApi.ts
@@ -219,9 +219,9 @@ export class DevToolsBackendApi {
     const lockfilePath = paths.resolveTargetRoot('yarn.lock');
     const lockfile = await Lockfile.load(lockfilePath);
 
-    const prefixes = this.config.getOptionalStringArray(
-      'devTools.packagePrefixes',
-    ) ?? ['@backstage/'];
+    const prefixes = ['@backstage', '@internal'].concat(
+      this.config.getOptionalStringArray('devTools.info.packagePrefixes') ?? [],
+    );
     const deps = [...lockfile.keys()].filter(n =>
       prefixes.some(prefix => n.startsWith(prefix)),
     );

--- a/plugins/devtools-backend/src/api/DevToolsBackendApi.ts
+++ b/plugins/devtools-backend/src/api/DevToolsBackendApi.ts
@@ -219,7 +219,12 @@ export class DevToolsBackendApi {
     const lockfilePath = paths.resolveTargetRoot('yarn.lock');
     const lockfile = await Lockfile.load(lockfilePath);
 
-    const deps = [...lockfile.keys()].filter(n => n.startsWith('@backstage/'));
+    const prefixes = this.config.getOptionalStringArray(
+      'devTools.packagePrefixes',
+    ) ?? ['@backstage/'];
+    const deps = [...lockfile.keys()].filter(n =>
+      prefixes.some(prefix => n.startsWith(prefix)),
+    );
 
     const infoDependencies: PackageDependency[] = [];
     for (const dep of deps) {

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -410,9 +410,21 @@ export const customDevToolsPage = <DevToolsPage />;
 
 The following sections outline the configuration for the DevTools plugin
 
+### Package Dependencies
+
+By default, only packages with names starting with `@backstage/` will be listed on the main "Info" tab. If you would like additional packages to be listed, you can specify the package prefixes in your `app-config.yaml`. For example, to include backstage plugins provided by the core application as well as `@roadiehq` and `@spotify`:
+
+```yaml
+devTools:
+  packagePrefixes:
+    - @backstage/
+    - @roadiehq/backstage-
+    - @spotify/backstage-
+```
+
 ### External Dependencies Configuration
 
-If you decide to use the External Dependencies tab then you'll need to setup the configuration for it in your `app-config.yaml`, if there is no config setup then the tab will be empty. Here's an example:
+If you decide to use the External Dependencies tab then you'll need to setup the configuration for it in your `app-config.yaml`. If there is no endpoints configured, then the tab will be empty. Here's an example:
 
 ```yaml
 devTools:

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -408,18 +408,18 @@ export const customDevToolsPage = <DevToolsPage />;
 
 ## Configuration
 
-The following sections outline the configuration for the DevTools plugin
+The following sections outline the configuration for the DevTools plugin.
 
 ### Package Dependencies
 
-By default, only packages with names starting with `@backstage/` will be listed on the main "Info" tab. If you would like additional packages to be listed, you can specify the package prefixes in your `app-config.yaml`. For example, to include backstage plugins provided by the core application as well as `@roadiehq` and `@spotify`:
+By default, only packages with names starting with `@backstage` and `@internal` will be listed on the main "Info" tab. If you would like additional packages to be listed, you can specify the package prefixes (not regular expressions) in your `app-config.yaml`. For example, to not only provide version information about backstage plugins provided by the core application (`@backstage/*` modules) but also `@roadiehq` and `@spotify` plugins, you can specify this configuration:
 
 ```yaml
 devTools:
-  packagePrefixes:
-    - @backstage/
-    - @roadiehq/backstage-
-    - @spotify/backstage-
+  info:
+    packagePrefixes:
+      - @roadiehq/backstage-
+      - @spotify/backstage-
 ```
 
 ### External Dependencies Configuration


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By default, the DevTools plugin shows a listing of package dependencies (with versions for each, very useful) that is limited to packages beginning with `@backstage/`. This PR adds configuration that allows multiple package prefixes to be specified to allow for other plugins to be surfaced on this page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
