### PR TITLE
[repo-tools] Fix description overwrite edge-case

### DIFF
--- a/.changeset/repo-tools-boo-descriptions-two-electric-boogaloo.md
+++ b/.changeset/repo-tools-boo-descriptions-two-electric-boogaloo.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fixed a bug with the `generate-catalog-info` command that could cause `metadata.description` values to be overwritten by `package.json` description values only because unrelated attributes were being changed.

--- a/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
+++ b/packages/repo-tools/src/commands/generate-catalog-info/generate-catalog-info.ts
@@ -253,7 +253,7 @@ function createOrMergeEntity(
       // Provide default name/title/description values.
       name: safeEntityName,
       title: packageJson.name,
-      ...(packageJson.description
+      ...(packageJson.description && !existingEntity.metadata?.description
         ? { description: packageJson.description }
         : undefined),
     },


### PR DESCRIPTION
## What / Why

Edge-case from https://github.com/backstage/backstage/pull/19439: when the `package.json` description and `metadata.description` values have diverged, updates to either of these values won't trigger an update/check.  ...However, if a _different_ attribute has changed (e.g. owner), then the description was being pulled from `package.json` description and overwriting the otherwise perfectly valid `metadata.description`.

This more completely severs the link.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
