### PR TITLE
Rename ConfigService to RootConfigService

### DIFF
--- a/.changeset/angry-beers-relate.md
+++ b/.changeset/angry-beers-relate.md
@@ -1,0 +1,46 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-server': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+'@backstage/plugin-catalog-backend-module-puppetdb': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-search-backend-module-techdocs': patch
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+'@backstage/plugin-catalog-backend-module-github': patch
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/plugin-events-backend-module-aws-sqs': patch
+'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-search-backend-module-explore': patch
+'@backstage/plugin-catalog-backend-module-azure': patch
+'@backstage/plugin-events-backend-module-github': patch
+'@backstage/plugin-events-backend-module-gitlab': patch
+'@backstage/plugin-catalog-backend-module-aws': patch
+'@backstage/plugin-catalog-backend-module-gcp': patch
+'@backstage/plugin-search-backend-module-pg': patch
+'@backstage/plugin-azure-devops-backend': patch
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-test-utils': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-lighthouse-backend': patch
+'@backstage/plugin-permission-backend': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/backend-defaults': patch
+'@backstage/backend-app-api': patch
+'@backstage/plugin-airbrake-backend': patch
+'@backstage/plugin-devtools-backend': patch
+'@backstage/plugin-periskop-backend': patch
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/backend-common': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-badges-backend': patch
+'@backstage/plugin-bazaar-backend': patch
+'@backstage/plugin-events-backend': patch
+'@backstage/plugin-search-backend': patch
+'@backstage/plugin-kafka-backend': patch
+'@backstage/plugin-proxy-backend': patch
+'@backstage/plugin-todo-backend': patch
+'@backstage/plugin-app-backend': patch
+---
+
+Use `coreServices.rootConfig` instead of `coreService.config`

--- a/.changeset/angry-beers-relate.md
+++ b/.changeset/angry-beers-relate.md
@@ -19,14 +19,11 @@
 '@backstage/plugin-catalog-backend-module-gcp': patch
 '@backstage/plugin-search-backend-module-pg': patch
 '@backstage/plugin-azure-devops-backend': patch
-'@backstage/backend-plugin-api': patch
-'@backstage/backend-test-utils': patch
 '@backstage/plugin-kubernetes-backend': patch
 '@backstage/plugin-lighthouse-backend': patch
 '@backstage/plugin-permission-backend': patch
 '@backstage/plugin-scaffolder-backend': patch
 '@backstage/backend-defaults': patch
-'@backstage/backend-app-api': patch
 '@backstage/plugin-airbrake-backend': patch
 '@backstage/plugin-devtools-backend': patch
 '@backstage/plugin-periskop-backend': patch

--- a/.changeset/mighty-lions-search-2.md
+++ b/.changeset/mighty-lions-search-2.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': minor
+---
+
+**BREAKING**: Renamed `mockServices.config` to `mockServices.rootConfig`.

--- a/.changeset/mighty-lions-search-3.md
+++ b/.changeset/mighty-lions-search-3.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+**BREAKING**: Renamed `configServiceFactory` to `rootConfigServiceFactory`.

--- a/.changeset/mighty-lions-search.md
+++ b/.changeset/mighty-lions-search.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-plugin-api': minor
+'@backstage/backend-app-api': minor
+'@backstage/backend-common': minor
+'@backstage/backend-test-utils': minor
+---
+
+Renamed `ConfigService` to `RootConfigService`

--- a/.changeset/mighty-lions-search.md
+++ b/.changeset/mighty-lions-search.md
@@ -1,8 +1,5 @@
 ---
 '@backstage/backend-plugin-api': minor
-'@backstage/backend-app-api': minor
-'@backstage/backend-common': minor
-'@backstage/backend-test-utils': minor
 ---
 
-Renamed `ConfigService` to `RootConfigService`
+**BREAKING**: Renamed `coreServices.config` to `coreServices.rootConfig`.

