### PR TITLE
Add remaining owned `catalog-info.yaml` files

### DIFF
--- a/plugins/adr-backend/catalog-info.yaml
+++ b/plugins/adr-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-adr-backend
+  title: '@backstage/plugin-adr-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: kuangp

--- a/plugins/adr-common/catalog-info.yaml
+++ b/plugins/adr-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-adr-common
+  title: '@backstage/plugin-adr-common'
+  description: Common functionalities for the adr plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: kuangp

--- a/plugins/adr/catalog-info.yaml
+++ b/plugins/adr/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-adr
+  title: '@backstage/plugin-adr'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: kuangp

--- a/plugins/api-docs/catalog-info.yaml
+++ b/plugins/api-docs/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-api-docs
+  title: '@backstage/plugin-api-docs'
+  description: A Backstage plugin that helps represent API entities in the frontend
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: sda-se-reviewers

--- a/plugins/azure-devops-backend/catalog-info.yaml
+++ b/plugins/azure-devops-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-azure-devops-backend
+  title: '@backstage/plugin-azure-devops-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: awanlin

--- a/plugins/azure-devops-common/catalog-info.yaml
+++ b/plugins/azure-devops-common/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-azure-devops-common
+  title: '@backstage/plugin-azure-devops-common'
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: awanlin

--- a/plugins/azure-devops/catalog-info.yaml
+++ b/plugins/azure-devops/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-azure-devops
+  title: '@backstage/plugin-azure-devops'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: awanlin

--- a/plugins/bitbucket-cloud-common/catalog-info.yaml
+++ b/plugins/bitbucket-cloud-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-bitbucket-cloud-common
+  title: '@backstage/plugin-bitbucket-cloud-common'
+  description: Common functionalities for bitbucket-cloud plugins
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: pjungermann

--- a/plugins/bitrise/catalog-info.yaml
+++ b/plugins/bitrise/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-bitrise
+  title: '@backstage/plugin-bitrise'
+  description: A Backstage plugin that integrates towards Bitrise
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: sda-se-reviewers

--- a/plugins/catalog-backend-module-aws/catalog-info.yaml
+++ b/plugins/catalog-backend-module-aws/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-aws
+  title: '@backstage/plugin-catalog-backend-module-aws'
+  description: A Backstage catalog backend module that helps integrate towards AWS
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/catalog-backend-module-bitbucket-cloud/catalog-info.yaml
+++ b/plugins/catalog-backend-module-bitbucket-cloud/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-bitbucket-cloud
+  title: '@backstage/plugin-catalog-backend-module-bitbucket-cloud'
+  description: >-
+    A Backstage catalog backend module that helps integrate towards Bitbucket
+    Cloud
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/catalog-backend-module-msgraph/catalog-info.yaml
+++ b/plugins/catalog-backend-module-msgraph/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-msgraph
+  title: '@backstage/plugin-catalog-backend-module-msgraph'
+  description: >-
+    A Backstage catalog backend module that helps integrate towards Microsoft
+    Graph
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/catalog-backend-module-puppetdb/catalog-info.yaml
+++ b/plugins/catalog-backend-module-puppetdb/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-puppetdb
+  title: '@backstage/plugin-catalog-backend-module-puppetdb'
+  description: A Backstage catalog backend module that helps integrate towards PuppetDB
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: catalog-maintainers

--- a/plugins/catalog-graph/catalog-info.yaml
+++ b/plugins/catalog-graph/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-graph
+  title: '@backstage/plugin-catalog-graph'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: sda-se-reviewers

--- a/plugins/circleci/catalog-info.yaml
+++ b/plugins/circleci/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-circleci
+  title: '@backstage/plugin-circleci'
+  description: A Backstage plugin that integrates towards Circle CI
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: adamdmharvey

--- a/plugins/code-coverage-backend/catalog-info.yaml
+++ b/plugins/code-coverage-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-code-coverage-backend
+  title: '@backstage/plugin-code-coverage-backend'
+  description: A Backstage backend plugin that helps you keep track of your code coverage
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: alde

--- a/plugins/code-coverage/catalog-info.yaml
+++ b/plugins/code-coverage/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-code-coverage
+  title: '@backstage/plugin-code-coverage'
+  description: A Backstage plugin that helps you keep track of your code coverage
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: alde

--- a/plugins/cost-insights-common/catalog-info.yaml
+++ b/plugins/cost-insights-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-cost-insights-common
+  title: '@backstage/plugin-cost-insights-common'
+  description: Common functionalities for the cost-insights plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: silver-lining

