### PR TITLE
chore(lighthouse): Add plugins to accessibility testing

### DIFF
--- a/docs/accessibility/index.md
+++ b/docs/accessibility/index.md
@@ -15,35 +15,35 @@ There are multiple ways to contribute to making Backstage more accessible, you'l
 If your plugin lives in the [Backstage main repository](https://github.com/backstage/backstage/) you can modify the [urls in the Lighthouse config](https://github.com/backstage/backstage/blob/39ba2284d73885b7ca8290cb38e2b1e4d983c8d6/lighthouserc.js#L19-L34) to run the Lighthouse checks on urls where your plugin exists as well. E.g.
 
 ```diff
- ci: {
-    collect: {
-      url: [
+  ci: {
+     collect: {
+       url: [
+         /** Software Catalog */
+         'http://localhost:3000/catalog',
+         'http://localhost:3000/catalog-import',
+         'http://localhost:3000/catalog/default/component/backstage',
+         ...
 +        /** Your plugin paths */
 +        'http://localhost:3000/your-plugin-path,
-        /** Software Catalog */
-        'http://localhost:3000/catalog',
-        'http://localhost:3000/catalog-import',
-        'http://localhost:3000/catalog/default/component/backstage',
+       ],
+       settings: {
         ...
-      ],
-      settings: {
-       ...
-      },
-     ...
-    },
-    assert: {
+       },
       ...
-    },
-  },
+     },
+     assert: {
+       ...
+     },
+   },
 ```
 
-To make sure the [Accessibility Github workflow](https://github.com/backstage/backstage/blob/master/.github/workflows/verify_accessibility.yml) is running when changes are made to your plugin folders, modify the [list of paths](https://github.com/backstage/backstage/blob/10759b6ad2561bd86183ad940256f9a309c7a6b0/.github/workflows/verify_accessibility.yml#L7-L16).
+To make sure the [Accessibility GitHub workflow](https://github.com/backstage/backstage/blob/master/.github/workflows/verify_accessibility.yml) is running when changes are made to your plugin folders, modify the [list of paths](https://github.com/backstage/backstage/blob/10759b6ad2561bd86183ad940256f9a309c7a6b0/.github/workflows/verify_accessibility.yml#L7-L16).
 
 ### Run the Lighthouse CLI locally when developing new features
 
 If you want to use the Lighthouse CLI and run the checks based on the config you can use the following command:
 
-```
+```shell
 yarn dlx @lhci/cli@0.11.x autorun
 ```
 

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -32,6 +32,17 @@ module.exports = {
         'http://localhost:3000/create/templates/default/react-ssr-template',
         /** Search */
         'http://localhost:3000/search',
+        /** Miscellaneous */
+        'http://localhost:3000/settings',
+        /** plugin-devtools */
+        'http://localhost:3000/devtools',
+        'http://localhost:3000/devtools/config',
+        /** plugin-explore */
+        'http://localhost:3000/explore',
+        'http://localhost:3000/explore/groups',
+        'http://localhost:3000/explore/tools',
+        /** plugin-tech-radar */
+        'http://localhost:3000/tech-radar',
       ],
       settings: {
         onlyCategories: ['accessibility'],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Using the excellent guidelines from https://backstage.io/docs/accessibility/, this PR adds a few additional plugins to the accessibility testing. All look pretty good so far, but it helps point out a few enhancements.

Also minor updates to the instructions.

| Example 1 | Example 2 | Example 3 |
| --- | --- | --- |
|  <img width="1028" alt="image" src="https://github.com/backstage/backstage/assets/33203301/ba483856-b1c6-4586-9f37-5320fb876d9f"> | <img width="1028" alt="image" src="https://github.com/backstage/backstage/assets/33203301/1b5813f9-b867-4c22-bc83-d26f3d394bb6"> | <img width="1028" alt="image" src="https://github.com/backstage/backstage/assets/33203301/94cba4be-7032-4af5-a6d4-a18101a82e66"> |

PS: `@lhci/cli` now has a v0.12 released which bumps to Lighthouse v10. However, when trying it it seemed to think I didn't have Chrome installed, though v0.11 worked just fine. So I avoided doing that bump for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
