### PR TITLE
Add missing slash to proxying docs

### DIFF
--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -36,7 +36,7 @@ Example:
 ```yaml
 # in app-config.yaml
 proxy:
-  simple-example: http://simple.example.com:8080
+  /simple-example: http://simple.example.com:8080
   '/larger-example/v1':
     target: http://larger.example.com:8080/svc.v1
     headers:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I noticed when I did not have a slash before the key, it did not work

I found this solution in [this issue](https://github.com/backstage/backstage/issues/11738#issuecomment-1561342427)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] ~~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~~
- [x] Added or updated documentation
- [x] ~~Tests for new functionality and regression tests for bug fixes~~
- [x] ~~Screenshots attached (for UI changes)~~
- [x] ~~All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))~~
