### PR TITLE
catalog-backend: inline synthetic load test module

### DIFF
--- a/.changeset/fast-peas-live.md
+++ b/.changeset/fast-peas-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Internal refactor for load test


### PR DESCRIPTION
🧹, figured it's easier to inline this