### PR TITLE
Fix the query filter in the MyGroupsPicker

### DIFF
--- a/.changeset/cold-numbers-sleep.md
+++ b/.changeset/cold-numbers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix the get entities query in the `MyGroupsPicker` to query the `kind=Group` entities.

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -129,7 +129,7 @@ describe('<MyGroupsPicker />', () => {
 
     expect(catalogApi.getEntities).toHaveBeenCalledWith({
       filter: {
-        type: 'Group',
+        kind: 'Group',
         'relations.hasMember': ['user:default/bob'],
       },
     });
@@ -201,8 +201,8 @@ describe('<MyGroupsPicker />', () => {
 
     // Simulate user input
     const inputField = getByRole('combobox');
-    userEvent.click(inputField);
-    userEvent.type(inputField, 'group');
+    await userEvent.click(inputField);
+    await userEvent.type(inputField, 'group');
 
     // Wait for the dropdown elements to appear
     await waitFor(() => {
@@ -257,8 +257,8 @@ describe('<MyGroupsPicker />', () => {
     );
 
     const inputField = getByRole('combobox');
-    userEvent.click(inputField);
-    userEvent.type(inputField, 'group');
+    await userEvent.click(inputField);
+    await userEvent.type(inputField, 'group');
 
     await waitFor(() => {
       expect(
@@ -267,7 +267,7 @@ describe('<MyGroupsPicker />', () => {
     });
 
     const option = getByRole('option', { name: 'My First Group' });
-    userEvent.click(option);
+    await userEvent.click(option);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -62,7 +62,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
 
     const { items } = await catalogApi.getEntities({
       filter: {
-        type: 'Group',
+        kind: 'Group',
         ['relations.hasMember']: [userEntityRef],
       },
     });


### PR DESCRIPTION
This PR fixes the `MyGroupsPicker` introduced in https://github.com/backstage/backstage/pull/17608.

The current implementation has filter `type=Group` which won't get any result from the catalog.

I believe that the purpose of this component is to query `Group` kind entities: https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group.

Also fixed the tests to properly `await` the user events to avoid warnings like this:

```
    console.error
      Warning: You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one.

      at printWarning (../../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:67:30)
      at error (../../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:43:5)
      at onDone (../../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:1034:9)
      at ../../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:1073:13
```

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
