### PR TITLE
Include auth token when fetching data in code coverage plugin

### DIFF
--- a/.changeset/nice-forks-remain.md
+++ b/.changeset/nice-forks-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage': patch
+---
+
+Include authorization token (if one exists) when fetching code-coverage data

--- a/.changeset/nice-forks-remain.md
+++ b/.changeset/nice-forks-remain.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-code-coverage': patch
 ---
 
-Include authorization token (if one exists) when fetching code-coverage data
+Use fetchApi to ensure authorization is used when fetching code-coverage data

--- a/plugins/code-coverage/src/api.ts
+++ b/plugins/code-coverage/src/api.ts
@@ -48,8 +48,6 @@ export class CodeCoverageRestApi implements CodeCoverageApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly fetchApi: FetchApi;
 
-  private url: string = '';
-
   public constructor(options: {
     discoveryApi: DiscoveryApi;
     fetchApi: FetchApi;
@@ -61,10 +59,8 @@ export class CodeCoverageRestApi implements CodeCoverageApi {
   private async fetch<T = unknown | string | JsonCoverageHistory>(
     path: string,
   ): Promise<T | string> {
-    if (!this.url) {
-      this.url = await this.discoveryApi.getBaseUrl('code-coverage');
-    }
-    const resp = await this.fetchApi.fetch(`${this.url}${path}`);
+    const url = await this.discoveryApi.getBaseUrl('code-coverage');
+    const resp = await this.fetchApi.fetch(`${url}${path}`);
     if (!resp.ok) {
       throw await ResponseError.fromResponse(resp);
     }

--- a/plugins/code-coverage/src/api.ts
+++ b/plugins/code-coverage/src/api.ts
@@ -23,7 +23,7 @@ import { JsonCodeCoverage, JsonCoverageHistory } from './types';
 import {
   createApiRef,
   DiscoveryApi,
-  IdentityApi,
+  FetchApi,
 } from '@backstage/core-plugin-api';
 
 export type CodeCoverageApi = {
@@ -46,16 +46,16 @@ export const codeCoverageApiRef = createApiRef<CodeCoverageApi>({
 
 export class CodeCoverageRestApi implements CodeCoverageApi {
   private readonly discoveryApi: DiscoveryApi;
-  private readonly identityApi: IdentityApi;
+  private readonly fetchApi: FetchApi;
 
   private url: string = '';
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
-    identityApi: IdentityApi;
+    fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
-    this.identityApi = options.identityApi;
+    this.fetchApi = options.fetchApi;
   }
 
   private async fetch<T = unknown | string | JsonCoverageHistory>(
@@ -64,10 +64,7 @@ export class CodeCoverageRestApi implements CodeCoverageApi {
     if (!this.url) {
       this.url = await this.discoveryApi.getBaseUrl('code-coverage');
     }
-    const { token } = await this.identityApi.getCredentials();
-    const resp = await fetch(`${this.url}${path}`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
+    const resp = await this.fetchApi.fetch(`${this.url}${path}`);
     if (!resp.ok) {
       throw await ResponseError.fromResponse(resp);
     }

--- a/plugins/code-coverage/src/plugin.ts
+++ b/plugins/code-coverage/src/plugin.ts
@@ -21,7 +21,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 /**
@@ -35,9 +35,9 @@ export const codeCoveragePlugin = createPlugin({
   apis: [
     createApiFactory({
       api: codeCoverageApiRef,
-      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ discoveryApi, identityApi }) =>
-        new CodeCoverageRestApi({ discoveryApi, identityApi }),
+      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new CodeCoverageRestApi({ discoveryApi, fetchApi }),
     }),
   ],
 });

--- a/plugins/code-coverage/src/plugin.ts
+++ b/plugins/code-coverage/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 /**
@@ -34,8 +35,9 @@ export const codeCoveragePlugin = createPlugin({
   apis: [
     createApiFactory({
       api: codeCoverageApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new CodeCoverageRestApi(discoveryApi),
+      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ discoveryApi, identityApi }) =>
+        new CodeCoverageRestApi({ discoveryApi, identityApi }),
     }),
   ],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We were planning to use the code-coverage plugin at my company and realized that it didn't support authentication middleware since the front end didn't include the authorization token (if one exists). This pull request should fix that, following patterns from other plugins.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
