### PR TITLE
Adding scroll to the playlist description to avoid overlapping

### DIFF
--- a/.changeset/light-hornets-approve.md
+++ b/.changeset/light-hornets-approve.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-playlist': patch
 ---
 
-Adding overflow tooltip to the playlist description
+Adding scroll to the playlist description

--- a/.changeset/light-hornets-approve.md
+++ b/.changeset/light-hornets-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-playlist': patch
+---
+
+Adding overflow tooltip to the playlist description

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.test.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.test.tsx
@@ -51,10 +51,8 @@ describe('<PlaylistCard/>', () => {
     expect(rendered.getByText('3 entities')).toBeInTheDocument();
     expect(rendered.getByText('2 followers')).toBeInTheDocument();
   });
-});
 
-describe('<OverflowTooltip />', () => {
-  it('renders without exploding', async () => {
+  it('renders description', async () => {
     render(<OverflowTooltip text="test description" />);
   });
 });

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.test.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.test.tsx
@@ -16,12 +16,10 @@
 
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
-import { render } from '@testing-library/react';
 import React from 'react';
 
 import { rootRouteRef } from '../../routes';
 import { PlaylistCard } from './PlaylistCard';
-import { OverflowTooltip } from '@backstage/core-components';
 
 describe('<PlaylistCard/>', () => {
   it('renders playlist info', async () => {
@@ -47,12 +45,9 @@ describe('<PlaylistCard/>', () => {
     );
 
     expect(rendered.getByText('playlist-1')).toBeInTheDocument();
+    expect(rendered.getByText('test description')).toBeInTheDocument();
     expect(rendered.getByText('some-owner')).toBeInTheDocument();
     expect(rendered.getByText('3 entities')).toBeInTheDocument();
     expect(rendered.getByText('2 followers')).toBeInTheDocument();
-  });
-
-  it('renders description', async () => {
-    render(<OverflowTooltip text="test description" />);
   });
 });

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.test.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.test.tsx
@@ -16,10 +16,12 @@
 
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { rootRouteRef } from '../../routes';
 import { PlaylistCard } from './PlaylistCard';
+import { OverflowTooltip } from '@backstage/core-components';
 
 describe('<PlaylistCard/>', () => {
   it('renders playlist info', async () => {
@@ -45,9 +47,14 @@ describe('<PlaylistCard/>', () => {
     );
 
     expect(rendered.getByText('playlist-1')).toBeInTheDocument();
-    expect(rendered.getByText('test description')).toBeInTheDocument();
     expect(rendered.getByText('some-owner')).toBeInTheDocument();
     expect(rendered.getByText('3 entities')).toBeInTheDocument();
     expect(rendered.getByText('2 followers')).toBeInTheDocument();
+  });
+});
+
+describe('<OverflowTooltip />', () => {
+  it('renders without exploding', async () => {
+    render(<OverflowTooltip text="test description" />);
   });
 });

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
@@ -17,7 +17,7 @@
 import {
   ItemCardHeader,
   LinkButton,
-  MarkdownContent,
+  OverflowTooltip,
 } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { EntityRefLinks } from '@backstage/plugin-catalog-react';
@@ -108,7 +108,7 @@ export const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
           <Typography variant="body2" className={classes.label}>
             Description
           </Typography>
-          <MarkdownContent content={playlist.description ?? ''} />
+          <OverflowTooltip text={playlist.description ?? ''} line={8} />
         </Box>
         <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
@@ -108,7 +108,7 @@ export const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
           <Typography variant="body2" className={classes.label}>
             Description
           </Typography>
-          <OverflowTooltip text={playlist.description ?? ''} line={8} />
+          <OverflowTooltip text={playlist.description ?? ''} line={4} />
         </Box>
         <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
@@ -109,11 +109,13 @@ export const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
         </ItemCardHeader>
       </CardMedia>
       <CardContent style={{ display: 'grid' }}>
-        <Box className={classes.descriptionBox}>
+        <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>
             Description
           </Typography>
-          <MarkdownContent content={playlist.description ?? ''} />
+          <Box className={classes.descriptionBox}>
+            <MarkdownContent content={playlist.description ?? ''} />
+          </Box>
         </Box>
         <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
@@ -17,7 +17,7 @@
 import {
   ItemCardHeader,
   LinkButton,
-  OverflowTooltip,
+  MarkdownContent,
 } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { EntityRefLinks } from '@backstage/plugin-catalog-react';
@@ -72,6 +72,11 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
     right: theme.spacing(0.5),
     padding: '0.25rem',
   },
+  descriptionBox: {
+    maxHeight: '20em',
+    overflow: 'auto',
+    paddingRight: theme.spacing(1),
+  },
 }));
 
 export type PlaylistCardProps = {
@@ -104,11 +109,11 @@ export const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
         </ItemCardHeader>
       </CardMedia>
       <CardContent style={{ display: 'grid' }}>
-        <Box className={classes.box}>
+        <Box className={classes.descriptionBox}>
           <Typography variant="body2" className={classes.label}>
             Description
           </Typography>
-          <OverflowTooltip text={playlist.description ?? ''} line={4} />
+          <MarkdownContent content={playlist.description ?? ''} />
         </Box>
         <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For playlist description if we enter the description more than the 8 lines its overlaps the UI 
see below screen shot:

![image](https://github.com/backstage/backstage/assets/133481507/7d51a446-96c2-483c-8524-7d54525c20e2)

To avoid it replacing it with overflowTooltip on hover the description:

![image](https://github.com/backstage/backstage/assets/133481507/b7d99673-eeda-4a30-99bf-679118286666)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
