### PR TITLE
[TechDocs] Fix footer links width for newer versions of mkdocs-material

### DIFF
--- a/.changeset/eight-radios-listen.md
+++ b/.changeset/eight-radios-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bug in styles that caused next and previous links in footer to overlap page content.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -120,7 +120,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
 .md-footer__title {
   background-color: unset;
 }
-.md-footer-nav__link {
+.md-footer-nav__link, .md-footer__link {
   width: 16rem;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/19383.

There is a [width restriction](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts#L123-L125) for next/previous links in a footer. But in newer version of `mkdocs-material` those links have a different class name -`md-footer__link` instead of `md-footer-nav__link` (details are [here](https://squidfunk.github.io/mkdocs-material/upgrade/#partialsfooterhtml_1)).

In this PR I added a new class name to the existing styles transformer to fix the issue.

Before:
<img width="1285" alt="Screenshot 2023-08-15 at 19 11 08" src="https://github.com/backstage/backstage/assets/445309/0e7cdeec-21b3-4926-bee3-968e236aaefc">

After:
<img width="1535" alt="Screenshot 2023-08-15 at 19 57 27" src="https://github.com/backstage/backstage/assets/445309/2366eb64-e531-4874-9a32-29e5cc2d4215">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
