### PR TITLE
feat(catalog): include owner in search result item

### DIFF
--- a/.changeset/lemon-cups-wait.md
+++ b/.changeset/lemon-cups-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+include owner chip in catalog search result item

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -110,6 +110,9 @@ export function CatalogSearchResultListItem(
           {result.lifecycle && (
             <Chip label={`Lifecycle: ${result.lifecycle}`} size="small" />
           )}
+          {result.owner && (
+            <Chip label={`Owner: ${result.owner}`} size="small" />
+          )}
         </Box>
       </div>
     </div>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Having the `owner` of a catalog entity quickly available in the search modal, etc. is quite useful for quick lookups.

<img width="870" alt="image" src="https://github.com/backstage/backstage/assets/6507159/8714f541-0a0e-4465-af6d-f6db39d90d83">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
