### PR TITLE
Improve consistency of results from azure provider

### DIFF
--- a/.changeset/fair-paws-flash.md
+++ b/.changeset/fair-paws-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-azure': patch
+---
+
+Improve consistency of results from the `AzureDevOpsEntityProvider`.

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -34,6 +34,12 @@ describe('azure', () => {
             expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
             expect(req.body).toEqual({
               searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
+              $orderBy: [
+                {
+                  field: 'path',
+                  sortOrder: 'ASC',
+                },
+              ],
               $skip: 0,
               $top: 1000,
             });
@@ -88,6 +94,12 @@ describe('azure', () => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
             searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
+            $orderBy: [
+              {
+                field: 'path',
+                sortOrder: 'ASC',
+              },
+            ],
             $skip: 0,
             $top: 1000,
           });
@@ -132,6 +144,12 @@ describe('azure', () => {
           expect(req.body).toEqual({
             searchText:
               'path:/catalog-info.yaml repo:backstage proj:engineering',
+            $orderBy: [
+              {
+                field: 'path',
+                sortOrder: 'ASC',
+              },
+            ],
             $skip: 0,
             $top: 1000,
           });
@@ -175,6 +193,12 @@ describe('azure', () => {
           expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
           expect(req.body).toEqual({
             searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
+            $orderBy: [
+              {
+                field: 'path',
+                sortOrder: 'ASC',
+              },
+            ],
             $skip: 0,
             $top: 1000,
           });

--- a/plugins/catalog-backend-module-azure/src/lib/azure.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.ts
@@ -64,6 +64,12 @@ export async function codeSearch(
       method: 'POST',
       body: JSON.stringify({
         searchText: `path:${path} repo:${repo || '*'} proj:${project || '*'}`,
+        $orderBy: [
+          {
+            field: 'path',
+            sortOrder: 'ASC',
+          },
+        ],
         $skip: items.length,
         $top: PAGE_SIZE,
       }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improve consistency of results from azure provider

The search feature does not produce consistent results across api pages. This seems to be more likely if the pages are sorted by search score (which is the default).

This changes the sort order based on each result's file name, in order to make the pages a little bit more consistent as the search index in azure changes. The sort order is more likely to be consistent using the file name.

Here is a graph showing the entity counts before and after then fix

<img width="924" alt="image" src="https://github.com/backstage/backstage/assets/553697/51869cf5-34bc-4967-9f19-5867ce4fd8a2">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
