### PR TITLE
fix linguist plugin options

### DIFF
--- a/.changeset/large-experts-poke.md
+++ b/.changeset/large-experts-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-linguist-backend': patch
+---
+
+Fixed bug in LinguistBackendClient.ts file where if the linguistJsOptions is specified and sent over to the linguist-js package it would get changed (another attribute would be added) causing future entities of the batch to fail with an error

--- a/plugins/linguist-backend/src/api/LinguistBackendClient.ts
+++ b/plugins/linguist-backend/src/api/LinguistBackendClient.ts
@@ -261,7 +261,7 @@ export class LinguistBackendClient implements LinguistBackendApi {
 
   /** @internal */
   async getLinguistResults(dir: string): Promise<Results> {
-    const results = await linguist(dir, this.linguistJsOptions);
+    const results = await linguist(dir, { ...this.linguistJsOptions });
     return results;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed bug in LinguistBackendClient.ts file where if the linguistJsOptions is specified and sent over to the linguist-js package it would get changed (another attribute would be added) causing future entities of the batch to fail with the following error

![image](https://github.com/backstage/backstage/assets/51959110/4f84f2e9-ab53-4da0-913b-cc930b5dc300)

You can check the issue yourself by adding options to the `linguist.ts` files createRouter()
```
  return createRouter(
    {
      schedule: schedule,
      age: { days: 30 },
      batchSize: 2,
      useSourceLocation: false,
      linguistJsOptions: {ignoredFiles: ['yarn.lock']}
    },
    { ...env },
  );
```

The added attribute is fileContents added here inside linguist-js package
![image](https://github.com/backstage/backstage/assets/51959110/36fa6eb7-88aa-4566-851b-fe98b7c4c3fd)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
