### PR TITLE
Add `catalog-info.yaml` for project area-owned packages

### DIFF
--- a/packages/techdocs-cli-embedded-app/catalog-info.yaml
+++ b/packages/techdocs-cli-embedded-app/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: techdocs-cli-embedded-app
+  title: techdocs-cli-embedded-app
+spec:
+  lifecycle: production
+  type: backstage-frontend
+  owner: techdocs-maintainers

--- a/packages/techdocs-cli/catalog-info.yaml
+++ b/packages/techdocs-cli/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: techdocs-cli
+  title: '@techdocs/cli'
+  description: Utility CLI for managing TechDocs sites in Backstage.
+spec:
+  lifecycle: production
+  type: backstage-cli
+  owner: techdocs-maintainers

--- a/plugins/catalog-backend-module-azure/catalog-info.yaml
+++ b/plugins/catalog-backend-module-azure/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-azure
+  title: '@backstage/plugin-catalog-backend-module-azure'
+  description: A Backstage catalog backend module that helps integrate towards Azure
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-bitbucket-server/catalog-info.yaml
+++ b/plugins/catalog-backend-module-bitbucket-server/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-bitbucket-server
+  title: '@backstage/plugin-catalog-backend-module-bitbucket-server'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-bitbucket/catalog-info.yaml
+++ b/plugins/catalog-backend-module-bitbucket/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-bitbucket
+  title: '@backstage/plugin-catalog-backend-module-bitbucket'
+  description: A Backstage catalog backend module that helps integrate towards Bitbucket
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-gcp/catalog-info.yaml
+++ b/plugins/catalog-backend-module-gcp/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-gcp
+  title: '@backstage/plugin-catalog-backend-module-gcp'
+  description: A Backstage catalog backend module that helps integrate towards GCP
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-gerrit/catalog-info.yaml
+++ b/plugins/catalog-backend-module-gerrit/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-gerrit
+  title: '@backstage/plugin-catalog-backend-module-gerrit'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-github/catalog-info.yaml
+++ b/plugins/catalog-backend-module-github/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-github
+  title: '@backstage/plugin-catalog-backend-module-github'
+  description: A Backstage catalog backend module that helps integrate towards GitHub
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-gitlab/catalog-info.yaml
+++ b/plugins/catalog-backend-module-gitlab/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-gitlab
+  title: '@backstage/plugin-catalog-backend-module-gitlab'
+  description: A Backstage catalog backend module that helps integrate towards GitLab
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-incremental-ingestion/catalog-info.yaml
+++ b/plugins/catalog-backend-module-incremental-ingestion/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-incremental-ingestion
+  title: '@backstage/plugin-catalog-backend-module-incremental-ingestion'
+  description: An entity provider for streaming large asset sources into the catalog
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-ldap/catalog-info.yaml
+++ b/plugins/catalog-backend-module-ldap/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-ldap
+  title: '@backstage/plugin-catalog-backend-module-ldap'
+  description: A Backstage catalog backend module that helps integrate towards LDAP
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-openapi/catalog-info.yaml
+++ b/plugins/catalog-backend-module-openapi/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-openapi
+  title: '@backstage/plugin-catalog-backend-module-openapi'
+  description: A Backstage catalog backend module that helps with OpenAPI specifications
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend-module-unprocessed/catalog-info.yaml
+++ b/plugins/catalog-backend-module-unprocessed/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-unprocessed
+  title: '@backstage/plugin-catalog-backend-module-unprocessed'
+  description: Backstage Catalog module to view unprocessed entities
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-backend/catalog-info.yaml
+++ b/plugins/catalog-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend
+  title: '@backstage/plugin-catalog-backend'
+  description: The Backstage backend plugin that provides the Backstage catalog
+spec:
+  lifecycle: production
+  type: backstage-backend-plugin
+  owner: catalog-maintainers

--- a/plugins/catalog-common/catalog-info.yaml
+++ b/plugins/catalog-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-common
+  title: '@backstage/plugin-catalog-common'
+  description: Common functionalities for the catalog plugin
+spec:
+  lifecycle: production
+  type: backstage-common-library
+  owner: catalog-maintainers

--- a/plugins/catalog-customized/catalog-info.yaml
+++ b/plugins/catalog-customized/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: internal-plugin-catalog-customized
+  title: '@internal/plugin-catalog-customized'
+  description: >-
+    The internal Backstage Customizable plugin for browsing the Backstage
+    catalog
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: catalog-maintainers

--- a/plugins/catalog-graphql/catalog-info.yaml
+++ b/plugins/catalog-graphql/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-graphql
+  title: '@backstage/plugin-catalog-graphql'
+  description: An experimental Backstage catalog GraphQL module
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: catalog-maintainers

