### PR TITLE
switch to TypeScript 5.0 + 5.2 in create-app

### DIFF
--- a/.changeset/cold-pillows-glow.md
+++ b/.changeset/cold-pillows-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Switched the template to use TypeScript 5.2 by default.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "semver": "^7.5.3",
     "shx": "^0.3.2",
     "ts-node": "^10.4.0",
-    "typescript": "~4.9.0"
+    "typescript": "~5.0.0"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -36,7 +36,7 @@
     "lerna": "^4.0.0",
     "node-gyp": "^9.0.0",
     "prettier": "^2.3.2",
-    "typescript": "~5.0.0"
+    "typescript": "~5.2.0"
   },
   "resolutions": {
     "@types/react": "^17",

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -53,7 +53,7 @@ export const coreExtensionData: {
   reactElement: ConfigurableExtensionDataRef<JSX_2.Element, {}>;
   routePath: ConfigurableExtensionDataRef<string, {}>;
   apiFactory: ConfigurableExtensionDataRef<AnyApiFactory, {}>;
-  routeRef: ConfigurableExtensionDataRef<RouteRef<any>, {}>;
+  routeRef: ConfigurableExtensionDataRef<RouteRef, {}>;
   navTarget: ConfigurableExtensionDataRef<NavTarget, {}>;
 };
 

--- a/plugins/catalog-backend/alpha-api-report.md
+++ b/plugins/catalog-backend/alpha-api-report.md
@@ -80,9 +80,7 @@ export default catalogPlugin;
 // @alpha
 export const createCatalogConditionalDecision: (
   permission: ResourcePermission<'catalog-entity'>,
-  conditions: PermissionCriteria<
-    PermissionCondition<'catalog-entity', PermissionRuleParams>
-  >,
+  conditions: PermissionCriteria<PermissionCondition<'catalog-entity'>>,
 ) => ConditionalPolicyDecision;
 
 // @alpha

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -75,17 +75,14 @@ export type ConditionTransformer<TQuery> = (
 
 // @public
 export const createConditionAuthorizer: <TResource, TQuery>(
-  rules: PermissionRule<TResource, TQuery, string, PermissionRuleParams>[],
+  rules: PermissionRule<TResource, TQuery, string>[],
 ) => (decision: PolicyDecision, resource: TResource | undefined) => boolean;
 
 // @public
 export const createConditionExports: <
   TResourceType extends string,
   TResource,
-  TRules extends Record<
-    string,
-    PermissionRule<TResource, any, TResourceType, PermissionRuleParams>
-  >,
+  TRules extends Record<string, PermissionRule<TResource, any, TResourceType>>,
 >(options: {
   pluginId: string;
   resourceType: TResourceType;
@@ -94,9 +91,7 @@ export const createConditionExports: <
   conditions: Conditions<TRules>;
   createConditionalDecision: (
     permission: ResourcePermission<TResourceType>,
-    conditions: PermissionCriteria<
-      PermissionCondition<TResourceType, PermissionRuleParams>
-    >,
+    conditions: PermissionCriteria<PermissionCondition<TResourceType>>,
   ) => ConditionalPolicyDecision;
 };
 
@@ -111,7 +106,7 @@ export const createConditionFactory: <
 // @public
 export const createConditionTransformer: <
   TQuery,
-  TRules extends PermissionRule<any, TQuery, string, PermissionRuleParams>[],
+  TRules extends PermissionRule<any, TQuery, string>[],
 >(
   permissionRules: [...TRules],
 ) => ConditionTransformer<TQuery>;

--- a/plugins/playlist-backend/api-report.md
+++ b/plugins/playlist-backend/api-report.md
@@ -15,7 +15,6 @@ import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionPolicy } from '@backstage/plugin-permission-node';
 import { PermissionRule } from '@backstage/plugin-permission-node';
-import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaylistMetadata } from '@backstage/plugin-playlist-common';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -26,9 +25,7 @@ import { ResourcePermission } from '@backstage/plugin-permission-common';
 // @public (undocumented)
 export const createPlaylistConditionalDecision: (
   permission: ResourcePermission<'playlist-list'>,
-  conditions: PermissionCriteria<
-    PermissionCondition<'playlist-list', PermissionRuleParams>
-  >,
+  conditions: PermissionCriteria<PermissionCondition<'playlist-list'>>,
 ) => ConditionalPolicyDecision;
 
 // @public (undocumented)

--- a/plugins/scaffolder-backend/alpha-api-report.md
+++ b/plugins/scaffolder-backend/alpha-api-report.md
@@ -10,7 +10,6 @@ import { JsonObject } from '@backstage/types';
 import { PermissionCondition } from '@backstage/plugin-permission-common';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
-import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { TemplateEntityStepV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
@@ -18,17 +17,13 @@ import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
 // @alpha (undocumented)
 export const createScaffolderActionConditionalDecision: (
   permission: ResourcePermission<'scaffolder-action'>,
-  conditions: PermissionCriteria<
-    PermissionCondition<'scaffolder-action', PermissionRuleParams>
-  >,
+  conditions: PermissionCriteria<PermissionCondition<'scaffolder-action'>>,
 ) => ConditionalPolicyDecision;
 
 // @alpha
 export const createScaffolderTemplateConditionalDecision: (
   permission: ResourcePermission<'scaffolder-template'>,
-  conditions: PermissionCriteria<
-    PermissionCondition<'scaffolder-template', PermissionRuleParams>
-  >,
+  conditions: PermissionCriteria<PermissionCondition<'scaffolder-template'>>,
 ) => ConditionalPolicyDecision;
 
 // @alpha

--- a/plugins/scaffolder-node/src/actions/createTemplateAction.ts
+++ b/plugins/scaffolder-node/src/actions/createTemplateAction.ts
@@ -90,8 +90,8 @@ export const createTemplateAction = <
     ...action,
     schema: {
       ...action.schema,
-      input: inputSchema,
-      output: outputSchema,
+      input: inputSchema as TInputSchema,
+      output: outputSchema as TOutputSchema,
     },
   };
 };

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -326,7 +326,7 @@ export type TemplateParameterSchema = {
 
 // @public
 export const useCustomFieldExtensions: <
-  TComponentDataType = FieldExtensionOptions<unknown, unknown>,
+  TComponentDataType = FieldExtensionOptions,
 >(
   outlet: React.ReactNode,
 ) => TComponentDataType[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -38858,7 +38858,7 @@ __metadata:
     semver: ^7.5.3
     shx: ^0.3.2
     ts-node: ^10.4.0
-    typescript: ~4.9.0
+    typescript: ~5.0.0
   languageName: unknown
   linkType: soft
 
@@ -41839,17 +41839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.9.0":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~5.0.4":
+"typescript@npm:~5.0.0, typescript@npm:~5.0.4":
   version: 5.0.4
   resolution: "typescript@npm:5.0.4"
   bin:
@@ -41869,17 +41859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.9.0#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=a1c5e5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@~5.0.0#~builtin<compat/typescript>, typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
   resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=a1c5e5"
   bin:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since TypeScript 5.2 is out we can now switch to requiring TypeScript 5.0, in accordance to our [TypeScript versioning policy](https://backstage.io/docs/overview/versioning-policy#typescript-releases).

I'm also thinking we try out having create-app use the most recent TypeScript version by default in order to test both ends of the version range. If that turns into too much trouble I'll skip that change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
