### PR TITLE
Patch release of #19488, #19510, #19495

### DIFF
--- a/.changeset/catalog-everybody-to-the-limit.md
+++ b/.changeset/catalog-everybody-to-the-limit.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend': patch
----
-
-Fix to the `limit` parameter on entity queries.

--- a/.changeset/catalog-everybody-to-the-limit.md
+++ b/.changeset/catalog-everybody-to-the-limit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix to the `limit` parameter on entity queries.

--- a/.changeset/four-masks-fry.md
+++ b/.changeset/four-masks-fry.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend': patch
----
-
-Update OpenAPI schema to relax the encoding validation of all request parameters.

--- a/.changeset/four-masks-fry.md
+++ b/.changeset/four-masks-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Update OpenAPI schema to relax the encoding validation of all request parameters.

--- a/.changeset/grumpy-papayas-tie.md
+++ b/.changeset/grumpy-papayas-tie.md
@@ -1,5 +1,0 @@
----
-'@backstage/integration': patch
----
-
-Additional fix for Gitiles auth links

--- a/.changeset/grumpy-papayas-tie.md
+++ b/.changeset/grumpy-papayas-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Additional fix for Gitiles auth links

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.17.2",
+  "version": "1.17.3",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3"

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,80 @@
 # example-app
 
+## 0.2.89
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.22.12
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-import@0.9.13
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/plugin-github-actions@0.6.4
+  - @backstage/plugin-scaffolder@1.14.4
+  - @backstage/plugin-techdocs@1.6.8
+  - @backstage/plugin-techdocs-module-addons-contrib@1.0.18
+  - @backstage/app-defaults@1.4.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-app-api@1.9.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-adr@0.6.6
+  - @backstage/plugin-airbrake@0.3.23
+  - @backstage/plugin-apache-airflow@0.2.14
+  - @backstage/plugin-api-docs@0.9.10
+  - @backstage/plugin-azure-devops@0.3.5
+  - @backstage/plugin-azure-sites@0.1.12
+  - @backstage/plugin-badges@0.2.47
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-catalog-graph@0.2.35
+  - @backstage/plugin-catalog-unprocessed-entities@0.1.2
+  - @backstage/plugin-circleci@0.3.23
+  - @backstage/plugin-cloudbuild@0.3.23
+  - @backstage/plugin-code-coverage@0.2.16
+  - @backstage/plugin-cost-insights@0.12.12
+  - @backstage/plugin-devtools@0.1.3
+  - @backstage/plugin-dynatrace@7.0.3
+  - @backstage/plugin-entity-feedback@0.2.6
+  - @backstage/plugin-explore@0.4.9
+  - @backstage/plugin-gcalendar@0.3.17
+  - @backstage/plugin-gcp-projects@0.3.40
+  - @backstage/plugin-gocd@0.1.29
+  - @backstage/plugin-graphiql@0.2.53
+  - @backstage/plugin-home@0.5.7
+  - @backstage/plugin-jenkins@0.8.5
+  - @backstage/plugin-kafka@0.3.23
+  - @backstage/plugin-kubernetes@0.10.2
+  - @backstage/plugin-lighthouse@0.4.8
+  - @backstage/plugin-linguist@0.1.8
+  - @backstage/plugin-linguist-common@0.1.1
+  - @backstage/plugin-microsoft-calendar@0.1.6
+  - @backstage/plugin-newrelic@0.3.39
+  - @backstage/plugin-newrelic-dashboard@0.2.16
+  - @backstage/plugin-nomad@0.1.4
+  - @backstage/plugin-octopus-deploy@0.2.5
+  - @backstage/plugin-org@0.6.13
+  - @backstage/plugin-pagerduty@0.6.4
+  - @backstage/plugin-permission-react@0.4.14
+  - @backstage/plugin-playlist@0.1.15
+  - @backstage/plugin-puppetdb@0.1.6
+  - @backstage/plugin-rollbar@0.4.23
+  - @backstage/plugin-scaffolder-react@1.5.4
+  - @backstage/plugin-search@1.3.6
+  - @backstage/plugin-search-common@1.2.5
+  - @backstage/plugin-search-react@1.6.4
+  - @backstage/plugin-sentry@0.5.8
+  - @backstage/plugin-shortcuts@0.3.13
+  - @backstage/plugin-stack-overflow@0.1.19
+  - @backstage/plugin-stackstorm@0.1.5
+  - @backstage/plugin-tech-insights@0.3.15
+  - @backstage/plugin-tech-radar@0.6.7
+  - @backstage/plugin-techdocs-react@1.1.9
+  - @backstage/plugin-todo@0.2.25
+  - @backstage/plugin-user-settings@0.7.8
+  - @internal/plugin-catalog-customized@0.0.16
+
 ## 0.2.88
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/backend-app-api/CHANGELOG.md
+++ b/packages/backend-app-api/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/backend-app-api
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/cli-common@0.1.12
+  - @backstage/cli-node@0.1.3
+  - @backstage/config@1.0.8
+  - @backstage/config-loader@1.4.0
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-app-api",
   "description": "Core API used by Backstage backend apps",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-common/CHANGELOG.md
+++ b/packages/backend-common/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/backend-common
 
+## 0.19.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-app-api@0.5.2
+  - @backstage/backend-dev-utils@0.1.1
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/cli-common@0.1.12
+  - @backstage/config@1.0.8
+  - @backstage/config-loader@1.4.0
+  - @backstage/errors@1.2.1
+  - @backstage/integration-aws-node@0.1.5
+  - @backstage/types@1.1.0
+
 ## 0.19.3
 
 ### Patch Changes

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-common",
   "description": "Common functionality library for Backstage backends",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-defaults/CHANGELOG.md
+++ b/packages/backend-defaults/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/backend-defaults
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-app-api@0.5.2
+  - @backstage/backend-plugin-api@0.6.2
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-defaults",
   "description": "Backend defaults used by Backstage backend apps",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-next/CHANGELOG.md
+++ b/packages/backend-next/CHANGELOG.md
@@ -1,5 +1,38 @@
 # example-backend-next
 
+## 0.0.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.12.2
+  - @backstage/plugin-scaffolder-backend@1.16.3
+  - @backstage/plugin-adr-backend@0.3.8
+  - @backstage/plugin-techdocs-backend@1.6.7
+  - @backstage/plugin-todo-backend@0.2.2
+  - @backstage/backend-defaults@0.2.2
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-app-backend@0.3.50
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-azure-devops-backend@0.3.29
+  - @backstage/plugin-badges-backend@0.2.5
+  - @backstage/plugin-devtools-backend@0.1.5
+  - @backstage/plugin-entity-feedback-backend@0.1.8
+  - @backstage/plugin-kubernetes-backend@0.11.5
+  - @backstage/plugin-lighthouse-backend@0.2.6
+  - @backstage/plugin-linguist-backend@0.4.2
+  - @backstage/plugin-permission-backend@0.5.25
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/plugin-proxy-backend@0.3.2
+  - @backstage/plugin-search-backend@1.4.2
+  - @backstage/plugin-search-backend-module-catalog@0.1.6
+  - @backstage/plugin-search-backend-module-explore@0.1.6
+  - @backstage/plugin-search-backend-module-techdocs@0.1.6
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.2.2
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-next",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/backend-plugin-api/CHANGELOG.md
+++ b/packages/backend-plugin-api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/backend-plugin-api
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-plugin-api",
   "description": "Core API used by Backstage backend plugins",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-tasks/CHANGELOG.md
+++ b/packages/backend-tasks/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/backend-tasks
 
+## 0.5.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/backend-tasks/package.json
+++ b/packages/backend-tasks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-tasks",
   "description": "Common distributed task management library for Backstage backends",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-test-utils/CHANGELOG.md
