### PR TITLE
Align zod dependency to match other packages

### DIFF
--- a/.changeset/hip-seahorses-exist.md
+++ b/.changeset/hip-seahorses-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Align zod dependency to align with other packages.

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -52,7 +52,7 @@
     "react-grid-layout": "^1.3.4",
     "react-resizable": "^3.0.4",
     "react-use": "^17.2.4",
-    "zod": "~3.21.4"
+    "zod": "^3.21.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7235,7 +7235,7 @@ __metadata:
     react-grid-layout: ^1.3.4
     react-resizable: ^3.0.4
     react-use: ^17.2.4
-    zod: ~3.21.4
+    zod: ^3.21.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed that `zod` dependencies diverged in my backstage update. This PR aligns the dependency range in the home plugin to match what we use elsewhere in the repo

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
