### PR TITLE
linguist-backend: fix config value being required

### DIFF
--- a/.changeset/new-sheep-cover.md
+++ b/.changeset/new-sheep-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-linguist-backend': patch
+---
+
+When creating the router using `createRouterFromConfig` or using the plugin for the new backend system the `linguist.useSourceLocation` configuration is now optional.

--- a/plugins/linguist-backend/src/service/router.ts
+++ b/plugins/linguist-backend/src/service/router.ts
@@ -150,9 +150,8 @@ export async function createRouterFromConfig(routerOptions: RouterOptions) {
       );
     }
     pluginOptions.batchSize = config.getOptionalNumber('linguist.batchSize');
-    pluginOptions.useSourceLocation = config.getBoolean(
-      'linguist.useSourceLocation',
-    );
+    pluginOptions.useSourceLocation =
+      config.getOptionalBoolean('linguist.useSourceLocation') ?? false;
     pluginOptions.age = config.getOptionalConfig('linguist.age') as
       | HumanDuration
       | undefined;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹 , fix for a small migration blip

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
