### PR TITLE
proxy-backend: move proxy configuration to proxy.endpoints

### DIFF
--- a/.changeset/rotten-rabbits-move.md
+++ b/.changeset/rotten-rabbits-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': minor
+---
+
+Defining proxy endpoints directly under the root `proxy` configuration key is deprecated. Endpoints should now be declared under `proxy.endpoints` instead. The `skipInvalidProxies` and `reviveConsumedRequestBodies` can now also be configured through static configuration.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -49,80 +49,81 @@ backend:
 
 # See README.md in the proxy-backend plugin for information on the configuration format
 proxy:
-  '/circleci/api':
-    target: https://circleci.com/api/v1.1
-    headers:
-      Circle-Token: ${CIRCLECI_AUTH_TOKEN}
+  endpoints:
+    '/circleci/api':
+      target: https://circleci.com/api/v1.1
+      headers:
+        Circle-Token: ${CIRCLECI_AUTH_TOKEN}
 
-  '/jenkins/api':
-    target: http://localhost:8080
-    headers:
-      Authorization: ${JENKINS_BASIC_AUTH_HEADER}
+    '/jenkins/api':
+      target: http://localhost:8080
+      headers:
+        Authorization: ${JENKINS_BASIC_AUTH_HEADER}
 
-  '/travisci/api':
-    target: https://api.travis-ci.com
-    changeOrigin: true
-    headers:
-      Authorization: ${TRAVISCI_AUTH_TOKEN}
-      travis-api-version: '3'
+    '/travisci/api':
+      target: https://api.travis-ci.com
+      changeOrigin: true
+      headers:
+        Authorization: ${TRAVISCI_AUTH_TOKEN}
+        travis-api-version: '3'
 
-  '/newrelic/apm/api':
-    target: https://api.newrelic.com/v2
-    headers:
-      X-Api-Key: ${NEW_RELIC_REST_API_KEY}
+    '/newrelic/apm/api':
+      target: https://api.newrelic.com/v2
+      headers:
+        X-Api-Key: ${NEW_RELIC_REST_API_KEY}
 
-  '/newrelic/api':
-    target: https://api.newrelic.com
-    headers:
-      X-Api-Key: ${NEW_RELIC_USER_KEY}
+    '/newrelic/api':
+      target: https://api.newrelic.com
+      headers:
+        X-Api-Key: ${NEW_RELIC_USER_KEY}
 
-  '/pagerduty':
-    target: https://api.pagerduty.com
-    headers:
-      Authorization: Token token=${PAGERDUTY_TOKEN}
+    '/pagerduty':
+      target: https://api.pagerduty.com
+      headers:
+        Authorization: Token token=${PAGERDUTY_TOKEN}
 
-  '/buildkite/api':
-    target: https://api.buildkite.com/v2/
-    headers:
-      Authorization: ${BUILDKITE_TOKEN}
+    '/buildkite/api':
+      target: https://api.buildkite.com/v2/
+      headers:
+        Authorization: ${BUILDKITE_TOKEN}
 
-  '/sentry/api':
-    target: https://sentry.io/api/
-    allowedMethods: ['GET']
-    headers:
-      Authorization: ${SENTRY_TOKEN}
+    '/sentry/api':
+      target: https://sentry.io/api/
+      allowedMethods: ['GET']
+      headers:
+        Authorization: ${SENTRY_TOKEN}
 
-  '/ilert':
-    target: https://api.ilert.com
-    allowedMethods: ['GET', 'POST', 'PUT']
-    allowedHeaders: ['Authorization']
-    headers:
-      Authorization: ${ILERT_AUTH_HEADER}
+    '/ilert':
+      target: https://api.ilert.com
+      allowedMethods: ['GET', 'POST', 'PUT']
+      allowedHeaders: ['Authorization']
+      headers:
+        Authorization: ${ILERT_AUTH_HEADER}
 
-  '/airflow':
-    target: https://your.airflow.instance.com/api/v1
-    headers:
-      Authorization: ${AIRFLOW_BASIC_AUTH_HEADER}
+    '/airflow':
+      target: https://your.airflow.instance.com/api/v1
+      headers:
+        Authorization: ${AIRFLOW_BASIC_AUTH_HEADER}
 
-  '/gocd':
-    target: https://your.gocd.instance.com/go/api
-    allowedMethods: ['GET']
-    allowedHeaders: ['Authorization']
-    headers:
-      Authorization: Basic ${GOCD_AUTH_CREDENTIALS}
+    '/gocd':
+      target: https://your.gocd.instance.com/go/api
+      allowedMethods: ['GET']
+      allowedHeaders: ['Authorization']
+      headers:
+        Authorization: Basic ${GOCD_AUTH_CREDENTIALS}
 
