### PR TITLE
frontend-*-api: publish packages

### DIFF
--- a/.changeset/chilly-balloons-enjoy.md
+++ b/.changeset/chilly-balloons-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-plugin-api': minor
+'@backstage/frontend-app-api': minor
+---
+
+Initial release

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@backstage/frontend-app-api",
-  "version": "0.0.1-next.1",
+  "version": "0.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@backstage/frontend-plugin-api",
-  "version": "0.0.1-next.0",
+  "version": "0.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Had some more discussion about the naming of these packages and whether they should exist at all. We decided that we do want to create new packages for the new frontend system rather than trying to build on top of the existing `core-*-api` packages, because:

- There's a lot of naming overlap, `createPlugin`, `createApiRef`, `useRouteRef` and so on. They're things we want in the new system but that will in some cases behave slightly or completely differently. Attempting to have them support both systems at once would be very messy.
- We won't break existing `core-*-api` to the furthest extent possible, things like `useApi` will still work. Potentially even with legacy adapters for things like `createPlugin` and `createRoutableExtension`.
- Unless the previous point proves to be enough, we'll provide codemods migrating to the new packages.

Regarding the naming of the new packages, we settled on keeping `frontend-*-api`, the main contender was simply `*-api`, but we also considered other prefixes, like `web-*-api`. We decided we did want some prefix, in particular for symmetry with `backend-*-api` and avoiding confusion. There are some packages that fall into an un-prefixed pattern, like `test-utils` and `backend-test-utils`, but we will also consider renaming those to match the `frontend-` prefix. The main reason for not going with any other prefix, like `web-`, was to have the `frontend-`/`backend-` symmetry, and it really feels the most clear anyway. In particular we considered `web-` because of the `web-library` package role, but decided that's not a significant enough connection.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
