### PR TITLE
Patch release of #19438 and #19441

### DIFF
--- a/.changeset/dull-tables-joke.md
+++ b/.changeset/dull-tables-joke.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog': patch
----
-
-Fixed an issue where `EntitySwitch` was preventing the display of entity errors.

--- a/.changeset/dull-tables-joke.md
+++ b/.changeset/dull-tables-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed an issue where `EntitySwitch` was preventing the display of entity errors.

--- a/.changeset/lazy-rice-rule.md
+++ b/.changeset/lazy-rice-rule.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder-backend': patch
----
-
-Fixed the plugin and module ID of the alpha `catalogModuleTemplateKind` export.

--- a/.changeset/lazy-rice-rule.md
+++ b/.changeset/lazy-rice-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed the plugin and module ID of the alpha `catalogModuleTemplateKind` export.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.17.0",
+  "version": "1.17.1",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3"

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,19 @@
 # example-app
 
+## 0.2.87
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-api-docs@0.9.8
+  - @internal/plugin-catalog-customized@0.0.14
+  - @backstage/plugin-catalog-graph@0.2.33
+  - @backstage/plugin-explore@0.4.7
+  - @backstage/plugin-org@0.6.11
+  - @backstage/plugin-scaffolder@1.14.2
+  - @backstage/plugin-scaffolder-react@1.5.2
+  - @backstage/plugin-techdocs-module-addons-contrib@1.0.16
+
 ## 0.2.86
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/backend-next/CHANGELOG.md
+++ b/packages/backend-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-backend-next
 
+## 0.0.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-backend@1.16.1
+
 ## 0.0.14
 
 ### Patch Changes

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-next",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-backend
 
+## 0.2.87
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-backend@1.16.1
+
 ## 0.2.86
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # techdocs-cli-embedded-app
 
+## 0.2.86
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.12.2
+
 ## 0.2.85
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/plugins/api-docs/CHANGELOG.md
+++ b/plugins/api-docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-api-docs
 
+## 0.9.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.12.2
+
 ## 0.9.7
 
 ### Patch Changes

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-api-docs",
   "description": "A Backstage plugin that helps represent API entities in the frontend",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bazaar/CHANGELOG.md
+++ b/plugins/bazaar/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-bazaar
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.12.2
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-bazaar",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-customized/CHANGELOG.md
+++ b/plugins/catalog-customized/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @internal/plugin-catalog-customized
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.12.2
+
 ## 0.0.13
 
 ### Patch Changes

--- a/plugins/catalog-customized/package.json
+++ b/plugins/catalog-customized/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internal/plugin-catalog-customized",
   "description": "The internal Backstage Customizable plugin for browsing the Backstage catalog",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog/CHANGELOG.md
+++ b/plugins/catalog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog
 
+## 1.12.2
+
+### Patch Changes
+
+- 6529eec003e1: Fixed an issue where `EntitySwitch` was preventing the display of entity errors.
+
 ## 1.12.1
 
 ### Patch Changes

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog",
   "description": "The Backstage plugin for browsing the Backstage catalog",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.test.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.test.tsx
@@ -59,6 +59,50 @@ describe('EntitySwitch', () => {
     expect(screen.queryByText('C')).not.toBeInTheDocument();
   });
 
+  it('should render the default case if entity is not found', () => {
+    const content = (
+      <EntitySwitch>
+        <EntitySwitch.Case if={isKind('component')} children="A" />
+        <EntitySwitch.Case if={isKind('api')} children="B" />
+        <EntitySwitch.Case children="C" />
+      </EntitySwitch>
+    );
+
+    render(
+      <Wrapper>
+        <AsyncEntityProvider entity={undefined} loading={false}>
+          {content}
+        </AsyncEntityProvider>
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).toBeInTheDocument();
+  });
+
+  it(`shouldn't render any children if entity is loading and no entity exists in the context`, () => {
+    const content = (
+      <EntitySwitch>
+        <EntitySwitch.Case if={isKind('component')} children="A" />
+        <EntitySwitch.Case if={isKind('api')} children="B" />
+        <EntitySwitch.Case children="C" />
+      </EntitySwitch>
+    );
+
+    render(
+      <Wrapper>
+        <AsyncEntityProvider entity={undefined} loading>
+          {content}
+        </AsyncEntityProvider>
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+  });
+
   it('should render the fallback if no cases are matching', () => {
     const content = (
       <EntitySwitch>
@@ -170,7 +214,7 @@ describe('EntitySwitch', () => {
 
     expect(screen.queryByText('A')).not.toBeInTheDocument();
     expect(screen.queryByText('B')).not.toBeInTheDocument();
-    expect(screen.queryByText('C')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).toBeInTheDocument();
   });
 
   it('should switch child when filters switch', () => {

--- a/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
+++ b/plugins/catalog/src/components/EntitySwitch/EntitySwitch.tsx
@@ -64,7 +64,7 @@ export interface EntitySwitchProps {
 
 /** @public */
 export const EntitySwitch = (props: EntitySwitchProps) => {
-  const { entity } = useAsyncEntity();
+  const { entity, loading } = useAsyncEntity();
   const apis = useApiHolder();
 
   const results = useElementFilter(
@@ -77,14 +77,21 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
         })
         .getElements()
         .flatMap<SwitchCaseResult>((element: ReactElement) => {
-          // If the entity is missing or there is an error, render nothing
-          if (!entity) {
+          if (loading && !entity) {
             return [];
           }
 
           const { if: condition, children: elementsChildren } =
             element.props as EntitySwitchCase;
 
+          if (!entity) {
+            return [
+              {
+                if: condition === undefined,
+                children: elementsChildren,
+              },
+            ];
+          }
           return [
             {
               if: condition?.(entity, { apis }),
@@ -92,7 +99,7 @@ export const EntitySwitch = (props: EntitySwitchProps) => {
             },
           ];
         }),
-    [apis, entity],
+    [apis, entity, loading],
   );
 
   const hasAsyncCases = results.some(

--- a/plugins/scaffolder-backend/CHANGELOG.md
+++ b/plugins/scaffolder-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-scaffolder-backend
 
+## 1.16.1
+
+### Patch Changes
+
+- 2ba07bcdb046: Fixed the plugin and module ID of the alpha `catalogModuleTemplateKind` export.
+
 ## 1.16.0
 
 ### Minor Changes

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-backend",
   "description": "The Backstage backend plugin that helps you create new things",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend/src/modules/catalogModuleTemplateKind.ts
+++ b/plugins/scaffolder-backend/src/modules/catalogModuleTemplateKind.ts
@@ -24,8 +24,8 @@ import { ScaffolderEntitiesProcessor } from '../processor';
  * @alpha
  */
 export const catalogModuleTemplateKind = createBackendModule({
-  moduleId: 'scaffolder',
-  pluginId: 'templateKind',
+  moduleId: 'templateKind',
+  pluginId: 'catalog',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/techdocs-addons-test-utils/CHANGELOG.md
+++ b/plugins/techdocs-addons-test-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-techdocs-addons-test-utils
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.12.2
+
 ## 1.0.17
 
 ### Patch Changes

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-addons-test-utils",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This release fixes an issue where the `EntitySwitch` component from `@backstage/plugin-catalog` was preventing the display of entity errors. It also fixes the alpha `catalogModuleTemplateKind` export from `@backstage/plugin-scaffolder-backend`, which had incorrect plugin and module IDs.