### PR TITLE
make `search-backend-module-explore` & `search-backend-module-techdocs` configurable from app-config

### DIFF
--- a/.changeset/tiny-squids-accept.md
+++ b/.changeset/tiny-squids-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-techdocs': minor
+---
+
+**BREAKING:** Moved `schedule` & `collators` settings from module options into app-config for the new backend system. You can now pass in a `TaskScheduleDefinitionConfig` through the `search.techdocs.schedule` configuration key & configure the `TechDocsCollatorFactory` with the key `search.techdocs.collators`.

--- a/.changeset/tiny-squids-accept.md
+++ b/.changeset/tiny-squids-accept.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-search-backend-module-techdocs': minor
+'@backstage/plugin-search-backend-module-techdocs': patch
 ---
 
-**BREAKING:** Moved `schedule` & `collators` settings from module options into app-config for the new backend system. You can now pass in a `TaskScheduleDefinitionConfig` through the `search.techdocs.schedule` configuration key & configure the `TechDocsCollatorFactory` with the key `search.techdocs.collators`.
+**BREAKING:** Moved `schedule` & `collators` settings from module options into app-config for the new backend system. You can now pass in a `TaskScheduleDefinitionConfig` through the `search.collators.techdocs.schedule` configuration key & configure the `TechDocsCollatorFactory` with the key `search.collators.techdocs`.

--- a/.changeset/tiny-squids-deny.md
+++ b/.changeset/tiny-squids-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-explore': minor
+---
+
+**BREAKING:** Moved `schedule` from module options into app-config for the new backend system. You can now pass in a `TaskScheduleDefinitionConfig` through the `search.explore.schedule` configuration key.

--- a/.changeset/tiny-squids-deny.md
+++ b/.changeset/tiny-squids-deny.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-search-backend-module-explore': minor
+'@backstage/plugin-search-backend-module-explore': patch
 ---
 
-**BREAKING:** Moved `schedule` from module options into app-config for the new backend system. You can now pass in a `TaskScheduleDefinitionConfig` through the `search.explore.schedule` configuration key.
+Breaking change for the alpha export moved `schedule` from module options into app-config for the new backend system. You can now pass in a `TaskScheduleDefinitionConfig` through the `search.collators.explore.schedule` configuration key.

--- a/.changeset/tiny-squids-undecide.md
+++ b/.changeset/tiny-squids-undecide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/permission-backend': patch
+---
+
+Refactor backend plugin creation parameter from callback to object.

