### PR TITLE
[repo-tools] Default created entities to using the first listed `CODEOWNER` as owner

### DIFF
--- a/.changeset/repo-p-lisa.md
+++ b/.changeset/repo-p-lisa.md
@@ -1,0 +1,7 @@
+---
+'@backstage/repo-tools': patch
+---
+
+The `generate-catalog-info` command now uses the first listed `CODEOWNER` as Component owner when initially
+creating the `catalog-info.yaml` file. It continues to allow any one listed `CODEOWNER` when updating
+entity metadata.

--- a/packages/repo-tools/src/commands/generate-catalog-info/codeowners.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/codeowners.ts
@@ -59,7 +59,7 @@ export function getOwnerFromCodeowners(
 ): string {
   const relPath = relativePath('.', absPath);
   const possibleOwners = getPossibleCodeowners(codeowners, relPath);
-  const owner = possibleOwners.slice(-1)[0];
+  const owner = possibleOwners[0];
 
   if (!owner) {
     throw new Error(`${relPath} isn't owned by anyone in CODEOWNERS`);


### PR DESCRIPTION
## What / Why

While experimenting with this command internally, we realized that it's more likely that the average repo's `CODEOWNERS` file will list the primary owner _first_ rather than last.  I had originally went with "last" because it seemed more appropriate in this particular repo, but _generally_, it seems more likely the other way around.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
