### PR TITLE
Exposes the useRedisSets config option for keyv redis

### DIFF
--- a/.changeset/small-avocados-live.md
+++ b/.changeset/small-avocados-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Adds the optional flag for useRedisSets for the Redis cache to the config.

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -323,7 +323,10 @@ backend:
   cache:
     store: redis
     connection: redis://user:pass@cache.example.com:6379
+    useRedisSets: true
 ```
+
+The useRedisSets flag is explained [here](https://github.com/jaredwray/keyv/tree/main/packages/redis#useredissets).
 
 Contributions supporting other cache stores are welcome!
 

--- a/packages/backend-common/src/cache/CacheManager.ts
+++ b/packages/backend-common/src/cache/CacheManager.ts
@@ -55,6 +55,7 @@ export class CacheManager {
   private readonly logger: LoggerService;
   private readonly store: keyof CacheManager['storeFactories'];
   private readonly connection: string;
+  private readonly useRedisSets: boolean;
   private readonly errorHandler: CacheManagerOptions['onError'];
 
   /**
@@ -72,15 +73,24 @@ export class CacheManager {
     const store = config.getOptionalString('backend.cache.store') || 'memory';
     const connectionString =
       config.getOptionalString('backend.cache.connection') || '';
+    const useRedisSets =
+      config.getOptionalBoolean('backend.cache.useRedisSets') ?? true;
     const logger = (options.logger || getRootLogger()).child({
       type: 'cacheManager',
     });
-    return new CacheManager(store, connectionString, logger, options.onError);
+    return new CacheManager(
+      store,
+      connectionString,
+      useRedisSets,
+      logger,
+      options.onError,
+    );
   }
 
   private constructor(
     store: string,
     connectionString: string,
+    useRedisSets: boolean,
     logger: LoggerService,
     errorHandler: CacheManagerOptions['onError'],
   ) {
@@ -90,6 +100,7 @@ export class CacheManager {
     this.logger = logger;
     this.store = store as keyof CacheManager['storeFactories'];
     this.connection = connectionString;
+    this.useRedisSets = useRedisSets;
     this.errorHandler = errorHandler;
   }
 
@@ -143,6 +154,7 @@ export class CacheManager {
       namespace: pluginId,
       ttl: defaultTtl,
       store: new KeyvRedis(this.connection),
+      useRedisSets: this.useRedisSets,
     });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This exposes the `useRedisSets` flag from keyv redis to Backstage users. What this does is explained [here](https://github.com/jaredwray/keyv/tree/main/packages/redis#useredissets) and the original github issue it's solving [here](https://github.com/jaredwray/keyv/issues/455). The dependency update with this change has already been pulled into Backstage [here](https://github.com/backstage/backstage/pull/18565)

The tl;dr is that in the current setup, the namespace sets in redis is added to every time a new record is added, and when that record is ttl-ed away, the original reference in the set never gets purged. As such, this grows slowly but surely over time. We've been seeing this behaviour within Backstage for Techdocs and have had to purge it a few times. The change allows the option for this functionality to be disabled, which prevents this from happening, but potentially degrades performance when using `.clear()`, which no client in the current Backstage caches supports anyway.

I've left it as an option at the app-config level since it felt cleaner to take a wholesale cache approach to it as opposed to defining it per-client like the defaultTtl, but i'm happy to push it down into a `CacheServiceOptions` if that's preferred.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
