### PR TITLE
fix(kubernetes): Typos in exported attributes

### DIFF
--- a/.changeset/modern-impalas-wave.md
+++ b/.changeset/modern-impalas-wave.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-kubernetes': minor
+---
+
+**BREAKING**: Fixed typos in exported module attributes. Many users may see no changes, but if you have customized the plugin output, you may have to rename the following:
+
+- Component attribute: `<ResourceUtilization totalFormated={} />` to `<ResourceUtilization totalFormatted={} />`
+- Interface attribute: `DetectedError.occuranceCount` to `DetectedError.occurrenceCount`.

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -137,7 +137,7 @@ export interface DetectedError {
   // (undocumented)
   message: string;
   // (undocumented)
-  occuranceCount: number;
+  occurrenceCount: number;
   // Warning: (ae-forgotten-export) The symbol "ProposedFix" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
@@ -714,7 +714,7 @@ export const ResourceUtilization: ({
   title,
   usage,
   total,
-  totalFormated,
+  totalFormatted,
 }: ResourceUtilizationProps) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "Router" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/kubernetes/src/components/Pods/ErrorList/ErrorList.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/ErrorList/ErrorList.test.tsx
@@ -38,7 +38,7 @@ describe('ErrorList', () => {
                 type: 'some-error',
                 severity: 10,
                 message: 'some error message',
-                occuranceCount: 1,
+                occurrenceCount: 1,
                 sourceRef: {
                   name: 'some-pod',
                   namespace: 'some-namespace',

--- a/plugins/kubernetes/src/components/Pods/FixDialog/FixDialog.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/FixDialog/FixDialog.test.tsx
@@ -50,7 +50,7 @@ describe('FixDialog', () => {
           type: 'some error type',
           severity: 10,
           message: 'some error message',
-          occuranceCount: 1,
+          occurrenceCount: 1,
           sourceRef: {
             name: 'some-pod',
             namespace: 'some-namespace',
@@ -91,7 +91,7 @@ describe('FixDialog', () => {
           type: 'some error type',
           severity: 10,
           message: 'some error message',
-          occuranceCount: 1,
+          occurrenceCount: 1,
           sourceRef: {
             name: 'some-pod',
             namespace: 'some-namespace',
@@ -132,7 +132,7 @@ describe('FixDialog', () => {
           type: 'some error type',
           severity: 10,
           message: 'some error message',
-          occuranceCount: 1,
+          occurrenceCount: 1,
           sourceRef: {
             name: 'some-pod',
             namespace: 'some-namespace',

--- a/plugins/kubernetes/src/components/Pods/PodDrawer/ContainerCard.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodDrawer/ContainerCard.tsx
@@ -31,7 +31,7 @@ import { PodScope, PodLogsDialog } from '../PodLogs';
 import { StructuredMetadataTable } from '@backstage/core-components';
 import { ClientContainerStatus } from '@backstage/plugin-kubernetes-common';
 import { ResourceUtilization } from '../../ResourceUtilization';
-import { bytesToMiB, formatMilicores } from '../../../utils/resources';
+import { bytesToMiB, formatMillicores } from '../../../utils/resources';
 
 const getContainerHealthChecks = (
   containerSpec: IContainer,
@@ -186,7 +186,7 @@ export const ContainerCard: React.FC<ContainerCardProps> = ({
                   title="CPU requests"
                   usage={containerMetrics.cpuUsage.currentUsage}
                   total={containerMetrics.cpuUsage.requestTotal}
-                  totalFormated={formatMilicores(
+                  totalFormatted={formatMillicores(
                     containerMetrics.cpuUsage.requestTotal,
                   )}
                 />
@@ -195,7 +195,7 @@ export const ContainerCard: React.FC<ContainerCardProps> = ({
                   title="CPU limits"
                   usage={containerMetrics.cpuUsage.currentUsage}
                   total={containerMetrics.cpuUsage.limitTotal}
-                  totalFormated={formatMilicores(
+                  totalFormatted={formatMillicores(
                     containerMetrics.cpuUsage.limitTotal,
                   )}
                 />
@@ -204,7 +204,7 @@ export const ContainerCard: React.FC<ContainerCardProps> = ({
                   title="Memory requests"
                   usage={containerMetrics.memoryUsage.currentUsage}
                   total={containerMetrics.memoryUsage.requestTotal}
-                  totalFormated={bytesToMiB(
+                  totalFormatted={bytesToMiB(
                     containerMetrics.memoryUsage.requestTotal,
                   )}
                 />
@@ -213,7 +213,7 @@ export const ContainerCard: React.FC<ContainerCardProps> = ({
                   title="Memory limits"
                   usage={containerMetrics.memoryUsage.currentUsage}
                   total={containerMetrics.memoryUsage.limitTotal}
-                  totalFormated={bytesToMiB(
+                  totalFormatted={bytesToMiB(
                     containerMetrics.memoryUsage.requestTotal,
                   )}
                 />

--- a/plugins/kubernetes/src/components/Pods/PodDrawer/PodDrawer.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodDrawer/PodDrawer.test.tsx
@@ -56,7 +56,7 @@ describe('PodDrawer', () => {
                   type: 'some-error',
                   severity: 10,
                   message: 'some error message',
-                  occuranceCount: 1,
+                  occurrenceCount: 1,
                   sourceRef: {
                     name: 'some-pod',
                     namespace: 'some-namespace',

--- a/plugins/kubernetes/src/components/Pods/PodDrawer/PodDrawer.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodDrawer/PodDrawer.tsx
@@ -35,7 +35,7 @@ import { PendingPodContent } from './PendingPodContent';
 import { ErrorList } from '../ErrorList';
 import { usePodMetrics } from '../../../hooks/usePodMetrics';
 import { ResourceUtilization } from '../../ResourceUtilization';
-import { bytesToMiB, formatMilicores } from '../../../utils/resources';
+import { bytesToMiB, formatMillicores } from '../../../utils/resources';
 
 const useDrawerContentStyles = makeStyles((_theme: Theme) =>
   createStyles({
@@ -109,13 +109,13 @@ export const PodDrawer = ({ podAndErrors, open }: PodDrawerProps) => {
                 title="CPU requests"
                 usage={podMetrics.cpu.currentUsage}
                 total={podMetrics.cpu.requestTotal}
-                totalFormated={formatMilicores(podMetrics.cpu.requestTotal)}
+                totalFormatted={formatMillicores(podMetrics.cpu.requestTotal)}
               />
               <ResourceUtilization
                 title="CPU limits"
                 usage={podMetrics.cpu.currentUsage}
                 total={podMetrics.cpu.limitTotal}
-                totalFormated={formatMilicores(podMetrics.cpu.limitTotal)}
+                totalFormatted={formatMillicores(podMetrics.cpu.limitTotal)}
               />
             </Grid>
             <Grid item xs={6}>
@@ -123,13 +123,13 @@ export const PodDrawer = ({ podAndErrors, open }: PodDrawerProps) => {
                 title="Memory requests"
                 usage={podMetrics.memory.currentUsage}
                 total={podMetrics.memory.requestTotal}
-                totalFormated={bytesToMiB(podMetrics.memory.requestTotal)}
+                totalFormatted={bytesToMiB(podMetrics.memory.requestTotal)}
               />
               <ResourceUtilization
                 title="Memory limits"
                 usage={podMetrics.memory.currentUsage}
                 total={podMetrics.memory.limitTotal}
-                totalFormated={bytesToMiB(podMetrics.memory.requestTotal)}
+                totalFormatted={bytesToMiB(podMetrics.memory.requestTotal)}
               />
             </Grid>
           </Grid>

--- a/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
@@ -124,7 +124,7 @@ describe('PodsTable', () => {
     expect(getByText('requests: 1% of 64MiB')).toBeInTheDocument();
     expect(getByText('limits: 0% of 128MiB')).toBeInTheDocument();
   });
-  it('should render placehoplder when empty metrics context', async () => {
+  it('should render placeholder when empty metrics context', async () => {
     const podNameToClientPodStatus = new Map<string, ClientPodStatus[]>();
 
     const wrapper = kubernetesProviders(

--- a/plugins/kubernetes/src/components/ResourceUtilization/ResourceUtilization.test.tsx
+++ b/plugins/kubernetes/src/components/ResourceUtilization/ResourceUtilization.test.tsx
@@ -27,7 +27,7 @@ describe('ResourceUtilization', () => {
           title="some-title"
           usage="1000"
           total="10000"
-          totalFormated="15%"
+          totalFormatted="15%"
         />,
       ),
     );
@@ -43,7 +43,7 @@ describe('ResourceUtilization', () => {
           title="some-title"
           usage="1000"
           total="10000"
-          totalFormated="15%"
+          totalFormatted="15%"
         />,
       ),
     );

--- a/plugins/kubernetes/src/components/ResourceUtilization/ResourceUtilization.tsx
+++ b/plugins/kubernetes/src/components/ResourceUtilization/ResourceUtilization.tsx
@@ -29,7 +29,7 @@ export interface ResourceUtilizationProps {
   title: string;
   usage: number | string;
   total: number | string;
-  totalFormated: string;
+  totalFormatted: string;
 }
 
 // Visible for testing
@@ -64,7 +64,7 @@ export const ResourceUtilization = ({
   title,
   usage,
   total,
-  totalFormated,
+  totalFormatted,
 }: ResourceUtilizationProps) => {
   const utilization = currentToDeclaredResourceToPerc(usage, total);
   return (
@@ -72,7 +72,7 @@ export const ResourceUtilization = ({
       <Grid item xs={12}>
         <Typography
           variant={compressed ? 'caption' : 'subtitle2'}
-        >{`${title}: ${totalFormated}`}</Typography>
+        >{`${title}: ${totalFormatted}`}</Typography>
       </Grid>
       <Grid item xs={12}>
         <LinearGauge

--- a/plugins/kubernetes/src/error-detection/deployments.ts
+++ b/plugins/kubernetes/src/error-detection/deployments.ts
@@ -34,7 +34,7 @@ const deploymentErrorMappers: ErrorMapper<Deployment>[] = [
             kind: 'Deployment',
             apiGroup: 'apps/v1',
           },
-          occuranceCount: 1,
+          occurrenceCount: 1,
         }));
     },
   },

--- a/plugins/kubernetes/src/error-detection/error-detection.test.ts
+++ b/plugins/kubernetes/src/error-detection/error-detection.test.ts
@@ -164,7 +164,7 @@ describe('detectErrors', () => {
           'The container other-side-car has crashed many times, it will be exponentially restarted until it stops crashing',
         type: 'logs',
       },
-      occuranceCount: 1,
+      occurrenceCount: 1,
       type: 'container-waiting',
     });
 
@@ -186,7 +186,7 @@ describe('detectErrors', () => {
       message:
         'back-off 5m0s restarting failed container=side-car pod=dice-roller-canary-7d64cd756c-55rfq_default(65ad28e3-5d51-4b4b-9bf8-4cb069803034)',
       severity: 4,
-      occuranceCount: 1,
+      occurrenceCount: 1,
       type: 'container-waiting',
     });
 
@@ -199,7 +199,7 @@ describe('detectErrors', () => {
       },
       message: 'container=other-side-car restarted 123 times',
       severity: 4,
-      occuranceCount: 123,
+      occurrenceCount: 123,
       proposedFix: {
         container: 'other-side-car',
         errorType: 'Error',
@@ -228,7 +228,7 @@ describe('detectErrors', () => {
       },
       message: 'container=side-car restarted 38 times',
       severity: 4,
-      occuranceCount: 38,
+      occurrenceCount: 38,
       type: 'containers-restarting',
     });
   });
@@ -246,7 +246,7 @@ describe('detectErrors', () => {
 
     expect(err1).toStrictEqual({
       message: 'configmap "some-cm" not found',
-      occuranceCount: 1,
+      occurrenceCount: 1,
       proposedFix: {
         docsLink:
           'https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/',
@@ -300,7 +300,7 @@ describe('detectErrors', () => {
       },
       message: 'Deployment does not have minimum availability.',
       severity: 6,
-      occuranceCount: 1,
+      occurrenceCount: 1,
       type: 'condition-message-present',
     });
   });
@@ -336,7 +336,7 @@ describe('detectErrors', () => {
       message:
         'Current number of replicas (10) is equal to the configured max number of replicas (10)',
       severity: 8,
-      occuranceCount: 1,
+      occurrenceCount: 1,
       type: 'hpa-max-current-replicas',
     });
   });
@@ -469,7 +469,7 @@ describe('detectErrors', () => {
     expect(err1).toStrictEqual({
       message:
         'The container some-container failed to start properly, but is not crashing',
-      occuranceCount: 1,
+      occurrenceCount: 1,
       proposedFix: {
         errorType: 'ReadinessProbeFailed',
         podName: '',

--- a/plugins/kubernetes/src/error-detection/hpas.ts
+++ b/plugins/kubernetes/src/error-detection/hpas.ts
@@ -37,7 +37,7 @@ const hpaErrorMappers: ErrorMapper<HorizontalPodAutoscaler>[] = [
               kind: 'HorizontalPodAutoscaler',
               apiGroup: 'autoscaling/v1',
             },
-            occuranceCount: 1,
+            occurrenceCount: 1,
           },
         ];
       }

--- a/plugins/kubernetes/src/error-detection/pods.ts
+++ b/plugins/kubernetes/src/error-detection/pods.ts
@@ -209,7 +209,7 @@ const podErrorMappers: ErrorMapper<Pod>[] = [
             kind: 'Pod',
             apiGroup: 'v1',
           },
-          occuranceCount: 1,
+          occurrenceCount: 1,
         }));
     },
   },
@@ -228,7 +228,7 @@ const podErrorMappers: ErrorMapper<Pod>[] = [
             kind: 'Pod',
             apiGroup: 'v1',
           },
-          occuranceCount: 1,
+          occurrenceCount: 1,
         }));
     },
   },
@@ -247,7 +247,7 @@ const podErrorMappers: ErrorMapper<Pod>[] = [
             kind: 'Pod',
             apiGroup: 'v1',
           },
-          occuranceCount: cs.restartCount,
+          occurrenceCount: cs.restartCount,
         }));
     },
   },

--- a/plugins/kubernetes/src/error-detection/types.ts
+++ b/plugins/kubernetes/src/error-detection/types.ts
@@ -51,7 +51,7 @@ export interface DetectedError {
   message: string;
   proposedFix?: ProposedFix;
   sourceRef: ResourceRef;
-  occuranceCount: number;
+  occurrenceCount: number;
 }
 
 export type ProposedFix = LogSolution | DocsSolution | EventsSolution;

--- a/plugins/kubernetes/src/hooks/useMatchingErrors.test.tsx
+++ b/plugins/kubernetes/src/hooks/useMatchingErrors.test.tsx
@@ -24,7 +24,7 @@ const genericErrorWithRef = (resourceRef: ResourceRef): DetectedError => {
     type: 'some-error',
     severity: 10,
     message: 'some error message',
-    occuranceCount: 1,
+    occurrenceCount: 1,
     sourceRef: resourceRef,
     proposedFix: {
       type: 'logs',

--- a/plugins/kubernetes/src/utils/pod.tsx
+++ b/plugins/kubernetes/src/utils/pod.tsx
@@ -29,7 +29,7 @@ import {
 } from '@backstage/core-components';
 import { ClientPodStatus } from '@backstage/plugin-kubernetes-common';
 import { Pod } from 'kubernetes-models/v1/Pod';
-import { bytesToMiB, formatMilicores } from './resources';
+import { bytesToMiB, formatMillicores } from './resources';
 
 export const imageChips = (pod: V1Pod): ReactNode => {
   const containerStatuses = pod.status?.containerStatuses ?? [];
@@ -148,11 +148,11 @@ export const podStatusToCpuUtil = (podStatus: ClientPodStatus): ReactNode => {
       value={`requests: ${currentToDeclaredResourceToPerc(
         currentUsage,
         cpuUtil.requestTotal,
-      )} of ${formatMilicores(cpuUtil.requestTotal)}`}
+      )} of ${formatMillicores(cpuUtil.requestTotal)}`}
       subvalue={`limits: ${currentToDeclaredResourceToPerc(
         currentUsage,
         cpuUtil.limitTotal,
-      )} of ${formatMilicores(cpuUtil.limitTotal)}`}
+      )} of ${formatMillicores(cpuUtil.limitTotal)}`}
     />
   );
 };

--- a/plugins/kubernetes/src/utils/resources.ts
+++ b/plugins/kubernetes/src/utils/resources.ts
@@ -33,6 +33,6 @@ export const bytesToMiB = (value: string | number): string => {
   return `${(parseFloat(value.toString()) / 1024 / 1024).toFixed(0)}MiB`;
 };
 
-export const formatMilicores = (value: string | number): string => {
+export const formatMillicores = (value: string | number): string => {
   return `${(parseFloat(value.toString()) * 1000).toFixed(0)}m`;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This minor fix 🧹  corrects a few Kubernetes plugin attributes that had typos in them. Most users may see no changes if they use and import the plugin as-is, however users who have uses the components in other ways or extended the public functionality may have to make simple renames.

Three attributes fixed:

* Public: `totalFormated` to `totalFormatted`
* Public: `occuranceCount` to `occurrenceCount`
* Private: `formatMilicores` to `formatMillicores`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
