### PR TITLE
feat: Add FOSSA security scan to continuous integration

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,25 @@
+# Configuration for FOSSA license compliance and security analysis.
+#
+# Reference: https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+
+version: 3
+
+project:
+  link: https://backstage.io
+  url: github.com/backstage/backstage
+
+targets:
+  only:
+    - type: yarn
+      path: .
+    - type: npm
+      path: .
+
+paths:
+  only:
+    - packages/
+    - plugins/
+  exclude:
+    - packages/app/
+    - packages/backend/
+    - packages/eslint-plugin/src/__fixtures__/

--- a/.github/workflows/verify_fossa.yml
+++ b/.github/workflows/verify_fossa.yml
@@ -1,4 +1,5 @@
 name: Verify FOSSA
+
 on:
   push:
     branches: [master]
@@ -6,19 +7,11 @@ on:
     branches: [master]
 
 jobs:
-  analyze:
+  fossa-scan:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Fossa
-        run: "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash"
-
-      - name: Fossa Configure & Analyze
-        env:
-          # FOSSA Push-Only API Token
-          GITHUB_REF: $GITHUB_REF
-          FOSSA_API_KEY: 9ee7e8893660832a7387dcc32377fb61
-        run: node scripts/run-fossa.js
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3; hash pinned for build security
+      - name: Run FOSSA analysis for license compliance and security
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f #v1.3.1; hash pinned for build security
+        with:
+          api-key: 9ee7e8893660832a7387dcc32377fb61

--- a/scripts/run-fossa.js
+++ b/scripts/run-fossa.js
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+// THIS SCRIPT IS NOT CURRENTLY USED. The .fossa.yaml at the root of the repo
+// should not be overwritten at this time.
+
 // This script generates an appropriate fossa config, and wraps the running
 // of `fossa analyze` in a retry loop as it frequently fails with a 502 error
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR re-adds the FOSSA license and security analysis scan to the GitHub Actions CI workflows, supporting https://github.com/backstage/backstage/issues/18821.

It refactors them to,

* Use the FOSSA GitHub Action
* Define the configuration with the new FOSSA CLI v3 config, negating the need to generate the config file via the `scripts/run-fossa.js` script.

A FOSSA scan involves two steps: an "analysis" (which this performs), and optionally a "test".  After the analysis is performed, a tests identifies issues and can exit with failure. This could be a future enhancement to add to PRs so new license compliance violations don't get added to the project without validating them first.

For now, this just adds the license compliance scanning so it can begin to be understood, and this helps to line up to the CNCF CLO Monitor reporting (https://clomonitor.io/projects/cncf/backstage) which currently identifies that this project lacks license compliance scanning.

Note: the actions also use their pinned hashes, which is also later to be a requirement from CNCF for hardening the build process used for the project. (specifying immutable hashes versus versions, which can be mistakenly or maliciously overwritten)

After review/merge, the GitHub Actions workflow will need to be manually re-enabled to be tested.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
