### PR TITLE
make `searchModuleCatalogCollator` configurable from app-config

### DIFF
--- a/.changeset/metal-kings-argue.md
+++ b/.changeset/metal-kings-argue.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-backend-module-catalog': patch
 ---
 
-Breaking change in the alpha export `searchModuleCatalogCollator`: Moved collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key.
+Breaking change in the alpha export `searchModuleCatalogCollator`: Moved collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key. There is also a new `catalogCollatorExtensionPoint` extension point for the module, wherein you can set custom transformers.

--- a/.changeset/metal-kings-argue.md
+++ b/.changeset/metal-kings-argue.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-search-backend-module-catalog': minor
 ---
 
-Move collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key.
+**BREAKING**: Moved collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key.

--- a/.changeset/metal-kings-argue.md
+++ b/.changeset/metal-kings-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-catalog': patch
+---
+
+Move collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key.

--- a/.changeset/metal-kings-argue.md
+++ b/.changeset/metal-kings-argue.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-search-backend-module-catalog': minor
+'@backstage/plugin-search-backend-module-catalog': patch
 ---
 
-**BREAKING**: Moved collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key.
+Breaking change in the alpha export `searchModuleCatalogCollator`: Moved collator settings from module options into app-config. You are now expected to set up the catalog collator under the `search.collators.catalog` configuration key.

