### PR TITLE
fix the config checking error for linguist

### DIFF
--- a/plugins/linguist-backend/config.d.ts
+++ b/plugins/linguist-backend/config.d.ts
@@ -35,7 +35,9 @@ export interface Config {
        * A custom mapping of linguist languages to how they should be rendered as entity tags.
        * If a language is mapped to '' it will not be included as a tag.
        */
-      languageMap?: Record<string, string | undefined>;
+      languageMap?: {
+        [language: string]: string | undefined;
+      };
       /**
        * How long to cache entity languages for in memory. Used to avoid constant db hits during
        * processing. Defaults to 30 minutes.


### PR DESCRIPTION
Fixes the config error in master that blocks builds:

```
Error: Invalid configuration schema in plugins/linguist-backend/config.d.ts, the following definitions are not supported:

  Record<string,string|undefined>
```

skipping changeset since this is unreleased (introduced with #18330)