### PR TITLE
Fix entity switch unmounting children

### DIFF
--- a/.changeset/twelve-ducks-swim.md
+++ b/.changeset/twelve-ducks-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed an issue causing `EntitySwitch` to unmount its children once entity refresh was invoked

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -405,6 +405,7 @@ unbreak
 Unconference
 unicode
 unmanaged
+unmount
 unregister
 unregistering
 unregistration

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
@@ -77,18 +77,14 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
         })
         .getElements()
         .flatMap<SwitchCaseResult>((element: ReactElement) => {
+          // If the entity is missing or there is an error, render nothing
+          if (!entity) {
+            return [];
+          }
+
           const { if: condition, children: elementsChildren } =
             element.props as EntitySwitchCase;
 
-          // If the entity is missing or there is an error, render the default page
-          if (!entity) {
-            return [
-              {
-                if: condition === undefined,
-                children: elementsChildren,
-              },
-            ];
-          }
           return [
             {
               if: condition?.(entity, { apis }),

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
@@ -64,8 +64,9 @@ export interface EntitySwitchProps {
 
 /** @public */
 export const EntitySwitch = (props: EntitySwitchProps) => {
-  const { entity, loading } = useAsyncEntity();
+  const { entity } = useAsyncEntity();
   const apis = useApiHolder();
+
   const results = useElementFilter(
     props.children,
     collection =>
@@ -76,11 +77,6 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
         })
         .getElements()
         .flatMap<SwitchCaseResult>((element: ReactElement) => {
-          // Nothing is rendered while loading
-          if (loading) {
-            return [];
-          }
-
           const { if: condition, children: elementsChildren } =
             element.props as EntitySwitchCase;
 
@@ -100,7 +96,7 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
             },
           ];
         }),
-    [apis, entity, loading],
+    [apis, entity],
   );
 
   const hasAsyncCases = results.some(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue which was causing `EntitySwitch` to unmount all its children once `refresh` was called. This was causing all the subcomponents to be unmounted and mounted again, losing any state and causing a "page reload effect"

Issue reported here: https://discord.com/channels/687207715902193673/1136236601010307092

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
