### PR TITLE
Fix bug 18924: caFile configuration is used when the Middleware is created

### DIFF
--- a/.changeset/fifty-pigs-travel.md
+++ b/.changeset/fifty-pigs-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+cluster.caFile configuration is used when the Middleware is created on KubernetesProxy

--- a/.changeset/fifty-pigs-travel.md
+++ b/.changeset/fifty-pigs-travel.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-cluster.caFile configuration is used when the Middleware is created on KubernetesProxy
+Fixed a bug where requests to the proxy endpoint would fail for clusters with `caFile` configured

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -158,7 +158,10 @@ export class KubernetesProxy {
             protocol: url.protocol,
             host: url.hostname,
             port: url.port,
-            ca: bufferFromFileOrString('', cluster.caData)?.toString(),
+            ca: bufferFromFileOrString(
+              cluster.caFile,
+              cluster.caData,
+            )?.toString(),
           };
         },
         onError: (error, req, res) => {


### PR DESCRIPTION
This PR fixes #18924

Now the caFile configuration is used when the Middleware is created on KubernetesProxy.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
