### PR TITLE
Update integrating-plugin-into-software-catalog.md

### DIFF
--- a/docs/plugins/integrating-plugin-into-software-catalog.md
+++ b/docs/plugins/integrating-plugin-into-software-catalog.md
@@ -37,7 +37,7 @@ You can access the currently selected entity using the backstage api
 import { useEntity } from '@backstage/plugin-catalog-react';
 
 export const MyPluginEntityContent = () => {
-  const { entity, loading, error, refresh } = useEntity();
+  const entity = useEntity();
 
   // Do something with the entity data...
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I updated the documentation for plugin development: I corrected the example code for useEntity() (current code of the function at https://github.com/backstage/backstage/blob/278994148b4056470c93bca227d910d01037f1b6/plugins/catalog-react/src/hooks/useEntity.tsx#L107). It only returns an Entity by now and no loading/error values anymore (changed from v0.71.0 to v1.0.0).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] _A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))_ => Only documentation was updated, so changeset not needed.
- [x] Added or updated documentation
- [x] _Tests for new functionality and regression tests for bug fixes_  => Only documentation was updated, so not tests needed
- [x] _Screenshots attached (for UI changes)_ => Only documentation was updated, so no UI screenshots.
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

#### Notes
I hope the signed-off-by message generated by GitHub itself is acceptable, otherwise I can redo the changes on my PC and reprovide them with a proper signed-off-by message.

**Please check if entity = useEntity() or { entity } = useEntity() is more common and feel free to adopt the change accordingly.**