### PR TITLE
Add support for importing ESM packages into node modules

### DIFF
--- a/.changeset/cold-coins-speak.md
+++ b/.changeset/cold-coins-speak.md
@@ -1,0 +1,23 @@
+---
+'@backstage/cli': patch
+'@backstage/app-defaults': patch
+'@backstage/catalog-client': patch
+'@backstage/catalog-model': patch
+'@backstage/config': patch
+'@backstage/core-app-api': patch
+'@backstage/core-components': patch
+'@backstage/core-plugin-api': patch
+'@backstage/dev-utils': patch
+'@backstage/errors': patch
+'@backstage/frontend-app-api': patch
+'@backstage/frontend-plugin-api': patch
+'@backstage/integration': patch
+'@backstage/integration-react': patch
+'@backstage/release-manifests': patch
+'@backstage/test-utils': patch
+'@backstage/theme': patch
+'@backstage/types': patch
+'@backstage/version-bridge': patch
+---
+
+Support esm in node

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -95,8 +95,8 @@ export async function makeRollupConfigs(
     if (options.outputs.has(Output.esm)) {
       output.push({
         dir: distDir,
-        entryFileNames: `[name].esm.js`,
-        chunkFileNames: `esm/[name]-[hash].esm.js`,
+        entryFileNames: `[name].mjs`,
+        chunkFileNames: `esm/[name]-[hash].mjs`,
         format: 'module',
         sourcemap: true,
       });

--- a/packages/cli/src/lib/packager/productionPack.ts
+++ b/packages/cli/src/lib/packager/productionPack.ts
@@ -167,7 +167,7 @@ async function writeReleaseStageEntrypoint(
 }
 
 const EXPORT_MAP = {
-  import: '.esm.js',
+  import: '.mjs',
   require: '.cjs.js',
   types: '.d.ts',
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Renamed esm.js files to mjs. This will allow node modules to import the packages.

Fixes issue https://github.com/backstage/backstage/issues/19854

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
