### PR TITLE
Customized titles of Card components on the catalog entity pages

### DIFF
--- a/.changeset/hungry-numbers-sing.md
+++ b/.changeset/hungry-numbers-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Customized the titles of of Card components displayed on the catalog entity pages.

--- a/.changeset/hungry-numbers-sing.md
+++ b/.changeset/hungry-numbers-sing.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Customized the titles of of Card components displayed on the catalog entity pages.
+Customized the titles of Card components displayed on the catalog entity pages.

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
@@ -27,14 +27,15 @@ import {
 /** @public */
 export interface HasComponentsCardProps {
   variant?: InfoCardVariants;
+  title?: string;
 }
 
 export function HasComponentsCard(props: HasComponentsCardProps) {
-  const { variant = 'gridItem' } = props;
+  const { variant = 'gridItem', title = 'Has components' } = props;
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Has components"
+      title={title}
       entityKind="Component"
       relationType={RELATION_HAS_PART}
       columns={componentEntityColumns}

--- a/plugins/catalog/src/components/HasResourcesCard/HasResourcesCard.tsx
+++ b/plugins/catalog/src/components/HasResourcesCard/HasResourcesCard.tsx
@@ -27,14 +27,15 @@ import {
 /** @public */
 export interface HasResourcesCardProps {
   variant?: InfoCardVariants;
+  title?: string;
 }
 
 export function HasResourcesCard(props: HasResourcesCardProps) {
-  const { variant = 'gridItem' } = props;
+  const { variant = 'gridItem', title = 'Has resources' } = props;
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Has resources"
+      title={title}
       entityKind="Resource"
       relationType={RELATION_HAS_PART}
       columns={resourceEntityColumns}

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
@@ -27,14 +27,19 @@ import {
 export interface HasSubcomponentsCardProps {
   variant?: InfoCardVariants;
   tableOptions?: TableOptions;
+  title?: string;
 }
 
 export function HasSubcomponentsCard(props: HasSubcomponentsCardProps) {
-  const { variant = 'gridItem', tableOptions = {} } = props;
+  const {
+    variant = 'gridItem',
+    tableOptions = {},
+    title = 'Has subcomponents',
+  } = props;
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Has subcomponents"
+      title={title}
       entityKind="Component"
       relationType={RELATION_HAS_PART}
       columns={componentEntityColumns}

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
@@ -27,14 +27,15 @@ import {
 /** @public */
 export interface HasSystemsCardProps {
   variant?: InfoCardVariants;
+  title?: string;
 }
 
 export function HasSystemsCard(props: HasSystemsCardProps) {
-  const { variant = 'gridItem' } = props;
+  const { variant = 'gridItem', title = 'Has systems' } = props;
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Has systems"
+      title={title}
       entityKind="System"
       relationType={RELATION_HAS_PART}
       columns={systemEntityColumns}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Issue #19323

Customized the titles of Card components displayed on the catalog entity pages. Made the ability to rename a card title consistent with Depends*On Card. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
