### PR TITLE
Docs: Add docs about config option to auto clean up orphans

### DIFF
--- a/.changeset/rich-apes-mix.md
+++ b/.changeset/rich-apes-mix.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog': patch
----
-
-Add docs about config option to auto clean up orphans

--- a/.changeset/rich-apes-mix.md
+++ b/.changeset/rich-apes-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add docs about config option to auto clean up orphans

--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -123,3 +123,14 @@ source that should be mirrored into Backstage. To make Backstage a mirror of
 this remote source, users cannot also register new entities with e.g. the
 [catalog-import](https://github.com/backstage/backstage/tree/master/plugins/catalog-import)
 plugin.
+
+## Clean up orphaned entities
+
+In short entities can become orphaned through multiple means, such as when a catalog-info YAML file is moved from one place to another in the version control system without updating the registration in the catalog. For safety reasons the default behavior is to just tag the orphaned entities, and keep them around. You can read more about orphaned entities [here](life-of-an-entity.md#orphaning).
+
+However, if you do with to automatically remove the orphaned entities, you can use the following configuration, and everything with an orphaned entity tag will be eventually deleted.
+
+```
+catalog:
+  orphanStrategy: delete
+```

--- a/docs/features/software-catalog/life-of-an-entity.md
+++ b/docs/features/software-catalog/life-of-an-entity.md
@@ -222,7 +222,8 @@ either, it becomes _orphaned_. The end result is as follows:
 - The stitching process injects a `backstage.io/orphan: 'true'` annotation on
   the child entity.
 - The child entity is _not_ removed from the catalog, but stays around until
-  explicitly deleted via the catalog API, or "reclaimed" by the original parent
+  explicitly deleted via the catalog API, implicitly if `orphanStrategy: delete`
+  configuration is set, or until it is "reclaimed" by the original parent
   or another parent starting to reference it.
 - The catalog page in Backstage for the child entity detects the new annotation
   and informs users about the orphan status.
@@ -259,9 +260,13 @@ entities without explicit owner consent. The catalog therefore takes the stance
 that entities that often were added by direct user action should also be deleted
 only by direct user action.
 
-It is possible to use the catalog API to build automated "reaper" systems that
-finally delete entities that are orphaned. This is however not something that's
-provided out of the box.
+However, if you want to delete orphaned entities automatically anyway, you can
+enable the automated clean up with the following app-config option.
+
+```
+catalog:
+  orphanStrategy: delete
+```
 
 ## Implicit Deletion
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Automated deletion of orphans was added in v1.13, but there is no documentation about it outside of a changelog. I did not read the whole docs, I just looked at the best place where this could be mentioned, and I considered the entity lifecycle to be the best place, so any suggestions are very welcome!
https://github.com/backstage/backstage/blob/ccc1a8d52a9afbea425896fee586a9f6497dac88/docs/releases/v1.13.0.md?plain=1#L41

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
