### PR TITLE
Switch to Node.js v18 + v20

### DIFF
--- a/.changeset/silent-years-bake.md
+++ b/.changeset/silent-years-bake.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+'@techdocs/cli': patch
+'@backstage/cli': patch
+'@backstage/cli-common': patch
+'@backstage/create-app': patch
+'@backstage/codemods': patch
+'@backstage/repo-tools': patch
+---
+
+Bumped `@types/node` dependency to `^18.17.8`.

--- a/.changeset/silent-years-bake.md
+++ b/.changeset/silent-years-bake.md
@@ -8,4 +8,4 @@
 '@backstage/repo-tools': patch
 ---
 
-Bumped `@types/node` dependency to `^18.17.8`.
+Bumped dev dependencies `@types/node` and `mock-fs`.

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     name: Verify ${{ matrix.node-version }}
     steps:
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     name: Test ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     name: Test ${{ matrix.node-version }}
     services:

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     services:
       postgres13:
@@ -130,7 +130,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     env:
       CI: 'true'

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -10,7 +10,7 @@ jobs:
       # Setup node & install deps before checkout, keeping install quick
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.x
       - name: Install dependencies
         # Just the deps for the assemble manifest script
         run: npm install semver@7.3.5 fs-extra@10.0.0 @manypkg/get-packages@1.1.1

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -25,13 +25,13 @@ jobs:
       - name: setup-node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/
 
       - name: yarn install
         uses: backstage/actions/yarn-install@v0.6.4
         with:
-          cache-prefix: linux-v16
+          cache-prefix: linux-v18
 
       - name: Use Uffizzi's backstage app config
         run: |

--- a/.github/workflows/verify_accessibility.yml
+++ b/.github/workflows/verify_accessibility.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: yarn install
         uses: backstage/actions/yarn-install@v0.6.4
         with:
-          cache-prefix: ${{ runner.os }}-v16.x
+          cache-prefix: ${{ runner.os }}-v18.x
       - name: run Lighthouse CI
         run: |
           yarn dlx @lhci/cli@0.11.x autorun

--- a/.github/workflows/verify_e2e-kubernetes-noop.yml
+++ b/.github/workflows/verify_e2e-kubernetes-noop.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     name: Kubernetes ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/verify_e2e-kubernetes.yml
+++ b/.github/workflows/verify_e2e-kubernetes.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_e2e-linux-noop.yml
+++ b/.github/workflows/verify_e2e-linux-noop.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     name: E2E Linux ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_e2e-windows-noop.yml
+++ b/.github/workflows/verify_e2e-windows-noop.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     name: E2E Windows ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_storybook.yml
+++ b/.github/workflows/verify_storybook.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [16.x]
+        node-version: [18.x]
 
     name: Storybook
     steps:

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     env:
       CI: true