--- a/plugins/cost-insights/catalog-info.yaml
+++ b/plugins/cost-insights/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-cost-insights
+  title: '@backstage/plugin-cost-insights'
+  description: A Backstage plugin that helps you keep track of your cloud spend
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: silver-lining

--- a/plugins/devtools-backend/catalog-info.yaml
+++ b/plugins/devtools-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-devtools-backend
+  title: '@backstage/plugin-devtools-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: awanlin

--- a/plugins/devtools-common/catalog-info.yaml
+++ b/plugins/devtools-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-devtools-common
+  title: '@backstage/plugin-devtools-common'
+  description: Common functionalities for the devtools plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: awanlin

--- a/plugins/devtools/catalog-info.yaml
+++ b/plugins/devtools/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-devtools
+  title: '@backstage/plugin-devtools'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: awanlin

--- a/plugins/entity-feedback-backend/catalog-info.yaml
+++ b/plugins/entity-feedback-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-entity-feedback-backend
+  title: '@backstage/plugin-entity-feedback-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: kuangp

--- a/plugins/entity-feedback-common/catalog-info.yaml
+++ b/plugins/entity-feedback-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-entity-feedback-common
+  title: '@backstage/plugin-entity-feedback-common'
+  description: Common functionalities for the entity-feedback plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: kuangp

--- a/plugins/entity-feedback/catalog-info.yaml
+++ b/plugins/entity-feedback/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-entity-feedback
+  title: '@backstage/plugin-entity-feedback'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: kuangp

--- a/plugins/events-backend-module-aws-sqs/catalog-info.yaml
+++ b/plugins/events-backend-module-aws-sqs/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-module-aws-sqs
+  title: '@backstage/plugin-events-backend-module-aws-sqs'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/events-backend-module-azure/catalog-info.yaml
+++ b/plugins/events-backend-module-azure/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-module-azure
+  title: '@backstage/plugin-events-backend-module-azure'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/events-backend-module-bitbucket-cloud/catalog-info.yaml
+++ b/plugins/events-backend-module-bitbucket-cloud/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-module-bitbucket-cloud
+  title: '@backstage/plugin-events-backend-module-bitbucket-cloud'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/events-backend-module-gerrit/catalog-info.yaml
+++ b/plugins/events-backend-module-gerrit/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-module-gerrit
+  title: '@backstage/plugin-events-backend-module-gerrit'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/events-backend-module-github/catalog-info.yaml
+++ b/plugins/events-backend-module-github/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-module-github
+  title: '@backstage/plugin-events-backend-module-github'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/events-backend-module-gitlab/catalog-info.yaml
+++ b/plugins/events-backend-module-gitlab/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-module-gitlab
+  title: '@backstage/plugin-events-backend-module-gitlab'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: pjungermann

--- a/plugins/events-backend-test-utils/catalog-info.yaml
+++ b/plugins/events-backend-test-utils/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend-test-utils
+  title: '@backstage/plugin-events-backend-test-utils'
+  description: The plugin-events-backend-test-utils for @backstage/plugin-events-node
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: pjungermann

--- a/plugins/events-backend/catalog-info.yaml
+++ b/plugins/events-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-backend
+  title: '@backstage/plugin-events-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: pjungermann

--- a/plugins/events-node/catalog-info.yaml
+++ b/plugins/events-node/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-events-node
+  title: '@backstage/plugin-events-node'
+  description: The plugin-events-node module for @backstage/plugin-events-backend
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: pjungermann

--- a/plugins/explore-react/catalog-info.yaml
+++ b/plugins/explore-react/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-explore-react
+  title: '@backstage/plugin-explore-react'
+  description: >-
+    A frontend library for Backstage plugins that want to interact with the
+    explore plugin
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: sda-se-reviewers

--- a/plugins/explore/catalog-info.yaml
+++ b/plugins/explore/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-explore
+  title: '@backstage/plugin-explore'
+  description: >-
+    A Backstage plugin for building an exploration page of your software
+    ecosystem
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: sda-se-reviewers

--- a/plugins/fossa/catalog-info.yaml
+++ b/plugins/fossa/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-fossa
+  title: '@backstage/plugin-fossa'
+  description: A Backstage plugin that integrates towards FOSSA
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: sda-se-reviewers

--- a/plugins/git-release-manager/catalog-info.yaml
+++ b/plugins/git-release-manager/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-git-release-manager
+  title: '@backstage/plugin-git-release-manager'
+  description: A Backstage plugin that helps you manage releases in git
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: erikengervall

--- a/plugins/kafka-backend/catalog-info.yaml
+++ b/plugins/kafka-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-kafka-backend
+  title: '@backstage/plugin-kafka-backend'
+  description: A Backstage backend plugin that integrates towards Kafka
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: andrewthauer