+++ b/packages/backend-test-utils/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/backend-test-utils
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-app-api@0.5.2
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/backend-test-utils/package.json
+++ b/packages/backend-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-test-utils",
   "description": "Test helpers library for Backstage backends",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,60 @@
 # example-backend
 
+## 0.2.89
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.12.2
+  - @backstage/integration@1.6.2
+  - @backstage/plugin-scaffolder-backend@1.16.3
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-adr-backend@0.3.8
+  - @backstage/plugin-code-coverage-backend@0.2.16
+  - @backstage/plugin-scaffolder-backend-module-confluence-to-markdown@0.2.3
+  - @backstage/plugin-scaffolder-backend-module-rails@0.4.19
+  - @backstage/plugin-techdocs-backend@1.6.7
+  - @backstage/plugin-todo-backend@0.2.2
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-app-backend@0.3.50
+  - @backstage/plugin-auth-backend@0.18.8
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-azure-devops-backend@0.3.29
+  - @backstage/plugin-azure-sites-backend@0.1.12
+  - @backstage/plugin-badges-backend@0.2.5
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/plugin-devtools-backend@0.1.5
+  - @backstage/plugin-entity-feedback-backend@0.1.8
+  - @backstage/plugin-events-backend@0.2.11
+  - @backstage/plugin-explore-backend@0.0.12
+  - @backstage/plugin-graphql-backend@0.1.40
+  - @backstage/plugin-jenkins-backend@0.2.5
+  - @backstage/plugin-kafka-backend@0.2.43
+  - @backstage/plugin-kubernetes-backend@0.11.5
+  - @backstage/plugin-lighthouse-backend@0.2.6
+  - @backstage/plugin-linguist-backend@0.4.2
+  - @backstage/plugin-nomad-backend@0.1.4
+  - @backstage/plugin-permission-backend@0.5.25
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/plugin-playlist-backend@0.3.6
+  - @backstage/plugin-proxy-backend@0.3.2
+  - @backstage/plugin-rollbar-backend@0.1.47
+  - @backstage/plugin-search-backend@1.4.2
+  - @backstage/plugin-search-backend-module-elasticsearch@1.3.5
+  - @backstage/plugin-search-backend-module-pg@0.5.11
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/plugin-tech-insights-backend@0.5.16
+  - @backstage/plugin-tech-insights-backend-module-jsonfc@0.1.34
+  - @backstage/plugin-tech-insights-node@0.4.8
+  - example-app@0.2.89
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.2.2
+  - @backstage/plugin-events-node@0.2.11
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.2.88
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/cli
 
+## 0.22.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/cli-common@0.1.12
+  - @backstage/cli-node@0.1.3
+  - @backstage/config@1.0.8
+  - @backstage/config-loader@1.4.0
+  - @backstage/errors@1.2.1
+  - @backstage/eslint-plugin@0.1.3
+  - @backstage/release-manifests@0.0.9
+  - @backstage/types@1.1.0
+
 ## 0.22.11
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/dev-utils/CHANGELOG.md
+++ b/packages/dev-utils/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/dev-utils
 
+## 1.0.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/app-defaults@1.4.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-app-api@1.9.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/test-utils@1.4.2
+  - @backstage/theme@0.4.1
+
 ## 1.0.19
 
 ### Patch Changes

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/dev-utils",
   "description": "Utilities for developing Backstage plugins.",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",

--- a/packages/integration-react/CHANGELOG.md
+++ b/packages/integration-react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/integration-react
 
+## 1.1.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 1.1.17
 
 ### Patch Changes

--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/integration-react",
   "description": "Frontend package for managing integrations towards external systems",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/integration/CHANGELOG.md
+++ b/packages/integration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/integration
 
+## 1.6.2
+
+### Patch Changes
+
+- cf196443d8da: Additional fix for Gitiles auth links
+- Updated dependencies
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 1.6.1
 
 ### Patch Changes

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/integration",
   "description": "Helpers for managing integrations towards external systems",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { trimStart } from 'lodash';
 import { GerritIntegrationConfig } from './config';
 
