### PR TITLE
Include auth token when using the CatalogClient in the code-coverage-backend plugin

### DIFF
--- a/.changeset/proud-lamps-cross.md
+++ b/.changeset/proud-lamps-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Include auth token when fetching entity

--- a/plugins/code-coverage-backend/package.json
+++ b/plugins/code-coverage-backend/package.json
@@ -35,6 +35,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
+    "@backstage/plugin-auth-node": "workspace:^",
     "@types/express": "^4.17.6",
     "body-parser": "^1.20.0",
     "body-parser-xml": "^2.0.5",

--- a/plugins/code-coverage-backend/src/service/router.ts
+++ b/plugins/code-coverage-backend/src/service/router.ts
@@ -33,6 +33,7 @@ import { CodeCoverageDatabase } from './CodeCoverageDatabase';
 import { aggregateCoverage, CoverageUtils } from './CoverageUtils';
 import { Converter, Jacoco, Cobertura, Lcov } from './converter';
 import { getEntitySourceLocation } from '@backstage/catalog-model';
+import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 
 /**
  * Options for {@link createRouter}.
@@ -79,7 +80,9 @@ export const makeRouter = async (
    */
   router.get('/report', async (req, res) => {
     const { entity } = req.query;
-    const entityLookup = await catalogApi.getEntityByRef(entity as string);
+    const entityLookup = await catalogApi.getEntityByRef(entity as string, {
+      token: getBearerTokenFromAuthorizationHeader(req.headers.authorization),
+    });
     if (!entityLookup) {
       throw new NotFoundError(`No entity found matching ${entity}`);
     }
@@ -101,7 +104,9 @@ export const makeRouter = async (
    */
   router.get('/history', async (req, res) => {
     const { entity } = req.query;
-    const entityLookup = await catalogApi.getEntityByRef(entity as string);
+    const entityLookup = await catalogApi.getEntityByRef(entity as string, {
+      token: getBearerTokenFromAuthorizationHeader(req.headers.authorization),
+    });
     if (!entityLookup) {
       throw new NotFoundError(`No entity found matching ${entity}`);
     }
@@ -119,7 +124,9 @@ export const makeRouter = async (
    */
   router.get('/file-content', async (req, res) => {
     const { entity, path } = req.query;
-    const entityLookup = await catalogApi.getEntityByRef(entity as string);
+    const entityLookup = await catalogApi.getEntityByRef(entity as string, {
+      token: getBearerTokenFromAuthorizationHeader(req.headers.authorization),
+    });
     if (!entityLookup) {
       throw new NotFoundError(`No entity found matching ${entity}`);
     }
@@ -170,7 +177,9 @@ export const makeRouter = async (
    */
   router.post('/report', async (req, res) => {
     const { entity: entityRef, coverageType } = req.query;
-    const entity = await catalogApi.getEntityByRef(entityRef as string);
+    const entity = await catalogApi.getEntityByRef(entityRef as string, {
+      token: getBearerTokenFromAuthorizationHeader(req.headers.authorization),
+    });
     if (!entity) {
       throw new NotFoundError(`No entity found matching ${entityRef}`);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6183,6 +6183,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
+    "@backstage/plugin-auth-node": "workspace:^"
     "@types/body-parser-xml": ^2.0.2
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.8


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We're trying to use the code-coverage plugin with authentication and I believe that the backend plugin must include the token (if one exists) when using the CatalogClient. This is because we're currently getting a 500 in the front end due to the fact that the code-coverage-backend gets a 401 when trying to look up the entity (as seen in the screenshot below).

From trying to understand how this is done in other plugins, I believe this PR should fix it. Let me know if it should be done in some other way.

Screenshot of issue:
<img width="678" alt="Screenshot 2023-08-31 at 11 35 12" src="https://github.com/backstage/backstage/assets/3415645/d0ff8872-66ea-4fad-b4d7-2224c57e92fa">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
