### PR TITLE
backend-system: export all features as default exports

### DIFF
--- a/.changeset/dirty-cars-poke.md
+++ b/.changeset/dirty-cars-poke.md
@@ -1,0 +1,34 @@
+---
+'@backstage/plugin-adr-backend': minor
+'@backstage/plugin-airbrake-backend': minor
+'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-azure-devops-backend': minor
+'@backstage/plugin-badges-backend': minor
+'@backstage/plugin-bazaar-backend': minor
+'@backstage/plugin-catalog-backend-module-unprocessed': minor
+'@backstage/plugin-devtools-backend': minor
+'@backstage/plugin-entity-feedback-backend': minor
+'@backstage/plugin-kafka-backend': minor
+'@backstage/plugin-lighthouse-backend': minor
+'@backstage/plugin-linguist-backend': minor
+'@backstage/plugin-periskop-backend': minor
+'@backstage/plugin-proxy-backend': minor
+'@backstage/plugin-todo-backend': minor
+'@backstage/plugin-user-settings-backend': minor
+---
+
+**BREAKING**: The export for the new backend system has been moved to be the `default` export.
+
+For example, if you are currently importing the plugin using the following pattern:
+
+```ts
+import { examplePlugin } from '@backstage/plugin-example-backend';
+
+backend.add(examplePlugin);
+```
+
+It should be migrated to this:
+
+```ts
+backend.add(import('@backstage/plugin-example-backend'));
+```

--- a/.changeset/dirty-cars-smoke.md
+++ b/.changeset/dirty-cars-smoke.md
@@ -1,0 +1,48 @@
+---
+'@backstage/plugin-app-backend': patch
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+'@backstage/plugin-auth-backend-module-github-provider': patch
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+'@backstage/plugin-auth-backend-module-google-provider': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-backend-module-aws': patch
+'@backstage/plugin-catalog-backend-module-azure': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-server': patch
+'@backstage/plugin-catalog-backend-module-gcp': patch
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+'@backstage/plugin-catalog-backend-module-github': patch
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-catalog-backend-module-puppetdb': patch
+'@backstage/plugin-events-backend': patch
+'@backstage/plugin-events-backend-module-aws-sqs': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-permission-backend': patch
+'@backstage/plugin-permission-backend-module-allow-all-policy': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-search-backend': patch
+'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+'@backstage/plugin-search-backend-module-explore': patch
+'@backstage/plugin-search-backend-module-pg': patch
+'@backstage/plugin-search-backend-module-techdocs': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+The export for the new backend system has been moved to be the `default` export.
+
+For example, if you are currently importing the plugin using the following pattern:
+
+```ts
+import { examplePlugin } from '@backstage/plugin-example-backend';
+
+backend.add(examplePlugin);
+```
+
+It should be migrated to this:
+
+```ts
+backend.add(import('@backstage/plugin-example-backend'));
+```

--- a/.changeset/eighty-emus-float.md
+++ b/.changeset/eighty-emus-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add ESM loader for the experimental backend start command.

--- a/.changeset/hungry-cherries-speak.md
+++ b/.changeset/hungry-cherries-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Add support for installing backend features via module imports, for example `startTestBackend({ features: [import('my-plugin')] })`.

--- a/.changeset/ninety-horses-remember.md
+++ b/.changeset/ninety-horses-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+The experimental backend feature discovery now only considers default exports from packages. It no longer filters packages to include based on the package role, except that `'cli'` packages are ignored. However, the `"backstage"` field is still required in `package.json`.

--- a/.changeset/thin-dryers-repeat.md
+++ b/.changeset/thin-dryers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Add support for installing features as package imports, for example `backend.add(import('my-plugin'))`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -43,7 +43,14 @@ import { UrlReader } from '@backstage/backend-common';
 // @public (undocumented)
 export interface Backend {
   // (undocumented)
-  add(feature: BackendFeature | (() => BackendFeature)): void;
+  add(
+    feature:
+      | BackendFeature
+      | (() => BackendFeature)
+      | Promise<{
+          default: BackendFeature | (() => BackendFeature);
+        }>,
+  ): void;
   // (undocumented)
   start(): Promise<void>;
   // (undocumented)

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
@@ -18,10 +18,6 @@ import mockFs from 'mock-fs';
 import { resolve as resolvePath, dirname } from 'path';
 import { startTestBackend, mockServices } from '@backstage/backend-test-utils';
 import { featureDiscoveryServiceFactory } from './featureDiscoveryServiceFactory';
-import {
-  coreServices,
-  createServiceFactory,
-} from '@backstage/backend-plugin-api';
 
 const rootDir = dirname(process.argv[1]);
 
@@ -35,6 +31,7 @@ describe('featureDiscoveryServiceFactory', () => {
             'detected-plugin': '0.0.0',
             'detected-module': '0.0.0',
             'detected-plugin-with-alpha': '0.0.0',
+            'detected-library': '0.0.0',
           },
         }),
       },
@@ -48,13 +45,13 @@ describe('featureDiscoveryServiceFactory', () => {
         }),
         'index.js': `
         const { createBackendPlugin, coreServices } = require('@backstage/backend-plugin-api');
-        exports.detectedPlugin = createBackendPlugin({
+        exports.default = createBackendPlugin({
             pluginId: 'detected',
             register(env) {
               env.registerInit({
-                deps: { identity: coreServices.identity },
-                async init({ identity }) {
-                  identity.getIdentity('detected-plugin');
+                deps: { logger: coreServices.rootLogger },
+                async init({ logger }) {
+                  logger.warn('detected-plugin');
                 },
               });
             },
@@ -71,14 +68,14 @@ describe('featureDiscoveryServiceFactory', () => {
         }),
         'index.js': `
         const { createBackendModule, coreServices } = require('@backstage/backend-plugin-api');
