### PR TITLE
chore(entity-feedback): Improve backend logging if posts fail

### DIFF
--- a/.changeset/few-nails-smile.md
+++ b/.changeset/few-nails-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-feedback': patch
+---
+
+Improve README to identify that Backstage identity is required to be configured

--- a/.changeset/few-nails-smile.md
+++ b/.changeset/few-nails-smile.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-entity-feedback': patch
 ---
 
-Improve README to identify that Backstage identity is required to be configured
+Improve README to note that Backstage identity is required to be configured

--- a/.changeset/poor-years-appear.md
+++ b/.changeset/poor-years-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-feedback-backend': patch
+---
+
+Improve backend logging if method calls fail

--- a/plugins/entity-feedback-backend/README.md
+++ b/plugins/entity-feedback-backend/README.md
@@ -4,6 +4,10 @@ Welcome to the entity-feedback backend plugin!
 
 ## Installation
 
+Note: this plugin requires authentication and identity configured so Backstage can identify
+which user has rated the entity. If you are using the guest identity provider which comes
+out of the box, this plugin will not work when you test it.
+
 ### Install the package
 
 ```bash

--- a/plugins/entity-feedback-backend/src/service/router.ts
+++ b/plugins/entity-feedback-backend/src/service/router.ts
@@ -134,6 +134,9 @@ export async function createRouter(
     const user = await identity.getIdentity({ request: req });
     const rating = req.body.rating;
     if (!user || !rating) {
+      logger.warn(
+        `Can't save rating because there is not enough info: user=${user}, rating=${rating}`,
+      );
       res.status(400).end();
       return;
     }
@@ -188,6 +191,7 @@ export async function createRouter(
     const { response, comments, consent } = req.body;
 
     if (!user) {
+      logger.warn(`Could not identify user to save responses, user=${user}`);
       res.status(400).end();
       return;
     }

--- a/plugins/entity-feedback/README.md
+++ b/plugins/entity-feedback/README.md
@@ -36,7 +36,11 @@ This plugin allows you give and view feedback on entities available in the Backs
 
 ## Setup
 
-The following sections will help you get the Entity Feedback plugin setup and running
+The following sections will help you get the Entity Feedback plugin setup and running.
+
+Note: this plugin requires authentication and identity configured so Backstage can identify
+which user has rated the entity. If you are using the guest identity provider which comes
+out of the box, this plugin will not work when you test it.
 
 ### Backend
 
@@ -133,4 +137,4 @@ const groupPage = (
 );
 ```
 
-Note: For a full example of this you can look at [this EntityPage](../../packages/app/src/components/catalog/EntityPage.tsx)
+Note: For a full example of this you can look at [this EntityPage](../../packages/app/src/components/catalog/EntityPage.tsx).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
The entity feedback plugin requires an authenticated user to be able to save ratings. When it lacks that information, saving responses fails with an HTTP 400 which is caught in the frontend but without user feedback.

In particular, users testing Backstage who have not setup authentication may try this plugin and be unable to identify why if they click thumbs up to like an entity, it immediately fails. This may help with more info in situations like reported in https://github.com/backstage/backstage/issues/19340 and https://github.com/backstage/backstage/issues/16755. (though those error may be different, conceptually users seem to be having problems troubleshooting?)

This PR adds a note to both the frontend and backend READMEs, and adds some warnings to the backend logs to help improve that debugging:

```diff
  [1] 2023-08-16T16:23:59.126Z backstage info ::1 - - [16/Aug/2023:16:23:59 +0000] "POST /api/permission/authorize HTTP/1.1" 200 74 "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" type=incomingRequest
  [1] 2023-08-16T16:23:59.130Z backstage info ::1 - - [16/Aug/2023:16:23:59 +0000] "POST /api/permission/authorize HTTP/1.1" 200 74 "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" type=incomingRequest
+ [1] 2023-08-16T16:24:00.162Z entityFeedback warn Can't save rating because there is not enough info: user=undefined, rating=LIKE type=plugin
  [1] 2023-08-16T16:24:00.162Z backstage info ::1 - - [16/Aug/2023:16:24:00 +0000] "POST /api/entity-feedback/ratings/component%3Adefault%2Fbackstage HTTP/1.1" 400 - "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" type=incomingRequest
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
