### PR TITLE
Resolve redirect flow error

### DIFF
--- a/.changeset/fluffy-pens-prove.md
+++ b/.changeset/fluffy-pens-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Updated `frameHandler` to return `undefined` when using the redirect flow instead of returning `postMessageReponse` which was causing errors

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -187,6 +187,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
           );
         }
         res.redirect(state.redirectUrl);
+        return undefined;
       }
       // post message back to popup if successful
       return postMessageResponse(res, appOrigin, responseObj);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `frameHandler` to return `undefined` when using the redirect flow instead of returning `postMessageReponse` which was causing errors as per #18930 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
