### PR TITLE
[kubernetes-backend plugin] fix undefined kind for custom resources

### DIFF
--- a/.changeset/nasty-cherries-exercise.md
+++ b/.changeset/nasty-cherries-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+fix "undefined" kind for custom resources

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -65,6 +65,7 @@
     "@backstage/plugin-kubernetes-common": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-permission-node": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@google-cloud/container": "^4.0.0",
     "@jest-mock/express": "^2.0.1",
     "@kubernetes/client-node": "0.18.1",

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -351,6 +351,7 @@ describe('KubernetesFetcher', () => {
           res(
             checkToken(req, ctx, 'token'),
             withLabels(req, ctx, {
+              kind: 'PodList',
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
@@ -359,6 +360,7 @@ describe('KubernetesFetcher', () => {
           res(
             checkToken(req, ctx, 'token'),
             withLabels(req, ctx, {
+              kind: 'ServiceList',
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
@@ -369,6 +371,7 @@ describe('KubernetesFetcher', () => {
             res(
               checkToken(req, ctx, 'token'),
               withLabels(req, ctx, {
+                kind: 'ThingList',
                 items: [{ metadata: { name: 'something-else' } }],
               }),
             ),
@@ -424,6 +427,7 @@ describe('KubernetesFetcher', () => {
             type: 'customresources',
             resources: [
               {
+                kind: 'Thing',
                 metadata: {
                   name: 'something-else',
                   labels: { 'backstage.io/kubernetes-id': 'some-service' },

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -104,9 +104,15 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
           (r: Response): Promise<FetchResult> =>
             r.ok
               ? r.json().then(
-                  ({ items }): FetchResponse => ({
+                  ({ kind, items }): FetchResponse => ({
                     type: objectType,
-                    resources: items,
+                    resources:
+                      objectType === 'customresources'
+                        ? items.map(i => ({
+                            ...i,
+                            kind: kind.replace(/(List)$/, ''),
+                          }))
+                        : items,
                   }),
                 )
               : this.handleUnsuccessfulResponse(params.clusterDetails.name, r),

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -41,6 +41,7 @@ import {
 import fetch, { RequestInit, Response } from 'node-fetch';
 import * as https from 'https';
 import fs from 'fs-extra';
+import { JsonObject } from '@backstage/types';
 
 export interface KubernetesClientBasedFetcherOptions {
   logger: Logger;
@@ -108,8 +109,8 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
                     type: objectType,
                     resources:
                       objectType === 'customresources'
-                        ? items.map(i => ({
-                            ...i,
+                        ? items.map((item: JsonObject) => ({
+                            ...item,
                             kind: kind.replace(/(List)$/, ''),
                           }))
                         : items,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7161,6 +7161,7 @@ __metadata:
     "@backstage/plugin-kubernetes-common": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@google-cloud/container": ^4.0.0
     "@jest-mock/express": ^2.0.1
     "@kubernetes/client-node": 0.18.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #7821

For custom resources, `itemObject.kind` is needed by the frontend (see [here](https://github.com/backstage/backstage/blob/master/plugins/kubernetes/src/components/CustomResources/CustomResources.tsx#L48)). However, it is not returned by the backend. K8s API does return `kind` at the same level as `items`:
```
{
  "kind": "CustomResourceList",
  "apiVersion": "my.domain.io/v1",
  "metadata": {
    "resourceVersion": "6493580294"
  },
  "items": [
    {
      "metadata": { ... },
      "spec": { ... },
      "status": { ... },
    }
  ]
}
```
And according to k8s's [official doc](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds), the name of a list kind must end with "List". This change trims the kind value (without the suffix `List`) and adds it to item object. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Before:

![image](https://github.com/backstage/backstage/assets/106562689/739ebc62-497d-40fd-ae70-80766e5fb181)

After:

![image](https://github.com/backstage/backstage/assets/106562689/e775e6e0-357a-4854-b1ef-10da2be31286)
