### PR TITLE
Fix logos of Janus IDP plugins

### DIFF
--- a/microsite/data/plugins/3scale.yaml
+++ b/microsite/data/plugins/3scale.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Discovery
 description: Synchronize 3scale content into the Backstage catalog.
 documentation: https://janus-idp.io/plugins/3scale
-iconUrl: http://janus-idp.io/images/plugins/3scale.svg
+iconUrl: https://janus-idp.io/images/plugins/3scale.svg
 npmPackageName: '@janus-idp/backstage-plugin-3scale-backend'
 addedDate: '2023-05-15'

--- a/microsite/data/plugins/jfrog-artifactory.yaml
+++ b/microsite/data/plugins/jfrog-artifactory.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Image
 description: View container image details from JFrog Artifactory in Backstage.
 documentation: https://janus-idp.io/plugins/jfrog-artifactory
-iconUrl: http://janus-idp.io/images/plugins/jfrog-artifactory.svg
+iconUrl: https://janus-idp.io/images/plugins/jfrog-artifactory.svg
 npmPackageName: '@janus-idp/backstage-plugin-jfrog-artifactory'
 addedDate: '2023-05-15'

--- a/microsite/data/plugins/keycloak.yaml
+++ b/microsite/data/plugins/keycloak.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Authentication/Authorization
 description: Load users and groups from Keycloak, enabling use of multiple authentication providers to be applied to Backstage entities.
 documentation: https://janus-idp.io/plugins/keycloak
-iconUrl: http://janus-idp.io/images/plugins/keycloak.svg
+iconUrl: https://janus-idp.io/images/plugins/keycloak.svg
 npmPackageName: '@janus-idp/backstage-plugin-keycloak-backend'
 addedDate: '2023-05-15'

--- a/microsite/data/plugins/ocm.yaml
+++ b/microsite/data/plugins/ocm.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Infrastructure
 description: View clusters from OCM's MultiClusterHub and MultiCluster Engine in Backstage.
 documentation: https://janus-idp.io/plugins/ocm
-iconUrl: http://janus-idp.io/images/plugins/ocm.svg
+iconUrl: https://janus-idp.io/images/plugins/ocm.svg
 npmPackageName: '@janus-idp/backstage-plugin-ocm'
 addedDate: '2023-05-15'

--- a/microsite/data/plugins/quay.yaml
+++ b/microsite/data/plugins/quay.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Image
 description: View container image details from Quay in Backstage.
 documentation: https://janus-idp.io/plugins/quay
-iconUrl: http://janus-idp.io/images/plugins/quay.svg
+iconUrl: https://janus-idp.io/images/plugins/quay.svg
 npmPackageName: '@janus-idp/backstage-plugin-quay'
 addedDate: '2023-05-15'

--- a/microsite/data/plugins/tekton.yaml
+++ b/microsite/data/plugins/tekton.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: CI/CD
 description: Easily view Tekton PipelineRun status for your services in Backstage.
 documentation: https://janus-idp.io/plugins/tekton
-iconUrl: http://janus-idp.io/images/plugins/tekton.svg
+iconUrl: https://janus-idp.io/images/plugins/tekton.svg
 npmPackageName: '@janus-idp/backstage-plugin-tekton'
 addedDate: '2023-05-15'

--- a/microsite/data/plugins/topology.yaml
+++ b/microsite/data/plugins/topology.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Kubernetes
 description: Visualize the deployment status and related resources of your applications deployed on any Kubernetes cluster.
 documentation: https://janus-idp.io/plugins/topology
-iconUrl: http://janus-idp.io/images/plugins/topology.svg
+iconUrl: https://janus-idp.io/images/plugins/topology.svg
 npmPackageName: '@janus-idp/backstage-plugin-topology'
 addedDate: '2023-05-15'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<img width="1519" alt="image" src="https://github.com/backstage/backstage/assets/74687/881cb866-5b80-41c7-8ba3-40aacf5453c3">

Logos of Janus IDP Plugins are not loading. It could be because they're using HTTP instead of https:// 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
