### PR TITLE
Add maintainer-owned `catalog-info.yaml` files

### DIFF
--- a/packages/app-defaults/catalog-info.yaml
+++ b/packages/app-defaults/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/app-defaults'
   description: Provides the default wiring of a Backstage App
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/app-defaults/catalog-info.yaml
+++ b/packages/app-defaults/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-app-defaults
+  title: '@backstage/app-defaults'
+  description: Provides the default wiring of a Backstage App
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/app-next/catalog-info.yaml
+++ b/packages/app-next/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: example-app-next
+  title: example-app-next
+spec:
+  lifecycle: experimental
+  type: backstage-frontend
+  owner: maintainers

--- a/packages/app/catalog-info.yaml
+++ b/packages/app/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: example-app
+  title: example-app
+spec:
+  lifecycle: experimental
+  type: backstage-frontend
+  owner: maintainers

--- a/packages/backend-app-api/catalog-info.yaml
+++ b/packages/backend-app-api/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-app-api
+  title: '@backstage/backend-app-api'
+  description: Core API used by Backstage backend apps
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-common/catalog-info.yaml
+++ b/packages/backend-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-common
+  title: '@backstage/backend-common'
+  description: Common functionality library for Backstage backends
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-defaults/catalog-info.yaml
+++ b/packages/backend-defaults/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-defaults
+  title: '@backstage/backend-defaults'
+  description: Backend defaults used by Backstage backend apps
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-dev-utils/catalog-info.yaml
+++ b/packages/backend-dev-utils/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-dev-utils
+  title: '@backstage/backend-dev-utils'
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-next/catalog-info.yaml
+++ b/packages/backend-next/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: example-backend-next
+  title: example-backend-next
+spec:
+  lifecycle: experimental
+  type: backstage-backend
+  owner: maintainers

--- a/packages/backend-openapi-utils/catalog-info.yaml
+++ b/packages/backend-openapi-utils/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-openapi-utils
+  title: '@backstage/backend-openapi-utils'
+  description: OpenAPI typescript support.
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-plugin-api/catalog-info.yaml
+++ b/packages/backend-plugin-api/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-plugin-api
+  title: '@backstage/backend-plugin-api'
+  description: Core API used by Backstage backend plugins
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-tasks/catalog-info.yaml
+++ b/packages/backend-tasks/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-tasks
+  title: '@backstage/backend-tasks'
+  description: Common distributed task management library for Backstage backends
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend-test-utils/catalog-info.yaml
+++ b/packages/backend-test-utils/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-test-utils
+  title: '@backstage/backend-test-utils'
+  description: Test helpers library for Backstage backends
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/backend/catalog-info.yaml
+++ b/packages/backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: example-backend
+  title: example-backend
+spec:
+  lifecycle: experimental
+  type: backstage-backend
+  owner: maintainers

--- a/packages/catalog-client/catalog-info.yaml
+++ b/packages/catalog-client/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/catalog-client'
   description: An isomorphic client for the catalog backend
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/packages/catalog-client/catalog-info.yaml
+++ b/packages/catalog-client/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-catalog-client
+  title: '@backstage/catalog-client'
+  description: An isomorphic client for the catalog backend
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/catalog-model/catalog-info.yaml
+++ b/packages/catalog-model/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/catalog-model'
   description: Types and validators that help describe the model of a Backstage Catalog
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/packages/catalog-model/catalog-info.yaml
+++ b/packages/catalog-model/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-catalog-model
+  title: '@backstage/catalog-model'
+  description: Types and validators that help describe the model of a Backstage Catalog
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/cli-common/catalog-info.yaml
+++ b/packages/cli-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-cli-common
+  title: '@backstage/cli-common'
+  description: Common functionality used by cli, backend, and create-app
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/cli-node/catalog-info.yaml
+++ b/packages/cli-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-cli-node
+  title: '@backstage/cli-node'
+  description: Node.js library for Backstage CLIs
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/cli/catalog-info.yaml
+++ b/packages/cli/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-cli
+  title: '@backstage/cli'
+  description: CLI for developing Backstage plugins and apps
+spec:
+  lifecycle: experimental
+  type: backstage-cli
+  owner: maintainers