--- a/plugins/catalog-import/catalog-info.yaml
+++ b/plugins/catalog-import/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-import
+  title: '@backstage/plugin-catalog-import'
+  description: A Backstage plugin the helps you import entities into your catalog
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: catalog-maintainers

--- a/plugins/catalog-node/catalog-info.yaml
+++ b/plugins/catalog-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-node
+  title: '@backstage/plugin-catalog-node'
+  description: The plugin-catalog-node module for @backstage/plugin-catalog-backend
+spec:
+  lifecycle: production
+  type: backstage-node-library
+  owner: catalog-maintainers

--- a/plugins/catalog-react/catalog-info.yaml
+++ b/plugins/catalog-react/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-react
+  title: '@backstage/plugin-catalog-react'
+  description: >-
+    A frontend library that helps other Backstage plugins interact with the
+    catalog
+spec:
+  lifecycle: production
+  type: backstage-web-library
+  owner: catalog-maintainers

--- a/plugins/catalog-unprocessed-entities/catalog-info.yaml
+++ b/plugins/catalog-unprocessed-entities/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-unprocessed-entities
+  title: '@backstage/plugin-catalog-unprocessed-entities'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: catalog-maintainers

--- a/plugins/catalog/catalog-info.yaml
+++ b/plugins/catalog/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog
+  title: '@backstage/plugin-catalog'
+  description: The Backstage plugin for browsing the Backstage catalog
+spec:
+  lifecycle: production
+  type: backstage-frontend-plugin
+  owner: catalog-maintainers

--- a/plugins/home-react/catalog-info.yaml
+++ b/plugins/home-react/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-home-react
+  title: '@backstage/plugin-home-react'
+  description: >-
+    A Backstage plugin that contains react components helps you build a home
+    page
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: discoverability-maintainers

--- a/plugins/home/catalog-info.yaml
+++ b/plugins/home/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-home
+  title: '@backstage/plugin-home'
+  description: A Backstage plugin that helps you build a home page
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: discoverability-maintainers

--- a/plugins/kubernetes-backend/catalog-info.yaml
+++ b/plugins/kubernetes-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-kubernetes-backend
+  title: '@backstage/plugin-kubernetes-backend'
+  description: A Backstage backend plugin that integrates towards Kubernetes
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: kubernetes-maintainers

--- a/plugins/kubernetes-common/catalog-info.yaml
+++ b/plugins/kubernetes-common/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-kubernetes-common
+  title: '@backstage/plugin-kubernetes-common'
+  description: >-
+    Common functionalities for kubernetes, to be shared between kubernetes and
+    kubernetes-backend plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: kubernetes-maintainers

--- a/plugins/kubernetes/catalog-info.yaml
+++ b/plugins/kubernetes/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-kubernetes
+  title: '@backstage/plugin-kubernetes'
+  description: A Backstage plugin that integrates towards Kubernetes
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: kubernetes-maintainers

--- a/plugins/permission-backend/catalog-info.yaml
+++ b/plugins/permission-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-permission-backend
+  title: '@backstage/plugin-permission-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: permission-maintainers

--- a/plugins/permission-common/catalog-info.yaml
+++ b/plugins/permission-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-permission-common
+  title: '@backstage/plugin-permission-common'
+  description: Isomorphic types and client for Backstage permissions and authorization
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: permission-maintainers

--- a/plugins/permission-node/catalog-info.yaml
+++ b/plugins/permission-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-permission-node
+  title: '@backstage/plugin-permission-node'
+  description: Common permission and authorization utilities for backend plugins
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: permission-maintainers

--- a/plugins/permission-react/catalog-info.yaml
+++ b/plugins/permission-react/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-permission-react
+  title: '@backstage/plugin-permission-react'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: permission-maintainers

--- a/plugins/search-backend-module-catalog/catalog-info.yaml
+++ b/plugins/search-backend-module-catalog/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend-module-catalog
+  title: '@backstage/plugin-search-backend-module-catalog'
+  description: A module for the search backend that exports catalog modules
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: discoverability-maintainers

--- a/plugins/search-backend-module-elasticsearch/catalog-info.yaml
+++ b/plugins/search-backend-module-elasticsearch/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend-module-elasticsearch
+  title: '@backstage/plugin-search-backend-module-elasticsearch'
+  description: A module for the search backend that implements search using ElasticSearch
+spec:
+  lifecycle: production
+  type: backstage-backend-plugin-module
+  owner: discoverability-maintainers

--- a/plugins/search-backend-module-explore/catalog-info.yaml
+++ b/plugins/search-backend-module-explore/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend-module-explore
+  title: '@backstage/plugin-search-backend-module-explore'
+  description: A module for the search backend that exports explore modules
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: discoverability-maintainers

--- a/plugins/search-backend-module-pg/catalog-info.yaml
+++ b/plugins/search-backend-module-pg/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend-module-pg
+  title: '@backstage/plugin-search-backend-module-pg'
+  description: A module for the search backend that implements search using PostgreSQL
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: discoverability-maintainers

