### PR TITLE
feat: add allowed kind props to catalog page

### DIFF
--- a/.changeset/tricky-months-raise.md
+++ b/.changeset/tricky-months-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+The CatalogPage can now have an `allowedKinds` props which is simply passed to the already existing `allowedKinds` props of the EntityKindPicker component to be more customizable.

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -103,6 +103,16 @@ describe('DefaultCatalogPage', () => {
       Promise.resolve({ id: 'id', type: 'url', target: 'url' }),
     getEntityFacets: async () => ({
       facets: {
+        kind: [
+          {
+            value: 'System',
+            count: 3,
+          },
+          {
+            value: 'Component',
+            count: 3,
+          },
+        ],
         'relations.ownedBy': [
           { count: 1, value: 'group:default/not-tools' },
           { count: 1, value: 'group:default/tools' },
@@ -298,5 +308,10 @@ describe('DefaultCatalogPage', () => {
     ).toBeInTheDocument();
     fireEvent.click(button);
     expect(screen.getByRole('presentation')).toBeVisible();
+  }, 20_000);
+
+  it('should render only allowed kinds in filter', async () => {
+    await renderWrapped(<DefaultCatalogPage allowedKinds={['System']} />);
+    expect(screen.queryByText('Component')).not.toBeInTheDocument();
   }, 20_000);
 });

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -53,6 +53,10 @@ export interface DefaultCatalogPageProps {
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
   initialKind?: string;
+  /**
+   * See {@link EntityKindPickerProps#allowedKinds}
+   */
+  allowedKinds?: string[];
   tableOptions?: TableProps<CatalogTableRow>['options'];
   emptyContent?: ReactNode;
   ownerPickerMode?: EntityOwnerPickerProps['mode'];
@@ -64,6 +68,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     actions,
     initiallySelectedFilter = 'owned',
     initialKind = 'component',
+    allowedKinds,
     tableOptions = {},
     emptyContent,
     ownerPickerMode,
@@ -87,7 +92,10 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
         <EntityListProvider>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
-              <EntityKindPicker initialFilter={initialKind} />
+              <EntityKindPicker
+                initialFilter={initialKind}
+                allowedKinds={allowedKinds}
+              />
               <EntityTypePicker />
               <UserListPicker initialFilter={initiallySelectedFilter} />
               <EntityOwnerPicker mode={ownerPickerMode} />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add allowed kind props to catalog page to make it more customizable. The props is simply passed to an already existing props of another component (EntityKindPicker).


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
