### PR TITLE
[Search] Page limit configuration followup

### DIFF
--- a/.changeset/many-tips-attend.md
+++ b/.changeset/many-tips-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Optionally initializes the search context with default settings for search queries only when the config is defined, rather than always overriding it.

--- a/plugins/search-react/src/context/SearchContext.tsx
+++ b/plugins/search-react/src/context/SearchContext.tsx
@@ -102,7 +102,7 @@ export const useSearchContextCheck = () => {
  * The initial state of `SearchContextProvider`.
  *
  */
-const searchInitialState: SearchContextState = {
+const defaultInitialSearchState: SearchContextState = {
   term: '',
   types: [],
   filters: {},
@@ -111,7 +111,7 @@ const searchInitialState: SearchContextState = {
 };
 
 const useSearchContextValue = (
-  initialValue: SearchContextState = searchInitialState,
+  initialValue: SearchContextState = defaultInitialSearchState,
 ) => {
   const searchApi = useApi(searchApiRef);
 
@@ -245,12 +245,16 @@ export const SearchContextProvider = (props: SearchContextProviderProps) => {
 
   const configApi = useApi(configApiRef);
 
+  const propsInitialSearchState = initialState ?? {};
+
+  const configInitialSearchState = configApi.has('search.query.pageLimit')
+    ? { pageLimit: configApi.getNumber('search.query.pageLimit') }
+    : {};
+
   const searchContextInitialState = {
-    ...searchInitialState,
-    ...(initialState || {}),
-    pageLimit:
-      configApi.getOptionalNumber('search.query.pageLimit') ||
-      initialState?.pageLimit,
+    ...defaultInitialSearchState,
+    ...propsInitialSearchState,
+    ...configInitialSearchState,
   };
 
   return hasParentContext && inheritParentContextIfAvailable ? (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up on https://github.com/backstage/backstage/pull/18401.

This pull request optionally initializes the search context with default settings for search queries only when the config is defined, rather than always overriding it.

Thanks @freben for suggesting this enhancement 🙌🏻 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
