### PR TITLE
microsite: remove BackstageCon 2023 CFP banner

### DIFF
--- a/microsite/src/pages/home/_home.tsx
+++ b/microsite/src/pages/home/_home.tsx
@@ -32,27 +32,6 @@ const HomePage = () => {
           <BannerSectionGrid
             header={
               <>
-                <div
-                  className={clsx(
-                    'card',
-                    'padding--md',
-                    homeStyles.newsletterBanner,
-                  )}
-                >
-                  <div className="text--left bannerContent">
-                    CFP is now open for BackstageCon 2023 🚀
-                  </div>
-                  <div>
-                    <a
-                      className="button button--outline button--secondary"
-                      href="https://bit.ly/BackstageConCFP"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      Submit a talk
-                    </a>
-                  </div>
-                </div>
                 {!hiddenNewsletterBanner && (
                   <div
                     className={clsx(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes the banner added in #18656 since the CFP itself has been closed since 2023-08-06

#### :heavy_check_mark: Checklist

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
