### PR TITLE
Automate `catalog-info.yaml` file upkeep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: verify api reference
         run: node scripts/verify-api-reference.js
 
+      - name: verify catalog-info.yaml consistency
+        run: yarn backstage-repo-tools generate-catalog-info --ci
+
       - name: lint openapi yaml files
         run: yarn backstage-repo-tools schema openapi lint
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,13 @@
     "*.md": [
       "node ./scripts/check-docs-quality"
     ],
+    "{plugins,packages}/*/catalog-info.yaml": [
+      "yarn backstage-repo-tools generate-catalog-info --ci"
+    ],
+    "{.github/CODEOWNERS,package.json}": [
+      "yarn backstage-repo-tools generate-catalog-info",
+      "git add */catalog-info.yaml"
+    ],
     "./yarn.lock": [
       "node ./scripts/verify-lockfile-duplicates --fix"
     ],

--- a/packages/app-next-example-plugin/catalog-info.yaml
+++ b/packages/app-next-example-plugin/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: app-next-example-plugin
+  title: app-next-example-plugin
+  description: Backstage internal example plugin
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/packages/backend-plugin-manager/catalog-info.yaml
+++ b/packages/backend-plugin-manager/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-backend-plugin-manager
+  title: '@backstage/backend-plugin-manager'
+  description: Backstage plugin management backend
+spec:
+  lifecycle: experimental
+  type: backstage-node-library
+  owner: maintainers

--- a/plugins/catalog-backend-module-scaffolder-entity-model/catalog-info.yaml
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-catalog-backend-module-scaffolder-entity-model
+  title: '@backstage/plugin-catalog-backend-module-scaffolder-entity-model'
+  description: >-
+    Adds support for the scaffolder specific entity model (e.g. the Template
+    kind) to the catalog backend plugin.
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: maintainers

--- a/plugins/permission-backend-module-policy-allow-all/catalog-info.yaml
+++ b/plugins/permission-backend-module-policy-allow-all/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-permission-backend-module-allow-all-policy
+  title: '@backstage/plugin-permission-backend-module-allow-all-policy'
+  description: Allow all policy backend module for the permission plugin.
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin-module
+  owner: permission-maintainers


### PR DESCRIPTION
## What / Why

In order to keep `catalog-info.yaml` metadata up-to-date on an ongoing basis, we need some automation in place. This PR introduces...

- A pre-commit hook that automatically updates relevant `catalog-info.yaml` files when an underlying source of truth changes (e.g. `CODEOWNERS` changes, or `package.json` changes). This will also create `catalog-info.yaml` files for net-new plugins.
- A pre-commit hook that fails the commit if a `catalog-info.yaml` file is edited in an invalid way (e.g. changing owner to someone who doesn't actually own the plugin, or changing a name to something that does not fit the standard).

To prevent situations where `package.json`, `CODEOWNERS`, and `catalog-info.yaml` files get out of sync (because the lint rule wasn't run--e.g. because an invalid change was made by editing files through the Github UI), we also add a check in CI.
