### PR TITLE
Fix 18745 Visibility filter in the GithubEntityProvider is case-sensitive 

### DIFF
--- a/.changeset/ninety-panthers-guess.md
+++ b/.changeset/ninety-panthers-guess.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-Fixed a bug where the visibility filter was case sensitive and casting was inconsistent. 
+Fixed a bug where the visibility filter was case sensitive and casting was inconsistent.
+

--- a/.changeset/ninety-panthers-guess.md
+++ b/.changeset/ninety-panthers-guess.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-changed visibilityfilter and visibility to lowercase to prevent case-sensitive error.
+Fixed a bug where the visibility filter was case sensitive and casting was inconsistent. 

--- a/.changeset/ninety-panthers-guess.md
+++ b/.changeset/ninety-panthers-guess.md
@@ -3,4 +3,3 @@
 ---
 
 Fixed a bug where the visibility filter was case sensitive and casting was inconsistent.
-

--- a/.changeset/ninety-panthers-guess.md
+++ b/.changeset/ninety-panthers-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+changed visibilityfilter and visibility to lowercase to prevent case-sensitive error.

--- a/plugins/catalog-backend-module-github/src/lib/util.ts
+++ b/plugins/catalog-backend-module-github/src/lib/util.ts
@@ -107,5 +107,10 @@ export function satisfiesVisibilityFilter(
   if (!visibilities.length) {
     return true;
   }
-  return visibilities.includes(visibility);
+  const lowerCaseVisibilities = visibilities.map(v =>
+    v.toLocaleLowerCase('en-US'),
+  );
+  const lowerCaseVisibility = visibility.toLocaleLowerCase('en-US');
+
+  return lowerCaseVisibilities.includes(lowerCaseVisibility);
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!
fix #18745 
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
