### PR TITLE
fix: change default entity toggle state for user entities

### DIFF
--- a/.changeset/long-flowers-sort.md
+++ b/.changeset/long-flowers-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Entity relations toggle should by default be aggregated for User entities

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -25,7 +25,7 @@ import {
   Switch,
   Tooltip,
 } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ComponentsGrid } from './ComponentsGrid';
 import { EntityRelationAggregation } from './types';
 
@@ -71,9 +71,17 @@ export const OwnershipCard = (props: {
     hideRelationsToggle === undefined ? false : hideRelationsToggle;
   const classes = useStyles();
   const { entity } = useEntity();
+
+  const defaultRelationsType = entity.kind === 'User' ? 'aggregated' : 'direct';
   const [getRelationsType, setRelationsType] = useState(
-    relationsType || 'direct',
+    relationsType ?? defaultRelationsType,
   );
+
+  useEffect(() => {
+    if (!relationsType) {
+      setRelationsType(defaultRelationsType);
+    }
+  }, [setRelationsType, defaultRelationsType, relationsType]);
 
   return (
     <InfoCard title="Ownership" variant={variant}>
@@ -95,11 +103,11 @@ export const OwnershipCard = (props: {
                 <Switch
                   color="primary"
                   checked={getRelationsType !== 'direct'}
-                  onChange={() =>
-                    getRelationsType === 'direct'
-                      ? setRelationsType('aggregated')
-                      : setRelationsType('direct')
-                  }
+                  onChange={() => {
+                    const updatedRelationsType =
+                      getRelationsType === 'direct' ? 'aggregated' : 'direct';
+                    setRelationsType(updatedRelationsType);
+                  }}
                   name="pin"
                   inputProps={{ 'aria-label': 'Ownership Type Switch' }}
                 />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ensure the default entity relations toggle state is `aggregated` for `kind: 'User'` entities.

This fixes a regression introduced in https://github.com/backstage/backstage/pull/18540 and later report in https://github.com/backstage/backstage/issues/19677

###

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
