### PR TITLE
Fixes the missing borders on customizable homepage cards

### DIFF
--- a/.changeset/big-masks-divide.md
+++ b/.changeset/big-masks-divide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fixed a bug where customizable home page cards would render missing their normal borders.

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -68,7 +68,6 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: theme.spacing(2),
     },
     widgetWrapper: {
-      overflow: 'hidden',
       '& > div[class*="MuiCard-root"]': {
         width: '100%',
         height: '100%',


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Fixes #19368 introduced in #17607 where borders of the cards in the customizable homepage arent rendered properly.
This restores the look of v1.14.

v1.14 and earlier
<img width="999" alt="260580494-ca2d38cb-e861-4d00-ae3a-b" src="https://github.com/backstage/backstage/assets/746474/1221e531-dbb1-4250-89df-2bc70758ffa8">

v1.15 with #17607 
<img width="1338" alt="260580489-c47bb332-aa48-4d33-89be-1" src="https://github.com/backstage/backstage/assets/746474/76923175-2d5c-4f44-9c28-63f1e77abfb1">

resolves #19368 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
