### PR TITLE
todo-backend: fix filter validation

### DIFF
--- a/.changeset/pretty-ways-knock.md
+++ b/.changeset/pretty-ways-knock.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-todo': patch
+'@backstage/plugin-todo-backend': patch
 ---
 
-Fixed URL encoding of filters where the filter was always rejected by the backend validation.
+Fixed a bug where filter queries from the frontend would always fail validation.

--- a/.changeset/pretty-ways-knock.md
+++ b/.changeset/pretty-ways-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-todo': patch
+---
+
+Fixed URL encoding of filters where the filter was always rejected by the backend validation.

--- a/plugins/todo-backend/src/schema/openapi.generated.ts
+++ b/plugins/todo-backend/src/schema/openapi.generated.ts
@@ -173,6 +173,7 @@ export const spec = {
             name: 'filter',
             in: 'query',
             required: false,
+            allowReserved: true,
             schema: {
               type: 'array',
               description:

--- a/plugins/todo-backend/src/schema/openapi.yaml
+++ b/plugins/todo-backend/src/schema/openapi.yaml
@@ -111,6 +111,7 @@ paths:
         - name: filter
           in: query
           required: false
+          allowReserved: true
           schema:
             type: array
             description: A list of filters used to narrow down the listed TODO items

--- a/plugins/todo-backend/src/service/router.test.ts
+++ b/plugins/todo-backend/src/service/router.test.ts
@@ -131,6 +131,23 @@ describe('createRouter', () => {
       );
     });
 
+    it('forwards filter query', async () => {
+      mockService.listTodos.mockResolvedValueOnce(mockListBody);
+
+      const response = await request(app).get('/v1/todos?filter=text=*borked*');
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(mockListBody);
+      expect(mockService.listTodos).toHaveBeenCalledWith(
+        {
+          entity: undefined,
+          offset: undefined,
+          limit: undefined,
+          filters: [{ field: 'text', value: '*borked*' }],
+        },
+        { token: undefined },
+      );
+    });
+
     it('rejects invalid queries', async () => {
       request(app)
         .get('/v1/todos?entity=k:n&entity=k:n')

--- a/plugins/todo/src/api/TodoClient.ts
+++ b/plugins/todo/src/api/TodoClient.ts
@@ -67,17 +67,13 @@ export class TodoClient implements TodoApi {
       }
     }
 
-    const res = await fetch(
-      // TODO(Rugvip): Figure out a better solution to '*' not being URL encoded but that being required by OpenAPI
-      `${baseUrl}/v1/todos?${String(query).replace(/\*/g, '%2A')}`,
-      {
-        headers: token
-          ? {
-              Authorization: `Bearer ${token}`,
-            }
-          : undefined,
-      },
-    );
+    const res = await fetch(`${baseUrl}/v1/todos?${query}`, {
+      headers: token
+        ? {
+            Authorization: `Bearer ${token}`,
+          }
+        : undefined,
+    });
 
     if (!res.ok) {
       throw await ResponseError.fromResponse(res);

--- a/plugins/todo/src/api/TodoClient.ts
+++ b/plugins/todo/src/api/TodoClient.ts
@@ -67,13 +67,17 @@ export class TodoClient implements TodoApi {
       }
     }
 
-    const res = await fetch(`${baseUrl}/v1/todos?${query}`, {
-      headers: token
-        ? {
-            Authorization: `Bearer ${token}`,
-          }
-        : undefined,
-    });
+    const res = await fetch(
+      // TODO(Rugvip): Figure out a better solution to '*' not being URL encoded but that being required by OpenAPI
+      `${baseUrl}/v1/todos?${String(query).replace(/\*/g, '%2A')}`,
+      {
+        headers: token
+          ? {
+              Authorization: `Bearer ${token}`,
+            }
+          : undefined,
+      },
+    );
 
     if (!res.ok) {
       throw await ResponseError.fromResponse(res);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #19269

The bug was due to the new OpenAPI validation being more strict and not accepting un-encoded `*`'s. That's a bit strange since `encodeURIComponent('*') === '*'`. This is a quick fix, will want to dig a bit deeper into why it behaves like this and what we can do about it.

CC @sennyeya 👀 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
