### PR TITLE
feature(sentry-scaffolder): Add Custom Domains and Client Key Generations

### DIFF
--- a/.changeset/giant-gifts-jog.md
+++ b/.changeset/giant-gifts-jog.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend-module-sentry': patch
+---
+
+- Custom Sentry Domains are now supported and can be configured via the 'apiBaseUrl' property
+- A new Action for Client Creation has been added. Create a Client key with 'sentry:client:create' and retrieve the needed sentry keys in the returned json response

--- a/plugins/scaffolder-backend-module-sentry/api-report.md
+++ b/plugins/scaffolder-backend-module-sentry/api-report.md
@@ -8,6 +8,17 @@ import { JsonObject } from '@backstage/types';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';
 
 // @public
+export function createSentryClientAction(config: Config): TemplateAction<
+  {
+    organizationSlug: string;
+    projectSlug?: string | undefined;
+    authToken?: string | undefined;
+    apiBaseUrl?: string | undefined;
+  },
+  JsonObject
+>;
+
+// @public
 export function createSentryCreateProjectAction(options: {
   config: Config;
 }): TemplateAction<
@@ -17,6 +28,7 @@ export function createSentryCreateProjectAction(options: {
     name: string;
     slug?: string | undefined;
     authToken?: string | undefined;
+    apiBaseUrl?: string | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-sentry/package.json
+++ b/plugins/scaffolder-backend-module-sentry/package.json
@@ -28,8 +28,8 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/config": "workspace:^",
     "@backstage/backend-common": "workspace:^",
+    "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^"
   },

--- a/plugins/scaffolder-backend-module-sentry/package.json
+++ b/plugins/scaffolder-backend-module-sentry/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@backstage/config": "workspace:^",
+    "@backstage/backend-common": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^"
   },

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
@@ -25,6 +25,7 @@ global.fetch = jest.fn(() =>
     headers: {
       get: jest.fn(() => ({ 'Content-Type': 'application/json' })),
     },
+    text: () => Promise.resolve(''),
     ok: false,
     redirected: false,
     status: 201,

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
@@ -19,6 +19,15 @@ import { PassThrough } from 'stream';
 import { ConfigReader } from '@backstage/config';
 import { exampleResponseBody } from './test-fixutres';
 
+if (!global.fetch) {
+  global.fetch = fetch;
+  global.Headers = fetch.Headers;
+  global.Response = fetch.Response;
+  global.AbortController = AbortController;
+}
+
+global.Headers = global.fetch.Headers;
+
 global.fetch = jest.fn(() => {
   const response = {
     json: () => Promise.resolve(exampleResponseBody),

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createSentryClientAction } from './createClientKey';
+import { getVoidLogger } from '@backstage/backend-common';
+import { PassThrough } from 'stream';
+import { ConfigReader } from '@backstage/config';
+import { exampleResponseBody } from './test-fixutres';
+
+global.fetch = jest.fn(() => {
+  const response = {
+    json: () => Promise.resolve(exampleResponseBody),
+    headers: new Headers([['Content-Type', 'application/json']]),
+    ok: false,
+    redirected: false,
+    status: 201,
+    statusText: 'string',
+    type: 'basic',
+    url: '',
+  } as Response;
+  return Promise.resolve(response);
+});
+
+describe('Create Sentry Client Key -', () => {
+  it('should throw error for missing Tokens', async () => {
+    // arrange
+    const mockContext = {
+      workspacePath: './',
+      logger: getVoidLogger(),
+      logStream: new PassThrough(),
+      output: jest.fn(),
+      createTemporaryDirectory: jest.fn(),
+    };
+    const config = new ConfigReader({});
+    const action = createSentryClientAction(config);
+
+    // act & assert
+    await expect(() =>
+      action.handler({
+        ...mockContext,
+        input: {
+          authToken: undefined,
+          apiBaseUrl: '',
+          organizationSlug: '',
+          projectSlug: '',
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should take token from config', async () => {
+    // arrange
+    const mockContext = {
+      workspacePath: './',
+      logger: getVoidLogger(),
+      logStream: new PassThrough(),
+      output: jest.fn(),
+      createTemporaryDirectory: jest.fn(),
+    };
+    const config = new ConfigReader({
+      scaffolder: { sentry: { token: 'testtoken' } },
+    });
+
+    const action = createSentryClientAction(config);
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        authToken: undefined,
+        apiBaseUrl: '',
+        organizationSlug: '',
+        projectSlug: '',
+      },
+    });
+
+    // act & assert
+    return expect(fetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer testtoken`,
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+  });
+
+  it('should take token apiBaseUrl from Config', async () => {
+    // arrange
+    const mockContext = {
+      workspacePath: './',
+      logger: getVoidLogger(),
+      logStream: new PassThrough(),
+      output: jest.fn(),
+      createTemporaryDirectory: jest.fn(),
+    };
+    const config = new ConfigReader({});
+
+    const action = createSentryClientAction(config);
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        authToken: 'token',
+        apiBaseUrl: 'testuri',
+        organizationSlug: '',
+        projectSlug: '',
+      },
+    });
+
+    // act & assert
+    return expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('testuri'),
+      expect.anything(),
+    );
+  });
+
+  it('should fall back to sentry api if no url provided', async () => {
+    // arrange
+    const mockContext = {
+      workspacePath: './',
+      logger: getVoidLogger(),
+      logStream: new PassThrough(),
+      output: jest.fn(),
+      createTemporaryDirectory: jest.fn(),
+    };
+    const config = new ConfigReader({});
+
+    const action = createSentryClientAction(config);
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        authToken: 'token',
+        organizationSlug: '',
+        projectSlug: '',
+      },
+    });
+
+    // act & assert
+    return expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://sentry.io/api/0'),
+      expect.anything(),
+    );
+  });
+
+  it('should provide all dsn keys for successful requests', async () => {
+    // arrange
+    const mockOutput = jest.fn();
+    const mockContext = {
+      workspacePath: './',
+      logger: getVoidLogger(),
+      logStream: new PassThrough(),
+      output: mockOutput,
+      createTemporaryDirectory: jest.fn(),
+    };
+    const config = new ConfigReader({});
+
+    const action = createSentryClientAction(config);
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        authToken: 'token',
+        organizationSlug: '',
+        projectSlug: '',
+      },
+    });
+
+    // act & assert
+    return expect(mockOutput).toHaveBeenCalledWith('sentryKeys', {
+      secret:
+        'https://a785682ddda742d7a8a4088810e67701:bcd99b3790b3441c85ce4b1eaa854f66@o4504765715316736.ingest.sentry.io/4505281256090153',
+      public:
+        'https://a785682ddda742d7a8a4088810e67791@o4504765715316736.ingest.sentry.io/4505281256090153',
+      csp: 'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/csp-report/?sentry_key=a785682ddda719b7a8a4011110d75598',
+      security:
+        'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598',
+      minidump:
+        'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598',
+      unreal:
+        'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/',
+      cdn: 'https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js',
+    });
+  });
+});

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
@@ -19,28 +19,20 @@ import { PassThrough } from 'stream';
 import { ConfigReader } from '@backstage/config';
 import { exampleResponseBody } from './test-fixutres';
 
-if (!global.fetch) {
-  global.fetch = fetch;
-  global.Headers = fetch.Headers;
-  global.Response = fetch.Response;
-  global.AbortController = AbortController;
-}
-
-global.Headers = global.fetch.Headers;
-
-global.fetch = jest.fn(() => {
-  const response = {
+global.fetch = jest.fn(() =>
+  Promise.resolve({
     json: () => Promise.resolve(exampleResponseBody),
-    headers: new global.Headers([['Content-Type', 'application/json']]),
+    headers: {
+      get: jest.fn(() => ({ 'Content-Type': 'application/json' })),
+    },
     ok: false,
     redirected: false,
     status: 201,
     statusText: 'string',
     type: 'basic',
     url: '',
-  } as Response;
-  return Promise.resolve(response);
-});
+  }),
+) as jest.Mock;
 
 describe('Create Sentry Client Key -', () => {
   it('should throw error for missing Tokens', async () => {

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createClientKey.test.ts
@@ -22,7 +22,7 @@ import { exampleResponseBody } from './test-fixutres';
 global.fetch = jest.fn(() => {
   const response = {
     json: () => Promise.resolve(exampleResponseBody),
-    headers: new Headers([['Content-Type', 'application/json']]),
+    headers: new global.Headers([['Content-Type', 'application/json']]),
     ok: false,
     redirected: false,
     status: 201,

--- a/plugins/scaffolder-backend-module-sentry/src/actions/test-fixutres.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/test-fixutres.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const exampleResponseBody = {
+  id: '60120449b6b1d5e45f75561e6dabd80b',
+  name: 'Liked Pegasus',
+  label: 'Liked Pegasus',
+  public: '60120449b6b1d5e45f75561e6dabd80b',
+  secret: '189485c3b8ccf582bf5e12c530ef8858',
+  projectId: 4505281256090153,
+  isActive: true,
+  rateLimit: {
+    window: 7200,
+    count: 1000,
+  },
+  dsn: {
+    secret:
+      'https://a785682ddda742d7a8a4088810e67701:bcd99b3790b3441c85ce4b1eaa854f66@o4504765715316736.ingest.sentry.io/4505281256090153',
+    public:
+      'https://a785682ddda742d7a8a4088810e67791@o4504765715316736.ingest.sentry.io/4505281256090153',
+    csp: 'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/csp-report/?sentry_key=a785682ddda719b7a8a4011110d75598',
+    security:
+      'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598',
+    minidump:
+      'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598',
+    unreal:
+      'https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/',
+    cdn: 'https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js',
+  },
+  browserSdkVersion: '7.x',
+  browserSdk: {
+    choices: [
+      ['latest', 'latest'],
+      ['7.x', '7.x'],
+    ],
+  },
+  dateCreated: '2023-06-21T19:50:26.036254Z',
+  dynamicSdkLoaderOptions: {
+    hasReplay: true,
+    hasPerformance: true,
+    hasDebug: true,
+  },
+};

--- a/plugins/scaffolder-backend-module-sentry/src/index.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { createSentryCreateProjectAction } from './actions/createProject';
+export { createSentryClientAction } from './actions/createClientKey';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8587,6 +8587,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-scaffolder-backend-module-sentry@workspace:plugins/scaffolder-backend-module-sentry"
   dependencies:
+    "@backstage/backend-common": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For the Sentry Scaffolder Module there were two features missing that are essential to my company:
- Being able to configure a custom api base url for self hosted sentry environments
- Being able to create new Client Keys for instrumentation pourpuses

I have added both features as well as unit tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