--- a/packages/codemods/catalog-info.yaml
+++ b/packages/codemods/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-codemods
+  title: '@backstage/codemods'
+  description: A collection of codemods for Backstage projects
+spec:
+  lifecycle: experimental
+  type: backstage-cli
+  owner: maintainers

--- a/packages/config-loader/catalog-info.yaml
+++ b/packages/config-loader/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-config-loader
+  title: '@backstage/config-loader'
+  description: Config loading functionality used by Backstage backend, and CLI
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/config-loader/catalog-info.yaml
+++ b/packages/config-loader/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/config-loader'
   description: Config loading functionality used by Backstage backend, and CLI
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-node-library
   owner: maintainers

--- a/packages/config/catalog-info.yaml
+++ b/packages/config/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/config'
   description: Config API used by Backstage core, backend, and CLI
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/packages/config/catalog-info.yaml
+++ b/packages/config/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-config
+  title: '@backstage/config'
+  description: Config API used by Backstage core, backend, and CLI
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/core-app-api/catalog-info.yaml
+++ b/packages/core-app-api/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/core-app-api'
   description: Core app API used by Backstage apps
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/core-app-api/catalog-info.yaml
+++ b/packages/core-app-api/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-core-app-api
+  title: '@backstage/core-app-api'
+  description: Core app API used by Backstage apps
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/core-components/catalog-info.yaml
+++ b/packages/core-components/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-core-components
+  title: '@backstage/core-components'
+  description: Core components used by Backstage plugins and apps
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/core-plugin-api/catalog-info.yaml
+++ b/packages/core-plugin-api/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-core-plugin-api
+  title: '@backstage/core-plugin-api'
+  description: Core API used by Backstage plugins
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/core-plugin-api/catalog-info.yaml
+++ b/packages/core-plugin-api/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/core-plugin-api'
   description: Core API used by Backstage plugins
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/create-app/catalog-info.yaml
+++ b/packages/create-app/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-create-app
+  title: '@backstage/create-app'
+  description: A CLI that helps you create your own Backstage app
+spec:
+  lifecycle: experimental
+  type: backstage-cli
+  owner: maintainers

--- a/packages/dev-utils/catalog-info.yaml
+++ b/packages/dev-utils/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/dev-utils'
   description: Utilities for developing Backstage plugins.
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/dev-utils/catalog-info.yaml
+++ b/packages/dev-utils/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-dev-utils
+  title: '@backstage/dev-utils'
+  description: Utilities for developing Backstage plugins.
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/e2e-test/catalog-info.yaml
+++ b/packages/e2e-test/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: e2e-test
+  title: e2e-test
+  description: E2E test for verifying Backstage packages
+spec:
+  lifecycle: experimental
+  type: backstage-cli
+  owner: maintainers

