### PR TITLE
Make <SupportButton /> overrideable

### DIFF
--- a/.changeset/lovely-islands-provide.md
+++ b/.changeset/lovely-islands-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Expose the <SupportButton /> component for the page

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -425,6 +425,7 @@ export type RouterProps = {
     editor?: boolean;
     actions?: boolean;
   };
+  supportButton?: React_2.ReactNode;
 };
 
 // @public @deprecated (undocumented)

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -74,6 +74,7 @@ export type RouterProps = {
     /** Whether to show a link to the actions documentation */
     actions?: boolean;
   };
+  supportButton?: React.ReactNode;
 };
 
 /**
@@ -87,6 +88,7 @@ export const Router = (props: RouterProps) => {
     templateFilter,
     components = {},
     defaultPreviewTemplate,
+    supportButton,
   } = props;
 
   const { ReviewStepComponent, TemplateCardComponent, TaskPageComponent } =
@@ -136,6 +138,7 @@ export const Router = (props: RouterProps) => {
             TemplateCardComponent={TemplateCardComponent}
             contextMenu={props.contextMenu}
             headerOptions={props.headerOptions}
+            supportButton={supportButton}
           />
         }
       />

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -59,6 +59,7 @@ export type ScaffolderPageProps = {
     title?: string;
     subtitle?: string;
   };
+  supportButton?: React.ReactNode;
 };
 
 export const ScaffolderPageContents = ({
@@ -67,6 +68,7 @@ export const ScaffolderPageContents = ({
   templateFilter,
   contextMenu,
   headerOptions,
+  supportButton,
 }: ScaffolderPageProps) => {
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
   const otherTemplatesGroup = {
@@ -99,11 +101,13 @@ export const ScaffolderPageContents = ({
               to={registerComponentLink && registerComponentLink()}
             />
           )}
-          <SupportButton>
-            Create new software components using standard templates. Different
-            templates create different kinds of components (services, websites,
-            documentation, ...).
-          </SupportButton>
+          {supportButton || (
+            <SupportButton>
+              Create new software components using standard templates. Different
+              templates create different kinds of components (services,
+              websites, documentation, ...).
+            </SupportButton>
+          )}
         </ContentHeader>
 
         <CatalogFilterLayout>
@@ -146,6 +150,7 @@ export const ScaffolderPage = ({
   templateFilter,
   contextMenu,
   headerOptions,
+  supportButton,
 }: ScaffolderPageProps) => (
   <EntityListProvider>
     <ScaffolderPageContents
@@ -154,6 +159,7 @@ export const ScaffolderPage = ({
       templateFilter={templateFilter}
       contextMenu={contextMenu}
       headerOptions={headerOptions}
+      supportButton={supportButton}
     />
   </EntityListProvider>
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Make the <SupportButton /> component overrideable for this page.

I'd like to link to a scaffolder specific documentation on this page with or instead of the general `app.support` items that are coming from the app-config.yaml


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
