### PR TITLE
color change for like and dislike icons in entity feedback

### DIFF
--- a/.changeset/purple-cats-drive.md
+++ b/.changeset/purple-cats-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-feedback': patch
+---
+
+Color change for like and dislike icons

--- a/plugins/entity-feedback/src/components/LikeDislikeButtons/LikeDislikeButtons.tsx
+++ b/plugins/entity-feedback/src/components/LikeDislikeButtons/LikeDislikeButtons.tsx
@@ -127,9 +127,9 @@ export const LikeDislikeButtons = (props: LikeDislikeButtonsProps) => {
         onClick={() => applyRating(FeedbackRatings.like)}
       >
         {rating === FeedbackRatings.like ? (
-          <ThumbUpIcon fontSize="small" />
+          <ThumbUpIcon fontSize="small" color="primary" />
         ) : (
-          <ThumbUpOutlinedIcon fontSize="small" />
+          <ThumbUpOutlinedIcon fontSize="small" color="primary" />
         )}
       </IconButton>
       <IconButton
@@ -137,9 +137,9 @@ export const LikeDislikeButtons = (props: LikeDislikeButtonsProps) => {
         onClick={() => applyRating(FeedbackRatings.dislike)}
       >
         {rating === FeedbackRatings.dislike ? (
-          <ThumbDownIcon fontSize="small" />
+          <ThumbDownIcon fontSize="small" color="secondary" />
         ) : (
-          <ThumbDownOutlinedIcon fontSize="small" />
+          <ThumbDownOutlinedIcon fontSize="small" color="secondary" />
         )}
       </IconButton>
       <FeedbackResponseDialog


### PR DESCRIPTION
## Hey, I just made a Pull Request!

 Added colors for like dislike icons so that it will cover user attention more.
     
![image](https://github.com/backstage/backstage/assets/133481507/972faae3-4b6b-473e-80b2-ef91e6f35b39)

![image](https://github.com/backstage/backstage/assets/133481507/9bc51ded-c1f1-4136-90f0-b2901e16d394)

![image](https://github.com/backstage/backstage/assets/133481507/232653fc-e4fa-4023-88c1-0d8d79adbfe5)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
