### PR TITLE
proxy-backend: Add info to the error message which proxy target isn't well configured

### DIFF
--- a/.changeset/dirty-boxes-give.md
+++ b/.changeset/dirty-boxes-give.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Add the route name to an error message that appears when the backend
+proxy wasn't well configured. This will help users to understand the
+issue and fix the right configuration.

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -157,7 +157,11 @@ describe('createRouter', () => {
           logger,
           discovery,
         }),
-      ).rejects.toThrow(new Error('Proxy target must be a string'));
+      ).rejects.toThrow(
+        new Error(
+          'Proxy target for route "/test" must be a string, but is of type undefined',
+        ),
+      );
     });
 
     it('works if skip failures is set', async () => {
@@ -189,7 +193,7 @@ describe('createRouter', () => {
         skipInvalidProxies: true,
       });
       expect((logger.warn as jest.Mock).mock.calls[0][0]).toEqual(
-        'skipped configuring /test due to Proxy target must be a string',
+        'skipped configuring /test due to Proxy target for route "/test" must be a string, but is of type undefined',
       );
       expect(router).toBeDefined();
     });

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -76,8 +76,11 @@ export function buildMiddleware(
     typeof config === 'string' ? { target: config } : { ...config };
 
   // Validate that target is a valid URL.
-  if (typeof fullConfig.target !== 'string') {
-    throw new Error(`Proxy target must be a string`);
+  const targetType = typeof fullConfig.target;
+  if (targetType !== 'string') {
+    throw new Error(
+      `Proxy target for route "${route}" must be a string, but is of type ${targetType}`,
+    );
   }
   try {
     // eslint-disable-next-line no-new


### PR DESCRIPTION
I got an error message when I tried a backstage instance without some required configs. The `proxy-backend` fails with the error message bwloe and I didn't know which of the different proxies was the reason.

This PR only makes the error message a bit more verbose:

Error message change:

```diff
-backend:start: Backend failed to start up Error: Proxy target must be a string
+backend:start: Backend failed to start up Error: Proxy target for route "/my-plugin-route" must be a string, but is undefined
backend:start:     at buildMiddleware (..../node_modules/@backstage/plugin-proxy-backend/dist/index.cjs.js:35:11)
```
