### PR TITLE
changed auto theme tooltip title to camel case

### DIFF
--- a/.changeset/lazy-pumas-hope.md
+++ b/.changeset/lazy-pumas-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+changed auto theme tooltip title to camel case

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
@@ -155,7 +155,7 @@ export const UserSettingsThemeToggle = () => {
               </TooltipToggleButton>
             );
           })}
-          <Tooltip placement="top" arrow title="Select auto theme">
+          <Tooltip placement="top" arrow title="Select Auto Theme">
             <ToggleButton value="auto" selected={themeId === undefined}>
               Auto&nbsp;
               <AutoIcon color={themeId === undefined ? 'primary' : undefined} />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
    In user setting theme feature if we see 
    for light theme & dark theme the tooltip name in camel case like Select Light Theme & Select Dark Theme
    but for Auto theme its shows Select auto theme which is not following correct camel case 
    
    have changed like following
    
    exist:
    
![image](https://github.com/backstage/backstage/assets/133481507/f71d95f5-3dbd-4586-8790-4ad7601f182d)

changed:

![image](https://github.com/backstage/backstage/assets/133481507/e5064863-b0ad-4e64-87b5-8ac1d5fd7e25)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
