### PR TITLE
frontend-app-api: implement most bits of AppManager + add sidebar

### DIFF
--- a/.changeset/mean-planes-smoke.md
+++ b/.changeset/mean-planes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Internal refactor

--- a/packages/app-next/app-config.yaml
+++ b/packages/app-next/app-config.yaml
@@ -3,7 +3,7 @@ app:
     packages: 'all' # ✨
 
   extensions:
-  - apis.plugin.graphiql.browse.gitlab: true
+    - apis.plugin.graphiql.browse.gitlab: true
 
   # scmAuthExtension: >-
   #   createScmAuthExtension({

--- a/packages/app-next/app-config.yaml
+++ b/packages/app-next/app-config.yaml
@@ -2,6 +2,8 @@ app:
   experimental:
     packages: 'all' # ✨
 
+  extensions:
+  - apis.plugin.graphiql.browse.gitlab: true
 
   # scmAuthExtension: >-
   #   createScmAuthExtension({

--- a/packages/app-next/src/App.test.tsx
+++ b/packages/app-next/src/App.test.tsx
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { renderWithEffects } from '@backstage/test-utils';
+
+jest.mock('@backstage/plugin-graphiql', () => ({
+  ...jest.requireActual('@backstage/plugin-graphiql'),
+  GraphiQLIcon: () => null,
+}));
 
 describe('App', () => {
   it('should render', async () => {
@@ -41,8 +45,8 @@ describe('App', () => {
       ] as any,
     };
 
-    const { default: App } = await import('./App');
-    const rendered = await renderWithEffects(<App />);
+    const { default: app } = await import('./App');
+    const rendered = await renderWithEffects(app);
     expect(rendered.baseElement).toBeInTheDocument();
   });
 });

--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { graphiqlPlugin as legacyGraphiqlPlugin } from '@backstage/plugin-graphiql';
-import { createApp as createLegacyApp } from '@backstage/app-defaults';
 import { createApp } from '@backstage/frontend-app-api';
 import { pagesPlugin } from './examples/pagesPlugin';
 import graphiqlPlugin from '@backstage/plugin-graphiql/alpha';
@@ -61,9 +59,9 @@ const app = createApp({
   // },
 });
 
-const legacyApp = createLegacyApp({ plugins: [legacyGraphiqlPlugin] });
+// const legacyApp = createLegacyApp({ plugins: [legacyGraphiqlPlugin] });
 
-export default legacyApp.createRoot(app.createRoot());
+export default app.createRoot();
 
 // const routes = (
 //   <FlatRoutes>

--- a/packages/app-next/src/index.tsx
+++ b/packages/app-next/src/index.tsx
@@ -15,8 +15,7 @@
  */
 
 import '@backstage/cli/asset-types';
-import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import app from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(app, document.getElementById('root'));

--- a/packages/core-app-api/src/app/defaultConfigLoader.test.ts
+++ b/packages/core-app-api/src/app/defaultConfigLoader.test.ts
@@ -14,40 +14,38 @@
  * limitations under the License.
  */
 
-import { defaultConfigLoader } from './defaultConfigLoader';
+import { defaultConfigLoaderSync } from './defaultConfigLoader';
 
 (process as any).env = { NODE_ENV: 'test' };
 const anyEnv = process.env as any;
 const anyWindow = window as any;
 
