### PR TITLE
Added OnBlur to set text to empty string in EntityOwnerPicker

### DIFF
--- a/.changeset/yellow-dryers-poke.md
+++ b/.changeset/yellow-dryers-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Added OnBlur to TextField of the EntityOwnerPicker to set text to empty string. This fixes bug of when user types into picker then clicks off of it. Current behavior when the user returns to picker the list is still filtered off of previous text string, but no text is displayed.

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -199,6 +199,7 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
                 setText(e.currentTarget.value);
               }}
               variant="outlined"
+              onBlur={() => setText('')}
             />
           )}
           ListboxProps={{


### PR DESCRIPTION
Added OnBlur to TextField of the EntityOwnerPicker to set text to empty string. This fixes bug of when user types into picker then clicks off of it. Current behavior when the user returns to picker the list is still filtered off of previous text string, but no text is displayed.