### PR TITLE
feat: allow custom sort order for entity pickers

### DIFF
--- a/.changeset/giant-apples-try.md
+++ b/.changeset/giant-apples-try.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Allow customizing sort order of entity pickers
+
+In some cases, for example the lifecycle, the order of
+the options should be according to the actual lifecycle
+instead alphabetical. This functionality was also expanded
+to other entity picker components so app developers can
+sort tags and namespaces as they like.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -172,6 +172,7 @@ export type EntityAutocompletePickerProps<
   };
   InputProps?: TextFieldProps;
   initialSelectedOptions?: string[];
+  optionsSortFn?: (option1: string, option2: string) => number;
 };
 
 // @public
@@ -230,9 +231,15 @@ export class EntityLifecycleFilter implements EntityFilter {
 }
 
 // @public (undocumented)
-export const EntityLifecyclePicker: (props: {
+export const EntityLifecyclePicker: (
+  props: EntityLifecyclePickerProps,
+) => React_2.JSX.Element;
+
+// @public (undocumented)
+export type EntityLifecyclePickerProps = {
   initialFilter?: string[];
-}) => React_2.JSX.Element;
+  optionsSortFn?: (option1: string, option2: string) => number;
+};
 
 // @public
 export const EntityListContext: React_2.Context<
@@ -281,7 +288,14 @@ export class EntityNamespaceFilter implements EntityFilter {
 }
 
 // @public (undocumented)
-export const EntityNamespacePicker: () => React_2.JSX.Element;
+export const EntityNamespacePicker: (
+  props: EntityNamespacePickerProps,
+) => React_2.JSX.Element;
+
+// @public (undocumented)
+export type EntityNamespacePickerProps = {
+  optionsSortFn?: (option1: string, option2: string) => number;
+};
 
 // @public
 export class EntityOrphanFilter implements EntityFilter {
@@ -460,6 +474,7 @@ export const EntityTagPicker: (
 // @public (undocumented)
 export type EntityTagPickerProps = {
   showCounts?: boolean;
+  optionsSortFn?: (option1: string, option2: string) => number;
 };
 
 // @public

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, render, waitFor, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
 import { EntityAutocompletePicker } from './EntityAutocompletePicker';
@@ -101,6 +101,39 @@ describe('<EntityAutocompletePicker/>', () => {
       'option2',
       'option3',
       'option4',
+    ]);
+  });
+
+  it('renders unique options in custom order', async () => {
+    render(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityAutocompletePicker<EntityFilters>
+            label="Options"
+            path="spec.options"
+            name="options"
+            Filter={EntityOptionFilter}
+            optionsSortFn={(a: string, b: string) => {
+              if (a === b) return 0;
+              if (a === 'option1') return 1;
+              if (b === 'option1') return -1;
+              return a < b ? -1 : 1;
+            }}
+          />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Options')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId('options-picker-expand'));
+
+    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
+      'option2',
+      'option3',
+      'option4',
+      'option1',
     ]);
   });
 

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -50,6 +50,7 @@ export type EntityAutocompletePickerProps<
   Filter: { new (values: string[]): NonNullable<T[Name]> };
   InputProps?: TextFieldProps;
   initialSelectedOptions?: string[];
+  optionsSortFn?: (option1: string, option2: string) => number;
 };
 
 /** @public */
@@ -65,6 +66,7 @@ export function EntityAutocompletePicker<
     Filter,
     InputProps,
     initialSelectedOptions = [],
+    optionsSortFn,
   } = props;
 
   const {
@@ -106,7 +108,9 @@ export function EntityAutocompletePicker<
     }
   }, [queryParameters]);
 