--- a/plugins/search-backend-module-catalog/alpha-api-report.md
+++ b/plugins/search-backend-module-catalog/alpha-api-report.md
@@ -5,7 +5,6 @@
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { DefaultCatalogCollatorFactoryOptions } from '@backstage/plugin-search-backend-module-catalog';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 
 // @alpha
 export const searchModuleCatalogCollator: (
@@ -13,12 +12,10 @@ export const searchModuleCatalogCollator: (
 ) => BackendFeature;
 
 // @alpha
-export type SearchModuleCatalogCollatorOptions = Omit<
+export type SearchModuleCatalogCollatorOptions = Pick<
   DefaultCatalogCollatorFactoryOptions,
-  'discovery' | 'tokenManager' | 'catalogClient'
-> & {
-  schedule?: TaskScheduleDefinition;
-};
+  'entityTransformer'
+>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-catalog/alpha-api-report.md
+++ b/plugins/search-backend-module-catalog/alpha-api-report.md
@@ -5,16 +5,18 @@
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CatalogCollatorEntityTransformer } from '@backstage/plugin-search-backend-module-catalog';
+import { ExtensionPoint } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const searchModuleCatalogCollator: (
-  options?: SearchModuleCatalogCollatorOptions | undefined,
-) => BackendFeature;
-
-// @alpha
-export type SearchModuleCatalogCollatorOptions = {
-  entityTransformer?: CatalogCollatorEntityTransformer;
+export type CatalogCollatorExtensionPoint = {
+  setEntityTransformer(transformer: CatalogCollatorEntityTransformer): void;
 };
+
+// @alpha
+export const catalogCollatorExtensionPoint: ExtensionPoint<CatalogCollatorExtensionPoint>;
+
+// @alpha
+export const searchModuleCatalogCollator: () => BackendFeature;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-catalog/alpha-api-report.md
+++ b/plugins/search-backend-module-catalog/alpha-api-report.md
@@ -4,7 +4,7 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { DefaultCatalogCollatorFactoryOptions } from '@backstage/plugin-search-backend-module-catalog';
+import { CatalogCollatorEntityTransformer } from '@backstage/plugin-search-backend-module-catalog';
 
 // @alpha
 export const searchModuleCatalogCollator: (
@@ -12,10 +12,9 @@ export const searchModuleCatalogCollator: (
 ) => BackendFeature;
 
 // @alpha
-export type SearchModuleCatalogCollatorOptions = Pick<
-  DefaultCatalogCollatorFactoryOptions,
-  'entityTransformer'
->;
+export type SearchModuleCatalogCollatorOptions = {
+  entityTransformer?: CatalogCollatorEntityTransformer;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-catalog/api-report.md
+++ b/plugins/search-backend-module-catalog/api-report.md
@@ -24,11 +24,11 @@ export type CatalogCollatorEntityTransformer = (
 // @public (undocumented)
 export const defaultCatalogCollatorEntityTransformer: CatalogCollatorEntityTransformer;
 
-// @public (undocumented)
+// @public
 export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
   // (undocumented)
   static fromConfig(
-    _config: Config,
+    configRoot: Config,
     options: DefaultCatalogCollatorFactoryOptions,
   ): DefaultCatalogCollatorFactory;
   // (undocumented)

--- a/plugins/search-backend-module-catalog/config.d.ts
+++ b/plugins/search-backend-module-catalog/config.d.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
+export interface Config {
+  search?: {
+    collators?: {
+      /**
+       * Configuration options for `@backstage/plugin-search-backend-module-catalog`
+       */
+      catalog?: {
+        /**
+         * A templating string with placeholders, to form the final location of
+         * the entity.
+         *
+         * Defaults to '/catalog/:namespace/:kind/:name'
+         */
+        locationTemplate?: string;
+        /**
+         * A filter expression passed to the catalog client, to select what
+         * entities to collate.
+         *
+         * Defaults to no filter, ie indexing all entities.
+         */
+        filter?: object;
+        /**
+         * The number of entities to process at a time. Keep this at a
+         * reasonable number to avoid overloading either the catalog or the
+         * search backend.
+         *
+         * Defaults to 500
+         */
+        batchSize?: number;
+        /**
+         * The schedule for how often to run the collation job.
+         */
+        schedule?: TaskScheduleDefinitionConfig;
+      };
+    };
+  };
+}

--- a/plugins/search-backend-module-catalog/package.json
+++ b/plugins/search-backend-module-catalog/package.json
@@ -48,6 +48,7 @@
     "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/errors": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
@@ -61,6 +62,8 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-catalog/src/alpha.test.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.test.ts
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-import { startTestBackend } from '@backstage/backend-test-utils';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
 import { searchModuleCatalogCollator } from './alpha';
 
 describe('searchModuleCatalogCollator', () => {
-  const schedule = {
-    frequency: { minutes: 10 },
-    timeout: { minutes: 15 },
-    initialDelay: { seconds: 3 },
-  };
-
   it('should register the catalog collator to the search index registry extension point with factory and schedule', async () => {
     const extensionPointMock = {
       addCollator: jest.fn(),
@@ -34,7 +28,7 @@ describe('searchModuleCatalogCollator', () => {
       extensionPoints: [
         [searchIndexRegistryExtensionPoint, extensionPointMock],
       ],
-      features: [searchModuleCatalogCollator({ schedule })],
+      features: [searchModuleCatalogCollator()],
     });
 
     expect(extensionPointMock.addCollator).toHaveBeenCalledTimes(1);
@@ -42,5 +36,38 @@ describe('searchModuleCatalogCollator', () => {
       factory: expect.objectContaining({ type: 'software-catalog' }),
       schedule: expect.objectContaining({ run: expect.any(Function) }),
     });
+  });
+
+  it('refuses to start up with a broken schedule', async () => {
+    await expect(
+      startTestBackend({
+        extensionPoints: [
+          [
+            searchIndexRegistryExtensionPoint,
+            {
+              addCollator: jest.fn(),
+            },
+          ],
+        ],
+        features: [searchModuleCatalogCollator()],
+        services: [
+          mockServices.rootConfig.factory({
+            data: {
+              search: {
+                collators: {
+                  catalog: {
+                    schedule: {
+                      frequency: { minutes: 10 },
+                      timeout: { minutes: 'boo' },
+                      initialDelay: { seconds: 3 },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        ],
+      }),
+    ).rejects.toThrow(/Invalid schedule/);
   });
 });

--- a/plugins/search-backend-module-catalog/src/alpha.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.ts
@@ -23,25 +23,23 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
-import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
-
+import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import {
   DefaultCatalogCollatorFactory,
   DefaultCatalogCollatorFactoryOptions,
 } from '@backstage/plugin-search-backend-module-catalog';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
+import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
+import { readScheduleConfigOptions } from './collators/config';
 
 /**
- * @alpha
  * Options for {@link searchModuleCatalogCollator}.
+ *
+ * @alpha
  */
-export type SearchModuleCatalogCollatorOptions = Omit<
+export type SearchModuleCatalogCollatorOptions = Pick<
   DefaultCatalogCollatorFactoryOptions,
-  'discovery' | 'tokenManager' | 'catalogClient'
-> & {
-  schedule?: TaskScheduleDefinition;
-};
+  'entityTransformer'
+>;
 
 /**
  * Search backend module for the Catalog index.
@@ -70,15 +68,9 @@ export const searchModuleCatalogCollator = createBackendModule(
           indexRegistry,
           catalog,
         }) {
-          const defaultSchedule = {
-            frequency: { minutes: 10 },
-            timeout: { minutes: 15 },
-            initialDelay: { seconds: 3 },
-          };
-
           indexRegistry.addCollator({
             schedule: scheduler.createScheduledTaskRunner(
-              options?.schedule ?? defaultSchedule,
+              readScheduleConfigOptions(config),
             ),
             factory: DefaultCatalogCollatorFactory.fromConfig(config, {
               ...options,

--- a/plugins/search-backend-module-catalog/src/alpha.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.ts
@@ -25,8 +25,8 @@ import {
 } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import {
+  CatalogCollatorEntityTransformer,
   DefaultCatalogCollatorFactory,
-  DefaultCatalogCollatorFactoryOptions,
 } from '@backstage/plugin-search-backend-module-catalog';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
 import { readScheduleConfigOptions } from './collators/config';
@@ -36,10 +36,12 @@ import { readScheduleConfigOptions } from './collators/config';
  *
  * @alpha
  */
-export type SearchModuleCatalogCollatorOptions = Pick<
-  DefaultCatalogCollatorFactoryOptions,
-  'entityTransformer'
->;
+export type SearchModuleCatalogCollatorOptions = {
+  /**
+   * Allows you to customize how entities are shaped into documents.
+   */
+  entityTransformer?: CatalogCollatorEntityTransformer;
+};
 
 /**
  * Search backend module for the Catalog index.
@@ -73,7 +75,7 @@ export const searchModuleCatalogCollator = createBackendModule(
               readScheduleConfigOptions(config),
             ),
             factory: DefaultCatalogCollatorFactory.fromConfig(config, {
-              ...options,
+              entityTransformer: options?.entityTransformer,
               discovery,
               tokenManager,
               catalogClient: catalog,

--- a/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.test.ts
+++ b/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   PluginEndpointDiscovery,
   TokenManager,

--- a/plugins/search-backend-module-catalog/src/collators/config.test.ts
+++ b/plugins/search-backend-module-catalog/src/collators/config.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import {
+  defaults,
+  readCollatorConfigOptions,
+  readScheduleConfigOptions,
+} from './config';
+
+describe('config', () => {
+  describe('readScheduleConfigOptions', () => {
+    it('reads config', () => {
+      const result = readScheduleConfigOptions(
+        new ConfigReader({
+          search: {
+            collators: {
+              catalog: {
+                schedule: {
+                  frequency: { minutes: 1 },
+                  timeout: { seconds: 2 },
+                  initialDelay: { hours: 3 },
+                },
+              },
+            },
+          },
+        }),
+      );
+      expect(result).toEqual({
+        frequency: { minutes: 1 },
+        timeout: { seconds: 2 },
+        initialDelay: { hours: 3 },
+      });
+    });
+
+    it('returns defaults', () => {
+      const result = readScheduleConfigOptions(new ConfigReader({}));
+      expect(result).toEqual(defaults.schedule);
+    });
+  });
+
+  describe('readCollatorConfigOptions', () => {
+    it('reads config', () => {
+      const result = readCollatorConfigOptions(
+        new ConfigReader({
+          search: {
+            collators: {
+              catalog: {
+                batchSize: 1,
+                locationTemplate: '/mock/:namespace/:kind/:name',
+                filter: { a: 1 },
+              },
+            },
+          },
+        }),
+      );
+      expect(result).toEqual({
+        batchSize: 1,
+        locationTemplate: '/mock/:namespace/:kind/:name',
+        filter: { a: 1 },
+      });
+    });
+
+    it('returns defaults', () => {
+      const result = readCollatorConfigOptions(new ConfigReader({}));
+      expect(result).toEqual(defaults.collatorOptions);
+    });
+  });
+});

--- a/plugins/search-backend-module-catalog/src/collators/config.ts
+++ b/plugins/search-backend-module-catalog/src/collators/config.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  readTaskScheduleDefinitionFromConfig,
+  TaskScheduleDefinition,
+} from '@backstage/backend-tasks';
+import { EntityFilterQuery } from '@backstage/catalog-client';
+import { Config } from '@backstage/config';
+import { InputError } from '@backstage/errors';
+
+const configKey = 'search.collators.catalog';
+
+export const defaults = {
+  schedule: {
+    frequency: { minutes: 10 },
+    timeout: { minutes: 15 },
+    initialDelay: { seconds: 3 },
+  },
+  collatorOptions: {
+    locationTemplate: '/catalog/:namespace/:kind/:name',
+    filter: undefined,
+    batchSize: 500,
+  },
+};
+
+export function readScheduleConfigOptions(
+  configRoot: Config,
+): TaskScheduleDefinition {
+  let schedule: TaskScheduleDefinition | undefined = undefined;
+
+  const config = configRoot.getOptionalConfig(configKey);
+  if (config) {
+    const scheduleConfig = config.getOptionalConfig('schedule');
+    if (scheduleConfig) {
+      try {
+        schedule = readTaskScheduleDefinitionFromConfig(scheduleConfig);
+      } catch (error) {
+        throw new InputError(`Invalid schedule at ${configKey}, ${error}`);
+      }
+    }
+  }
+
+  return schedule ?? defaults.schedule;
+}
+
+export function readCollatorConfigOptions(configRoot: Config): {
+  locationTemplate: string;
+  filter: EntityFilterQuery | undefined;
+  batchSize: number;
+} {
+  const config = configRoot.getOptionalConfig(configKey);
+  if (!config) {
+    return defaults.collatorOptions;
+  }
+
+  return {
+    locationTemplate:
+      config.getOptionalString('locationTemplate') ??
+      defaults.collatorOptions.locationTemplate,
+    filter:
+      config.getOptionalConfig('filter')?.get<EntityFilterQuery>() ??
+      defaults.collatorOptions.filter,
+    batchSize:
+      config.getOptionalNumber('batchSize') ??
+      defaults.collatorOptions.batchSize,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8441,6 +8441,7 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/errors": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"


### PR DESCRIPTION
As part of the declarative integration effort.

This is on top of https://github.com/backstage/backstage/pull/19337; the only real change is in the catalog collator module.