### PR TITLE
expose Content of EntityValidationPage.tsx in new Component EntityVal…

### DIFF
--- a/.changeset/curly-parrots-knock.md
+++ b/.changeset/curly-parrots-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-validation': patch
+---
+
+Expose the Content of EntityValidation Page in new Component EntityValidationContent

--- a/plugins/entity-validation/src/components/EntityValidationContent/EntityValidationContent.tsx
+++ b/plugins/entity-validation/src/components/EntityValidationContent/EntityValidationContent.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { Grid, TextField } from '@material-ui/core';
+import { LinkButton } from '@backstage/core-components';
+import { EntityTextArea } from '../EntityTextArea';
+import { EntityValidationOutput } from '../EntityValidationOutput';
+import { CatalogProcessorResult } from '../../types';
+import { parseEntityYaml } from '../../utils';
+
+const EXAMPLE_CATALOG_INFO_YAML = `# Put your catalog-info.yaml below and validate it
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: test
+  description: Component description
+  links: []
+  tags: []
+  annotations: {}
+spec:
+  type: service
+  lifecycle: experimental
+  owner: owner
+`;
+export const EntityValidationContent = (props: {
+  defaultYaml?: string;
+  defaultLocation?: string;
+}) => {
+  const {
+    defaultYaml = EXAMPLE_CATALOG_INFO_YAML,
+    defaultLocation = 'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+  } = props;
+
+  const [catalogYaml, setCatalogYaml] = useState(defaultYaml);
+  const [yamlFiles, setYamlFiles] = useState<CatalogProcessorResult[]>();
+  const [locationUrl, setLocationUrl] = useState(defaultLocation);
+
+  const parseYaml = () => {
+    const parsedFiles = [
+      ...parseEntityYaml(Buffer.from(catalogYaml), {
+        type: 'url',
+        target: locationUrl ? locationUrl : 'http://localhost',
+      }),
+    ];
+    setYamlFiles(parsedFiles);
+  };
+
+  return (
+    <React.Fragment>
+      <Grid container>
+        <Grid item md={9} xs={12}>
+          <TextField
+            fullWidth
+            label="File Location"
+            margin="normal"
+            variant="outlined"
+            required
+            value={locationUrl}
+            helperText="Location where your catalog-info.yaml file is, or will be, located"
+            onChange={e => setLocationUrl(e.target.value)}
+          />
+        </Grid>
+        <Grid item md={3} xs={12}>
+          <Grid container alignItems="center" style={{ height: '100%' }}>
+            <Grid item>
+              <LinkButton size="large" onClick={parseYaml} to="#">
+                Validate
+              </LinkButton>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid container direction="row" style={{ height: '90%' }}>
+        <Grid item md={6} xs={12}>
+          <EntityTextArea
+            onValidate={parseYaml}
+            onChange={(value: string) => setCatalogYaml(value)}
+            catalogYaml={catalogYaml}
+          />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <EntityValidationOutput
+                processorResults={yamlFiles}
+                locationUrl={locationUrl}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </React.Fragment>
+  );
+};

--- a/plugins/entity-validation/src/components/EntityValidationContent/index.ts
+++ b/plugins/entity-validation/src/components/EntityValidationContent/index.ts
@@ -13,21 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import React from 'react';
-import { Content, Header, Page } from '@backstage/core-components';
-import { EntityValidationContent } from '../EntityValidationContent';
-
-export const EntityValidationPage = () => {
-  return (
-    <Page themeId="tool">
-      <Header
-        title="Entity Validator"
-        subtitle="Tool to validate catalog-info.yaml files"
-      />
-      <Content>
-        <EntityValidationContent />
-      </Content>
-    </Page>
-  );
-};
+export * from './EntityValidationContent';

--- a/plugins/entity-validation/src/index.ts
+++ b/plugins/entity-validation/src/index.ts
@@ -13,4 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { entityValidationPlugin, EntityValidationPage } from './plugin';
+export {
+  entityValidationPlugin,
+  EntityValidationPage,
+  EntityValidationContent,
+} from './plugin';

--- a/plugins/entity-validation/src/plugin.ts
+++ b/plugins/entity-validation/src/plugin.ts
@@ -40,3 +40,15 @@ export const EntityValidationPage = entityValidationPlugin.provide(
     },
   }),
 );
+
+export const EntityValidationContent = entityValidationPlugin.provide(
+  createComponentExtension({
+    name: 'EntityValidationContent',
+    component: {
+      lazy: () =>
+        import('./components/EntityValidationContent').then(
+          m => m.EntityValidationContent,
+        ),
+    },
+  }),
+);


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Added a new component EntityValidationContent to expose the content of the EntityValidationPage

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
