### PR TITLE
Allow `UnifiedTheme` to return a theme-provider function

### DIFF
--- a/.changeset/angry-flowers-flash.md
+++ b/.changeset/angry-flowers-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': minor
+---
+
+Allow `UnifiedTheme` to return a theme-provider function as an alternative to a theme-object.

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -388,9 +388,6 @@ export type SimpleThemeOptions = {
 };
 
 // @public
-export type SupportedThemes = Theme_2 | Theme;
-
-// @public
 export type SupportedVersions = 'v4' | 'v5';
 
 // @public
@@ -411,7 +408,12 @@ export function transformV5ComponentThemesToV4(
 // @public
 export interface UnifiedTheme {
   // (undocumented)
-  getTheme(version: SupportedVersions): SupportedThemes | undefined;
+  getTheme<Version extends SupportedVersions>(
+    version: Version,
+  ):
+    | VersionedTheme<Version>
+    | ((outerTheme: VersionedTheme<Version>) => VersionedTheme<Version>)
+    | undefined;
 }
 
 // @public
@@ -446,4 +448,8 @@ export interface UnifiedThemeProviderProps {
   // (undocumented)
   theme: UnifiedTheme;
 }
+
+// @public
+export type VersionedTheme<Version extends SupportedVersions> =
+  Version extends 'v4' ? Theme_2 : Version extends 'v5' ? Theme : never;
 ```

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -32,23 +32,22 @@ import { createBaseThemeOptions } from '../base/createBaseThemeOptions';
 import { BackstageTypography, PageTheme } from '../base/types';
 import { defaultComponentThemes } from '../v5';
 import { transformV5ComponentThemesToV4 } from './overrides';
-import { SupportedThemes, SupportedVersions, UnifiedTheme } from './types';
+import { SupportedVersions, UnifiedTheme, VersionedTheme } from './types';
 
 export class UnifiedThemeHolder implements UnifiedTheme {
-  #themes = new Map<SupportedVersions, SupportedThemes>();
+  constructor(readonly v4?: Mui4Theme, readonly v5?: Mui5Theme) {}
 
-  constructor(v4?: Mui4Theme, v5?: Mui5Theme) {
-    this.#themes = new Map();
-    if (v4) {
-      this.#themes.set('v4', v4);
+  getTheme<Version extends SupportedVersions>(
+    version: Version,
+  ): VersionedTheme<Version> | undefined {
+    switch (version) {
+      case 'v4':
+        return this.v4 as VersionedTheme<Version> | undefined;
+      case 'v5':
+        return this.v5 as VersionedTheme<Version> | undefined;
+      default:
+        return undefined;
     }
-    if (v5) {
-      this.#themes.set('v5', v5);
-    }
-  }
-
-  getTheme(version: SupportedVersions): SupportedThemes | undefined {
-    return this.#themes.get(version);
   }
 }
 

--- a/packages/theme/src/unified/UnifiedThemeProvider.tsx
+++ b/packages/theme/src/unified/UnifiedThemeProvider.tsx
@@ -59,8 +59,8 @@ export function UnifiedThemeProvider(
 ): JSX.Element {
   const { children, theme, noCssBaseline = false } = props;
 
-  const v4Theme = theme.getTheme('v4') as Mui4Theme;
-  const v5Theme = theme.getTheme('v5') as Mui5Theme;
+  const v4Theme = theme.getTheme('v4');
+  const v5Theme = theme.getTheme('v5');
 
   let cssBaseline: JSX.Element | undefined = undefined;
   if (!noCssBaseline) {
@@ -77,7 +77,7 @@ export function UnifiedThemeProvider(
   if (v4Theme) {
     result = (
       <StylesProvider generateClassName={generateV4ClassName}>
-        <ThemeProvider theme={v4Theme}>{result}</ThemeProvider>
+        <ThemeProvider<Mui4Theme> theme={v4Theme}>{result}</ThemeProvider>
       </StylesProvider>
     );
   }
@@ -85,7 +85,7 @@ export function UnifiedThemeProvider(
   if (v5Theme) {
     result = (
       <StyledEngineProvider injectFirst>
-        <Mui5Provider theme={v5Theme}>{result}</Mui5Provider>
+        <Mui5Provider<Mui5Theme> theme={v5Theme}>{result}</Mui5Provider>
       </StyledEngineProvider>
     );
   }

--- a/packages/theme/src/unified/index.ts
+++ b/packages/theme/src/unified/index.ts
@@ -20,4 +20,4 @@ export type { UnifiedThemeOptions } from './UnifiedTheme';
 export { themes } from './themes';
 export { UnifiedThemeProvider } from './UnifiedThemeProvider';
 export type { UnifiedThemeProviderProps } from './UnifiedThemeProvider';
-export type { UnifiedTheme, SupportedThemes, SupportedVersions } from './types';
+export type { UnifiedTheme, VersionedTheme, SupportedVersions } from './types';

--- a/packages/theme/src/unified/types.ts
+++ b/packages/theme/src/unified/types.ts
@@ -31,7 +31,8 @@ export type SupportedVersions = 'v4' | 'v5';
  *
  * @public
  */
-export type SupportedThemes = Mui4Theme | Mui5Theme;
+export type VersionedTheme<Version extends SupportedVersions> =
+  Version extends 'v4' ? Mui4Theme : Version extends 'v5' ? Mui5Theme : never;
 
 /**
  * A container of one theme for multiple different Material UI versions.
@@ -41,5 +42,10 @@ export type SupportedThemes = Mui4Theme | Mui5Theme;
  * @public
  */
 export interface UnifiedTheme {
-  getTheme(version: SupportedVersions): SupportedThemes | undefined;
+  getTheme<Version extends SupportedVersions>(
+    version: Version,
+  ):
+    | VersionedTheme<Version>
+    | ((outerTheme: VersionedTheme<Version>) => VersionedTheme<Version>)
+    | undefined;
 }


### PR DESCRIPTION
 Allow `UnifiedTheme` to return a theme-provider function as an alternative to a theme-object.

### Background:

We have a component like this:

```typescript
export function CustomPage(props: Props) {
  const { themeId, children } = props;
  const classes = useStyles();
  return (
    <ThemeProvider
      theme={(baseTheme: BackstageTheme) => ({
        ...baseTheme,
        page: baseTheme.getPageTheme({ themeId }),
      })}
    >
      <main className={classes.root}>{children}</main>
    </ThemeProvider>
  );
}
```

wich should be migrated to use `UnifiedThemeProvider` like:

```typescript
export function CustomPage(props: Props) {
  const { themeId, children } = props;
  const classes = useStyles();
  return (
    <UnifiedThemeProvider
      theme={{
        getTheme<Version extends SupportedVersions>() {
          return (baseTheme: VersionedTheme<Version>) => ({
            ...baseTheme,
            page: baseTheme.getPageTheme({ themeId }),
          });
        },
      }}
    >
      <main className={classes.root}>{children}</main>
    </UnifiedThemeProvider>
  );
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
