### PR TITLE
feat(scaffolder): allow default kind and namespace args on parseEntityRef filter

### DIFF
--- a/.changeset/tame-jokes-do.md
+++ b/.changeset/tame-jokes-do.md
@@ -2,19 +2,14 @@
 '@backstage/plugin-scaffolder-backend': minor
 ---
 
-Improved the `parseEntityRef` Scaffolder filter by introducing the ability for users to provide default kind and namespace values. The filter now takes
-3 arguments:
+Improved the `parseEntityRef` Scaffolder filter by introducing the ability for users to provide default kind and/or namespace values. The filter now takes
+2 arguments, similarly to the original [parseEntityRef](<(https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/entity/ref.ts#L77)>):
 
 1. Entity reference
-2. (Optional) Default kind
-3. (Optional) Default namespace
+2. [Context optional object](https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/entity/ref.ts#L77)
 
-So you can now provide default `kind` and/or `namespace`. Check out the following examples:
+Check out the following examples:
 
-- Without default values: `${{ parameters.entity | parseEntityRef | pick('name') }}`
-- With default kind: `${{ parameters.entity | parseEntityRef('group') | pick('name') }}`
-- With default kind and namespace: `${{ parameters.entity | parseEntityRef('group', 'another-namespace') | pick('name') }}`
-- With default namespace:
-  - `${{ parameters.entity | parseEntityRef(null, 'another-namespace') | pick('name') }}`
-  - `${{ parameters.entity | parseEntityRef(undefined, 'another-namespace') | pick('name') }}`
-  - `${{ parameters.entity | parseEntityRef('', 'another-namespace') | pick('name') }}`
+- `${{ parameters.entityRef | parseEntityRef | pick('name') }}`
+- `${{ parameters.entityRef | parseEntityRef({ defaultKind:"group", defaultNamespace:"default" }) | pick('name') }}`
+- `${{ parameters.entityRef | parseEntityRef({ defaultKind:"group" }) | pick('name') }}`

--- a/.changeset/tame-jokes-do.md
+++ b/.changeset/tame-jokes-do.md
@@ -3,13 +3,4 @@
 ---
 
 Improved the `parseEntityRef` Scaffolder filter by introducing the ability for users to provide default kind and/or namespace values. The filter now takes
-2 arguments, similarly to the original [parseEntityRef](<(https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/entity/ref.ts#L77)>):
-
-1. Entity reference
-2. [Context optional object](https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/entity/ref.ts#L77)
-
-Check out the following examples:
-
-- `${{ parameters.entityRef | parseEntityRef | pick('name') }}`
-- `${{ parameters.entityRef | parseEntityRef({ defaultKind:"group", defaultNamespace:"default" }) | pick('name') }}`
-- `${{ parameters.entityRef | parseEntityRef({ defaultKind:"group" }) | pick('name') }}`
+2 arguments, similarly to the original [parseEntityRef](https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/entity/ref.ts#L77).

--- a/.changeset/tame-jokes-do.md
+++ b/.changeset/tame-jokes-do.md
@@ -1,0 +1,20 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Improved the `parseEntityRef` Scaffolder filter by introducing the ability for users to provide default kind and namespace values. The filter now takes
+3 arguments:
+
+1. Entity reference
+2. (Optional) Default kind
+3. (Optional) Default namespace
+
+So you can now provide default `kind` and/or `namespace`. Check out the following examples:
+
+- Without default values: `${{ parameters.entity | parseEntityRef | pick('name') }}`
+- With default kind: `${{ parameters.entity | parseEntityRef('group') | pick('name') }}`
+- With default kind and namespace: `${{ parameters.entity | parseEntityRef('group', 'another-namespace') | pick('name') }}`
+- With default namespace:
+  - `${{ parameters.entity | parseEntityRef(null, 'another-namespace') | pick('name') }}`
+  - `${{ parameters.entity | parseEntityRef(undefined, 'another-namespace') | pick('name') }}`
+  - `${{ parameters.entity | parseEntityRef('', 'another-namespace') | pick('name') }}`

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -627,7 +627,7 @@ its components, such as `owner`, repository `name`, and more.
     extra: ${{ parameters.repoUrl | parseRepoUrl }}
 ```
 
-- **Input**: `https://github.com/backstage/backstage`
+- **Input**: `github.com?repo=backstage&org=backstage`
 - **Output**: [RepoSpec](https://github.com/backstage/backstage/blob/v1.17.2/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts#L39)
 
 ### parseEntityRef
@@ -677,8 +677,8 @@ This `pick` filter allows you to select specific properties from an object.
     extra: ${{ parameters.owner | parseEntityRef | pick('name') }}
 ```
 
-- **Input**: `group:techdocs`
-- **Output**: `techndocs`
+- **Input**: `{ kind: 'Group', namespace: 'default', name: 'techdocs' }`
+- **Output**: `techdocs`
 
 ### projectSlug
 
@@ -694,5 +694,5 @@ The `projectSlug` filter generates a project slug from a repository URL
     extra: ${{ parameters.repoUrl | projectSlug }}
 ```
 
-- **Input**: `https://github.com/backstage/backstage`
+- **Input**: `github.com?repo=backstage&org=backstage`
 - **Output**: `backstage/backstage`

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -601,3 +601,98 @@ output things. You can grab that output using `steps.$stepId.output.$property`.
 You can read more about all the `inputs` and `outputs` defined in the actions in
 code part of the `JSONSchema`, or you can read more about our
 [built in actions](./builtin-actions.md).
+
+## Built in Filters
+
+Template filters are functions that help you transform data, extract specific information,
+and perform various operations in Scaffolder Templates.
+
+This section introduces the built-in filters provided by Backstage and offers examples of
+how to use them in the Scaffolder templates. It's important to mention that Backstage also leverages the
+native filters from the Nunjucks library. For a complete list of these native filters and their usage,
+refer to the [Nunjucks documentation](https://mozilla.github.io/nunjucks/templating.html#builtin-filters).
+
+### parseRepoUrl
+
+The `parseRepoUrl` filter parse a repository URL into
+its components, such as `owner`, repository `name`, and more.
+
+**Usage Example:**
+
+```yaml
+- id: log
+  name: Parse Repo URL
+  action: debug:log
+  input:
+    extra: ${{ parameters.repoUrl | parseRepoUrl }}
+```
+
+- **Input**: `https://github.com/backstage/backstage`
+- **Output**: [RepoSpec](https://github.com/backstage/backstage/blob/v1.17.2/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts#L39)
+
+### parseEntityRef
+
+The `parseEntityRef` filter allows you to extract different parts of
+an entity reference, such as the `kind`, `namespace`, and `name`.
+
+**Usage example**
+
+1. Without context
+
+```yaml
+- id: log
+  name: Parse Entity Reference
+  action: debug:log
+  input:
+    extra: ${{ parameters.owner | parseEntityRef }}
+```
+
+- **Input**: `group:techdocs`
+- **Output**: [CompoundEntityRef](https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/types.ts#L23)
+
+2. With context
+
+```yaml
+- id: log
+  name: Parse Entity Reference
+  action: debug:log
+  input:
+    extra: ${{ parameters.owner | parseEntityRef({ defaultKind:"group", defaultNamespace:"another-namespace" }) }}
+```
+
+- **Input**: `techdocs`
+- **Output**: [CompoundEntityRef](https://github.com/backstage/backstage/blob/v1.17.2/packages/catalog-model/src/types.ts#L23)
+
+### pick
+
+This `pick` filter allows you to select specific properties from an object.
+
+**Usage Example**
+
+```yaml
+- id: log
+  name: Pick
+  action: debug:log
+  input:
+    extra: ${{ parameters.owner | parseEntityRef | pick('name') }}
+```
+
+- **Input**: `group:techdocs`
+- **Output**: `techndocs`
+
+### projectSlug
+
+The `projectSlug` filter generates a project slug from a repository URL
+
+**Usage Example**
+
+```yaml
+- id: log
+  name: Project Slug
+  action: debug:log
+  input:
+    extra: ${{ parameters.repoUrl | projectSlug }}
+```
+
+- **Input**: `https://github.com/backstage/backstage`
+- **Output**: `backstage/backstage`

--- a/plugins/scaffolder-backend/src/lib/templating/filters.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/filters.ts
@@ -27,7 +27,15 @@ export const createDefaultFilters = ({
 }): Record<string, TemplateFilter> => {
   return {
     parseRepoUrl: url => parseRepoUrl(url as string, integrations),
-    parseEntityRef: ref => parseEntityRef(ref as string),
+    parseEntityRef: (
+      ref,
+      defaultKind?: JsonValue,
+      defaultNamespace?: JsonValue,
+    ) =>
+      parseEntityRef(ref as string, {
+        defaultKind: defaultKind?.toString(),
+        defaultNamespace: defaultNamespace?.toString(),
+      }),
     pick: (obj: JsonValue, key: JsonValue) => get(obj, key as string),
     projectSlug: repoUrl => {
       const { owner, repo } = parseRepoUrl(repoUrl as string, integrations);

--- a/plugins/scaffolder-backend/src/lib/templating/filters.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/filters.ts
@@ -15,7 +15,7 @@
  */
 import { parseEntityRef } from '@backstage/catalog-model';
 import { ScmIntegrations } from '@backstage/integration';
-import { JsonValue } from '@backstage/types';
+import type { JsonObject, JsonValue } from '@backstage/types';
 import { TemplateFilter } from '..';
 import { parseRepoUrl } from '../../scaffolder/actions/builtin/publish/util';
 import get from 'lodash/get';
@@ -27,15 +27,8 @@ export const createDefaultFilters = ({
 }): Record<string, TemplateFilter> => {
   return {
     parseRepoUrl: url => parseRepoUrl(url as string, integrations),
-    parseEntityRef: (
-      ref,
-      defaultKind?: JsonValue,
-      defaultNamespace?: JsonValue,
-    ) =>
-      parseEntityRef(ref as string, {
-        defaultKind: defaultKind?.toString(),
-        defaultNamespace: defaultNamespace?.toString(),
-      }),
+    parseEntityRef: (ref, context?) =>
+      parseEntityRef(ref as string, context as JsonObject),
     pick: (obj: JsonValue, key: JsonValue) => get(obj, key as string),
     projectSlug: repoUrl => {
       const { owner, repo } = parseRepoUrl(repoUrl as string, integrations);

--- a/plugins/scaffolder-backend/src/lib/templating/filters.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/filters.ts
@@ -27,7 +27,7 @@ export const createDefaultFilters = ({
 }): Record<string, TemplateFilter> => {
   return {
     parseRepoUrl: url => parseRepoUrl(url as string, integrations),
-    parseEntityRef: (ref, context?) =>
+    parseEntityRef: (ref: JsonValue, context?: JsonValue) =>
       parseEntityRef(ref as string, context as JsonObject),
     pick: (obj: JsonValue, key: JsonValue) => get(obj, key as string),
     projectSlug: repoUrl => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Relates to https://github.com/backstage/backstage/issues/19519

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Testing

### Template

```yaml
apiVersion: scaffolder.backstage.io/v1beta3
kind: Template
metadata:
  name: parse-entity-ref-filter-test-template
  title: Parse Entity Ref Test
  description: Parse Entity Ref Filter Test Template
  tags:
    - recommended
spec:
  owner: backstage/techdocs-core
  type: documentation
  parameters:
    - title: Fill in some steps
      required:
        - component
      properties:
        component:
          title: Entity Picker
          type: string
          description: Select the component
          ui:field: EntityPicker
          ui:options:
            allowArbitraryValues: false
            catalogFilter:
              kind: Component

  steps:
    - id: fetch
      name: Fetch Component Defailts
      action: catalog:fetch
      input:
        entityRef: ${{ parameters.component }}
        optional: true
    
    - id: log
      name: Parse Entity Ref (Just Ref)
      action: debug:log
      input:
        extra: ${{ steps.fetch.output.entity.spec.owner | parseEntityRef }}

    - id: log-2
      name: Parse Entity Ref With Context
      action: debug:log
      input:
        extra: ${{ steps.fetch.output.entity.spec.owner | parseEntityRef({ defaultKind:"group", defaultNamespace:"another-namespace" }) }}

    - id: log-3
      name: Parse Entity Ref With Context (Kind only)
      action: debug:log
      input:
        extra: ${{ steps.fetch.output.entity.spec.owner | parseEntityRef({ defaultKind:"group" }) }}

    - id: log-4
      name: Parse Entity Ref With Context (Namespace only)
      action: debug:log
      input:
        extra: ${{ steps.fetch.output.entity.spec.owner | parseEntityRef({ defaultNamespace:"another-namespace" }) }}

```

### Output

#### Component with `owner: user:guest`

![Screenshot 2023-08-28 at 9 32 12 AM](https://github.com/backstage/backstage/assets/5296417/0ef52200-96c8-401a-9aa5-84d7c6bfa656)
![Screenshot 2023-08-28 at 9 32 59 AM](https://github.com/backstage/backstage/assets/5296417/99704907-40f9-403e-9b4f-d8838d67c75f)
![Screenshot 2023-08-28 at 9 33 06 AM](https://github.com/backstage/backstage/assets/5296417/b4f72c22-8ea2-4716-80d2-94693881a949)
![Screenshot 2023-08-28 at 9 33 13 AM](https://github.com/backstage/backstage/assets/5296417/8b7afc78-2bcb-4264-8e89-9f48b1561c8b)


#### Component with `owner: guest`

![Screenshot 2023-08-28 at 9 37 30 AM](https://github.com/backstage/backstage/assets/5296417/3946dc05-16c4-40c3-9b09-2aafb2e8e8b1) 
![Screenshot 2023-08-28 at 9 37 35 AM](https://github.com/backstage/backstage/assets/5296417/859da3a9-d193-4fcd-ae8f-03475e794ec4)
![Screenshot 2023-08-28 at 9 37 40 AM](https://github.com/backstage/backstage/assets/5296417/135da727-6310-44af-a57c-e5619cd90b63)
![Screenshot 2023-08-28 at 9 37 48 AM](https://github.com/backstage/backstage/assets/5296417/789553ff-67b0-4561-926a-58d02ed03d3f)

ParseEntityRef errors when parsing an entity ref without kind and default kind

```plain
2023-08-28T16:34:25.299Z scaffolder error Failed to parse template string: ${{ steps.fetch.output.entity.spec.owner | parseEntityRef }} with error (unknown path)
  Error: Entity reference "guest" had missing or empty kind (e.g. did not start with "component:" or similar) type=plugin
2023-08-28T16:34:25.320Z scaffolder error Failed to parse template string: ${{ steps.fetch.output.entity.spec.owner | parseEntityRef({ defaultNamespace:"another-namespace" }) }} with error (unknown path)
  Error: Entity reference "guest" had missing or empty kind (e.g. did not start with "component:" or similar) type=plugin
```


