### PR TITLE
Added TextEncoder to setupTests

### DIFF
--- a/.changeset/brown-rivers-explode.md
+++ b/.changeset/brown-rivers-explode.md
@@ -1,0 +1,13 @@
+---
+'@backstage/create-app': patch
+---
+
+Added setting the global `TextEncoder` to `setupTests.ts` to get the `App.test.tsx` test to pass when using the Kubernetes plugin. For those who have an existing Backstage instance just add the following to your to `setupTests.ts` file:
+
+```ts
+// Do not remove, patching jsdom environment to support TextEncoder, refer to https://github.com/jsdom/jsdom/issues/2524
+// eslint-disable-next-line no-restricted-imports
+import { TextEncoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+```

--- a/packages/create-app/templates/default-app/packages/app/src/setupTests.ts
+++ b/packages/create-app/templates/default-app/packages/app/src/setupTests.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+
+// Do not remove, patching jsdom environment to support TextEncoder, refer to https://github.com/jsdom/jsdom/issues/2524
+// eslint-disable-next-line no-restricted-imports
+import { TextEncoder } from 'util';
+
+global.TextEncoder = TextEncoder;

--- a/plugins/kubernetes/CHANGELOG.md
+++ b/plugins/kubernetes/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 ### Patch Changes
 
-- 7032c214f3b4: Add pod exec terminal to Container Card
+- 7032c214f3b4: Add pod exec terminal to Container Card, as part of this change you will also want to add the following to your `/packages/app/src/setupTests.ts` to get your `App.test.tsx` test to pass:
+
+  ```ts
+  // Do not remove, patching jsdom environment to support TextEncoder, refer to https://github.com/jsdom/jsdom/issues/2524
+  // eslint-disable-next-line no-restricted-imports
+  import { TextEncoder } from 'util';
+
+  global.TextEncoder = TextEncoder;
+  ```
+
 - 406b786a2a2c: Mark package as being free of side effects, allowing more optimized Webpack builds.
 - Updated dependencies
   - @backstage/catalog-model@1.4.2-next.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added setting the global `TextEncoder` to `setupTests.ts` to get the `App.test.tsx` test to pass when using the Kubernetes plugin. For those who have an existing Backstage instance just add the following to your to `setupTests.ts` file:

```ts
// Do not remove, patching jsdom environment to support TextEncoder, refer to https://github.com/jsdom/jsdom/issues/2524
// eslint-disable-next-line no-restricted-imports
import { TextEncoder } from 'util';

global.TextEncoder = TextEncoder;
```

I've also update the `CHANGELOG.md` for the Kubernetes plugin to include this information.

This addresses https://github.com/backstage/backstage/issues/19925

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