-  '/dynatrace':
-    target: https://your.dynatrace.instance.com/api/v2
-    headers:
-      Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
+    '/dynatrace':
+      target: https://your.dynatrace.instance.com/api/v2
+      headers:
+        Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
 
-  '/stackstorm':
-    target: https://your.stackstorm.instance.com/api
-    headers:
-      St2-Api-Key: ${ST2_API_KEY}
+    '/stackstorm':
+      target: https://your.stackstorm.instance.com/api
+      headers:
+        St2-Api-Key: ${ST2_API_KEY}
 
-  '/puppetdb':
-    target: https://your.puppetdb.instance.com
+    '/puppetdb':
+      target: https://your.puppetdb.instance.com
 
 organization:
   name: My Company

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -42,6 +42,7 @@
     "@backstage/plugin-permission-backend": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-permission-node": "workspace:^",
+    "@backstage/plugin-proxy-backend": "workspace:^",
     "@backstage/plugin-scaffolder-backend": "workspace:^",
     "@backstage/plugin-search-backend": "workspace:^",
     "@backstage/plugin-search-backend-module-catalog": "workspace:^",

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -39,6 +39,7 @@ import { devtoolsPlugin } from '@backstage/plugin-devtools-backend';
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { adrPlugin } from '@backstage/plugin-adr-backend';
 import { lighthousePlugin } from '@backstage/plugin-lighthouse-backend';
+import { proxyPlugin } from '@backstage/plugin-proxy-backend';
 
 const backend = createBackend();
 
@@ -97,6 +98,9 @@ backend.add(kubernetesPlugin());
 
 // Lighthouse
 backend.add(lighthousePlugin());
+
+// Proxy
+backend.add(proxyPlugin());
 
 // Permissions
 backend.add(permissionPlugin());

--- a/plugins/proxy-backend/api-report.md
+++ b/plugins/proxy-backend/api-report.md
@@ -13,14 +13,7 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @alpha
-export const proxyPlugin: (
-  options?:
-    | {
-        skipInvalidProxies?: boolean | undefined;
-        reviveConsumedRequestBodies?: boolean | undefined;
-      }
-    | undefined,
-) => BackendFeature;
+export const proxyPlugin: () => BackendFeature;
 
 // @public (undocumented)
 export interface RouterOptions {

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -15,51 +15,63 @@
  */
 
 export interface Config {
-  /**
-   * A list of forwarding-proxies. Each key is a route to match,
-   * below the prefix that the proxy plugin is mounted on. It must
-   * start with a '/'.
-   */
   proxy?: {
-    [key: string]:
-      | string
-      | {
-          /**
-           * Target of the proxy. Url string to be parsed with the url module.
-           */
-          target: string;
-          /**
-           * Object with extra headers to be added to target requests.
-           */
-          headers?: {
-            /** @visibility secret */
-            Authorization?: string;
-            /** @visibility secret */
-            authorization?: string;
-            /** @visibility secret */
-            'X-Api-Key'?: string;
-            /** @visibility secret */
-            'x-api-key'?: string;
-            [key: string]: string | undefined;
+    /**
+     * Rather than failing to start up, the proxy backend will instead just warn on invalid endpoints.
+     */
+    skipInvalidProxies?: boolean;
+
+    /**
+     * Revive request bodies that have already been consumed by earlier middleware.
+     */
+    reviveConsumedRequestBodies?: boolean;
+
+    /**
+     * A list of forwarding-proxies. Each key is a route to match,
+     * below the prefix that the proxy plugin is mounted on. It must
+     * start with a '/'.
+     */
+    endpoints?: {
+      [key: string]:
+        | string
+        | {
+            /**
+             * Target of the proxy. Url string to be parsed with the url module.
+             */
+            target: string;
+            /**
+             * Object with extra headers to be added to target requests.
+             */
+            headers?: {
+              /** @visibility secret */
+              Authorization?: string;
+              /** @visibility secret */
+              authorization?: string;
+              /** @visibility secret */
+              'X-Api-Key'?: string;
+              /** @visibility secret */
+              'x-api-key'?: string;
+              [key: string]: string | undefined;
+            };
+            /**
+             * Changes the origin of the host header to the target URL. Default: true.
+             */
+            changeOrigin?: boolean;
+            /**
+             * Rewrite target's url path. Object-keys will be used as RegExp to match paths.
+             * If pathRewrite is not specified, it is set to a single rewrite that removes the entire prefix and route.
+             */
+            pathRewrite?: { [regexp: string]: string };
+            /**
+             * Limit the forwarded HTTP methods, for example allowedMethods: ['GET'] to enforce read-only access.
+             */
+            allowedMethods?: string[];
+            /**
+             * Limit the forwarded HTTP methods. By default, only the headers that are considered safe for CORS
+             * and headers that are set by the proxy will be forwarded.
+             */
+            allowedHeaders?: string[];
           };
-          /**
-           * Changes the origin of the host header to the target URL. Default: true.
-           */
-          changeOrigin?: boolean;
-          /**
-           * Rewrite target's url path. Object-keys will be used as RegExp to match paths.
-           * If pathRewrite is not specified, it is set to a single rewrite that removes the entire prefix and route.
-           */
-          pathRewrite?: { [regexp: string]: string };
-          /**
-           * Limit the forwarded HTTP methods, for example allowedMethods: ['GET'] to enforce read-only access.
-           */
-          allowedMethods?: string[];
-          /**
-           * Limit the forwarded HTTP methods. By default, only the headers that are considered safe for CORS
-           * and headers that are set by the proxy will be forwarded.
-           */
-          allowedHeaders?: string[];
-        };
+    };
   };
 }

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
+    "@backstage/config-loader": "workspace:^",
     "@types/http-proxy-middleware": "^0.19.3",
     "@types/supertest": "^2.0.8",
     "@types/uuid": "^8.0.0",

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -48,6 +48,7 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/config-loader": "workspace:^",
     "@types/http-proxy-middleware": "^0.19.3",

--- a/plugins/proxy-backend/src/plugin.ts
+++ b/plugins/proxy-backend/src/plugin.ts
@@ -26,32 +26,25 @@ import { createRouter } from './service/router';
  *
  * @alpha
  */
-export const proxyPlugin = createBackendPlugin(
-  (options?: {
-    skipInvalidProxies?: boolean;
-    reviveConsumedRequestBodies?: boolean;
-  }) => ({
-    pluginId: 'proxy',
-    register(env) {
-      env.registerInit({
-        deps: {
-          config: coreServices.rootConfig,
-          discovery: coreServices.discovery,
-          logger: coreServices.logger,
-          httpRouter: coreServices.httpRouter,
-        },
-        async init({ config, discovery, logger, httpRouter }) {
-          httpRouter.use(
-            await createRouter({
-              config,
-              discovery,
-              logger: loggerToWinstonLogger(logger),
-              skipInvalidProxies: options?.skipInvalidProxies,
-              reviveConsumedRequestBodies: options?.reviveConsumedRequestBodies,
-            }),
-          );
-        },
-      });
-    },
-  }),
-);
+export const proxyPlugin = createBackendPlugin({
+  pluginId: 'proxy',
+  register(env) {
+    env.registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        discovery: coreServices.discovery,
+        logger: coreServices.logger,
+        httpRouter: coreServices.httpRouter,
+      },
+      async init({ config, discovery, logger, httpRouter }) {
+        httpRouter.use(
+          await createRouter({
+            config,
+            discovery,
+            logger: loggerToWinstonLogger(logger),
+          }),
+        );
+      },
+    });
+  },
+});

