### PR TITLE
Add info about our Artifactory plugins to the marketplace

### DIFF
--- a/microsite/data/plugins/artifactory.yaml
+++ b/microsite/data/plugins/artifactory.yaml
@@ -4,8 +4,8 @@ author: StageCentral
 authorUrl: https://stagecentral.io
 category: Artifacts
 description: |
-    Connect Backstage entities to software artifacts stored in JFrog Artifactory.
-    Display information about artifacts, such as their version, size, and download links.
+  Connect Backstage entities to software artifacts stored in JFrog Artifactory.
+  Display information about artifacts, such as their version, size, and download links.
 documentation: https://github.com/StageCentral/backstage-artifactory-plugin/tree/main#readme
 iconUrl: https://raw.githubusercontent.com/StageCentral/backstage-artifactory-plugin/main/logo/logo.png
 npmPackageName: '@stagecentral/plugin-artifactory'

--- a/microsite/data/plugins/artifactory.yaml
+++ b/microsite/data/plugins/artifactory.yaml
@@ -1,0 +1,12 @@
+---
+title: Artifacts Plugin for JFrog Artifactory
+author: StageCentral
+authorUrl: https://stagecentral.io
+category: Artifacts
+description: |
+    Connect Backstage entities to software artifacts stored in JFrog Artifactory.
+    Display information about artifacts, such as their version, size, and download links.
+documentation: https://github.com/StageCentral/backstage-artifactory-plugin/tree/main#readme
+iconUrl: https://raw.githubusercontent.com/StageCentral/backstage-artifactory-plugin/main/logo/logo.png
+npmPackageName: '@stagecentral/plugin-artifactory'
+addedDate: '2023-08-23'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the information about the Artifactory plugin suite to the plugin marketplace.
The difference from the existing Artifactory plugins is that this is frontend+backend and the backend is using the official [Jfrog js-client](https://github.com/jfrog/jfrog-client-js)
So the plan is to evolve it to be the backend for additional Jfrog integrations