--- a/packages/errors/catalog-info.yaml
+++ b/packages/errors/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/errors'
   description: Common utilities for error handling within Backstage
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/packages/errors/catalog-info.yaml
+++ b/packages/errors/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-errors
+  title: '@backstage/errors'
+  description: Common utilities for error handling within Backstage
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/frontend-app-api/catalog-info.yaml
+++ b/packages/frontend-app-api/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-frontend-app-api
+  title: '@backstage/frontend-app-api'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/frontend-plugin-api/catalog-info.yaml
+++ b/packages/frontend-plugin-api/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-frontend-plugin-api
+  title: '@backstage/frontend-plugin-api'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/integration-aws-node/catalog-info.yaml
+++ b/packages/integration-aws-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-integration-aws-node
+  title: '@backstage/integration-aws-node'
+  description: Helpers for fetching AWS account credentials
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/packages/integration-react/catalog-info.yaml
+++ b/packages/integration-react/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-integration-react
+  title: '@backstage/integration-react'
+  description: Frontend package for managing integrations towards external systems
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/integration-react/catalog-info.yaml
+++ b/packages/integration-react/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/integration-react'
   description: Frontend package for managing integrations towards external systems
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/integration/catalog-info.yaml
+++ b/packages/integration/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/integration'
   description: Helpers for managing integrations towards external systems
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/packages/integration/catalog-info.yaml
+++ b/packages/integration/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-integration
+  title: '@backstage/integration'
+  description: Helpers for managing integrations towards external systems
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/release-manifests/catalog-info.yaml
+++ b/packages/release-manifests/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-release-manifests
+  title: '@backstage/release-manifests'
+  description: Helper library for receiving release manifests
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/repo-tools/catalog-info.yaml
+++ b/packages/repo-tools/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-repo-tools
+  title: '@backstage/repo-tools'
+  description: 'CLI for Backstage repo tooling '
+spec:
+  lifecycle: experimental
+  type: backstage-cli
+  owner: maintainers

--- a/packages/test-utils/catalog-info.yaml
+++ b/packages/test-utils/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/test-utils'
   description: Utilities to test Backstage plugins and apps.
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/test-utils/catalog-info.yaml
+++ b/packages/test-utils/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-test-utils
+  title: '@backstage/test-utils'
+  description: Utilities to test Backstage plugins and apps.
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/theme/catalog-info.yaml
+++ b/packages/theme/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-theme
+  title: '@backstage/theme'
+  description: material-ui theme for use with Backstage.
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/packages/types/catalog-info.yaml
+++ b/packages/types/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-types
+  title: '@backstage/types'
+  description: Common TypeScript types used within Backstage
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/packages/types/catalog-info.yaml
+++ b/packages/types/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/types'
   description: Common TypeScript types used within Backstage
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/packages/version-bridge/catalog-info.yaml
+++ b/packages/version-bridge/catalog-info.yaml
@@ -7,6 +7,6 @@ metadata:
     Utilities used by @backstage packages to support multiple concurrent
     versions
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/packages/version-bridge/catalog-info.yaml
+++ b/packages/version-bridge/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-version-bridge
+  title: '@backstage/version-bridge'
+  description: >-
+    Utilities used by @backstage packages to support multiple concurrent
+    versions
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/airbrake-backend/catalog-info.yaml
+++ b/plugins/airbrake-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-airbrake-backend
+  title: '@backstage/plugin-airbrake-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/airbrake/catalog-info.yaml
+++ b/plugins/airbrake/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-airbrake
+  title: '@backstage/plugin-airbrake'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/allure/catalog-info.yaml
+++ b/plugins/allure/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-allure
+  title: '@backstage/plugin-allure'
+  description: A Backstage plugin that integrates with Allure
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/analytics-module-ga/catalog-info.yaml
+++ b/plugins/analytics-module-ga/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-analytics-module-ga
+  title: '@backstage/plugin-analytics-module-ga'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin-module
+  owner: maintainers

--- a/plugins/analytics-module-ga4/catalog-info.yaml
+++ b/plugins/analytics-module-ga4/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-analytics-module-ga4
+  title: '@backstage/plugin-analytics-module-ga4'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin-module
+  owner: maintainers

--- a/plugins/analytics-module-newrelic-browser/catalog-info.yaml
+++ b/plugins/analytics-module-newrelic-browser/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-analytics-module-newrelic-browser
+  title: '@backstage/plugin-analytics-module-newrelic-browser'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin-module
+  owner: maintainers

--- a/plugins/apache-airflow/catalog-info.yaml
+++ b/plugins/apache-airflow/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-apache-airflow
+  title: '@backstage/plugin-apache-airflow'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/api-docs-module-protoc-gen-doc/catalog-info.yaml
+++ b/plugins/api-docs-module-protoc-gen-doc/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-api-docs-module-protoc-gen-doc
+  title: '@backstage/plugin-api-docs-module-protoc-gen-doc'
+  description: >-
+    Additional functionalities for the api-docs plugin that renders the output
+    of the protoc-gen-doc
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin-module
+  owner: maintainers

