### PR TITLE
Clarify where users should run yarn add command

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -66,7 +66,7 @@ Stop Backstage, and go to the root directory of your freshly installed Backstage
 App. Use the following commands to start the PostgreSQL client installation:
 
 ```bash
-# From your Backstage root directory
+# From your Backstage app root directory
 yarn add --cwd packages/backend pg
 ```
 


### PR DESCRIPTION
Add a small clarification to the comment preceding the PostgreSQL client install command to address #19746

## Hey, I just made a Pull Request!

This is a very small documentation change. It will help prevent people (like me!) from getting stuck on the `yarn add --cwd packages/backend pg` by clarifying where they should run that command. "Backstage root" could mean the app root or the repository root, and the command fails if it is run in the repository root directory.

#### :heavy_check_mark: Checklist

(This is a one-word documentation change, most items below don't apply)

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

