### PR TITLE
backend-app-api: disallow required service factory options

### DIFF
--- a/.changeset/eighty-swans-sip.md
+++ b/.changeset/eighty-swans-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': minor
+---
+
+**BREAKING**: It is no longer possible to declare options as being required with `createServiceFactory`.

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -49,10 +49,10 @@ function toInternalServiceFactory<TService, TScope extends 'plugin' | 'root'>(
 }
 
 const pluginMetadataServiceFactory = createServiceFactory(
-  (options: { pluginId: string }) => ({
+  (options?: { pluginId: string }) => ({
     service: coreServices.pluginMetadata,
     deps: {},
-    factory: async () => ({ getId: () => options.pluginId }),
+    factory: async () => ({ getId: () => options?.pluginId! }),
   }),
 );
 

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -159,18 +159,6 @@ export function createServiceFactory<
   TDeps extends {
     [name in string]: ServiceRef<unknown>;
   },
-  TOpts extends object | undefined = undefined,
->(
-  config: (options: TOpts) => RootServiceFactoryConfig<TService, TImpl, TDeps>,
-): (options: TOpts) => ServiceFactory<TService, 'root'>;
-
-// @public
-export function createServiceFactory<
-  TService,
-  TImpl extends TService,
-  TDeps extends {
-    [name in string]: ServiceRef<unknown>;
-  },
   TContext = undefined,
   TOpts extends object | undefined = undefined,
 >(
@@ -191,23 +179,6 @@ export function createServiceFactory<
     options?: TOpts,
   ) => PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>,
 ): (options?: TOpts) => ServiceFactory<TService, 'plugin'>;
-
-// @public
-export function createServiceFactory<
-  TService,
-  TImpl extends TService,
-  TDeps extends {
-    [name in string]: ServiceRef<unknown>;
-  },
-  TContext = undefined,
-  TOpts extends object | undefined = undefined,
->(
-  config:
-    | PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>
-    | ((
-        options: TOpts,
-      ) => PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>),
-): (options: TOpts) => ServiceFactory<TService, 'plugin'>;
 
 // @public
 export function createServiceRef<TService>(

--- a/packages/backend-plugin-api/src/services/system/types.test.ts
+++ b/packages/backend-plugin-api/src/services/system/types.test.ts
@@ -26,7 +26,7 @@ interface TestOptions {
 function unused(..._any: any[]) {}
 
 describe('createServiceFactory', () => {
-  it('should create a sync factory with no options', () => {
+  it('should create a sync factory', () => {
     const metaFactory = createServiceFactory({
       service: ref,
       deps: {},
@@ -51,7 +51,7 @@ describe('createServiceFactory', () => {
     metaFactory();
   });
 
-  it('should create a sync root factory with no options', () => {
+  it('should create a sync root factory', () => {
     const metaFactory = createServiceFactory({
       service: rootDep,
       deps: {},
@@ -75,7 +75,7 @@ describe('createServiceFactory', () => {
     metaFactory();
   });
 
-  it('should create a factory with no options', () => {
+  it('should create a factory', () => {
     const metaFactory = createServiceFactory({
       service: ref,
       deps: {},
@@ -100,7 +100,7 @@ describe('createServiceFactory', () => {
     metaFactory();
   });
 
-  it('should create a factory with optional options', () => {
+  it('should create a factory with options', () => {
     const metaFactory = createServiceFactory((_opts?: { x: number }) => ({
       service: ref,
       deps: {},
@@ -124,7 +124,8 @@ describe('createServiceFactory', () => {
     metaFactory();
   });
 
-  it('should create a factory with required options', () => {
+  it('should not be allowed to require options', () => {
+    // @ts-expect-error
     const metaFactory = createServiceFactory((_opts: { x: number }) => ({
       service: ref,
       deps: {},
@@ -134,23 +135,9 @@ describe('createServiceFactory', () => {
       },
     }));
     expect(metaFactory).toEqual(expect.any(Function));
-
-    // @ts-expect-error
-    metaFactory('string');
-    // @ts-expect-error
-    metaFactory({});
-    metaFactory({ x: 1 });
-    // @ts-expect-error
-    metaFactory({ x: 1, y: 2 });
-    // @ts-expect-error
-    metaFactory(null);
-    // @ts-expect-error
-    metaFactory(undefined);
-    // @ts-expect-error
-    metaFactory();
   });
 
-  it('should create a factory with optional options as interface', () => {
+  it('should create a factory with options as interface', () => {
     const metaFactory = createServiceFactory((_opts?: TestOptions) => ({
       service: ref,
       deps: {},
@@ -171,32 +158,6 @@ describe('createServiceFactory', () => {
     // @ts-expect-error
     metaFactory(null);
     metaFactory(undefined);
-    metaFactory();
-  });
-
-  it('should create a factory with required options as interface', () => {
-    const metaFactory = createServiceFactory((_opts: TestOptions) => ({
-      service: ref,
-      deps: {},
-      async createRootContext() {},
-      async factory() {
-        return 'x';
-      },
-    }));
-    expect(metaFactory).toEqual(expect.any(Function));
-
-    // @ts-expect-error
-    metaFactory('string');
-    // @ts-expect-error
-    metaFactory({});
-    metaFactory({ x: 1 });
-    // @ts-expect-error
-    metaFactory({ x: 1, y: 2 });
-    // @ts-expect-error
-    metaFactory(null);
-    // @ts-expect-error
-    metaFactory(undefined);
-    // @ts-expect-error
     metaFactory();
   });
 
@@ -226,7 +187,7 @@ describe('createServiceFactory', () => {
     metaFactory();
   });
 
-  it('should create root scoped factory with dependencies and optional options', () => {
+  it('should create root scoped factory with dependencies and options', () => {
     const metaFactory = createServiceFactory((_options?: TestOptions) => ({
       service: createServiceRef({ id: 'foo', scope: 'root' }),
       deps: {
@@ -325,49 +286,7 @@ describe('createServiceFactory', () => {
     metaFactory();
   });
 
-  it('should create factory with required options and dependencies', () => {
-    const metaFactory = createServiceFactory((_opts: TestOptions) => ({
-      service: ref,
-      deps: {
-        root: rootDep,
-        plugin: pluginDep,
-      },
-      async createRootContext({ root }) {
-        const root1: number = root;
-        // @ts-expect-error
-        const root2: string = root;
-        unused(root1, root2);
-        return { root };
-      },
-      async factory({ plugin }, { root }) {
-        const root1: number = root;
-        // @ts-expect-error
-        const root2: string = root;
-        const plugin3: boolean = plugin;
-        // @ts-expect-error
-        const plugin4: number = plugin;
-        unused(root1, root2, plugin3, plugin4);
-        return 'x';
-      },
-    }));
-    expect(metaFactory).toEqual(expect.any(Function));
-
-    // @ts-expect-error
-    metaFactory('string');
-    // @ts-expect-error
-    metaFactory({});
-    metaFactory({ x: 1 });
-    // @ts-expect-error
-    metaFactory({ x: 1, y: 2 });
-    // @ts-expect-error
-    metaFactory(null);
-    // @ts-expect-error
-    metaFactory(undefined);
-    // @ts-expect-error
-    metaFactory();
-  });
-
-  it('should create factory with optional options and dependencies', () => {
+  it('should create factory with options and dependencies', () => {
     const metaFactory = createServiceFactory((_opts?: TestOptions) => ({
       service: ref,
       deps: {

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -192,20 +192,6 @@ export function createServiceFactory<
   config: (options?: TOpts) => RootServiceFactoryConfig<TService, TImpl, TDeps>,
 ): (options?: TOpts) => ServiceFactory<TService, 'root'>;
 /**
- * Creates a root scoped service factory with required options.
- *
- * @public
- * @param config - The service factory configuration.
- */
-export function createServiceFactory<
-  TService,
-  TImpl extends TService,
-  TDeps extends { [name in string]: ServiceRef<unknown> },
-  TOpts extends object | undefined = undefined,
->(
-  config: (options: TOpts) => RootServiceFactoryConfig<TService, TImpl, TDeps>,
-): (options: TOpts) => ServiceFactory<TService, 'root'>;
-/**
  * Creates a plugin scoped service factory without options.
  *
  * @public
@@ -237,25 +223,6 @@ export function createServiceFactory<
     options?: TOpts,
   ) => PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>,
 ): (options?: TOpts) => ServiceFactory<TService, 'plugin'>;
-/**
- * Creates a plugin scoped service factory with required options.
- *
- * @public
- * @param config - The service factory configuration.
- */
-export function createServiceFactory<
-  TService,
-  TImpl extends TService,
-  TDeps extends { [name in string]: ServiceRef<unknown> },
-  TContext = undefined,
-  TOpts extends object | undefined = undefined,
->(
-  config:
-    | PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>
-    | ((
-        options: TOpts,
-      ) => PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>),
-): (options: TOpts) => ServiceFactory<TService, 'plugin'>;
 export function createServiceFactory<
   TService,
   TImpl extends TService,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We want it to always be possible to instantiate a service factory using a default options, so we limit the ability to declare options as being required at the TypeScript level.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
