### PR TITLE
fix[core-components] Fix cannot convert undefined or null to object error

### DIFF
--- a/.changeset/eighty-fans-provide.md
+++ b/.changeset/eighty-fans-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix "cannot convert undefined or null to object"

--- a/.changeset/eighty-fans-provide.md
+++ b/.changeset/eighty-fans-provide.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Fix "cannot convert undefined or null to object"
+Fixed an issue causing `StructuredMetadataTable` to crash in case metadata contained `null` values.

--- a/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.test.tsx
+++ b/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.test.tsx
@@ -21,7 +21,7 @@ import { StructuredMetadataTable } from './StructuredMetadataTable';
 
 describe('<StructuredMetadataTable />', () => {
   it('renders without exploding', () => {
-    const metadata = { hello: 'world' };
+    const metadata = { hello: 'world', foo: null };
     const { getByText } = render(
       <StructuredMetadataTable metadata={metadata} />,
     );

--- a/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.tsx
+++ b/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.tsx
@@ -113,7 +113,7 @@ function toValue(
     return <Fragment>{value}</Fragment>;
   }
 
-  if (typeof value === 'object' && !Array.isArray(value)) {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
     return renderMap(value, options, nested);
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix error "Cannot convert undefined or null to object error". The k8s frontend plugin uses `StructuredMetadataTable` component to render accordion details for custom resources, see [code](https://github.com/backstage/backstage/blob/master/plugins/kubernetes/src/components/CustomResources/DefaultCustomResource.tsx#L89). If the `metadata` object in custom resources' data payload contains `null` values, the page explodes and the error `Cannot convert undefined or null to object error` occurs.

Before:

![image](https://github.com/backstage/backstage/assets/106562689/e427a071-1841-478f-b7b5-22475e9b5155)
![image](https://github.com/backstage/backstage/assets/106562689/7d3e7283-d057-4cdc-b4ff-329c9dfd4a7d)

After:

![image](https://github.com/backstage/backstage/assets/106562689/57c47b06-1eda-4557-9b9d-156f002e6ba5)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