@@ -156,14 +155,23 @@ export function getAuthenticationPrefix(
 export function getGitilesAuthenticationUrl(
   config: GerritIntegrationConfig,
 ): string {
-  const parsedUrl = new URL(config.gitilesBaseUrl!);
-  parsedUrl.pathname = parsedUrl.pathname.replace(/\/?$/, '');
-  parsedUrl.pathname = parsedUrl.pathname.replace(
-    /\/([^\/]*)$/,
-    `${getAuthenticationPrefix(config)}$1`,
-  );
-
-  return parsedUrl.toString();
+  if (!config.baseUrl || !config.gitilesBaseUrl) {
+    throw new Error(
+      'Unexpected Gerrit config values. baseUrl or gitilesBaseUrl not set.',
+    );
+  }
+  if (config.gitilesBaseUrl.startsWith(config.baseUrl)) {
+    return config.gitilesBaseUrl.replace(
+      config.baseUrl.concat('/'),
+      config.baseUrl.concat(getAuthenticationPrefix(config)),
+    );
+  }
+  if (config.password) {
+    throw new Error(
+      'Since the baseUrl (Gerrit) is not part of the gitilesBaseUrl, an authentication URL could not be constructed.',
+    );
+  }
+  return config.gitilesBaseUrl!;
 }
 
 /**

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,24 @@
 # techdocs-cli-embedded-app
 
+## 0.2.88
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.22.12
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-techdocs@1.6.8
+  - @backstage/app-defaults@1.4.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-app-api@1.9.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/test-utils@1.4.2
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-catalog@1.12.4
+  - @backstage/plugin-techdocs-react@1.1.9
+
 ## 0.2.87
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.87",
+  "version": "0.2.88",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/techdocs-cli/CHANGELOG.md
+++ b/packages/techdocs-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @techdocs/cli
 
+## 1.4.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-techdocs-node@1.7.6
+  - @backstage/catalog-model@1.4.1
+  - @backstage/cli-common@0.1.12
+  - @backstage/config@1.0.8
+
 ## 1.4.6
 
 ### Patch Changes

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@techdocs/cli",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/adr-backend/CHANGELOG.md
+++ b/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-adr-backend
 
+## 0.3.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-adr-common@0.2.14
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.3.7
 
 ### Patch Changes

--- a/plugins/adr-backend/package.json
+++ b/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-adr-backend",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/adr-common/CHANGELOG.md
+++ b/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-adr-common
 
+## 0.2.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.2.13
 
 ### Patch Changes

--- a/plugins/adr-common/package.json
+++ b/plugins/adr-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-adr-common",
   "description": "Common functionalities for the adr plugin",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/adr/CHANGELOG.md
+++ b/plugins/adr/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-adr
 
+## 0.6.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-adr-common@0.2.14
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-search-common@1.2.5
+  - @backstage/plugin-search-react@1.6.4
+
 ## 0.6.5
 
 ### Patch Changes

--- a/plugins/adr/package.json
+++ b/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-adr",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/airbrake-backend/CHANGELOG.md
+++ b/plugins/airbrake-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-airbrake-backend
 
+## 0.2.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+
 ## 0.2.22
 
 ### Patch Changes

--- a/plugins/airbrake-backend/package.json
+++ b/plugins/airbrake-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-airbrake-backend",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/airbrake/CHANGELOG.md
+++ b/plugins/airbrake/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-airbrake
 
+## 0.3.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/dev-utils@1.0.20
+  - @backstage/test-utils@1.4.2
+  - @backstage/theme@0.4.1
+
 ## 0.3.22
 
 ### Patch Changes

--- a/plugins/airbrake/package.json
+++ b/plugins/airbrake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-airbrake",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/allure/CHANGELOG.md
+++ b/plugins/allure/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-allure
 
+## 0.1.39
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.1.38
 
 ### Patch Changes

--- a/plugins/allure/package.json
+++ b/plugins/allure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-allure",
   "description": "A Backstage plugin that integrates with Allure",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/api-docs/CHANGELOG.md
+++ b/plugins/api-docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-api-docs
 
+## 0.9.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-catalog@1.12.4
+
 ## 0.9.9
 
 ### Patch Changes

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-api-docs",
   "description": "A Backstage plugin that helps represent API entities in the frontend",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/app-backend/CHANGELOG.md
+++ b/plugins/app-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-app-backend
 
+## 0.3.50
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/config-loader@1.4.0
+  - @backstage/types@1.1.0
+  - @backstage/plugin-app-node@0.1.2
+
 ## 0.3.49
 
 ### Patch Changes

--- a/plugins/app-backend/package.json
+++ b/plugins/app-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-app-backend",
   "description": "A Backstage backend plugin that serves the Backstage frontend app",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/app-node/CHANGELOG.md
+++ b/plugins/app-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-app-node
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/plugins/app-node/package.json
+++ b/plugins/app-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-app-node",
   "description": "Node.js library for the app plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend/CHANGELOG.md
+++ b/plugins/auth-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-auth-backend
 
+## 0.18.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.18.7
 
 ### Patch Changes

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-auth-backend",
   "description": "A Backstage backend plugin that handles authentication",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-node/CHANGELOG.md
+++ b/plugins/auth-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-auth-node
 
+## 0.2.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.18
 
 ### Patch Changes

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-node",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-devops-backend/CHANGELOG.md
+++ b/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-azure-devops-backend
 
+## 0.3.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-azure-devops-common@0.3.0
+
 ## 0.3.28
 
 ### Patch Changes

--- a/plugins/azure-devops-backend/package.json
+++ b/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-devops-backend",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-devops/CHANGELOG.md
+++ b/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-azure-devops
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-azure-devops-common@0.3.0
+
 ## 0.3.4
 
 ### Patch Changes

--- a/plugins/azure-devops/package.json
+++ b/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-devops",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-sites-backend/CHANGELOG.md
+++ b/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-azure-sites-backend
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/plugin-azure-sites-common@0.1.0
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/azure-sites-backend/package.json
+++ b/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-sites-backend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-sites/CHANGELOG.md
+++ b/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-azure-sites
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-azure-sites-common@0.1.0
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/azure-sites/package.json
+++ b/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-sites",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/badges-backend/CHANGELOG.md
+++ b/plugins/badges-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-badges-backend
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/badges-backend/package.json
+++ b/plugins/badges-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-badges-backend",
   "description": "A Backstage backend plugin that generates README badges for your entities",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/badges/CHANGELOG.md
+++ b/plugins/badges/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-badges
 
+## 0.2.47
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.2.46
 
 ### Patch Changes

--- a/plugins/badges/package.json
+++ b/plugins/badges/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-badges",
   "description": "A Backstage plugin that generates README badges for your entities",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bazaar-backend/CHANGELOG.md
+++ b/plugins/bazaar-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-bazaar-backend
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/bazaar-backend/package.json
+++ b/plugins/bazaar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-bazaar-backend",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bazaar/CHANGELOG.md
+++ b/plugins/bazaar/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-bazaar
 
+## 0.2.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.22.12
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-catalog@1.12.4
+
 ## 0.2.14
 
 ### Patch Changes

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-bazaar",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bitbucket-cloud-common/CHANGELOG.md
+++ b/plugins/bitbucket-cloud-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-bitbucket-cloud-common
 
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+
 ## 0.2.10
 
 ### Patch Changes

--- a/plugins/bitbucket-cloud-common/package.json
+++ b/plugins/bitbucket-cloud-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-bitbucket-cloud-common",
   "description": "Common functionalities for bitbucket-cloud plugins",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bitrise/CHANGELOG.md
+++ b/plugins/bitrise/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-bitrise
 
+## 0.1.50
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.1.49
 
 ### Patch Changes

--- a/plugins/bitrise/package.json
+++ b/plugins/bitrise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-bitrise",
   "description": "A Backstage plugin that integrates towards Bitrise",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-aws/CHANGELOG.md
+++ b/plugins/catalog-backend-module-aws/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-catalog-backend-module-aws
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/integration-aws-node@0.1.5
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-kubernetes-common@0.6.5
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-aws",
   "description": "A Backstage catalog backend module that helps integrate towards AWS",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-azure/CHANGELOG.md
+++ b/plugins/catalog-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-catalog-backend-module-azure
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-azure/package.json
+++ b/plugins/catalog-backend-module-azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-azure",
   "description": "A Backstage catalog backend module that helps integrate towards Azure",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-cloud
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-bitbucket-cloud-common@0.2.11
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.16
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-bitbucket-cloud/package.json
+++ b/plugins/catalog-backend-module-bitbucket-cloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-cloud",
   "description": "A Backstage catalog backend module that helps integrate towards Bitbucket Cloud",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-bitbucket-server/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-server/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-server
 
+## 0.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.1.14
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-bitbucket-server/package.json
+++ b/plugins/catalog-backend-module-bitbucket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-server",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-bitbucket/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-catalog-backend-module-bitbucket
 
+## 0.2.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-bitbucket-cloud-common@0.2.11
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.2.16
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-bitbucket/package.json
+++ b/plugins/catalog-backend-module-bitbucket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket",
   "description": "A Backstage catalog backend module that helps integrate towards Bitbucket",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "deprecated": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/catalog-backend-module-gcp/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gcp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-catalog-backend-module-gcp
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-kubernetes-common@0.6.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gcp/package.json
+++ b/plugins/catalog-backend-module-gcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gcp",
   "description": "A Backstage catalog backend module that helps integrate towards GCP",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-catalog-backend-module-gerrit
 
+## 0.1.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.1.17
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gerrit/package.json
+++ b/plugins/catalog-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gerrit",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.12.2
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.3.4
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-catalog-backend-module-gitlab
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.2.5
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab",
   "description": "A Backstage catalog backend module that helps integrate towards GitLab",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-catalog-backend-module-incremental-ingestion
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.12.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-events-node@0.2.11
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.4.2
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-incremental-ingestion",
   "description": "An entity provider for streaming large asset sources into the catalog",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-ldap/CHANGELOG.md
+++ b/plugins/catalog-backend-module-ldap/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-catalog-backend-module-ldap
 
+## 0.5.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 0.5.16
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-ldap/package.json
+++ b/plugins/catalog-backend-module-ldap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-ldap",
   "description": "A Backstage catalog backend module that helps integrate towards LDAP",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-msgraph/CHANGELOG.md
+++ b/plugins/catalog-backend-module-msgraph/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-catalog-backend-module-msgraph
 
+## 0.5.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 0.5.8
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-msgraph/package.json
+++ b/plugins/catalog-backend-module-msgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-msgraph",
   "description": "A Backstage catalog backend module that helps integrate towards Microsoft Graph",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-openapi/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-catalog-backend-module-openapi
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.12.2
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 0.1.15
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-openapi",
   "description": "A Backstage catalog backend module that helps with OpenAPI specifications",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-puppetdb/CHANGELOG.md
+++ b/plugins/catalog-backend-module-puppetdb/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-catalog-backend-module-puppetdb
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-puppetdb/package.json
+++ b/plugins/catalog-backend-module-puppetdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-puppetdb",
   "description": "A Backstage catalog backend module that helps integrate towards PuppetDB",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-unprocessed/CHANGELOG.md
+++ b/plugins/catalog-backend-module-unprocessed/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-unprocessed
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-unprocessed",
   "description": "Backstage Catalog module to view unprocessed entities",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @backstage/plugin-catalog-backend
 
+## 1.12.2
+
+### Patch Changes
+
+- 97655cdf891f: Fix to the `limit` parameter on entity queries.
+- be5c0f4b7744: Update OpenAPI schema to relax the encoding validation of all request parameters.
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/plugin-search-backend-module-catalog@0.1.6
+  - @backstage/backend-openapi-utils@0.0.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-events-node@0.2.11
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-scaffolder-common@1.4.0
+  - @backstage/plugin-search-common@1.2.5
+
 ## 1.12.1
 
 ### Patch Changes

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend/src/schema/openapi.generated.ts
+++ b/plugins/catalog-backend/src/schema/openapi.generated.ts
@@ -144,7 +144,7 @@ export const spec = {
         allowReserved: true,
         schema: {
           type: 'integer',
-          minimum: 1,
+          minimum: 0,
         },
       },
       orderField: {

--- a/plugins/catalog-backend/src/schema/openapi.generated.ts
+++ b/plugins/catalog-backend/src/schema/openapi.generated.ts
@@ -45,6 +45,7 @@ export const spec = {
         name: 'kind',
         in: 'path',
         required: true,
+        allowReserved: true,
         schema: {
           type: 'string',
         },
@@ -53,6 +54,7 @@ export const spec = {
         name: 'namespace',
         in: 'path',
         required: true,
+        allowReserved: true,
         schema: {
           type: 'string',
         },
@@ -61,6 +63,7 @@ export const spec = {
         name: 'name',
         in: 'path',
         required: true,
+        allowReserved: true,
         schema: {
           type: 'string',
         },
@@ -69,6 +72,7 @@ export const spec = {
         name: 'uid',
         in: 'path',
         required: true,
+        allowReserved: true,
         schema: {
           type: 'string',
         },
@@ -78,6 +82,7 @@ export const spec = {
         in: 'query',
         description: 'Cursor to a set page of results.',
         required: false,
+        allowReserved: true,
         schema: {
           type: 'string',
           minLength: 1,
@@ -88,6 +93,7 @@ export const spec = {
         in: 'query',
         description: 'Pointer to the previous page of results.',
         required: false,
+        allowReserved: true,
         schema: {
           type: 'string',
           minLength: 1,
@@ -111,6 +117,7 @@ export const spec = {
         in: 'query',
         description: 'Filter for just the entities defined by this filter.',
         required: false,
+        allowReserved: true,
         schema: {
           type: 'array',
           items: {
@@ -123,6 +130,7 @@ export const spec = {
         in: 'query',
         description: 'Number of records to skip in the query page.',
         required: false,
+        allowReserved: true,
         schema: {
           type: 'integer',
           minimum: 0,
@@ -133,6 +141,7 @@ export const spec = {
         in: 'query',
         description: 'Number of records to return in the response.',
         required: false,
+        allowReserved: true,
         schema: {
           type: 'integer',
           minimum: 1,
@@ -1037,6 +1046,7 @@ export const spec = {
             in: 'query',
             description: 'Text search term.',
             required: false,
+            allowReserved: true,
             schema: {
               type: 'string',
             },
@@ -1047,6 +1057,7 @@ export const spec = {
             description:
               'A comma separated list of fields to sort returned results by.',
             required: false,
+            allowReserved: true,
             schema: {
               type: 'array',
               items: {
@@ -1086,6 +1097,7 @@ export const spec = {
             in: 'query',
             name: 'facet',
             required: true,
+            allowReserved: true,
             schema: {
               type: 'array',
               items: {
@@ -1141,6 +1153,7 @@ export const spec = {
             in: 'query',
             name: 'dryRun',
             required: false,
+            allowReserved: true,
             schema: {
               type: 'string',
             },
@@ -1226,6 +1239,7 @@ export const spec = {
             in: 'path',
             name: 'id',
             required: true,
+            allowReserved: true,
             schema: {
               type: 'string',
             },
@@ -1251,6 +1265,7 @@ export const spec = {
             in: 'path',
             name: 'id',
             required: true,
+            allowReserved: true,
             schema: {
               type: 'string',
             },

--- a/plugins/catalog-backend/src/schema/openapi.yaml
+++ b/plugins/catalog-backend/src/schema/openapi.yaml
@@ -99,7 +99,7 @@ components:
       allowReserved: true
       schema:
         type: integer
-        minimum: 1
+        minimum: 0
     orderField:
       name: orderField
       in: query

--- a/plugins/catalog-backend/src/schema/openapi.yaml
+++ b/plugins/catalog-backend/src/schema/openapi.yaml
@@ -20,24 +20,28 @@ components:
       name: kind
       in: path
       required: true
+      allowReserved: true
       schema:
         type: string
     namespace:
       name: namespace
       in: path
       required: true
+      allowReserved: true
       schema:
         type: string
     name:
       name: name
       in: path
       required: true
+      allowReserved: true
       schema:
         type: string
     uid:
       name: uid
       in: path
       required: true
+      allowReserved: true
       schema:
         type: string
     cursor:
@@ -45,6 +49,7 @@ components:
       in: query
       description: Cursor to a set page of results.
       required: false
+      allowReserved: true
       schema:
         type: string
         minLength: 1
@@ -53,6 +58,7 @@ components:
       in: query
       description: Pointer to the previous page of results.
       required: false
+      allowReserved: true
       schema:
         type: string
         minLength: 1
@@ -71,6 +77,7 @@ components:
       in: query
       description: Filter for just the entities defined by this filter.
       required: false
+      allowReserved: true
       schema:
         type: array
         items:
@@ -80,6 +87,7 @@ components:
       in: query
       description: Number of records to skip in the query page.
       required: false
+      allowReserved: true
       schema:
         type: integer
         minimum: 0
@@ -88,6 +96,7 @@ components:
       in: query
       description: Number of records to return in the response.
       required: false
+      allowReserved: true
       schema:
         type: integer
         minimum: 1
@@ -788,12 +797,14 @@ paths:
           in: query
           description: Text search term.
           required: false
+          allowReserved: true
           schema:
             type: string
         - name: fullTextFilterFields
           in: query
           description: A comma separated list of fields to sort returned results by.
           required: false
+          allowReserved: true
           schema:
             type: array
             items:
@@ -818,6 +829,7 @@ paths:
         - in: query
           name: facet
           required: true
+          allowReserved: true
           schema:
             type: array
             items:
@@ -853,6 +865,7 @@ paths:
         - in: query
           name: dryRun
           required: false
+          allowReserved: true
           schema:
             type: string
       requestBody:
@@ -908,6 +921,7 @@ paths:
         - in: path
           name: id
           required: true
+          allowReserved: true
           schema:
             type: string
     delete:
@@ -923,6 +937,7 @@ paths:
         - in: path
           name: id
           required: true
+          allowReserved: true
           schema:
             type: string
   /analyze-location:

--- a/plugins/catalog-customized/CHANGELOG.md
+++ b/plugins/catalog-customized/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @internal/plugin-catalog-customized
 
+## 0.0.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/plugin-catalog@1.12.4
+
 ## 0.0.15
 
 ### Patch Changes

--- a/plugins/catalog-customized/package.json
+++ b/plugins/catalog-customized/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internal/plugin-catalog-customized",
   "description": "The internal Backstage Customizable plugin for browsing the Backstage catalog",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-graph/CHANGELOG.md
+++ b/plugins/catalog-graph/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-catalog-graph
 
+## 0.2.35
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+
 ## 0.2.34
 
 ### Patch Changes

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-graph",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-import/CHANGELOG.md
+++ b/plugins/catalog-import/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-catalog-import
 
+## 0.9.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 0.9.12
 
 ### Patch Changes

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-import",
   "description": "A Backstage plugin the helps you import entities into your catalog",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-node/CHANGELOG.md
+++ b/plugins/catalog-node/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-catalog-node
 
+## 1.4.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 1.4.2
 
 ### Patch Changes

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-node",
   "description": "The plugin-catalog-node module for @backstage/plugin-catalog-backend",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-react/CHANGELOG.md
+++ b/plugins/catalog-react/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-catalog-react
 
+## 1.8.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+  - @backstage/version-bridge@1.0.4
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-permission-react@0.4.14
+
 ## 1.8.2
 
 ### Patch Changes

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-react",
   "description": "A frontend library that helps other Backstage plugins interact with the catalog",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog/CHANGELOG.md
+++ b/plugins/catalog/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @backstage/plugin-catalog
 
+## 1.12.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-scaffolder-common@1.4.0
+  - @backstage/plugin-search-common@1.2.5
+  - @backstage/plugin-search-react@1.6.4
+
 ## 1.12.3
 
 ### Patch Changes

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog",
   "description": "The Backstage plugin for browsing the Backstage catalog",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-cicd-statistics-module-gitlab
 
+## 0.1.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/plugin-cicd-statistics@0.1.25
+
 ## 0.1.18
 
 ### Patch Changes

--- a/plugins/cicd-statistics-module-gitlab/package.json
+++ b/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cicd-statistics-module-gitlab",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cicd-statistics/CHANGELOG.md
+++ b/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-cicd-statistics
 
+## 0.1.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-plugin-api@1.5.3
+
 ## 0.1.24
 
 ### Patch Changes

--- a/plugins/cicd-statistics/package.json
+++ b/plugins/cicd-statistics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cicd-statistics",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/circleci/CHANGELOG.md
+++ b/plugins/circleci/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-circleci
 
+## 0.3.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.3.22
 
 ### Patch Changes

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-circleci",
   "description": "A Backstage plugin that integrates towards Circle CI",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cloudbuild/CHANGELOG.md
+++ b/plugins/cloudbuild/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-cloudbuild
 
+## 0.3.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.3.22
 
 ### Patch Changes

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cloudbuild",
   "description": "A Backstage plugin that integrates towards Google Cloud Build",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/code-climate/CHANGELOG.md
+++ b/plugins/code-climate/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-code-climate
 
+## 0.1.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.1.22
 
 ### Patch Changes

--- a/plugins/code-climate/package.json
+++ b/plugins/code-climate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-code-climate",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/code-coverage-backend/CHANGELOG.md
+++ b/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-code-coverage-backend
 
+## 0.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.15
 
 ### Patch Changes

--- a/plugins/code-coverage-backend/package.json
+++ b/plugins/code-coverage-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-code-coverage-backend",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/code-coverage/CHANGELOG.md
+++ b/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-code-coverage
 
+## 0.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.2.15
 
 ### Patch Changes

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cost-insights/CHANGELOG.md
+++ b/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-cost-insights
 
+## 0.12.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-cost-insights-common@0.1.1
+
 ## 0.12.11
 
 ### Patch Changes

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cost-insights",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/devtools-backend/CHANGELOG.md
+++ b/plugins/devtools-backend/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-devtools-backend
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/cli-common@0.1.12
+  - @backstage/config@1.0.8
+  - @backstage/config-loader@1.4.0
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-devtools-common@0.1.3
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.1.4
 
 ### Patch Changes

--- a/plugins/devtools-backend/package.json
+++ b/plugins/devtools-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-devtools-backend",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/dynatrace/CHANGELOG.md
+++ b/plugins/dynatrace/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-dynatrace
 
+## 7.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 7.0.2
 
 ### Patch Changes

--- a/plugins/dynatrace/package.json
+++ b/plugins/dynatrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-dynatrace",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-entity-feedback-backend
 
+## 0.1.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/plugin-entity-feedback-common@0.1.2
+
 ## 0.1.7
 
 ### Patch Changes

--- a/plugins/entity-feedback-backend/package.json
+++ b/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-entity-feedback-backend",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/entity-feedback/CHANGELOG.md
+++ b/plugins/entity-feedback/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-entity-feedback
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-entity-feedback-common@0.1.2
+
 ## 0.2.5
 
 ### Patch Changes

--- a/plugins/entity-feedback/package.json
+++ b/plugins/entity-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-entity-feedback",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/entity-validation/CHANGELOG.md
+++ b/plugins/entity-validation/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-entity-validation
 
+## 0.1.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-catalog-common@1.0.15
+
 ## 0.1.7
 
 ### Patch Changes

--- a/plugins/entity-validation/package.json
+++ b/plugins/entity-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-entity-validation",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-module-aws-sqs/CHANGELOG.md
+++ b/plugins/events-backend-module-aws-sqs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-events-backend-module-aws-sqs
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/events-backend-module-aws-sqs/package.json
+++ b/plugins/events-backend-module-aws-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-aws-sqs",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-module-azure/CHANGELOG.md
+++ b/plugins/events-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-azure
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/events-backend-module-azure/package.json
+++ b/plugins/events-backend-module-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-azure",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/events-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-bitbucket-cloud
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/events-backend-module-bitbucket-cloud/package.json
+++ b/plugins/events-backend-module-bitbucket-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-bitbucket-cloud",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/events-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-gerrit
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/events-backend-module-gerrit/package.json
+++ b/plugins/events-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-gerrit",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-module-github/CHANGELOG.md
+++ b/plugins/events-backend-module-github/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-events-backend-module-github
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/events-backend-module-github/package.json
+++ b/plugins/events-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-github",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/events-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-events-backend-module-gitlab
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/events-backend-module-gitlab/package.json
+++ b/plugins/events-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-gitlab",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend-test-utils/CHANGELOG.md
+++ b/plugins/events-backend-test-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-events-backend-test-utils
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/events-backend-test-utils/package.json
+++ b/plugins/events-backend-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-events-backend-test-utils",
   "description": "The plugin-events-backend-test-utils for @backstage/plugin-events-node",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend/CHANGELOG.md
+++ b/plugins/events-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-events-backend
 
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-events-node@0.2.11
+
 ## 0.2.10
 
 ### Patch Changes

--- a/plugins/events-backend/package.json
+++ b/plugins/events-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-node/CHANGELOG.md
+++ b/plugins/events-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-events-node
 
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.2
+
 ## 0.2.10
 
 ### Patch Changes

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-events-node",
   "description": "The plugin-events-node module for @backstage/plugin-events-backend",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/example-todo-list-backend/CHANGELOG.md
+++ b/plugins/example-todo-list-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @internal/plugin-todo-list-backend
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 1.0.17
 
 ### Patch Changes

--- a/plugins/example-todo-list-backend/package.json
+++ b/plugins/example-todo-list-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/plugin-todo-list-backend",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/explore-backend/CHANGELOG.md
+++ b/plugins/explore-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-explore-backend
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-search-backend-module-explore@0.1.6
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+  - @backstage/plugin-explore-common@0.0.1
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.0.11
 
 ### Patch Changes

--- a/plugins/explore-backend/package.json
+++ b/plugins/explore-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-explore-backend",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/explore/CHANGELOG.md
+++ b/plugins/explore/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-explore
 
+## 0.4.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-explore-common@0.0.1
+  - @backstage/plugin-explore-react@0.0.30
+  - @backstage/plugin-search-common@1.2.5
+  - @backstage/plugin-search-react@1.6.4
+
 ## 0.4.8
 
 ### Patch Changes

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-explore",
   "description": "A Backstage plugin for building an exploration page of your software ecosystem",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/firehydrant/CHANGELOG.md
+++ b/plugins/firehydrant/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-firehydrant
 
+## 0.2.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.2.6
 
 ### Patch Changes

--- a/plugins/firehydrant/package.json
+++ b/plugins/firehydrant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-firehydrant",
   "description": "A Backstage plugin that integrates towards FireHydrant",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/fossa/CHANGELOG.md
+++ b/plugins/fossa/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-fossa
 
+## 0.2.55
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.2.54
 
 ### Patch Changes

--- a/plugins/fossa/package.json
+++ b/plugins/fossa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-fossa",
   "description": "A Backstage plugin that integrates towards FOSSA",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/git-release-manager/CHANGELOG.md
+++ b/plugins/git-release-manager/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-git-release-manager
 
+## 0.3.36
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.3.35
 
 ### Patch Changes

--- a/plugins/git-release-manager/package.json
+++ b/plugins/git-release-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-git-release-manager",
   "description": "A Backstage plugin that helps you manage releases in git",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-actions/CHANGELOG.md
+++ b/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-github-actions
 
+## 0.6.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.6.3
 
 ### Patch Changes

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-github-actions",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-deployments/CHANGELOG.md
+++ b/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-github-deployments
 
+## 0.1.54
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.1.53
 
 ### Patch Changes

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-github-deployments",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-issues/CHANGELOG.md
+++ b/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-github-issues
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.2.11
 
 ### Patch Changes

--- a/plugins/github-issues/package.json
+++ b/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-github-issues",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-github-pull-requests-board
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.1.16
 
 ### Patch Changes

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-github-pull-requests-board",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/gocd/CHANGELOG.md
+++ b/plugins/gocd/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-gocd
 
+## 0.1.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.1.28
 
 ### Patch Changes

--- a/plugins/gocd/package.json
+++ b/plugins/gocd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-gocd",
   "description": "A Backstage plugin that integrates towards GoCD",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/graphql-backend/CHANGELOG.md
+++ b/plugins/graphql-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-graphql-backend
 
+## 0.1.40
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/plugin-catalog-graphql@0.3.22
+
 ## 0.1.39
 
 ### Patch Changes

--- a/plugins/graphql-backend/package.json
+++ b/plugins/graphql-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-graphql-backend",
   "description": "An experimental Backstage backend plugin for GraphQL",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/home/CHANGELOG.md
+++ b/plugins/home/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-home
 
+## 0.5.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-home-react@0.1.2
+
 ## 0.5.6
 
 ### Patch Changes

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-home",
   "description": "A Backstage plugin that helps you build a home page",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/ilert/CHANGELOG.md
+++ b/plugins/ilert/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-ilert
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.2.11
 
 ### Patch Changes

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-ilert",
   "description": "A Backstage plugin that integrates towards iLert",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/jenkins-backend/CHANGELOG.md
+++ b/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-jenkins-backend
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-jenkins-common@0.1.18
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/jenkins-backend/package.json
+++ b/plugins/jenkins-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-jenkins-backend",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/jenkins/CHANGELOG.md
+++ b/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-jenkins
 
+## 0.8.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-jenkins-common@0.1.18
+
 ## 0.8.4
 
 ### Patch Changes

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-jenkins",
   "description": "A Backstage plugin that integrates towards Jenkins",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kafka-backend/CHANGELOG.md
+++ b/plugins/kafka-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-kafka-backend
 
+## 0.2.43
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.42
 
 ### Patch Changes

--- a/plugins/kafka-backend/package.json
+++ b/plugins/kafka-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kafka-backend",
   "description": "A Backstage backend plugin that integrates towards Kafka",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kafka/CHANGELOG.md
+++ b/plugins/kafka/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-kafka
 
+## 0.3.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.3.22
 
 ### Patch Changes

--- a/plugins/kafka/package.json
+++ b/plugins/kafka/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kafka",
   "description": "A Backstage plugin that integrates towards Kafka",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-backend/CHANGELOG.md
+++ b/plugins/kubernetes-backend/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-kubernetes-backend
 
+## 0.11.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/integration-aws-node@0.1.5
+  - @backstage/plugin-kubernetes-common@0.6.5
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.11.4
 
 ### Patch Changes

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kubernetes-backend",
   "description": "A Backstage backend plugin that integrates towards Kubernetes",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes/CHANGELOG.md
+++ b/plugins/kubernetes/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-kubernetes
 
+## 0.10.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-kubernetes-common@0.6.5
+
 ## 0.10.1
 
 ### Patch Changes

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kubernetes",
   "description": "A Backstage plugin that integrates towards Kubernetes",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/lighthouse-backend/CHANGELOG.md
+++ b/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-lighthouse-backend
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+  - @backstage/plugin-lighthouse-common@0.1.2
+
 ## 0.2.5
 
 ### Patch Changes

--- a/plugins/lighthouse-backend/package.json
+++ b/plugins/lighthouse-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-lighthouse-backend",
   "description": "Backend functionalities for lighthouse",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/lighthouse/CHANGELOG.md
+++ b/plugins/lighthouse/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-lighthouse
 
+## 0.4.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-lighthouse-common@0.1.2
+
 ## 0.4.7
 
 ### Patch Changes

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-lighthouse",
   "description": "A Backstage plugin that integrates towards Lighthouse",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/linguist-backend/CHANGELOG.md
+++ b/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-linguist-backend
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-linguist-common@0.1.1
+
 ## 0.4.1
 
 ### Patch Changes

--- a/plugins/linguist-backend/package.json
+++ b/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-linguist-backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/linguist/CHANGELOG.md
+++ b/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-linguist
 
+## 0.1.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-linguist-common@0.1.1
+
 ## 0.1.7
 
 ### Patch Changes

--- a/plugins/linguist/package.json
+++ b/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-linguist",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/newrelic-dashboard/CHANGELOG.md
+++ b/plugins/newrelic-dashboard/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-newrelic-dashboard
 
+## 0.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+
 ## 0.2.15
 
 ### Patch Changes

--- a/plugins/newrelic-dashboard/package.json
+++ b/plugins/newrelic-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-newrelic-dashboard",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/nomad-backend/CHANGELOG.md
+++ b/plugins/nomad-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-nomad-backend
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/plugins/nomad-backend/package.json
+++ b/plugins/nomad-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-nomad-backend",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/nomad/CHANGELOG.md
+++ b/plugins/nomad/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-nomad
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/plugins/nomad/package.json
+++ b/plugins/nomad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-nomad",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/octopus-deploy/CHANGELOG.md
+++ b/plugins/octopus-deploy/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-octopus-deploy
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-octopus-deploy",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org-react/CHANGELOG.md
+++ b/plugins/org-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-org-react
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/org-react/package.json
+++ b/plugins/org-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-org-react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-org
 
+## 0.6.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.6.12
 
 ### Patch Changes

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-org",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/pagerduty/CHANGELOG.md
+++ b/plugins/pagerduty/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-pagerduty
 
+## 0.6.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-home-react@0.1.2
+
 ## 0.6.3
 
 ### Patch Changes

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-pagerduty",
   "description": "A Backstage plugin that integrates towards PagerDuty",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/periskop-backend/CHANGELOG.md
+++ b/plugins/periskop-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-periskop-backend
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/periskop-backend/package.json
+++ b/plugins/periskop-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-periskop-backend",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/periskop/CHANGELOG.md
+++ b/plugins/periskop/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-periskop
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/periskop/package.json
+++ b/plugins/periskop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-periskop",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/permission-backend/CHANGELOG.md
+++ b/plugins/permission-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-permission-backend
 
+## 0.5.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.5.24
 
 ### Patch Changes

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-permission-backend",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/permission-node/CHANGELOG.md
+++ b/plugins/permission-node/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-permission-node
 
+## 0.7.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-permission-common@0.7.7
+
 ## 0.7.12
 
 ### Patch Changes

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-permission-node",
   "description": "Common permission and authorization utilities for backend plugins",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/playlist-backend/CHANGELOG.md
+++ b/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-playlist-backend
 
+## 0.3.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-playlist-common@0.1.9
+
 ## 0.3.5
 
 ### Patch Changes

--- a/plugins/playlist-backend/package.json
+++ b/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-playlist-backend",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/playlist/CHANGELOG.md
+++ b/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-playlist
 
+## 0.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-permission-react@0.4.14
+  - @backstage/plugin-playlist-common@0.1.9
+  - @backstage/plugin-search-react@1.6.4
+
 ## 0.1.14
 
 ### Patch Changes

--- a/plugins/playlist/package.json
+++ b/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-playlist",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/proxy-backend/CHANGELOG.md
+++ b/plugins/proxy-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-proxy-backend
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+
 ## 0.3.1
 
 ### Patch Changes

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-proxy-backend",
   "description": "A Backstage backend plugin that helps you set up proxy endpoints in the backend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/puppetdb/CHANGELOG.md
+++ b/plugins/puppetdb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-puppetdb
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/plugins/puppetdb/package.json
+++ b/plugins/puppetdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-puppetdb",
   "description": "Backstage plugin to visualize resource information and Puppet facts from PuppetDB.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/rollbar-backend/CHANGELOG.md
+++ b/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-rollbar-backend
 
+## 0.1.47
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+
 ## 0.1.46
 
 ### Patch Changes

--- a/plugins/rollbar-backend/package.json
+++ b/plugins/rollbar-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-rollbar-backend",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/rollbar/CHANGELOG.md
+++ b/plugins/rollbar/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-rollbar
 
+## 0.4.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.4.22
 
 ### Patch Changes

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-rollbar",
   "description": "A Backstage plugin that integrates towards Rollbar",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-scaffolder-backend-module-confluence-to-markdown
 
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.2.2
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-confluence-to-markdown",
   "description": "The confluence-to-markdown module for @backstage/plugin-scaffolder-backend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-cookiecutter/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-scaffolder-backend-module-cookiecutter
 
+## 0.2.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.2.25
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-cookiecutter/package.json
+++ b/plugins/scaffolder-backend-module-cookiecutter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-cookiecutter",
   "description": "A module for the scaffolder backend that lets you template projects using cookiecutter",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder-backend-module-gitlab
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-gitlab/package.json
+++ b/plugins/scaffolder-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gitlab",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-rails/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-rails/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-scaffolder-backend-module-rails
 
+## 0.4.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.4.18
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-rails",
   "description": "A module for the scaffolder backend that lets you template projects using Rails",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-sentry/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-sentry/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-sentry
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.1.9
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-sentry/package.json
+++ b/plugins/scaffolder-backend-module-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-sentry",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-yeoman
 
+## 0.2.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+
 ## 0.2.22
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-yeoman/package.json
+++ b/plugins/scaffolder-backend-module-yeoman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-yeoman",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend/CHANGELOG.md
+++ b/plugins/scaffolder-backend/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @backstage/plugin-scaffolder-backend
 
+## 1.16.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.12.2
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-scaffolder-node@0.2.2
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-scaffolder-common@1.4.0
+
 ## 1.16.2
 
 ### Patch Changes

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-backend",
   "description": "The Backstage backend plugin that helps you create new things",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-node/CHANGELOG.md
+++ b/plugins/scaffolder-node/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-scaffolder-node
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-scaffolder-common@1.4.0
+
 ## 0.2.1
 
 ### Patch Changes

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-node",
   "description": "The plugin-scaffolder-node module for @backstage/plugin-scaffolder-backend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-react/CHANGELOG.md
+++ b/plugins/scaffolder-react/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-scaffolder-react
 
+## 1.5.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+  - @backstage/version-bridge@1.0.4
+  - @backstage/plugin-scaffolder-common@1.4.0
+
 ## 1.5.3
 
 ### Patch Changes

--- a/plugins/scaffolder-react/package.json
+++ b/plugins/scaffolder-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-react",
   "description": "A frontend library that helps other Backstage plugins interact with the Scaffolder",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder/CHANGELOG.md
+++ b/plugins/scaffolder/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @backstage/plugin-scaffolder
 
+## 1.14.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-react@0.4.14
+  - @backstage/plugin-scaffolder-common@1.4.0
+  - @backstage/plugin-scaffolder-react@1.5.4
+
 ## 1.14.3
 
 ### Patch Changes

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder",
   "description": "The Backstage plugin that helps you create new things",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend-module-catalog/CHANGELOG.md
+++ b/plugins/search-backend-module-catalog/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-search-backend-module-catalog
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.1.5
 
 ### Patch Changes

--- a/plugins/search-backend-module-catalog/package.json
+++ b/plugins/search-backend-module-catalog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend-module-catalog",
   "description": "A module for the search backend that exports catalog modules",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend-module-elasticsearch/CHANGELOG.md
+++ b/plugins/search-backend-module-elasticsearch/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-search-backend-module-elasticsearch
 
+## 1.3.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/integration-aws-node@0.1.5
+  - @backstage/plugin-search-common@1.2.5
+
 ## 1.3.4
 
 ### Patch Changes

--- a/plugins/search-backend-module-elasticsearch/package.json
+++ b/plugins/search-backend-module-elasticsearch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend-module-elasticsearch",
   "description": "A module for the search backend that implements search using ElasticSearch",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend-module-explore/CHANGELOG.md
+++ b/plugins/search-backend-module-explore/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-search-backend-module-explore
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-explore-common@0.0.1
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.1.5
 
 ### Patch Changes

--- a/plugins/search-backend-module-explore/package.json
+++ b/plugins/search-backend-module-explore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend-module-explore",
   "description": "A module for the search backend that exports explore modules",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend-module-pg/CHANGELOG.md
+++ b/plugins/search-backend-module-pg/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-search-backend-module-pg
 
+## 0.5.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.5.10
 
 ### Patch Changes

--- a/plugins/search-backend-module-pg/package.json
+++ b/plugins/search-backend-module-pg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend-module-pg",
   "description": "A module for the search backend that implements search using PostgreSQL",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend-module-techdocs/CHANGELOG.md
+++ b/plugins/search-backend-module-techdocs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-search-backend-module-techdocs
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-techdocs-node@1.7.6
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.1.5
 
 ### Patch Changes

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend-module-techdocs",
   "description": "A module for the search backend that exports techdocs modules",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend-node/CHANGELOG.md
+++ b/plugins/search-backend-node/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-search-backend-node
 
+## 1.2.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-search-common@1.2.5
+
 ## 1.2.5
 
 ### Patch Changes

--- a/plugins/search-backend-node/package.json
+++ b/plugins/search-backend-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend-node",
   "description": "A library for Backstage backend plugins that want to interact with the search backend plugin",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend/CHANGELOG.md
+++ b/plugins/search-backend/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-search-backend
 
+## 1.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/plugin-permission-node@0.7.13
+  - @backstage/plugin-search-backend-node@1.2.6
+  - @backstage/backend-openapi-utils@0.0.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-search-common@1.2.5
+
 ## 1.4.1
 
 ### Patch Changes

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend",
   "description": "The Backstage backend plugin that provides your backstage app with search",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search/CHANGELOG.md
+++ b/plugins/search/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-search
 
+## 1.3.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+  - @backstage/version-bridge@1.0.4
+  - @backstage/plugin-search-common@1.2.5
+  - @backstage/plugin-search-react@1.6.4
+
 ## 1.3.5
 
 ### Patch Changes

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search",
   "description": "The Backstage plugin that provides your backstage app with search",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/sentry/CHANGELOG.md
+++ b/plugins/sentry/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-sentry
 
+## 0.5.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.5.7
 
 ### Patch Changes

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-sentry",
   "description": "A Backstage plugin that integrates towards Sentry",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/sonarqube-backend/CHANGELOG.md
+++ b/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-sonarqube-backend
 
+## 0.2.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.3
 
 ### Patch Changes

--- a/plugins/sonarqube-backend/package.json
+++ b/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-sonarqube-backend",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/sonarqube/CHANGELOG.md
+++ b/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-sonarqube
 
+## 0.7.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-sonarqube-react@0.1.7
+
 ## 0.7.3
 
 ### Patch Changes

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-sonarqube",
   "description": "",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/splunk-on-call/CHANGELOG.md
+++ b/plugins/splunk-on-call/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-splunk-on-call
 
+## 0.4.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+
 ## 0.4.11
 
 ### Patch Changes

--- a/plugins/splunk-on-call/package.json
+++ b/plugins/splunk-on-call/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-splunk-on-call",
   "description": "A Backstage plugin that integrates towards Splunk On-Call",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/stack-overflow-backend/CHANGELOG.md
+++ b/plugins/stack-overflow-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-stack-overflow-backend
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/config@1.0.8
+  - @backstage/plugin-search-common@1.2.5
+
 ## 0.2.5
 
 ### Patch Changes

--- a/plugins/stack-overflow-backend/package.json
+++ b/plugins/stack-overflow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-stack-overflow-backend",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
+++ b/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-tech-insights-backend-module-jsonfc
 
+## 0.1.34
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-tech-insights-node@0.4.8
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-tech-insights-common@0.2.11
+
 ## 0.1.33
 
 ### Patch Changes

--- a/plugins/tech-insights-backend-module-jsonfc/package.json
+++ b/plugins/tech-insights-backend-module-jsonfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights-backend-module-jsonfc",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights-backend/CHANGELOG.md
+++ b/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-tech-insights-backend
 
+## 0.5.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/plugin-tech-insights-node@0.4.8
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-tech-insights-common@0.2.11
+
 ## 0.5.15
 
 ### Patch Changes

--- a/plugins/tech-insights-backend/package.json
+++ b/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights-backend",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights-node/CHANGELOG.md
+++ b/plugins/tech-insights-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-tech-insights-node
 
+## 0.4.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/config@1.0.8
+  - @backstage/types@1.1.0
+  - @backstage/plugin-tech-insights-common@0.2.11
+
 ## 0.4.7
 
 ### Patch Changes

--- a/plugins/tech-insights-node/package.json
+++ b/plugins/tech-insights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights-node",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights/CHANGELOG.md
+++ b/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/plugin-tech-insights
 
+## 0.3.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+  - @backstage/plugin-tech-insights-common@0.2.11
+
 ## 0.3.14
 
 ### Patch Changes

--- a/plugins/tech-insights/package.json
+++ b/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/techdocs-addons-test-utils/CHANGELOG.md
+++ b/plugins/techdocs-addons-test-utils/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-techdocs-addons-test-utils
 
+## 1.0.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-techdocs@1.6.8
+  - @backstage/core-app-api@1.9.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/test-utils@1.4.2
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-catalog@1.12.4
+  - @backstage/plugin-search-react@1.6.4
+  - @backstage/plugin-techdocs-react@1.1.9
+
 ## 1.0.19
 
 ### Patch Changes

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-addons-test-utils",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/techdocs-backend/CHANGELOG.md
+++ b/plugins/techdocs-backend/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-techdocs-backend
 
+## 1.6.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-techdocs-node@1.7.6
+  - @backstage/plugin-search-backend-module-techdocs@0.1.6
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/plugin-catalog-common@1.0.15
+  - @backstage/plugin-permission-common@0.7.7
+  - @backstage/plugin-search-common@1.2.5
+
 ## 1.6.6
 
 ### Patch Changes

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-techdocs-backend",
   "description": "The Backstage backend plugin that renders technical documentation for your components",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/techdocs-module-addons-contrib/CHANGELOG.md
+++ b/plugins/techdocs-module-addons-contrib/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-techdocs-module-addons-contrib
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/integration-react@1.1.18
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-techdocs-react@1.1.9
+
 ## 1.0.17
 
 ### Patch Changes

--- a/plugins/techdocs-module-addons-contrib/package.json
+++ b/plugins/techdocs-module-addons-contrib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-techdocs-module-addons-contrib",
   "description": "Plugin module for contributed TechDocs Addons",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/techdocs-node/CHANGELOG.md
+++ b/plugins/techdocs-node/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-techdocs-node
 
+## 1.7.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+  - @backstage/integration-aws-node@0.1.5
+  - @backstage/plugin-search-common@1.2.5
+
 ## 1.7.5
 
 ### Patch Changes

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-techdocs-node",
   "description": "Common node.js functionalities for TechDocs, to be shared between techdocs-backend plugin and techdocs-cli",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/techdocs/CHANGELOG.md
+++ b/plugins/techdocs/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/plugin-techdocs
 
+## 1.6.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/integration-react@1.1.18
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/plugin-search-common@1.2.5
+  - @backstage/plugin-search-react@1.6.4
+  - @backstage/plugin-techdocs-react@1.1.9
+
 ## 1.6.7
 
 ### Patch Changes

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-techdocs",
   "description": "The Backstage plugin that renders technical documentation for your components",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/todo-backend/CHANGELOG.md
+++ b/plugins/todo-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-todo-backend
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration@1.6.2
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-catalog-node@1.4.3
+  - @backstage/backend-openapi-utils@0.0.3
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-client@1.4.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/plugins/todo-backend/package.json
+++ b/plugins/todo-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-todo-backend",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/todo/CHANGELOG.md
+++ b/plugins/todo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-todo
 
+## 0.2.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.2.24
 
 ### Patch Changes

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-todo",
   "description": "A Backstage plugin that lets you browse TODO comments in your source code",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/user-settings-backend/CHANGELOG.md
+++ b/plugins/user-settings-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-user-settings-backend
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/plugin-auth-node@0.2.19
+  - @backstage/backend-plugin-api@0.6.2
+  - @backstage/catalog-model@1.4.1
+  - @backstage/errors@1.2.1
+  - @backstage/types@1.1.0
+
 ## 0.1.13
 
 ### Patch Changes

--- a/plugins/user-settings-backend/package.json
+++ b/plugins/user-settings-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-user-settings-backend",
   "description": "The Backstage backend plugin to manage user settings",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/user-settings/CHANGELOG.md
+++ b/plugins/user-settings/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-user-settings
 
+## 0.7.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/core-app-api@1.9.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+  - @backstage/types@1.1.0
+
 ## 0.7.7
 
 ### Patch Changes

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-user-settings",
   "description": "A Backstage plugin that provides a settings page",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/vault-backend/CHANGELOG.md
+++ b/plugins/vault-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-vault-backend
 
+## 0.3.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.19.4
+  - @backstage/backend-tasks@0.5.7
+  - @backstage/config@1.0.8
+  - @backstage/errors@1.2.1
+
 ## 0.3.5
 
 ### Patch Changes

--- a/plugins/vault-backend/package.json
+++ b/plugins/vault-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-vault-backend",
   "description": "A Backstage backend plugin that integrates towards Vault",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/vault/CHANGELOG.md
+++ b/plugins/vault/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-vault
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.8.3
+  - @backstage/catalog-model@1.4.1
+  - @backstage/core-components@0.13.4
+  - @backstage/core-plugin-api@1.5.3
+  - @backstage/errors@1.2.1
+  - @backstage/theme@0.4.1
+
 ## 0.1.16
 
 ### Patch Changes

--- a/plugins/vault/package.json
+++ b/plugins/vault/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-vault",
   "description": "A Backstage plugin that integrates towards Vault",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This release provides further fixes for the Gitiles integration, and relaxes the validation of the encoding of all query parameters of the catalog backend as well as allowing `limit=0` queries.