### PR TITLE
feat(tech-radar): Allow rings to be hidden and create a new search view for tech radar.

### DIFF
--- a/.changeset/slow-years-rescue.md
+++ b/.changeset/slow-years-rescue.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-tech-radar': minor
+---
+
+Allows entries to be defined as `hidden` from the API. This hides the entries from the main radar with the goal of allowing users to have an additional category ("In Use", "Use", "Keep", etc). This additional category holds tech radar items that are company wide and already in use, removing them from the radar reduces clutter.
+
+However, they still need to be visible, thus this adds a new search table and routing to the tech radar plugin. The new `/search` route allows searching for items, `hidden` or not, by title, area, etc. It also integrates with the description popup.

--- a/plugins/tech-radar/api-report.md
+++ b/plugins/tech-radar/api-report.md
@@ -44,9 +44,6 @@ export interface RadarEntrySnapshot {
 }
 
 // @public
-export function RadarPage(props: TechRadarPageProps): JSX.Element;
-
-// @public
 export interface RadarQuadrant {
   id: string;
   name: string;
@@ -55,12 +52,13 @@ export interface RadarQuadrant {
 // @public
 export interface RadarRing {
   color: string;
+  hidden?: boolean;
   id: string;
   name: string;
 }
 
 // @public @deprecated (undocumented)
-export const Router: typeof RadarPage;
+export const Router: (props: TechRadarPageProps) => JSX.Element;
 
 // @public
 export interface TechRadarApi {
@@ -77,6 +75,8 @@ export function TechRadarComponent(props: TechRadarComponentProps): JSX.Element;
 export interface TechRadarComponentProps {
   height: number;
   id?: string;
+  // (undocumented)
+  pageTitle?: string;
   searchText?: string;
   svgProps?: object;
   width: number;
@@ -90,10 +90,11 @@ export interface TechRadarLoaderResponse {
 }
 
 // @public
-export const TechRadarPage: RadarPage;
+export const TechRadarPage: (props: TechRadarPageProps) => JSX.Element;
 
 // @public
 export interface TechRadarPageProps extends TechRadarComponentProps {
+  // (undocumented)
   pageTitle?: string;
   subtitle?: string;
   title?: string;
@@ -102,7 +103,7 @@ export interface TechRadarPageProps extends TechRadarComponentProps {
 // @public
 const techRadarPlugin: BackstagePlugin<
   {
-    root: RouteRef<undefined>;
+    radar: RouteRef<undefined>;
   },
   {},
   {}

--- a/plugins/tech-radar/src/api.ts
+++ b/plugins/tech-radar/src/api.ts
@@ -71,6 +71,12 @@ export interface RadarRing {
    * Supports any value parseable by {@link https://www.npmjs.com/package/color-string | color-string}
    */
   color: string;
+
+  /**
+   * Used to hide rings from the radar view. Useful for adding items to search but not in the main view,
+   *  ie archived or already widely accepted items.
+   */
+  hidden?: boolean;
 }
 
 /**

--- a/plugins/tech-radar/src/components/DefaultRadarPage.tsx
+++ b/plugins/tech-radar/src/components/DefaultRadarPage.tsx
@@ -13,16 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
-import { useOutlet } from 'react-router-dom';
-import { DefaultRadarPage } from './DefaultRadarPage';
+import { RadarComponent } from './RadarComponent';
+import { RadarLayout } from './RadarLayout/RadarLayout';
+import { RadarTablePage } from './RadarTable';
 import { TechRadarPageProps } from './types';
 
 /**
+ * Main Page of Tech Radar
+ *
  * @public
  */
-export const TechRadarPage = (props: TechRadarPageProps) => {
-  const outlet = useOutlet();
-
-  return <>{outlet || <DefaultRadarPage {...props} />}</>;
-};
+export function DefaultRadarPage(props: TechRadarPageProps) {
+  const {
+    title = 'Tech Radar',
+    subtitle = 'Pick the recommended technologies for your projects',
+  } = props;
+  return (
+    <RadarLayout title={title} subtitle={subtitle}>
+      <RadarLayout.Route path="/" title="Radar">
+        <RadarComponent {...props} />
+      </RadarLayout.Route>
+      <RadarLayout.Route path="search" title="Search">
+        <RadarTablePage />
+      </RadarLayout.Route>
+    </RadarLayout>
+  );
+}

--- a/plugins/tech-radar/src/components/RadarDescription/RadarDescription.tsx
+++ b/plugins/tech-radar/src/components/RadarDescription/RadarDescription.tsx
@@ -17,7 +17,13 @@
 import React from 'react';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import { Button, DialogActions, DialogContent } from '@material-ui/core';
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  Grid,
+  Typography,
+} from '@material-ui/core';
 import LinkIcon from '@material-ui/icons/Link';
 import { Link, MarkdownContent } from '@backstage/core-components';
 import { isValidUrl } from '../../utils/components';
@@ -28,7 +34,7 @@ export type Props = {
   open: boolean;
   onClose: () => void;
   title: string;
-  description: string;
+  description?: string;
   timeline?: EntrySnapshot[];
   url?: string;
   links?: Array<{ url: string; title: string }>;
@@ -45,13 +51,34 @@ const RadarDescription = (props: Props): JSX.Element => {
   const { open, onClose, title, description, timeline, url, links } = props;
 
   return (
-    <Dialog data-testid="radar-description" open={open} onClose={onClose}>
+    <Dialog
+      data-testid="radar-description"
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="md"
+    >
       <DialogTitle data-testid="radar-description-dialog-title">
         {title}
       </DialogTitle>
       <DialogContent dividers>
-        <MarkdownContent content={description} />
-        <RadarTimeline timeline={timeline} />
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <Typography variant="h6" gutterBottom>
+              Description
+            </Typography>
+            {description ? (
+              <MarkdownContent content={description} />
+            ) : (
+              <Typography component="i" variant="body2">
+                No description for this radar entry.
+              </Typography>
+            )}
+          </Grid>
+          <Grid item xs={12}>
+            <RadarTimeline timeline={timeline} />
+          </Grid>
+        </Grid>
       </DialogContent>
       {showDialogActions(url, links) && (
         <DialogActions>

--- a/plugins/tech-radar/src/components/RadarEntry/RadarEntry.tsx
+++ b/plugins/tech-radar/src/components/RadarEntry/RadarEntry.tsx
@@ -15,8 +15,7 @@
  */
 
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
-import { WithLink } from '../../utils/components';
+import { Link, makeStyles, Theme } from '@material-ui/core';
 import { RadarDescription } from '../RadarDescription';
 import type { EntrySnapshot } from '../../utils/types';
 
@@ -111,29 +110,23 @@ const RadarEntry = (props: Props): JSX.Element => {
           open={open}
           onClose={handleClose}
           title={title ? title : 'no title'}
-          description={description ? description : 'no description'}
+          description={description}
           timeline={timeline ? timeline : []}
           url={url}
           links={links}
         />
       )}
-      {description ? (
-        // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a
-          className={classes.link}
-          onClick={handleClickOpen}
-          role="button"
-          href="#"
-          tabIndex={0}
-          onKeyPress={toggle}
-        >
-          {blip}
-        </a>
-      ) : (
-        <WithLink url={url} className={classes.link}>
-          {blip}
-        </WithLink>
-      )}
+      <Link
+        variant="button"
+        className={classes.link}
+        onClick={handleClickOpen}
+        role="button"
+        href="#"
+        tabIndex={0}
+        onKeyPress={toggle}
+      >
+        {blip}
+      </Link>
       <text y={3} className={classes.text}>
         {value}
       </text>

--- a/plugins/tech-radar/src/components/RadarLayout/RadarLayout.tsx
+++ b/plugins/tech-radar/src/components/RadarLayout/RadarLayout.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Header, Page, RoutedTabs } from '@backstage/core-components';
+import {
+  attachComponentData,
+  useElementFilter,
+} from '@backstage/core-plugin-api';
+import { TabProps } from '@material-ui/core';
+import { default as React } from 'react';
+
+// TODO: This layout could be a shared based component if it was possible to create custom TabbedLayouts
+//    A generalized version of createSubRoutesFromChildren, etc. would be required
+/** @public */
+export type SubRoute = {
+  path: string;
+  title: string;
+  children: JSX.Element;
+  tabProps?: TabProps<React.ElementType, { component?: React.ElementType }>;
+};
+
+const dataKey = 'plugin.explore.RadarLayoutRoute';
+
+const Route: (props: SubRoute) => null = () => null;
+attachComponentData(Route, dataKey, true);
+
+// This causes all mount points that are discovered within this route to use the path of the route itself
+attachComponentData(Route, 'core.gatherMountPoints', true);
+
+/** @public */
+export type RadarLayoutProps = {
+  title?: string;
+  subtitle?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * Radar is a compound component, which allows you to define a custom layout
+ *
+ * @example
+ * ```jsx
+ * <RadarLayout title="Explore ACME's ecosystem">
+ *   <RadarLayout.Route path="/example" title="Example tab">
+ *     <div>This is rendered under /example/anything-here route</div>
+ *   </RadarLayout.Route>
+ * </RadarLayout>
+ * ```
+ *
+ * @public
+ */
+export const RadarLayout = (props: RadarLayoutProps) => {
+  const { title, subtitle, children } = props;
+
+  const routes = useElementFilter(children, elements =>
+    elements
+      .selectByComponentData({
+        key: dataKey,
+        withStrictError: 'Child of RadarLayout must be an RadarLayout.Route',
+      })
+      .getElements<SubRoute>()
+      .map(child => child.props),
+  );
+
+  return (
+    <Page themeId="tech-radar">
+      <Header title={title} subtitle={subtitle} />
+      <RoutedTabs routes={routes} />
+    </Page>
+  );
+};
+
+RadarLayout.Route = Route;

--- a/plugins/tech-radar/src/components/RadarLegend/RadarLegend.tsx
+++ b/plugins/tech-radar/src/components/RadarLegend/RadarLegend.tsx
@@ -66,19 +66,15 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
   entry: {
     pointerEvents: 'visiblePainted',
-    userSelect: 'none',
     fontSize: '11px',
+    userSelect: 'none',
   },
   activeEntry: {
     pointerEvents: 'visiblePainted',
-    userSelect: 'none',
     fontSize: '11px',
+    userSelect: 'none',
     background: '#6f6f6f',
     color: theme.palette.common.white,
-  },
-  entryLink: {
-    pointerEvents: 'visiblePainted',
-    cursor: 'pointer',
   },
 }));
 

--- a/plugins/tech-radar/src/components/RadarLegend/RadarLegendLink.tsx
+++ b/plugins/tech-radar/src/components/RadarLegend/RadarLegendLink.tsx
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Link, makeStyles, Theme } from '@material-ui/core';
 import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
-import { WithLink } from '../../utils/components';
+import { EntrySnapshot } from '../../utils/types';
 import { RadarDescription } from '../RadarDescription';
-import type { EntrySnapshot } from '../../utils/types';
 
 type RadarLegendLinkProps = {
   url?: string;
@@ -30,15 +30,15 @@ type RadarLegendLinkProps = {
   timeline: EntrySnapshot[];
 };
 
-export const RadarLegendLink = ({
-  url,
-  description,
-  title,
-  classes,
-  active,
-  links,
-  timeline,
-}: RadarLegendLinkProps) => {
+const useStyles = makeStyles<Theme>(() => ({
+  entryLink: {
+    cursor: 'pointer',
+  },
+}));
+
+export const RadarLegendLink = (props: RadarLegendLinkProps) => {
+  const { url, description, title, active, links, timeline, classes } = props;
+  const internalClasses = useStyles();
   const [open, setOpen] = React.useState(false);
 
   const handleClickOpen = () => {
@@ -53,46 +53,36 @@ export const RadarLegendLink = ({
     setOpen(!open);
   };
 
-  if (description) {
-    return (
-      <>
+  return (
+    <>
+      {/** TODO(sennyeya): Update this to use the internal link implementation which requires to={...}. */}
+      <Link
+        component="a"
+        onClick={handleClickOpen}
+        role="button"
+        tabIndex={0}
+        className={internalClasses.entryLink}
+        onKeyPress={toggle}
+      >
         <Typography
           component="span"
-          className={classes.entryLink}
-          onClick={handleClickOpen}
-          role="button"
-          tabIndex={0}
-          onKeyPress={toggle}
+          variant="inherit"
+          className={active ? classes.activeEntry : classes.entry}
         >
-          <Typography
-            component="span"
-            className={active ? classes.activeEntry : classes.entry}
-          >
-            {title}
-          </Typography>
+          {title}
         </Typography>
-        {open && (
-          <RadarDescription
-            open={open}
-            onClose={handleClose}
-            title={title ? title : 'no title'}
-            url={url}
-            description={description}
-            timeline={timeline ? timeline : []}
-            links={links}
-          />
-        )}
-      </>
-    );
-  }
-  return (
-    <WithLink url={url} className={classes.entryLink}>
-      <Typography
-        component="span"
-        className={active ? classes.activeEntry : classes.entry}
-      >
-        {title}
-      </Typography>
-    </WithLink>
+      </Link>
+      {open && (
+        <RadarDescription
+          open={open}
+          onClose={handleClose}
+          title={title ? title : 'no title'}
+          url={url}
+          description={description}
+          timeline={timeline ? timeline : []}
+          links={links}
+        />
+      )}
+    </>
   );
 };

--- a/plugins/tech-radar/src/components/RadarPage.test.tsx
+++ b/plugins/tech-radar/src/components/RadarPage.test.tsx
@@ -23,7 +23,7 @@ import {
 import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import GetBBoxPolyfill from '../utils/polyfills/getBBox';
-import { RadarPage } from './RadarPage';
+import { TechRadarPage as RadarPage } from './RadarPage';
 import { TechRadarLoaderResponse, techRadarApiRef, TechRadarApi } from '../api';
 
 import { errorApiRef } from '@backstage/core-plugin-api';

--- a/plugins/tech-radar/src/components/RadarTable/RadarTable.tsx
+++ b/plugins/tech-radar/src/components/RadarTable/RadarTable.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import {
+  EmptyState,
+  LinkButton,
+  Table,
+  TableColumn,
+  TableOptions,
+  TableProps,
+} from '@backstage/core-components';
+import { columnFactories } from './columns';
+import { RadarEntryTableRow } from './types';
+import { Entry } from '../../utils/types';
+/**
+ * Props for {@link DocsTable}.
+ *
+ * @public
+ */
+export type RadarEntryTableProps = {
+  entries: Entry[] | undefined;
+  title?: string | undefined;
+  loading?: boolean | undefined;
+  columns?: TableColumn<RadarEntryTableRow>[];
+  actions?: TableProps<RadarEntryTableRow>['actions'];
+  options?: TableOptions<RadarEntryTableRow>;
+};
+
+/**
+ * Component which renders a table of radar entries.
+ *
+ * @public
+ */
+const RadarEntryTable = ({
+  loading,
+  entries,
+  options,
+  columns,
+  title,
+}: RadarEntryTableProps) => {
+  const defaultColumns: TableColumn<RadarEntryTableRow>[] = [
+    columnFactories.createTitleColumn(),
+    columnFactories.createQuadrantColumn(),
+    columnFactories.createRingColumn(),
+    columnFactories.createMovedColumn(),
+  ];
+  if (!entries) return null;
+
+  const rows = entries;
+
+  return (
+    <>
+      {loading || (rows && rows.length > 0) ? (
+        <Table<RadarEntryTableRow>
+          isLoading={loading}
+          options={{
+            paging: true,
+            pageSize: 20,
+            search: true,
+            actionsColumnIndex: -1,
+            ...options,
+          }}
+          data={rows}
+          columns={columns || defaultColumns}
+          title={title ? `${title} (${rows.length})` : `All (${rows.length})`}
+        />
+      ) : (
+        <EmptyState
+          missing="data"
+          title="No elements to show"
+          description="Create your own tech radar. Check out the documentation to get started."
+          action={
+            <LinkButton
+              color="primary"
+              to="https://github.com/backstage/backstage/tree/master/plugins/tech-radar"
+              variant="contained"
+            >
+              DOCS
+            </LinkButton>
+          }
+        />
+      )}
+    </>
+  );
+};
+RadarEntryTable.columns = columnFactories;
+
+export default RadarEntryTable;

--- a/plugins/tech-radar/src/components/RadarTable/RadarTablePage.tsx
+++ b/plugins/tech-radar/src/components/RadarTable/RadarTablePage.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Grid } from '@material-ui/core';
+import React from 'react';
+import useTechRadarLoader from '../../hooks/useTechRadarLoader';
+import { mapToEntries } from '../../utils/processor';
+import RadarEntryTable from './RadarTable';
+
+const RadarTablePage = ({ id }: { id?: string }) => {
+  const { loading, value: data } = useTechRadarLoader(id);
+  const entries =
+    data &&
+    mapToEntries({
+      ...data,
+      rings: data.rings.map((e, i) => ({ ...e, index: i })),
+    });
+  return (
+    <Grid container spacing={3} direction="row">
+      <Grid item xs={12}>
+        <RadarEntryTable loading={loading} entries={entries} />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default RadarTablePage;

--- a/plugins/tech-radar/src/components/RadarTable/columns.tsx
+++ b/plugins/tech-radar/src/components/RadarTable/columns.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { TableColumn } from '@backstage/core-components';
+import { RadarEntryTableRow } from './types';
+import AdjustIcon from '@material-ui/icons/Adjust';
+import { MovedState } from '../../api';
+import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
+import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import { RadarLegendLink } from '../RadarLegend/RadarLegendLink';
+
+/**
+ * Not directly exported, but through DocsTable.columns and EntityListDocsTable.columns
+ *
+ * @public
+ */
+export const columnFactories = {
+  createTitleColumn(): TableColumn<RadarEntryTableRow> {
+    return {
+      title: 'Title',
+      field: 'title',
+      highlight: true,
+      render: entry => {
+        return (
+          <RadarLegendLink
+            classes={{ 'text-underline': 'test' }}
+            url={entry.url}
+            title={entry.title}
+            description={entry.description!}
+            active={entry.active}
+            links={entry.links ?? []}
+            timeline={entry.timeline ?? []}
+          />
+        );
+      },
+    };
+  },
+  createQuadrantColumn(): TableColumn<RadarEntryTableRow> {
+    return {
+      title: 'Quadrant',
+      field: 'quadrant.name',
+    };
+  },
+  createRingColumn(): TableColumn<RadarEntryTableRow> {
+    return {
+      title: 'Ring',
+      field: 'ring.name',
+      defaultSort: 'asc',
+      customSort(data1, data2) {
+        if (data1.ring.index === undefined) return -1;
+        else if (data2.ring.index === undefined) return 1;
+        return (
+          data1.ring.index - data2.ring.index ||
+          data1.title.localeCompare(data2.title)
+        );
+      },
+    };
+  },
+  createMovedColumn(): TableColumn<RadarEntryTableRow> {
+    return {
+      title: 'Movement',
+      field: 'moved',
+      render: ({ moved }) => {
+        if (moved === MovedState.NoChange) {
+          return <AdjustIcon />;
+        } else if (moved === MovedState.Up) {
+          return <ArrowUpwardIcon />;
+        } else if (moved === MovedState.Down) {
+          return <ArrowDownwardIcon />;
+        }
+        return null;
+      },
+    };
+  },
+  createSeeMoreColumn(): TableColumn<RadarEntryTableRow> {
+    return {
+      title: 'Movement',
+      field: 'moved',
+    };
+  },
+  // name,
+};

--- a/plugins/tech-radar/src/components/RadarTable/index.ts
+++ b/plugins/tech-radar/src/components/RadarTable/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { useOutlet } from 'react-router-dom';
-import { DefaultRadarPage } from './DefaultRadarPage';
-import { TechRadarPageProps } from './types';
 
-/**
- * @public
- */
-export const TechRadarPage = (props: TechRadarPageProps) => {
-  const outlet = useOutlet();
-
-  return <>{outlet || <DefaultRadarPage {...props} />}</>;
-};
+export { default as RadarEntryTable } from './RadarTable';
+export { default as RadarTablePage } from './RadarTablePage';

--- a/plugins/tech-radar/src/components/RadarTable/types.ts
+++ b/plugins/tech-radar/src/components/RadarTable/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { useOutlet } from 'react-router-dom';
-import { DefaultRadarPage } from './DefaultRadarPage';
-import { TechRadarPageProps } from './types';
+
+import { Entry } from '../../utils/types';
 
 /**
  * @public
  */
-export const TechRadarPage = (props: TechRadarPageProps) => {
-  const outlet = useOutlet();
-
-  return <>{outlet || <DefaultRadarPage {...props} />}</>;
-};
+export type RadarEntryTableRow = Entry;

--- a/plugins/tech-radar/src/components/RadarTimeline/RadarTimeline.tsx
+++ b/plugins/tech-radar/src/components/RadarTimeline/RadarTimeline.tsx
@@ -44,7 +44,7 @@ const RadarTimeline = (props: Props): JSX.Element => {
         History
       </Typography>
       <TableContainer component={Paper}>
-        <Table aria-label="simple table">
+        <Table>
           <TableHead>
             <TableRow>
               <TableCell align="left">Moved in direction</TableCell>
@@ -61,9 +61,11 @@ const RadarTimeline = (props: Props): JSX.Element => {
                 </TableCell>
               </TableRow>
             )}
-            {timeline?.map(timeEntry => (
-              <TableRow key={timeEntry.description}>
-                <TableCell component="th" scope="row">
+            {timeline?.map((timeEntry, timeEntryIndex) => (
+              <TableRow
+                key={`time-entry-${timeEntry.ring.id}-${timeEntry.date}-${timeEntryIndex}`}
+              >
+                <TableCell>
                   {timeEntry.moved === MovedState.Up ? <ArrowUpwardIcon /> : ''}
                   {timeEntry.moved === MovedState.Down ? (
                     <ArrowDownwardIcon />

--- a/plugins/tech-radar/src/components/index.ts
+++ b/plugins/tech-radar/src/components/index.ts
@@ -16,4 +16,5 @@
 
 export { RadarComponent as TechRadarComponent } from './RadarComponent';
 export type { TechRadarComponentProps } from './RadarComponent';
+export type { TechRadarPageProps } from './types';
 export * from './RadarPage';

--- a/plugins/tech-radar/src/components/types.ts
+++ b/plugins/tech-radar/src/components/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { useOutlet } from 'react-router-dom';
-import { DefaultRadarPage } from './DefaultRadarPage';
-import { TechRadarPageProps } from './types';
+
+import { TechRadarComponentProps } from './RadarComponent';
 
 /**
+ * Properties for {@link TechRadarPage}
+ *
  * @public
  */
-export const TechRadarPage = (props: TechRadarPageProps) => {
-  const outlet = useOutlet();
+export interface TechRadarPageProps extends TechRadarComponentProps {
+  /**
+   * Title
+   */
+  title?: string;
+  /**
+   * Subtitle
+   */
+  subtitle?: string;
 
-  return <>{outlet || <DefaultRadarPage {...props} />}</>;
-};
+  pageTitle?: string;
+}

--- a/plugins/tech-radar/src/hooks/useTechRadarLoader.tsx
+++ b/plugins/tech-radar/src/hooks/useTechRadarLoader.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { errorApiRef, useApi } from '@backstage/core-plugin-api';
+import { useEffect } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { techRadarApiRef } from '../api';
+
+const useTechRadarLoader = (id: string | undefined) => {
+  const errorApi = useApi(errorApiRef);
+  const techRadarApi = useApi(techRadarApiRef);
+
+  const { error, value, loading } = useAsync(
+    async () => techRadarApi.load(id),
+    [techRadarApi, id],
+  );
+
+  useEffect(() => {
+    if (error) {
+      errorApi.post(error);
+    }
+  }, [error, errorApi]);
+
+  return { loading, value, error };
+};
+
+export default useTechRadarLoader;

--- a/plugins/tech-radar/src/index.ts
+++ b/plugins/tech-radar/src/index.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import { TechRadarPage } from './components';
+
 /**
  * A Backstage plugin that lets you display a Tech Radar for your organization
  *
  * @packageDocumentation
  */
-
-import { RadarPage } from './components';
 
 export {
   techRadarPlugin,
@@ -35,7 +35,7 @@ export * from './components';
  *
  * @public
  */
-export const Router = RadarPage;
+export const Router = TechRadarPage;
 
 /**
  * The TypeScript API for configuring Tech Radar.

--- a/plugins/tech-radar/src/plugin.ts
+++ b/plugins/tech-radar/src/plugin.ts
@@ -23,7 +23,7 @@ import {
   createApiFactory,
 } from '@backstage/core-plugin-api';
 
-const rootRouteRef = createRouteRef({
+export const radarRouteRef = createRouteRef({
   id: 'tech-radar',
 });
 
@@ -35,7 +35,7 @@ const rootRouteRef = createRouteRef({
 export const techRadarPlugin = createPlugin({
   id: 'tech-radar',
   routes: {
-    root: rootRouteRef,
+    radar: radarRouteRef,
   },
   apis: [createApiFactory(techRadarApiRef, new SampleTechRadarApi())],
 });
@@ -52,7 +52,8 @@ export const techRadarPlugin = createPlugin({
 export const TechRadarPage = techRadarPlugin.provide(
   createRoutableExtension({
     name: 'TechRadarPage',
-    component: () => import('./components/RadarPage').then(m => m.RadarPage),
-    mountPoint: rootRouteRef,
+    component: () =>
+      import('./components/RadarPage').then(m => m.TechRadarPage),
+    mountPoint: radarRouteRef,
   }),
 );

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -23,6 +23,7 @@ import {
 } from './api';
 
 const rings = new Array<RadarRing>();
+rings.push({ id: 'use', name: 'USE', color: '#000000', hidden: true });
 rings.push({ id: 'adopt', name: 'ADOPT', color: '#5BA300' });
 rings.push({ id: 'trial', name: 'TRIAL', color: '#009EB0' });
 rings.push({ id: 'assess', name: 'ASSESS', color: '#C7BA00' });
@@ -35,6 +36,22 @@ quadrants.push({ id: 'languages', name: 'Languages' });
 quadrants.push({ id: 'process', name: 'Process' });
 
 const entries = new Array<RadarEntry>();
+entries.push({
+  timeline: [
+    {
+      moved: 0,
+      ringId: 'use',
+      date: new Date('2022-09-03'),
+      description: '',
+    },
+  ],
+  key: 'docker',
+  id: 'docker',
+  title: 'Docker',
+  quadrant: 'infrastructure',
+  links: [],
+  description: '',
+});
 entries.push({
   timeline: [
     {

--- a/plugins/tech-radar/src/utils/processor.ts
+++ b/plugins/tech-radar/src/utils/processor.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RadarEntry, TechRadarLoaderResponse } from '../api';
+import { Entry } from './types';
+
+export function matchFilter(filter?: string): (entry: RadarEntry) => boolean {
+  const terms = filter
+    ?.toLocaleLowerCase('en-US')
+    .split(/\s/)
+    .map(e => e.trim())
+    .filter(Boolean);
+
+  if (!terms?.length) {
+    return () => true;
+  }
+
+  return entry => {
+    const text = `${entry.title} ${
+      entry.timeline[0]?.description || ''
+    }`.toLocaleLowerCase('en-US');
+    return terms.every(term => text.includes(term));
+  };
+}
+
+export const mapToEntries = (
+  loaderResponse: TechRadarLoaderResponse,
+): Array<Entry> => {
+  return loaderResponse.entries.map(entry => ({
+    id: entry.key,
+    quadrant: loaderResponse.quadrants.find(q => q.id === entry.quadrant)!,
+    title: entry.title,
+    ring: loaderResponse.rings.find(r => r.id === entry.timeline[0].ringId)!,
+    timeline: entry.timeline.map(e => {
+      return {
+        date: e.date,
+        ring: loaderResponse.rings.find(a => a.id === e.ringId)!,
+        description: e.description,
+        moved: e.moved,
+      };
+    }),
+    moved: entry.timeline[0].moved,
+    description: entry.description || entry.timeline[0].description,
+    url: entry.url,
+    links: entry.links,
+  }));
+};

--- a/plugins/tech-radar/src/utils/types.ts
+++ b/plugins/tech-radar/src/utils/types.ts
@@ -21,6 +21,7 @@ export type Ring = {
   index?: number;
   name: string;
   color: string;
+  hidden?: boolean;
   outerRadius?: number;
   innerRadius?: number;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #18616.
1. Adds a new property `hidden` to rings. These rings are removed from the radar view but will be accessible from the API for other displays (like a table).
2. Updates the tech radar to be a nested tab view with 2 tabs "Radar" and "Search".
3. Search is a new table view that shows all radar entries regardless of `hidden` status.
<img width="1470" alt="Screenshot 2023-07-22 at 4 05 31 PM" src="https://github.com/backstage/backstage/assets/34432188/7acfd367-230b-4eda-a23e-1d43191791c6">
<img width="1470" alt="Screenshot 2023-07-22 at 4 05 46 PM" src="https://github.com/backstage/backstage/assets/34432188/bfe19df5-29b1-4043-b05d-11ad613b00d3">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
