### PR TITLE
[CLI] Log duplicates instead of throwing error when doing a version bump

### DIFF
--- a/.changeset/short-planets-argue.md
+++ b/.changeset/short-planets-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+When running `version:bump` it will now log duplicates instead of throwing an error

--- a/packages/cli/src/commands/versions/bump.test.ts
+++ b/packages/cli/src/commands/versions/bump.test.ts
@@ -29,6 +29,7 @@ import { YarnInfoInspectData } from '../../lib/versioning/packages';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import { NotFoundError } from '@backstage/errors';
+import { Lockfile } from '../../lib/versioning/Lockfile';
 
 // Remove log coloring to simplify log matching
 jest.mock('chalk', () => ({
@@ -795,6 +796,33 @@ describe('bump', () => {
   });
 
   it('should log duplicates', async () => {
+    jest.spyOn(Lockfile.prototype, 'analyze').mockReturnValue({
+      invalidRanges: [],
+      newVersions: [],
+      newRanges: [
+        {
+          name: 'first-duplicate',
+          oldRange: 'first-duplicate',
+          newRange: 'first-duplicate',
+          oldVersion: '1.0.0',
+          newVersion: '2.0.0',
+        },
+        {
+          name: 'second-duplicate',
+          oldRange: 'second-duplicate',
+          newRange: 'second-duplicate',
+          oldVersion: '1.0.0',
+          newVersion: '2.0.0',
+        },
+        {
+          name: 'third-duplicate',
+          oldRange: 'third-duplicate',
+          newRange: 'third-duplicate',
+          oldVersion: '1.0.0',
+          newVersion: '2.0.0',
+        },
+      ],
+    });
     mockFs({
       '/yarn.lock': lockfileMock,
       '/package.json': JSON.stringify({
@@ -854,6 +882,7 @@ describe('bump', () => {
       '    https://github.com/backstage/backstage/blob/master/packages/theme/CHANGELOG.md',
       'Version bump complete!',
       'The following packages have duplicates but have been allowed:',
+      'first-duplicate, second-duplicate, third-duplicate',
     ]);
   });
 });

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -314,10 +314,6 @@ export default async (opts: OptionValues) => {
     ),
   });
 
-  if (result.newVersions.length > 0) {
-    throw new Error('Duplicate versions present after package bump');
-  }
-
   const forbiddenNewRanges = result.newRanges.filter(({ name }) =>
     forbiddenDuplicatesFilter(name),
   );
@@ -327,6 +323,19 @@ export default async (opts: OptionValues) => {
         .map(i => i.name)
         .join(', ')}`,
     );
+  }
+
+  const allowedDuplicates = result.newRanges.filter(
+    ({ name }) => !forbiddenDuplicatesFilter(name),
+  );
+
+  if (allowedDuplicates.length > 0) {
+    console.log(
+      chalk.yellow(
+        'The following packages have duplicates but have been allowed:',
+      ),
+    );
+    console.log(chalk.yellow(allowedDuplicates.map(i => i.name).join(', ')));
   }
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When running `version:bump` it will now log duplicates instead of throwing an error

Context: we ran into issues today doing the version bump where we had duplicate packages that should be allowed, more details in this Discord thread: https://discord.com/channels/687207715902193673/1141436702787899402

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
