### PR TITLE
feat: Table initial loading

### DIFF
--- a/.changeset/strange-frogs-count.md
+++ b/.changeset/strange-frogs-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add loading indicator to Table

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1354,7 +1354,7 @@ export interface TableProps<T extends object = {}>
   // (undocumented)
   filters?: TableFilter[];
   // (undocumented)
-  initialContentLoading?: boolean;
+  isLoading?: boolean;
   // (undocumented)
   initialState?: TableState;
   // (undocumented)

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1354,9 +1354,9 @@ export interface TableProps<T extends object = {}>
   // (undocumented)
   filters?: TableFilter[];
   // (undocumented)
-  isLoading?: boolean;
-  // (undocumented)
   initialState?: TableState;
+  // (undocumented)
+  isLoading?: boolean;
   // (undocumented)
   onStateChange?: (state: TableState) => any;
   // (undocumented)

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1354,6 +1354,8 @@ export interface TableProps<T extends object = {}>
   // (undocumented)
   filters?: TableFilter[];
   // (undocumented)
+  initialContentLoading?: boolean;
+  // (undocumented)
   initialState?: TableState;
   // (undocumented)
   onStateChange?: (state: TableState) => any;

--- a/packages/core-components/src/components/Table/Table.stories.tsx
+++ b/packages/core-components/src/components/Table/Table.stories.tsx
@@ -89,7 +89,7 @@ export const DefaultTable = () => {
   );
 };
 
