### PR TITLE
cli: add backend dev entry point

### DIFF
--- a/.changeset/slow-ducks-hunt.md
+++ b/.changeset/slow-ducks-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added support for the `dev/index` entry point for backend plugins and modules.

--- a/packages/cli/src/commands/start/startBackend.ts
+++ b/packages/cli/src/commands/start/startBackend.ts
@@ -26,7 +26,17 @@ interface StartBackendOptions {
 }
 
 export async function startBackend(options: StartBackendOptions) {
-  if (process.env.EXPERIMENTAL_BACKEND_START) {
+  const hasDev = await fs.pathExists(paths.resolveTarget('dev'));
+  if (hasDev) {
+    const waitForExit = await startBackendExperimental({
+      entry: 'dev/index',
+      checksEnabled: false, // not supported
+      inspectEnabled: options.inspectEnabled,
+      inspectBrkEnabled: options.inspectBrkEnabled,
+    });
+
+    await waitForExit();
+  } else if (process.env.EXPERIMENTAL_BACKEND_START) {
     const waitForExit = await startBackendExperimental({
       entry: 'src/index',
       checksEnabled: false, // not supported


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is intended to replace the existing `run.ts` entry point. Since that one is in `src/` it doesn't work as well with our dep/devDep linting.

Figured this is also a good opportunity to switch over to using the new experimental backend setup by default. Only for this entry point though.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