--- a/plugins/search-backend-module-techdocs/catalog-info.yaml
+++ b/plugins/search-backend-module-techdocs/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend-module-techdocs
+  title: '@backstage/plugin-search-backend-module-techdocs'
+  description: A module for the search backend that exports techdocs modules
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: discoverability-maintainers

--- a/plugins/search-backend-node/catalog-info.yaml
+++ b/plugins/search-backend-node/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend-node
+  title: '@backstage/plugin-search-backend-node'
+  description: >-
+    A library for Backstage backend plugins that want to interact with the
+    search backend plugin
+spec:
+  lifecycle: production
+  type: backstage-node-library
+  owner: discoverability-maintainers

--- a/plugins/search-backend/catalog-info.yaml
+++ b/plugins/search-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-backend
+  title: '@backstage/plugin-search-backend'
+  description: The Backstage backend plugin that provides your backstage app with search
+spec:
+  lifecycle: production
+  type: backstage-backend-plugin
+  owner: discoverability-maintainers

--- a/plugins/search-common/catalog-info.yaml
+++ b/plugins/search-common/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-common
+  title: '@backstage/plugin-search-common'
+  description: >-
+    Common functionalities for Search, to be shared between various
+    search-enabled plugins
+spec:
+  lifecycle: production
+  type: backstage-common-library
+  owner: discoverability-maintainers

--- a/plugins/search-react/catalog-info.yaml
+++ b/plugins/search-react/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search-react
+  title: '@backstage/plugin-search-react'
+spec:
+  lifecycle: production
+  type: backstage-web-library
+  owner: discoverability-maintainers

--- a/plugins/search/catalog-info.yaml
+++ b/plugins/search/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-search
+  title: '@backstage/plugin-search'
+  description: The Backstage plugin that provides your backstage app with search
+spec:
+  lifecycle: production
+  type: backstage-frontend-plugin
+  owner: discoverability-maintainers

--- a/plugins/techdocs-addons-test-utils/catalog-info.yaml
+++ b/plugins/techdocs-addons-test-utils/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-techdocs-addons-test-utils
+  title: '@backstage/plugin-techdocs-addons-test-utils'
+spec:
+  lifecycle: production
+  type: backstage-web-library
+  owner: techdocs-maintainers

--- a/plugins/techdocs-backend/catalog-info.yaml
+++ b/plugins/techdocs-backend/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-techdocs-backend
+  title: '@backstage/plugin-techdocs-backend'
+  description: >-
+    The Backstage backend plugin that renders technical documentation for your
+    components
+spec:
+  lifecycle: production
+  type: backstage-backend-plugin
+  owner: techdocs-maintainers

--- a/plugins/techdocs-module-addons-contrib/catalog-info.yaml
+++ b/plugins/techdocs-module-addons-contrib/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-techdocs-module-addons-contrib
+  title: '@backstage/plugin-techdocs-module-addons-contrib'
+  description: Plugin module for contributed TechDocs Addons
+spec:
+  lifecycle: production
+  type: backstage-frontend-plugin-module
+  owner: techdocs-maintainers

--- a/plugins/techdocs-node/catalog-info.yaml
+++ b/plugins/techdocs-node/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-techdocs-node
+  title: '@backstage/plugin-techdocs-node'
+  description: >-
+    Common node.js functionalities for TechDocs, to be shared between
+    techdocs-backend plugin and techdocs-cli
+spec:
+  lifecycle: production
+  type: backstage-node-library
+  owner: techdocs-maintainers

--- a/plugins/techdocs-react/catalog-info.yaml
+++ b/plugins/techdocs-react/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-techdocs-react
+  title: '@backstage/plugin-techdocs-react'
+  description: Shared frontend utilities for TechDocs and Addons
+spec:
+  lifecycle: production
+  type: backstage-web-library
+  owner: techdocs-maintainers

--- a/plugins/techdocs/catalog-info.yaml
+++ b/plugins/techdocs/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-techdocs
+  title: '@backstage/plugin-techdocs'
+  description: >-
+    The Backstage plugin that renders technical documentation for your
+    components
+spec:
+  lifecycle: production
+  type: backstage-frontend-plugin
+  owner: techdocs-maintainers


### PR DESCRIPTION
## What / Why

This is a follow-up to https://github.com/backstage/backstage/pull/18354, which adds minimal `catalog-info.yaml` files for just the packages that are definitively owned by project areas (to keep the reviewers list short 😅 ).

The aim of these files, at least initially, is to better catalog (:smile:) these packages in something like a demo Backstage instance.  ...These files are not guaranteed to remain in the repo!  Do not rely on their existence.

I will open up additional PRs for
- Maintainer-owned packages
- Packages with other ownership claims
- Eventual automation for maintaining these files

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
