### PR TITLE
conditionally rendering the user email

### DIFF
--- a/.changeset/khaki-spiders-sniff.md
+++ b/.changeset/khaki-spiders-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+conditionally rendering the user email in user profile card

--- a/plugins/user-settings/src/components/General/UserSettingsProfileCard.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsProfileCard.tsx
@@ -37,9 +37,11 @@ export const UserSettingsProfileCard = () => {
               <Typography variant="subtitle1" gutterBottom>
                 {displayName}
               </Typography>
-              <Typography variant="body2" color="textSecondary">
-                {profile.email}
-              </Typography>
+              {profile.email && (
+                <Typography variant="body2" color="textSecondary">
+                  {profile.email}
+                </Typography>
+              )}
             </Grid>
           </Grid>
           <Grid item>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When i login in to backstage using auth provider the profile card takes empty <p> in UI for email , so the profile
object don't have a email id. 
 
![image](https://github.com/backstage/backstage/assets/133481507/aa430987-7a87-4194-bf65-68ab56421e65)

to prevent the empty space in UI conditionally rendering the email field in UI

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
