### PR TITLE
Fix logs height

### DIFF
--- a/.changeset/nasty-snails-complain.md
+++ b/.changeset/nasty-snails-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+fix logs dialog min height

--- a/plugins/kubernetes/src/components/Pods/PodLogs/PodLogs.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodLogs/PodLogs.tsx
@@ -64,7 +64,7 @@ export const PodLogs: React.FC<PodLogsProps> = ({
       )}
       <Paper
         elevation={1}
-        style={{ height: '100%', width: '100%', minHeight: '15rem' }}
+        style={{ height: '100%', width: '100%', minHeight: '55rem' }}
       >
         {loading && <Skeleton variant="rect" width="100%" height="100%" />}
         {!loading &&


### PR DESCRIPTION
The current logs dialog is very small, it should be much bigger by default

Before
![Screenshot 2023-08-25 at 10 15 33 AM](https://github.com/backstage/backstage/assets/6514980/4838dc6c-3b5a-49e1-a19b-1de536929a53)


After
![Screenshot 2023-08-25 at 10 15 24 AM](https://github.com/backstage/backstage/assets/6514980/07fa6a4b-1100-436e-aa2f-50f6d3ea5266)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
