### PR TITLE
Restore functionality to OwnedEntityPicker

### DIFF
--- a/.changeset/grumpy-bikes-beg.md
+++ b/.changeset/grumpy-bikes-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Restored functionality to OwnedEntityPicker by converting deprecated ui:options input to catalogFilter

--- a/.changeset/grumpy-bikes-beg.md
+++ b/.changeset/grumpy-bikes-beg.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Restored functionality to OwnedEntityPicker by converting deprecated ui:options input to catalogFilter
+Restored functionality to `OwnedEntityPicker` by converting deprecated `ui:options` input to `catalogFilter`.

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -241,6 +241,24 @@ export const OwnedEntityPickerFieldExtension: FieldExtensionComponent_2<
     defaultKind?: string | undefined;
     allowArbitraryValues?: boolean | undefined;
     defaultNamespace?: string | false | undefined;
+    catalogFilter?:
+      | Record<
+          string,
+          | string
+          | string[]
+          | {
+              exists?: boolean | undefined;
+            }
+        >
+      | Record<
+          string,
+          | string
+          | string[]
+          | {
+              exists?: boolean | undefined;
+            }
+        >[]
+      | undefined;
   }
 >;
 
@@ -252,6 +270,24 @@ export const OwnedEntityPickerFieldSchema: FieldSchema<
     defaultKind?: string | undefined;
     allowArbitraryValues?: boolean | undefined;
     defaultNamespace?: string | false | undefined;
+    catalogFilter?:
+      | Record<
+          string,
+          | string
+          | string[]
+          | {
+              exists?: boolean | undefined;
+            }
+        >
+      | Record<
+          string,
+          | string
+          | string[]
+          | {
+              exists?: boolean | undefined;
+            }
+        >[]
+      | undefined;
   }
 >;
 

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/schema.ts
@@ -15,6 +15,7 @@
  */
 import { z } from 'zod';
 import { makeFieldSchemaFromZod } from '../utils';
+import { entityQueryFilterExpressionSchema } from '../EntityPicker/schema';
 
 /**
  * @public
@@ -25,7 +26,9 @@ export const OwnedEntityPickerFieldSchema = makeFieldSchemaFromZod(
     allowedKinds: z
       .array(z.string())
       .optional()
-      .describe('List of kinds of entities to derive options from'),
+      .describe(
+        'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from',
+      ),
     defaultKind: z
       .string()
       .optional()
@@ -42,6 +45,11 @@ export const OwnedEntityPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'The default namespace. Options with this namespace will not be prefixed.',
       ),
+    catalogFilter: z
+      .array(entityQueryFilterExpressionSchema)
+      .or(entityQueryFilterExpressionSchema)
+      .optional()
+      .describe('List of key-value filter expression for entities'),
   }),
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

```OwnedEntityPicker``` currently does NOT work. The additional ```catalogFilter``` built by the parent ```OwnedEntityPicker``` is not respected by the child ```EntityPicker```

I have updated ```OwnedEntityPicker``` to pass an updated ```uiSchema``` to the child ```EntityPicker``` which:
1. Allows passthrough of ```catalogFilter``` from parent ```OwnerEntityPicker``` to child ```EntityPicker```
2. Appends additional ```RELATION_OWNED_BY``` filter to ```catalogFilter```
3. Converts deprecated ```allowKinds``` to ```catalogFilter.kinds``` maintaining backwards-compatibility.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
