### PR TITLE
Remove the concept of extension instances on the surface

### DIFF
--- a/packages/app-next/app-config.yaml
+++ b/packages/app-next/app-config.yaml
@@ -1,7 +1,6 @@
 app:
   packages: 'all' # ✨
   extensions:
-    - core.router
     - graphiql.page:
         config:
           path: /

--- a/packages/app-next/src/examples/graphiqlPlugin.tsx
+++ b/packages/app-next/src/examples/graphiqlPlugin.tsx
@@ -21,6 +21,7 @@ import {
 import React from 'react';
 
 export const GraphiqlPage = createPageExtension({
+  id: 'graphiql.page',
   defaultPath: '/graphiql',
   component: () =>
     import('@backstage/plugin-graphiql').then(({ Router }) => <Router />),
@@ -28,11 +29,5 @@ export const GraphiqlPage = createPageExtension({
 
 export const graphiqlPlugin = createPlugin({
   id: 'graphiql',
-  defaultExtensionInstances: [
-    {
-      id: 'graphiql.page',
-      at: 'core.router/routes',
-      extension: GraphiqlPage,
-    },
-  ],
+  defaultExtensions: [GraphiqlPage],
 });

--- a/packages/frontend-app-api/src/createExtensionInstance.ts
+++ b/packages/frontend-app-api/src/createExtensionInstance.ts
@@ -26,12 +26,11 @@ export interface ExtensionInstance {
 
 /** @internal */
 export function createExtensionInstance(options: {
-  id: string;
   extension: Extension<unknown>;
   config: unknown;
   attachments: Record<string, ExtensionInstance[]>;
 }): ExtensionInstance {
-  const { id, extension, config, attachments } = options;
+  const { extension, config, attachments } = options;
   const extensionData = new Map<string, unknown>();
 
   let parsedConfig: unknown;
@@ -39,7 +38,7 @@ export function createExtensionInstance(options: {
     parsedConfig = extension.configSchema?.parse(config ?? {});
   } catch (e) {
     throw new Error(
-      `Invalid configuration for extension instance '${id}', ${e}`,
+      `Invalid configuration for extension instance '${extension.id}', ${e}`,
     );
   }
 
@@ -60,11 +59,13 @@ export function createExtensionInstance(options: {
       ),
     });
   } catch (e) {
-    throw new Error(`Failed to instantiate extension instance '${id}', ${e}`);
+    throw new Error(
+      `Failed to instantiate extension instance '${extension.id}', ${e}`,
+    );
   }
 
   return {
-    id: options.id,
+    id: options.extension.id,
     data: extensionData,
     $$type: 'extension-instance',
   };

--- a/packages/frontend-app-api/src/extensions/RouteExtension.tsx
+++ b/packages/frontend-app-api/src/extensions/RouteExtension.tsx
@@ -22,6 +22,8 @@ import {
 import { BrowserRouter, useRoutes } from 'react-router-dom';
 
 export const RouteExtension = createExtension({
+  id: 'core.router',
+  at: 'root',
   inputs: {
     routes: {
       extensionData: {

--- a/packages/frontend-app-api/src/wiring/parameters.test.ts
+++ b/packages/frontend-app-api/src/wiring/parameters.test.ts
@@ -211,7 +211,7 @@ describe('readAppExtensionParameters', () => {
         }),
       ),
     ).toThrow(
-      'Invalid extension configuration at app.extensions[0], key must only contain letters, numbers and dots, got core.router/routes',
+      "Invalid extension configuration at app.extensions[0], extension ID must only contain letters, numbers, dashes, and dots, got 'core.router/routes'",
     );
   });
 });
@@ -260,10 +260,10 @@ describe('expandShorthandExtensionParameters', () => {
       disabled: false,
     });
     expect(() => run('')).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1], string shorthand cannot be the empty string"`,
+      `"Invalid extension configuration at app.extensions[1], extension ID must only contain letters, numbers, dashes, and dots, got ''"`,
     );
     expect(() => run('core.router/routes')).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1], cannot target an extension instance input with the string shorthand (key cannot contain slashes; did you mean 'core.router'?)"`,
+      `"Invalid extension configuration at app.extensions[1], extension ID must only contain letters, numbers, dashes, and dots, got 'core.router/routes'"`,
     );
   });
 

