### PR TITLE
fix(security): Simplify merge message job

### DIFF
--- a/.github/workflows/automate_merge_message.yml
+++ b/.github/workflows/automate_merge_message.yml
@@ -23,8 +23,7 @@ jobs:
     if: github.repository == 'backstage/backstage' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-
-        # We avoid using the in-source script since this workflow has elevated permissions that we don't want to expose
+      # We avoid using the in-source script since this workflow has elevated permissions that we don't want to expose
       - name: Generate Message
         id: generate-message
         run: |

--- a/.github/workflows/automate_merge_message.yml
+++ b/.github/workflows/automate_merge_message.yml
@@ -23,12 +23,6 @@ jobs:
     if: github.repository == 'backstage/backstage' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: '${{ github.event.pull_request.merge_commit_sha }}'
-
-      - name: fetch head & base
-        run: git fetch --depth 1 origin ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }}
 
         # We avoid using the in-source script since this workflow has elevated permissions that we don't want to expose
       - name: Generate Message


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Backstage's record on the CNCF CLO Monitor, as well as the OpenSSF score card, indicate some exposure to dangerous workflows. In fact, the relevant workflows in the repo seem to have some mitigating statements in there to help protect them so they may not have the full exposure the score card suggests.

However, for the Automate merge message job which posts on a PR after it's merged to tell a user "Your work will be included in Backstage v1.xx on YY date", I had a hunch that in fact based on workflow steps, which a) statically get the message generation script using the public GitHub API off `master` and not via a Git clone, then b) use a post action  to run some inline code to post a message, there may not actually be ANY reason whatsoever to a) clone the repo, and b) then do a secondary fetch against it since we don't seem to be using ANY repo content in this job what so ever? (but maybe originally during testing/creation of this workflow it needed it?)

If this is the case, then not only would this quick job run a bit faster, but removing the clone action this actually eliminates the warning in OpenSSF scorecard about this particular workflow because it's warning about the actions/checkout step which I've removed.

I've validated that running the scorecard locally, this action  no longer gets flagged (1 warning, not 2):

```
scorecard --checks Dangerous-Workflow --local . --show-details
Starting [Dangerous-Workflow]
Finished [Dangerous-Workflow]

RESULTS
-------
Aggregate score: 0.0 / 10

Check scores:
|--------|--------------------|--------------------------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
| SCORE  |        NAME        |             REASON             |                       DETAILS                        |                                             DOCUMENTATION/REMEDIATION                                             |
|--------|--------------------|--------------------------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
| 0 / 10 | Dangerous-Workflow | dangerous workflow patterns    | Warn: untrusted code checkout 'refs/pull/${{         | https://github.com/ossf/scorecard/blob/4edb07802fdad892fa8d10f8fd47666b6ccc27c9/docs/checks.md#dangerous-workflow |
|        |                    | detected                       | github.event.pull_request.number }}/merge':          |                                                                                                                   |
|        |                    |                                | .github/workflows/automate_changeset_feedback.yml:25 |                                                                                                                   |
|--------|--------------------|--------------------------------|------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
```


Welcome a close eye on this one; not sure exactly a great way to test this other than sort of playing around on my own fork, but welcome feedback.

<img width="790" alt="image" src="https://github.com/backstage/backstage/assets/33203301/afe71b61-5664-4197-a902-7cef621f3422">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
