### PR TITLE
backend-app-api: add support for discoverying additional service factories

### DIFF
--- a/.changeset/chatty-spiders-serve.md
+++ b/.changeset/chatty-spiders-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Add support for discovering additional service factories during startup.

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
@@ -188,6 +188,32 @@ describe('ServiceRegistry', () => {
     });
   });
 
+  it('should use added service factories for each ref', async () => {
+    const registry = ServiceRegistry.create([sf2()]);
+    registry.add(sf2b());
+    await expect(registry.get(ref2, 'catalog')).resolves.toEqual({
+      x: 22,
+    });
+  });
+
+  it('should not allow factories to be added after instantiation', async () => {
+    const registry = ServiceRegistry.create([sf2()]);
+    await expect(registry.get(ref2, 'catalog')).resolves.toEqual({
+      x: 2,
+    });
+    expect(() => registry.add(sf2b())).toThrow(
+      'Unable to set service factory with id 2, service has already been instantiated',
+    );
+  });
+
+  it('should not allow the same factory to be added twice', async () => {
+    const registry = ServiceRegistry.create([sf2()]);
+    registry.add(sf2b());
+    expect(() => registry.add(sf2b())).toThrow(
+      'Duplicate service implementations provided for 2',
+    );
+  });
+
   it('should use the defaultFactory from the ref if not provided to the registry', async () => {
     const registry = ServiceRegistry.create([]);
     await expect(registry.get(refDefault1, 'catalog')).resolves.toEqual({

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -37,17 +37,6 @@ export interface CreateSpecializedBackendOptions {
   defaultServiceFactories: ServiceFactoryOrFunction[];
 }
 
-export interface ServiceHolder {
-  get<T>(api: ServiceRef<T>, pluginId: string): Promise<T> | undefined;
-}
-
-/**
- * @internal
- */
-export interface EnumerableServiceHolder extends ServiceHolder {
-  getServiceRefs(): ServiceRef<unknown>[];
-}
-
 /**
  * @public
  */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously it was not possible for feature discovery to provide additional service factories, as they would not be picked up by the backend.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
