### PR TITLE
frontend-*-api: introduce ExtensionBoundary and pass source to extension factories

### DIFF
--- a/packages/frontend-app-api/src/createApp.tsx
+++ b/packages/frontend-app-api/src/createApp.tsx
@@ -41,13 +41,11 @@ export function createApp(options: { plugins: BackstagePlugin[] }): {
 
   // pull in default extension instance from discovered packages
   // apply config to adjust default extension instances and add more
-  const extensionParams = mergeExtensionParameters(
-    [
-      ...options.plugins.flatMap(plugin => plugin.extensions),
-      ...builtinExtensions,
-    ],
-    readAppExtensionParameters(appConfig),
-  );
+  const extensionParams = mergeExtensionParameters({
+    sources: options.plugins,
+    builtinExtensions,
+    parameters: readAppExtensionParameters(appConfig),
+  });
 
   // TODO: validate the config of all extension instances
   // We do it at this point to ensure that merging (if any) of config has already happened
@@ -96,6 +94,7 @@ export function createApp(options: { plugins: BackstagePlugin[] }): {
 
     return createExtensionInstance({
       extension: instanceParams.extension,
+      source: instanceParams.source,
       config: instanceParams.config,
       attachments,
     });

--- a/packages/frontend-app-api/src/createExtensionInstance.ts
+++ b/packages/frontend-app-api/src/createExtensionInstance.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Extension } from '@backstage/frontend-plugin-api';
+import { BackstagePlugin, Extension } from '@backstage/frontend-plugin-api';
 import mapValues from 'lodash/mapValues';
 
 /** @internal */
@@ -28,9 +28,10 @@ export interface ExtensionInstance {
 export function createExtensionInstance(options: {
   extension: Extension<unknown>;
   config: unknown;
+  source?: BackstagePlugin;
   attachments: Record<string, ExtensionInstance[]>;
 }): ExtensionInstance {
-  const { extension, config, attachments } = options;
+  const { extension, config, source, attachments } = options;
   const extensionData = new Map<string, unknown>();
 
   let parsedConfig: unknown;
@@ -44,6 +45,7 @@ export function createExtensionInstance(options: {
 
   try {
     extension.factory({
+      source,
       config: parsedConfig,
       bind: mapValues(extension.output, ref => {
         return (value: unknown) => extensionData.set(ref.id, value);

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -9,6 +9,8 @@ import { AnyApiFactory } from '@backstage/core-plugin-api';
 import { AnyApiRef } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { JsonObject } from '@backstage/types';
+import { default as React_2 } from 'react';
+import { ReactNode } from 'react';
 import { z } from 'zod';
 import { ZodSchema } from 'zod';
 import { ZodTypeDef } from 'zod';
@@ -95,6 +97,7 @@ export interface CreateExtensionOptions<
   disabled?: boolean;
   // (undocumented)
   factory(options: {
+    source?: BackstagePlugin;
     bind: ExtensionDataBind<TData>;
     config: TConfig;
     inputs: {
@@ -166,6 +169,7 @@ export interface Extension<TConfig> {
   disabled: boolean;
   // (undocumented)
   factory(options: {
+    source?: BackstagePlugin;
     bind: ExtensionDataBind<AnyExtensionDataMap>;
     config: TConfig;
     inputs: Record<string, Array<Record<string, unknown>>>;
@@ -181,6 +185,19 @@ export interface Extension<TConfig> {
   >;
   // (undocumented)
   output: AnyExtensionDataMap;
+}
+
+// @public (undocumented)
+export function ExtensionBoundary(
+  props: ExtensionBoundaryProps,
+): React_2.JSX.Element;
+
+// @public (undocumented)
+export interface ExtensionBoundaryProps {
+  // (undocumented)
+  children: ReactNode;
+  // (undocumented)
+  source?: BackstagePlugin;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -14,26 +14,16 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage frontend plugins.
- *
- * @packageDocumentation
- */
+import React, { ReactNode } from 'react';
+import { BackstagePlugin } from '../wiring';
 
-export {
-  createSchemaFromZod,
-  type PortableSchema,
-} from './createSchemaFromZod';
-export * from './components';
-export * from './extensions';
-export {
-  coreExtensionData,
-  createExtension,
-  type AnyExtensionDataMap,
-  type CreateExtensionOptions,
-  type Extension,
-  type ExtensionDataBind,
-  type ExtensionDataRef,
-  type ExtensionDataValue,
-} from './types';
-export * from './wiring';
+/** @public */
+export interface ExtensionBoundaryProps {
+  children: ReactNode;
+  source?: BackstagePlugin;
+}
+
+/** @public */
+export function ExtensionBoundary(props: ExtensionBoundaryProps) {
+  return <>{props.children}</>;
+}

--- a/packages/frontend-plugin-api/src/components/index.ts
+++ b/packages/frontend-plugin-api/src/components/index.ts
@@ -14,26 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage frontend plugins.
- *
- * @packageDocumentation
- */
-
 export {
-  createSchemaFromZod,
-  type PortableSchema,
-} from './createSchemaFromZod';
-export * from './components';
-export * from './extensions';
-export {
-  coreExtensionData,
-  createExtension,
-  type AnyExtensionDataMap,
-  type CreateExtensionOptions,
-  type Extension,
-  type ExtensionDataBind,
-  type ExtensionDataRef,
-  type ExtensionDataValue,
-} from './types';
-export * from './wiring';
+  ExtensionBoundary,
+  type ExtensionBoundaryProps,
+} from './ExtensionBoundary';

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { ExtensionBoundary } from '../components';
 import { createSchemaFromZod, PortableSchema } from '../createSchemaFromZod';
 import {
   AnyExtensionDataMap,
@@ -72,7 +73,7 @@ export function createPageExtension<
     },
     inputs: options.inputs,
     configSchema,
-    factory({ bind, config, inputs }) {
+    factory({ bind, config, inputs, source }) {
       const LazyComponent = React.lazy(() =>
         options
           .component({ config, inputs })
@@ -80,9 +81,11 @@ export function createPageExtension<
       );
       bind.path(config.path);
       bind.component(() => (
-        <React.Suspense fallback="...">
-          <LazyComponent />
-        </React.Suspense>
+        <ExtensionBoundary source={source}>
+          <React.Suspense fallback="...">
+            <LazyComponent />
+          </React.Suspense>
+        </ExtensionBoundary>
       ));
     },
   });

--- a/packages/frontend-plugin-api/src/types.ts
+++ b/packages/frontend-plugin-api/src/types.ts
@@ -17,6 +17,7 @@
 import { AnyApiFactory } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { PortableSchema } from './createSchemaFromZod';
+import { BackstagePlugin } from './wiring';
 
 /** @public */
 export type ExtensionDataRef<T> = {
@@ -64,6 +65,7 @@ export interface CreateExtensionOptions<
   output: TData;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
+    source?: BackstagePlugin;
     bind: ExtensionDataBind<TData>;
     config: TConfig;
     inputs: {
@@ -84,6 +86,7 @@ export interface Extension<TConfig> {
   output: AnyExtensionDataMap;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
+    source?: BackstagePlugin;
     bind: ExtensionDataBind<AnyExtensionDataMap>;
     config: TConfig;
     inputs: Record<string, Array<Record<string, unknown>>>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #19545, we found this was the cleanest way to connect extensions to individual plugins.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
