### PR TITLE
create-app: warn if yarn install is taking a long time

### DIFF
--- a/.changeset/grumpy-ties-know.md
+++ b/.changeset/grumpy-ties-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Add a notification when `yarn install` is taking a long time.

--- a/packages/create-app/src/lib/tasks.ts
+++ b/packages/create-app/src/lib/tasks.ts
@@ -31,6 +31,7 @@ import { promisify } from 'util';
 import os from 'os';
 
 const TASK_NAME_MAX_LENGTH = 14;
+const TEN_MINUTES_MS = 1000 * 60 * 10;
 const exec = promisify(execCb);
 
 export type GitConfig = {
@@ -222,7 +223,13 @@ export async function buildAppTask(appDir: string) {
     });
   };
 
-  await runCmd('yarn install');
+  const installTimeout = setTimeout(() => {
+    Task.error(
+      "\n⏱️  It's taking a long time to install dependencies, you may want to exit (Ctrl-C) and run 'yarn install' and 'yarn tsc' manually",
+    );
+  }, TEN_MINUTES_MS);
+
+  await runCmd('yarn install').finally(() => clearTimeout(installTimeout));
   await runCmd('yarn tsc');
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #18058. Opted for a 10 minute timeout since yarn install can take a very long time. It also just prints a warning with instructions for how to proceed rather than cancelling.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
