### PR TITLE
fix(auth-backend): Overly permissive regex in test

### DIFF
--- a/plugins/auth-backend/src/lib/flow/authFlowHelpers.test.ts
+++ b/plugins/auth-backend/src/lib/flow/authFlowHelpers.test.ts
@@ -125,7 +125,7 @@ describe('oauth helpers', () => {
       postMessageResponse(mockResponse, appOrigin, data);
       expect(responseBody.match(/.postMessage\(/g)).toHaveLength(2);
       expect(
-        responseBody.match(/.postMessage\([a-zA-z.()]*, \'\*\'\)/g),
+        responseBody.match(/.postMessage\([a-zA-Z.()]*, \'\*\'\)/g),
       ).toHaveLength(1);
 
       const errData: WebMessageResponse = {
@@ -135,7 +135,7 @@ describe('oauth helpers', () => {
       postMessageResponse(mockResponse, appOrigin, errData);
       expect(responseBody.match(/.postMessage\(/g)).toHaveLength(2);
       expect(
-        responseBody.match(/.postMessage\([a-zA-z.()]*, \'\*\'\)/g),
+        responseBody.match(/.postMessage\([a-zA-Z.()]*, \'\*\'\)/g),
       ).toHaveLength(1);
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fixes what I suspect was a simple typo in a regular expression used to test the `auth-backend` plugin.

This PR fixes https://github.com/backstage/backstage/security/code-scanning/241 https://github.com/backstage/backstage/security/code-scanning/240 CodeQL warnings.

Local testing runs clean.  I've not provided a changeset since this changes no functionality.


With a console.log for validation...
```diff
 yarn test
   console.log
     <html><body><script>
         var authResponse = decodeURIComponent('%7B%22type%22%3A%22authorization_response%22%2C%22response%22%3A%7B%22providerInfo%22%3A%7B%22accessToken%22%3A%22ACCESS_TOKEN%22%2C%22idToken%22%3A%22ID_TOKEN%22%2C%22expiresInSeconds%22%3A10%2C%22scope%22%3A%22email%22%7D%2C%22profile%22%3A%7B%22email%22%3A%22foo%40bar.com%22%7D%2C%22backstageIdentity%22%3A%7B%22token%22%3A%22a.b.c%22%2C%22identity%22%3A%7B%22type%22%3A%22user%22%2C%22ownershipEntityRefs%22%3A%5B%5D%2C%22userEntityRef%22%3A%22a%22%7D%7D%7D%7D');
         var origin = decodeURIComponent('http%3A%2F%2Flocalhost%3A3000');
         var originInfo = {'type': 'config_info', 'targetOrigin': origin};
+        (window.opener || window.parent).postMessage(originInfo, '*');
+        (window.opener || window.parent).postMessage(JSON.parse(authResponse), origin);
         setTimeout(() => {
           window.close();
         }, 100); // same as the interval of the core-app-api lib/loginPopup.ts (to address race conditions)
       </script></body></html>

      at Object.<anonymous> (lib/flow/authFlowHelpers.test.ts:127:15)

 PASS  src/lib/flow/authFlowHelpers.test.ts
  oauth helpers
    safelyEncodeURIComponent
      ✓ encodes all occurrences of single quotes
    postMessageResponse
      ✓ should post a message back with payload success (2 ms)
      ✓ should post a message back with payload error (1 ms)
      ✓ should call postMessage twice but only one of them with target * (3 ms)
      ✓ handles single quotes and unicode chars safely (1 ms)
    ensuresXRequestedWith
      ✓ should return false if no header present
      ✓ should return false if header present with incorrect value (1 ms)
      ✓ should return true if header present with correct value

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        0.153 s, estimated 1 s
Ran all test suites related to changed files.

Watch Usage: Press w to show more.
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
