### PR TITLE
chore: Ignore more folders for Uffizi

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, synchronize, reopened, closed]
     paths-ignore:
       - 'microsite/**'
+      - 'storybook/**'
+      - 'contrib/**'
       - '*.md'
 
 jobs:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
When I opened a PR for modifying Storybook (https://github.com/backstage/backstage/pull/19226), I noticed Uffizi fired to deploy the site.

This just adds a few more ignores for when the project won't need an Uffizi build.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
