### PR TITLE
doc(home-plugin): Adds documentation on <HomePageVisitedByType/> usage

### DIFF
--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -266,7 +266,7 @@ export const homePage = (
 
 There are some requirements to provide its functionality, so please ensure the following:
 
-These components need an api to handle visit data, please refer to the [utility-apis](../../docs/api/utility-apis.md)
+These components need an API to handle visit data, please refer to the [utility-apis](../../docs/api/utility-apis.md)
 documentation for more information. Bellow you can see an example for two options:
 
 ```ts

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -248,6 +248,7 @@ This component shows the homepage user a view for "Recently visited" or "Top vis
 Being provided by the `<HomePageVisitedByType/>` component, see it in use on a homepage example below:
 
 ```tsx
+// packages/app/src/components/home/HomePage.tsx
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import { HomePageVisitedByType } from '@backstage/plugin-home';

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -264,7 +264,7 @@ export const homePage = (
 );
 ```
 
-There ase some requirements to provide its functionality, so please ensure the following:
+There are some requirements to provide its functionality, so please ensure the following:
 
 These components need an api to handle visit data, please refer to the [utility-apis](../../docs/api/utility-apis.md)
 documentation for more information. Bellow you can see an example for two options:

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -242,6 +242,84 @@ const defaultConfig = [
 <CustomHomepageGrid config={defaultConfig}>
 ```
 
+## Page visit homepage component (HomePageVisitedByType)
+
+This component shows the homepage user a view for "Recently visited" or "Top visited".
+Being provided by the `<HomePageVisitedByType/>` component, see it in usage on a homepage example bellow:
+
+```tsx
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import { HomePageVisitedByType } from '@backstage/plugin-home';
+
+export const homePage = (
+  <Grid container spacing={3}>
+    <Grid item xs={12} md={4}>
+      <HomePageVisitedByType kind="top" />
+    </Grid>
+    <Grid item xs={12} md={4}>
+      <HomePageVisitedByType kind="recent" />
+    </Grid>
+  </Grid>
+);
+```
+
+There ase some requirements to provide its functionality, so please ensure the following:
+
+These components need an api to handle visit data, please refer to the [utility-apis](../../docs/api/utility-apis.md)
+documentation for more information. Bellow you can see an example for two options:
+
+```ts
+// apis.ts
+// ...
+import {
+  CoreStorageVisitsApi,
+  LocalStoreVisitsApi,
+  visitsApiRef,
+} from '@backstage/plugin-home';
+// ...
+export const apis: AnyApiFactory[] = [
+  // Implementation that relies on the integration with storageApi
+  createApiFactory({
+    api: visitsApiRef,
+    deps: {
+      storageApi: storageApiRef,
+      identityApi: identityApiRef,
+    },
+    factory: ({ storageApi, identityApi }) =>
+      CoreStorageVisitsApi.create({ storageApi, identityApi }),
+  }),
+
+  // Or a local data implementation, relies on the browser's window.localStorage
+  createApiFactory({
+    api: visitsApiRef,
+    deps: {
+      identityApi: identityApiRef,
+    },
+    factory: ({ identityApi }) => LocalStoreVisitsApi.create({ identityApi }),
+  }),
+  // ...
+```
+
+To monitor page visit activity and save it on behalf of the user a component is provided, please add it to your app.
+See the example usage:
+
+```ts
+// App.tsx
+import { VisitsListener } from '@backstage/plugin-home';
+// ...
+export default app.createRoot(
+  <>
+    <AlertDisplay />
+    <OAuthRequestDialog />
+    <AppRouter>
+      <VisitsListener />
+      <Root>{routes}</Root>
+    </AppRouter>
+  </>,
+);
+```
+
 ## Contributing
 
 ### Homepage Components

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -270,7 +270,7 @@ These components need an API to handle visit data, please refer to the [utility-
 documentation for more information. Bellow you can see an example for two options:
 
 ```ts
-// apis.ts
+// packages/app/src/apis.ts
 // ...
 import {
   CoreStorageVisitsApi,

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -245,7 +245,7 @@ const defaultConfig = [
 ## Page visit homepage component (HomePageVisitedByType)
 
 This component shows the homepage user a view for "Recently visited" or "Top visited".
-Being provided by the `<HomePageVisitedByType/>` component, see it in usage on a homepage example bellow:
+Being provided by the `<HomePageVisitedByType/>` component, see it in use on a homepage example below:
 
 ```tsx
 import React from 'react';

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -305,7 +305,7 @@ To monitor page visit activity and save it on behalf of the user a component is 
 See the example usage:
 
 ```ts
-// App.tsx
+// packages/app/src/App.tsx
 import { VisitsListener } from '@backstage/plugin-home';
 // ...
 export default app.createRoot(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is part of a series with the objective of releasing a "Recently Visited" and "Top Visited" experience to open source. They are using the [home-page-visit-components-0](https://github.com/backstage/backstage/tree/home-page-visit-components-0) feature branch as an intermediary step before a PR to master.
The PRs in this series:
* [feature(home-plugin): Bootstrap Recently Visited and Top Visited components](https://github.com/backstage/backstage/pull/19645)
* [feature(home-plugin): Creates the VisitListener component](https://github.com/backstage/backstage/pull/19644)
* [feature(home-plugin): Create reference implementation (localStorage and storeApi)](https://github.com/backstage/backstage/pull/19643)
* [doc(home-plugin): Adds documentation on <HomePageVisitedByType/> usage](https://github.com/backstage/backstage/pull/19688)

A quick preview of the component in storybook:
<img width="810" alt="Screenshot 2023-09-08 at 11 11 21" src="https://github.com/backstage/backstage/assets/187639/4c95c542-5497-4fe9-9cd9-078192ccef6c">

This patch is only about the plugin documentation on the component usage and requirements.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
