### PR TITLE
fix(graphql-voyager): Typo in install instructions

### DIFF
--- a/.changeset/gold-steaks-thank.md
+++ b/.changeset/gold-steaks-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphql-voyager': patch
+---
+
+Fix typo in install instructions.

--- a/plugins/graphql-voyager/README.md
+++ b/plugins/graphql-voyager/README.md
@@ -27,7 +27,7 @@ In order to be able to navigate to the graphQL voyager page, a new route needs t
 
   const routes = (
     <FlatRoutes>
-      <Route path="/graphql-voyager" element={<GraphqlVoyagerPage title="This is Voyager!"/>}/>
+      <Route path="/graphql-voyager" element={<GraphQLVoyagerPage title="This is Voyager!"/>}/>
 ```
 
 ### Configuration


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I went trying to trace a security vulnerability in the repo, and identified it was due to the GraphQL Voyager plugin (which is installed in the `yarn.lock` in the mono repo but NOT installed in the example app). 

While I was there testing it, I noticed the GraphQL Voyger install instructions had a typo. An imported variable just had a different case than the instructions listed, so fixed that with a changeset.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
