### PR TITLE
Gerrit: Gitiles auth-links could still be broken.

### DIFF
--- a/.changeset/grumpy-papayas-tie.md
+++ b/.changeset/grumpy-papayas-tie.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Gerrit: Gitiles auth-links could still be broken
+Additional fix for Gitiles auth links

--- a/packages/integration/src/gerrit/core.test.ts
+++ b/packages/integration/src/gerrit/core.test.ts
@@ -90,11 +90,21 @@ describe('gerrit core', () => {
         'https://gerrit.com/gerrit/a/plugins/gitiles/repo/+archive/refs/heads/dev/docs.tar.gz',
       );
     });
-    it('can create an authenticated url when auth is enabled and an url-path + slash is used', () => {
+    it('Cannot build an authenticated url when a dedicated Gitiles server is used', () => {
       const authConfig = {
         ...configWithDedicatedGitiles,
         username: 'username',
         password: 'password',
+      };
+      expect(() =>
+        buildGerritGitilesArchiveUrl(authConfig, 'repo', 'dev', 'docs'),
+      ).toThrow(
+        'Since the baseUrl (Gerrit) is not part of the gitilesBaseUrl, an authentication URL could not be constructed.',
+      );
+    });
+    it('Build a non-authenticated url when a dedicated Gitiles server is used', () => {
+      const authConfig = {
+        ...configWithDedicatedGitiles,
       };
       expect(
         buildGerritGitilesArchiveUrl(authConfig, 'repo', 'dev', 'docs'),

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { logger } from '@azure/identity';
 import { trimStart } from 'lodash';
 import { GerritIntegrationConfig } from './config';
 
@@ -169,7 +167,7 @@ export function getGitilesAuthenticationUrl(
     );
   }
   if (config.password) {
-    logger.warning(
+    throw new Error(
       'Since the baseUrl (Gerrit) is not part of the gitilesBaseUrl, an authentication URL could not be constructed.',
     );
   }


### PR DESCRIPTION
This change includes a much more robust way to insert the /a/-
prefix in the correct place.

We now check that gitiles-files are actually served from the
Gerrit-server and if so, the authentication prefix is inserted after
Gerrit's baseUrl.

Signed-off-by: Gustaf Lundh <gustaf.lundh@axis.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