--- a/plugins/apollo-explorer/catalog-info.yaml
+++ b/plugins/apollo-explorer/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-apollo-explorer
+  title: '@backstage/plugin-apollo-explorer'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/app-backend/catalog-info.yaml
+++ b/plugins/app-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-app-backend
+  title: '@backstage/plugin-app-backend'
+  description: A Backstage backend plugin that serves the Backstage frontend app
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/app-node/catalog-info.yaml
+++ b/plugins/app-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-app-node
+  title: '@backstage/plugin-app-node'
+  description: Node.js library for the app plugin
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/plugins/auth-backend-module-gcp-iap-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-gcp-iap-provider/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-auth-backend-module-gcp-iap-provider
+  title: '@backstage/plugin-auth-backend-module-gcp-iap-provider'
+  description: A GCP IAP auth provider module for the Backstage auth backend
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/auth-backend-module-github-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-github-provider/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-auth-backend-module-github-provider
+  title: '@backstage/plugin-auth-backend-module-github-provider'
+  description: The github-provider backend module for the auth plugin.
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/auth-backend-module-gitlab-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-gitlab-provider/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-auth-backend-module-gitlab-provider
+  title: '@backstage/plugin-auth-backend-module-gitlab-provider'
+  description: The gitlab-provider backend module for the auth plugin.
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/auth-backend-module-google-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-google-provider/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-auth-backend-module-google-provider
+  title: '@backstage/plugin-auth-backend-module-google-provider'
+  description: A Google auth provider module for the Backstage auth backend
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/auth-backend/catalog-info.yaml
+++ b/plugins/auth-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-auth-backend
+  title: '@backstage/plugin-auth-backend'
+  description: A Backstage backend plugin that handles authentication
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/auth-node/catalog-info.yaml
+++ b/plugins/auth-node/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-auth-node
+  title: '@backstage/plugin-auth-node'
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/plugins/azure-sites-backend/catalog-info.yaml
+++ b/plugins/azure-sites-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-azure-sites-backend
+  title: '@backstage/plugin-azure-sites-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/azure-sites-common/catalog-info.yaml
+++ b/plugins/azure-sites-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-azure-sites-common
+  title: '@backstage/plugin-azure-sites-common'
+  description: Common functionalities for the azure plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/azure-sites/catalog-info.yaml
+++ b/plugins/azure-sites/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-azure-sites
+  title: '@backstage/plugin-azure-sites'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/badges-backend/catalog-info.yaml
+++ b/plugins/badges-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-badges-backend
+  title: '@backstage/plugin-badges-backend'
+  description: A Backstage backend plugin that generates README badges for your entities
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/badges/catalog-info.yaml
+++ b/plugins/badges/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-badges
+  title: '@backstage/plugin-badges'
+  description: A Backstage plugin that generates README badges for your entities
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/bazaar-backend/catalog-info.yaml
+++ b/plugins/bazaar-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-bazaar-backend
+  title: '@backstage/plugin-bazaar-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/bazaar/catalog-info.yaml
+++ b/plugins/bazaar/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-bazaar
+  title: '@backstage/plugin-bazaar'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/cicd-statistics-module-gitlab/catalog-info.yaml
+++ b/plugins/cicd-statistics-module-gitlab/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-cicd-statistics-module-gitlab
+  title: '@backstage/plugin-cicd-statistics-module-gitlab'
+  description: CI/CD Statistics plugin module; Gitlab CICD
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin-module
+  owner: maintainers

