### PR TITLE
backend-plugin-api: properly mark service factory functions as such

### DIFF
--- a/.changeset/wise-tables-add.md
+++ b/.changeset/wise-tables-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Service factory functions are now marked as feature factories that can be installed in the backend.

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -241,7 +241,7 @@ export function createServiceFactory<
     | (() => PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>),
 ): (options: TOpts) => ServiceFactory {
   const configCallback = typeof config === 'function' ? config : () => config;
-  return (
+  const factory = (
     options: TOpts,
   ): InternalServiceFactory<TService, 'plugin' | 'root'> => {
     const anyConf = configCallback(options);
@@ -275,4 +275,8 @@ export function createServiceFactory<
       factory: async (deps: TDeps, ctx: TContext) => c.factory(deps, ctx),
     };
   };
+
+  factory.$$type = '@backstage/BackendFeatureFactory';
+
+  return factory;
 }


### PR DESCRIPTION
🧹 