### PR TITLE
feat(catalog-backend-module-aws): AwsEksClusterProcessor adds ability to pass in entity and pass in region to EKS client callback function

### DIFF
--- a/.changeset/five-mangos-joke.md
+++ b/.changeset/five-mangos-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+AwsEksClusterProcessor pass in region when initialize EKS cluster

--- a/.changeset/five-mangos-joke.md
+++ b/.changeset/five-mangos-joke.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-aws': patch
----
-
-AwsEksClusterProcessor pass in region when initialize EKS cluster

--- a/.changeset/twenty-masks-exist.md
+++ b/.changeset/twenty-masks-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': minor
+---
+
+AwsEksClusterProcessor supports Entity callback function

--- a/.changeset/twenty-masks-exist.md
+++ b/.changeset/twenty-masks-exist.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-aws': minor
 ---
 
-AwsEksClusterProcessor supports Entity callback function
+AwsEksClusterProcessor supports Entity callback function and passes in region when initialize EKS cluster

--- a/plugins/catalog-backend-module-aws/api-report.md
+++ b/plugins/catalog-backend-module-aws/api-report.md
@@ -32,16 +32,16 @@ export type AWSCredentialFactory = (
 
 // @public
 export class AwsEKSClusterProcessor implements CatalogProcessor {
-  constructor(options?: {
+  constructor(options: {
     credentialsFactory?: AWSCredentialFactory;
     credentialsManager?: AwsCredentialsManager;
-    clusterEntityTransformer?: EKSClusterEntityTransformer;
+    clusterEntityTransformer?: EksClusterEntityTransformer;
   });
   // (undocumented)
   static fromConfig(
     configRoot: Config,
     options?: {
-      clusterEntityTransformer?: EKSClusterEntityTransformer;
+      clusterEntityTransformer?: EksClusterEntityTransformer;
     },
   ): AwsEKSClusterProcessor;
   // (undocumented)
@@ -107,7 +107,7 @@ export class AwsS3EntityProvider implements EntityProvider {
 }
 
 // @public
-export type EKSClusterEntityTransformer = (
+export type EksClusterEntityTransformer = (
   cluster: Cluster,
   accountId: string,
 ) => Promise<Entity>;

--- a/plugins/catalog-backend-module-aws/api-report.md
+++ b/plugins/catalog-backend-module-aws/api-report.md
@@ -8,7 +8,9 @@ import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorParser } from '@backstage/plugin-catalog-node';
+import type { Cluster } from '@aws-sdk/client-eks';
 import { Config } from '@backstage/config';
+import type { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
@@ -18,22 +20,32 @@ import { TaskRunner } from '@backstage/backend-tasks';
 import { UrlReader } from '@backstage/backend-common';
 
 // @public
+export const ANNOTATION_AWS_ACCOUNT_ID: string;
+
+// @public
+export const ANNOTATION_AWS_ARN: string;
+
+// @public
 export type AWSCredentialFactory = (
   awsAccountId: string,
 ) => Promise<AwsCredentialIdentity>;
 
 // @public
 export class AwsEKSClusterProcessor implements CatalogProcessor {
-  constructor(options: {
+  constructor(options?: {
     credentialsFactory?: AWSCredentialFactory;
     credentialsManager?: AwsCredentialsManager;
+    clusterEntityTransformer?: EKSClusterEntityTransformer;
   });
   // (undocumented)
-  static fromConfig(configRoot: Config): AwsEKSClusterProcessor;
+  static fromConfig(
+    configRoot: Config,
+    options?: {
+      clusterEntityTransformer?: EKSClusterEntityTransformer;
+    },
+  ): AwsEKSClusterProcessor;
   // (undocumented)
   getProcessorName(): string;
-  // (undocumented)
-  normalizeName(name: string): string;
   // (undocumented)
   readLocation(
     location: LocationSpec,
@@ -93,4 +105,10 @@ export class AwsS3EntityProvider implements EntityProvider {
   // (undocumented)
   refresh(logger: Logger): Promise<void>;
 }
+
+// @public
+export type EKSClusterEntityTransformer = (
+  cluster: Cluster,
+  accountId: string,
+) => Promise<Entity>;
 ```

--- a/plugins/catalog-backend-module-aws/src/constants.ts
+++ b/plugins/catalog-backend-module-aws/src/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 
 /**
- * A Backstage catalog backend module that helps integrate towards AWS
+ * Annotation for specifying AWS account id
  *
- * @packageDocumentation
+ * @public
  */
-
-export * from './processors';
-export * from './providers';
-export * from './types';
-export * from './constants';
+export const ANNOTATION_AWS_ACCOUNT_ID: string = 'amazonaws.com/account-id';
+/**
+ * Annotation for specifying AWS arn
+ *
+ * @public
+ */
+export const ANNOTATION_AWS_ARN: string = 'amazonaws.com/arn';

--- a/plugins/catalog-backend-module-aws/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-aws/src/lib/defaultTransformers.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { EKSClusterEntityTransformer } from '../processors/types';
+import { type Cluster } from '@aws-sdk/client-eks';
+import {
+  ANNOTATION_KUBERNETES_API_SERVER,
+  ANNOTATION_KUBERNETES_API_SERVER_CA,
+  ANNOTATION_KUBERNETES_AUTH_PROVIDER,
+} from '@backstage/plugin-kubernetes-common';
+import { ANNOTATION_AWS_ACCOUNT_ID, ANNOTATION_AWS_ARN } from '../constants';
+
+/**
+ * Default transformer for EKS Cluster to Resource Entity
+ * @public
+ */
+export const defaultEKSClusterTransformer: EKSClusterEntityTransformer = async (
+  cluster: Cluster,
+  accountId: string,
+) => {
+  const { arn, endpoint, certificateAuthority, name } = cluster;
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Resource',
+    metadata: {
+      annotations: {
+        [ANNOTATION_AWS_ACCOUNT_ID]: accountId,
+        [ANNOTATION_AWS_ARN]: arn || '',
+        [ANNOTATION_KUBERNETES_API_SERVER]: endpoint || '',
+        [ANNOTATION_KUBERNETES_API_SERVER_CA]: certificateAuthority?.data || '',
+        [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
+      },
+      name: normalizeName(name as string),
+      namespace: 'default',
+    },
+    spec: {
+      type: 'kubernetes-cluster',
+      owner: 'unknown',
+    },
+  };
+};
+
+function normalizeName(name: string): string {
+  return name
+    .trim()
+    .toLocaleLowerCase('en-US')
+    .replace(/[^a-zA-Z0-9\-]/g, '-');
+}

--- a/plugins/catalog-backend-module-aws/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-aws/src/lib/defaultTransformers.ts
@@ -13,44 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { EKSClusterEntityTransformer } from '../processors/types';
 import { type Cluster } from '@aws-sdk/client-eks';
 import {
   ANNOTATION_KUBERNETES_API_SERVER,
   ANNOTATION_KUBERNETES_API_SERVER_CA,
   ANNOTATION_KUBERNETES_AUTH_PROVIDER,
 } from '@backstage/plugin-kubernetes-common';
+import type { EksClusterEntityTransformer } from '../processors/types';
 import { ANNOTATION_AWS_ACCOUNT_ID, ANNOTATION_AWS_ARN } from '../constants';
 
 /**
  * Default transformer for EKS Cluster to Resource Entity
  * @public
  */
-export const defaultEKSClusterTransformer: EKSClusterEntityTransformer = async (
-  cluster: Cluster,
-  accountId: string,
-) => {
-  const { arn, endpoint, certificateAuthority, name } = cluster;
-  return {
-    apiVersion: 'backstage.io/v1alpha1',
-    kind: 'Resource',
-    metadata: {
-      annotations: {
-        [ANNOTATION_AWS_ACCOUNT_ID]: accountId,
-        [ANNOTATION_AWS_ARN]: arn || '',
-        [ANNOTATION_KUBERNETES_API_SERVER]: endpoint || '',
-        [ANNOTATION_KUBERNETES_API_SERVER_CA]: certificateAuthority?.data || '',
-        [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
+export const defaultEksClusterEntityTransformer: EksClusterEntityTransformer =
+  async (cluster: Cluster, accountId: string) => {
+    const { arn, endpoint, certificateAuthority, name } = cluster;
+    return {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Resource',
+      metadata: {
+        annotations: {
+          [ANNOTATION_AWS_ACCOUNT_ID]: accountId,
+          [ANNOTATION_AWS_ARN]: arn || '',
+          [ANNOTATION_KUBERNETES_API_SERVER]: endpoint || '',
+          [ANNOTATION_KUBERNETES_API_SERVER_CA]:
+            certificateAuthority?.data || '',
+          [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
+        },
+        name: normalizeName(name as string),
+        namespace: 'default',
       },
-      name: normalizeName(name as string),
-      namespace: 'default',
-    },
-    spec: {
-      type: 'kubernetes-cluster',
-      owner: 'unknown',
-    },
+      spec: {
+        type: 'kubernetes-cluster',
+        owner: 'unknown',
+      },
+    };
   };
-};
 
 function normalizeName(name: string): string {
   return name

--- a/plugins/catalog-backend-module-aws/src/lib/index.ts
+++ b/plugins/catalog-backend-module-aws/src/lib/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * A Backstage catalog backend module that helps integrate towards AWS
- *
- * @packageDocumentation
- */
-
-export * from './processors';
-export * from './providers';
-export * from './types';
-export * from './constants';
+export * from './defaultTransformers';

--- a/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts
@@ -108,6 +108,7 @@ export class AwsEKSClusterProcessor implements CatalogProcessor {
     const eksClient = new EKS({
       credentials,
       credentialDefaultProvider: providerFunction,
+      region,
     });
     const clusters = await eksClient.listClusters({});
     if (clusters.clusters === undefined) {

--- a/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts
@@ -28,8 +28,8 @@ import {
 } from '@backstage/integration-aws-node';
 import { Config } from '@backstage/config';
 
-import type { EKSClusterEntityTransformer } from './types';
-import { defaultEKSClusterTransformer } from '../lib';
+import type { EksClusterEntityTransformer } from './types';
+import { defaultEksClusterEntityTransformer } from '../lib';
 
 /**
  * A processor for automatic discovery of resources from EKS clusters. Handles the
@@ -41,12 +41,12 @@ import { defaultEKSClusterTransformer } from '../lib';
 export class AwsEKSClusterProcessor implements CatalogProcessor {
   private credentialsFactory?: AWSCredentialFactory;
   private credentialsManager?: AwsCredentialsManager;
-  private readonly clusterEntityTransformer: EKSClusterEntityTransformer;
+  private readonly clusterEntityTransformer: EksClusterEntityTransformer;
 
   static fromConfig(
     configRoot: Config,
     options?: {
-      clusterEntityTransformer?: EKSClusterEntityTransformer;
+      clusterEntityTransformer?: EksClusterEntityTransformer;
     },
   ): AwsEKSClusterProcessor {
     const awsCredentaislManager =
@@ -57,17 +57,17 @@ export class AwsEKSClusterProcessor implements CatalogProcessor {
     });
   }
 
-  constructor(options?: {
+  constructor(options: {
     credentialsFactory?: AWSCredentialFactory;
     credentialsManager?: AwsCredentialsManager;
-    clusterEntityTransformer?: EKSClusterEntityTransformer;
+    clusterEntityTransformer?: EksClusterEntityTransformer;
   }) {
-    this.credentialsFactory = options?.credentialsFactory;
-    this.credentialsManager = options?.credentialsManager;
+    this.credentialsFactory = options.credentialsFactory;
+    this.credentialsManager = options.credentialsManager;
 
     // If the callback function is not passed in, then default to the one upstream is using
     this.clusterEntityTransformer =
-      options?.clusterEntityTransformer || defaultEKSClusterTransformer;
+      options.clusterEntityTransformer || defaultEksClusterEntityTransformer;
   }
 
   getProcessorName(): string {

--- a/plugins/catalog-backend-module-aws/src/processors/index.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/index.ts
@@ -17,3 +17,4 @@
 export { AwsEKSClusterProcessor } from './AwsEKSClusterProcessor';
 export { AwsOrganizationCloudAccountProcessor } from './AwsOrganizationCloudAccountProcessor';
 export { AwsS3DiscoveryProcessor } from './AwsS3DiscoveryProcessor';
+export * from './types';

--- a/plugins/catalog-backend-module-aws/src/processors/types.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2023 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { Cluster } from '@aws-sdk/client-eks';
+import type { Entity } from '@backstage/catalog-model';
 
 /**
- * A Backstage catalog backend module that helps integrate towards AWS
+ * Options for the eks cluster entity callback function
  *
- * @packageDocumentation
+ * @public
  */
-
-export * from './processors';
-export * from './providers';
-export * from './types';
-export * from './constants';
+export type EKSClusterEntityTransformer = (
+  cluster: Cluster,
+  accountId: string,
+) => Promise<Entity>;

--- a/plugins/catalog-backend-module-aws/src/processors/types.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/types.ts
@@ -17,11 +17,11 @@ import type { Cluster } from '@aws-sdk/client-eks';
 import type { Entity } from '@backstage/catalog-model';
 
 /**
- * Options for the eks cluster entity callback function
+ * Options for the EKS cluster entity callback function
  *
  * @public
  */
-export type EKSClusterEntityTransformer = (
+export type EksClusterEntityTransformer = (
   cluster: Cluster,
   accountId: string,
 ) => Promise<Entity>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

https://github.com/backstage/backstage/issues/18497

- AwsEksClusterProcessor adds ability to pass in entity
  - customization of emitted EKS Entities for Backstage instances that allows for just greater configuration of Entities based on the AWS cluster metadata.
- pass in region to EKS client callback function
  -  [region is required in the location entity](https://github.com/backstage/backstage/blob/v1.16.0/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts#L89-L93). However, it is never being used. I think the intention for region is being used/passed in to [initialize the EKS client](https://github.com/backstage/backstage/blob/v1.16.0/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts#L108-L111). Since region is not currently passed in when initializing the EKS client, backstage is only querying the region that the backstage is deploying to 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
