### PR TITLE
Added Ascending and Descending sorting to the playlist

### DIFF
--- a/.changeset/lemon-snails-notice.md
+++ b/.changeset/lemon-snails-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-playlist': patch
+---
+
+Added ascending and descending sorting to the playlist page

--- a/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.test.tsx
+++ b/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.test.tsx
@@ -40,13 +40,24 @@ describe('PlaylistSortPicker', () => {
         getByRole(getByTestId('sort-picker-select'), 'button'),
       );
     });
-    const abcSort = getByText('Alphabetical');
+
+    const abcSort = getByText('A-Z');
     expect(abcSort).toBeInTheDocument();
 
     fireEvent.click(abcSort);
     await waitFor(() => {
       expect(updateSort).toHaveBeenLastCalledWith(
-        DefaultSortCompareFunctions[DefaultPlaylistSortTypes.alphabetical],
+        DefaultSortCompareFunctions[DefaultPlaylistSortTypes.ascending],
+      );
+    });
+
+    const zyxSort = getByText('Z-A');
+    expect(zyxSort).toBeInTheDocument();
+
+    fireEvent.click(zyxSort);
+    await waitFor(() => {
+      expect(updateSort).toHaveBeenLastCalledWith(
+        DefaultSortCompareFunctions[DefaultPlaylistSortTypes.descending],
       );
     });
 

--- a/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.test.tsx
+++ b/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.test.tsx
@@ -41,7 +41,7 @@ describe('PlaylistSortPicker', () => {
       );
     });
 
-    const abcSort = getByText('A-Z');
+    const abcSort = getByText('A-Z (ascending)');
     expect(abcSort).toBeInTheDocument();
 
     fireEvent.click(abcSort);
@@ -51,7 +51,7 @@ describe('PlaylistSortPicker', () => {
       );
     });
 
-    const zyxSort = getByText('Z-A');
+    const zyxSort = getByText('Z-A (descending)');
     expect(zyxSort).toBeInTheDocument();
 
     fireEvent.click(zyxSort);

--- a/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.test.tsx
+++ b/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.test.tsx
@@ -27,6 +27,7 @@ import {
 } from './PlaylistSortPicker';
 import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 import { PlaylistList } from '../PlaylistList';
+import { Playlist } from '@backstage/plugin-playlist-common';
 
 const mockConfigApi = {
   getOptionalString: () => undefined,

--- a/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.tsx
+++ b/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.tsx
@@ -32,8 +32,8 @@ import { PlaylistSortCompareFunction } from '../../types';
 export const enum DefaultPlaylistSortTypes {
   popular = 'popular',
   numEntities = 'numEntities',
-  ascending = 'A-Z',
-  descending = 'Z-A',
+  ascending = 'ascending',
+  descending = 'descending',
 }
 
 export const DefaultSortCompareFunctions: {
@@ -65,7 +65,7 @@ const sortTypeLabels = {
   [DefaultPlaylistSortTypes.popular]: 'Popular',
   [DefaultPlaylistSortTypes.numEntities]: '# Entities',
   [DefaultPlaylistSortTypes.ascending]: 'A-Z (ascending)',
-  [DefaultPlaylistSortTypes.descending]: 'Z-A (descending )',
+  [DefaultPlaylistSortTypes.descending]: 'Z-A (descending)',
 };
 
 const useStyles = makeStyles({

--- a/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.tsx
+++ b/plugins/playlist/src/components/PlaylistSortPicker/PlaylistSortPicker.tsx
@@ -31,8 +31,9 @@ import { PlaylistSortCompareFunction } from '../../types';
 
 export const enum DefaultPlaylistSortTypes {
   popular = 'popular',
-  alphabetical = 'alphabetical',
   numEntities = 'numEntities',
+  ascending = 'A-Z',
+  descending = 'Z-A',
 }
 
 export const DefaultSortCompareFunctions: {
@@ -46,8 +47,10 @@ export const DefaultSortCompareFunctions: {
     }
     return 0;
   },
-  [DefaultPlaylistSortTypes.alphabetical]: (a: Playlist, b: Playlist) =>
+  [DefaultPlaylistSortTypes.ascending]: (a: Playlist, b: Playlist) =>
     a.name.localeCompare(b.name),
+  [DefaultPlaylistSortTypes.descending]: (a: Playlist, b: Playlist) =>
+    b.name.localeCompare(a.name),
   [DefaultPlaylistSortTypes.numEntities]: (a: Playlist, b: Playlist) => {
     if (a.entities < b.entities) {
       return 1;
@@ -60,8 +63,9 @@ export const DefaultSortCompareFunctions: {
 
 const sortTypeLabels = {
   [DefaultPlaylistSortTypes.popular]: 'Popular',
-  [DefaultPlaylistSortTypes.alphabetical]: 'Alphabetical',
   [DefaultPlaylistSortTypes.numEntities]: '# Entities',
+  [DefaultPlaylistSortTypes.ascending]: 'A-Z (ascending)',
+  [DefaultPlaylistSortTypes.descending]: 'Z-A (descending )',
 };
 
 const useStyles = makeStyles({


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Added Ascending and Descending sorting to the playlist

![image](https://github.com/backstage/backstage/assets/133481507/3fdb84af-48a9-4571-9853-9df4fa230f38)

![image](https://github.com/backstage/backstage/assets/133481507/07912757-5f3b-4bf2-81e4-136601027da8)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