--- a/packages/frontend-app-api/src/wiring/parameters.test.ts
+++ b/packages/frontend-app-api/src/wiring/parameters.test.ts
@@ -211,7 +211,7 @@ describe('readAppExtensionParameters', () => {
         }),
       ),
     ).toThrow(
-      "Invalid extension configuration at app.extensions[0], extension ID must only contain letters, numbers, dashes, and dots, got 'core.router/routes'",
+      "Invalid extension configuration at app.extensions[0], extension ID must only contain letters, numbers, and dots; got 'core.router/routes'",
     );
   });
 });
@@ -260,10 +260,10 @@ describe('expandShorthandExtensionParameters', () => {
       disabled: false,
     });
     expect(() => run('')).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1], extension ID must only contain letters, numbers, dashes, and dots, got ''"`,
+      `"Invalid extension configuration at app.extensions[1], extension ID must only contain letters, numbers, and dots; got ''"`,
     );
     expect(() => run('core.router/routes')).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1], extension ID must only contain letters, numbers, dashes, and dots, got 'core.router/routes'"`,
+      `"Invalid extension configuration at app.extensions[1], extension ID must only contain letters, numbers, and dots; got 'core.router/routes'"`,
     );
   });
 

--- a/packages/frontend-app-api/src/wiring/parameters.ts
+++ b/packages/frontend-app-api/src/wiring/parameters.ts
@@ -61,10 +61,10 @@ export function expandShorthandExtensionParameters(
   }
 
   function assertValidId(id: string) {
-    if (!id.match(/^[\.a-zA-Z0-9-]+$/)) {
+    if (!id.match(/^[\.a-zA-Z0-9]+$/)) {
       throw new Error(
         errorMsg(
-          `extension ID must only contain letters, numbers, dashes, and dots, got '${id}'`,
+          `extension ID must only contain letters, numbers, and dots; got '${id}'`,
         ),
       );
     }

--- a/packages/frontend-app-api/src/wiring/parameters.ts
+++ b/packages/frontend-app-api/src/wiring/parameters.ts
@@ -15,19 +15,17 @@
  */
 
 import { Config } from '@backstage/config';
-import {
-  Extension,
-  ExtensionInstanceParameters,
-} from '@backstage/frontend-plugin-api';
+import { Extension } from '@backstage/frontend-plugin-api';
 import { JsonValue } from '@backstage/types';
-import omitBy from 'lodash/omitBy';
 
-const knownExtensionInstanceParameters = [
-  'at',
-  'disabled',
-  'extension',
-  'config',
-];
+export interface ExtensionParameters {
+  id: string;
+  at?: string;
+  disabled?: boolean;
+  config?: unknown;
+}
+
+const knownExtensionParameters = ['at', 'disabled', 'config'];
 
 // Since we'll never merge arrays in config the config reader context
 // isn't too much of a help. Fall back to manual config reading logic
@@ -35,10 +33,7 @@ const knownExtensionInstanceParameters = [
 /** @internal */
 export function readAppExtensionParameters(
   rootConfig: Config,
-  resolveExtensionRef: (ref: string) => Extension<unknown> = () => {
-    throw new Error('Not Implemented');
-  },
-): Partial<ExtensionInstanceParameters>[] {
+): ExtensionParameters[] {
   const arr = rootConfig.getOptional('app.extensions');
   if (!Array.isArray(arr)) {
     if (arr === undefined) {
@@ -49,18 +44,8 @@ export function readAppExtensionParameters(
     return [];
   }
 
-  const generateExtensionId = (() => {
-    let index = 1;
-    return () => `generated.${index++}`;
-  })();
-
   return arr.map((arrayEntry, arrayIndex) =>
-    expandShorthandExtensionParameters(
-      arrayEntry,
-      arrayIndex,
-      resolveExtensionRef,
-      generateExtensionId,
-    ),
+    expandShorthandExtensionParameters(arrayEntry, arrayIndex),
   );
 }
 
@@ -68,9 +53,7 @@ export function readAppExtensionParameters(
 export function expandShorthandExtensionParameters(
   arrayEntry: JsonValue,
   arrayIndex: number,
-  resolveExtensionRef: (ref: string) => Extension<unknown>,
-  generateExtensionId: () => string,
-): Partial<ExtensionInstanceParameters> {
+): ExtensionParameters {
   function errorMsg(msg: string, key?: string, prop?: string) {
     return `Invalid extension configuration at app.extensions[${arrayIndex}]${
       key ? `[${key}]` : ''
@@ -93,6 +76,7 @@ export function expandShorthandExtensionParameters(
     }
     return {
       id: arrayEntry,
+      disabled: false,
     };
   }
 
@@ -110,111 +94,43 @@ export function expandShorthandExtensionParameters(
     throw new Error(errorMsg(`must have exactly one key, got ${joinedKeys}`));
   }
 
-  const key = keys[0];
+  const key = String(keys[0]);
   const value = arrayEntry[key];
+  if (!key.match(/^[\.a-zA-Z0-9]+$/)) {
+    throw new Error(
+      errorMsg(`key must only contain letters, numbers and dots, got ${key}`),
+    );
+  }
 
   // Example YAML:
   // - catalog.page.cicd: false
   if (typeof value === 'boolean') {
-    if (key.includes('/')) {
-      const suggestion = key.split('/')[0];
-      throw new Error(
-        errorMsg(
-          `cannot target an extension instance input (key cannot contain slashes; did you mean '${suggestion}'?)`,
-          key,
-        ),
-      );
-    }
-
     return {
       id: key,
       disabled: !value,
     };
   }
 
-  // Example YAML:
-  // - core.router/routes: '@backstage/plugin-some-plugin#MyPage'
-  // - some-plugin.page: '@internal/frontend-customizations#MyModifiedPage'
-  if (typeof value === 'string') {
-    if (key.includes('/')) {
-      return {
-        id: generateExtensionId(),
-        at: key,
-        extension: resolveExtensionRef(value),
-      };
-    }
-
-    return {
-      id: key,
-      extension: resolveExtensionRef(value),
-    };
-  }
-
   // The remaining case is the generic object. Example YAML:
-  // - core.router/routes:
-  //     extension: '@backstage/core-app-api#Redirect'
-  //     config:
-  //       path: /
-  //       to: /catalog
   //  - tech-radar.page:
   //      at: core.router/routes
-  //      extension: '@backstage/plugin-tech-radar#TechRadarPage'
+  //      disabled: false
   //      config:
   //        path: /tech-radar
   //        width: 1500
   //        height: 800
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(
-      errorMsg('value must be a boolean, string, or object', key),
-    );
+    throw new Error(errorMsg('value must be a boolean or object', key));
   }
 
-  let id = value.id;
-  let at = value.at;
+  const at = value.at;
   const disabled = value.disabled;
-  const extensionRef = value.extension;
   const config = value.config;
 
-  if (key.includes('/')) {
-    if (at !== undefined) {
-      throw new Error(
-        errorMsg(
-          `must not redundantly specify 'at' when the extension input ID form of the key is used (with a slash); the 'at' is already implicitly '${key}'`,
-          key,
-        ),
-      );
-    }
-    if (id !== undefined) {
-      throw new Error(
-        errorMsg(
-          `must not specify 'id' when the extension input ID form of the key is used (with a slash); please replace the key '${key}' with the id instead, and put that key in the 'at' field`,
-          key,
-          'id',
-        ),
-      );
-    }
-    id = generateExtensionId();
-    at = key;
-  } else {
-    if (id !== undefined) {
-      throw new Error(
-        errorMsg(
-          `must not redundantly specify 'id' when the extension instance ID form of the key is used (without a slash); the 'id' is already implicitly '${key}'`,
-          key,
-        ),
-      );
-    }
-    id = key;
-  }
-
-  if (id !== undefined && typeof id !== 'string') {
-    throw new Error(errorMsg('must be a string', key, 'id'));
-  } else if (at !== undefined && typeof at !== 'string') {
+  if (at !== undefined && typeof at !== 'string') {
     throw new Error(errorMsg('must be a string', key, 'at'));
   } else if (disabled !== undefined && typeof disabled !== 'boolean') {
     throw new Error(errorMsg('must be a boolean', key, 'disabled'));
-  } else if (extensionRef !== undefined && typeof extensionRef !== 'string') {
-    throw new Error(errorMsg('must be a string', key, 'extension'));
   } else if (
     config !== undefined &&
     (typeof config !== 'object' || config === null || Array.isArray(config))
@@ -223,12 +139,12 @@ export function expandShorthandExtensionParameters(
   }
 
   const unknownKeys = Object.keys(value).filter(
-    k => !knownExtensionInstanceParameters.includes(k),
+    k => !knownExtensionParameters.includes(k),
   );
   if (unknownKeys.length > 0) {
     throw new Error(
       errorMsg(
-        `unknown parameter; expected one of '${knownExtensionInstanceParameters.join(
+        `unknown parameter; expected one of '${knownExtensionParameters.join(
           "', '",
         )}'`,
         key,
@@ -237,63 +153,67 @@ export function expandShorthandExtensionParameters(
     );
   }
 
-  const extension: Extension<unknown> | undefined = extensionRef
-    ? resolveExtensionRef(extensionRef)
-    : undefined;
+  return {
+    id: key,
+    at,
+    disabled,
+    config,
+  };
+}
 
-  return omitBy(
-    {
-      id,
-      at,
-      disabled,
-      extension,
-      config,
-    },
-    v => v === undefined,
-  );
+export interface ExtensionInstanceParameters {
+  extension: Extension<unknown>;
+  at: string;
+  config?: unknown;
 }
 
 /** @internal */
 export function mergeExtensionParameters(
-  base: ExtensionInstanceParameters[],
-  overrides: Array<Partial<ExtensionInstanceParameters>>,
+  base: Extension<unknown>[],
+  parameters: Array<ExtensionParameters>,
 ): ExtensionInstanceParameters[] {
-  const extensionInstanceParams = base.slice();
+  const overrides = base.map(extension => ({
+    extension,
+    params: {
+      at: extension.at,
+      disabled: extension.disabled,
+      config: undefined as unknown,
+    },
+  }));
 
-  for (const overrideParam of overrides) {
-    const existingParamIndex = extensionInstanceParams.findIndex(
-      e => e.id === overrideParam.id,
+  for (const overrideParam of parameters) {
+    const existingIndex = overrides.findIndex(
+      e => e.extension.id === overrideParam.id,
     );
-    if (existingParamIndex !== -1) {
-      const existingParam = extensionInstanceParams[existingParamIndex];
+    if (existingIndex !== -1) {
+      const existing = overrides[existingIndex];
       if (overrideParam.at) {
-        existingParam.at = overrideParam.at;
-      }
-      if (overrideParam.extension) {
-        // TODO: do we want to reset config here? it might be completely
-        // unrelated to the previous one
-        existingParam.extension = overrideParam.extension;
+        existing.params.at = overrideParam.at;
       }
       if (overrideParam.config) {
         // TODO: merge config?
-        existingParam.config = overrideParam.config;
+        existing.params.config = overrideParam.config;
       }
-      if (Boolean(existingParam.disabled) !== Boolean(overrideParam.disabled)) {
-        existingParam.disabled = Boolean(overrideParam.disabled);
-        if (!existingParam.disabled) {
+      if (
+        Boolean(existing.params.disabled) !== Boolean(overrideParam.disabled)
+      ) {
+        existing.params.disabled = Boolean(overrideParam.disabled);
+        if (!existing.params.disabled) {
           // bump
-          extensionInstanceParams.splice(existingParamIndex, 1);
-          extensionInstanceParams.push(existingParam);
+          overrides.splice(existingIndex, 1);
+          overrides.push(existing);
         }
       }
-    } else if (overrideParam.id) {
-      const { id, at, extension, config } = overrideParam;
-      if (!at || !extension) {
-        throw new Error(`Extension ${overrideParam.id} is incomplete`);
-      }
-      extensionInstanceParams.push({ id, at, extension, config });
+    } else {
+      throw new Error(`Extension ${overrideParam.id} does not exist`);
     }
   }
 
-  return extensionInstanceParams.filter(param => !param.disabled);
+  return overrides
+    .filter(override => !override.params.disabled)
+    .map(param => ({
+      extension: param.extension,
+      at: param.params.at,
+      config: param.params.config,
+    }));
 }

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -19,7 +19,7 @@ export interface BackstagePlugin {
   // (undocumented)
   $$type: 'backstage-plugin';
   // (undocumented)
-  defaultExtensionInstances: ExtensionInstanceParameters[];
+  defaultExtensions: Extension<unknown>[];
   // (undocumented)
   id: string;
 }
@@ -27,7 +27,7 @@ export interface BackstagePlugin {
 // @public (undocumented)
 export interface BackstagePluginOptions {
   // (undocumented)
-  defaultExtensionInstances?: ExtensionInstanceParameters[];
+  defaultExtensions?: Extension<unknown>[];
   // (undocumented)
   id: string;
 }
@@ -62,7 +62,11 @@ export interface CreateExtensionOptions<
   TConfig,
 > {
   // (undocumented)
+  at: string;
+  // (undocumented)
   configSchema?: PortableSchema<TConfig>;
+  // (undocumented)
+  disabled?: boolean;
   // (undocumented)
   factory(options: {
     bind: ExtensionDataBind<TData>;
@@ -73,6 +77,8 @@ export interface CreateExtensionOptions<
       >[];
     };
   }): void;
+  // (undocumented)
+  id: string;
   // (undocumented)
   inputs?: TPoint;
   // (undocumented)
@@ -99,6 +105,9 @@ export function createPageExtension<
         configSchema: PortableSchema<TConfig>;
       }
   ) & {
+    id: string;
+    at?: string;
+    disabled?: boolean;
     inputs?: TInputs;
     component: (props: {
       config: TConfig;
@@ -124,13 +133,19 @@ export interface Extension<TConfig> {
   // (undocumented)
   $$type: 'extension';
   // (undocumented)
+  at: string;
+  // (undocumented)
   configSchema?: PortableSchema<TConfig>;
+  // (undocumented)
+  disabled: boolean;
   // (undocumented)
   factory(options: {
     bind: ExtensionDataBind<AnyExtensionDataMap>;
     config: TConfig;
     inputs: Record<string, Array<Record<string, unknown>>>;
   }): void;
+  // (undocumented)
+  id: string;
   // (undocumented)
   inputs: Record<
     string,
@@ -158,20 +173,6 @@ export type ExtensionDataRef<T> = {
 export type ExtensionDataValue<TData extends AnyExtensionDataMap> = {
   [K in keyof TData]: TData[K]['T'];
 };
-
-// @public (undocumented)
-export interface ExtensionInstanceParameters {
-  // (undocumented)
-  at: string;
-  // (undocumented)
-  config?: unknown;
-  // (undocumented)
-  disabled?: boolean;
-  // (undocumented)
-  extension: Extension<unknown>;
-  // (undocumented)
-  id: string;
-}
 
 // @public (undocumented)
 export type PortableSchema<TOutput> = {

--- a/packages/frontend-plugin-api/src/createPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/createPageExtension.tsx
@@ -41,6 +41,9 @@ export function createPageExtension<
         configSchema: PortableSchema<TConfig>;
       }
   ) & {
+    id: string;
+    at?: string;
+    disabled?: boolean;
     inputs?: TInputs;
     component: (props: {
       config: TConfig;
@@ -60,6 +63,9 @@ export function createPageExtension<
         ) as PortableSchema<TConfig>);
 
   return createExtension({
+    id: options.id,
+    at: options.at ?? 'core.router/routes',
+    disabled: options.disabled,
     output: {
       component: coreExtensionData.reactComponent,
       path: coreExtensionData.routePath,

--- a/packages/frontend-plugin-api/src/index.ts
+++ b/packages/frontend-plugin-api/src/index.ts
@@ -37,5 +37,4 @@ export {
   type ExtensionDataBind,
   type ExtensionDataRef,
   type ExtensionDataValue,
-  type ExtensionInstanceParameters,
 } from './types';

--- a/packages/frontend-plugin-api/src/types.ts
+++ b/packages/frontend-plugin-api/src/types.ts
@@ -54,6 +54,9 @@ export interface CreateExtensionOptions<
   TPoint extends Record<string, { extensionData: AnyExtensionDataMap }>,
   TConfig,
 > {
+  id: string;
+  at: string;
+  disabled?: boolean;
   inputs?: TPoint;
   output: TData;
   configSchema?: PortableSchema<TConfig>;
@@ -71,7 +74,9 @@ export interface CreateExtensionOptions<
 /** @public */
 export interface Extension<TConfig> {
   $$type: 'extension';
-  // TODO: will extensions have a default "at" as part of their contract, making it optional in the instance config?
+  id: string;
+  at: string;
+  disabled: boolean;
   inputs: Record<string, { extensionData: AnyExtensionDataMap }>;
   output: AnyExtensionDataMap;
   configSchema?: PortableSchema<TConfig>;
@@ -88,29 +93,25 @@ export function createExtension<
   TPoint extends Record<string, { extensionData: AnyExtensionDataMap }>,
   TConfig = never,
 >(options: CreateExtensionOptions<TData, TPoint, TConfig>): Extension<TConfig> {
-  return { ...options, $$type: 'extension', inputs: options.inputs ?? {} };
-}
-
-/** @public */
-export interface ExtensionInstanceParameters {
-  id: string;
-  at: string;
-  extension: Extension<unknown>;
-  config?: unknown;
-  disabled?: boolean;
+  return {
+    ...options,
+    disabled: options.disabled ?? false,
+    $$type: 'extension',
+    inputs: options.inputs ?? {},
+  };
 }
 
 /** @public */
 export interface BackstagePluginOptions {
   id: string;
-  defaultExtensionInstances?: ExtensionInstanceParameters[];
+  defaultExtensions?: Extension<unknown>[];
 }
 
 /** @public */
 export interface BackstagePlugin {
   $$type: 'backstage-plugin';
   id: string;
-  defaultExtensionInstances: ExtensionInstanceParameters[];
+  defaultExtensions: Extension<unknown>[];
 }
 
 /** @public */
@@ -118,6 +119,6 @@ export function createPlugin(options: BackstagePluginOptions): BackstagePlugin {
   return {
     ...options,
     $$type: 'backstage-plugin',
-    defaultExtensionInstances: options.defaultExtensionInstances ?? [],
+    defaultExtensions: options.defaultExtensions ?? [],
   };
 }


### PR DESCRIPTION
You no longer "think" in terms of extension instantiation at the surface of the configuration or the definition of extensions. IDs are now assigned directly on extensions themselves, and they have a default `at`. When writing config, you no longer put attachment points as keys; all you can do is to target extensions by ID, and then possibly changing their `at` if that's the desired action.

Later on, we may start allowing multiple occurrences of the same ID in the extensions config, leading to multiple instances. But that's still TBD.