### PR TITLE
Langeno/k8s plugin add table

### DIFF
--- a/.changeset/large-weeks-accept.md
+++ b/.changeset/large-weeks-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Added ID property to the table displaying kubernetes pods to avoid it beeing rerendered too often, which caused open sidebars to close.

--- a/.changeset/large-weeks-accept.md
+++ b/.changeset/large-weeks-accept.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes': patch
 ---
 
-Added ID property to the table displaying kubernetes pods to avoid it beeing rerendered too often, which caused open sidebars to close.
+Added ID property to the table displaying kubernetes pods to avoid it rerendering too often, which caused open sidebars to close.

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -126,6 +126,11 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
   const cluster = useContext(ClusterContext);
   const defaultColumns: TableColumn<Pod>[] = [
     {
+      title: 'ID',
+      field: 'id',
+      hidden: true,
+    },
+    {
       title: 'name',
       highlight: true,
       render: (pod: Pod) => {
@@ -176,7 +181,12 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
     <div style={tableStyle}>
       <Table
         options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
-        data={pods as Pod[]}
+        // Unique ID is added to avoid the table refreshing on every render and closing e.g. open sidebars
+        // This does not get rid of the error in the browser console though, which must be investigated separetley
+        data={(pods as Pod[])?.map((pod: Pod) => ({
+          ...pod,
+          id: pod?.metadata?.uid,
+        }))}
         columns={columns}
       />
     </div>

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -125,9 +125,12 @@ const Memory = ({ clusterName, pod }: { clusterName: string; pod: Pod }) => {
 export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
   const cluster = useContext(ClusterContext);
   const defaultColumns: TableColumn<Pod>[] = [
+    // It was observed in some instances that the pod "sideboard" closes randomly, likely due to table reloads.
+    // This ID field should hopefully fix this, however the problem e.g. was not observed in the example app.
+    // So worst case the issues resides elsewhere.
     {
       title: 'ID',
-      field: 'id',
+      field: 'metadata.uid',
       hidden: true,
     },
     {
@@ -183,10 +186,7 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
         options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
         // Unique ID is added to avoid the table refreshing on every render and closing e.g. open sidebars
         // This does not get rid of the error in the browser console though, which must be investigated separetley
-        data={(pods as Pod[])?.map((pod: Pod) => ({
-          ...pod,
-          id: pod?.metadata?.uid,
-        }))}
+        data={pods as Pod[]}
         columns={columns}
       />
     </div>

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -184,8 +184,6 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
     <div style={tableStyle}>
       <Table
         options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
-        // Unique ID is added to avoid the table refreshing on every render and closing e.g. open sidebars
-        // This does not get rid of the error in the browser console though, which must be investigated separetley
         data={pods as Pod[]}
         columns={columns}
       />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

See https://github.com/backstage/backstage/issues/18471#issuecomment-1704292855.
This hopefully fixes said bug by adding an ID property to the Pods table.

Please cross-check this change if possible, as e.g. the warning mentioned in the bug still appear in the browser console.
However local tests have shown that the sidebar does not close anymore.

However tests had to be done with our local backstage setup, as I needed a working k8s cluster to connect to.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation -> Changes are so minimal I see no need for this
- [x] Tests for new functionality and regression tests for bug fixes -> I have no clue how to write a good regression test for this. Any hints welcome, I am willing to add one.
- [x] Screenshots attached (for UI changes) -> UI did not change.
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
