### PR TITLE
fix(GithubMultiOrgEntityProvider): handle undefined values from userTransformer

### DIFF
--- a/.changeset/weak-tomatoes-dance.md
+++ b/.changeset/weak-tomatoes-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Properly support custom `userTransformer` returning `undefined` in `GithubMultiOrgEntityProvider`

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -1702,31 +1702,6 @@ describe('GithubMultiOrgEntityProvider', () => {
             {
               entity: {
                 apiVersion: 'backstage.io/v1alpha1',
-                kind: 'User',
-                metadata: {
-                  annotations: {
-                    'backstage.io/managed-by-location':
-                      'url:https://github.com/a',
-                    'backstage.io/managed-by-origin-location':
-                      'url:https://github.com/a',
-                    'github.com/user-login': 'a',
-                  },
-                  name: 'a',
-                },
-                spec: {
-                  memberOf: ['orga/team', 'orgb/team'],
-                  profile: {
-                    displayName: 'a',
-                    email: 'user1@test.com',
-                    picture: 'https://avatars.githubusercontent.com/u/83820368',
-                  },
-                },
-              },
-              locationKey: 'github-multi-org-provider:my-id',
-            },
-            {
-              entity: {
-                apiVersion: 'backstage.io/v1alpha1',
                 kind: 'Group',
                 metadata: {
                   annotations: {
@@ -1750,6 +1725,31 @@ describe('GithubMultiOrgEntityProvider', () => {
                   },
                   type: 'team',
                   members: ['default/a'],
+                },
+              },
+              locationKey: 'github-multi-org-provider:my-id',
+            },
+            {
+              entity: {
+                apiVersion: 'backstage.io/v1alpha1',
+                kind: 'User',
+                metadata: {
+                  annotations: {
+                    'backstage.io/managed-by-location':
+                      'url:https://github.com/a',
+                    'backstage.io/managed-by-origin-location':
+                      'url:https://github.com/a',
+                    'github.com/user-login': 'a',
+                  },
+                  name: 'a',
+                },
+                spec: {
+                  memberOf: ['orga/team', 'orgb/team'],
+                  profile: {
+                    displayName: 'a',
+                    email: 'user1@test.com',
+                    picture: 'https://avatars.githubusercontent.com/u/83820368',
+                  },
                 },
               },
               locationKey: 'github-multi-org-provider:my-id',
@@ -1874,31 +1874,6 @@ describe('GithubMultiOrgEntityProvider', () => {
             {
               entity: {
                 apiVersion: 'backstage.io/v1alpha1',
-                kind: 'User',
-                metadata: {
-                  annotations: {
-                    'backstage.io/managed-by-location':
-                      'url:https://github.com/a',
-                    'backstage.io/managed-by-origin-location':
-                      'url:https://github.com/a',
-                    'github.com/user-login': 'a',
-                  },
-                  name: 'a',
-                },
-                spec: {
-                  memberOf: ['orgb/team'],
-                  profile: {
-                    displayName: 'a',
-                    email: 'user1@test.com',
-                    picture: 'https://avatars.githubusercontent.com/u/83820368',
-                  },
-                },
-              },
-              locationKey: 'github-multi-org-provider:my-id',
-            },
-            {
-              entity: {
-                apiVersion: 'backstage.io/v1alpha1',
                 kind: 'Group',
                 metadata: {
                   annotations: {
@@ -1922,6 +1897,31 @@ describe('GithubMultiOrgEntityProvider', () => {
                   },
                   type: 'team',
                   members: [],
+                },
+              },
+              locationKey: 'github-multi-org-provider:my-id',
+            },
+            {
+              entity: {
+                apiVersion: 'backstage.io/v1alpha1',
+                kind: 'User',
+                metadata: {
+                  annotations: {
+                    'backstage.io/managed-by-location':
+                      'url:https://github.com/a',
+                    'backstage.io/managed-by-origin-location':
+                      'url:https://github.com/a',
+                    'github.com/user-login': 'a',
+                  },
+                  name: 'a',
+                },
+                spec: {
+                  memberOf: ['orgb/team'],
+                  profile: {
+                    displayName: 'a',
+                    email: 'user1@test.com',
+                    picture: 'https://avatars.githubusercontent.com/u/83820368',
+                  },
                 },
               },
               locationKey: 'github-multi-org-provider:my-id',


### PR DESCRIPTION
## Hey, I just made a Pull Request!
According to https://github.com/backstage/backstage/blob/ae810386bed7b46ee404bf6be8cf634bc6129bae/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts#L41-L44
a `UserTransformer` could potential return `undefined` which should result in the user being ignored. Previously we were assuming this would always be defined via type coercion - this change properly handles this scenario 



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