--- a/.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch
+++ b/.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/binding.js b/lib/binding.js
+index a4a3e6cdc197bd0f12fe2d060640e91ac58ab457..ab04ce3115fe93073a3e25008730272b6fa21bd7 100644
+--- a/lib/binding.js
++++ b/lib/binding.js
+@@ -165,6 +165,8 @@ function Binding(system) {
+   this.trackDescriptor(stderr);
+ }
+ 
++Binding.prototype.readFileSync = path => require('fs').readFileSync(path).toString('utf8');
++
+ /**
+  * Get the file system underlying this binding.
+  * @return {FileSystem} The underlying file system.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@spotify/eslint-plugin": "^14.1.3",
     "@spotify/prettier-config": "^14.0.0",
     "@techdocs/cli": "workspace:*",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "@types/webpack": "^5.28.0",
     "command-exists": "^1.2.9",
     "concurrently": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": "16 || 18"
+    "node": "18 || 20"
   },
   "scripts": {
     "dev": "concurrently 'yarn start' 'yarn start-backend'",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   },
   "resolutions": {
     "@types/react": "^17",
-    "@types/react-dom": "^17"
+    "@types/react-dom": "^17",
+    "mock-fs@^5.2.0": "patch:mock-fs@npm%3A5.2.0#./.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch"
   },
   "version": "1.18.0",
   "dependencies": {

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -138,7 +138,7 @@
     "aws-sdk-client-mock": "^2.0.0",
     "better-sqlite3": "^8.0.0",
     "http-errors": "^2.0.0",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "msw": "^1.0.0",
     "mysql2": "^2.2.5",
     "recursive-readdir": "^2.2.2",

--- a/packages/backend-common/src/reading/ReadUrlResponseFactory.test.ts
+++ b/packages/backend-common/src/reading/ReadUrlResponseFactory.test.ts
@@ -78,7 +78,9 @@ describe('ReadUrlResponseFactory', () => {
     let readable: NodeJS.ReadableStream;
 
     beforeEach(() => {
-      readable = new Stream({ encoding: 'utf-8' }) as NodeJS.ReadableStream;
+      readable = new Stream({
+        encoding: 'utf-8',
+      }) as unknown as NodeJS.ReadableStream;
       readable.readable = true;
 
       // Write data asynchronously, as soon as possible.

--- a/packages/backend-common/src/reading/tree/ReadableArrayResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/ReadableArrayResponse.test.ts
@@ -72,11 +72,11 @@ describe('ReadableArrayResponse', () => {
     const res = new ReadableArrayResponse(arr, '/tmp', 'etag');
     const dir = await res.dir();
 
-    expect(fs.readFileSync(resolvePath(dir, 'file1.yaml'), 'utf8').trim()).toBe(
-      'site_name: Test',
-    );
-    expect(fs.readFileSync(resolvePath(dir, 'file2.yaml'), 'utf8').trim()).toBe(
-      'site_name: Test2',
-    );
+    await expect(
+      fs.readFile(resolvePath(dir, 'file1.yaml'), 'utf8'),
+    ).resolves.toBe('site_name: Test\n');
+    await expect(
+      fs.readFile(resolvePath(dir, 'file2.yaml'), 'utf8'),
+    ).resolves.toBe('site_name: Test2\n');
   });
 });

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -18,16 +18,24 @@ import {
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
-import { mockServices } from '@backstage/backend-test-utils';
 import { createBackend } from './CreateBackend';
 
 describe('createBackend', () => {
   it('should not throw when overriding a default service implementation', async () => {
     const backend = createBackend();
 
-    backend.add(mockServices.rootConfig.factory());
+    backend.add(
+      createServiceFactory({
+        service: coreServices.rootConfig,
+        deps: {},
+        factory(): never {
+          throw new Error('NOPE');
+        },
+      }),
+    );
 
-    await expect(backend.start()).resolves.toBe(undefined);
+    // We expect the service factory error to be thrown, rather than any earlier validation
+    await expect(backend.start()).rejects.toThrow('NOPE');
   });
 
   it('should throw on duplicate service implementations', async () => {

--- a/packages/backend-plugin-manager/src/manager/plugin-manager.test.ts
+++ b/packages/backend-plugin-manager/src/manager/plugin-manager.test.ts
@@ -274,7 +274,7 @@ describe('backend-plugin-manager', () => {
               {
                 message: `an error occured while loading dynamic backend plugin 'backend-dynamic-plugin-test' from '${location}'`,
                 meta: {
-                  message: 'Unexpected identifier',
+                  message: expect.stringContaining('Unexpected identifier'),
                   name: 'SyntaxError',
                 },
               },

--- a/packages/backend-plugin-manager/src/scanner/plugin-scanner.test.ts
+++ b/packages/backend-plugin-manager/src/scanner/plugin-scanner.test.ts
@@ -571,7 +571,7 @@ Please add '/backstageRoot/node_modules' to the 'NODE_PATH' when running the bac
                 "failed to load dynamic plugin manifest from '/backstageRoot/dist-dynamic/test-backend-plugin/alpha'",
               meta: {
                 name: 'SyntaxError',
-                message: 'Unexpected token i in JSON at position 0',
+                message: expect.stringContaining('Unexpected token'),
               },
             },
           ],
@@ -604,7 +604,7 @@ Please add '/backstageRoot/node_modules' to the 'NODE_PATH' when running the bac
                 "failed to load dynamic plugin manifest from '/backstageRoot/dist-dynamic/test-backend-plugin'",
               meta: {
                 name: 'SyntaxError',
-                message: 'Unexpected token i in JSON at position 0',
+                message: expect.stringContaining('Unexpected token'),
               },
             },
           ],

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "@types/node": "^16.0.0"
+    "@types/node": "^18.17.8"
   },
   "files": [
     "dist"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -158,7 +158,7 @@
     "@types/inquirer": "^8.1.3",
     "@types/minimatch": "^5.0.0",
     "@types/mock-fs": "^4.13.0",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "@types/npm-packlist": "^3.0.0",
     "@types/recursive-readdir": "^2.2.0",
     "@types/rollup-plugin-peer-deps-external": "^2.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -168,7 +168,7 @@
     "@types/terser-webpack-plugin": "^5.0.4",
     "@types/yarnpkg__lockfile": "^1.1.4",
     "del": "^7.0.0",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "msw": "^1.0.0",
     "nodemon": "^3.0.1",
     "ts-node": "^10.0.0",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/jscodeshift": "^0.11.0",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "ts-node": "^10.0.0"
   },
   "nodemonConfig": {

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -57,7 +57,7 @@
     "@types/json-schema-merge-allof": "^0.6.0",
     "@types/mock-fs": "^4.10.0",
     "@types/yup": "^0.29.13",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "msw": "^1.0.0",
     "zen-observable": "^0.10.0"
   },

--- a/packages/core-app-api/src/app/defaultConfigLoader.test.ts
+++ b/packages/core-app-api/src/app/defaultConfigLoader.test.ts
@@ -70,7 +70,7 @@ describe('defaultConfigLoaderSync', () => {
     anyEnv.APP_CONFIG = [{ data: { my: 'config' }, context: 'a' }];
 
     expect(() => defaultConfigLoaderSync('}')).toThrow(
-      'Failed to load runtime configuration, SyntaxError: Unexpected token } in JSON at position 0',
+      'Failed to load runtime configuration, SyntaxError: Unexpected token',
     );
   });
 

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -46,7 +46,7 @@
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^9.0.1",
     "@types/inquirer": "^8.1.3",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "@types/recursive-readdir": "^2.2.0",
     "mock-fs": "^5.1.1",
     "nodemon": "^3.0.1",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -48,7 +48,7 @@
     "@types/inquirer": "^8.1.3",
     "@types/node": "^18.17.8",
     "@types/recursive-readdir": "^2.2.0",
-    "mock-fs": "^5.1.1",
+    "mock-fs": "^5.2.0",
     "nodemon": "^3.0.1",
     "ts-node": "^10.0.0"
   },

--- a/packages/create-app/src/lib/tasks.test.ts
+++ b/packages/create-app/src/lib/tasks.test.ts
@@ -304,13 +304,13 @@ describe('tasks', () => {
         },
       );
       // catalog was populated with `context.name`
-      expect(
-        fs.readFileSync('templatedApp/catalog-info.yaml', 'utf-8'),
-      ).toContain('name: SuperCoolBackstageInstance');
+      await expect(
+        fs.readFile('templatedApp/catalog-info.yaml', 'utf-8'),
+      ).resolves.toContain('name: SuperCoolBackstageInstance');
       // backend dependencies include `sqlite3` from `context.SQLite`
-      expect(
-        fs.readFileSync('templatedApp/packages/backend/package.json', 'utf-8'),
-      ).toContain('sqlite3"');
+      await expect(
+        fs.readFile('templatedApp/packages/backend/package.json', 'utf-8'),
+      ).resolves.toContain('sqlite3"');
     });
   });
 

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "16 || 18"
+    "node": "18 || 20"
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",

--- a/packages/e2e-test/package.json
+++ b/packages/e2e-test/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/fs-extra": "^9.0.1",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "@types/puppeteer": "^5.4.4",
     "nodemon": "^3.0.1",
     "ts-node": "^10.0.0"

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -181,6 +181,12 @@ async function buildDistWorkspace(workspaceName: string, rootDir: string) {
   print('Pinning yarn version in workspace');
   await pinYarnVersion(workspaceDir);
 
+  const yarnPatchesPath = paths.resolveOwnRoot('.yarn/patches');
+  if (await fs.pathExists(yarnPatchesPath)) {
+    print('Copying yarn patches');
+    await fs.copy(yarnPatchesPath, resolvePath(workspaceDir, '.yarn/patches'));
+  }
+
   print('Installing workspace dependencies');
   await runPlain(['yarn', 'workspaces', 'focus', '--all', '--production'], {
     cwd: workspaceDir,

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -65,7 +65,7 @@
     "@types/is-glob": "^4.0.2",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^18.17.8",
-    "mock-fs": "^5.1.0"
+    "mock-fs": "^5.2.0"
   },
   "peerDependencies": {
     "@microsoft/api-extractor-model": "*",

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -64,7 +64,7 @@
     "@backstage/types": "workspace:^",
     "@types/is-glob": "^4.0.2",
     "@types/mock-fs": "^4.13.0",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "mock-fs": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -41,7 +41,7 @@
     "@types/commander": "^2.12.2",
     "@types/fs-extra": "^9.0.6",
     "@types/http-proxy": "^1.17.4",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "@types/serve-handler": "^6.1.0",
     "@types/webpack-env": "^1.15.3",
     "cypress": "^10.0.0",

--- a/plugins/app-backend/package.json
+++ b/plugins/app-backend/package.json
@@ -69,7 +69,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/supertest": "^2.0.8",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "msw": "^1.0.0",
     "node-fetch": "^2.6.7",
     "supertest": "^6.1.3"

--- a/plugins/scaffolder-backend-module-cookiecutter/package.json
+++ b/plugins/scaffolder-backend-module-cookiecutter/package.json
@@ -45,7 +45,7 @@
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^9.0.1",
     "@types/mock-fs": "^4.13.0",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "msw": "^1.0.0"
   },
   "files": [

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -43,7 +43,7 @@
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^9.0.1",
     "@types/mock-fs": "^4.13.0",
-    "@types/node": "^16.11.26",
+    "@types/node": "^18.17.8",
     "jest-when": "^3.1.0",
     "mock-fs": "^5.1.0"
   },

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -45,7 +45,7 @@
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^18.17.8",
     "jest-when": "^3.1.0",
-    "mock-fs": "^5.1.0"
+    "mock-fs": "^5.2.0"
   },
   "files": [
     "dist"

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -113,7 +113,7 @@
     "@types/zen-observable": "^0.8.0",
     "esbuild": "^0.19.0",
     "jest-when": "^3.1.0",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "msw": "^1.0.0",
     "supertest": "^6.1.3",
     "wait-for-expect": "^3.0.2",

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/rename.examples.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/rename.examples.test.ts
@@ -85,8 +85,8 @@ describe('fs:rename examples', () => {
     const sourceFilePath = resolvePath(workspacePath, sourceFile);
     const destFilePath = resolvePath(workspacePath, destFile);
 
-    const sourceBeforeContent = fs.readFileSync(sourceFilePath, 'utf-8');
-    const destBeforeContent = fs.readFileSync(destFilePath, 'utf-8');
+    const sourceBeforeContent = await fs.readFile(sourceFilePath, 'utf-8');
+    const destBeforeContent = await fs.readFile(destFilePath, 'utf-8');
 
     expect(sourceBeforeContent).not.toEqual(destBeforeContent);
 
@@ -97,7 +97,7 @@ describe('fs:rename examples', () => {
       },
     });
 
-    const destAfterContent = fs.readFileSync(destFilePath, 'utf-8');
+    const destAfterContent = await fs.readFile(destFilePath, 'utf-8');
 
     expect(sourceBeforeContent).toEqual(destAfterContent);
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/rename.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/rename.test.ts
@@ -148,7 +148,7 @@ describe('fs:rename', () => {
   it('should throw is trying to override by mistake', async () => {
     const destFile = 'unit-test-c.js';
     const filePath = resolvePath(workspacePath, destFile);
-    const beforeContent = fs.readFileSync(filePath, 'utf-8');
+    const beforeContent = await fs.readFile(filePath, 'utf-8');
 
     await expect(
       action.handler({
@@ -164,7 +164,7 @@ describe('fs:rename', () => {
       }),
     ).rejects.toThrow(/dest already exists/);
 
-    const afterContent = fs.readFileSync(filePath, 'utf-8');
+    const afterContent = await fs.readFile(filePath, 'utf-8');
 
     expect(beforeContent).toEqual(afterContent);
   });
@@ -191,8 +191,8 @@ describe('fs:rename', () => {
     const sourceFilePath = resolvePath(workspacePath, sourceFile);
     const destFilePath = resolvePath(workspacePath, destFile);
 
-    const sourceBeforeContent = fs.readFileSync(sourceFilePath, 'utf-8');
-    const destBeforeContent = fs.readFileSync(destFilePath, 'utf-8');
+    const sourceBeforeContent = await fs.readFile(sourceFilePath, 'utf-8');
+    const destBeforeContent = await fs.readFile(destFilePath, 'utf-8');
 
     expect(sourceBeforeContent).not.toEqual(destBeforeContent);
 
@@ -209,7 +209,7 @@ describe('fs:rename', () => {
       },
     });
 
-    const destAfterContent = fs.readFileSync(destFilePath, 'utf-8');
+    const destAfterContent = await fs.readFile(destFilePath, 'utf-8');
 
     expect(sourceBeforeContent).toEqual(destAfterContent);
   });

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -63,7 +63,7 @@
     "js-yaml": "^4.0.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",
-    "mock-fs": "^5.1.0",
+    "mock-fs": "^5.2.0",
     "p-limit": "^3.1.0",
     "recursive-readdir": "^2.2.2",
     "winston": "^3.2.1"

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -393,7 +393,7 @@ describe('helpers', () => {
 
       await patchIndexPreBuild({ inputDir: '/', logger: mockLogger });
 
-      expect(fs.readFileSync('/docs/index.md', 'utf-8')).toEqual(
+      await expect(fs.readFile('/docs/index.md', 'utf-8')).resolves.toEqual(
         'index.md content',
       );
       expect(warn).not.toHaveBeenCalledWith();
@@ -407,7 +407,7 @@ describe('helpers', () => {
 
       await patchIndexPreBuild({ inputDir: '/', logger: mockLogger });
 
-      expect(fs.readFileSync('/docs/index.md', 'utf-8')).toEqual(
+      await expect(fs.readFile('/docs/index.md', 'utf-8')).resolves.toEqual(
         'docs/README.md content',
       );
       expect(warn.mock.calls).toEqual([
@@ -422,7 +422,7 @@ describe('helpers', () => {
 
       await patchIndexPreBuild({ inputDir: '/', logger: mockLogger });
 
-      expect(fs.readFileSync('/docs/index.md', 'utf-8')).toEqual(
+      await expect(fs.readFile('/docs/index.md', 'utf-8')).resolves.toEqual(
         'main README.md content',
       );
       expect(warn.mock.calls).toEqual([
@@ -437,7 +437,7 @@ describe('helpers', () => {
 
       await patchIndexPreBuild({ inputDir: '/', logger: mockLogger });
 
-      expect(() => fs.readFileSync('/docs/index.md', 'utf-8')).toThrow();
+      await expect(fs.readFile('/docs/index.md', 'utf-8')).rejects.toThrow();
       const paths = [
         path.normalize('docs/index.md'),
         path.normalize('docs/README.md'),
@@ -483,7 +483,7 @@ describe('helpers', () => {
 
       await expect(
         createOrUpdateMetadata(filePath, mockLogger),
-      ).rejects.toThrow('Unexpected token d in JSON at position 0');
+      ).rejects.toThrow('Unexpected token');
     });
 
     it('should add build timestamp to the metadata json', async () => {
@@ -520,7 +520,7 @@ describe('helpers', () => {
       const filePath = path.join(rootDir, 'invalid_techdocs_metadata.json');
 
       await expect(storeEtagMetadata(filePath, 'etag123abc')).rejects.toThrow(
-        'Unexpected token d in JSON at position 0',
+        'Unexpected token',
       );
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,7 +3696,7 @@ __metadata:
   resolution: "@backstage/cli-common@workspace:packages/cli-common"
   dependencies:
     "@backstage/cli": "workspace:^"
-    "@types/node": ^16.0.0
+    "@types/node": ^18.17.8
   languageName: unknown
   linkType: soft
 
@@ -3773,7 +3773,7 @@ __metadata:
     "@types/jest": ^29.0.0
     "@types/minimatch": ^5.0.0
     "@types/mock-fs": ^4.13.0
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     "@types/npm-packlist": ^3.0.0
     "@types/recursive-readdir": ^2.2.0
     "@types/rollup-plugin-peer-deps-external": ^2.2.0
@@ -3878,7 +3878,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@types/jscodeshift": ^0.11.0
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     chalk: ^4.0.0
     commander: ^9.1.0
     jscodeshift: ^0.15.0
@@ -4133,7 +4133,7 @@ __metadata:
     "@types/command-exists": ^1.2.0
     "@types/fs-extra": ^9.0.1
     "@types/inquirer": ^8.1.3
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     "@types/recursive-readdir": ^2.2.0
     chalk: ^4.0.0
     commander: ^9.1.0
@@ -8344,7 +8344,7 @@ __metadata:
     "@types/command-exists": ^1.2.0
     "@types/fs-extra": ^9.0.1
     "@types/mock-fs": ^4.13.0
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     command-exists: ^1.2.9
     fs-extra: ^10.0.1
     jest-when: ^3.1.0
@@ -9719,7 +9719,7 @@ __metadata:
     "@stoplight/types": ^13.14.0
     "@types/is-glob": ^4.0.2
     "@types/mock-fs": ^4.13.0
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     chalk: ^4.0.0
     codeowners-utils: ^1.0.2
     commander: ^9.1.0
@@ -16457,7 +16457,7 @@ __metadata:
     "@types/dockerode": ^3.3.0
     "@types/fs-extra": ^9.0.6
     "@types/http-proxy": ^1.17.4
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     "@types/serve-handler": ^6.1.0
     "@types/webpack-env": ^1.15.3
     commander: ^9.1.0
@@ -17767,17 +17767,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.0.0, @types/node@npm:^16.11.26, @types/node@npm:^16.9.2":
-  version: 16.18.50
-  resolution: "@types/node@npm:16.18.50"
-  checksum: 8aec1eaf83407197ec2fe947182c238f49b82a7aace867cee1f81f72eb8a76c3c8b2adb1fd356e7443317cffb2546708da8934299a579edd25e3160bf7af30a1
+"@types/node@npm:^16.9.2":
+  version: 16.18.43
+  resolution: "@types/node@npm:16.18.43"
+  checksum: a3ae424834818d1aa53d05e9de954b4559aaa9c02294e654403d9bd2a2b1db608c328755970071369a0c85159a6f2969502e1b9c7e1f29d2629ca677c33c8bdb
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.11.17":
-  version: 18.17.15
-  resolution: "@types/node@npm:18.17.15"
-  checksum: eed11d4398ccdb999a4c65658ee75de621a4ad57aece48ed2fb8803b1e2711fadf58d8aefbdb0a447d69cf3cba602ca32fe0fc92077575950a796e1dc13baa0f
+"@types/node@npm:^18.11.17, @types/node@npm:^18.17.8":
+  version: 18.17.8
+  resolution: "@types/node@npm:18.17.8"
+  checksum: ebb71526368c9c58f03e2c2408bfda4aa686c13d84226e2c9b48d9c4aee244fb82e672aaf4aa8ccb6e4993b4274d5f4b2b3d52d0a2e57ab187ae653903376411
   languageName: node
   linkType: hard
 
@@ -23929,7 +23929,7 @@ __metadata:
     "@backstage/create-app": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@types/fs-extra": ^9.0.1
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     "@types/puppeteer": ^5.4.4
     chalk: ^4.0.0
     commander: ^9.1.0
@@ -38444,7 +38444,7 @@ __metadata:
     "@spotify/eslint-plugin": ^14.1.3
     "@spotify/prettier-config": ^14.0.0
     "@techdocs/cli": "workspace:*"
-    "@types/node": ^16.11.26
+    "@types/node": ^18.17.8
     "@types/webpack": ^5.28.0
     command-exists: ^1.2.9
     concurrently: ^8.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -33198,10 +33198,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mock-fs@npm:^5.2.0":
+"mock-fs@npm:5.2.0":
   version: 5.2.0
   resolution: "mock-fs@npm:5.2.0"
   checksum: c25835247bd26fa4e0189addd61f98973f61a72741e4d2a5694b143a2069b84978443a7ac0fdb1a71aead99273ec22ff4e9c968de11bbd076db020264c5b8312
+  languageName: node
+  linkType: hard
+
+"mock-fs@patch:mock-fs@npm%3A5.2.0#./.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch::locator=root%40workspace%3A.":
+  version: 5.2.0
+  resolution: "mock-fs@patch:mock-fs@npm%3A5.2.0#./.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch::version=5.2.0&hash=920f99&locator=root%40workspace%3A."
+  checksum: 84e306d7a798735ed8ee110b60ed8fc0b5db451df3a990e2a01432fac99decd15e5534c92d87f8067425329dbd9bf5c12e2673d3d770fb40f2936810e02bb07a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3497,7 +3497,7 @@ __metadata:
     luxon: ^3.0.0
     minimatch: ^5.0.0
     minimist: ^1.2.5
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     morgan: ^1.10.0
     msw: ^1.0.0
     mysql2: ^2.2.5
@@ -3826,7 +3826,7 @@ __metadata:
     lodash: ^4.17.21
     mini-css-extract-plugin: ^2.4.2
     minimatch: ^5.1.1
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     msw: ^1.0.0
     node-fetch: ^2.6.7
     node-libs-browser: ^2.2.1
@@ -3911,7 +3911,7 @@ __metadata:
     json-schema-traverse: ^1.0.0
     lodash: ^4.17.21
     minimist: ^1.2.5
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     msw: ^1.0.0
     node-fetch: ^2.6.7
     typescript-json-schema: ^0.55.0
@@ -4140,7 +4140,7 @@ __metadata:
     fs-extra: 10.1.0
     handlebars: ^4.7.3
     inquirer: ^8.2.0
-    mock-fs: ^5.1.1
+    mock-fs: ^5.2.0
     nodemon: ^3.0.1
     ora: ^5.3.0
     recursive-readdir: ^2.2.2
@@ -4691,7 +4691,7 @@ __metadata:
     knex: ^2.0.0
     lodash: ^4.17.21
     luxon: ^3.0.0
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     msw: ^1.0.0
     node-fetch: ^2.6.7
     supertest: ^6.1.3
@@ -8307,7 +8307,7 @@ __metadata:
     "@types/mock-fs": ^4.13.0
     command-exists: ^1.2.9
     fs-extra: 10.1.0
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     msw: ^1.0.0
     winston: ^3.2.1
     yn: ^4.0.0
@@ -8348,7 +8348,7 @@ __metadata:
     command-exists: ^1.2.9
     fs-extra: ^10.0.1
     jest-when: ^3.1.0
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
   languageName: unknown
   linkType: soft
 
@@ -8433,7 +8433,7 @@ __metadata:
     libsodium-wrappers: ^0.7.11
     lodash: ^4.17.21
     luxon: ^3.0.0
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     morgan: ^1.10.0
     msw: ^1.0.0
     node-fetch: ^2.6.7
@@ -9391,7 +9391,7 @@ __metadata:
     js-yaml: ^4.0.0
     json5: ^2.1.3
     mime-types: ^2.1.27
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     p-limit: ^3.1.0
     recursive-readdir: ^2.2.2
     supertest: ^6.1.3
@@ -9729,7 +9729,7 @@ __metadata:
     js-yaml: ^4.1.0
     lodash: ^4.17.21
     minimatch: ^5.1.1
-    mock-fs: ^5.1.0
+    mock-fs: ^5.2.0
     p-limit: ^3.0.2
     ts-node: ^10.0.0
     yaml-diff-patch: ^2.0.0
@@ -33198,7 +33198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mock-fs@npm:^5.1.0, mock-fs@npm:^5.1.1, mock-fs@npm:^5.2.0":
+"mock-fs@npm:^5.2.0":
   version: 5.2.0
   resolution: "mock-fs@npm:5.2.0"
   checksum: c25835247bd26fa4e0189addd61f98973f61a72741e4d2a5694b143a2069b84978443a7ac0fdb1a71aead99273ec22ff4e9c968de11bbd076db020264c5b8312


### PR DESCRIPTION
Just a draft for now, to check how this behaves in CI. It's still a while before we'll switch over

Current known issues:

- mock-fs breakage in v20: https://github.com/tschaub/mock-fs/issues/377

Update: Node.js v16 is now EOL so we're accelerating this with less optimal workarounds. Proper fix is pending in https://github.com/tschaub/mock-fs/pull/378