-export const InitialLoadingTable = () => {
+export const LoadingTable = () => {
   const classes = useStyles();
   const columns: TableColumn[] = [
     {
@@ -119,7 +119,7 @@ export const InitialLoadingTable = () => {
         options={{ paging: false }}
         data={[]}
         columns={columns}
-        initialContentLoading
+        isLoading
         title="Backstage Table"
       />
     </div>

--- a/packages/core-components/src/components/Table/Table.stories.tsx
+++ b/packages/core-components/src/components/Table/Table.stories.tsx
@@ -89,6 +89,43 @@ export const DefaultTable = () => {
   );
 };
 
+export const InitialLoadingTable = () => {
+  const classes = useStyles();
+  const columns: TableColumn[] = [
+    {
+      title: 'Column 1',
+      field: 'col1',
+      highlight: true,
+    },
+    {
+      title: 'Column 2',
+      field: 'col2',
+    },
+    {
+      title: 'Numeric value',
+      field: 'number',
+      type: 'numeric',
+    },
+    {
+      title: 'A Date',
+      field: 'date',
+      type: 'date',
+    },
+  ];
+
+  return (
+    <div className={classes.container}>
+      <Table
+        options={{ paging: false }}
+        data={[]}
+        columns={columns}
+        initialContentLoading
+        title="Backstage Table"
+      />
+    </div>
+  );
+};
+
 export const EmptyTable = () => {
   const classes = useStyles();
   const columns: TableColumn[] = [

--- a/packages/core-components/src/components/Table/Table.test.tsx
+++ b/packages/core-components/src/components/Table/Table.test.tsx
@@ -49,9 +49,7 @@ describe('<Table />', () => {
   });
 
   it('renders loading without exploding', async () => {
-    const rendered = await renderInTestApp(
-      <Table {...minProps} initialContentLoading />,
-    );
+    const rendered = await renderInTestApp(<Table {...minProps} isLoading />);
     expect(rendered.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 

--- a/packages/core-components/src/components/Table/Table.test.tsx
+++ b/packages/core-components/src/components/Table/Table.test.tsx
@@ -48,6 +48,13 @@ describe('<Table />', () => {
     expect(rendered.getByText('second value, second row')).toBeInTheDocument();
   });
 
+  it('renders loading without exploding', async () => {
+    const rendered = await renderInTestApp(
+      <Table {...minProps} initialContentLoading />,
+    );
+    expect(rendered.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
   describe('with style rows', () => {
     describe('with CSS Properties object', () => {
       const styledColumn2 = {

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -237,7 +237,7 @@ export interface TableProps<T extends object = {}>
   filters?: TableFilter[];
   initialState?: TableState;
   emptyContent?: ReactNode;
-  initialContentLoading?: boolean;
+  isLoading?: boolean;
   onStateChange?: (state: TableState) => any;
 }
 
@@ -311,7 +311,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
     emptyContent,
     onStateChange,
     components,
-    initialContentLoading,
+    isLoading: isLoading,
     ...restProps
   } = props;
   const tableClasses = useTableStyles();
@@ -473,7 +473,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
   const columnCount = columns.length;
   const Body = useCallback(
     bodyProps => {
-      if (initialContentLoading) {
+      if (isLoading) {
         return (
           <tbody data-testid="loading-indicator">
             <tr>
@@ -507,7 +507,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
 
       return <MTableBody {...bodyProps} />;
     },
-    [hasNoRows, emptyContent, columnCount, initialContentLoading],
+    [hasNoRows, emptyContent, columnCount, isLoading],
   );
 
   return (

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -53,6 +53,7 @@ import React, {
 
 import { SelectProps } from '../Select/Select';
 import { Filter, Filters, SelectedFilters, Without } from './Filters';
+import { Skeleton } from '@material-ui/lab';
 
 // Material-table is not using the standard icons available in in material-ui. https://github.com/mbrn/material-table/issues/51
 const tableIcons: Icons = {
@@ -159,6 +160,10 @@ const useTableStyles = makeStyles<BackstageTheme>(
       display: 'flex',
       alignItems: 'start',
     },
+    loadingTd: {
+      width: '90%',
+      paddingLeft: '0.5rem',
+    },
   }),
   { name: 'BackstageTable' },
 );
@@ -236,6 +241,7 @@ export interface TableProps<T extends object = {}>
   filters?: TableFilter[];
   initialState?: TableState;
   emptyContent?: ReactNode;
+  initialContentLoading?: boolean;
   onStateChange?: (state: TableState) => any;
 }
 
@@ -309,6 +315,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
     emptyContent,
     onStateChange,
     components,
+    initialContentLoading,
     ...restProps
   } = props;
   const tableClasses = useTableStyles();
@@ -470,6 +477,32 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
   const columnCount = columns.length;
   const Body = useCallback(
     bodyProps => {
+      if (initialContentLoading) {
+        return (
+          <tbody>
+            {Array.from({ length: 5 }, row => {
+              return (
+                <tr key={`table-placeholder-row-${row}`}>
+                  {Array.from({ length: columnCount }, col => {
+                    return (
+                      <td
+                        key={`table-placeholder-row-${row}-col-${col}`}
+                        colSpan={1}
+                      >
+                        <Skeleton
+                          className={tableClasses.loadingTd}
+                          height="4rem"
+                        />
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        );
+      }
+
       if (emptyContent && hasNoRows) {
         return (
           <tbody>
@@ -482,7 +515,13 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
 
       return <MTableBody {...bodyProps} />;
     },
-    [hasNoRows, emptyContent, columnCount],
+    [
+      hasNoRows,
+      emptyContent,
+      columnCount,
+      initialContentLoading,
+      tableClasses.loadingTd,
+    ],
   );
 
   return (

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -22,7 +22,6 @@ import MTable, {
   MTableHeader,
   MTableToolbar,
   Options,
-  CircularProgress,
 } from '@material-table/core';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
@@ -54,6 +53,7 @@ import React, {
 
 import { SelectProps } from '../Select/Select';
 import { Filter, Filters, SelectedFilters, Without } from './Filters';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 // Material-table is not using the standard icons available in in material-ui. https://github.com/mbrn/material-table/issues/51
 const tableIcons: Icons = {
@@ -475,7 +475,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
     bodyProps => {
       if (initialContentLoading) {
         return (
-          <tbody>
+          <tbody data-testid="loading-indicator">
             <tr>
               <td colSpan={columnCount}>
                 <Box

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -22,6 +22,7 @@ import MTable, {
   MTableHeader,
   MTableToolbar,
   Options,
+  CircularProgress,
 } from '@material-table/core';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
@@ -53,7 +54,6 @@ import React, {
 
 import { SelectProps } from '../Select/Select';
 import { Filter, Filters, SelectedFilters, Without } from './Filters';
-import { Skeleton } from '@material-ui/lab';
 
 // Material-table is not using the standard icons available in in material-ui. https://github.com/mbrn/material-table/issues/51
 const tableIcons: Icons = {
@@ -159,10 +159,6 @@ const useTableStyles = makeStyles<BackstageTheme>(
     root: {
       display: 'flex',
       alignItems: 'start',
-    },
-    loadingTd: {
-      width: '90%',
-      paddingLeft: '0.5rem',
     },
   }),
   { name: 'BackstageTable' },
@@ -480,25 +476,21 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
       if (initialContentLoading) {
         return (
           <tbody>
-            {Array.from({ length: 5 }, row => {
-              return (
-                <tr key={`table-placeholder-row-${row}`}>
-                  {Array.from({ length: columnCount }, col => {
-                    return (
-                      <td
-                        key={`table-placeholder-row-${row}-col-${col}`}
-                        colSpan={1}
-                      >
-                        <Skeleton
-                          className={tableClasses.loadingTd}
-                          height="4rem"
-                        />
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
+            <tr>
+              <td colSpan={columnCount}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    width: '100%',
+                    minHeight: '15rem',
+                  }}
+                >
+                  <CircularProgress size="5rem" />
+                </Box>
+              </td>
+            </tr>
           </tbody>
         );
       }
@@ -515,13 +507,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
 
       return <MTableBody {...bodyProps} />;
     },
-    [
-      hasNoRows,
-      emptyContent,
-      columnCount,
-      initialContentLoading,
-      tableClasses.loadingTd,
-    ],
+    [hasNoRows, emptyContent, columnCount, initialContentLoading],
   );
 
   return (


### PR DESCRIPTION
When loading data asynchronously you normally have to show some loading indicator, this should reduce boilerplate code across the codebase

![Screenshot 2023-08-11 at 11 43 12 AM](https://github.com/backstage/backstage/assets/6514980/2b4c9b46-45b8-4174-b450-b8e3d2ac3470)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
