### PR TITLE
backend-app-api: Feature Discovery - include, exclude & alpha exports

### DIFF
--- a/.changeset/funny-ligers-matter.md
+++ b/.changeset/funny-ligers-matter.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Adds include and exclude configuration to feature discovery of backend packages
+Adds alpha exports to feature discovery

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
@@ -65,7 +65,7 @@ describe('featureDiscoveryServiceFactory', () => {
           name: 'detected-module',
           main: 'index.js',
           backstage: {
-            role: 'backend-module',
+            role: 'backend-plugin-module',
           },
         }),
         'index.js': `

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
@@ -34,7 +34,7 @@ describe('featureDiscoveryServiceFactory', () => {
           dependencies: {
             'detected-plugin': '0.0.0',
             'detected-module': '0.0.0',
-            'another-detected-plugin': '0.0.0',
+            'detected-plugin-with-alpha': '0.0.0',
           },
         }),
       },
@@ -85,23 +85,33 @@ describe('featureDiscoveryServiceFactory', () => {
         });
         `,
       },
-      [resolvePath(rootDir, 'node_modules/another-detected-plugin')]: {
+      [resolvePath(rootDir, 'node_modules/detected-plugin-with-alpha')]: {
         'package.json': JSON.stringify({
-          name: 'another-detected-plugin',
+          name: 'detected-plugin-with-alpha',
           main: 'index.js',
+          exports: {
+            '.': {
+              default: 'index.js',
+            },
+            './alpha': {
+              default: 'alpha.js',
+            },
+            './package.json': './package.json',
+          },
           backstage: {
             role: 'backend-plugin',
           },
         }),
-        'index.js': `
+        'index.js': `exports.detectedPlugin = undefined;`,
+        'alpha.js': `
         const { createBackendPlugin, coreServices } = require('@backstage/backend-plugin-api');
-        exports.detectedPlugin = createBackendPlugin({
-            pluginId: 'another-detected',
+        exports.detectedPluginAlpha = createBackendPlugin({
+            pluginId: 'detected-alpha',
             register(env) {
               env.registerInit({
                 deps: { identity: coreServices.identity },
                 async init({ identity }) {
-                  identity.getIdentity('another-detected-plugin');
+                  identity.getIdentity('detected-plugin-with-alpha');
                 },
               });
             },
@@ -134,7 +144,7 @@ describe('featureDiscoveryServiceFactory', () => {
 
     expect(fn).toHaveBeenCalledWith('detected-plugin');
     expect(fn).toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('another-detected-plugin');
+    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
   });
 
   it('detects only the packages that are listed as included', async () => {
@@ -152,7 +162,7 @@ describe('featureDiscoveryServiceFactory', () => {
           data: {
             backend: {
               packages: {
-                include: ['detected-plugin', 'another-detected-plugin'],
+                include: ['detected-plugin', 'detected-plugin-with-alpha'],
               },
             },
           },
@@ -161,7 +171,7 @@ describe('featureDiscoveryServiceFactory', () => {
     });
 
     expect(fn).toHaveBeenCalledWith('detected-plugin');
-    expect(fn).toHaveBeenCalledWith('another-detected-plugin');
+    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
     expect(fn).not.toHaveBeenCalledWith('detected-module');
   });
 
@@ -189,7 +199,7 @@ describe('featureDiscoveryServiceFactory', () => {
     });
 
     expect(fn).not.toHaveBeenCalledWith('detected-plugin');
-    expect(fn).not.toHaveBeenCalledWith('another-detected-plugin');
+    expect(fn).not.toHaveBeenCalledWith('detected-plugin-with-alpha');
     expect(fn).not.toHaveBeenCalledWith('detected-module');
   });
 
@@ -218,7 +228,7 @@ describe('featureDiscoveryServiceFactory', () => {
 
     expect(fn).not.toHaveBeenCalledWith('detected-plugin');
     expect(fn).not.toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('another-detected-plugin');
+    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
   });
 
   it('does not excluded packages when it is an empty list', async () => {
@@ -246,7 +256,7 @@ describe('featureDiscoveryServiceFactory', () => {
 
     expect(fn).toHaveBeenCalledWith('detected-plugin');
     expect(fn).toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('another-detected-plugin');
+    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
   });
 
   it('does not detect packages that are included and excluded', async () => {
@@ -267,7 +277,7 @@ describe('featureDiscoveryServiceFactory', () => {
                 include: [
                   'detected-plugin',
                   'detected-module',
-                  'another-detected-plugin',
+                  'detected-plugin-with-alpha',
                 ],
                 exclude: ['detected-plugin'],
               },
@@ -279,7 +289,7 @@ describe('featureDiscoveryServiceFactory', () => {
 
     expect(fn).not.toHaveBeenCalledWith('detected-plugin');
     expect(fn).toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('another-detected-plugin');
+    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
   });
 
   it('does not detect any packages when "packages" is empty', async () => {

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.ts
@@ -27,7 +27,6 @@ import {
 import { resolve as resolvePath, dirname } from 'path';
 import fs from 'fs-extra';
 import { BackstagePackageJson } from '@backstage/cli-node';
-import { JsonObject, JsonValue } from '@backstage/types';
 
 const LOADED_PACKAGE_ROLES = ['backend-plugin', 'backend-plugin-module'];
 

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.ts
@@ -28,7 +28,7 @@ import { resolve as resolvePath, dirname } from 'path';
 import fs from 'fs-extra';
 import { BackstagePackageJson } from '@backstage/cli-node';
 
-const LOADED_PACKAGE_ROLES = ['backend-plugin', 'backend-module'];
+const LOADED_PACKAGE_ROLES = ['backend-plugin', 'backend-plugin-module'];
 
 /** @internal */
 async function findClosestPackageDir(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Adds `include` and `exclude` to backend feature discovery
```yaml
backend:
  packages:
    include:
      - @backstage/plugin-auth-backend
    exclude:
      - @backstage/plugin-backend-backend
```
- Adds alpha exports to discovery
- Fixes issue with backend-plugin-module role

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
