### PR TITLE
Make test-utils not depend on testing-library directly

### DIFF
--- a/.changeset/three-nails-remember.md
+++ b/.changeset/three-nails-remember.md
@@ -1,0 +1,7 @@
+---
+'@backstage/test-utils': patch
+---
+
+Add support for React Testing Library 13+, and thus React 18.
+
+We're exposing an additional option to the `render*` methods to enable the [legacyRoot](https://testing-library.com/docs/react-testing-library/api/#legacyroot) flow.

--- a/.changeset/three-nails-remember.md
+++ b/.changeset/three-nails-remember.md
@@ -4,4 +4,4 @@
 
 Add support for React Testing Library 13+, and thus React 18.
 
-We're exposing an additional option to the `render*` methods to enable the [legacyRoot](https://testing-library.com/docs/react-testing-library/api/#legacyroot) flow.
+We're exposing an additional option to the `render*` methods to enable the [`legacyRoot`](https://testing-library.com/docs/react-testing-library/api/#legacyroot) flow.

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -56,6 +56,11 @@ export type ErrorWithContext = {
 };
 
 // @public
+export type LegacyRootOption = {
+  legacyRoot?: boolean;
+};
+
+// @public
 export type LogCollector = AsyncLogCollector | SyncLogCollector;
 
 // @public
@@ -194,13 +199,13 @@ export type MockStorageBucket = {
 // @public
 export function renderInTestApp(
   Component: ComponentType<PropsWithChildren<{}>> | ReactNode,
-  options?: TestAppOptions,
+  options?: TestAppOptions & LegacyRootOption,
 ): Promise<RenderResult>;
 
 // @public
 export function renderWithEffects(
   nodes: ReactElement,
-  options?: Pick<RenderOptions, 'wrapper'>,
+  options?: Pick<RenderOptions, 'wrapper'> & LegacyRootOption,
 ): Promise<RenderResult>;
 
 // @public

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -60,9 +60,9 @@
     "zen-observable": "^0.10.0"
   },
   "peerDependencies": {
-    "@testing-library/react": "^12.1.3",
-    "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0",
+    "@testing-library/react": "^12.1.3 || ^13.0.0 || ^14.0.0",
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -55,21 +55,19 @@
     "@backstage/types": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@testing-library/dom": "^8.0.0",
-    "@testing-library/jest-dom": "^5.10.1",
-    "@testing-library/react": "^12.1.3",
-    "@testing-library/user-event": "^14.0.0",
     "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "zen-observable": "^0.10.0"
   },
   "peerDependencies": {
+    "@testing-library/react": "^12.1.3",
     "react": "^16.13.1 || ^17.0.0",
     "react-dom": "^16.13.1 || ^17.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
+    "@testing-library/jest-dom": "^5.10.1",
     "msw": "^1.0.0"
   },
   "files": [

--- a/packages/test-utils/src/testUtils/appWrappers.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.tsx
@@ -33,7 +33,7 @@ import {
   createRouteRef,
 } from '@backstage/core-plugin-api';
 import { MatcherFunction, RenderResult } from '@testing-library/react';
-import { renderWithEffects } from './testingLibrary';
+import { renderWithEffects, LegacyRootOption } from './testingLibrary';
 import { defaultApis } from './defaultApis';
 import { mockApis } from './mockApis';
 
@@ -232,7 +232,7 @@ export function wrapInTestApp(
  */
 export async function renderInTestApp(
   Component: ComponentType<PropsWithChildren<{}>> | ReactNode,
-  options: TestAppOptions = {},
+  options: TestAppOptions & LegacyRootOption = {},
 ): Promise<RenderResult> {
   let wrappedElement: React.ReactElement;
   if (Component instanceof Function) {
@@ -240,9 +240,11 @@ export async function renderInTestApp(
   } else {
     wrappedElement = Component as React.ReactElement;
   }
+  const { legacyRoot } = options;
 
   return renderWithEffects(wrappedElement, {
     wrapper: createTestAppWrapper(options),
+    legacyRoot,
   });
 }
 

--- a/packages/test-utils/src/testUtils/testingLibrary.ts
+++ b/packages/test-utils/src/testUtils/testingLibrary.ts
@@ -24,6 +24,13 @@ import {
 
 /**
  * @public
+ * Set legacy mode when using React 18/RTL 13+.
+ * Mock this option while we're working against React 17 or lower.
+ */
+export type LegacyRootOption = { legacyRoot?: boolean };
+
+/**
+ * @public
  * Simplifies rendering of async components in by taking care of the wrapping inside act
  *
  * @remarks
@@ -36,7 +43,7 @@ import {
  */
 export async function renderWithEffects(
   nodes: ReactElement,
-  options?: Pick<RenderOptions, 'wrapper'>,
+  options?: Pick<RenderOptions, 'wrapper'> & LegacyRootOption,
 ): Promise<RenderResult> {
   let value: RenderResult;
   await act(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10049,7 +10049,6 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
-    "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^14.0.0
@@ -10058,6 +10057,7 @@ __metadata:
     msw: ^1.0.0
     zen-observable: ^0.10.0
   peerDependencies:
+    "@testing-library/react": ^12.1.3
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -10050,16 +10050,14 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@testing-library/jest-dom": ^5.10.1
-    "@testing-library/react": ^12.1.3
-    "@testing-library/user-event": ^14.0.0
     "@types/react": ^16.13.1 || ^17.0.0
     cross-fetch: ^3.1.5
     msw: ^1.0.0
     zen-observable: ^0.10.0
   peerDependencies:
-    "@testing-library/react": ^12.1.3
-    react: ^16.13.1 || ^17.0.0
-    react-dom: ^16.13.1 || ^17.0.0
+    "@testing-library/react": ^12.1.3 || ^13.0.0 || ^14.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This should help transition to React 18

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
