### PR TITLE
[catalog-backend] add support to override processingEngine

### DIFF
--- a/.changeset/smart-zebras-judge.md
+++ b/.changeset/smart-zebras-judge.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Add possibility to override processingEngine
+Add possibility to override `processingEngine`

--- a/.changeset/smart-zebras-judge.md
+++ b/.changeset/smart-zebras-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add possibility to override processingEngine

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -284,6 +284,7 @@ prebaked
 preconfigured
 prepack
 Preprarer
+processingEngine
 productional
 Protobuf
 proxying

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -284,7 +284,6 @@ prebaked
 preconfigured
 prepack
 Preprarer
-processingEngine
 productional
 Protobuf
 proxying

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -161,6 +161,9 @@ export class CatalogBuilder {
     key: string,
     resolver: PlaceholderResolver,
   ): CatalogBuilder;
+  setProcessingEngine(
+    processingEngine: CatalogProcessingEngine,
+  ): CatalogBuilder;
   setProcessingInterval(
     processingInterval: ProcessingIntervalFunction,
   ): CatalogBuilder;
@@ -173,9 +176,6 @@ export class CatalogBuilder {
     }) => Promise<void> | void;
   }): void;
   useLegacySingleProcessorValidation(): this;
-  withProcessingEngine(
-    processingEngine: CatalogProcessingEngine,
-  ): CatalogBuilder;
 }
 
 // @public @deprecated (undocumented)

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -173,6 +173,9 @@ export class CatalogBuilder {
     }) => Promise<void> | void;
   }): void;
   useLegacySingleProcessorValidation(): this;
+  withProcessingEngine(
+    processingEngine: CatalogProcessingEngine,
+  ): CatalogBuilder;
 }
 
 // @public @deprecated (undocumented)

--- a/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UrlReaderService } from '@backstage/backend-plugin-api';
+import { CatalogProcessingEngine } from '../processing';
+import { CatalogBuilder } from './CatalogBuilder';
+import { PermissionEvaluator } from '@backstage/plugin-permission-common';
+import { ConfigReader } from '@backstage/config';
+import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
+import { Knex } from 'knex';
+import { applyDatabaseMigrations } from '../database/migrations';
+import { getVoidLogger } from '@backstage/backend-common';
+
+describe('CatalogBuilder', () => {
+  let knex: Knex;
+
+  afterEach(async () => {
+    await knex.destroy();
+  });
+
+  const databases = TestDatabases.create({
+    ids: ['SQLITE_3'],
+  });
+
+  async function createDatabase(databaseId: TestDatabaseId) {
+    knex = await databases.init(databaseId);
+    await applyDatabaseMigrations(knex);
+  }
+
+  it.each(databases.eachSupportedId())(
+    'processingEngine can be replaced',
+    async databaseId => {
+      await createDatabase(databaseId);
+
+      const fakeEngine: CatalogProcessingEngine = {
+        start: async () => {},
+        stop: async () => {},
+      };
+      const builder = CatalogBuilder.create({
+        database: { getClient: async () => knex },
+        config: ConfigReader.fromConfigs([]),
+        logger: getVoidLogger(),
+        permissions: jest.fn() as unknown as PermissionEvaluator,
+        reader: jest.fn() as unknown as UrlReaderService,
+      });
+      builder.withProcessingEngine(fakeEngine);
+
+      const { processingEngine } = await builder.build();
+
+      expect(processingEngine).toBe(fakeEngine);
+    },
+  );
+});

--- a/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
@@ -55,7 +55,7 @@ describe('CatalogBuilder', () => {
         permissions: jest.fn() as unknown as PermissionEvaluator,
         reader: jest.fn() as unknown as UrlReaderService,
       });
-      builder.withProcessingEngine(fakeEngine);
+      builder.setProcessingEngine(fakeEngine);
 
       const { processingEngine } = await builder.build();
 

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -434,7 +434,7 @@ export class CatalogBuilder {
   /**
    * Use a custom CatalogProcessingEngine instead of the default.
    */
-  withProcessingEngine(
+  setProcessingEngine(
     processingEngine: CatalogProcessingEngine,
   ): CatalogBuilder {
     this.processingEngine = processingEngine;

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -167,6 +167,7 @@ export class CatalogBuilder {
   private allowedLocationType: string[];
   private legacySingleProcessorValidation = false;
   private eventBroker?: EventBroker;
+  private processingEngine?: CatalogProcessingEngine;
 
   /**
    * Creates a catalog builder.
@@ -431,6 +432,16 @@ export class CatalogBuilder {
   }
 
   /**
+   * Use a custom CatalogProcessingEngine instead of the default.
+   */
+  withProcessingEngine(
+    processingEngine: CatalogProcessingEngine,
+  ): CatalogBuilder {
+    this.processingEngine = processingEngine;
+    return this;
+  }
+
+  /**
    * Wires up and returns all of the component parts of the catalog
    */
   async build(): Promise<{
@@ -531,19 +542,21 @@ export class CatalogBuilder {
       provider => provider.getProviderName(),
     );
 
-    const processingEngine = new DefaultCatalogProcessingEngine({
-      config,
-      scheduler,
-      logger,
-      processingDatabase,
-      orchestrator,
-      stitcher,
-      createHash: () => createHash('sha1'),
-      pollingIntervalMs: 1000,
-      onProcessingError: event => {
-        this.onProcessingError?.(event);
-      },
-    });
+    const processingEngine =
+      this.processingEngine ||
+      new DefaultCatalogProcessingEngine({
+        config,
+        scheduler,
+        logger,
+        processingDatabase,
+        orchestrator,
+        stitcher,
+        createHash: () => createHash('sha1'),
+        pollingIntervalMs: 1000,
+        onProcessingError: event => {
+          this.onProcessingError?.(event);
+        },
+      });
 
     const locationAnalyzer =
       this.locationAnalyzer ??


### PR DESCRIPTION
Currently the CatalogBuilder will always return DefaultCatalogProcessingEngine. This PR enables us to add a custom ProcessingEngine to the builder to use instead.

If `withProcessingEngine` is not invoked, the current behaviour is retained.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
