### PR TITLE
Fixed table sort in NewRelicFetchComponent

### DIFF
--- a/.changeset/mean-queens-act.md
+++ b/.changeset/mean-queens-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-newrelic': patch
+---
+
+Fixed bug in NewRelicComponent component where table would not sort correctly for numerical values.

--- a/plugins/newrelic/src/components/NewRelicFetchComponent/NewRelicFetchComponent.tsx
+++ b/plugins/newrelic/src/components/NewRelicFetchComponent/NewRelicFetchComponent.tsx
@@ -25,9 +25,9 @@ import { useApi } from '@backstage/core-plugin-api';
 export const NewRelicAPMTable = ({ applications }: NewRelicApplications) => {
   const columns: TableColumn[] = [
     { title: 'Application', field: 'name' },
-    { title: 'Response Time', field: 'responseTime' },
-    { title: 'Throughput', field: 'throughput' },
-    { title: 'Error Rate', field: 'errorRate' },
+    { title: 'Response Time (ms)', field: 'responseTime' },
+    { title: 'Throughput (rpm)', field: 'throughput' },
+    { title: 'Error Rate (%)', field: 'errorRate' },
     { title: 'Instance Count', field: 'instanceCount' },
     { title: 'Apdex', field: 'apdexScore' },
   ];
@@ -43,9 +43,9 @@ export const NewRelicAPMTable = ({ applications }: NewRelicApplications) => {
 
     return {
       name,
-      responseTime: `${responseTime} ms`,
-      throughput: `${throughput} rpm`,
-      errorRate: `${errorRate}%`,
+      responseTime,
+      throughput,
+      errorRate,
       instanceCount,
       apdexScore,
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Patch for [Issue 19621](https://github.com/backstage/backstage/issues/19621), relating to [NewRelicFetchComponent](https://github.com/backstage/backstage/blob/49b2ea4cf8e5224aaa6c0335e3b0fb308cb710c1/plugins/newrelic/src/components/NewRelicFetchComponent/NewRelicFetchComponent.tsx).

This component uses [core-components/Table](https://github.com/backstage/backstage/blob/master/packages/core-components/src/components/Table/Table.tsx). The table was not sorting correctly on the columns which contained a string containing both text and numbers.

While it might be worth updating the Table Component to handle this better, a quick fix for the NewRelic plugin was to put the units (ms, rpm, %) from the cells into the header and keep the cell value as a number, rather than an alphanumerical string.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
