### PR TITLE
Added tooltip for support button menu items

### DIFF
--- a/.changeset/great-days-tell.md
+++ b/.changeset/great-days-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added tooltip for support button items

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -26,6 +26,7 @@ import MenuList from '@material-ui/core/MenuList';
 import Popover from '@material-ui/core/Popover';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import Tooltip from '@material-ui/core/Tooltip';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import React, { MouseEventHandler, useState } from 'react';
 import { SupportItem, SupportItemLink, useSupportConfig } from '../../hooks';
@@ -62,22 +63,24 @@ const SupportLink = ({ link }: { link: SupportItemLink }) => (
 
 const SupportListItem = ({ item }: { item: SupportItem }) => {
   return (
-    <MenuItem>
-      <ListItemIcon>
-        <SupportIcon icon={item.icon} />
-      </ListItemIcon>
-      <ListItemText
-        primary={item.title}
-        secondary={item.links?.reduce<React.ReactNode[]>(
-          (prev, link, idx) => [
-            ...prev,
-            idx > 0 && <br key={idx} />,
-            <SupportLink link={link} key={link.url} />,
-          ],
-          [],
-        )}
-      />
-    </MenuItem>
+    <Tooltip title={item.title}>
+      <MenuItem>
+        <ListItemIcon>
+          <SupportIcon icon={item.icon} />
+        </ListItemIcon>
+        <ListItemText
+          primary={item.title}
+          secondary={item.links?.reduce<React.ReactNode[]>(
+            (prev, link, idx) => [
+              ...prev,
+              idx > 0 && <br key={idx} />,
+              <SupportLink link={link} key={link.url} />,
+            ],
+            [],
+          )}
+        />
+      </MenuItem>
+    </Tooltip>
   );
 };
 
@@ -146,13 +149,17 @@ export function SupportButton(props: SupportButtonProps) {
         >
           {title && (
             <MenuItem alignItems="flex-start">
-              <Typography variant="subtitle1">{title}</Typography>
+              <Tooltip title={title}>
+                <Typography variant="subtitle1">{title}</Typography>
+              </Tooltip>
             </MenuItem>
           )}
           {React.Children.map(children, (child, i) => (
-            <MenuItem alignItems="flex-start" key={`child-${i}`}>
-              {child}
-            </MenuItem>
+            <Tooltip title={child}>
+              <MenuItem alignItems="flex-start" key={`child-${i}`}>
+                {child}
+              </MenuItem>
+            </Tooltip>
           ))}
           {(items ?? configItems).map((item, i) => (
             <SupportListItem item={item} key={`item-${i}`} />

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -155,7 +155,7 @@ export function SupportButton(props: SupportButtonProps) {
             </MenuItem>
           )}
           {React.Children.map(children, (child, i) => (
-            <Tooltip title={child}>
+            <Tooltip title={child || ''} key={`child-${i}`}>
               <MenuItem alignItems="flex-start" key={`child-${i}`}>
                 {child}
               </MenuItem>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added tooltip for support button menu items to avoid the readability issue 

for example below plugins current behavior:
in below user not able to read the title 

![image](https://github.com/backstage/backstage/assets/133481507/2c36a55c-9f8e-499a-83bb-3bc13a4c3c99)

![image](https://github.com/backstage/backstage/assets/133481507/54b492e6-ed3b-4a9a-86df-954c5888ff84)


changed to tooltip :

![image](https://github.com/backstage/backstage/assets/133481507/4e4793da-bf64-443d-9924-8e757f6af6fa)

![image](https://github.com/backstage/backstage/assets/133481507/82a663c4-7ac5-4b81-bf2a-21f4e9fddc44)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
