### PR TITLE
fix: Send fewer files as base64 encoded for githubPullRequest

### DIFF
--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -282,6 +282,7 @@ export interface CreateGithubPullRequestActionOptions {
   clientFactory?: (
     input: CreateGithubPullRequestClientFactoryInput,
   ) => Promise<OctokitWithPullRequestPluginClient>;
+  config: Config;
   githubCredentialsProvider?: GithubCredentialsProvider;
   integrations: ScmIntegrationRegistry;
 }
@@ -294,6 +295,7 @@ export type CreateGithubPullRequestClientFactoryInput = {
   owner: string;
   repo: string;
   token?: string;
+  throttleEnabled?: boolean;
 };
 
 // @public

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -37,5 +37,13 @@ export interface Config {
      * Set to 0 to disable task workers altogether.
      */
     concurrentTasksLimit?: number;
+
+    /**
+     * Whether to use experimental safe mode for creating GitHub pull requests.
+     * This should eliminate rate limit errors, but may make creating pull requests
+     * slower. Do not enable if you use .gitattributes to mark files as binary.
+     * @see {@link https://github.com/backstage/backstage/issues/17188|Issue #17188}
+     */
+    githubPullRequestExperimentalSafeMode?: boolean;
   };
 }

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -89,7 +89,7 @@
     "node-fetch": "^2.6.7",
     "nunjucks": "^3.2.3",
     "octokit": "^2.0.0",
-    "octokit-plugin-create-pull-request": "^3.10.0",
+    "octokit-plugin-create-pull-request": "^5.1.1",
     "p-limit": "^3.1.0",
     "p-queue": "^6.6.2",
     "prom-client": "^14.0.1",

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -145,6 +145,7 @@ export const createBuiltinActions = (
     createPublishGithubPullRequestAction({
       integrations,
       githubCredentialsProvider,
+      config,
     }),
     createPublishGitlabAction({
       integrations,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -43,6 +43,12 @@ type GithubPullRequestActionInput = ReturnType<
   : never;
 
 describe('createPublishGithubPullRequestAction', () => {
+  const config = new ConfigReader({});
+  const integrations = ScmIntegrations.fromConfig(config);
+  const githubCredentialsProvider: GithubCredentialsProvider = {
+    getCredentials: jest.fn(),
+  };
+
   let instance: TemplateAction<GithubPullRequestActionInput>;
   let clientFactory: jest.Mock;
   let fakeClient: {
@@ -53,7 +59,6 @@ describe('createPublishGithubPullRequestAction', () => {
   };
 
   beforeEach(() => {
-    const integrations = ScmIntegrations.fromConfig(new ConfigReader({}));
     fakeClient = {
       createPullRequest: jest.fn(async (_: any) => {
         return {
@@ -78,14 +83,12 @@ describe('createPublishGithubPullRequestAction', () => {
     clientFactory = jest.fn(
       async () => fakeClient as unknown as OctokitWithPullRequestPluginClient,
     );
-    const githubCredentialsProvider: GithubCredentialsProvider = {
-      getCredentials: jest.fn(),
-    };
 
     instance = createPublishGithubPullRequestAction({
       integrations,
       githubCredentialsProvider,
       clientFactory,
+      config,
     });
   });
 
@@ -775,12 +778,22 @@ describe('createPublishGithubPullRequestAction', () => {
     const base64Content = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
 
     beforeEach(() => {
+      instance = createPublishGithubPullRequestAction({
+        integrations: integrations,
+        githubCredentialsProvider: githubCredentialsProvider,
+        clientFactory,
+        config: new ConfigReader({
+          scaffolder: {
+            githubPullRequestExperimentalSafeMode: true,
+          },
+        }),
+      });
+
       input = {
         repoUrl: 'github.com?owner=myorg&repo=myrepo',
         title: 'Create my new app',
         branchName: 'new-app',
         description: 'This PR is really good',
-        experimentalSafeMode: true,
       };
 
       mockFs({

--- a/yarn.lock
+++ b/yarn.lock
@@ -8714,7 +8714,7 @@ __metadata:
     node-fetch: ^2.6.7
     nunjucks: ^3.2.3
     octokit: ^2.0.0
-    octokit-plugin-create-pull-request: ^3.10.0
+    octokit-plugin-create-pull-request: ^5.1.1
     p-limit: ^3.1.0
     p-queue: ^6.6.2
     prom-client: ^14.0.1
@@ -14130,6 +14130,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/openapi-types@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@octokit/openapi-types@npm:14.0.0"
+  checksum: 0a1f8f3be998cd82c5a640e9166d43fd183b33d5d36f5e1a9b81608e94d0da87c01ec46c9988f69cd26585d4e2ffc4d3ec99ee4f75e5fe997fc86dad0aa8293c
+  languageName: node
+  linkType: hard
+
 "@octokit/openapi-types@npm:^17.2.0":
   version: 17.2.0
   resolution: "@octokit/openapi-types@npm:17.2.0"
@@ -14263,7 +14270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^6.0.3, @octokit/types@npm:^6.10.0, @octokit/types@npm:^6.12.2, @octokit/types@npm:^6.16.1, @octokit/types@npm:^6.8.2":
+"@octokit/types@npm:^6.0.3, @octokit/types@npm:^6.10.0, @octokit/types@npm:^6.12.2, @octokit/types@npm:^6.16.1":
   version: 6.41.0
   resolution: "@octokit/types@npm:6.41.0"
   dependencies:
@@ -14278,6 +14285,15 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": ^13.0.0
   checksum: 54d714c1e8296da7ff68eec6a72061313a3f4836793fe844a120aa8604336e03423c631d6316fa2ab00c34aae7a4be0ecb6aed192d04f891084e00674d176fcb
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^8.0.0":
+  version: 8.2.1
+  resolution: "@octokit/types@npm:8.2.1"
+  dependencies:
+    "@octokit/openapi-types": ^14.0.0
+  checksum: 92f2fe5ea8c4c6ddbb2363c74cd865c64e5753eaa4895bc925b5064390890b1441c5406015d8a92285f386cc7e6fe714c47fe4beda370fcda9177153299c9e37
   languageName: node
   linkType: hard
 
@@ -34371,12 +34387,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"octokit-plugin-create-pull-request@npm:^3.10.0":
-  version: 3.13.1
-  resolution: "octokit-plugin-create-pull-request@npm:3.13.1"
+"octokit-plugin-create-pull-request@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "octokit-plugin-create-pull-request@npm:5.1.1"
   dependencies:
-    "@octokit/types": ^6.8.2
-  checksum: 169e393046cecc51b9c9be23321086fc60681bfdfe2bcec5477d0916e5b8e3b64b54588f631f61d98677a0561f5d44fa85589abd75ff851122c798795921292b
+    "@octokit/types": ^8.0.0
+  checksum: bed96700c795868d1fc6a95d41c87b98c370d84421125b561c6b8632bb85bbb399a9fa6d35abb2c3d342e42f8b10032afb195470cac9b640161064b68d276d9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/17188

WIP, still need to:

* test in an actual Backstage instance
* generate changeset & API report
* figure out if there's a way to do this without breaking API changes if it's reverted
  * We can do this on the integration config, so it's set in one place, and that way there's less code churn when undoing. 
* write real commit message & PR description

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
