### PR TITLE
Index features on `id` instead of object.

### DIFF
--- a/.changeset/silent-icons-deny.md
+++ b/.changeset/silent-icons-deny.md
@@ -2,7 +2,4 @@
 '@backstage/backend-app-api': patch
 ---
 
-Index features on id instead of object.
-
-This will allow features added from an external package location to be loaded correctly,
-without the requirement of making backstage packages singletons.
+Extension points are now tracked via their ID rather than reference, in order to support package duplication.

--- a/.changeset/silent-icons-deny.md
+++ b/.changeset/silent-icons-deny.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Index features on id instead of object.
+
+This will allow features added from an external package location to be loaded correctly,
+without the requirement of making backstage packages singletons.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -44,10 +44,7 @@ export interface BackendRegisterInit {
 export class BackendInitializer {
   #startPromise?: Promise<void>;
   #features = new Array<InternalBackendFeature>();
-  #extensionPoints = new Map<
-    ExtensionPoint<unknown>,
-    { impl: unknown; pluginId: string }
-  >();
+  #extensionPoints = new Map<string, { impl: unknown; pluginId: string }>();
   #serviceHolder: EnumerableServiceHolder | undefined;
   #providedServiceFactories = new Array<ServiceFactory>();
   #defaultApiFactories: ServiceFactory[];
@@ -64,7 +61,7 @@ export class BackendInitializer {
     const missingRefs = new Set<ServiceOrExtensionPoint>();
 
     for (const [name, ref] of Object.entries(deps)) {
-      const ep = this.#extensionPoints.get(ref as ExtensionPoint<unknown>);
+      const ep = this.#extensionPoints.get(ref.id);
       if (ep) {
         if (ep.pluginId !== pluginId) {
           throw new Error(
@@ -201,12 +198,12 @@ export class BackendInitializer {
 
         if (r.type === 'plugin' || r.type === 'module') {
           for (const [extRef, extImpl] of r.extensionPoints) {
-            if (this.#extensionPoints.has(extRef)) {
+            if (this.#extensionPoints.has(extRef.id)) {
               throw new Error(
                 `ExtensionPoint with ID '${extRef.id}' is already registered`,
               );
             }
-            this.#extensionPoints.set(extRef, {
+            this.#extensionPoints.set(extRef.id, {
               impl: extImpl,
               pluginId: r.pluginId,
             });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Index features on `id` instead of object.

This will allow features loaded from an external package location to be loaded correctly.,
without the requirement of making backstage packages singletons.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
