### PR TITLE
fix(explore): don't put ? if no query params

### DIFF
--- a/.changeset/violet-dogs-breathe.md
+++ b/.changeset/violet-dogs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Don't put "?" in URL if no query parameters.

--- a/plugins/explore/src/api/ExploreClient.test.ts
+++ b/plugins/explore/src/api/ExploreClient.test.ts
@@ -83,6 +83,22 @@ describe('ExploreClient', () => {
       });
       expect(response).toEqual(expectedResponse);
     });
+
+    it('should request explore tools without filters', async () => {
+      const expectedResponse: GetExploreToolsResponse = {
+        tools: mockTools,
+      };
+
+      server.use(
+        rest.get(`${mockBaseUrl}/tools`, (req, res, ctx) => {
+          expect(req.url.search).toBe('');
+          return res(ctx.json(expectedResponse));
+        }),
+      );
+
+      const response = await client.getTools();
+      expect(response).toEqual(expectedResponse);
+    });
   });
 
   describe('when using exploreToolsConfig for backwards compatibility', () => {

--- a/plugins/explore/src/api/ExploreClient.ts
+++ b/plugins/explore/src/api/ExploreClient.ts
@@ -71,7 +71,7 @@ export class ExploreClient implements ExploreApi {
       filter?.lifecycle?.map(l => `lifecycle=${encodeURIComponent(l)}`) ?? [];
     const query = [...tags, ...lifecycles].join('&');
 
-    const response = await fetch(`${baseUrl}/tools?${query}`);
+    const response = await fetch(`${baseUrl}/tools${query ? `?${query}` : ''}`);
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello,

The Explore plugin frontend do a call to `/api/explore/tools?` with a trailing "?" sign at the end of the URL, when there are no filters.

I've some trouble on my internal proxy on this request , so I push this fix.

Thank you!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
