### PR TITLE
fix(security): Bump dep to eliminate ProtobufJS security vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -35919,11 +35919,11 @@ __metadata:
   linkType: hard
 
 "proto3-json-serializer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "proto3-json-serializer@npm:1.0.0"
+  version: 1.1.1
+  resolution: "proto3-json-serializer@npm:1.1.1"
   dependencies:
-    protobufjs: ^6.11.2
-  checksum: 47ac3b7c48eb177aba3e59431704c5db24d670827bd47ef7488e3529ab85e0de4833ed22615945fa72597dd382aa505b8dd427c917c4c50d31e7570d8af21294
+    protobufjs: ^7.0.0
+  checksum: 0cd94cb635a9b9b3a2d047700175be4a6c7b7a43e2698826edad17604793764bcdfc270585ea58cb94aa690211b6cdaae5bf7a22522bea68ca67a2844773b4b7
   languageName: node
   linkType: hard
 
@@ -35967,30 +35967,6 @@ __metadata:
     "@types/node": ">=13.7.0"
     long: ^5.0.0
   checksum: 9afa6de5fced0139a5180c063718508fac3ea734a9f1aceb99712367b15473a83327f91193f16b63540f9112b09a40912f5f0441a9b0d3f3c6a1c7f707d78249
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^6.11.2":
-  version: 6.11.3
-  resolution: "protobufjs@npm:6.11.3"
-  dependencies:
-    "@protobufjs/aspromise": ^1.1.2
-    "@protobufjs/base64": ^1.1.2
-    "@protobufjs/codegen": ^2.0.4
-    "@protobufjs/eventemitter": ^1.1.0
-    "@protobufjs/fetch": ^1.1.0
-    "@protobufjs/float": ^1.0.2
-    "@protobufjs/inquire": ^1.1.0
-    "@protobufjs/path": ^1.1.2
-    "@protobufjs/pool": ^1.1.0
-    "@protobufjs/utf8": ^1.1.0
-    "@types/long": ^4.0.1
-    "@types/node": ">=13.7.0"
-    long: ^4.0.0
-  bin:
-    pbjs: bin/pbjs
-    pbts: bin/pbts
-  checksum: 4a6ce1964167e4c45c53fd8a312d7646415c777dd31b4ba346719947b88e61654912326101f927da387d6b6473ab52a7ea4f54d6f15d63b31130ce28e2e15070
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR includes a manual bump of a transitive dependency which should fix a high security vulnerability reported in the repo.

Interestingly, Dependabot wasn't able to update it, and various combinations of commands in yarn weren't locally either. (for maintainers -> https://github.com/backstage/backstage/security/dependabot/245 )

Related: https://github.com/backstage/backstage/issues/18744 (but not a direct fix for)

I ended up just removing the `proto3-json-serializer@1.0.0` reference from the Yarn.lock, and a `yarn install` reinstall found it was missing, and *properly* installed v1.1.1 (which was within Google GAX's semver compliance).  This version has a transitive dependency on the actual vulnerable ProtobufJS package, with the upgrade eliminating ProtobufJS v6 and bumping it to v7, which is the version which patches the CVE. (fixed in proto3-json-serializer v1.0.3: https://github.com/googleapis/proto3-json-serializer-nodejs/releases/tag/v1.0.3 )

```
# before
google-gax
  --> proto3-json-serializer: ^1.0.0
    v1.0.0 required:
    --> protobufjs: ^6.11.2

# after:
google-gax
  --> proto3-json-serializer: ^1.0.0
    v1.1.0 requires:
    --> protobufjs: ^7.0.0
```

I ran tests locally against the Backend Auth plugin which included these transitive references for Google usage and all looks good so far.  The change itself is actually within semver compliance all through, so should be good!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
