### PR TITLE
feat: (auth) Add optional  parameter for bitbucketServer Auth Provider.

### DIFF
--- a/.changeset/ninety-cobras-punch.md
+++ b/.changeset/ninety-cobras-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added optional `scope` parameter for bitbucketServer Auth provider. parameter overrides default settings.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -380,6 +380,12 @@ auth:
       development:
         clientId: ${AUTH_BITBUCKET_CLIENT_ID}
         clientSecret: ${AUTH_BITBUCKET_CLIENT_SECRET}
+    bitbucketServer:
+      development:
+        host: bitbucket.org
+        clientId: ${AUTH_BITBUCKET_SERVER_CLIENT_ID}
+        clientSecret: ${AUTH_BITBUCKET_SERVER_CLIENT_SECRET}
+        scope: ${AUTH_BITBUCKET_SERVER_SCOPE} # Optional parameter which overrides default value - ['REPO_READ']
     atlassian:
       development:
         clientId: ${AUTH_ATLASSIAN_CLIENT_ID}

--- a/docs/auth/bitbucketServer/provider.md
+++ b/docs/auth/bitbucketServer/provider.md
@@ -27,6 +27,7 @@ auth:
         host: bitbucket.org
         clientId: ${AUTH_BITBUCKET_SERVER_CLIENT_ID}
         clientSecret: ${AUTH_BITBUCKET_SERVER_CLIENT_SECRET}
+        scope: ${AUTH_BITBUCKET_SERVER_SCOPE} # Optional parameter which overrides default value - ['REPO_READ']
 ```
 
 The Bitbucket Server provider is a structure with two configuration keys:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added an optional `scope` parameter which would be added to app-config.yaml file.
Parameter allows to define permissions request default scope  Bitbucket Server in app-config.yaml.

This change is backward compatible and adds more flexibility to the bitbucketServer auth provider.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
