### PR TITLE
Fix docs token endpoint alb

### DIFF
--- a/contrib/docs/tutorials/aws-alb-aad-oidc-auth.md
+++ b/contrib/docs/tutorials/aws-alb-aad-oidc-auth.md
@@ -29,7 +29,7 @@ In the AWS console, configure ALB Authentication:
 - Select `OIDC` under `Authenticate`
 - Set `Issuer` to `https://login.microsoftonline.com/{TENANT_ID}/v2.0`, replacing `{TENANT_ID}` with the value of `Directory (tenant) ID` of the AAD App.
 - Set `Authorization endpoint` to `https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/authorize`, replacing `{TENANT_ID}` with the value of `Directory (tenant) ID` of the AAD App.
-- Set `Token endpoint` to `https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/authorize`, replacing `{TENANT_ID}` with the value of `Directory (tenant) ID` of the AAD App.
+- Set `Token endpoint` to `https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token`, replacing `{TENANT_ID}` with the value of `Directory (tenant) ID` of the AAD App.
 - Set `User info endpoint` to `https://graph.microsoft.com/oidc/userinfo`
 - Set `Client ID` to the AAD App `Application (client) Id`
 - Set `Client secret` to the AAD APP `client secret`


### PR DESCRIPTION
Small docs update fixing the example token endpoint to point to token instead of authroize

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