--- a/plugins/cicd-statistics/catalog-info.yaml
+++ b/plugins/cicd-statistics/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-cicd-statistics
+  title: '@backstage/plugin-cicd-statistics'
+  description: A frontend plugin visualizing CI/CD pipeline statistics (build time)
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/cloudbuild/catalog-info.yaml
+++ b/plugins/cloudbuild/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-cloudbuild
+  title: '@backstage/plugin-cloudbuild'
+  description: A Backstage plugin that integrates towards Google Cloud Build
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/code-climate/catalog-info.yaml
+++ b/plugins/code-climate/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-code-climate
+  title: '@backstage/plugin-code-climate'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/codescene/catalog-info.yaml
+++ b/plugins/codescene/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-codescene
+  title: '@backstage/plugin-codescene'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/config-schema/catalog-info.yaml
+++ b/plugins/config-schema/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-config-schema
+  title: '@backstage/plugin-config-schema'
+  description: A Backstage plugin that lets you browse the configuration schema of your app
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/dynatrace/catalog-info.yaml
+++ b/plugins/dynatrace/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-dynatrace
+  title: '@backstage/plugin-dynatrace'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/entity-validation/catalog-info.yaml
+++ b/plugins/entity-validation/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-entity-validation
+  title: '@backstage/plugin-entity-validation'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/example-todo-list-backend/catalog-info.yaml
+++ b/plugins/example-todo-list-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: internal-plugin-todo-list-backend
+  title: '@internal/plugin-todo-list-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/example-todo-list-common/catalog-info.yaml
+++ b/plugins/example-todo-list-common/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: internal-plugin-todo-list-common
+  title: '@internal/plugin-todo-list-common'
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/example-todo-list/catalog-info.yaml
+++ b/plugins/example-todo-list/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: internal-plugin-todo-list
+  title: '@internal/plugin-todo-list'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/explore-backend/catalog-info.yaml
+++ b/plugins/explore-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-explore-backend
+  title: '@backstage/plugin-explore-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/explore-common/catalog-info.yaml
+++ b/plugins/explore-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-explore-common
+  title: '@backstage/plugin-explore-common'
+  description: Common functionalities for the explore plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/firehydrant/catalog-info.yaml
+++ b/plugins/firehydrant/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-firehydrant
+  title: '@backstage/plugin-firehydrant'
+  description: A Backstage plugin that integrates towards FireHydrant
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/gcalendar/catalog-info.yaml
+++ b/plugins/gcalendar/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-gcalendar
+  title: '@backstage/plugin-gcalendar'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/gcp-projects/catalog-info.yaml
+++ b/plugins/gcp-projects/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-gcp-projects
+  title: '@backstage/plugin-gcp-projects'
+  description: A Backstage plugin that helps you manage projects in GCP
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/github-actions/catalog-info.yaml
+++ b/plugins/github-actions/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-github-actions
+  title: '@backstage/plugin-github-actions'
+  description: A Backstage plugin that integrates towards GitHub Actions
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/github-deployments/catalog-info.yaml
+++ b/plugins/github-deployments/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-github-deployments
+  title: '@backstage/plugin-github-deployments'
+  description: A Backstage plugin that integrates towards GitHub Deployments
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/github-issues/catalog-info.yaml
+++ b/plugins/github-issues/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-github-issues
+  title: '@backstage/plugin-github-issues'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/github-pull-requests-board/catalog-info.yaml
+++ b/plugins/github-pull-requests-board/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-github-pull-requests-board
+  title: '@backstage/plugin-github-pull-requests-board'
+  description: >-
+    A Backstage plugin that allows you to see all open Pull Requests for all the
+    repositories owned by your team
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/gitops-profiles/catalog-info.yaml
+++ b/plugins/gitops-profiles/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-gitops-profiles
+  title: '@backstage/plugin-gitops-profiles'
+  description: A Backstage plugin that helps you manage GitOps profiles
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/gocd/catalog-info.yaml
+++ b/plugins/gocd/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-gocd
+  title: '@backstage/plugin-gocd'
+  description: A Backstage plugin that integrates towards GoCD
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/graphiql/catalog-info.yaml
+++ b/plugins/graphiql/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-graphiql
+  title: '@backstage/plugin-graphiql'
+  description: Backstage plugin for browsing GraphQL APIs
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/graphql-backend/catalog-info.yaml
+++ b/plugins/graphql-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-graphql-backend
+  title: '@backstage/plugin-graphql-backend'
+  description: An experimental Backstage backend plugin for GraphQL
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/graphql-voyager/catalog-info.yaml
+++ b/plugins/graphql-voyager/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-graphql-voyager
+  title: '@backstage/plugin-graphql-voyager'
+  description: Backstage plugin for GraphQL Voyager
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/ilert/catalog-info.yaml
+++ b/plugins/ilert/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-ilert
+  title: '@backstage/plugin-ilert'
+  description: A Backstage plugin that integrates towards iLert
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/jenkins-backend/catalog-info.yaml
+++ b/plugins/jenkins-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-jenkins-backend
+  title: '@backstage/plugin-jenkins-backend'
+  description: A Backstage backend plugin that integrates towards Jenkins
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/jenkins-common/catalog-info.yaml
+++ b/plugins/jenkins-common/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-jenkins-common
+  title: '@backstage/plugin-jenkins-common'
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/jenkins/catalog-info.yaml
+++ b/plugins/jenkins/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-jenkins
+  title: '@backstage/plugin-jenkins'
+  description: A Backstage plugin that integrates towards Jenkins
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/lighthouse-backend/catalog-info.yaml
+++ b/plugins/lighthouse-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-lighthouse-backend
+  title: '@backstage/plugin-lighthouse-backend'
+  description: Backend functionalities for lighthouse
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/lighthouse-common/catalog-info.yaml
+++ b/plugins/lighthouse-common/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-lighthouse-common
+  title: '@backstage/plugin-lighthouse-common'
+  description: >-
+    Common functionalities for lighthouse, to be shared between lighthouse and
+    lighthouse-backend plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/lighthouse/catalog-info.yaml
+++ b/plugins/lighthouse/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-lighthouse
+  title: '@backstage/plugin-lighthouse'
+  description: A Backstage plugin that integrates towards Lighthouse
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/microsoft-calendar/catalog-info.yaml
+++ b/plugins/microsoft-calendar/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-microsoft-calendar
+  title: '@backstage/plugin-microsoft-calendar'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/newrelic-dashboard/catalog-info.yaml
+++ b/plugins/newrelic-dashboard/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-newrelic-dashboard
+  title: '@backstage/plugin-newrelic-dashboard'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/newrelic/catalog-info.yaml
+++ b/plugins/newrelic/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-newrelic
+  title: '@backstage/plugin-newrelic'
+  description: A Backstage plugin that integrates towards New Relic
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/nomad-backend/catalog-info.yaml
+++ b/plugins/nomad-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-nomad-backend
+  title: '@backstage/plugin-nomad-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/nomad/catalog-info.yaml
+++ b/plugins/nomad/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-nomad
+  title: '@backstage/plugin-nomad'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/octopus-deploy/catalog-info.yaml
+++ b/plugins/octopus-deploy/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-octopus-deploy
+  title: '@backstage/plugin-octopus-deploy'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/opencost/catalog-info.yaml
+++ b/plugins/opencost/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-opencost
+  title: '@backstage/plugin-opencost'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/org-react/catalog-info.yaml
+++ b/plugins/org-react/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-org-react
+  title: '@backstage/plugin-org-react'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/org/catalog-info.yaml
+++ b/plugins/org/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-org
+  title: '@backstage/plugin-org'
+  description: A Backstage plugin that helps you create entity pages for your organization
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/pagerduty/catalog-info.yaml
+++ b/plugins/pagerduty/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-pagerduty
+  title: '@backstage/plugin-pagerduty'
+  description: A Backstage plugin that integrates towards PagerDuty
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/periskop-backend/catalog-info.yaml
+++ b/plugins/periskop-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-periskop-backend
+  title: '@backstage/plugin-periskop-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/periskop/catalog-info.yaml
+++ b/plugins/periskop/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-periskop
+  title: '@backstage/plugin-periskop'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/proxy-backend/catalog-info.yaml
+++ b/plugins/proxy-backend/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-proxy-backend
+  title: '@backstage/plugin-proxy-backend'
+  description: >-
+    A Backstage backend plugin that helps you set up proxy endpoints in the
+    backend
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/puppetdb/catalog-info.yaml
+++ b/plugins/puppetdb/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-puppetdb
+  title: '@backstage/plugin-puppetdb'
+  description: >-
+    Backstage plugin to visualize resource information and Puppet facts from
+    PuppetDB.
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/catalog-info.yaml
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-confluence-to-markdown
+  title: '@backstage/plugin-scaffolder-backend-module-confluence-to-markdown'
+  description: The confluence-to-markdown module for @backstage/plugin-scaffolder-backend
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/scaffolder-backend-module-cookiecutter/catalog-info.yaml
+++ b/plugins/scaffolder-backend-module-cookiecutter/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-cookiecutter
+  title: '@backstage/plugin-scaffolder-backend-module-cookiecutter'
+  description: >-
+    A module for the scaffolder backend that lets you template projects using
+    cookiecutter
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/scaffolder-backend-module-gitlab/catalog-info.yaml
+++ b/plugins/scaffolder-backend-module-gitlab/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-gitlab
+  title: '@backstage/plugin-scaffolder-backend-module-gitlab'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/scaffolder-backend-module-rails/catalog-info.yaml
+++ b/plugins/scaffolder-backend-module-rails/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-rails
+  title: '@backstage/plugin-scaffolder-backend-module-rails'
+  description: >-
+    A module for the scaffolder backend that lets you template projects using
+    Rails
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/scaffolder-backend-module-sentry/catalog-info.yaml
+++ b/plugins/scaffolder-backend-module-sentry/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-sentry
+  title: '@backstage/plugin-scaffolder-backend-module-sentry'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/scaffolder-backend-module-yeoman/catalog-info.yaml
+++ b/plugins/scaffolder-backend-module-yeoman/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-yeoman
+  title: '@backstage/plugin-scaffolder-backend-module-yeoman'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/scaffolder-backend/catalog-info.yaml
+++ b/plugins/scaffolder-backend/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/plugin-scaffolder-backend'
   description: The Backstage backend plugin that helps you create new things
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-backend-plugin
   owner: maintainers

