### PR TITLE
fix(actions): Increase memory for running Snyk monitoring

### DIFF
--- a/.github/workflows/sync_snyk-monitor.yml
+++ b/.github/workflows/sync_snyk-monitor.yml
@@ -30,7 +30,7 @@ jobs:
             --remote-repo-url=https://github.com/backstage/backstage
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=7168
 
       # Above we run the `monitor` command, this runs the `test` command which is
       # the one that generates the SARIF report that we can upload to GitHub.
@@ -45,7 +45,7 @@ jobs:
             --sarif-file-output=snyk.sarif
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=7168
       - name: Upload Snyk report
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I noticed the Sync Snyk Monitoring action has been failing a lot.  Turns out, it can't create the output file (`snyk.sarif`) because it's running out of memory. This isn't blocking because it only runs on `master`, but it's been failing constantly.

<img width="1261" alt="image" src="https://github.com/backstage/backstage/assets/33203301/5efed19a-6d7d-4d67-bb69-d97cfc0692da">

<img width="1486" alt="image" src="https://github.com/backstage/backstage/assets/33203301/2fca071c-528f-4898-b114-ad748b1a9f9e">

Another Snyk action was already bumped to 7168 MB, so I just set this Snyk action to use the same for consistency:

https://github.com/backstage/backstage/blob/f6b10802ff60c1ade8c48cf7dd186ea9eb72a34f/.github/workflows/sync_snyk-github-issues.yml#L37-L39

Snyk's doc recommends this change if you hit the heap errors when calling the CLI:

https://support.snyk.io/hc/en-us/articles/360002046418-JavaScript-heap-out-of-memory

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
