### PR TITLE
Allow using FetchApi in graphiql api setup

### DIFF
--- a/.changeset/chilled-beds-exist.md
+++ b/.changeset/chilled-beds-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphiql': patch
+---
+
+Add support for using the FetchApi

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -33,6 +33,7 @@ import {
   createApiFactory,
   discoveryApiRef,
   errorApiRef,
+  fetchApiRef,
   githubAuthApiRef,
 } from '@backstage/core-plugin-api';
 import { AuthProxyDiscoveryApi } from './AuthProxyDiscoveryApi';
@@ -53,18 +54,24 @@ export const apis: AnyApiFactory[] = [
 
   createApiFactory({
     api: graphQlBrowseApiRef,
-    deps: { errorApi: errorApiRef, githubAuthApi: githubAuthApiRef },
-    factory: ({ errorApi, githubAuthApi }) =>
+    deps: {
+      errorApi: errorApiRef,
+      fetchApi: fetchApiRef,
+      githubAuthApi: githubAuthApiRef,
+    },
+    factory: ({ errorApi, fetchApi, githubAuthApi }) =>
       GraphQLEndpoints.from([
         GraphQLEndpoints.create({
           id: 'gitlab',
           title: 'GitLab',
           url: 'https://gitlab.com/api/graphql',
+          fetchApi,
         }),
         GraphQLEndpoints.github({
           id: 'github',
           title: 'GitHub',
           errorApi,
+          fetchApi,
           githubAuthApi,
         }),
       ]),

--- a/plugins/graphiql/api-report.md
+++ b/plugins/graphiql/api-report.md
@@ -8,6 +8,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ErrorApi } from '@backstage/core-plugin-api';
+import { FetchApi } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { OAuthApi } from '@backstage/core-plugin-api';
@@ -23,6 +24,7 @@ export type EndpointConfig = {
   headers?: {
     [name in string]: string;
   };
+  fetchApi?: FetchApi;
 };
 
 // @public (undocumented)
@@ -31,6 +33,7 @@ export type GithubEndpointConfig = {
   title: string;
   url?: string;
   errorApi?: ErrorApi;
+  fetchApi?: FetchApi;
   githubAuthApi: OAuthApi;
 };
 


### PR DESCRIPTION
## FetchApi in GraphiQL

This PR adds support for providing the FetchApi to `GraphQLEndpoints.create()` so that setting up GraphiQL endpoints is static and simple, but allow GraphiQL to use the FetchApi so one can inject e.g. `Authorization` headers and whatnot.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
