### PR TITLE
feat: added disable config watching flag

### DIFF
--- a/.changeset/stale-eagles-reply.md
+++ b/.changeset/stale-eagles-reply.md
@@ -1,0 +1,6 @@
+---
+'@backstage/config-loader': patch
+'@backstage/backend-app-api': patch
+---
+
+Added `watch` option to configuration loaders that can be used to disable file watching by setting it to `false`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -190,6 +190,7 @@ export function loadBackendConfig(options: {
   remote?: LoadConfigOptionsRemote;
   argv: string[];
   additionalConfigs?: AppConfig[];
+  watch?: boolean;
 }): Promise<{
   config: Config;
 }>;

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -552,6 +552,7 @@ export function loadBackendConfig(options: {
   remote?: LoadConfigOptionsRemote;
   additionalConfigs?: AppConfig[];
   argv: string[];
+  watch?: boolean;
 }): Promise<Config>;
 
 // @public (undocumented)

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -36,6 +36,7 @@ export async function loadBackendConfig(options: {
   remote?: LoadConfigOptionsRemote;
   additionalConfigs?: AppConfig[];
   argv: string[];
+  watch?: boolean;
 }): Promise<Config> {
   const secretEnumerator = await createConfigSecretEnumerator({
     logger: options.logger,

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -27,6 +27,8 @@ export interface BaseConfigSourcesOptions {
   rootDir?: string;
   // (undocumented)
   substitutionFunc?: EnvFunc;
+  // (undocumented)
+  watch?: boolean;
 }
 
 // @public
@@ -142,6 +144,7 @@ export class FileConfigSource implements ConfigSource {
 export interface FileConfigSourceOptions {
   path: string;
   substitutionFunc?: EnvFunc;
+  watch?: boolean;
 }
 
 // @public @deprecated

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -107,6 +107,7 @@ export async function loadConfig(
     remote: options.remote && {
       reloadInterval: { seconds: options.remote.reloadIntervalSeconds },
     },
+    watch: Boolean(options.watch),
     rootDir: options.configRoot,
     argv: options.configTargets.flatMap(t => [
       '--config',

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -71,6 +71,7 @@ export interface ClosableConfig extends Config {
  * @public
  */
 export interface BaseConfigSourcesOptions {
+  watch?: boolean;
   rootDir?: string;
   remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;
   substitutionFunc?: SubstitutionFunc;
@@ -159,6 +160,7 @@ export class ConfigSources {
         });
       }
       return FileConfigSource.create({
+        watch: options.watch,
         path: arg.target,
         substitutionFunc: options.substitutionFunc,
       });
@@ -170,6 +172,7 @@ export class ConfigSources {
 
       argSources.push(
         FileConfigSource.create({
+          watch: options.watch,
           path: defaultPath,
           substitutionFunc: options.substitutionFunc,
         }),
@@ -177,6 +180,7 @@ export class ConfigSources {
       if (fs.pathExistsSync(localPath)) {
         argSources.push(
           FileConfigSource.create({
+            watch: options.watch,
             path: localPath,
             substitutionFunc: options.substitutionFunc,
           }),

--- a/packages/config-loader/src/sources/FileConfigSource.ts
+++ b/packages/config-loader/src/sources/FileConfigSource.ts
@@ -40,6 +40,11 @@ export interface FileConfigSourceOptions {
   path: string;
 
   /**
+   * Enable watching file
+   */
+  watch?: boolean;
+
+  /**
    * A substitution function to use instead of the default environment substitution.
    */
   substitutionFunc?: SubstitutionFunc;
@@ -89,10 +94,12 @@ export class FileConfigSource implements ConfigSource {
 
   readonly #path: string;
   readonly #substitutionFunc?: SubstitutionFunc;
+  readonly #watch?: boolean;
 
   private constructor(options: FileConfigSourceOptions) {
     this.#path = options.path;
     this.#substitutionFunc = options.substitutionFunc;
+    this.#watch = options.watch ?? true;
   }
 
   // Work is duplicated across each read, in practice that should not
@@ -104,20 +111,27 @@ export class FileConfigSource implements ConfigSource {
     const signal = options?.signal;
     const configFileName = basename(this.#path);
 
-    // Keep track of watched paths, since this is simpler than resetting the watcher
-    const watchedPaths = new Array<string>();
-    const watcher = chokidar.watch(this.#path, {
-      usePolling: process.env.NODE_ENV === 'test',
-    });
+    let watchedPaths: Array<string> | null = null;
+    let watcher: FSWatcher | null = null;
+
+    if (this.#watch) {
+      // Keep track of watched paths, since this is simpler than resetting the watcher
+      watchedPaths = new Array<string>();
+      watcher = chokidar.watch(this.#path, {
+        usePolling: process.env.NODE_ENV === 'test',
+      });
+    }
 
     const dir = dirname(this.#path);
     const transformer = createConfigTransformer({
       substitutionFunc: this.#substitutionFunc,
       readFile: async path => {
         const fullPath = resolvePath(dir, path);
-        // Any files discovered while reading this config should be watched too
-        watcher.add(fullPath);
-        watchedPaths.push(fullPath);
+        if (watcher && watchedPaths) {
+          // Any files discovered while reading this config should be watched too
+          watcher.add(fullPath);
+          watchedPaths.push(fullPath);
+        }
 
         const data = await readFile(fullPath);
         if (data === undefined) {
@@ -131,12 +145,15 @@ export class FileConfigSource implements ConfigSource {
 
     // This is the entry point for reading the file, called initially and on change
     const readConfigFile = async (): Promise<ConfigSourceData[]> => {
-      // We clear the watched files every time we initiate a new read
-      watcher.unwatch(watchedPaths);
-      watchedPaths.length = 0;
+      if (watcher && watchedPaths) {
+        // We clear the watched files every time we initiate a new read
+        watcher.unwatch(watchedPaths);
+        watchedPaths.length = 0;
 
-      watcher.add(this.#path);
-      watchedPaths.push(this.#path);
+        watcher.add(this.#path);
+        watchedPaths.push(this.#path);
+      }
+
       const content = await readFile(this.#path);
       if (content === undefined) {
         throw new NotFoundError(`Config file "${this.#path}" does not exist`);
@@ -157,18 +174,20 @@ export class FileConfigSource implements ConfigSource {
 
     const onAbort = () => {
       signal?.removeEventListener('abort', onAbort);
-      watcher.close();
+      if (watcher) watcher.close();
     };
     signal?.addEventListener('abort', onAbort);
 
     yield { configs: await readConfigFile() };
 
-    for (;;) {
-      const event = await this.#waitForEvent(watcher, signal);
-      if (event === 'abort') {
-        return;
+    if (watcher) {
+      for (;;) {
+        const event = await this.#waitForEvent(watcher, signal);
+        if (event === 'abort') {
+          return;
+        }
+        yield { configs: await readConfigFile() };
       }
-      yield { configs: await readConfigFile() };
     }
   }
 

--- a/packages/config-loader/src/sources/FileConfigSource.ts
+++ b/packages/config-loader/src/sources/FileConfigSource.ts
@@ -40,7 +40,7 @@ export interface FileConfigSourceOptions {
   path: string;
 
   /**
-   * Enable watching file
+   * Set to `false` to disable file watching, defaults to `true`.
    */
   watch?: boolean;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I added a new flag to disable config file watching. WDYT?

close #19619 

I note that even with this new flag, the number of `inotify` remains high. There is some library that uses a large number of watch files. I think that this is related only to dev env. In production, it should work.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
