### PR TITLE
Adding the ability to not render the change events tab for the PagerDuty Card

### DIFF
--- a/.changeset/clever-adults-add.md
+++ b/.changeset/clever-adults-add.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-pagerduty': minor
+'@backstage/plugin-pagerduty': patch
 ---
 
-Add new 'disableChangeEvents' attribute to PagerDuty Card to hide the Change Events tab and disable fetching of change events for the PagerDuty service.
+Add new `disableChangeEvents` prop to `EntityPagerDutyCard` to hide the Change Events tab and disable fetching of change events for the PagerDuty service.

--- a/.changeset/clever-adults-add.md
+++ b/.changeset/clever-adults-add.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-pagerduty': minor
 ---
 
-Add new 'disableChangeEvents' attribute to PagerDuty Card to hide the Change Events tab and disable fetching of chang events for a the service.
+Add new 'disableChangeEvents' attribute to PagerDuty Card to hide the Change Events tab and disable fetching of change events for the PagerDuty service.

--- a/.changeset/clever-adults-add.md
+++ b/.changeset/clever-adults-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-pagerduty': minor
+---
+
+Add new 'disableChangeEvents' attribute to PagerDuty Card to hide the Change Events tab and disable fetching of chang events for a the service.

--- a/plugins/pagerduty/api-report.md
+++ b/plugins/pagerduty/api-report.md
@@ -22,6 +22,7 @@ export const EntityPagerDutyCard: (
 // @public (undocumented)
 export type EntityPagerDutyCardProps = {
   readOnly?: boolean;
+  disableChangeEvents?: boolean;
 };
 
 // @public (undocumented)

--- a/plugins/pagerduty/src/components/EntityPagerDutyCard/index.tsx
+++ b/plugins/pagerduty/src/components/EntityPagerDutyCard/index.tsx
@@ -30,12 +30,19 @@ export const isPluginApplicableToEntity = (entity: Entity) =>
 /** @public */
 export type EntityPagerDutyCardProps = {
   readOnly?: boolean;
+  disableChangeEvents?: boolean;
 };
 
 /** @public */
 export const EntityPagerDutyCard = (props: EntityPagerDutyCardProps) => {
-  const { readOnly } = props;
+  const { readOnly, disableChangeEvents } = props;
   const { entity } = useEntity();
   const pagerDutyEntity = getPagerDutyEntity(entity);
-  return <PagerDutyCard {...pagerDutyEntity} readOnly={readOnly} />;
+  return (
+    <PagerDutyCard
+      {...pagerDutyEntity}
+      readOnly={readOnly}
+      disableChangeEvents={disableChangeEvents}
+    />
+  );
 };

--- a/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
+++ b/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
@@ -171,7 +171,7 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
               />
             </CardTab>
             <>
-              {disableChangeEvents === true && (
+              {disableChangeEvents !== true && (
                 <CardTab label="Change Events">
                   <ChangeEvents
                     serviceId={service!.id}

--- a/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
+++ b/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
@@ -46,11 +46,12 @@ const BasicCard = ({ children }: { children: ReactNode }) => (
 /** @public */
 export type PagerDutyCardProps = PagerDutyEntity & {
   readOnly?: boolean;
+  disableChangeEvents?: boolean;
 };
 
 /** @public */
 export const PagerDutyCard = (props: PagerDutyCardProps) => {
-  const { readOnly, integrationKey, name } = props;
+  const { readOnly, disableChangeEvents, integrationKey, name } = props;
   const api = useApi(pagerDutyApiRef);
   const [refreshIncidents, setRefreshIncidents] = useState<boolean>(false);
   const [refreshChangeEvents, setRefreshChangeEvents] =
@@ -169,12 +170,16 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
                 refreshIncidents={refreshIncidents}
               />
             </CardTab>
-            <CardTab label="Change Events">
-              <ChangeEvents
-                serviceId={service!.id}
-                refreshEvents={refreshChangeEvents}
-              />
-            </CardTab>
+            <>
+              {disableChangeEvents === true && (
+                <CardTab label="Change Events">
+                  <ChangeEvents
+                    serviceId={service!.id}
+                    refreshEvents={refreshChangeEvents}
+                  />
+                </CardTab>
+              )}
+            </>
           </TabbedCard>
           <EscalationPolicy policyId={service!.policyId} />
         </CardContent>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello! PagerDuty changed how the Change Event stuff works and now you have to subscribe to another feature (https://support.pagerduty.com/docs/aiops). This PR adds the ability to hide the change events tab for the PD card so it's not always erroring out if users can't access their services change events through the API.

Willing to change anything about this! Please let me know how you want me to add this functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