-  const availableOptions = Object.keys(availableValues ?? {});
+  const availableOptions = Object.keys(availableValues ?? {}).sort(
+    optionsSortFn,
+  );
   const shouldAddFilter = selectedOptions.length && availableOptions.length;
 
   useEffect(() => {

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -32,8 +32,14 @@ const useStyles = makeStyles(
 );
 
 /** @public */
-export const EntityLifecyclePicker = (props: { initialFilter?: string[] }) => {
-  const { initialFilter = [] } = props;
+export type EntityLifecyclePickerProps = {
+  initialFilter?: string[];
+  optionsSortFn?: (option1: string, option2: string) => number;
+};
+
+/** @public */
+export const EntityLifecyclePicker = (props: EntityLifecyclePickerProps) => {
+  const { initialFilter = [], optionsSortFn } = props;
   const classes = useStyles();
 
   return (
@@ -44,6 +50,7 @@ export const EntityLifecyclePicker = (props: { initialFilter?: string[] }) => {
       Filter={EntityLifecycleFilter}
       InputProps={{ className: classes.input }}
       initialSelectedOptions={initialFilter}
+      optionsSortFn={optionsSortFn}
     />
   );
 };

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EntityLifecyclePicker } from './EntityLifecyclePicker';
-export type { CatalogReactEntityLifecyclePickerClassKey } from './EntityLifecyclePicker';
+export type {
+  CatalogReactEntityLifecyclePickerClassKey,
+  EntityLifecyclePickerProps,
+} from './EntityLifecyclePicker';

--- a/plugins/catalog-react/src/components/EntityNamespacePicker/EntityNamespacePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityNamespacePicker/EntityNamespacePicker.test.tsx
@@ -76,6 +76,34 @@ describe('<EntityNamespacePicker/>', () => {
     ]);
   });
 
+  it('renders unique namespaces in custom order', async () => {
+    render(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiRef]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityNamespacePicker
+            optionsSortFn={(a: string, b: string) => {
+              if (a === b) return 0;
+              if (a === 'namespace-1') return 1;
+              if (b === 'namespace-1') return -1;
+              return a < b ? -1 : 1;
+            }}
+          />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Namespace')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId('namespace-picker-expand'));
+
+    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
+      'namespace-2',
+      'namespace-3',
+      'namespace-1',
+    ]);
+  });
+
   it('respects the query parameter filter value', async () => {
     const updateFilters = jest.fn();
     const queryParameters = { namespace: ['namespace-1'] };

--- a/plugins/catalog-react/src/components/EntityNamespacePicker/EntityNamespacePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityNamespacePicker/EntityNamespacePicker.tsx
@@ -33,7 +33,13 @@ const useStyles = makeStyles(
 );
 
 /** @public */
-export const EntityNamespacePicker = () => {
+export type EntityNamespacePickerProps = {
+  optionsSortFn?: (option1: string, option2: string) => number;
+};
+
+/** @public */
+export const EntityNamespacePicker = (props: EntityNamespacePickerProps) => {
+  const { optionsSortFn } = props;
   const classes = useStyles();
   return (
     <EntityAutocompletePicker
@@ -42,6 +48,7 @@ export const EntityNamespacePicker = () => {
       path="metadata.namespace"
       Filter={EntityNamespaceFilter}
       InputProps={{ className: classes.input }}
+      optionsSortFn={optionsSortFn}
     />
   );
 };

--- a/plugins/catalog-react/src/components/EntityNamespacePicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityNamespacePicker/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EntityNamespacePicker } from './EntityNamespacePicker';
-export type { CatalogReactEntityNamespacePickerClassKey } from './EntityNamespacePicker';
+export type {
+  CatalogReactEntityNamespacePickerClassKey,
+  EntityNamespacePickerProps,
+} from './EntityNamespacePicker';

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, render, waitFor, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
 import { EntityTagFilter } from '../../filters';
@@ -67,6 +67,33 @@ describe('<EntityTagPicker/>', () => {
       'tag2',
       'tag3',
       'tag4',
+    ]);
+  });
+
+  it('renders unique tags in custom order', async () => {
+    render(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiRef]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityTagPicker
+            optionsSortFn={(a: string, b: string) => {
+              if (a === b) return 0;
+              if (a === 'tag1') return 1;
+              if (b === 'tag1') return -1;
+              return a < b ? -1 : 1;
+            }}
+          />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() => expect(screen.getByText('Tags')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('tags-picker-expand'));
+
+    expect(screen.getAllByRole('option').map(o => o.textContent)).toEqual([
+      'tag2',
+      'tag3',
+      'tag4',
+      'tag1',
     ]);
   });
 

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -25,6 +25,7 @@ export type CatalogReactEntityTagPickerClassKey = 'input';
 /** @public */
 export type EntityTagPickerProps = {
   showCounts?: boolean;
+  optionsSortFn?: (option1: string, option2: string) => number;
 };
 
 const useStyles = makeStyles(
@@ -34,6 +35,7 @@ const useStyles = makeStyles(
 
 /** @public */
 export const EntityTagPicker = (props: EntityTagPickerProps) => {
+  const { showCounts, optionsSortFn } = props;
   const classes = useStyles();
 
   return (
@@ -42,8 +44,9 @@ export const EntityTagPicker = (props: EntityTagPickerProps) => {
       name="tags"
       path="metadata.tags"
       Filter={EntityTagFilter}
-      showCounts={props.showCounts}
+      showCounts={showCounts}
       InputProps={{ className: classes.input }}
+      optionsSortFn={optionsSortFn}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow customizing sort order of entity pickers

In some cases, for example the lifecycle, the order of
the options should be according to the actual lifecycle
instead alphabetical. This functionality was also expanded
to other entity picker components so app developers can
sort tags and namespaces as they like.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