--- a/plugins/proxy-backend/src/service/router.config.test.ts
+++ b/plugins/proxy-backend/src/service/router.config.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { getVoidLogger, SingleHostDiscovery } from '@backstage/backend-common';
-import { ConfigReader } from '@backstage/config';
+import {
+  ConfigSources,
+  MutableConfigSource,
+  StaticConfigSource,
+} from '@backstage/config-loader';
 import express from 'express';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
@@ -56,34 +60,36 @@ describe('createRouter reloadable configuration', () => {
     const logger = getVoidLogger();
 
     // Grab the subscriber function and use mutable config data to mock a config file change
-    let subscriber: () => void;
-    const mutableConfigData: any = {
-      backend: {
-        baseUrl: 'http://localhost:7007',
-        listen: {
-          port: 7007,
-        },
-      },
-      proxy: {
-        '/test': {
-          target: 'https://non-existing-example.com',
-          pathRewrite: {
-            '.*': '/',
+    const mutableConfigSource = MutableConfigSource.create({ data: {} });
+    const config = await ConfigSources.toConfig(
+      ConfigSources.merge([
+        StaticConfigSource.create({
+          data: {
+            backend: {
+              baseUrl: 'http://localhost:7007',
+              listen: {
+                port: 7007,
+              },
+            },
+            proxy: {
+              endpoints: {
+                '/test': {
+                  target: 'https://non-existing-example.com',
+                  pathRewrite: {
+                    '.*': '/',
+                  },
+                },
+              },
+            },
           },
-        },
-      },
-    };
+        }),
+        mutableConfigSource,
+      ]),
+    );
 
-    const mockConfig = Object.assign(new ConfigReader(mutableConfigData), {
-      subscribe: (s: () => void) => {
-        subscriber = s;
-        return { unsubscribe: () => {} };
-      },
-    });
-
-    const discovery = SingleHostDiscovery.fromConfig(mockConfig);
+    const discovery = SingleHostDiscovery.fromConfig(config);
     const router = await createRouter({
-      config: mockConfig,
+      config,
       logger,
       discovery,
     });
@@ -100,13 +106,18 @@ describe('createRouter reloadable configuration', () => {
 
     expect(response1.status).toEqual(200);
 
-    mutableConfigData.proxy['/test2'] = {
-      target: 'https://non-existing-example.com',
-      pathRewrite: {
-        '.*': '/',
+    mutableConfigSource.setData({
+      proxy: {
+        endpoints: {
+          '/test2': {
+            target: 'https://non-existing-example.com',
+            pathRewrite: {
+              '.*': '/',
+            },
+          },
+        },
       },
-    };
-    subscriber!();
+    });
 
     const response2 = await agent.get('/test2');
 

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -45,10 +45,12 @@ describe('createRouter', () => {
         },
       },
       proxy: {
-        '/test': {
-          target: 'https://example.com',
-          headers: {
-            Authorization: 'Bearer supersecret',
+        endpoints: {
+          '/test': {
+            target: 'https://example.com',
+            headers: {
+              Authorization: 'Bearer supersecret',
+            },
           },
         },
       },
@@ -112,9 +114,11 @@ describe('createRouter', () => {
         },
         // no target would cause the buildMiddleware to fail
         proxy: {
-          '/test': {
-            headers: {
-              Authorization: 'Bearer supersecret',
+          endpoints: {
+            '/test': {
+              headers: {
+                Authorization: 'Bearer supersecret',
+              },
             },
           },
         },
@@ -141,9 +145,11 @@ describe('createRouter', () => {
         },
         // no target would cause the buildMiddleware to fail
         proxy: {
-          '/test': {
-            headers: {
-              Authorization: 'Bearer supersecret',
+          endpoints: {
+            '/test': {
+              headers: {
+                Authorization: 'Bearer supersecret',
+              },
             },
           },
         },

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { getVoidLogger, SingleHostDiscovery } from '@backstage/backend-common';
+import { mockServices } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { Request, Response } from 'express';
 import * as http from 'http';
@@ -68,6 +69,32 @@ describe('createRouter', () => {
         discovery,
       });
       expect(router).toBeDefined();
+    });
+
+    it('supports deprecated proxy configuration', async () => {
+      const router = await createRouter({
+        config: mockServices.rootConfig({
+          data: {
+            proxy: {
+              '/test': {
+                target: 'https://example.com',
+                headers: {
+                  Authorization: 'Bearer supersecret',
+                },
+              },
+            },
+          },
+        }),
+        logger,
+        discovery,
+      });
+      expect(router).toBeDefined();
+      expect(mockCreateProxyMiddleware).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          target: 'https://example.com',
+        }),
+      );
     });
 
     it('revives request bodies when set', async () => {

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -192,20 +192,14 @@ export function buildMiddleware(
 }
 
 function readProxyConfig(config: Config, logger: Logger): unknown {
-  const endpoints = config.getOptional('proxy.endpoints');
+  const endpoints = config.getOptionalConfig('proxy.endpoints')?.get();
   if (endpoints) {
-    if (typeof endpoints !== 'object' || Array.isArray(endpoints)) {
-      throw new Error('proxy configuration must be an object');
-    }
     return endpoints;
   }
 
-  const root = config.getOptional('proxy');
+  const root = config.getOptionalConfig('proxy')?.get();
   if (!root) {
     return {};
-  }
-  if (typeof root !== 'object' || Array.isArray(root)) {
-    throw new Error('deprecated proxy configuration must be an object');
   }
 
   const rootEndpoints = Object.fromEntries(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8055,6 +8055,7 @@ __metadata:
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/config-loader": "workspace:^"
     "@types/express": ^4.17.6
     "@types/http-proxy-middleware": ^0.19.3
     "@types/supertest": ^2.0.8

--- a/yarn.lock
+++ b/yarn.lock
@@ -25172,6 +25172,7 @@ __metadata:
     "@backstage/plugin-permission-backend": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"
+    "@backstage/plugin-proxy-backend": "workspace:^"
     "@backstage/plugin-scaffolder-backend": "workspace:^"
     "@backstage/plugin-search-backend": "workspace:^"
     "@backstage/plugin-search-backend-module-catalog": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8053,6 +8053,7 @@ __metadata:
   dependencies:
     "@backstage/backend-common": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

More work towards #18390. Proxy endpoints are now defined under `proxy.endpoints`, to make space for other configuration under the root `proxy` key.

Perhaps bit of a discussion to be had around whether `proxy.endpoints` is the best choice.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
