### PR TITLE
Add text body-parser to coverage-backend-plugin for LCOV reports

### DIFF
--- a/.changeset/late-roses-dream.md
+++ b/.changeset/late-roses-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Add text body parser for LCOV reports

--- a/plugins/code-coverage-backend/src/service/converter/lcov.ts
+++ b/plugins/code-coverage-backend/src/service/converter/lcov.ts
@@ -75,9 +75,9 @@ export class Lcov implements Converter {
 
     this.logger.debug(`matched ${file} to ${filename}`);
 
-    if (filename) {
+    if (scmFiles.length === 0 || filename) {
       return {
-        filename,
+        filename: filename || file,
         lineHits: {},
         branchHits: {},
       };

--- a/plugins/code-coverage-backend/src/service/router.ts
+++ b/plugins/code-coverage-backend/src/service/router.ts
@@ -67,6 +67,7 @@ export const makeRouter = async (
   bodyParserXml(BodyParser);
   const router = Router();
   router.use(BodyParser.xml());
+  router.use(BodyParser.text());
   router.use(express.json());
 
   const utils = new CoverageUtils(scm, urlReader);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I missed adding the text body-parser when adding support for sending LCOV reports, which is added with this PR.

I also fixed an issue with the LCOV reports. It didn't include the files from the report even though scm-only was set to false, now it does. Which maps to the behavior of the Cobertura reports:

[/plugins/code-coverage-backend/src/service/converter/cobertura.ts#L65](https://github.com/backstage/backstage/blob/master/plugins/code-coverage-backend/src/service/converter/cobertura.ts#L65):
```ts
const currentFile = scmFiles
  .map(f => f.trimEnd())
  .find(f => f.endsWith(packageAndFilename));
this.logger.debug(`matched ${packageAndFilename} to ${currentFile}`);
if (
  scmFiles.length === 0 ||
  (Object.keys(lineHits).length > 0 && currentFile)
) {
  jscov.push({
    filename: currentFile || packageAndFilename,
    branchHits: branchHits,
    lineHits: lineHits,
  });
}
```

Hopefully, this should be the last PR in my series of PR's related to the code-coverage plugins 😊 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
