### PR TITLE
fix(devcontainer): fixes python new requirements for venvs

### DIFF
--- a/contrib/.devcontainer/devcontainer.json
+++ b/contrib/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:1": {},
     "ghcr.io/devcontainers/features/docker-from-docker:1": {},
-    "ghcr.io/devcontainers-contrib/features/mkdocs:1": {}
+    "ghcr.io/devcontainers-contrib/features/mkdocs:2": {}
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/contrib/.devcontainer/postCreate.sh
+++ b/contrib/.devcontainer/postCreate.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 yarn install
-pip install mkdocs-techdocs-core
+export VIRTUAL_ENV=$HOME/venv
+python3 -m venv $VIRTUAL_ENV
+export PATH="$VIRTUAL_ENV/bin:$PATH"
+python3 -m pip install mkdocs-techdocs-core


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Python3 new versions were blocking us from installing pip dependencies directly in the system, without specifying a VENV first.

When trying to build the current devcontainer, it would fail with the following error:

```bash
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.
```


This PR fixes the devcontainer by upgrading the mkdocs feature to **v2** and updating the **postCreate** to setup a venv

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
