### PR TITLE
auth-backend: add plugin export for new backend system

### DIFF
--- a/.changeset/dirty-carrots-notice.md
+++ b/.changeset/dirty-carrots-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added `authPlugin` export for the new backend system. The plugin does not include any built-in auth providers, they must instead be added by installing additional modules, for example `authModuleGoogleProvider` from `@backstage/plugin-auth-backend-module-google-provider`.

--- a/.changeset/mighty-crabs-cheat.md
+++ b/.changeset/mighty-crabs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added the ability to disable the built-in auth providers by passing `disableDefaultProviderFactories` to `createRouter`.

--- a/.changeset/ninety-news-visit.md
+++ b/.changeset/ninety-news-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+The algorithm used when generating Backstage tokens can be configured via `auth.identityTokenAlgorithm`.

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -10,6 +10,7 @@ import { AuthProviderFactory as AuthProviderFactory_2 } from '@backstage/plugin-
 import { AuthProviderRouteHandlers as AuthProviderRouteHandlers_2 } from '@backstage/plugin-auth-node';
 import { AuthResolverCatalogUserQuery as AuthResolverCatalogUserQuery_2 } from '@backstage/plugin-auth-node';
 import { AuthResolverContext as AuthResolverContext_2 } from '@backstage/plugin-auth-node';
+import { BackendFeature } from '@backstage/backend-plugin-api';
 import { BackstageSignInResult } from '@backstage/plugin-auth-node';
 import { CacheService } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -50,6 +51,9 @@ export type AuthHandler<TAuthResult> = (
 export type AuthHandlerResult = {
   profile: ProfileInfo;
 };
+
+// @public
+export const authPlugin: () => BackendFeature;
 
 // @public @deprecated (undocumented)
 export type AuthProviderConfig = AuthProviderConfig_2;
@@ -657,6 +661,8 @@ export interface RouterOptions {
   config: Config;
   // (undocumented)
   database: PluginDatabaseManager;
+  // (undocumented)
+  disableDefaultProviderFactories?: boolean;
   // (undocumented)
   discovery: PluginEndpointDiscovery;
   // (undocumented)

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -31,6 +31,16 @@ export interface Config {
       secret?: string;
     };
 
+    /**
+     * JWS "alg" (Algorithm) Header Parameter value. Defaults to ES256.
+     * Must match one of the algorithms defined for IdentityClient.
+     * When setting a different algorithm, check if the `key` field
+     * of the `signing_keys` table can fit the length of the generated keys.
+     * If not, add a knex migration file in the migrations folder.
+     * More info on supported algorithms: https://github.com/panva/jose
+     */
+    identityTokenAlgorithm?: string;
+
     /** To control how to store JWK data in auth-backend */
     keyStore?: {
       provider?: 'database' | 'memory' | 'firestore';

--- a/plugins/auth-backend/dev/index.ts
+++ b/plugins/auth-backend/dev/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createBackend } from '@backstage/backend-defaults';
+import { authPlugin } from '../src';
+import { authModuleGoogleProvider } from '@backstage/plugin-auth-backend-module-google-provider';
+
+const backend = createBackend();
+
+backend.add(authPlugin);
+backend.add(authModuleGoogleProvider);
+
+backend.start();

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -41,6 +41,7 @@
     "@backstage/plugin-auth-backend-module-gcp-iap-provider": "workspace:^",
     "@backstage/plugin-auth-backend-module-google-provider": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
+    "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "@davidzemon/passport-okta-oauth": "^0.0.5",
     "@google-cloud/firestore": "^6.0.0",
@@ -80,6 +81,7 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/body-parser": "^1.19.0",

--- a/plugins/auth-backend/src/authPlugin.test.ts
+++ b/plugins/auth-backend/src/authPlugin.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import request from 'supertest';
+import { authPlugin } from './authPlugin';
+
+describe('authPlugin', () => {
+  it('should provide an OpenID configuration', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        authPlugin,
+        mockServices.rootConfig.factory({
+          data: {
+            app: {
+              baseUrl: 'http://localhost:3000',
+            },
+          },
+        }),
+      ],
+    });
+
+    const res = await request(server).get(
+      '/api/auth/.well-known/openid-configuration',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      claims_supported: ['sub'],
+      issuer: `http://localhost:${server.port()}/api/auth`,
+    });
+  });
+});

--- a/plugins/auth-backend/src/authPlugin.ts
+++ b/plugins/auth-backend/src/authPlugin.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import {
+  AuthProviderFactory,
+  authProvidersExtensionPoint,
+} from '@backstage/plugin-auth-node';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
+import { createRouter } from './service/router';
+
+/**
+ * Auth plugin
+ *
+ * @public
+ */
+export const authPlugin = createBackendPlugin({
+  pluginId: 'auth',
+  register(reg) {
+    const providers = new Map<string, AuthProviderFactory>();
+
+    reg.registerExtensionPoint(authProvidersExtensionPoint, {
+      registerProvider({ providerId, factory }) {
+        if (providers.has(providerId)) {
+          throw new Error(
+            `Auth provider '${providerId}' was already registered`,
+          );
+        }
+        providers.set(providerId, factory);
+      },
+    });
+
+    reg.registerInit({
+      deps: {
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+        database: coreServices.database,
+        discovery: coreServices.discovery,
+        tokenManager: coreServices.tokenManager,
+        catalogApi: catalogServiceRef,
+      },
+      async init({
+        httpRouter,
+        logger,
+        config,
+        database,
+        discovery,
+        tokenManager,
+        catalogApi,
+      }) {
+        const router = await createRouter({
+          logger,
+          config,
+          database,
+          discovery,
+          tokenManager,
+          catalogApi,
+          providerFactories: Object.fromEntries(providers),
+          disableDefaultProviderFactories: true,
+        });
+        httpRouter.use(router);
+      },
+    });
+  },
+});

--- a/plugins/auth-backend/src/index.ts
+++ b/plugins/auth-backend/src/index.ts
@@ -20,6 +20,7 @@
  * @packageDocumentation
  */
 
+export { authPlugin } from './authPlugin';
 export * from './service/router';
 export type { TokenParams } from './identity';
 export * from './providers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4570,6 +4570,7 @@ __metadata:
   resolution: "@backstage/plugin-auth-backend@workspace:plugins/auth-backend"
   dependencies:
     "@backstage/backend-common": "workspace:^"
+    "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/catalog-client": "workspace:^"
@@ -4580,6 +4581,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-gcp-iap-provider": "workspace:^"
     "@backstage/plugin-auth-backend-module-google-provider": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
+    "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@davidzemon/passport-okta-oauth": ^0.0.5
     "@google-cloud/firestore": ^6.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `authPlugin` export for the auth backend. Since we want to move auth providers to be implemented in separate modules instead the plugin no longer installs all built-in providers by default.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
