### PR TITLE
chore: Add OpenSSF Badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [![Codecov](https://img.shields.io/codecov/c/github/backstage/backstage)](https://codecov.io/gh/backstage/backstage)
 [![](https://img.shields.io/github/v/release/backstage/backstage)](https://github.com/backstage/backstage/releases)
 [![Uffizzi](https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.uffizzi.com%2Fapi%2Fv1%2Fpublic%2Fshields%2Fgithub.com%2Fbackstage%2Fbackstage)](https://app.uffizzi.com/ephemeral-environments/backstage/backstage)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7678/badge)](https://bestpractices.coreinfrastructure.org/projects/7678)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/backstage/backstage/badge)](https://securityscorecards.dev/viewer/?uri=github.com/backstage/backstage)
 
 > 🏖️ The week beginning the 26th of June, some of the maintainers will be taking a well earned Summer Holiday break. We will be slower to respond to issues and PRs during this time. Releases will continue to be shipped weekly. Normal service will resume on the 24th of July. 🏝️
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR adds two OpenSSF Badges to the main project README:

[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7678/badge)](https://bestpractices.coreinfrastructure.org/projects/7678) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/backstage/backstage/badge)](https://securityscorecards.dev/viewer/?uri=github.com/backstage/backstage)

Specifically, the CNCF CLO Monitor web site tracks automated alignment to best practicer for all CNCF projects:
https://clomonitor.io/projects/cncf/backstage
<img width="1321" alt="image" src="https://github.com/backstage/backstage/assets/33203301/ad23b16a-b4c9-40ed-a752-76859cad27f6">

Two of the best practices are to have these badges. Backstage currently lists as 45% in the best practice category, with four entries missing (three red ❌ , and one n/a for Slack). This will fix two of them, and I'm not quite sure on the maths as they must be weighted, but this should pull up Backstage.

<img width="1180" alt="image" src="https://github.com/backstage/backstage/assets/33203301/f351ffa8-14b0-49f8-8493-77a0b11ddcd8">

To get one of them, I manually added Backstage to the OpenSSF Best Practices Badge site. (i thought it had been there before, TBH! seems like it's gone through a bit of rebranding and gotten fully pulled into OpenSSF)  It says I "own" it, but anyone with write access to the repo can edit the entry here:  https://bestpractices.coreinfrastructure.org/en/projects/7678  Happy to "reassign it"; just need one of the maintainers to login to that site and tell me what their "numeric" user ID is. (i can't choose like, freben,rugvip, or benjdlambert, has to be a 4-6 digit ID from that site!) I spent a few minutes trying to manually answer the questions, but for sure a maintainer might be able to bang out a few more and get this to green passing with no problem I'd guess. Just needs a bit more tweaking, and aligning to some of the current policies. (but i linked in things like the Spotify bug bounty/security policy, issue reporting, stuff like that)

Over time, we could add the OpenSSF scorecard action to this repo so it automatically scans each time a merge to `master` is performed; that could prove useful to keep the site up to date! But for now, a manual scan is sufficient (and I've run a fresh one, and can run another one after this PR is reviewed and if merged!).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
