### PR TITLE
Add more default kinds to Ownership Card

### DIFF
--- a/.changeset/empty-gifts-prove.md
+++ b/.changeset/empty-gifts-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Add more entity kinds as defaults to show for Ownership Card

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -175,7 +175,7 @@ describe('OwnershipCard', () => {
     expect(catalogApi.getEntities).toHaveBeenCalledWith({
       filter: [
         {
-          kind: ['Component', 'API', 'System'],
+          kind: ['Component', 'API', 'System', 'Resource', 'Domain'],
           'relations.ownedBy': ['group:default/my-team'],
         },
       ],

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
@@ -176,7 +176,13 @@ export function useGetEntities(
   error?: Error;
 } {
   const catalogApi = useApi(catalogApiRef);
-  const kinds = entityFilterKind ?? ['Component', 'API', 'System'];
+  const kinds = entityFilterKind ?? [
+    'Component',
+    'API',
+    'System',
+    'Domain',
+    'Resource',
+  ];
 
   const {
     loading,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The ownership card only shows three kinds by default. It seems to me that these should be broader in scope to include Domains and Resources. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