--- a/plugins/permission-backend/src/plugin.ts
+++ b/plugins/permission-backend/src/plugin.ts
@@ -80,7 +80,7 @@ export const permissionModuleAllowAllPolicy = createBackendModule({
  *
  * @alpha
  */
-export const permissionPlugin = createBackendPlugin(() => ({
+export const permissionPlugin = createBackendPlugin({
   pluginId: 'permission',
   register(env) {
     const policies = new PolicyExtensionPointImpl();
@@ -115,4 +115,4 @@ export const permissionPlugin = createBackendPlugin(() => ({
       },
     });
   },
-}));
+});

--- a/plugins/search-backend-module-explore/alpha-api-report.md
+++ b/plugins/search-backend-module-explore/alpha-api-report.md
@@ -4,17 +4,9 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 
 // @alpha
-export const searchModuleExploreCollator: (
-  options?: SearchModuleExploreCollatorOptions | undefined,
-) => BackendFeature;
-
-// @alpha
-export type SearchModuleExploreCollatorOptions = {
-  schedule?: TaskScheduleDefinition;
-};
+export const searchModuleExploreCollator: () => BackendFeature;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-explore/config.d.ts
+++ b/plugins/search-backend-module-explore/config.d.ts
@@ -18,8 +18,10 @@ import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
 
 export interface Config {
   search?: {
-    explore?: {
-      schedule?: TaskScheduleDefinitionConfig;
+    collators?: {
+      explore?: {
+        schedule?: TaskScheduleDefinitionConfig;
+      };
     };
   };
 }

--- a/plugins/search-backend-module-explore/config.d.ts
+++ b/plugins/search-backend-module-explore/config.d.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
+export interface Config {
+  search?: {
+    explore?: {
+      schedule?: TaskScheduleDefinitionConfig;
+    };
+  };
+}

--- a/plugins/search-backend-module-explore/package.json
+++ b/plugins/search-backend-module-explore/package.json
@@ -58,6 +58,8 @@
     "msw": "^1.2.1"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-explore/src/alpha.test.ts
+++ b/plugins/search-backend-module-explore/src/alpha.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { startTestBackend } from '@backstage/backend-test-utils';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
 import { searchModuleExploreCollator } from './alpha';
 
@@ -34,7 +34,18 @@ describe('searchModuleExploreCollator', () => {
       extensionPoints: [
         [searchIndexRegistryExtensionPoint, extensionPointMock],
       ],
-      features: [searchModuleExploreCollator({ schedule })],
+      features: [searchModuleExploreCollator()],
+      services: [
+        mockServices.rootConfig.factory({
+          data: {
+            search: {
+              explore: {
+                schedule,
+              },
+            },
+          },
+        }),
+      ],
     });
 
     expect(extensionPointMock.addCollator).toHaveBeenCalledTimes(1);

--- a/plugins/search-backend-module-explore/src/alpha.ts
+++ b/plugins/search-backend-module-explore/src/alpha.ts
@@ -23,66 +23,59 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { loggerToWinstonLogger } from '@backstage/backend-common';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
 
 import { ToolDocumentCollatorFactory } from '@backstage/plugin-search-backend-module-explore';
-
-/**
- * Options for {@link searchModuleExploreCollator}.
- *
- * @alpha
- */
-export type SearchModuleExploreCollatorOptions = {
-  schedule?: TaskScheduleDefinition;
-};
+import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
 
 /**
  * Search backend module for the Explore index.
  *
  * @alpha
  */
-export const searchModuleExploreCollator = createBackendModule(
-  (options?: SearchModuleExploreCollatorOptions) => ({
-    moduleId: 'exploreCollator',
-    pluginId: 'search',
-    register(env) {
-      env.registerInit({
-        deps: {
-          config: coreServices.rootConfig,
-          logger: coreServices.logger,
-          discovery: coreServices.discovery,
-          scheduler: coreServices.scheduler,
-          tokenManager: coreServices.tokenManager,
-          indexRegistry: searchIndexRegistryExtensionPoint,
-        },
-        async init({
-          config,
-          logger,
-          discovery,
-          scheduler,
-          indexRegistry,
-          tokenManager,
-        }) {
-          const defaultSchedule = {
-            frequency: { minutes: 10 },
-            timeout: { minutes: 15 },
-            initialDelay: { seconds: 3 },
-          };
+export const searchModuleExploreCollator = createBackendModule({
+  moduleId: 'exploreCollator',
+  pluginId: 'search',
+  register(env) {
+    env.registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        logger: coreServices.logger,
+        discovery: coreServices.discovery,
+        scheduler: coreServices.scheduler,
+        tokenManager: coreServices.tokenManager,
+        indexRegistry: searchIndexRegistryExtensionPoint,
+      },
+      async init({
+        config,
+        logger,
+        discovery,
+        scheduler,
+        indexRegistry,
+        tokenManager,
+      }) {
+        const defaultSchedule = {
+          frequency: { minutes: 10 },
+          timeout: { minutes: 15 },
+          initialDelay: { seconds: 3 },
+        };
 
-          indexRegistry.addCollator({
-            schedule: scheduler.createScheduledTaskRunner(
-              options?.schedule ?? defaultSchedule,
-            ),
-            factory: ToolDocumentCollatorFactory.fromConfig(config, {
-              discovery,
-              logger: loggerToWinstonLogger(logger),
-              tokenManager,
-            }),
-          });
-        },
-      });
-    },
-  }),
-);
+        const schedule = config.has('search.explore.schedule')
+          ? readTaskScheduleDefinitionFromConfig(
+              config.getConfig('search.explore.schedule'),
+            )
+          : defaultSchedule;
+
+        indexRegistry.addCollator({
+          schedule: scheduler.createScheduledTaskRunner(schedule),
+          factory: ToolDocumentCollatorFactory.fromConfig(config, {
+            discovery,
+            logger: loggerToWinstonLogger(logger),
+            tokenManager,
+          }),
+        });
+      },
+    });
+  },
+});