-describe('defaultConfigLoader', () => {
+describe('defaultConfigLoaderSync', () => {
   afterEach(() => {
     delete anyEnv.APP_CONFIG;
     delete anyWindow.__APP_CONFIG__;
   });
 
-  it('loads static config', async () => {
+  it('loads static config', () => {
     anyEnv.APP_CONFIG = [
       { data: { my: 'config' }, context: 'a' },
       { data: { my: 'override-config' }, context: 'b' },
     ];
 
-    const configs = await defaultConfigLoader();
+    const configs = defaultConfigLoaderSync();
     expect(configs).toEqual([
       { data: { my: 'config' }, context: 'a' },
       { data: { my: 'override-config' }, context: 'b' },
     ]);
   });
 
-  it('loads runtime config', async () => {
+  it('loads runtime config', () => {
     anyEnv.APP_CONFIG = [
       { data: { my: 'override-config' }, context: 'a' },
       { data: { my: 'config' }, context: 'b' },
     ];
 
-    const configs = await (defaultConfigLoader as any)(
-      '{"my":"runtime-config"}',
-    );
+    const configs = (defaultConfigLoaderSync as any)('{"my":"runtime-config"}');
     expect(configs).toEqual([
       { data: { my: 'override-config' }, context: 'a' },
       { data: { my: 'config' }, context: 'b' },
@@ -55,28 +53,28 @@ describe('defaultConfigLoader', () => {
     ]);
   });
 
-  it('fails to load invalid missing config', async () => {
-    await expect(defaultConfigLoader()).rejects.toThrow(
+  it('fails to load invalid missing config', () => {
+    expect(() => defaultConfigLoaderSync()).toThrow(
       'No static configuration provided',
     );
   });
 
-  it('fails to load invalid static config', async () => {
+  it('fails to load invalid static config', () => {
     anyEnv.APP_CONFIG = { my: 'invalid-config' };
-    await expect(defaultConfigLoader()).rejects.toThrow(
+    expect(() => defaultConfigLoaderSync()).toThrow(
       'Static configuration has invalid format',
     );
   });
 
-  it('fails to load bad runtime config', async () => {
+  it('fails to load bad runtime config', () => {
     anyEnv.APP_CONFIG = [{ data: { my: 'config' }, context: 'a' }];
 
-    await expect((defaultConfigLoader as any)('}')).rejects.toThrow(
+    expect(() => defaultConfigLoaderSync('}')).toThrow(
       'Failed to load runtime configuration, SyntaxError: Unexpected token } in JSON at position 0',
     );
   });
 
-  it('loads config from window.__APP_CONFIG__', async () => {
+  it('loads config from window.__APP_CONFIG__', () => {
     anyEnv.APP_CONFIG = [
       { data: { my: 'config' }, context: 'a' },
       { data: { my: 'override-config' }, context: 'b' },
@@ -84,7 +82,7 @@ describe('defaultConfigLoader', () => {
     const windowConfig = { app: { configKey: 'config-value' } };
     anyWindow.__APP_CONFIG__ = windowConfig;
 
-    const configs = await defaultConfigLoader();
+    const configs = defaultConfigLoaderSync();
 
     expect(configs).toEqual([
       ...anyEnv.APP_CONFIG,

--- a/packages/core-app-api/src/app/defaultConfigLoader.ts
+++ b/packages/core-app-api/src/app/defaultConfigLoader.ts
@@ -16,7 +16,6 @@
 
 import { AppConfig } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
-import { AppConfigLoader } from './types';
 
 /**
  * The default config loader, which expects that config is available at compile-time
@@ -30,12 +29,17 @@ import { AppConfigLoader } from './types';
  *
  * @public
  */
-export const defaultConfigLoader: AppConfigLoader = async (
+export async function defaultConfigLoader(): Promise<AppConfig[]> {
+  return defaultConfigLoaderSync();
+}
+
+/** @internal */
+export function defaultConfigLoaderSync(
   // This string may be replaced at runtime to provide additional config.
   // It should be replaced by a JSON-serialized config object.
   // It's a param so we can test it, but at runtime this will always fall back to default.
   runtimeConfigJson: string = '__APP_INJECTED_RUNTIME_CONFIG__',
-) => {
+) {
   const appConfig = process.env.APP_CONFIG;
   if (!appConfig) {
     throw new Error('No static configuration provided');
@@ -70,4 +74,4 @@ export const defaultConfigLoader: AppConfigLoader = async (
     });
   }
   return configs;
-};
+}

--- a/packages/core-app-api/src/app/defaultConfigLoader.ts
+++ b/packages/core-app-api/src/app/defaultConfigLoader.ts
@@ -16,6 +16,7 @@
 
 import { AppConfig } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
+import { AppConfigLoader } from './types';
 
 /**
  * The default config loader, which expects that config is available at compile-time
@@ -29,9 +30,8 @@ import { JsonObject } from '@backstage/types';
  *
  * @public
  */
-export async function defaultConfigLoader(): Promise<AppConfig[]> {
-  return defaultConfigLoaderSync();
-}
+export const defaultConfigLoader: AppConfigLoader = async () =>
+  defaultConfigLoaderSync();
 
 /** @internal */
 export function defaultConfigLoaderSync(

--- a/packages/core-app-api/src/app/overrideBaseUrlConfigs.ts
+++ b/packages/core-app-api/src/app/overrideBaseUrlConfigs.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppConfig, ConfigReader } from '@backstage/config';
+
+/**
+ * Creates a base URL that uses to the current document origin.
+ */
+function createLocalBaseUrl(fullUrl: string): string {
+  const url = new URL(fullUrl);
+  url.protocol = document.location.protocol;
+  url.hostname = document.location.hostname;
+  url.port = document.location.port;
+  return url.toString().replace(/\/$/, '');
+}
+
+/**
+ * If we are able to override the app and backend base URLs to values that
+ * match the origin of the current location, then this function returns a
+ * new array of app configs that contain the overrides.
+ *
+ * @internal
+ */
+export function overrideBaseUrlConfigs(inputConfigs: AppConfig[]): AppConfig[] {
+  const urlConfigReader = ConfigReader.fromConfigs(inputConfigs);
+
+  // In tests we may not have `app.baseUrl` or `backend.baseUrl`, to keep them optional
+  const appBaseUrl = urlConfigReader.getOptionalString('app.baseUrl');
+  const backendBaseUrl = urlConfigReader.getOptionalString('backend.baseUrl');
+
+  let configs = inputConfigs;
+
+  let newBackendBaseUrl: string | undefined = undefined;
+  let newAppBaseUrl: string | undefined = undefined;
+
+  if (appBaseUrl && backendBaseUrl) {
+    const appOrigin = new URL(appBaseUrl).origin;
+    const backendOrigin = new URL(backendBaseUrl).origin;
+
+    if (appOrigin === backendOrigin) {
+      const maybeNewBackendBaseUrl = createLocalBaseUrl(backendBaseUrl);
+      if (backendBaseUrl !== maybeNewBackendBaseUrl) {
+        newBackendBaseUrl = maybeNewBackendBaseUrl;
+      }
+    }
+  }
+
+  if (appBaseUrl) {
+    const maybeNewAppBaseUrl = createLocalBaseUrl(appBaseUrl);
+    if (appBaseUrl !== maybeNewAppBaseUrl) {
+      newAppBaseUrl = maybeNewAppBaseUrl;
+    }
+  }
+
+  // Only add the relative config if there is actually data to add.
+  if (newAppBaseUrl || newBackendBaseUrl) {
+    configs = configs.concat({
+      data: {
+        app: newAppBaseUrl && {
+          baseUrl: newAppBaseUrl,
+        },
+        backend: newBackendBaseUrl && {
+          baseUrl: newBackendBaseUrl,
+        },
+      },
+      context: 'relative-resolver',
+    });
+  }
+
+  return configs;
+}

--- a/packages/frontend-app-api/api-report.md
+++ b/packages/frontend-app-api/api-report.md
@@ -6,9 +6,13 @@
 /// <reference types="react" />
 
 import { BackstagePlugin } from '@backstage/frontend-plugin-api';
+import { ConfigApi } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
-export function createApp(options: { plugins: BackstagePlugin[] }): {
+export function createApp(options: {
+  plugins: BackstagePlugin[];
+  config?: ConfigApi;
+}): {
   createRoot(): JSX.Element;
 };
 ```

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@backstage/config": "workspace:^",
+    "@backstage/core-app-api": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-graphiql": "workspace:^",

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -35,10 +35,12 @@
   "dependencies": {
     "@backstage/config": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
+    "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-graphiql": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@material-ui/core": "^4.12.4",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/frontend-app-api/src/createApp.tsx
+++ b/packages/frontend-app-api/src/createApp.tsx
@@ -53,6 +53,8 @@ import { AppThemeProvider } from '../../core-app-api/src/app/AppThemeProvider';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { defaultConfigLoaderSync } from '../../core-app-api/src/app/defaultConfigLoader';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { overrideBaseUrlConfigs } from '../../core-app-api/src/app/overrideBaseUrlConfigs';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { themes } from '../../app-defaults/src/defaults/themes';
 
 /** @public */
@@ -63,7 +65,8 @@ export function createApp(options: {
   createRoot(): JSX.Element;
 } {
   const appConfig =
-    options?.config ?? ConfigReader.fromConfigs(defaultConfigLoaderSync());
+    options?.config ??
+    ConfigReader.fromConfigs(overrideBaseUrlConfigs(defaultConfigLoaderSync()));
 
   const builtinExtensions = [CoreRouter, Core];
   const discoveredPlugins = getAvailablePlugins();

--- a/packages/frontend-app-api/src/extensions/Core.tsx
+++ b/packages/frontend-app-api/src/extensions/Core.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreExtensionData,
+  createExtension,
+} from '@backstage/frontend-plugin-api';
+
+export const Core = createExtension({
+  id: 'core',
+  at: 'root',
+  inputs: {
+    apis: {
+      extensionData: {
+        api: coreExtensionData.apiFactory,
+      },
+    },
+  },
+  output: {},
+  factory() {},
+});

--- a/packages/frontend-app-api/src/extensions/CoreLayout.tsx
+++ b/packages/frontend-app-api/src/extensions/CoreLayout.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  createExtension,
+  coreExtensionData,
+} from '@backstage/frontend-plugin-api';
+import { SidebarPage } from '@backstage/core-components';
+
+export const CoreLayout = createExtension({
+  id: 'core.layout',
+  at: 'root',
+  inputs: {
+    nav: {
+      extensionData: {
+        component: coreExtensionData.reactComponent,
+      },
+    },
+    content: {
+      extensionData: {
+        component: coreExtensionData.reactComponent,
+      },
+    },
+  },
+  output: {
+    component: coreExtensionData.reactComponent,
+  },
+  factory({ bind, inputs }) {
+    // TODO: Support this as part of the core system
+    if (inputs.nav.length !== 1) {
+      throw Error(
+        `Extension 'core.layout' did not receive exactly one 'nav' input, got ${inputs.nav.length}`,
+      );
+    }
+    const Nav = inputs.nav[0].component;
+
+    if (inputs.content.length !== 1) {
+      throw Error(
+        `Extension 'core.layout' did not receive exactly one 'content' input, got ${inputs.content.length}`,
+      );
+    }
+    const Content = inputs.content[0].component;
+
+    bind({
+      // TODO: set base path using the logic from AppRouter
+      component: () => (
+        <SidebarPage>
+          <Nav />
+          <Content />
+        </SidebarPage>
+      ),
+    });
+  },
+});

--- a/packages/frontend-app-api/src/extensions/CoreNav.tsx
+++ b/packages/frontend-app-api/src/extensions/CoreNav.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  createExtension,
+  coreExtensionData,
+} from '@backstage/frontend-plugin-api';
+import { makeStyles } from '@material-ui/core';
+import {
+  Sidebar,
+  useSidebarOpenState,
+  Link,
+  sidebarConfig,
+  SidebarDivider,
+  SidebarItem,
+} from '@backstage/core-components';
+import { GraphiQLIcon } from '@backstage/plugin-graphiql';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import LogoIcon from '../../../app/src/components/Root/LogoIcon';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import LogoFull from '../../../app/src/components/Root/LogoFull';
+
+const useSidebarLogoStyles = makeStyles({
+  root: {
+    width: sidebarConfig.drawerWidthClosed,
+    height: 3 * sidebarConfig.logoHeight,
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    marginBottom: -14,
+  },
+  link: {
+    width: sidebarConfig.drawerWidthClosed,
+    marginLeft: 24,
+  },
+});
+
+const SidebarLogo = () => {
+  const classes = useSidebarLogoStyles();
+  const { isOpen } = useSidebarOpenState();
+
+  return (
+    <div className={classes.root}>
+      <Link to="/" underline="none" className={classes.link} aria-label="Home">
+        {isOpen ? <LogoFull /> : <LogoIcon />}
+      </Link>
+    </div>
+  );
+};
+
+export const CoreNav = createExtension({
+  id: 'core.nav',
+  at: 'core.layout/nav',
+  inputs: {},
+  output: {
+    component: coreExtensionData.reactComponent,
+  },
+  factory({ bind }) {
+    bind({
+      // TODO: set base path using the logic from AppRouter
+      component: () => (
+        <Sidebar>
+          <SidebarLogo />
+          <SidebarDivider />
+          <SidebarItem icon={GraphiQLIcon} to="graphiql" text="GraphiQL" />
+        </Sidebar>
+      ),
+    });
+  },
+});

--- a/packages/frontend-app-api/src/extensions/CoreRouter.tsx
+++ b/packages/frontend-app-api/src/extensions/CoreRouter.tsx
@@ -48,6 +48,7 @@ export const CoreRouter = createExtension({
       return element;
     };
     bind({
+      // TODO: set base path using the logic from AppRouter
       component: () => (
         <BrowserRouter>
           <Routes />

--- a/packages/frontend-app-api/src/extensions/CoreRoutes.tsx
+++ b/packages/frontend-app-api/src/extensions/CoreRoutes.tsx
@@ -19,11 +19,11 @@ import {
   createExtension,
   coreExtensionData,
 } from '@backstage/frontend-plugin-api';
-import { BrowserRouter, useRoutes } from 'react-router-dom';
+import { useRoutes } from 'react-router-dom';
 
-export const CoreRouter = createExtension({
-  id: 'core.router',
-  at: 'root',
+export const CoreRoutes = createExtension({
+  id: 'core.routes',
+  at: 'core.layout/content',
   inputs: {
     routes: {
       extensionData: {
@@ -48,12 +48,7 @@ export const CoreRouter = createExtension({
       return element;
     };
     bind({
-      // TODO: set base path using the logic from AppRouter
-      component: () => (
-        <BrowserRouter>
-          <Routes />
-        </BrowserRouter>
-      ),
+      component: () => <Routes />,
     });
   },
 });

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/frontend-app-api": "workspace:^",
+    "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3"
   },

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.test.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.test.tsx
@@ -35,7 +35,7 @@ describe('createPageExtension', () => {
     ).toEqual({
       $$type: 'extension',
       id: 'test',
-      at: 'core.router/routes',
+      at: 'core.routes/routes',
       configSchema: expect.anything(),
       disabled: false,
       inputs: {},
@@ -88,7 +88,7 @@ describe('createPageExtension', () => {
     ).toEqual({
       $$type: 'extension',
       id: 'test',
-      at: 'core.router/routes',
+      at: 'core.routes/routes',
       configSchema: expect.anything(),
       disabled: false,
       inputs: {},

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
@@ -63,7 +63,7 @@ export function createPageExtension<
 
   return createExtension({
     id: options.id,
-    at: options.at ?? 'core.router/routes',
+    at: options.at ?? 'core.routes/routes',
     disabled: options.disabled,
     output: {
       component: coreExtensionData.reactComponent,

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -23,6 +23,7 @@ import { JsonObject } from '@backstage/types';
 import { createExtension } from './createExtension';
 import { createExtensionDataRef } from './createExtensionDataRef';
 import { coreExtensionData } from './coreExtensionData';
+import { MockConfigApi } from '@backstage/test-utils';
 
 const nameExtensionDataRef = createExtensionDataRef<string>('name');
 
@@ -113,17 +114,10 @@ function createTestAppRoot({
   plugins: BackstagePlugin[];
   config: JsonObject;
 }) {
-  Object.defineProperty(process.env, 'APP_CONFIG', {
-    value: [
-      {
-        data: config,
-        context: 'test',
-      },
-    ],
-    configurable: true,
-  });
-
-  return createApp({ plugins: plugins }).createRoot();
+  return createApp({
+    plugins: plugins,
+    config: new MockConfigApi(config),
+  }).createRoot();
 }
 
 describe('createPlugin', () => {
@@ -143,7 +137,7 @@ describe('createPlugin', () => {
     render(
       createTestAppRoot({
         plugins: [plugin],
-        config: { app: { extensions: [{ 'core.routes': false }] } },
+        config: { app: { extensions: [{ 'core.layout': false }] } },
       }),
     );
 
@@ -169,7 +163,7 @@ describe('createPlugin', () => {
         config: {
           app: {
             extensions: [
-              { 'core.routes': false },
+              { 'core.layout': false },
               {
                 'plugin.catalog.page': {
                   config: { name: 'CatalogRenamed' },

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -143,7 +143,7 @@ describe('createPlugin', () => {
     render(
       createTestAppRoot({
         plugins: [plugin],
-        config: { app: { extensions: [{ 'core.router': false }] } },
+        config: { app: { extensions: [{ 'core.routes': false }] } },
       }),
     );
 
@@ -169,7 +169,7 @@ describe('createPlugin', () => {
         config: {
           app: {
             extensions: [
-              { 'core.router': false },
+              { 'core.routes': false },
               {
                 'plugin.catalog.page': {
                   config: { name: 'CatalogRenamed' },

--- a/plugins/graphiql/alpha-api-report.md
+++ b/plugins/graphiql/alpha-api-report.md
@@ -12,6 +12,7 @@ import { PortableSchema } from '@backstage/frontend-plugin-api';
 export function createEndpointExtension<TConfig extends {}>(options: {
   id: string;
   configSchema?: PortableSchema<TConfig>;
+  disabled?: boolean;
   factory: (options: { config: TConfig }) => {
     endpoint: GraphQLEndpoint;
   };

--- a/plugins/graphiql/src/alpha.tsx
+++ b/plugins/graphiql/src/alpha.tsx
@@ -65,13 +65,14 @@ export const graphiqlBrowseApi = createApiExtension({
 export function createEndpointExtension<TConfig extends {}>(options: {
   id: string;
   configSchema?: PortableSchema<TConfig>;
+  disabled?: boolean;
   factory: (options: { config: TConfig }) => { endpoint: GraphQLEndpoint };
 }) {
   return createExtension({
     id: `apis.plugin.graphiql.browse.${options.id}`,
     at: 'apis.plugin.graphiql.browse/endpoints',
     configSchema: options.configSchema,
-    disabled: true,
+    disabled: options.disabled ?? false,
     output: {
       endpoint: endpointDataRef,
     },
@@ -86,6 +87,7 @@ export function createEndpointExtension<TConfig extends {}>(options: {
 /** @alpha */
 const gitlabGraphiQLBrowseExtension = createEndpointExtension({
   id: 'gitlab',
+  disabled: true,
   configSchema: createSchemaFromZod(z =>
     z
       .object({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4339,6 +4339,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/frontend-app-api": "workspace:^"
+    "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -4317,6 +4317,7 @@ __metadata:
   dependencies:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/core-app-api": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-graphiql": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4318,10 +4318,12 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/core-app-api": "workspace:^"
+    "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-graphiql": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@material-ui/core": ^4.12.4
     "@testing-library/jest-dom": ^5.10.1
     lodash: ^4.17.21
   peerDependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #19545, this implements a lot of the context providers and functionality from [AppManager](https://github.com/backstage/backstage/blob/master/packages/core-app-api/src/app/AppManager.tsx).

We also add support for discovery APIs, as well as restructured the app a bit to make space for an initial sidebar implementation.

Skipping changesets for all but core-app-api, since it's all pending work

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