--- a/docs/backend-system/building-backends/01-index.md
+++ b/docs/backend-system/building-backends/01-index.md
@@ -61,11 +61,11 @@ All of these services can be replaced with your own implementations if you need 
 For example, let's say we want to customize the core configuration service to enable remote configuration loading. That would look something like this:
 
 ```ts
-import { configServiceFactory } from '@backstage/backend-app-api';
+import { rootConfigServiceFactory } from '@backstage/backend-app-api';
 
 const backend = createBackend({
   services: [
-    configServiceFactory({
+    rootConfigServiceFactory({
       remote: { reloadIntervalSeconds: 60 },
     }),
   ],

--- a/docs/backend-system/building-plugins-and-modules/02-testing.md
+++ b/docs/backend-system/building-plugins-and-modules/02-testing.md
@@ -37,7 +37,7 @@ describe('myPlugin', () => {
 
     const { server } = await startTestBackend({
       features: [myPlugin()],
-      services: [mockServices.config.factory({ data: fakeConfig })],
+      services: [mockServices.rootConfig.factory({ data: fakeConfig })],
     });
 
     const response = await request(server).get('/api/example/get-value');

--- a/docs/backend-system/core-services/01-index.md
+++ b/docs/backend-system/core-services/01-index.md
@@ -183,11 +183,11 @@ There's additional configuration that you can optionally pass to setup the `conf
 You can configure these additional options by adding an override for the core service when calling `createBackend` like follows:
 
 ```ts
-import { configServiceFactory } from '@backstage/backend-app-api';
+import { rootConfigServiceFactory } from '@backstage/backend-app-api';
 
 const backend = createBackend({
   services: [
-    configServiceFactory({
+    rootConfigServiceFactory({
       argv: [
         '--config',
         '/backstage/app-config.development.yaml',

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -9,7 +9,6 @@ import type { AppConfig } from '@backstage/config';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CacheClient } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
-import { ConfigService } from '@backstage/backend-plugin-api';
 import { CorsOptions } from 'cors';
 import { ErrorRequestHandler } from 'express';
 import { Express as Express_2 } from 'express';
@@ -30,6 +29,7 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { RemoteConfigSourceOptions } from '@backstage/config-loader';
 import { RequestHandler } from 'express';
 import { RequestListener } from 'http';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { RootLoggerService } from '@backstage/backend-plugin-api';
@@ -52,17 +52,6 @@ export interface Backend {
 
 // @public (undocumented)
 export const cacheServiceFactory: () => ServiceFactory<CacheClient, 'plugin'>;
-
-// @public (undocumented)
-export interface ConfigFactoryOptions {
-  argv?: string[];
-  remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;
-}
-
-// @public (undocumented)
-export const configServiceFactory: (
-  options?: ConfigFactoryOptions | undefined,
-) => ServiceFactory<ConfigService, 'root'>;
 
 // @public (undocumented)
 export function createConfigSecretEnumerator(options: {
@@ -224,7 +213,7 @@ export interface MiddlewareFactoryErrorOptions {
 // @public
 export interface MiddlewareFactoryOptions {
   // (undocumented)
-  config: ConfigService;
+  config: RootConfigService;
   // (undocumented)
   logger: LoggerService;
 }
@@ -245,11 +234,22 @@ export function readHelmetOptions(config?: Config): HelmetOptions;
 export function readHttpServerOptions(config?: Config): HttpServerOptions;
 
 // @public (undocumented)
+export interface RootConfigFactoryOptions {
+  argv?: string[];
+  remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;
+}
+
+// @public (undocumented)
+export const rootConfigServiceFactory: (
+  options?: RootConfigFactoryOptions | undefined,
+) => ServiceFactory<RootConfigService, 'root'>;
+
+// @public (undocumented)
 export interface RootHttpRouterConfigureContext {
   // (undocumented)
   app: Express_2;
   // (undocumented)
-  config: ConfigService;
+  config: RootConfigService;
   // (undocumented)
   lifecycle: LifecycleService;
   // (undocumented)

--- a/packages/backend-app-api/src/config/ObservableConfigProxy.ts
+++ b/packages/backend-app-api/src/config/ObservableConfigProxy.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { ConfigService } from '@backstage/backend-plugin-api';
-import { ConfigReader } from '@backstage/config';
+import { Config, ConfigReader } from '@backstage/config';
 import { JsonValue } from '@backstage/types';
 
-export class ObservableConfigProxy implements ConfigService {
-  private config: ConfigService = new ConfigReader({});
+export class ObservableConfigProxy implements Config {
+  private config: Config = new ConfigReader({});
 
   private readonly subscribers: (() => void)[] = [];
 
@@ -32,7 +31,7 @@ export class ObservableConfigProxy implements ConfigService {
     }
   }
 
-  setConfig(config: ConfigService) {
+  setConfig(config: Config) {
     if (this.parent) {
       throw new Error('immutable');
     }
@@ -62,9 +61,9 @@ export class ObservableConfigProxy implements ConfigService {
     };
   }
 
-  private select(required: true): ConfigService;
-  private select(required: false): ConfigService | undefined;
-  private select(required: boolean): ConfigService | undefined {
+  private select(required: true): Config;
+  private select(required: false): Config | undefined;
+  private select(required: boolean): Config | undefined {
     if (this.parent && this.parentKey) {
       if (required) {
         return this.parent.select(true).getConfig(this.parentKey);
@@ -87,19 +86,19 @@ export class ObservableConfigProxy implements ConfigService {
   getOptional<T = JsonValue>(key?: string): T | undefined {
     return this.select(false)?.getOptional(key);
   }
-  getConfig(key: string): ConfigService {
+  getConfig(key: string): Config {
     return new ObservableConfigProxy(this, key);
   }
-  getOptionalConfig(key: string): ConfigService | undefined {
+  getOptionalConfig(key: string): Config | undefined {
     if (this.select(false)?.has(key)) {
       return new ObservableConfigProxy(this, key);
     }
     return undefined;
   }
-  getConfigArray(key: string): ConfigService[] {
+  getConfigArray(key: string): Config[] {
     return this.select(true).getConfigArray(key);
   }
-  getOptionalConfigArray(key: string): ConfigService[] | undefined {
+  getOptionalConfigArray(key: string): Config[] | undefined {
     return this.select(false)?.getOptionalConfigArray(key);
   }
   getNumber(key: string): number {

--- a/packages/backend-app-api/src/http/MiddlewareFactory.ts
+++ b/packages/backend-app-api/src/http/MiddlewareFactory.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { ConfigService, LoggerService } from '@backstage/backend-plugin-api';
+import {
+  RootConfigService,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
 import {
   Request,
   Response,
@@ -47,7 +50,7 @@ import { NotImplementedError } from '@backstage/errors';
  * @public
  */
 export interface MiddlewareFactoryOptions {
-  config: ConfigService;
+  config: RootConfigService;
   logger: LoggerService;
 }
 
@@ -78,7 +81,7 @@ export interface MiddlewareFactoryErrorOptions {
  * @public
  */
 export class MiddlewareFactory {
-  #config: ConfigService;
+  #config: RootConfigService;
   #logger: LoggerService;
 
   /**

--- a/packages/backend-app-api/src/services/implementations/cache/cacheServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/cache/cacheServiceFactory.ts
@@ -24,7 +24,7 @@ import {
 export const cacheServiceFactory = createServiceFactory({
   service: coreServices.cache,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
     plugin: coreServices.pluginMetadata,
   },
   async createRootContext({ config }) {

--- a/packages/backend-app-api/src/services/implementations/config/index.ts
+++ b/packages/backend-app-api/src/services/implementations/config/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { configServiceFactory } from './configServiceFactory';
-export type { ConfigFactoryOptions } from './configServiceFactory';
+export { rootConfigServiceFactory } from './rootConfigServiceFactory';
+export type { RootConfigFactoryOptions } from './rootConfigServiceFactory';

--- a/packages/backend-app-api/src/services/implementations/config/rootConfigServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/config/rootConfigServiceFactory.ts
@@ -24,7 +24,7 @@ import {
 } from '@backstage/config-loader';
 
 /** @public */
-export interface ConfigFactoryOptions {
+export interface RootConfigFactoryOptions {
   /**
    * Process arguments to use instead of the default `process.argv()`.
    */
@@ -37,9 +37,9 @@ export interface ConfigFactoryOptions {
 }
 
 /** @public */
-export const configServiceFactory = createServiceFactory(
-  (options?: ConfigFactoryOptions) => ({
-    service: coreServices.config,
+export const rootConfigServiceFactory = createServiceFactory(
+  (options?: RootConfigFactoryOptions) => ({
+    service: coreServices.rootConfig,
     deps: {},
     async factory() {
       const source = ConfigSources.default({

--- a/packages/backend-app-api/src/services/implementations/database/databaseServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/database/databaseServiceFactory.ts
@@ -25,7 +25,7 @@ import { ConfigReader } from '@backstage/config';
 export const databaseServiceFactory = createServiceFactory({
   service: coreServices.database,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
     lifecycle: coreServices.lifecycle,
     pluginMetadata: coreServices.pluginMetadata,
   },

--- a/packages/backend-app-api/src/services/implementations/discovery/discoveryServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/discovery/discoveryServiceFactory.ts
@@ -24,7 +24,7 @@ import {
 export const discoveryServiceFactory = createServiceFactory({
   service: coreServices.discovery,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
   },
   async factory({ config }) {
     return HostDiscovery.fromConfig(config);

--- a/packages/backend-app-api/src/services/implementations/permissions/permissionsServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/permissions/permissionsServiceFactory.ts
@@ -24,7 +24,7 @@ import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 export const permissionsServiceFactory = createServiceFactory({
   service: coreServices.permissions,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
     discovery: coreServices.discovery,
     tokenManager: coreServices.tokenManager,
   },

--- a/packages/backend-app-api/src/services/implementations/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  ConfigService,
+  RootConfigService,
   coreServices,
   createServiceFactory,
   LifecycleService,
@@ -36,7 +36,7 @@ export interface RootHttpRouterConfigureContext {
   app: Express;
   middleware: MiddlewareFactory;
   routes: RequestHandler;
-  config: ConfigService;
+  config: RootConfigService;
   logger: LoggerService;
   lifecycle: LifecycleService;
 }
@@ -70,7 +70,7 @@ export const rootHttpRouterServiceFactory = createServiceFactory(
   (options?: RootHttpRouterFactoryOptions) => ({
     service: coreServices.rootHttpRouter,
     deps: {
-      config: coreServices.config,
+      config: coreServices.rootConfig,
       rootLogger: coreServices.rootLogger,
       lifecycle: coreServices.rootLifecycle,
     },

--- a/packages/backend-app-api/src/services/implementations/rootLogger/rootLoggerServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLogger/rootLoggerServiceFactory.ts
@@ -26,7 +26,7 @@ import { createConfigSecretEnumerator } from '../../../config';
 export const rootLoggerServiceFactory = createServiceFactory({
   service: coreServices.rootLogger,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
   },
   async factory({ config }) {
     const logger = WinstonLogger.create({

--- a/packages/backend-app-api/src/services/implementations/tokenManager/tokenManagerServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/tokenManager/tokenManagerServiceFactory.ts
@@ -24,7 +24,7 @@ import { ServerTokenManager } from '@backstage/backend-common';
 export const tokenManagerServiceFactory = createServiceFactory({
   service: coreServices.tokenManager,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
     logger: coreServices.rootLogger,
   },
   createRootContext({ config, logger }) {

--- a/packages/backend-app-api/src/services/implementations/urlReader/urlReaderServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/urlReader/urlReaderServiceFactory.ts
@@ -24,7 +24,7 @@ import {
 export const urlReaderServiceFactory = createServiceFactory({
   service: coreServices.urlReader,
   deps: {
-    config: coreServices.config,
+    config: coreServices.rootConfig,
     logger: coreServices.logger,
   },
   async factory({ config, logger }) {

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -18,7 +18,6 @@ import { CacheService as CacheClient } from '@backstage/backend-plugin-api';
 import { CacheServiceOptions as CacheClientOptions } from '@backstage/backend-plugin-api';
 import { CacheServiceSetOptions as CacheClientSetOptions } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { ConfigService } from '@backstage/backend-plugin-api';
 import cors from 'cors';
 import Docker from 'dockerode';
 import { ErrorRequestHandler } from 'express';
@@ -51,6 +50,7 @@ import { ReadTreeResponseFile } from '@backstage/backend-plugin-api';
 import { ReadUrlOptions } from '@backstage/backend-plugin-api';
 import { ReadUrlResponse } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { Router } from 'express';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { SearchOptions } from '@backstage/backend-plugin-api';
@@ -525,7 +525,7 @@ export const legacyPlugin: (
       TransformedEnv<
         {
           cache: CacheClient;
-          config: ConfigService;
+          config: RootConfigService;
           database: PluginDatabaseManager;
           discovery: PluginEndpointDiscovery;
           logger: LoggerService;

--- a/packages/backend-common/src/legacy.ts
+++ b/packages/backend-common/src/legacy.ts
@@ -108,7 +108,7 @@ export function makeLegacyPlugin<
 export const legacyPlugin = makeLegacyPlugin(
   {
     cache: coreServices.cache,
-    config: coreServices.config,
+    config: coreServices.rootConfig,
     database: coreServices.database,
     discovery: coreServices.discovery,
     logger: coreServices.logger,

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -17,7 +17,7 @@
 import {
   Backend,
   cacheServiceFactory,
-  configServiceFactory,
+  rootConfigServiceFactory,
   createSpecializedBackend,
   databaseServiceFactory,
   discoveryServiceFactory,
@@ -40,7 +40,7 @@ import {
 
 export const defaultServiceFactories = [
   cacheServiceFactory(),
-  configServiceFactory(),
+  rootConfigServiceFactory(),
   databaseServiceFactory(),
   discoveryServiceFactory(),
   httpRouterServiceFactory(),

--- a/packages/backend-plugin-api/CHANGELOG.md
+++ b/packages/backend-plugin-api/CHANGELOG.md
@@ -321,7 +321,7 @@
   createServiceFactory({
     service: coreServices.cache,
     deps: {
-      config: coreServices.rootConfig,
+      config: coreServices.config,
       plugin: coreServices.pluginMetadata,
     },
     async createRootContext({ config }) {

--- a/packages/backend-plugin-api/CHANGELOG.md
+++ b/packages/backend-plugin-api/CHANGELOG.md
@@ -321,7 +321,7 @@
   createServiceFactory({
     service: coreServices.cache,
     deps: {
-      config: coreServices.config,
+      config: coreServices.rootConfig,
       plugin: coreServices.pluginMetadata,
     },
     async createRootContext({ config }) {

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -93,13 +93,10 @@ export type CacheServiceSetOptions = {
   ttl?: number;
 };
 
-// @public (undocumented)
-export interface ConfigService extends Config {}
-
 // @public
 export namespace coreServices {
   const cache: ServiceRef<CacheService, 'plugin'>;
-  const config: ServiceRef<ConfigService, 'root'>;
+  const rootConfig: ServiceRef<RootConfigService, 'root'>;
   const database: ServiceRef<DatabaseService, 'plugin'>;
   const discovery: ServiceRef<DiscoveryService, 'plugin'>;
   const httpRouter: ServiceRef<HttpRouterService, 'plugin'>;
@@ -379,6 +376,9 @@ export type ReadUrlResponse = {
   etag?: string;
   lastModifiedAt?: Date;
 };
+
+// @public (undocumented)
+export interface RootConfigService extends Config {}
 
 // @public (undocumented)
 export interface RootHttpRouterService {

--- a/packages/backend-plugin-api/src/services/definitions/RootConfigService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootConfigService.ts
@@ -19,4 +19,4 @@ import { Config } from '@backstage/config';
 /**
  * @public
  */
-export interface ConfigService extends Config {}
+export interface RootConfigService extends Config {}

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -32,7 +32,7 @@ export namespace coreServices {
   });
 
   /**
-   * The service reference for the root scoped {@link ConfigService}.
+   * The service reference for the root scoped {@link RootConfigService}.
    *
    * @public
    */

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -36,9 +36,9 @@ export namespace coreServices {
    *
    * @public
    */
-  export const config = createServiceRef<
-    import('./ConfigService').ConfigService
-  >({ id: 'core.config', scope: 'root' });
+  export const rootConfig = createServiceRef<
+    import('./RootConfigService').RootConfigService
+  >({ id: 'core.rootConfig', scope: 'root' });
 
   /**
    * The service reference for the plugin scoped {@link DatabaseService}.

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -20,7 +20,7 @@ export type {
   CacheServiceOptions,
   CacheServiceSetOptions,
 } from './CacheService';
-export type { ConfigService } from './ConfigService';
+export type { RootConfigService } from './RootConfigService';
 export type { DatabaseService } from './DatabaseService';
 export type { DiscoveryService } from './DiscoveryService';
 export type { HttpRouterService } from './HttpRouterService';

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -36,19 +36,6 @@ export namespace mockServices {
       factory: () => ServiceFactory<CacheService, 'plugin'>;
   }
   // (undocumented)
-  export function config(options?: config.Options): RootConfigService;
-  // (undocumented)
-  export namespace config {
-    // (undocumented)
-    export type Options = {
-      data?: JsonObject;
-    };
-    const // (undocumented)
-      factory: (
-        options?: Options | undefined,
-      ) => ServiceFactory<RootConfigService, 'root'>;
-  }
-  // (undocumented)
   export namespace database {
     const // (undocumented)
       factory: () => ServiceFactory<DatabaseService, 'plugin'>;
@@ -81,6 +68,19 @@ export namespace mockServices {
   export namespace permissions {
     const // (undocumented)
       factory: () => ServiceFactory<PermissionsService, 'plugin'>;
+  }
+  // (undocumented)
+  export function rootConfig(options?: rootConfig.Options): RootConfigService;
+  // (undocumented)
+  export namespace rootConfig {
+    // (undocumented)
+    export type Options = {
+      data?: JsonObject;
+    };
+    const // (undocumented)
+      factory: (
+        options?: Options | undefined,
+      ) => ServiceFactory<RootConfigService, 'root'>;
   }
   // (undocumented)
   export namespace rootLifecycle {

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -6,7 +6,6 @@
 import { Backend } from '@backstage/backend-app-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CacheService } from '@backstage/backend-plugin-api';
-import { ConfigService } from '@backstage/backend-plugin-api';
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import { ExtendedHttpServer } from '@backstage/backend-app-api';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
@@ -18,6 +17,7 @@ import { Knex } from 'knex';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { PermissionsService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
@@ -36,7 +36,7 @@ export namespace mockServices {
       factory: () => ServiceFactory<CacheService, 'plugin'>;
   }
   // (undocumented)
-  export function config(options?: config.Options): ConfigService;
+  export function config(options?: config.Options): RootConfigService;
   // (undocumented)
   export namespace config {
     // (undocumented)
@@ -46,7 +46,7 @@ export namespace mockServices {
     const // (undocumented)
       factory: (
         options?: Options | undefined,
-      ) => ServiceFactory<ConfigService, 'root'>;
+      ) => ServiceFactory<RootConfigService, 'root'>;
   }
   // (undocumented)
   export namespace database {

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  ConfigService,
+  RootConfigService,
   coreServices,
   createServiceFactory,
   IdentityService,
@@ -61,13 +61,13 @@ function simpleFactory<
  * @public
  */
 export namespace mockServices {
-  export function config(options?: config.Options): ConfigService {
+  export function config(options?: config.Options): RootConfigService {
     return new ConfigReader(options?.data, 'mock-config');
   }
   export namespace config {
     export type Options = { data?: JsonObject };
 
-    export const factory = simpleFactory(coreServices.config, config);
+    export const factory = simpleFactory(coreServices.rootConfig, config);
   }
 
   export function rootLogger(options?: rootLogger.Options): LoggerService {

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -61,13 +61,13 @@ function simpleFactory<
  * @public
  */
 export namespace mockServices {
-  export function config(options?: config.Options): RootConfigService {
+  export function rootConfig(options?: rootConfig.Options): RootConfigService {
     return new ConfigReader(options?.data, 'mock-config');
   }
-  export namespace config {
+  export namespace rootConfig {
     export type Options = { data?: JsonObject };
 
-    export const factory = simpleFactory(coreServices.rootConfig, config);
+    export const factory = simpleFactory(coreServices.rootConfig, rootConfig);
   }
 
   export function rootLogger(options?: rootLogger.Options): LoggerService {

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
@@ -168,7 +168,7 @@ describe('TestBackend', () => {
         env.registerInit({
           deps: {
             cache: coreServices.cache,
-            config: coreServices.config,
+            config: coreServices.rootConfig,
             database: coreServices.database,
             discovery: coreServices.discovery,
             httpRouter: coreServices.httpRouter,

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -108,7 +108,7 @@ export async function startTestBackend<
   const rootHttpRouterFactory = createServiceFactory({
     service: coreServices.rootHttpRouter,
     deps: {
-      config: coreServices.config,
+      config: coreServices.rootConfig,
       lifecycle: coreServices.rootLifecycle,
       rootLogger: coreServices.rootLogger,
     },

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -73,7 +73,7 @@ export interface TestBackend extends Backend {
 
 const defaultServiceFactories = [
   mockServices.cache.factory(),
-  mockServices.config.factory(),
+  mockServices.rootConfig.factory(),
   mockServices.database.factory(),
   mockServices.httpRouter.factory(),
   mockServices.identity.factory(),

--- a/plugins/airbrake-backend/src/plugin.ts
+++ b/plugins/airbrake-backend/src/plugin.ts
@@ -32,7 +32,7 @@ export const airbrakePlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
       },

--- a/plugins/app-backend/src/service/appPlugin.ts
+++ b/plugins/app-backend/src/service/appPlugin.ts
@@ -76,7 +76,7 @@ export const appPlugin = createBackendPlugin((options: AppPluginOptions) => ({
     env.registerInit({
       deps: {
         logger: coreServices.logger,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         database: coreServices.database,
         httpRouter: coreServices.httpRouter,
       },

--- a/plugins/azure-devops-backend/src/plugin.ts
+++ b/plugins/azure-devops-backend/src/plugin.ts
@@ -31,7 +31,7 @@ export const azureDevOpsPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         reader: coreServices.urlReader,
         httpRouter: coreServices.httpRouter,

--- a/plugins/badges-backend/src/plugin.ts
+++ b/plugins/badges-backend/src/plugin.ts
@@ -31,7 +31,7 @@ export const badgesPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         discovery: coreServices.discovery,
         tokenManager: coreServices.tokenManager,

--- a/plugins/bazaar-backend/src/plugin.ts
+++ b/plugins/bazaar-backend/src/plugin.ts
@@ -31,7 +31,7 @@ export const bazaarPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         database: coreServices.database,
         identity: coreServices.identity,
         logger: coreServices.logger,

--- a/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts
+++ b/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts
@@ -62,7 +62,7 @@ describe('catalogModuleAwsS3EntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.ts
@@ -33,7 +33,7 @@ export const catalogModuleAwsS3EntityProvider = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         catalog: catalogProcessingExtensionPoint,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,

--- a/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.test.ts
@@ -65,7 +65,7 @@ describe('catalogModuleAzureDevOpsEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.ts
+++ b/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.ts
@@ -33,7 +33,7 @@ export const catalogModuleAzureDevOpsEntityProvider = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         catalog: catalogProcessingExtensionPoint,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.test.ts
@@ -56,7 +56,7 @@ describe('catalogModuleBitbucketCloudEntityProvider', () => {
         [eventsExtensionPoint, eventsExtensionPointImpl],
       ],
       services: [
-        mockServices.config.factory({
+        mockServices.rootConfig.factory({
           data: {
             catalog: {
               providers: {

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.ts
@@ -37,7 +37,7 @@ export const catalogModuleBitbucketCloudEntityProvider = createBackendModule({
       deps: {
         catalog: catalogProcessingExtensionPoint,
         catalogApi: catalogServiceRef,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         // TODO(pjungermann): How to make this optional for those which only want the provider without event support?
         //  Do we even want to support this?
         events: eventsExtensionPoint,

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.test.ts
@@ -69,7 +69,7 @@ describe('catalogModuleBitbucketServerEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.ts
@@ -32,7 +32,7 @@ export const catalogModuleBitbucketServerEntityProvider = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
       },

--- a/plugins/catalog-backend-module-gcp/src/module/catalogModuleGcpGkeEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/module/catalogModuleGcpGkeEntityProvider.ts
@@ -33,7 +33,7 @@ export const catalogModuleGcpGkeEntityProvider = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         catalog: catalogProcessingExtensionPoint,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,

--- a/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.test.ts
@@ -75,7 +75,7 @@ describe('catalogModuleGerritEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.ts
@@ -32,7 +32,7 @@ export const catalogModuleGerritEntityProvider = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
       },

--- a/plugins/catalog-backend-module-github/src/module/catalogModuleGithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/module/catalogModuleGithubEntityProvider.test.ts
@@ -62,7 +62,7 @@ describe('catalogModuleGithubEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-github/src/module/catalogModuleGithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/module/catalogModuleGithubEntityProvider.ts
@@ -34,7 +34,7 @@ export const catalogModuleGithubEntityProvider = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
       },

--- a/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.test.ts
@@ -74,7 +74,7 @@ describe('catalogModuleGitlabDiscoveryEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.ts
@@ -33,7 +33,7 @@ export const catalogModuleGitlabDiscoveryEntityProvider = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         catalog: catalogProcessingExtensionPoint,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  ConfigService,
+  RootConfigService,
   LoggerService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
@@ -49,7 +49,7 @@ export class WrapperProviders {
 
   constructor(
     private readonly options: {
-      config: ConfigService;
+      config: RootConfigService;
       logger: LoggerService;
       client: Knex;
       scheduler: SchedulerService;

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.test.ts
@@ -50,7 +50,7 @@ describe('catalogModuleIncrementalIngestionEntityProvider', () => {
         [catalogProcessingExtensionPoint, { addEntityProvider }],
       ],
       services: [
-        [coreServices.config, new ConfigReader({})],
+        [coreServices.rootConfig, new ConfigReader({})],
         [coreServices.database, database],
         [coreServices.httpRouter, httpRouter],
         [coreServices.logger, getVoidLogger()],

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.ts
@@ -44,7 +44,7 @@ export const catalogModuleIncrementalIngestionEntityProvider =
         env.registerInit({
           deps: {
             catalog: catalogProcessingExtensionPoint,
-            config: coreServices.config,
+            config: coreServices.rootConfig,
             database: coreServices.database,
             httpRouter: coreServices.httpRouter,
             logger: coreServices.logger,

--- a/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
@@ -54,7 +54,7 @@ async function main() {
   const backend = createBackend({
     services: [
       createServiceFactory({
-        service: coreServices.config,
+        service: coreServices.rootConfig,
         deps: {},
         factory: () => new ConfigReader(config),
       }),

--- a/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.test.ts
@@ -67,7 +67,7 @@ describe('catalogModuleMicrosoftGraphOrgEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.ts
@@ -70,7 +70,7 @@ export const catalogModuleMicrosoftGraphOrgEntityProvider = createBackendModule(
       env.registerInit({
         deps: {
           catalog: catalogProcessingExtensionPoint,
-          config: coreServices.config,
+          config: coreServices.rootConfig,
           logger: coreServices.logger,
           scheduler: coreServices.scheduler,
         },

--- a/plugins/catalog-backend-module-puppetdb/src/module/catalogModulePuppetDbEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/module/catalogModulePuppetDbEntityProvider.test.ts
@@ -61,7 +61,7 @@ describe('catalogModulePuppetDbEntityProvider', () => {
     await startTestBackend({
       extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/catalog-backend-module-puppetdb/src/module/catalogModulePuppetDbEntityProvider.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/module/catalogModulePuppetDbEntityProvider.ts
@@ -34,7 +34,7 @@ export const catalogModulePuppetDbEntityProvider = createBackendModule({
     env.registerInit({
       deps: {
         catalog: catalogProcessingExtensionPoint,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
       },

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -84,7 +84,7 @@ export const catalogPlugin = createBackendPlugin({
     env.registerInit({
       deps: {
         logger: coreServices.logger,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         reader: coreServices.urlReader,
         permissions: coreServices.permissions,
         database: coreServices.database,

--- a/plugins/devtools-backend/src/plugin.ts
+++ b/plugins/devtools-backend/src/plugin.ts
@@ -31,7 +31,7 @@ export const devtoolsPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         permissions: coreServices.permissions,
         httpRouter: coreServices.httpRouter,

--- a/plugins/events-backend-module-aws-sqs/src/service/eventsModuleAwsSqsConsumingEventPublisher.test.ts
+++ b/plugins/events-backend-module-aws-sqs/src/service/eventsModuleAwsSqsConsumingEventPublisher.test.ts
@@ -64,7 +64,7 @@ describe('eventsModuleAwsSqsConsumingEventPublisher', () => {
     await startTestBackend({
       extensionPoints: [[eventsExtensionPoint, extensionPoint]],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.logger, getVoidLogger()],
         [coreServices.scheduler, scheduler],
       ],

--- a/plugins/events-backend-module-aws-sqs/src/service/eventsModuleAwsSqsConsumingEventPublisher.ts
+++ b/plugins/events-backend-module-aws-sqs/src/service/eventsModuleAwsSqsConsumingEventPublisher.ts
@@ -33,7 +33,7 @@ export const eventsModuleAwsSqsConsumingEventPublisher = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         events: eventsExtensionPoint,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,

--- a/plugins/events-backend-module-github/src/service/eventsModuleGithubWebhook.test.ts
+++ b/plugins/events-backend-module-github/src/service/eventsModuleGithubWebhook.test.ts
@@ -59,7 +59,7 @@ describe('eventsModuleGithubWebhook', () => {
 
     await startTestBackend({
       extensionPoints: [[eventsExtensionPoint, extensionPoint]],
-      services: [[coreServices.config, config]],
+      services: [[coreServices.rootConfig, config]],
       features: [eventsModuleGithubWebhook()],
     });
 

--- a/plugins/events-backend-module-github/src/service/eventsModuleGithubWebhook.ts
+++ b/plugins/events-backend-module-github/src/service/eventsModuleGithubWebhook.ts
@@ -34,7 +34,7 @@ export const eventsModuleGithubWebhook = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         events: eventsExtensionPoint,
       },
       async init({ config, events }) {

--- a/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabWebhook.test.ts
+++ b/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabWebhook.test.ts
@@ -54,7 +54,7 @@ describe('gitlabWebhookEventsModule', () => {
 
     await startTestBackend({
       extensionPoints: [[eventsExtensionPoint, extensionPoint]],
-      services: [[coreServices.config, config]],
+      services: [[coreServices.rootConfig, config]],
       features: [eventsModuleGitlabWebhook()],
     });
 

--- a/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabWebhook.ts
+++ b/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabWebhook.ts
@@ -36,7 +36,7 @@ export const eventsModuleGitlabWebhook = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         events: eventsExtensionPoint,
       },
       async init({ config, events }) {

--- a/plugins/events-backend/src/service/EventsPlugin.test.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.test.ts
@@ -71,7 +71,7 @@ describe('eventPlugin', () => {
     await startTestBackend({
       extensionPoints: [],
       services: [
-        [coreServices.config, config],
+        [coreServices.rootConfig, config],
         [coreServices.httpRouter, httpRouter],
         [coreServices.logger, getVoidLogger()],
       ],

--- a/plugins/events-backend/src/service/EventsPlugin.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.ts
@@ -89,7 +89,7 @@ export const eventsPlugin = createBackendPlugin({
 
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         router: coreServices.httpRouter,
       },

--- a/plugins/kafka-backend/src/plugin.ts
+++ b/plugins/kafka-backend/src/plugin.ts
@@ -31,7 +31,7 @@ export const kafkaPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
       },

--- a/plugins/kubernetes-backend/src/plugin.ts
+++ b/plugins/kubernetes-backend/src/plugin.ts
@@ -34,7 +34,7 @@ export const kubernetesPlugin = createBackendPlugin({
       deps: {
         http: coreServices.httpRouter,
         logger: coreServices.logger,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         catalogApi: catalogServiceRef,
         permissions: coreServices.permissions,
       },

--- a/plugins/lighthouse-backend/src/plugin.ts
+++ b/plugins/lighthouse-backend/src/plugin.ts
@@ -34,7 +34,7 @@ export const lighthousePlugin = createBackendPlugin({
     env.registerInit({
       deps: {
         catalogClient: catalogServiceRef,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
         tokenManager: coreServices.tokenManager,

--- a/plugins/periskop-backend/src/plugin.ts
+++ b/plugins/periskop-backend/src/plugin.ts
@@ -31,7 +31,7 @@ export const periskopPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
       },

--- a/plugins/permission-backend/src/plugin.ts
+++ b/plugins/permission-backend/src/plugin.ts
@@ -90,7 +90,7 @@ export const permissionPlugin = createBackendPlugin(() => ({
     env.registerInit({
       deps: {
         http: coreServices.httpRouter,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         discovery: coreServices.discovery,
         identity: coreServices.identity,

--- a/plugins/proxy-backend/src/plugin.ts
+++ b/plugins/proxy-backend/src/plugin.ts
@@ -35,7 +35,7 @@ export const proxyPlugin = createBackendPlugin(
     register(env) {
       env.registerInit({
         deps: {
-          config: coreServices.config,
+          config: coreServices.rootConfig,
           discovery: coreServices.discovery,
           logger: coreServices.logger,
           httpRouter: coreServices.httpRouter,

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -80,7 +80,7 @@ export const scaffolderPlugin = createBackendPlugin(
       env.registerInit({
         deps: {
           logger: coreServices.logger,
-          config: coreServices.config,
+          config: coreServices.rootConfig,
           reader: coreServices.urlReader,
           permissions: coreServices.permissions,
           database: coreServices.database,

--- a/plugins/search-backend-module-catalog/src/alpha.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.ts
@@ -53,7 +53,7 @@ export const searchModuleCatalogCollator = createBackendModule(
     register(env) {
       env.registerInit({
         deps: {
-          config: coreServices.config,
+          config: coreServices.rootConfig,
           discovery: coreServices.discovery,
           tokenManager: coreServices.tokenManager,
           scheduler: coreServices.scheduler,

--- a/plugins/search-backend-module-elasticsearch/src/alpha.ts
+++ b/plugins/search-backend-module-elasticsearch/src/alpha.ts
@@ -48,7 +48,7 @@ export const searchModuleElasticsearchEngine = createBackendModule(
         deps: {
           searchEngineRegistry: searchEngineRegistryExtensionPoint,
           logger: coreServices.logger,
-          config: coreServices.config,
+          config: coreServices.rootConfig,
         },
         async init({ searchEngineRegistry, logger, config }) {
           const searchEngine = await ElasticSearchSearchEngine.fromConfig({

--- a/plugins/search-backend-module-explore/src/alpha.ts
+++ b/plugins/search-backend-module-explore/src/alpha.ts
@@ -54,7 +54,7 @@ export const searchModuleExploreCollator = createBackendModule(
     register(env) {
       env.registerInit({
         deps: {
-          config: coreServices.config,
+          config: coreServices.rootConfig,
           logger: coreServices.logger,
           discovery: coreServices.discovery,
           scheduler: coreServices.scheduler,

--- a/plugins/search-backend-module-pg/src/alpha.ts
+++ b/plugins/search-backend-module-pg/src/alpha.ts
@@ -32,7 +32,7 @@ export const searchModulePostgresEngine = createBackendModule({
       deps: {
         searchEngineRegistry: searchEngineRegistryExtensionPoint,
         database: coreServices.database,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
       },
       async init({ searchEngineRegistry, database, config }) {
         searchEngineRegistry.setSearchEngine(

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -54,7 +54,7 @@ export const searchModuleTechDocsCollator = createBackendModule(
     register(env) {
       env.registerInit({
         deps: {
-          config: coreServices.config,
+          config: coreServices.rootConfig,
           logger: coreServices.logger,
           discovery: coreServices.discovery,
           tokenManager: coreServices.tokenManager,

--- a/plugins/search-backend/src/alpha.ts
+++ b/plugins/search-backend/src/alpha.ts
@@ -93,7 +93,7 @@ export const searchPlugin = createBackendPlugin({
     env.registerInit({
       deps: {
         logger: coreServices.logger,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         permissions: coreServices.permissions,
         http: coreServices.httpRouter,
         searchIndexService: searchIndexServiceRef,

--- a/plugins/techdocs-backend/src/plugin.ts
+++ b/plugins/techdocs-backend/src/plugin.ts
@@ -41,7 +41,7 @@ export const techdocsPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         urlReader: coreServices.urlReader,
         http: coreServices.httpRouter,

--- a/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.ts
+++ b/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.ts
@@ -183,7 +183,7 @@ export const todoReaderServiceRef = createServiceRef<TodoReader>({
       service,
       deps: {
         reader: coreServices.urlReader,
-        config: coreServices.config,
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
       },
       factory: async ({ reader, config, logger }) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR renames the core `config` service to `rootConfig` in order to  match the rest of the root services and to make space for a potential future plugin-scoped config service

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