--- a/plugins/kafka/catalog-info.yaml
+++ b/plugins/kafka/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-kafka
+  title: '@backstage/plugin-kafka'
+  description: A Backstage plugin that integrates towards Kafka
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: andrewthauer

--- a/plugins/linguist-backend/catalog-info.yaml
+++ b/plugins/linguist-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-linguist-backend
+  title: '@backstage/plugin-linguist-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: awanlin

--- a/plugins/linguist-common/catalog-info.yaml
+++ b/plugins/linguist-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-linguist-common
+  title: '@backstage/plugin-linguist-common'
+  description: Common functionalities for the linguist plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: awanlin

--- a/plugins/linguist/catalog-info.yaml
+++ b/plugins/linguist/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-linguist
+  title: '@backstage/plugin-linguist'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: awanlin

--- a/plugins/playlist-backend/catalog-info.yaml
+++ b/plugins/playlist-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-playlist-backend
+  title: '@backstage/plugin-playlist-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: kuangp

--- a/plugins/playlist-common/catalog-info.yaml
+++ b/plugins/playlist-common/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-playlist-common
+  title: '@backstage/plugin-playlist-common'
+  description: Common functionalities for the playlist plugin
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: kuangp

--- a/plugins/playlist/catalog-info.yaml
+++ b/plugins/playlist/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-playlist
+  title: '@backstage/plugin-playlist'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: kuangp

--- a/plugins/rollbar-backend/catalog-info.yaml
+++ b/plugins/rollbar-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-rollbar-backend
+  title: '@backstage/plugin-rollbar-backend'
+  description: A Backstage backend plugin that integrates towards Rollbar
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: andrewthauer

--- a/plugins/rollbar/catalog-info.yaml
+++ b/plugins/rollbar/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-rollbar
+  title: '@backstage/plugin-rollbar'
+  description: A Backstage plugin that integrates towards Rollbar
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: andrewthauer

--- a/plugins/sonarqube/catalog-info.yaml
+++ b/plugins/sonarqube/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-sonarqube
+  title: '@backstage/plugin-sonarqube'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: sda-se-reviewers

--- a/plugins/stack-overflow-backend/catalog-info.yaml
+++ b/plugins/stack-overflow-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-stack-overflow-backend
+  title: '@backstage/plugin-stack-overflow-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: discoverability-maintainers

--- a/plugins/stack-overflow/catalog-info.yaml
+++ b/plugins/stack-overflow/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-stack-overflow
+  title: '@backstage/plugin-stack-overflow'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: discoverability-maintainers

--- a/plugins/tech-insights-backend-module-jsonfc/catalog-info.yaml
+++ b/plugins/tech-insights-backend-module-jsonfc/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tech-insights-backend-module-jsonfc
+  title: '@backstage/plugin-tech-insights-backend-module-jsonfc'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: xantier

--- a/plugins/tech-insights-backend/catalog-info.yaml
+++ b/plugins/tech-insights-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tech-insights-backend
+  title: '@backstage/plugin-tech-insights-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: xantier

--- a/plugins/tech-insights-common/catalog-info.yaml
+++ b/plugins/tech-insights-common/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tech-insights-common
+  title: '@backstage/plugin-tech-insights-common'
+spec:
+  lifecycle: experimental
+  type: backstage-common-library
+  owner: maintainers

--- a/plugins/tech-insights-node/catalog-info.yaml
+++ b/plugins/tech-insights-node/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tech-insights-node
+  title: '@backstage/plugin-tech-insights-node'
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/plugins/tech-insights/catalog-info.yaml
+++ b/plugins/tech-insights/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tech-insights
+  title: '@backstage/plugin-tech-insights'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/user-settings-backend/catalog-info.yaml
+++ b/plugins/user-settings-backend/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-user-settings-backend
+  title: '@backstage/plugin-user-settings-backend'
+  description: The Backstage backend plugin to manage user settings
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: sda-se-reviewers


### PR DESCRIPTION
## What / Why

Hello again everyone! 👋 

This is a continuation off of https://github.com/backstage/backstage/pull/19555, where I'm adding `catalog-info.yaml` files for non-maintainer / non-project area plugins.

Reminder: The aim of these files, at least initially, is to better catalog (😄) these packages in something like a demo Backstage instance. ...These files are not guaranteed to remain in the repo! Do not rely on their existence (but feel free to adorn them with whatever metadata makes sense).

I will open up an additional PR that automates some of the toil around maintaining these files in a follow-up PR
