### PR TITLE
Use AzureDevOpsCredentialsProvider

### DIFF
--- a/.changeset/unlucky-clouds-build.md
+++ b/.changeset/unlucky-clouds-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Added support for using `AzureDevOpsCredentialsProvider` and deprecated `azureDevOps.token` configuration value

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -20,11 +20,10 @@ import { RepoBuild } from '@backstage/plugin-azure-devops-common';
 import { Team } from '@backstage/plugin-azure-devops-common';
 import { TeamMember } from '@backstage/plugin-azure-devops-common';
 import { UrlReader } from '@backstage/backend-common';
-import { WebApi } from 'azure-devops-node-api';
 
 // @public (undocumented)
 export class AzureDevOpsApi {
-  constructor(logger: Logger, webApi: WebApi, urlReader: UrlReader);
+  constructor(logger: Logger, urlReader: UrlReader, config: Config);
   // (undocumented)
   getAllTeams(): Promise<Team[]>;
   // (undocumented)

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -24,6 +24,8 @@ export interface Config {
     /**
      * Token used to authenticate requests.
      * @visibility secret
+     * @deprecated Use `integrations.azure` instead.
+     * @see https://backstage.io/docs/integrations/azure/locations
      */
     token: string;
     /**

--- a/plugins/azure-devops-backend/package.json
+++ b/plugins/azure-devops-backend/package.json
@@ -31,6 +31,7 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/integration": "workspace:^",
     "@backstage/plugin-azure-devops-common": "workspace:^",
     "@types/express": "^4.17.6",
     "azure-devops-node-api": "^11.0.1",

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -19,7 +19,6 @@ import {
   PullRequestOptions,
   PullRequestStatus,
 } from '@backstage/plugin-azure-devops-common';
-import { WebApi, getPersonalAccessTokenHandler } from 'azure-devops-node-api';
 
 import { AzureDevOpsApi } from '../api';
 import { Config } from '@backstage/config';
@@ -43,18 +42,10 @@ export interface RouterOptions {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, reader } = options;
-  const config = options.config.getConfig('azureDevOps');
-
-  const token = config.getString('token');
-  const host = config.getString('host');
-  const organization = config.getString('organization');
-
-  const authHandler = getPersonalAccessTokenHandler(token);
-  const webApi = new WebApi(`https://${host}/${organization}`, authHandler);
+  const { logger, reader, config } = options;
 
   const azureDevOpsApi =
-    options.azureDevOpsApi || new AzureDevOpsApi(logger, webApi, reader);
+    options.azureDevOpsApi || new AzureDevOpsApi(logger, reader, config);
 
   const pullRequestsDashboardProvider =
     await PullRequestsDashboardProvider.create(logger, azureDevOpsApi);
@@ -195,6 +186,8 @@ export async function createRouter(
   });
 
   router.get('/readme/:projectName/:repoName', async (req, res) => {
+    const host = config.getString('azureDevOps.host');
+    const organization = config.getString('azureDevOps.organization');
     const { projectName, repoName } = req.params;
     const readme = await azureDevOpsApi.getReadme(
       host,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4857,6 +4857,7 @@ __metadata:
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/integration": "workspace:^"
     "@backstage/plugin-azure-devops-common": "workspace:^"
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.8


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for using `AzureDevOpsCredentialsProvider` and deprecated `azureDevOps.token` configuration value.

This lays the foundation along with https://github.com/backstage/backstage/pull/19616 towards adding multi-org support to the Azure DevOps plugin

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
