### PR TITLE
docs: fix a link to the frontend Backstage plugin

### DIFF
--- a/.changeset/late-cows-turn.md
+++ b/.changeset/late-cows-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a link to the frontend Backstage plugin that had pointed to itself.

--- a/docs/features/software-catalog/references.md
+++ b/docs/features/software-catalog/references.md
@@ -23,9 +23,9 @@ compound reference structure.
 
 ## String References
 
-This is the most common alternative, that is used in almost all circumstances.
+This is the most common alternative and is used in almost all circumstances.
 
-The string is on the form `[<kind>:][<namespace>/]<name>`, that is, it is
+The string is of the form `[<kind>:][<namespace>/]<name>`. That is, it is
 composed of between one and three parts in this specific order, without any
 additional encoding:
 

--- a/plugins/catalog-backend/README.md
+++ b/plugins/catalog-backend/README.md
@@ -86,5 +86,5 @@ some example entities.
 
 ## Links
 
-- [catalog](https://github.com/backstage/backstage/tree/master/plugins/catalog-backend)
+- [catalog](https://github.com/backstage/backstage/tree/master/plugins/catalog)
   is the frontend interface for this plugin.


### PR DESCRIPTION
This just fixes a link to the frontend Backstage plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
