### PR TITLE
[repo-tools] Fix `--dry-run` issue when descriptions aren't sync'd

### DIFF
--- a/.changeset/repo-tools-boo-descriptions.md
+++ b/.changeset/repo-tools-boo-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fixed a bug with the `generate-catalog-info` command that could cause the `--dry-run` flag to indicate changes to files when no changes would actually be made if the command were run without the flag.

--- a/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
@@ -149,9 +149,8 @@ function fixCatalogInfoYaml(options: FixOptions) {
   const badName = yamlJson.metadata.name !== safeName;
   const badType =
     yamlJson.spec?.type !== `backstage-${packageJson.backstage.role}`;
-  const badDesc = yamlJson.metadata.description !== packageJson.description;
 
-  if (badOwner || badTitle || badName || badType || badDesc) {
+  if (badOwner || badTitle || badName || badType) {
     const owner = badOwner
       ? getOwnerFromCodeowners(codeowners, yamlPath)
       : yamlJson.spec?.owner;


### PR DESCRIPTION
## What / Why

The situation: you have a `metadata.description` set in your `catalog-info.yaml` file, but no `description` key set in your `package.json`.

If you run `backstage-repo-tools generate-catalog-info --dry-run`, it will indicate that the `catalog-info.yaml` file will be updated, because the descriptions "differ" (technically).  ...However if you then run the command without the `--dry-run` flag, nothing happens.

This is because the description is optional!  It's used to help seed entity descriptions at seed-time, but neither field is strictly required, and it likely makes sense to allow the values to drift somewhat anyway (one may want a different description for a plugin in one's internal Software Catalog compared with the description published to a package registry).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
