### PR TITLE
Fixed changelog for fromConfig and moved config example to as config section of readme

### DIFF
--- a/.changeset/hot-cats-rush.md
+++ b/.changeset/hot-cats-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore-backend': patch
+---
+
+Moved the config example from the "Tools as Code" section to the "Tools as Config" section of the README

--- a/plugins/explore-backend/CHANGELOG.md
+++ b/plugins/explore-backend/CHANGELOG.md
@@ -99,7 +99,7 @@
   - ];
   -
   - StaticExploreToolProvider.fromData(tools)
-  + StaticExploreToolProvider.fromData(env.config)
+  + StaticExploreToolProvider.fromConfig(env.config)
   ```
 
 - Updated dependencies

--- a/plugins/explore-backend/README.md
+++ b/plugins/explore-backend/README.md
@@ -39,15 +39,6 @@ export default async function createPlugin(
 }
 ```
 
-#### Tools as Code
-
-Install dependencies
-
-```bash
-# From your Backstage root directory
-yarn add --cwd packages/backend @backstage/plugin-explore-backend @backstage/plugin-explore-common
-```
-
 Config:
 
 ```yaml
@@ -61,6 +52,15 @@ explore:
         - newrelic
         - proxy
         - nerdGraph
+```
+
+#### Tools as Code
+
+Install dependencies
+
+```bash
+# From your Backstage root directory
+yarn add --cwd packages/backend @backstage/plugin-explore-backend @backstage/plugin-explore-common
 ```
 
 You'll need to add the plugin to the router in your `backend` package. You can


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The changelog for the 0.0.8 release of the explore backend plugin had a mistake in the example for switching to the use of the config for tools. It should use fromConfig but it used fromData. Also, the readme had the configuration example in the "Tools as Code" section instead of the "Tools as Config" section making it a bit confusing. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
