### PR TITLE
EntitySwitch render children when entity is not found

### DIFF
--- a/.changeset/dull-tables-joke.md
+++ b/.changeset/dull-tables-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed an issue where `EntitySwitch` was preventing the display of entity errors.

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.test.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.test.tsx
@@ -59,6 +59,50 @@ describe('EntitySwitch', () => {
     expect(screen.queryByText('C')).not.toBeInTheDocument();
   });
 
+  it('should render the default case if entity is not found', () => {
+    const content = (
+      <EntitySwitch>
+        <EntitySwitch.Case if={isKind('component')} children="A" />
+        <EntitySwitch.Case if={isKind('api')} children="B" />
+        <EntitySwitch.Case children="C" />
+      </EntitySwitch>
+    );
+
+    render(
+      <Wrapper>
+        <AsyncEntityProvider entity={undefined} loading={false}>
+          {content}
+        </AsyncEntityProvider>
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).toBeInTheDocument();
+  });
+
+  it(`shouldn't render any children if entity is loading and no entity exists in the context`, () => {
+    const content = (
+      <EntitySwitch>
+        <EntitySwitch.Case if={isKind('component')} children="A" />
+        <EntitySwitch.Case if={isKind('api')} children="B" />
+        <EntitySwitch.Case children="C" />
+      </EntitySwitch>
+    );
+
+    render(
+      <Wrapper>
+        <AsyncEntityProvider entity={undefined} loading>
+          {content}
+        </AsyncEntityProvider>
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+  });
+
   it('should render the fallback if no cases are matching', () => {
     const content = (
       <EntitySwitch>
@@ -170,7 +214,7 @@ describe('EntitySwitch', () => {
 
     expect(screen.queryByText('A')).not.toBeInTheDocument();
     expect(screen.queryByText('B')).not.toBeInTheDocument();
-    expect(screen.queryByText('C')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).toBeInTheDocument();
   });
 
   it('should switch child when filters switch', () => {

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
@@ -64,7 +64,7 @@ export interface EntitySwitchProps {
 
 /** @public */
 export const EntitySwitch = (props: EntitySwitchProps) => {
-  const { entity } = useAsyncEntity();
+  const { entity, loading } = useAsyncEntity();
   const apis = useApiHolder();
 
   const results = useElementFilter(
@@ -77,14 +77,21 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
         })
         .getElements()
         .flatMap<SwitchCaseResult>((element: ReactElement) => {
-          // If the entity is missing or there is an error, render nothing
-          if (!entity) {
+          if (loading && !entity) {
             return [];
           }
 
           const { if: condition, children: elementsChildren } =
             element.props as EntitySwitchCase;
 
+          if (!entity) {
+            return [
+              {
+                if: condition === undefined,
+                children: elementsChildren,
+              },
+            ];
+          }
           return [
             {
               if: condition?.(entity, { apis }),
@@ -92,7 +99,7 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
             },
           ];
         }),
-    [apis, entity],
+    [apis, entity, loading],
   );
 
   const hasAsyncCases = results.some(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR closes #19418 by rendering the children in case an entity is not found.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