--- a/plugins/search-backend-module-explore/src/alpha.ts
+++ b/plugins/search-backend-module-explore/src/alpha.ts
@@ -61,9 +61,9 @@ export const searchModuleExploreCollator = createBackendModule({
           initialDelay: { seconds: 3 },
         };
 
-        const schedule = config.has('search.explore.schedule')
+        const schedule = config.has('search.collators.explore.schedule')
           ? readTaskScheduleDefinitionFromConfig(
-              config.getConfig('search.explore.schedule'),
+              config.getConfig('search.collators.explore.schedule'),
             )
           : defaultSchedule;
 

--- a/plugins/search-backend-module-techdocs/alpha-api-report.md
+++ b/plugins/search-backend-module-techdocs/alpha-api-report.md
@@ -4,21 +4,9 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
-import { TechDocsCollatorFactoryOptions } from '@backstage/plugin-search-backend-module-techdocs';
 
 // @alpha
-export const searchModuleTechDocsCollator: (
-  options?: SearchModuleTechDocsCollatorOptions | undefined,
-) => BackendFeature;
-
-// @alpha
-export type SearchModuleTechDocsCollatorOptions = Omit<
-  TechDocsCollatorFactoryOptions,
-  'logger' | 'discovery' | 'tokenManager' | 'catalogClient'
-> & {
-  schedule?: TaskScheduleDefinition;
-};
+export const searchModuleTechDocsCollator: () => BackendFeature;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-techdocs/config.d.ts
+++ b/plugins/search-backend-module-techdocs/config.d.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
+export interface Config {
+  search?: {
+    techdocs?: {
+      schedule?: TaskScheduleDefinitionConfig;
+      collatorsFactory?: {
+        locationTemplate?: string;
+        parallelismLimit?: number;
+        legacyPathCasing?: boolean;
+      };
+    };
+  };
+}

--- a/plugins/search-backend-module-techdocs/config.d.ts
+++ b/plugins/search-backend-module-techdocs/config.d.ts
@@ -20,7 +20,7 @@ export interface Config {
   search?: {
     techdocs?: {
       schedule?: TaskScheduleDefinitionConfig;
-      collatorsFactory?: {
+      collators?: {
         locationTemplate?: string;
         parallelismLimit?: number;
         legacyPathCasing?: boolean;

--- a/plugins/search-backend-module-techdocs/config.d.ts
+++ b/plugins/search-backend-module-techdocs/config.d.ts
@@ -18,9 +18,9 @@ import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
 
 export interface Config {
   search?: {
-    techdocs?: {
-      schedule?: TaskScheduleDefinitionConfig;
-      collators?: {
+    collators?: {
+      techdocs?: {
+        schedule?: TaskScheduleDefinitionConfig;
         locationTemplate?: string;
         parallelismLimit?: number;
         legacyPathCasing?: boolean;

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -65,6 +65,8 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-techdocs/src/alpha.test.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { startTestBackend } from '@backstage/backend-test-utils';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
 import { searchModuleTechDocsCollator } from './alpha';
 
@@ -34,7 +34,18 @@ describe('searchModuleTechDocsCollator', () => {
       extensionPoints: [
         [searchIndexRegistryExtensionPoint, extensionPointMock],
       ],
-      features: [searchModuleTechDocsCollator({ schedule })],
+      features: [searchModuleTechDocsCollator()],
+      services: [
+        mockServices.rootConfig.factory({
+          data: {
+            search: {
+              techdocs: {
+                schedule,
+              },
+            },
+          },
+        }),
+      ],
     });
 
     expect(extensionPointMock.addCollator).toHaveBeenCalledTimes(1);

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -71,15 +71,6 @@ export const searchModuleTechDocsCollator = createBackendModule({
         indexRegistry.addCollator({
           schedule: scheduler.createScheduledTaskRunner(schedule),
           factory: DefaultTechDocsCollatorFactory.fromConfig(config, {
-            locationTemplate: config.getOptionalString(
-              'search.techdocs.collatorsFactory.locationTemplate',
-            ),
-            parallelismLimit: config.getOptionalNumber(
-              'search.techdocs.collatorsFactory.parallelismLimit',
-            ),
-            legacyPathCasing: config.getOptionalBoolean(
-              'search.techdocs.collatorsFactory.legacyPathCasing',
-            ),
             discovery,
             tokenManager,
             logger: loggerToWinstonLogger(logger),

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -62,9 +62,9 @@ export const searchModuleTechDocsCollator = createBackendModule({
           initialDelay: { seconds: 3 },
         };
 
-        const schedule = config.has('search.explore.schedule')
+        const schedule = config.has('search.collators.techdocs.schedule')
           ? readTaskScheduleDefinitionFromConfig(
-              config.getConfig('search.explore.schedule'),
+              config.getConfig('search.collators.techdocs.schedule'),
             )
           : defaultSchedule;
 

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -19,79 +19,74 @@
  * A module for the search backend that exports TechDocs modules.
  */
 
+import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
-import { loggerToWinstonLogger } from '@backstage/backend-common';
-import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
+import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
-
-import {
-  DefaultTechDocsCollatorFactory,
-  TechDocsCollatorFactoryOptions,
-} from '@backstage/plugin-search-backend-module-techdocs';
-
-/**
- * @alpha
- * Options for {@link searchModuleTechDocsCollator}.
- */
-export type SearchModuleTechDocsCollatorOptions = Omit<
-  TechDocsCollatorFactoryOptions,
-  'logger' | 'discovery' | 'tokenManager' | 'catalogClient'
-> & {
-  schedule?: TaskScheduleDefinition;
-};
+import { DefaultTechDocsCollatorFactory } from '@backstage/plugin-search-backend-module-techdocs';
+import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
 
 /**
  * @alpha
  * Search backend module for the TechDocs index.
  */
-export const searchModuleTechDocsCollator = createBackendModule(
-  (options?: SearchModuleTechDocsCollatorOptions) => ({
-    moduleId: 'techDocsCollator',
-    pluginId: 'search',
-    register(env) {
-      env.registerInit({
-        deps: {
-          config: coreServices.rootConfig,
-          logger: coreServices.logger,
-          discovery: coreServices.discovery,
-          tokenManager: coreServices.tokenManager,
-          scheduler: coreServices.scheduler,
-          catalog: catalogServiceRef,
-          indexRegistry: searchIndexRegistryExtensionPoint,
-        },
-        async init({
-          config,
-          logger,
-          discovery,
-          tokenManager,
-          scheduler,
-          catalog,
-          indexRegistry,
-        }) {
-          const defaultSchedule = {
-            frequency: { minutes: 10 },
-            timeout: { minutes: 15 },
-            initialDelay: { seconds: 3 },
-          };
+export const searchModuleTechDocsCollator = createBackendModule({
+  moduleId: 'techDocsCollator',
+  pluginId: 'search',
+  register(env) {
+    env.registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        logger: coreServices.logger,
+        discovery: coreServices.discovery,
+        tokenManager: coreServices.tokenManager,
+        scheduler: coreServices.scheduler,
+        catalog: catalogServiceRef,
+        indexRegistry: searchIndexRegistryExtensionPoint,
+      },
+      async init({
+        config,
+        logger,
+        discovery,
+        tokenManager,
+        scheduler,
+        catalog,
+        indexRegistry,
+      }) {
+        const defaultSchedule = {
+          frequency: { minutes: 10 },
+          timeout: { minutes: 15 },
+          initialDelay: { seconds: 3 },
+        };
 
-          indexRegistry.addCollator({
-            schedule: scheduler.createScheduledTaskRunner(
-              options?.schedule ?? defaultSchedule,
+        const schedule = config.has('search.explore.schedule')
+          ? readTaskScheduleDefinitionFromConfig(
+              config.getConfig('search.explore.schedule'),
+            )
+          : defaultSchedule;
+
+        indexRegistry.addCollator({
+          schedule: scheduler.createScheduledTaskRunner(schedule),
+          factory: DefaultTechDocsCollatorFactory.fromConfig(config, {
+            locationTemplate: config.getOptionalString(
+              'search.techdocs.collatorsFactory.locationTemplate',
             ),
-            factory: DefaultTechDocsCollatorFactory.fromConfig(config, {
-              ...options,
-              discovery,
-              tokenManager,
-              logger: loggerToWinstonLogger(logger),
-              catalogClient: catalog,
-            }),
-          });
-        },
-      });
-    },
-  }),
-);
+            parallelismLimit: config.getOptionalNumber(
+              'search.techdocs.collatorsFactory.parallelismLimit',
+            ),
+            legacyPathCasing: config.getOptionalBoolean(
+              'search.techdocs.collatorsFactory.legacyPathCasing',
+            ),
+            discovery,
+            tokenManager,
+            logger: loggerToWinstonLogger(logger),
+            catalogClient: catalog,
+          }),
+        });
+      },
+    });
+  },
+});

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -217,7 +217,7 @@ describe('DefaultTechDocsCollatorFactory', () => {
 
       // Only 1 entity with TechDocs configured multiplied by 3 pages.
       expect(documents).toHaveLength(3);
-      expect(_config.get('search.techdocs.collators.parallelismLimit')).toEqual(
+      expect(_config.get('search.collators.techdocs.parallelismLimit')).toEqual(
         1,
       );
     });

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -177,7 +177,7 @@ describe('DefaultTechDocsCollatorFactory', () => {
       const _config = new ConfigReader({
         ...config.get(),
         search: {
-          techdocs: { collators: { locationTemplate: '/software/:name' } },
+          collators: { techdocs: { locationTemplate: '/software/:name' } },
         },
       });
       factory = DefaultTechDocsCollatorFactory.fromConfig(_config, {
@@ -202,8 +202,8 @@ describe('DefaultTechDocsCollatorFactory', () => {
       const _config = new ConfigReader({
         ...config.get(),
         search: {
-          techdocs: {
-            collators: {
+          collators: {
+            techdocs: {
               parallelismLimit: 1,
             },
           },

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -174,10 +174,15 @@ describe('DefaultTechDocsCollatorFactory', () => {
 
     it('maps a returned entity with a custom locationTemplate', async () => {
       // Provide an alternate location template.
-      factory = DefaultTechDocsCollatorFactory.fromConfig(config, {
+      const _config = new ConfigReader({
+        ...config.get(),
+        search: {
+          techdocs: { collators: { locationTemplate: '/software/:name' } },
+        },
+      });
+      factory = DefaultTechDocsCollatorFactory.fromConfig(_config, {
         discovery: mockDiscoveryApi,
         tokenManager: mockTokenManager,
-        locationTemplate: '/software/:name',
         logger,
       });
       collator = await factory.getCollator();
@@ -194,10 +199,17 @@ describe('DefaultTechDocsCollatorFactory', () => {
       // A parallelismLimit of 1 is a catalog limit of 50 per request. Code
       // above in the /entities handler ensures valid entities are only
       // returned on the second page.
-      factory = DefaultTechDocsCollatorFactory.fromConfig(config, {
-        ...options,
-        parallelismLimit: 1,
+      const _config = new ConfigReader({
+        ...config.get(),
+        search: {
+          techdocs: {
+            collators: {
+              parallelismLimit: 1,
+            },
+          },
+        },
       });
+      factory = DefaultTechDocsCollatorFactory.fromConfig(_config, options);
       collator = await factory.getCollator();
 
       const pipeline = TestPipeline.fromCollator(collator);
@@ -205,6 +217,9 @@ describe('DefaultTechDocsCollatorFactory', () => {
 
       // Only 1 entity with TechDocs configured multiplied by 3 pages.
       expect(documents).toHaveLength(3);
+      expect(_config.get('search.techdocs.collators.parallelismLimit')).toEqual(
+        1,
+      );
     });
 
     describe('with legacyPathCasing configuration', () => {

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
@@ -104,7 +104,18 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
       config.getOptionalBoolean(
         'techdocs.legacyUseCaseSensitiveTripletPaths',
       ) || false;
-    return new DefaultTechDocsCollatorFactory({ ...options, legacyPathCasing });
+    const locationTemplate = config.getOptionalString(
+      'search.techdocs.collators.locationTemplate',
+    );
+    const parallelismLimit = config.getOptionalNumber(
+      'search.techdocs.collators.parallelismLimit',
+    );
+    return new DefaultTechDocsCollatorFactory({
+      ...options,
+      locationTemplate,
+      parallelismLimit,
+      legacyPathCasing,
+    });
   }
 
   async getCollator(): Promise<Readable> {

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
@@ -105,10 +105,10 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
         'techdocs.legacyUseCaseSensitiveTripletPaths',
       ) || false;
     const locationTemplate = config.getOptionalString(
-      'search.techdocs.collators.locationTemplate',
+      'search.collators.techdocs.locationTemplate',
     );
     const parallelismLimit = config.getOptionalNumber(
-      'search.techdocs.collators.parallelismLimit',
+      'search.collators.techdocs.parallelismLimit',
     );
     return new DefaultTechDocsCollatorFactory({
       ...options,


### PR DESCRIPTION
- Removing options from backend modules `search-backend-module-explore` & `search-backend-module-techdocs`
- Add respective `config.d.ts` & change effected tests
- Convert `permission-backend` from callback to object in favour of not wanting options in the future

---

- In addition to https://github.com/backstage/backstage/pull/19278
- Works towards https://github.com/backstage/backstage/issues/18390

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
