### PR TITLE
[repo-tools] the first listed codowner takes precedence for the catalog owner field

### DIFF
--- a/.changeset/twenty-rings-leave.md
+++ b/.changeset/twenty-rings-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': minor
+---
+
+When the script updates owner in catalog-info.yaml, the first listed codeowner will always take precedence

--- a/packages/repo-tools/src/commands/generate-catalog-info/codeowners.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/codeowners.ts
@@ -59,7 +59,7 @@ export function getOwnerFromCodeowners(
 ): string {
   const relPath = relativePath('.', absPath);
   const possibleOwners = getPossibleCodeowners(codeowners, relPath);
-  const owner = possibleOwners.slice(-1)[0];
+  const owner = possibleOwners[0];
 
   if (!owner) {
     throw new Error(`${relPath} isn't owned by anyone in CODEOWNERS`);

--- a/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
@@ -144,7 +144,7 @@ function fixCatalogInfoYaml(options: FixOptions) {
     throw new Error(`Unable to parse ${relativePath('.', yamlPath)}: ${e}`);
   }
 
-  const badOwner = !possibleOwners.includes(yamlJson.spec?.owner);
+  const badOwner = possibleOwners[0] !== yamlJson.spec?.owner; // we want the first codeowner to take precedence
   const badTitle = yamlJson.metadata.title !== packageJson.name;
   const badName = yamlJson.metadata.name !== safeName;
   const badType =


### PR DESCRIPTION
@iamEAP 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
