### PR TITLE
Fixed invalid deprecated code comments referencing invalid package names - PR18932

### DIFF
--- a/plugins/catalog-backend/src/index.ts
+++ b/plugins/catalog-backend/src/index.ts
@@ -36,13 +36,13 @@ import {
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-catalog` instead
+ * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
  */
 export const DefaultCatalogCollatorFactory = _DefaultCatalogCollatorFactory;
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-catalog` instead
+ * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
  */
 export const defaultCatalogCollatorEntityTransformer =
   _defaultCatalogCollatorEntityTransformer;
@@ -54,14 +54,14 @@ import type {
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-catalog` instead
+ * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
  */
 export type DefaultCatalogCollatorFactoryOptions =
   _DefaultCatalogCollatorFactoryOptions;
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-catalog` instead
+ * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
  */
 export type CatalogCollatorEntityTransformer =
   _CatalogCollatorEntityTransformer;

--- a/plugins/catalog-backend/src/index.ts
+++ b/plugins/catalog-backend/src/index.ts
@@ -36,13 +36,13 @@ import {
 
 /**
  * @public
- * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-catalog` instead
  */
 export const DefaultCatalogCollatorFactory = _DefaultCatalogCollatorFactory;
 
 /**
  * @public
- * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-catalog` instead
  */
 export const defaultCatalogCollatorEntityTransformer =
   _defaultCatalogCollatorEntityTransformer;
@@ -54,14 +54,14 @@ import type {
 
 /**
  * @public
- * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-catalog` instead
  */
 export type DefaultCatalogCollatorFactoryOptions =
   _DefaultCatalogCollatorFactoryOptions;
 
 /**
  * @public
- * @deprecated import from @backstage/plugin-search-backend-module-catalog` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-catalog` instead
  */
 export type CatalogCollatorEntityTransformer =
   _CatalogCollatorEntityTransformer;

--- a/plugins/explore-backend/src/index.ts
+++ b/plugins/explore-backend/src/index.ts
@@ -36,19 +36,19 @@ import type {
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-explore` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-explore` instead
  */
 export const ToolDocumentCollatorFactory = _ToolDocumentCollatorFactory;
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-explore` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-explore` instead
  */
 export type ToolDocument = _ToolDocument;
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-explore` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-explore` instead
  */
 export type ToolDocumentCollatorFactoryOptions =
   _ToolDocumentCollatorFactoryOptions;

--- a/plugins/techdocs-backend/src/search/index.ts
+++ b/plugins/techdocs-backend/src/search/index.ts
@@ -25,12 +25,12 @@ import type { TechDocsCollatorFactoryOptions as _TechDocsCollatorFactoryOptions 
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-techdocs` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-techdocs` instead
  */
 export type TechDocsCollatorFactoryOptions = _TechDocsCollatorFactoryOptions;
 
 /**
  * @public
- * @deprecated import from `@backstage/search-backend-module-techdocs` instead
+ * @deprecated import from `@backstage/plugin-search-backend-module-techdocs` instead
  */
 export const DefaultTechDocsCollatorFactory = _DefaultTechDocsCollatorFactory;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed invalid import package references that would result in a failure to import the correct backstage plugins that are being provided. The author of the deprecated comments referenced the folder and not the actual package.json name of the plugin packages.

This results in invalid import statements and leads to confusion.

> Note: 
> Added issue https://github.com/backstage/backstage/issues/18932 to outline specifically the identified invalid packages and the suggested corrections that were made within this PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
