### PR TITLE
Refreshes user settings list when flag state changes.

### DIFF
--- a/.changeset/five-vans-approve.md
+++ b/.changeset/five-vans-approve.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Refreshes user settings list when flag state changes.
+
+Previous behavior asked user to refresh the page to see the change.

--- a/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
@@ -53,7 +53,7 @@ export const UserSettingsFeatureFlags = () => {
     initialFeatureFlags,
     featureFlagsApi,
   );
-  const [featureFlags] = useState(initialFeatureFlagsSorted);
+  const [featureFlags, setFeatureFlags] = useState(initialFeatureFlagsSorted);
 
   const initialFlagState = Object.fromEntries(
     featureFlags.map(({ name }) => [name, featureFlagsApi.isActive(name)]),
@@ -77,6 +77,13 @@ export const UserSettingsFeatureFlags = () => {
         ...prevState,
         [flagName]: newState === FeatureFlagState.Active,
       }));
+
+      const updatedFlags = sortFlags(
+        featureFlagsApi.getRegisteredFlags(),
+        featureFlagsApi,
+      );
+
+      setFeatureFlags(updatedFlags);
     },
     [featureFlagsApi],
   );
@@ -99,9 +106,6 @@ export const UserSettingsFeatureFlags = () => {
     <Grid container style={{ justifyContent: 'space-between' }}>
       <Grid item xs={6} md={8}>
         <Typography variant="h5">Feature Flags</Typography>
-        <Typography variant="subtitle1">
-          Please refresh the page when toggling feature flags
-        </Typography>
       </Grid>
       {featureFlags.length >= 10 && (
         <Grid item xs={6} md={4}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates feature flags settings page so that the flags displayed change when the flag state changes.

Reflects the same state when the page is refreshed.

https://github.com/backstage/backstage/assets/1228728/138abce4-74fd-4a2c-8c5b-a892683083cf

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
