### PR TITLE
delete popup added for entity delete action when user delete entity by unregister entity

### DIFF
--- a/.changeset/gorgeous-coins-attack.md
+++ b/.changeset/gorgeous-coins-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Added delete alert popup when user delete the entity

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
@@ -48,6 +48,10 @@ describe('UnregisterEntityDialog', () => {
     },
   };
 
+  beforeEach(() => {
+    jest.spyOn(alertApi, 'post').mockImplementation(() => {});
+  });
+
   const entity = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Component',
@@ -346,6 +350,11 @@ describe('UnregisterEntityDialog', () => {
     await waitFor(() => {
       expect(deleteEntity).toHaveBeenCalled();
       expect(onConfirm).toHaveBeenCalled();
+      expect(alertApi.post).toHaveBeenCalledWith({
+        message: 'Removed entity n',
+        severity: 'success',
+        display: 'transient',
+      });
     });
   });
 });

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -85,17 +85,10 @@ const Contents = ({
         setBusy(true);
         try {
           await state.deleteEntity();
-          const entityNames = [entity]
-            .flat()
-            .map(item => item.metadata.title ?? item.metadata.name);
+          const entityName = entity.metadata.title ?? entity.metadata.name;
           onConfirm();
-          const message =
-            entityNames.length === 1
-              ? `Removed entity ${entityNames[0]}`
-              : `Removed entities: ${entityNames.join("', '")}`;
-
           alertApi.post({
-            message,
+            message: `Removed entity ${entityName}`,
             severity: 'success',
             display: 'transient',
           });

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -85,7 +85,21 @@ const Contents = ({
         setBusy(true);
         try {
           await state.deleteEntity();
+          const entityArray = [entity].flat();
+          const entityNames = entityArray.map(
+            item => item.metadata.title ?? item.metadata.name,
+          );
           onConfirm();
+          const message =
+            entityNames.length === 1
+              ? `Removed entity '${entityNames[0]}'`
+              : `Removed entities: '${entityNames.join("', '")}'`;
+
+          alertApi.post({
+            message,
+            severity: 'success',
+            display: 'transient',
+          });
         } catch (err) {
           assertError(err);
           alertApi.post({ message: err.message });
@@ -94,7 +108,7 @@ const Contents = ({
         }
       }
     },
-    [alertApi, onConfirm, state],
+    [alertApi, onConfirm, state, entity],
   );
 
   const DialogActionsPanel = () => (

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -85,15 +85,14 @@ const Contents = ({
         setBusy(true);
         try {
           await state.deleteEntity();
-          const entityArray = [entity].flat();
-          const entityNames = entityArray.map(
-            item => item.metadata.title ?? item.metadata.name,
-          );
+          const entityNames = [entity]
+            .flat()
+            .map(item => item.metadata.title ?? item.metadata.name);
           onConfirm();
           const message =
             entityNames.length === 1
-              ? `Removed entity '${entityNames[0]}'`
-              : `Removed entities: '${entityNames.join("', '")}'`;
+              ? `Removed entity ${entityNames[0]}`
+              : `Removed entities: ${entityNames.join("', '")}`;
 
           alertApi.post({
             message,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
delete popup added for entity delete action when user delete entity by unregister entity

![image](https://github.com/backstage/backstage/assets/133481507/ee1584c5-d322-4362-a078-15f3cb349801)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
