### PR TITLE
Added option to configure AWS accountId in AwsS3EntityProvider

### DIFF
--- a/.changeset/stale-wombats-talk.md
+++ b/.changeset/stale-wombats-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Added option to configure AWS `accountId` in `AwsS3EntityProvider`

--- a/plugins/catalog-backend-module-aws/config.d.ts
+++ b/plugins/catalog-backend-module-aws/config.d.ts
@@ -55,6 +55,12 @@ export interface Config {
              */
             region?: string;
             /**
+             * (Optional) AWS Account id.
+             * If not set, main account is used.
+             * @see https://github.com/backstage/backstage/blob/master/packages/integration-aws-node/README.md
+             */
+            accountId?: string;
+            /**
              * (Optional) TaskScheduleDefinition for the refresh.
              */
             schedule?: TaskScheduleDefinitionConfig;
@@ -77,6 +83,12 @@ export interface Config {
                * @see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html
                */
               region?: string;
+              /**
+               * (Optional) AWS Account id.
+               * If not set, main account is used.
+               * @see https://github.com/backstage/backstage/blob/master/packages/integration-aws-node/README.md
+               */
+              accountId?: string;
               /**
                * (Optional) TaskScheduleDefinition for the refresh.
                */

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
@@ -146,20 +146,22 @@ export class AwsS3EntityProvider implements EntityProvider {
   /** {@inheritdoc @backstage/plugin-catalog-backend#EntityProvider.connect} */
   async connect(connection: EntityProviderConnection): Promise<void> {
     this.connection = connection;
-    const credProvider =
-      await this.awsCredentialsManager.getCredentialProvider();
+    const { accountId, region, bucketName } = this.config;
+    const credProvider = await this.awsCredentialsManager.getCredentialProvider(
+      accountId ? { accountId } : undefined,
+    );
     this.s3 = new S3({
       apiVersion: '2006-03-01',
       credentialDefaultProvider: () => credProvider.sdkCredentialProvider,
       endpoint: this.integration.config.endpoint,
-      region: this.config.region,
+      region,
       forcePathStyle: this.integration.config.s3ForcePathStyle,
     });
 
     // https://github.com/aws/aws-sdk-js-v3/issues/4122#issuecomment-1298968804
     const endpoint = await getEndpointFromInstructions(
       {
-        Bucket: this.config.bucketName,
+        Bucket: bucketName,
       },
       ListObjectsV2Command,
       this.s3.config as unknown as Record<string, unknown>,

--- a/plugins/catalog-backend-module-aws/src/providers/config.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/config.ts
@@ -46,6 +46,7 @@ function readAwsS3Config(id: string, config: Config): AwsS3Config {
   const bucketName = config.getString('bucketName');
   const region = config.getOptionalString('region');
   const prefix = config.getOptionalString('prefix');
+  const accountId = config.getOptionalString('accountId');
 
   const schedule = config.has('schedule')
     ? readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'))
@@ -57,5 +58,6 @@ function readAwsS3Config(id: string, config: Config): AwsS3Config {
     region,
     prefix,
     schedule,
+    accountId,
   };
 }

--- a/plugins/catalog-backend-module-aws/src/providers/types.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/types.ts
@@ -22,4 +22,5 @@ export type AwsS3Config = {
   prefix?: string;
   region?: string;
   schedule?: TaskScheduleDefinition;
+  accountId?: string;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since version `0.2.0` of `plugin-catalog-backend-module-aws`, in which AWS configuration has been moved to the [new format](https://github.com/backstage/backstage/blob/master/packages/integration-aws-node/README.md), it is not possible in the `AwsS3EntityProvider` to use a role to access the S3 bucket since it only uses the main account.

This change makes it possible to configure an `accountId` in the provider so that it can use an account configuration with `roleName` and `externalId` while keeping the main account as default.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
