### PR TITLE
chore: add kind column by default to TechDocsTable

### DIFF
--- a/.changeset/stupid-drinks-trade.md
+++ b/.changeset/stupid-drinks-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add kind column by default to TechDocsTable

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -79,6 +79,7 @@ export const DocsTable: {
   columns: {
     createNameColumn(): TableColumn<DocsTableRow>;
     createOwnerColumn(): TableColumn<DocsTableRow>;
+    createKindColumn(): TableColumn<DocsTableRow>;
     createTypeColumn(): TableColumn<DocsTableRow>;
   };
   actions: {
@@ -142,6 +143,7 @@ export const EntityListDocsTable: {
   columns: {
     createNameColumn(): TableColumn<DocsTableRow>;
     createOwnerColumn(): TableColumn<DocsTableRow>;
+    createKindColumn(): TableColumn<DocsTableRow>;
     createTypeColumn(): TableColumn<DocsTableRow>;
   };
   actions: {

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -17,16 +17,16 @@
 import React from 'react';
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard';
 
-import { useRouteRef, useApi, configApiRef } from '@backstage/core-plugin-api';
+import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
 import {
-  humanizeEntityRef,
   getEntityRelations,
+  humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
 import { rootDocsRouteRef } from '../../../routes';
 import {
-  LinkButton,
   EmptyState,
+  LinkButton,
   Table,
   TableColumn,
   TableOptions,
@@ -87,6 +87,7 @@ export const DocsTable = (props: DocsTableProps) => {
   const defaultColumns: TableColumn<DocsTableRow>[] = [
     columnFactories.createNameColumn(),
     columnFactories.createOwnerColumn(),
+    columnFactories.createKindColumn(),
     columnFactories.createTypeColumn(),
   ];
 

--- a/plugins/techdocs/src/home/components/Tables/columns.tsx
+++ b/plugins/techdocs/src/home/components/Tables/columns.tsx
@@ -57,6 +57,12 @@ export const columnFactories = {
       ),
     };
   },
+  createKindColumn(): TableColumn<DocsTableRow> {
+    return {
+      title: 'Kind',
+      field: 'entity.kind',
+    };
+  },
   createTypeColumn(): TableColumn<DocsTableRow> {
     return {
       title: 'Type',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds kind column by default to TechDocsTable. Having only type makes it a bit useless.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