-        exports.detectedModuleDerp = createBackendModule({
+        exports.default = createBackendModule({
             pluginId: 'detected',
             moduleId: 'derp',
             register(env) {
               env.registerInit({
-                deps: { identity: coreServices.identity },
-                async init({ identity }) {
-                  identity.getIdentity('detected-module');
+                deps: { logger: coreServices.rootLogger },
+                async init({ logger }) {
+                  logger.warn('detected-module');
                 },
               });
             },
@@ -102,19 +99,39 @@ describe('featureDiscoveryServiceFactory', () => {
             role: 'backend-plugin',
           },
         }),
-        'index.js': `exports.detectedPlugin = undefined;`,
+        'index.js': `exports.default = undefined;`,
         'alpha.js': `
         const { createBackendPlugin, coreServices } = require('@backstage/backend-plugin-api');
-        exports.detectedPluginAlpha = createBackendPlugin({
+        exports.default = createBackendPlugin({
             pluginId: 'detected-alpha',
             register(env) {
               env.registerInit({
-                deps: { identity: coreServices.identity },
-                async init({ identity }) {
-                  identity.getIdentity('detected-plugin-with-alpha');
+                deps: { logger: coreServices.rootLogger },
+                async init({ logger }) {
+                  logger.warn('detected-plugin-with-alpha');
                 },
               });
             },
+        });
+        `,
+      },
+      [resolvePath(rootDir, 'node_modules/detected-library')]: {
+        'package.json': JSON.stringify({
+          name: 'detected-library',
+          main: 'index.js',
+          backstage: {
+            role: 'node-library',
+          },
+        }),
+        'index.js': `
+        const { createServiceFactory, createServiceRef, coreServices } = require('@backstage/backend-plugin-api');
+        exports.default = createServiceFactory({
+          service: createServiceRef({ id: 'test', scope: 'root' }),
+          deps: { logger: coreServices.rootLogger },
+          factory({ logger }) {
+            logger.warn('detected-library');
+            return {};
+          },
         });
         `,
       },
@@ -126,15 +143,11 @@ describe('featureDiscoveryServiceFactory', () => {
   });
 
   it('should detect plugin and module packages when "all" is specified', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: { backend: { packages: 'all' } },
@@ -142,27 +155,28 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).toHaveBeenCalledWith('detected-plugin');
-    expect(fn).toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).toHaveBeenCalledWith('detected-library');
   });
 
   it('detects only the packages that are listed as included', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: {
             backend: {
               packages: {
-                include: ['detected-plugin', 'detected-plugin-with-alpha'],
+                include: [
+                  'detected-plugin',
+                  'detected-plugin-with-alpha',
+                  'detected-library',
+                ],
               },
             },
           },
@@ -170,21 +184,18 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).toHaveBeenCalledWith('detected-plugin');
-    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
-    expect(fn).not.toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).toHaveBeenCalledWith('detected-library');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-module');
   });
 
   it('does not detect packages when included is an empty list', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: {
@@ -198,21 +209,18 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).not.toHaveBeenCalledWith('detected-plugin');
-    expect(fn).not.toHaveBeenCalledWith('detected-plugin-with-alpha');
-    expect(fn).not.toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-library');
   });
 
   it('does not detect an excluded packages', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: {
@@ -226,21 +234,18 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).not.toHaveBeenCalledWith('detected-plugin');
-    expect(fn).not.toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).toHaveBeenCalledWith('detected-library');
   });
 
   it('does not excluded packages when it is an empty list', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: {
@@ -254,21 +259,18 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).toHaveBeenCalledWith('detected-plugin');
-    expect(fn).toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).toHaveBeenCalledWith('detected-library');
   });
 
   it('does not detect packages that are included and excluded', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: {
@@ -287,21 +289,18 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).not.toHaveBeenCalledWith('detected-plugin');
-    expect(fn).toHaveBeenCalledWith('detected-module');
-    expect(fn).toHaveBeenCalledWith('detected-plugin-with-alpha');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-library');
+    expect(mock.warn).toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin-with-alpha');
   });
 
   it('does not detect any packages when "packages" is empty', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: { backend: { packages: {} } },
@@ -309,19 +308,15 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).not.toHaveBeenCalled();
+    expect(mock.warn).not.toHaveBeenCalled();
   });
 
   it('does not detect any packages when "packages" is not present', async () => {
-    const fn = jest.fn().mockResolvedValue({});
+    const mock = mockServices.rootLogger.mock({ child: () => mock });
 
     await startTestBackend({
       features: [
-        createServiceFactory({
-          service: coreServices.identity,
-          deps: {},
-          factory: () => ({ getIdentity: fn }),
-        }),
+        mock.factory,
         featureDiscoveryServiceFactory(),
         mockServices.rootConfig.factory({
           data: { backend: {} },
@@ -329,6 +324,6 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(fn).not.toHaveBeenCalled();
+    expect(mock.warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -91,11 +91,11 @@ export class BackendInitializer {
     return Object.fromEntries(result);
   }
 
-  add(feature: Promise<BackendFeature>) {
+  add(feature: BackendFeature | Promise<BackendFeature>) {
     if (this.#startPromise) {
       throw new Error('feature can not be added after the backend has started');
     }
-    this.#registeredFeatures.push(feature);
+    this.#registeredFeatures.push(Promise.resolve(feature));
   }
 
   #addFeature(feature: BackendFeature) {

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -34,7 +34,7 @@ export class BackstageBackend implements Backend {
     if (isPromise(feature)) {
       this.#initializer.add(feature.then(f => unwrapFeature(f.default)));
     } else {
-      this.#initializer.add(Promise.resolve(unwrapFeature(feature)));
+      this.#initializer.add(unwrapFeature(feature));
     }
   }
 

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -25,8 +25,17 @@ export class BackstageBackend implements Backend {
     this.#initializer = new BackendInitializer(defaultServiceFactories);
   }
 
-  add(feature: BackendFeature | (() => BackendFeature)): void {
-    this.#initializer.add(typeof feature === 'function' ? feature() : feature);
+  add(
+    feature:
+      | BackendFeature
+      | (() => BackendFeature)
+      | Promise<{ default: BackendFeature | (() => BackendFeature) }>,
+  ): void {
+    if (isPromise(feature)) {
+      this.#initializer.add(feature.then(f => unwrapFeature(f.default)));
+    } else {
+      this.#initializer.add(Promise.resolve(unwrapFeature(feature)));
+    }
   }
 
   async start(): Promise<void> {
@@ -36,4 +45,19 @@ export class BackstageBackend implements Backend {
   async stop(): Promise<void> {
     await this.#initializer.stop();
   }
+}
+
+function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
+function unwrapFeature(
+  feature: BackendFeature | (() => BackendFeature),
+): BackendFeature {
+  return typeof feature === 'function' ? feature() : feature;
 }

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -25,7 +25,12 @@ import {
  * @public
  */
 export interface Backend {
-  add(feature: BackendFeature | (() => BackendFeature)): void;
+  add(
+    feature:
+      | BackendFeature
+      | (() => BackendFeature)
+      | Promise<{ default: BackendFeature | (() => BackendFeature) }>,
+  ): void;
   start(): Promise<void>;
   stop(): Promise<void>;
 }

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -15,81 +15,31 @@
  */
 
 import { createBackend } from '@backstage/backend-defaults';
-import { appPlugin } from '@backstage/plugin-app-backend/alpha';
-import { catalogPlugin } from '@backstage/plugin-catalog-backend/alpha';
-import { kubernetesPlugin } from '@backstage/plugin-kubernetes-backend/alpha';
-import { permissionPlugin } from '@backstage/plugin-permission-backend/alpha';
-import { permissionModuleAllowAllPolicy } from '@backstage/plugin-permission-backend-module-allow-all-policy';
-import { scaffolderPlugin } from '@backstage/plugin-scaffolder-backend/alpha';
-import { catalogModuleTemplateKind } from '@backstage/plugin-scaffolder-backend/alpha';
-import { searchModuleCatalogCollator } from '@backstage/plugin-search-backend-module-catalog/alpha';
-import { searchModuleExploreCollator } from '@backstage/plugin-search-backend-module-explore/alpha';
-import { searchModuleTechDocsCollator } from '@backstage/plugin-search-backend-module-techdocs/alpha';
-import { searchPlugin } from '@backstage/plugin-search-backend/alpha';
-import { techdocsPlugin } from '@backstage/plugin-techdocs-backend/alpha';
-import { todoPlugin } from '@backstage/plugin-todo-backend';
-import { entityFeedbackPlugin } from '@backstage/plugin-entity-feedback-backend';
-import { catalogModuleUnprocessedEntities } from '@backstage/plugin-catalog-backend-module-unprocessed';
-import { badgesPlugin } from '@backstage/plugin-badges-backend';
-import { azureDevOpsPlugin } from '@backstage/plugin-azure-devops-backend';
-import { linguistPlugin } from '@backstage/plugin-linguist-backend';
-import { devtoolsPlugin } from '@backstage/plugin-devtools-backend';
-import { adrPlugin } from '@backstage/plugin-adr-backend';
-import { lighthousePlugin } from '@backstage/plugin-lighthouse-backend';
-import { proxyPlugin } from '@backstage/plugin-proxy-backend';
 
 const backend = createBackend();
 
-backend.add(appPlugin());
-
-// Badges
-backend.add(badgesPlugin());
-
-// Azure DevOps
-backend.add(azureDevOpsPlugin());
-
-// DevTools
-backend.add(devtoolsPlugin());
-
-// Entity Feedback
-backend.add(entityFeedbackPlugin());
-
-// Linguist
-backend.add(linguistPlugin());
-
-// Todo
-backend.add(todoPlugin());
-
-backend.add(adrPlugin());
-
-// Techdocs
-backend.add(techdocsPlugin());
-
-// Catalog
-backend.add(catalogPlugin());
-backend.add(catalogModuleTemplateKind());
-
-backend.add(scaffolderPlugin());
-
-// Search
-backend.add(searchPlugin());
-backend.add(searchModuleCatalogCollator());
-backend.add(searchModuleTechDocsCollator());
-backend.add(searchModuleExploreCollator());
-
-// Kubernetes
-backend.add(kubernetesPlugin());
-
-// Lighthouse
-backend.add(lighthousePlugin());
-
-// Proxy
-backend.add(proxyPlugin());
-
-// Permissions
-backend.add(permissionPlugin());
-backend.add(permissionModuleAllowAllPolicy());
-
-backend.add(catalogModuleUnprocessedEntities());
+backend.add(import('@backstage/plugin-adr-backend'));
+backend.add(import('@backstage/plugin-app-backend/alpha'));
+backend.add(import('@backstage/plugin-azure-devops-backend'));
+backend.add(import('@backstage/plugin-badges-backend'));
+backend.add(import('@backstage/plugin-catalog-backend-module-unprocessed'));
+backend.add(import('@backstage/plugin-catalog-backend/alpha'));
+backend.add(import('@backstage/plugin-devtools-backend'));
+backend.add(import('@backstage/plugin-entity-feedback-backend'));
+backend.add(import('@backstage/plugin-kubernetes-backend/alpha'));
+backend.add(import('@backstage/plugin-lighthouse-backend'));
+backend.add(import('@backstage/plugin-linguist-backend'));
+backend.add(
+  import('@backstage/plugin-permission-backend-module-allow-all-policy'),
+);
+backend.add(import('@backstage/plugin-permission-backend/alpha'));
+backend.add(import('@backstage/plugin-proxy-backend'));
+backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
+backend.add(import('@backstage/plugin-search-backend-module-catalog/alpha'));
+backend.add(import('@backstage/plugin-search-backend-module-explore/alpha'));
+backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
+backend.add(import('@backstage/plugin-search-backend/alpha'));
+backend.add(import('@backstage/plugin-techdocs-backend/alpha'));
+backend.add(import('@backstage/plugin-todo-backend'));
 
 backend.start();

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -246,7 +246,13 @@ export interface TestBackendOptions<TExtensionPoints extends any[]> {
     },
   ];
   // (undocumented)
-  features?: Array<BackendFeature | (() => BackendFeature)>;
+  features?: Array<
+    | BackendFeature
+    | (() => BackendFeature)
+    | Promise<{
+        default: BackendFeature | (() => BackendFeature);
+      }>
+  >;
 }
 
 // @public

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@backstage/release-manifests": "workspace:^",
     "@backstage/types": "workspace:^",
     "@esbuild-kit/cjs-loader": "^2.4.1",
+    "@esbuild-kit/esm-loader": "^2.5.5",
     "@manypkg/get-packages": "^1.1.3",
     "@octokit/graphql": "^5.0.0",
     "@octokit/graphql-schema": "^13.7.0",

--- a/packages/cli/src/lib/experimental/startBackendExperimental.ts
+++ b/packages/cli/src/lib/experimental/startBackendExperimental.ts
@@ -25,7 +25,12 @@ import debounce from 'lodash/debounce';
 import spawn from 'cross-spawn';
 import { paths } from '../paths';
 
-const loaderArgs = ['--require', require.resolve('@esbuild-kit/cjs-loader')];
+const loaderArgs = [
+  '--require',
+  require.resolve('@esbuild-kit/cjs-loader'),
+  '--loader',
+  require.resolve('@esbuild-kit/esm-loader'),
+];
 
 export async function startBackendExperimental(options: BackendServeOptions) {
   const envEnv = process.env as { NODE_ENV: string };

--- a/plugins/adr-backend/api-report.md
+++ b/plugins/adr-backend/api-report.md
@@ -45,7 +45,8 @@ export type AdrParserContext = {
 };
 
 // @public
-export const adrPlugin: () => BackendFeature;
+const adrPlugin: () => BackendFeature;
+export default adrPlugin;
 
 // @public (undocumented)
 export type AdrRouterOptions = {

--- a/plugins/adr-backend/src/index.ts
+++ b/plugins/adr-backend/src/index.ts
@@ -22,4 +22,4 @@
 
 export * from './search';
 export * from './service';
-export { adrPlugin } from './plugin';
+export { adrPlugin as default } from './plugin';

--- a/plugins/airbrake-backend/api-report.md
+++ b/plugins/airbrake-backend/api-report.md
@@ -14,7 +14,8 @@ export interface AirbrakeConfig {
 }
 
 // @public
-export const airbrakePlugin: () => BackendFeature;
+const airbrakePlugin: () => BackendFeature;
+export default airbrakePlugin;
 
 // @public
 export function createRouter(options: RouterOptions): Promise<express.Router>;

--- a/plugins/airbrake-backend/src/index.ts
+++ b/plugins/airbrake-backend/src/index.ts
@@ -22,4 +22,4 @@
 
 export * from './service/router';
 export * from './config';
-export { airbrakePlugin } from './plugin';
+export { airbrakePlugin as default } from './plugin';

--- a/plugins/app-backend/alpha-api-report.md
+++ b/plugins/app-backend/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const appPlugin: () => BackendFeature;
+const appPlugin: () => BackendFeature;
+export default appPlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/app-backend/src/alpha.ts
+++ b/plugins/app-backend/src/alpha.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { appPlugin } from './service/appPlugin';
+export { appPlugin as default } from './service/appPlugin';

--- a/plugins/auth-backend-module-gcp-iap-provider/api-report.md
+++ b/plugins/auth-backend-module-gcp-iap-provider/api-report.md
@@ -9,7 +9,8 @@ import { ProxyAuthenticator } from '@backstage/plugin-auth-node';
 import { SignInResolverFactory } from '@backstage/plugin-auth-node';
 
 // @public (undocumented)
-export const authModuleGcpIapProvider: () => BackendFeature;
+const authModuleGcpIapProvider: () => BackendFeature;
+export default authModuleGcpIapProvider;
 
 // @public (undocumented)
 export const gcpIapAuthenticator: ProxyAuthenticator<

--- a/plugins/auth-backend-module-gcp-iap-provider/src/index.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 export { gcpIapAuthenticator } from './authenticator';
-export { authModuleGcpIapProvider } from './module';
+export { authModuleGcpIapProvider as default } from './module';
 export { gcpIapSignInResolvers } from './resolvers';
 export { type GcpIapResult, type GcpIapTokenInfo } from './types';

--- a/plugins/auth-backend-module-github-provider/api-report.md
+++ b/plugins/auth-backend-module-github-provider/api-report.md
@@ -11,7 +11,8 @@ import { PassportProfile } from '@backstage/plugin-auth-node';
 import { SignInResolverFactory } from '@backstage/plugin-auth-node';
 
 // @public (undocumented)
-export const authModuleGithubProvider: () => BackendFeature;
+const authModuleGithubProvider: () => BackendFeature;
+export default authModuleGithubProvider;
 
 // @public (undocumented)
 export const githubAuthenticator: OAuthAuthenticator<

--- a/plugins/auth-backend-module-github-provider/dev/index.ts
+++ b/plugins/auth-backend-module-github-provider/dev/index.ts
@@ -15,12 +15,10 @@
  */
 
 import { createBackend } from '@backstage/backend-defaults';
-import { authPlugin } from '@backstage/plugin-auth-backend';
-import { authModuleGithubProvider } from '../src';
 
 const backend = createBackend();
 
-backend.add(authPlugin);
-backend.add(authModuleGithubProvider);
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('../src'));
 
 backend.start();

--- a/plugins/auth-backend-module-github-provider/src/index.ts
+++ b/plugins/auth-backend-module-github-provider/src/index.ts
@@ -21,5 +21,5 @@
  */
 
 export { githubAuthenticator } from './authenticator';
-export { authModuleGithubProvider } from './module';
+export { authModuleGithubProvider as default } from './module';
 export { githubSignInResolvers } from './resolvers';

--- a/plugins/auth-backend-module-github-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-github-provider/src/module.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
-import { authPlugin } from '@backstage/plugin-auth-backend';
 import { authModuleGithubProvider } from './module';
 import request from 'supertest';
 import { decodeOAuthState } from '@backstage/plugin-auth-node';
@@ -24,7 +23,7 @@ describe('authModuleGithubProvider', () => {
   it('should start', async () => {
     const { server } = await startTestBackend({
       features: [
-        authPlugin,
+        import('@backstage/plugin-auth-backend'),
         authModuleGithubProvider,
         mockServices.rootConfig.factory({
           data: {

--- a/plugins/auth-backend-module-gitlab-provider/api-report.md
+++ b/plugins/auth-backend-module-gitlab-provider/api-report.md
@@ -11,7 +11,8 @@ import { PassportProfile } from '@backstage/plugin-auth-node';
 import { SignInResolverFactory } from '@backstage/plugin-auth-node';
 
 // @public (undocumented)
-export const authModuleGitlabProvider: () => BackendFeature;
+const authModuleGitlabProvider: () => BackendFeature;
+export default authModuleGitlabProvider;
 
 // @public (undocumented)
 export const gitlabAuthenticator: OAuthAuthenticator<

--- a/plugins/auth-backend-module-gitlab-provider/dev/index.ts
+++ b/plugins/auth-backend-module-gitlab-provider/dev/index.ts
@@ -15,12 +15,10 @@
  */
 
 import { createBackend } from '@backstage/backend-defaults';
-import { authPlugin } from '@backstage/plugin-auth-backend';
-import { authModuleGitlabProvider } from '../src';
 
 const backend = createBackend();
 
-backend.add(authPlugin);
-backend.add(authModuleGitlabProvider);
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('../src'));
 
 backend.start();

--- a/plugins/auth-backend-module-gitlab-provider/src/index.ts
+++ b/plugins/auth-backend-module-gitlab-provider/src/index.ts
@@ -21,5 +21,5 @@
  */
 
 export { gitlabAuthenticator } from './authenticator';
-export { authModuleGitlabProvider } from './module';
+export { authModuleGitlabProvider as default } from './module';
 export { gitlabSignInResolvers } from './resolvers';

--- a/plugins/auth-backend-module-gitlab-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-gitlab-provider/src/module.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
-import { authPlugin } from '@backstage/plugin-auth-backend';
 import { authModuleGitlabProvider } from './module';
 import request from 'supertest';
 import { decodeOAuthState } from '@backstage/plugin-auth-node';
@@ -24,7 +23,7 @@ describe('authModuleGitlabProvider', () => {
   it('should start', async () => {
     const { server } = await startTestBackend({
       features: [
-        authPlugin,
+        import('@backstage/plugin-auth-backend'),
         authModuleGitlabProvider,
         mockServices.rootConfig.factory({
           data: {

--- a/plugins/auth-backend-module-google-provider/api-report.md
+++ b/plugins/auth-backend-module-google-provider/api-report.md
@@ -11,7 +11,8 @@ import { PassportProfile } from '@backstage/plugin-auth-node';
 import { SignInResolverFactory } from '@backstage/plugin-auth-node';
 
 // @public (undocumented)
-export const authModuleGoogleProvider: () => BackendFeature;
+const authModuleGoogleProvider: () => BackendFeature;
+export default authModuleGoogleProvider;
 
 // @public (undocumented)
 export const googleAuthenticator: OAuthAuthenticator<

--- a/plugins/auth-backend-module-google-provider/src/index.ts
+++ b/plugins/auth-backend-module-google-provider/src/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { googleAuthenticator } from './authenticator';
-export { authModuleGoogleProvider } from './module';
+export { authModuleGoogleProvider as default } from './module';
 export { googleSignInResolvers } from './resolvers';

--- a/plugins/auth-backend-module-google-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-google-provider/src/module.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
-import { authPlugin } from '@backstage/plugin-auth-backend';
 import { authModuleGoogleProvider } from './module';
 import request from 'supertest';
 import { decodeOAuthState } from '@backstage/plugin-auth-node';
@@ -24,7 +23,7 @@ describe('authModuleGoogleProvider', () => {
   it('should start', async () => {
     const { server } = await startTestBackend({
       features: [
-        authPlugin,
+        import('@backstage/plugin-auth-backend'),
         authModuleGoogleProvider,
         mockServices.rootConfig.factory({
           data: {

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -53,7 +53,8 @@ export type AuthHandlerResult = {
 };
 
 // @public
-export const authPlugin: () => BackendFeature;
+const authPlugin: () => BackendFeature;
+export default authPlugin;
 
 // @public @deprecated (undocumented)
 export type AuthProviderConfig = AuthProviderConfig_2;

--- a/plugins/auth-backend/dev/index.ts
+++ b/plugins/auth-backend/dev/index.ts
@@ -15,12 +15,10 @@
  */
 
 import { createBackend } from '@backstage/backend-defaults';
-import { authPlugin } from '../src';
-import { authModuleGoogleProvider } from '@backstage/plugin-auth-backend-module-google-provider';
 
 const backend = createBackend();
 
-backend.add(authPlugin);
-backend.add(authModuleGoogleProvider);
+backend.add(import('../src'));
+backend.add(import('@backstage/plugin-auth-backend-module-google-provider'));
 
 backend.start();

--- a/plugins/auth-backend/src/index.ts
+++ b/plugins/auth-backend/src/index.ts
@@ -20,7 +20,7 @@
  * @packageDocumentation
  */
 
-export { authPlugin } from './authPlugin';
+export { authPlugin as default } from './authPlugin';
 export * from './service/router';
 export type { TokenParams } from './identity';
 export * from './providers';

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -96,7 +96,8 @@ export class AzureDevOpsApi {
 }
 
 // @public
-export const azureDevOpsPlugin: () => BackendFeature;
+const azureDevOpsPlugin: () => BackendFeature;
+export default azureDevOpsPlugin;
 
 // @public (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;

--- a/plugins/azure-devops-backend/src/index.ts
+++ b/plugins/azure-devops-backend/src/index.ts
@@ -22,4 +22,4 @@
 
 export { AzureDevOpsApi } from './api';
 export * from './service/router';
-export { azureDevOpsPlugin } from './plugin';
+export { azureDevOpsPlugin as default } from './plugin';

--- a/plugins/badges-backend/api-report.md
+++ b/plugins/badges-backend/api-report.md
@@ -83,7 +83,8 @@ export type BadgeSpec = {
 };
 
 // @public
-export const badgesPlugin: () => BackendFeature;
+const badgesPlugin: () => BackendFeature;
+export default badgesPlugin;
 
 // @public
 export interface BadgesStore {

--- a/plugins/badges-backend/src/index.ts
+++ b/plugins/badges-backend/src/index.ts
@@ -25,4 +25,4 @@ export * from './lib';
 export * from './service/router';
 export * from './types';
 export * from './database/badgesStore';
-export { badgesPlugin } from './plugin';
+export { badgesPlugin as default } from './plugin';

--- a/plugins/bazaar-backend/api-report.md
+++ b/plugins/bazaar-backend/api-report.md
@@ -11,7 +11,8 @@ import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 
 // @alpha
-export const bazaarPlugin: () => BackendFeature;
+const bazaarPlugin: () => BackendFeature;
+export default bazaarPlugin;
 
 // @public (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;

--- a/plugins/bazaar-backend/src/index.ts
+++ b/plugins/bazaar-backend/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export * from './service/router';
-export { bazaarPlugin } from './plugin';
+export { bazaarPlugin as default } from './plugin';

--- a/plugins/catalog-backend-module-aws/alpha-api-report.md
+++ b/plugins/catalog-backend-module-aws/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const catalogModuleAwsS3EntityProvider: () => BackendFeature;
+const catalogModuleAwsS3EntityProvider: () => BackendFeature;
+export default catalogModuleAwsS3EntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-aws/src/alpha.ts
+++ b/plugins/catalog-backend-module-aws/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-aws/src/module/index.ts
+++ b/plugins/catalog-backend-module-aws/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleAwsS3EntityProvider } from './catalogModuleAwsS3EntityProvider';
+export { catalogModuleAwsS3EntityProvider as default } from './catalogModuleAwsS3EntityProvider';

--- a/plugins/catalog-backend-module-azure/alpha-api-report.md
+++ b/plugins/catalog-backend-module-azure/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const catalogModuleAzureDevOpsEntityProvider: () => BackendFeature;
+const catalogModuleAzureDevOpsEntityProvider: () => BackendFeature;
+export default catalogModuleAzureDevOpsEntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-azure/src/alpha.ts
+++ b/plugins/catalog-backend-module-azure/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-azure/src/module/index.ts
+++ b/plugins/catalog-backend-module-azure/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleAzureDevOpsEntityProvider } from './catalogModuleAzureDevOpsEntityProvider';
+export { catalogModuleAzureDevOpsEntityProvider as default } from './catalogModuleAzureDevOpsEntityProvider';

--- a/plugins/catalog-backend-module-bitbucket-cloud/alpha-api-report.md
+++ b/plugins/catalog-backend-module-bitbucket-cloud/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha (undocumented)
-export const catalogModuleBitbucketCloudEntityProvider: () => BackendFeature;
+const catalogModuleBitbucketCloudEntityProvider: () => BackendFeature;
+export default catalogModuleBitbucketCloudEntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/alpha.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/module/index.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleBitbucketCloudEntityProvider } from './catalogModuleBitbucketCloudEntityProvider';
+export { catalogModuleBitbucketCloudEntityProvider as default } from './catalogModuleBitbucketCloudEntityProvider';

--- a/plugins/catalog-backend-module-bitbucket-server/alpha-api-report.md
+++ b/plugins/catalog-backend-module-bitbucket-server/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha (undocumented)
-export const catalogModuleBitbucketServerEntityProvider: () => BackendFeature;
+const catalogModuleBitbucketServerEntityProvider: () => BackendFeature;
+export default catalogModuleBitbucketServerEntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-bitbucket-server/src/alpha.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/index.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleBitbucketServerEntityProvider } from './catalogModuleBitbucketServerEntityProvider';
+export { catalogModuleBitbucketServerEntityProvider as default } from './catalogModuleBitbucketServerEntityProvider';

--- a/plugins/catalog-backend-module-gcp/api-report.md
+++ b/plugins/catalog-backend-module-gcp/api-report.md
@@ -12,7 +12,8 @@ import { Logger } from 'winston';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 
 // @public
-export const catalogModuleGcpGkeEntityProvider: () => BackendFeature;
+const catalogModuleGcpGkeEntityProvider: () => BackendFeature;
+export default catalogModuleGcpGkeEntityProvider;
 
 // @public
 export class GkeEntityProvider implements EntityProvider {

--- a/plugins/catalog-backend-module-gcp/src/index.ts
+++ b/plugins/catalog-backend-module-gcp/src/index.ts
@@ -22,3 +22,4 @@
 
 export * from './providers';
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-gcp/src/module/index.ts
+++ b/plugins/catalog-backend-module-gcp/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleGcpGkeEntityProvider } from './catalogModuleGcpGkeEntityProvider';
+export { catalogModuleGcpGkeEntityProvider as default } from './catalogModuleGcpGkeEntityProvider';

--- a/plugins/catalog-backend-module-gerrit/alpha-api-report.md
+++ b/plugins/catalog-backend-module-gerrit/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha (undocumented)
-export const catalogModuleGerritEntityProvider: () => BackendFeature;
+const catalogModuleGerritEntityProvider: () => BackendFeature;
+export default catalogModuleGerritEntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-gerrit/src/alpha.ts
+++ b/plugins/catalog-backend-module-gerrit/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-gerrit/src/module/index.ts
+++ b/plugins/catalog-backend-module-gerrit/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleGerritEntityProvider } from './catalogModuleGerritEntityProvider';
+export { catalogModuleGerritEntityProvider as default } from './catalogModuleGerritEntityProvider';

--- a/plugins/catalog-backend-module-github/alpha-api-report.md
+++ b/plugins/catalog-backend-module-github/alpha-api-report.md
@@ -9,7 +9,8 @@ import { TeamTransformer } from '@backstage/plugin-catalog-backend-module-github
 import { UserTransformer } from '@backstage/plugin-catalog-backend-module-github';
 
 // @alpha
-export const catalogModuleGithubEntityProvider: () => BackendFeature;
+const catalogModuleGithubEntityProvider: () => BackendFeature;
+export default catalogModuleGithubEntityProvider;
 
 // @alpha
 export const catalogModuleGithubOrgEntityProvider: () => BackendFeature;

--- a/plugins/catalog-backend-module-github/src/alpha.ts
+++ b/plugins/catalog-backend-module-github/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-github/src/module/index.ts
+++ b/plugins/catalog-backend-module-github/src/module/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { catalogModuleGithubEntityProvider } from './catalogModuleGithubEntityProvider';
+export { catalogModuleGithubEntityProvider as default } from './catalogModuleGithubEntityProvider';
 export {
   catalogModuleGithubOrgEntityProvider,
   githubOrgEntityProviderTransformsExtensionPoint,

--- a/plugins/catalog-backend-module-gitlab/alpha-api-report.md
+++ b/plugins/catalog-backend-module-gitlab/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const catalogModuleGitlabDiscoveryEntityProvider: () => BackendFeature;
+const catalogModuleGitlabDiscoveryEntityProvider: () => BackendFeature;
+export default catalogModuleGitlabDiscoveryEntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-gitlab/src/alpha.ts
+++ b/plugins/catalog-backend-module-gitlab/src/alpha.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModuleGitlabDiscoveryEntityProvider } from './module/catalogModuleGitlabDiscoveryEntityProvider';
+export { catalogModuleGitlabDiscoveryEntityProvider as default } from './module/catalogModuleGitlabDiscoveryEntityProvider';

--- a/plugins/catalog-backend-module-incremental-ingestion/alpha-api-report.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/alpha-api-report.md
@@ -9,7 +9,8 @@ import { IncrementalEntityProvider } from '@backstage/plugin-catalog-backend-mod
 import { IncrementalEntityProviderOptions } from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
 
 // @alpha
-export const catalogModuleIncrementalIngestionEntityProvider: () => BackendFeature;
+const catalogModuleIncrementalIngestionEntityProvider: () => BackendFeature;
+export default catalogModuleIncrementalIngestionEntityProvider;
 
 // @alpha
 export interface IncrementalIngestionProviderExtensionPoint {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/alpha.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/index.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/index.ts
@@ -15,7 +15,7 @@
  */
 
 export {
-  catalogModuleIncrementalIngestionEntityProvider,
+  catalogModuleIncrementalIngestionEntityProvider as default,
   incrementalIngestionProvidersExtensionPoint,
   type IncrementalIngestionProviderExtensionPoint,
 } from './catalogModuleIncrementalIngestionEntityProvider';

--- a/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
@@ -24,10 +24,8 @@ import {
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
-import { catalogPlugin } from '@backstage/plugin-catalog-backend/alpha';
 import { IncrementalEntityProvider } from '.';
-import {
-  catalogModuleIncrementalIngestionEntityProvider,
+import catalogModuleIncrementalIngestionEntityProvider, {
   incrementalIngestionProvidersExtensionPoint,
 } from './alpha';
 
@@ -64,7 +62,7 @@ async function main() {
       factory: () => new ConfigReader(config),
     }),
   );
-  backend.add(catalogPlugin());
+  backend.add(import('@backstage/plugin-catalog-backend/alpha'));
   backend.add(catalogModuleIncrementalIngestionEntityProvider());
   backend.add(
     createBackendModule({

--- a/plugins/catalog-backend-module-msgraph/alpha-api-report.md
+++ b/plugins/catalog-backend-module-msgraph/alpha-api-report.md
@@ -10,7 +10,8 @@ import { OrganizationTransformer } from '@backstage/plugin-catalog-backend-modul
 import { UserTransformer } from '@backstage/plugin-catalog-backend-module-msgraph';
 
 // @alpha
-export const catalogModuleMicrosoftGraphOrgEntityProvider: () => BackendFeature;
+const catalogModuleMicrosoftGraphOrgEntityProvider: () => BackendFeature;
+export default catalogModuleMicrosoftGraphOrgEntityProvider;
 
 // @alpha
 export const microsoftGraphOrgEntityProviderTransformExtensionPoint: ExtensionPoint<MicrosoftGraphOrgEntityProviderTransformsExtensionPoint>;

--- a/plugins/catalog-backend-module-msgraph/src/alpha.ts
+++ b/plugins/catalog-backend-module-msgraph/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.ts
@@ -62,7 +62,7 @@ export interface MicrosoftGraphOrgEntityProviderTransformsExtensionPoint {
 }
 
 /**
- * Extension point used to customize the transforms used by the {@link catalogModuleMicrosoftGraphOrgEntityProvider}.
+ * Extension point used to customize the transforms used by the module.
  *
  * @alpha
  */

--- a/plugins/catalog-backend-module-msgraph/src/module/index.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/index.ts
@@ -15,7 +15,7 @@
  */
 
 export {
-  catalogModuleMicrosoftGraphOrgEntityProvider,
+  catalogModuleMicrosoftGraphOrgEntityProvider as default,
   microsoftGraphOrgEntityProviderTransformExtensionPoint,
   type MicrosoftGraphOrgEntityProviderTransformsExtensionPoint,
 } from './catalogModuleMicrosoftGraphOrgEntityProvider';

--- a/plugins/catalog-backend-module-puppetdb/alpha-api-report.md
+++ b/plugins/catalog-backend-module-puppetdb/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const catalogModulePuppetDbEntityProvider: () => BackendFeature;
+const catalogModulePuppetDbEntityProvider: () => BackendFeature;
+export default catalogModulePuppetDbEntityProvider;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-backend-module-puppetdb/src/alpha.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/alpha.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './module';
+export { default } from './module';

--- a/plugins/catalog-backend-module-puppetdb/src/module/index.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/module/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { catalogModulePuppetDbEntityProvider } from './catalogModulePuppetDbEntityProvider';
+export { catalogModulePuppetDbEntityProvider as default } from './catalogModulePuppetDbEntityProvider';

--- a/plugins/catalog-backend-module-unprocessed/api-report.md
+++ b/plugins/catalog-backend-module-unprocessed/api-report.md
@@ -8,7 +8,8 @@ import { HttpRouterService } from '@backstage/backend-plugin-api';
 import { Knex } from 'knex';
 
 // @public
-export const catalogModuleUnprocessedEntities: () => BackendFeature;
+const catalogModuleUnprocessedEntities: () => BackendFeature;
+export default catalogModuleUnprocessedEntities;
 
 // @public
 export class UnprocessedEntitiesModule {

--- a/plugins/catalog-backend-module-unprocessed/src/index.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/index.ts
@@ -20,5 +20,5 @@
  * @packageDocumentation
  */
 
-export * from './module';
+export { catalogModuleUnprocessedEntities as default } from './module';
 export * from './UnprocessedEntitiesModule';

--- a/plugins/catalog-backend/alpha-api-report.md
+++ b/plugins/catalog-backend/alpha-api-report.md
@@ -74,7 +74,8 @@ export type CatalogPermissionRule<
 > = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 // @alpha
-export const catalogPlugin: () => BackendFeature;
+const catalogPlugin: () => BackendFeature;
+export default catalogPlugin;
 
 // @alpha
 export const createCatalogConditionalDecision: (

--- a/plugins/catalog-backend/src/alpha.ts
+++ b/plugins/catalog-backend/src/alpha.ts
@@ -21,4 +21,4 @@ import type { EntitiesSearchFilter } from './catalog/types';
 export type { /** @alpha */ EntitiesSearchFilter };
 
 export * from './permissions';
-export { catalogPlugin } from './service/CatalogPlugin';
+export { catalogPlugin as default } from './service/CatalogPlugin';

--- a/plugins/catalog-backend/src/tests/performance/stitchingPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/stitchingPerformance.test.ts
@@ -20,7 +20,6 @@ import {
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { TestDatabases, startTestBackend } from '@backstage/backend-test-utils';
-import { catalogPlugin } from '@backstage/plugin-catalog-backend/alpha';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { Knex } from 'knex';
 import { applyDatabaseMigrations } from '../../database/migrations';
@@ -181,7 +180,7 @@ describePerformanceTest('stitchingPerformance', () => {
 
       const backend = await startTestBackend({
         features: [
-          catalogPlugin(),
+          import('@backstage/plugin-catalog-backend/alpha'),
           createBackendModule({
             moduleId: 'syntheticLoadEntities',
             pluginId: 'catalog',

--- a/plugins/devtools-backend/api-report.md
+++ b/plugins/devtools-backend/api-report.md
@@ -27,7 +27,8 @@ export class DevToolsBackendApi {
 }
 
 // @public
-export const devtoolsPlugin: () => BackendFeature;
+const devtoolsPlugin: () => BackendFeature;
+export default devtoolsPlugin;
 
 // @public (undocumented)
 export interface RouterOptions {

--- a/plugins/devtools-backend/src/index.ts
+++ b/plugins/devtools-backend/src/index.ts
@@ -22,4 +22,4 @@
 
 export { DevToolsBackendApi } from './api';
 export * from './service/router';
-export { devtoolsPlugin } from './plugin';
+export { devtoolsPlugin as default } from './plugin';

--- a/plugins/entity-feedback-backend/api-report.md
+++ b/plugins/entity-feedback-backend/api-report.md
@@ -14,7 +14,8 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
-export const entityFeedbackPlugin: () => BackendFeature;
+const entityFeedbackPlugin: () => BackendFeature;
+export default entityFeedbackPlugin;
 
 // @public (undocumented)
 export interface RouterOptions {

--- a/plugins/entity-feedback-backend/src/index.ts
+++ b/plugins/entity-feedback-backend/src/index.ts
@@ -20,4 +20,4 @@
  * @packageDocumentation
  */
 export * from './service/router';
-export { entityFeedbackPlugin } from './plugin';
+export { entityFeedbackPlugin as default } from './plugin';

--- a/plugins/events-backend-module-aws-sqs/alpha-api-report.md
+++ b/plugins/events-backend-module-aws-sqs/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const eventsModuleAwsSqsConsumingEventPublisher: () => BackendFeature;
+const eventsModuleAwsSqsConsumingEventPublisher: () => BackendFeature;
+export default eventsModuleAwsSqsConsumingEventPublisher;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/events-backend-module-aws-sqs/src/alpha.ts
+++ b/plugins/events-backend-module-aws-sqs/src/alpha.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { eventsModuleAwsSqsConsumingEventPublisher } from './service/eventsModuleAwsSqsConsumingEventPublisher';
+export { eventsModuleAwsSqsConsumingEventPublisher as default } from './service/eventsModuleAwsSqsConsumingEventPublisher';

--- a/plugins/events-backend/alpha-api-report.md
+++ b/plugins/events-backend/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const eventsPlugin: () => BackendFeature;
+const eventsPlugin: () => BackendFeature;
+export default eventsPlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/events-backend/src/alpha.ts
+++ b/plugins/events-backend/src/alpha.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { eventsPlugin } from './service/EventsPlugin';
+export { eventsPlugin as default } from './service/EventsPlugin';

--- a/plugins/example-todo-list-backend/api-report.md
+++ b/plugins/example-todo-list-backend/api-report.md
@@ -12,7 +12,8 @@ import { Logger } from 'winston';
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @alpha
-export const exampleTodoListPlugin: () => BackendFeature;
+const exampleTodoListPlugin: () => BackendFeature;
+export default exampleTodoListPlugin;
 
 // @public
 export interface RouterOptions {

--- a/plugins/example-todo-list-backend/src/index.ts
+++ b/plugins/example-todo-list-backend/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export * from './service/router';
-export { exampleTodoListPlugin } from './plugin';
+export { exampleTodoListPlugin as default } from './plugin';

--- a/plugins/kafka-backend/api-report.md
+++ b/plugins/kafka-backend/api-report.md
@@ -12,7 +12,8 @@ import { Logger } from 'winston';
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @alpha
-export const kafkaPlugin: () => BackendFeature;
+const kafkaPlugin: () => BackendFeature;
+export default kafkaPlugin;
 
 // @public (undocumented)
 export interface RouterOptions {

--- a/plugins/kafka-backend/src/index.ts
+++ b/plugins/kafka-backend/src/index.ts
@@ -22,4 +22,4 @@
 
 export type { RouterOptions } from './service/router';
 export { createRouter } from './service/router';
-export { kafkaPlugin } from './plugin';
+export { kafkaPlugin as default } from './plugin';

--- a/plugins/kubernetes-backend/alpha-api-report.md
+++ b/plugins/kubernetes-backend/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const kubernetesPlugin: () => BackendFeature;
+const kubernetesPlugin: () => BackendFeature;
+export default kubernetesPlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/kubernetes-backend/src/alpha.ts
+++ b/plugins/kubernetes-backend/src/alpha.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { kubernetesPlugin } from './plugin';
+export { kubernetesPlugin as default } from './plugin';

--- a/plugins/lighthouse-backend/api-report.md
+++ b/plugins/lighthouse-backend/api-report.md
@@ -30,7 +30,8 @@ export function createScheduler(
 ): Promise<void>;
 
 // @public
-export const lighthousePlugin: () => BackendFeature;
+const lighthousePlugin: () => BackendFeature;
+export default lighthousePlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/lighthouse-backend/src/index.ts
+++ b/plugins/lighthouse-backend/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export * from './service/createScheduler';
-export { lighthousePlugin } from './plugin';
+export { lighthousePlugin as default } from './plugin';

--- a/plugins/linguist-backend/api-report.md
+++ b/plugins/linguist-backend/api-report.md
@@ -41,7 +41,8 @@ export interface LinguistBackendApi {
 }
 
 // @public
-export const linguistPlugin: () => BackendFeature;
+const linguistPlugin: () => BackendFeature;
+export default linguistPlugin;
 
 // @public
 export class LinguistTagsProcessor implements CatalogProcessor {

--- a/plugins/linguist-backend/src/index.ts
+++ b/plugins/linguist-backend/src/index.ts
@@ -23,4 +23,4 @@
 export * from './processor';
 export * from './service/router';
 export type { LinguistBackendApi } from './api';
-export { linguistPlugin } from './plugin';
+export { linguistPlugin as default } from './plugin';

--- a/plugins/periskop-backend/api-report.md
+++ b/plugins/periskop-backend/api-report.md
@@ -12,7 +12,8 @@ import { Logger } from 'winston';
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @alpha
-export const periskopPlugin: () => BackendFeature;
+const periskopPlugin: () => BackendFeature;
+export default periskopPlugin;
 
 // @public (undocumented)
 export interface RouterOptions {

--- a/plugins/periskop-backend/src/index.ts
+++ b/plugins/periskop-backend/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export * from './service/router';
-export { periskopPlugin } from './plugin';
+export { periskopPlugin as default } from './plugin';

--- a/plugins/permission-backend-module-policy-allow-all/api-report.md
+++ b/plugins/permission-backend-module-policy-allow-all/api-report.md
@@ -6,5 +6,6 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @public
-export const permissionModuleAllowAllPolicy: () => BackendFeature;
+const permissionModuleAllowAllPolicy: () => BackendFeature;
+export default permissionModuleAllowAllPolicy;
 ```

--- a/plugins/permission-backend-module-policy-allow-all/src/index.ts
+++ b/plugins/permission-backend-module-policy-allow-all/src/index.ts
@@ -20,4 +20,4 @@
  * @packageDocumentation
  */
 
-export { permissionModuleAllowAllPolicy } from './module';
+export { permissionModuleAllowAllPolicy as default } from './module';

--- a/plugins/permission-backend/alpha-api-report.md
+++ b/plugins/permission-backend/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const permissionPlugin: () => BackendFeature;
+const permissionPlugin: () => BackendFeature;
+export default permissionPlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/permission-backend/src/alpha.ts
+++ b/plugins/permission-backend/src/alpha.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { permissionPlugin } from './plugin';
+export { permissionPlugin as default } from './plugin';

--- a/plugins/proxy-backend/api-report.md
+++ b/plugins/proxy-backend/api-report.md
@@ -13,7 +13,8 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @alpha
-export const proxyPlugin: () => BackendFeature;
+const proxyPlugin: () => BackendFeature;
+export default proxyPlugin;
 
 // @public (undocumented)
 export interface RouterOptions {

--- a/plugins/proxy-backend/src/index.ts
+++ b/plugins/proxy-backend/src/index.ts
@@ -21,4 +21,4 @@
  */
 
 export * from './service';
-export { proxyPlugin } from './plugin';
+export { proxyPlugin as default } from './plugin';

--- a/plugins/scaffolder-backend/alpha-api-report.md
+++ b/plugins/scaffolder-backend/alpha-api-report.md
@@ -86,7 +86,8 @@ export const scaffolderActionConditions: Conditions<{
 }>;
 
 // @alpha
-export const scaffolderPlugin: () => BackendFeature;
+const scaffolderPlugin: () => BackendFeature;
+export default scaffolderPlugin;
 
 // @alpha
 export const scaffolderTemplateConditions: Conditions<{

--- a/plugins/scaffolder-backend/src/alpha.ts
+++ b/plugins/scaffolder-backend/src/alpha.ts
@@ -16,4 +16,4 @@
 
 export * from './modules';
 export * from './service';
-export { scaffolderPlugin } from './ScaffolderPlugin';
+export { scaffolderPlugin as default } from './ScaffolderPlugin';

--- a/plugins/search-backend-module-catalog/alpha-api-report.md
+++ b/plugins/search-backend-module-catalog/alpha-api-report.md
@@ -16,7 +16,8 @@ export type CatalogCollatorExtensionPoint = {
 export const catalogCollatorExtensionPoint: ExtensionPoint<CatalogCollatorExtensionPoint>;
 
 // @alpha
-export const searchModuleCatalogCollator: () => BackendFeature;
+const _default: () => BackendFeature;
+export default _default;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-catalog/src/alpha.test.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.test.ts
@@ -16,7 +16,7 @@
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
-import { searchModuleCatalogCollator } from './alpha';
+import searchModuleCatalogCollator from './alpha';
 
 describe('searchModuleCatalogCollator', () => {
   it('should register the catalog collator to the search index registry extension point with factory and schedule', async () => {

--- a/plugins/search-backend-module-catalog/src/alpha.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.ts
@@ -46,8 +46,7 @@ export type CatalogCollatorExtensionPoint = {
 
 /**
  * Extension point for customizing how catalog entities are shaped into
- * documents for the search backend, when using
- * {@link searchModuleCatalogCollator}.
+ * documents for the search backend.
  *
  * @alpha
  */
@@ -61,7 +60,7 @@ export const catalogCollatorExtensionPoint =
  *
  * @alpha
  */
-export const searchModuleCatalogCollator = createBackendModule({
+export default createBackendModule({
   moduleId: 'catalogCollator',
   pluginId: 'search',
   register(env) {

--- a/plugins/search-backend-module-elasticsearch/alpha-api-report.md
+++ b/plugins/search-backend-module-elasticsearch/alpha-api-report.md
@@ -7,6 +7,10 @@ import { BackendFeature } from '@backstage/backend-plugin-api';
 import { ElasticSearchQueryTranslator } from '@backstage/plugin-search-backend-module-elasticsearch';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 
+// @alpha
+const _default: () => BackendFeature;
+export default _default;
+
 // @alpha (undocumented)
 export interface ElasticSearchQueryTranslatorExtensionPoint {
   // (undocumented)
@@ -15,9 +19,6 @@ export interface ElasticSearchQueryTranslatorExtensionPoint {
 
 // @alpha
 export const elasticsearchTranslatorExtensionPoint: ExtensionPoint<ElasticSearchQueryTranslatorExtensionPoint>;
-
-// @alpha
-export const searchModuleElasticsearchEngine: () => BackendFeature;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-elasticsearch/src/alpha.ts
+++ b/plugins/search-backend-module-elasticsearch/src/alpha.ts
@@ -44,7 +44,7 @@ export const elasticsearchTranslatorExtensionPoint =
  *
  * @alpha
  */
-export const searchModuleElasticsearchEngine = createBackendModule({
+export default createBackendModule({
   moduleId: 'elasticsearchEngine',
   pluginId: 'search',
   register(env) {

--- a/plugins/search-backend-module-explore/alpha-api-report.md
+++ b/plugins/search-backend-module-explore/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const searchModuleExploreCollator: () => BackendFeature;
+const _default: () => BackendFeature;
+export default _default;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-explore/src/alpha.test.ts
+++ b/plugins/search-backend-module-explore/src/alpha.test.ts
@@ -16,7 +16,7 @@
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
-import { searchModuleExploreCollator } from './alpha';
+import searchModuleExploreCollator from './alpha';
 
 describe('searchModuleExploreCollator', () => {
   const schedule = {

--- a/plugins/search-backend-module-explore/src/alpha.ts
+++ b/plugins/search-backend-module-explore/src/alpha.ts
@@ -34,7 +34,7 @@ import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
  *
  * @alpha
  */
-export const searchModuleExploreCollator = createBackendModule({
+export default createBackendModule({
   moduleId: 'exploreCollator',
   pluginId: 'search',
   register(env) {

--- a/plugins/search-backend-module-pg/alpha-api-report.md
+++ b/plugins/search-backend-module-pg/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const searchModulePostgresEngine: () => BackendFeature;
+const _default: () => BackendFeature;
+export default _default;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-pg/src/alpha.ts
+++ b/plugins/search-backend-module-pg/src/alpha.ts
@@ -24,7 +24,7 @@ import { PgSearchEngine } from './PgSearchEngine';
  * @alpha
  * Search backend module for the Postgres engine.
  */
-export const searchModulePostgresEngine = createBackendModule({
+export default createBackendModule({
   moduleId: 'postgresEngine',
   pluginId: 'search',
   register(env) {

--- a/plugins/search-backend-module-techdocs/alpha-api-report.md
+++ b/plugins/search-backend-module-techdocs/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const searchModuleTechDocsCollator: () => BackendFeature;
+const _default: () => BackendFeature;
+export default _default;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-module-techdocs/src/alpha.test.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.test.ts
@@ -16,7 +16,7 @@
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
-import { searchModuleTechDocsCollator } from './alpha';
+import searchModuleTechDocsCollator from './alpha';
 
 describe('searchModuleTechDocsCollator', () => {
   const schedule = {

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -33,7 +33,7 @@ import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-back
  * @alpha
  * Search backend module for the TechDocs index.
  */
-export const searchModuleTechDocsCollator = createBackendModule({
+export default createBackendModule({
   moduleId: 'techDocsCollator',
   pluginId: 'search',
   register(env) {

--- a/plugins/search-backend/alpha-api-report.md
+++ b/plugins/search-backend/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const searchPlugin: () => BackendFeature;
+const _default: () => BackendFeature;
+export default _default;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend/src/alpha.test.ts
+++ b/plugins/search-backend/src/alpha.test.ts
@@ -16,7 +16,7 @@
 
 import { startTestBackend } from '@backstage/backend-test-utils';
 import request from 'supertest';
-import { searchPlugin } from './alpha';
+import searchPlugin from './alpha';
 
 describe('searchPlugin', () => {
   it('should serve search results on query endpoint', async () => {

--- a/plugins/search-backend/src/alpha.ts
+++ b/plugins/search-backend/src/alpha.ts
@@ -75,7 +75,7 @@ class SearchEngineRegistry implements SearchEngineRegistryExtensionPoint {
  * The Search plugin is responsible for starting search indexing processes and return search results.
  * @alpha
  */
-export const searchPlugin = createBackendPlugin({
+export default createBackendPlugin({
   pluginId: 'search',
   register(env) {
     const searchIndexRegistry = new SearchIndexRegistry();

--- a/plugins/techdocs-backend/alpha-api-report.md
+++ b/plugins/techdocs-backend/alpha-api-report.md
@@ -6,7 +6,8 @@
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
 // @alpha
-export const techdocsPlugin: () => BackendFeature;
+const techdocsPlugin: () => BackendFeature;
+export default techdocsPlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/techdocs-backend/src/alpha.ts
+++ b/plugins/techdocs-backend/src/alpha.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { techdocsPlugin } from './plugin';
+
+export { techdocsPlugin as default } from './plugin';

--- a/plugins/todo-backend/api-report.md
+++ b/plugins/todo-backend/api-report.md
@@ -91,7 +91,8 @@ export type TodoParserResult = {
 };
 
 // @public
-export const todoPlugin: () => BackendFeature;
+const todoPlugin: () => BackendFeature;
+export default todoPlugin;
 
 // @public (undocumented)
 export interface TodoReader {

--- a/plugins/todo-backend/src/index.ts
+++ b/plugins/todo-backend/src/index.ts
@@ -22,4 +22,4 @@
 
 export * from './lib';
 export * from './service';
-export * from './plugin';
+export { todoPlugin as default } from './plugin';

--- a/plugins/user-settings-backend/api-report.md
+++ b/plugins/user-settings-backend/api-report.md
@@ -20,7 +20,8 @@ export interface RouterOptions {
 }
 
 // @alpha
-export const userSettingsPlugin: () => BackendFeature;
+const userSettingsPlugin: () => BackendFeature;
+export default userSettingsPlugin;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/user-settings-backend/src/index.ts
+++ b/plugins/user-settings-backend/src/index.ts
@@ -16,4 +16,4 @@
 
 export * from './service';
 export * from './database';
-export { userSettingsPlugin } from './plugin';
+export { userSettingsPlugin as default } from './plugin';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3767,6 +3767,7 @@ __metadata:
     "@backstage/theme": "workspace:^"
     "@backstage/types": "workspace:^"
     "@esbuild-kit/cjs-loader": ^2.4.1
+    "@esbuild-kit/esm-loader": ^2.5.5
     "@manypkg/get-packages": ^1.1.3
     "@octokit/graphql": ^5.0.0
     "@octokit/graphql-schema": ^13.7.0
@@ -10755,6 +10756,16 @@ __metadata:
     esbuild: ~0.15.10
     source-map-support: ^0.5.21
   checksum: 0e89ec718e2211bf95c48a8085aaef88e8e416f42abd1c62d488d5458eecd3fbc144179a0c5570ad36fa7e2d3bbc411f8d3fb28802c37ced2154dc2c6ded9dfe
+  languageName: node
+  linkType: hard
+
+"@esbuild-kit/esm-loader@npm:^2.5.5":
+  version: 2.5.5
+  resolution: "@esbuild-kit/esm-loader@npm:2.5.5"
+  dependencies:
+    "@esbuild-kit/core-utils": ^3.0.0
+    get-tsconfig: ^4.4.0
+  checksum: 9d4a03ffc937fbec75a8456c3d45d7cdb1a65768416791a5720081753502bc9f485ba27942a46f564b12483b140a8a46c12433a4496430d93e4513e430484ec7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes feature (plugin/module/service factories) export from using named export to the default export.

There are a couple of reasons for this change, but the primary driver for it is to support declarative integration for the new backend system. We currently discovery all exports and include them automatically. This is quite fragile, since it means we won't be able to export optional features without additions to the system, and in general it's risks the future evolution of the system. More importantly though, this is a problem for services factories, since we want service factories to be installable via discovery too. The problem is that any app depending on `@backstage/backend-app-api` would install of default factories, which in turn means you won't be able to override them. By only considering default exports we can instead create an explicit service factory export to be installed in the app.

Worth noting that we still have the idea of "presets" as a potential new feature for the backend system, which essentially ends up being a collection of features. This could help out in situations where a single package needs to export multiple features, but it's something we'll visit in the future.

Now in addition to this change and the impact on feature discovery, we also introduce a new pattern for feature installation in code. Rather than a separate import with the installation happening afterwards in `backend.add(...)`, it's now possible to pass an import of a package with a default package export straight to `backend.add(...)` This new pattern will be what we encourage for all backend setups implemented with code. For example:

```ts
backend.add(import('@backstage/plugin-catalog-backend'));
```

CC @davidfestal, this'll have an impact on dynamic plugins

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
