### PR TITLE
Enables dry-run for yeoman scaffolder action

### DIFF
--- a/.changeset/big-spies-agree.md
+++ b/.changeset/big-spies-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-yeoman': patch
+---
+
+Enables dry-run functionality for the run:yeoman scaffolder action

--- a/plugins/scaffolder-backend-module-yeoman/src/actions/run/yeoman.ts
+++ b/plugins/scaffolder-backend-module-yeoman/src/actions/run/yeoman.ts
@@ -61,6 +61,7 @@ export function createRunYeomanAction() {
         },
       },
     },
+    supportsDryRun: true,
     async handler(ctx) {
       ctx.logger.info(
         `Templating using Yeoman generator: ${ctx.input.namespace}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This enables dry-run functionality for the run yeoman scaffolder action. Given it's supported for the standard nunjucks templating (i.e. https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts#L138), this seems like a reasonably safe addition since it's just templating values, unless there's a deliberate reason I've missed for not having this be enabled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
