### PR TITLE
Change styling in banner

### DIFF
--- a/.changeset/sweet-geese-wink.md
+++ b/.changeset/sweet-geese-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Update background color used in the palette for `info` banners

--- a/packages/theme/src/base/palettes.ts
+++ b/packages/theme/src/base/palettes.ts
@@ -49,7 +49,7 @@ export const palettes = {
       main: '#1F5493',
     },
     banner: {
-      info: '#2E77D0',
+      info: '#348FCB',
       error: '#E22134',
       text: '#FFFFFF',
       link: '#000000',
@@ -123,7 +123,7 @@ export const palettes = {
       main: '#FF88B2',
     },
     banner: {
-      info: '#2E77D0',
+      info: '#348FCB',
       error: '#E22134',
       text: '#FFFFFF',
       link: '#000000',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change allows the info banner to have a lighter background, which improves the readability for the link.

This is how it looked like before:

![Screenshot from 2023-08-22 15-58-39](https://github.com/backstage/backstage/assets/49096359/308cdbf9-a584-4a50-bb86-4f2b890fee79)

This is how it would look like now:

![Screenshot from 2023-08-22 15-58-28](https://github.com/backstage/backstage/assets/49096359/e1434936-375b-4e05-b85d-cde3edef7679)

I believe this new background color is nicer when the text is black. But feel free to suggest another color instead.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