--- a/plugins/scaffolder-backend/catalog-info.yaml
+++ b/plugins/scaffolder-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend
+  title: '@backstage/plugin-scaffolder-backend'
+  description: The Backstage backend plugin that helps you create new things
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/scaffolder-common/catalog-info.yaml
+++ b/plugins/scaffolder-common/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-common
+  title: '@backstage/plugin-scaffolder-common'
+  description: >-
+    Common functionalities for the scaffolder, to be shared between scaffolder
+    and scaffolder-backend plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/scaffolder-common/catalog-info.yaml
+++ b/plugins/scaffolder-common/catalog-info.yaml
@@ -7,6 +7,6 @@ metadata:
     Common functionalities for the scaffolder, to be shared between scaffolder
     and scaffolder-backend plugin
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-common-library
   owner: maintainers

--- a/plugins/scaffolder-node/catalog-info.yaml
+++ b/plugins/scaffolder-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-node
+  title: '@backstage/plugin-scaffolder-node'
+  description: The plugin-scaffolder-node module for @backstage/plugin-scaffolder-backend
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/plugins/scaffolder-react/catalog-info.yaml
+++ b/plugins/scaffolder-react/catalog-info.yaml
@@ -7,6 +7,6 @@ metadata:
     A frontend library that helps other Backstage plugins interact with the
     Scaffolder
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-web-library
   owner: maintainers

--- a/plugins/scaffolder-react/catalog-info.yaml
+++ b/plugins/scaffolder-react/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-react
+  title: '@backstage/plugin-scaffolder-react'
+  description: >-
+    A frontend library that helps other Backstage plugins interact with the
+    Scaffolder
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/scaffolder/catalog-info.yaml
+++ b/plugins/scaffolder/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder
+  title: '@backstage/plugin-scaffolder'
+  description: The Backstage plugin that helps you create new things
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/scaffolder/catalog-info.yaml
+++ b/plugins/scaffolder/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   title: '@backstage/plugin-scaffolder'
   description: The Backstage plugin that helps you create new things
 spec:
-  lifecycle: experimental
+  lifecycle: production
   type: backstage-frontend-plugin
   owner: maintainers

--- a/plugins/sentry/catalog-info.yaml
+++ b/plugins/sentry/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-sentry
+  title: '@backstage/plugin-sentry'
+  description: A Backstage plugin that integrates towards Sentry
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/shortcuts/catalog-info.yaml
+++ b/plugins/shortcuts/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-shortcuts
+  title: '@backstage/plugin-shortcuts'
+  description: A Backstage plugin that provides a shortcuts feature to the sidebar
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/sonarqube-backend/catalog-info.yaml
+++ b/plugins/sonarqube-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-sonarqube-backend
+  title: '@backstage/plugin-sonarqube-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/sonarqube-react/catalog-info.yaml
+++ b/plugins/sonarqube-react/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-sonarqube-react
+  title: '@backstage/plugin-sonarqube-react'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/splunk-on-call/catalog-info.yaml
+++ b/plugins/splunk-on-call/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-splunk-on-call
+  title: '@backstage/plugin-splunk-on-call'
+  description: A Backstage plugin that integrates towards Splunk On-Call
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/stackstorm/catalog-info.yaml
+++ b/plugins/stackstorm/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-stackstorm
+  title: '@backstage/plugin-stackstorm'
+  description: A Backstage plugin that integrates towards StackStorm
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/tech-radar/catalog-info.yaml
+++ b/plugins/tech-radar/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tech-radar
+  title: '@backstage/plugin-tech-radar'
+  description: A Backstage plugin that lets you display a Tech Radar for your organization
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/todo-backend/catalog-info.yaml
+++ b/plugins/todo-backend/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-todo-backend
+  title: '@backstage/plugin-todo-backend'
+  description: >-
+    A Backstage backend plugin that lets you browse TODO comments in your source
+    code
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/todo/catalog-info.yaml
+++ b/plugins/todo/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-todo
+  title: '@backstage/plugin-todo'
+  description: A Backstage plugin that lets you browse TODO comments in your source code
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/user-settings/catalog-info.yaml
+++ b/plugins/user-settings/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-user-settings
+  title: '@backstage/plugin-user-settings'
+  description: A Backstage plugin that provides a settings page
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/vault-backend/catalog-info.yaml
+++ b/plugins/vault-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-vault-backend
+  title: '@backstage/plugin-vault-backend'
+  description: A Backstage backend plugin that integrates towards Vault
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/vault/catalog-info.yaml
+++ b/plugins/vault/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-vault
+  title: '@backstage/plugin-vault'
+  description: A Backstage plugin that integrates towards Vault
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/xcmetrics/catalog-info.yaml
+++ b/plugins/xcmetrics/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-xcmetrics
+  title: '@backstage/plugin-xcmetrics'
+  description: A Backstage plugin that shows XCode build metrics for your components
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers


### PR DESCRIPTION
## What / Why

Continuing from #19485, here's all of the info YAMLs for packages definitively owned by maintainers.

Reminder: The aim of these files, at least initially, is to better catalog (😄) these packages in something like a demo Backstage instance. ...These files are not guaranteed to remain in the repo! Do not rely on their existence.

I will open up additional PRs for

- Packages with other ownership claims
- Automation for maintaining these files
