### PR TITLE
do not create duplicate db connection pools in the old backend

### DIFF
--- a/.changeset/angry-ghosts-brush.md
+++ b/.changeset/angry-ghosts-brush.md
@@ -1,0 +1,13 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated the backend template to no longer create duplicate connection pools to plugins that use the task scheduler.
+
+To apply this change in your own repository, perform the following small update:
+
+```diff
+// in packages/backend/src/index.ts
+-  const taskScheduler = TaskScheduler.fromConfig(config);
++  const taskScheduler = TaskScheduler.fromConfig(config, { databaseManager });
+```

--- a/.changeset/thin-ladybugs-lick.md
+++ b/.changeset/thin-ladybugs-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Minor internal refactor

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -56,13 +56,14 @@ export type DatabaseManagerOptions = {
 /**
  * Manages database connections for Backstage backend plugins.
  *
+ * @public
+ * @remarks
+ *
  * The database manager allows the user to set connection and client settings on
  * a per pluginId basis by defining a database config block under
  * `plugin.<pluginId>` in addition to top level defaults. Optionally, a user may
  * set `prefix` which is used to prefix generated database names if config is
  * not provided.
- *
- * @public
  */
 export class DatabaseManager {
   /**
@@ -105,17 +106,9 @@ export class DatabaseManager {
       pluginMetadata: PluginMetadataService;
     },
   ): PluginDatabaseManager {
-    const _this = this;
-
-    return {
-      getClient(): Promise<Knex> {
-        return _this.getDatabase(pluginId, deps);
-      },
-      migrations: {
-        skip: false,
-        ..._this.options?.migrations,
-      },
-    };
+    const getClient = () => this.getDatabase(pluginId, deps);
+    const migrations = { skip: false, ...this.options?.migrations };
+    return { getClient, migrations };
   }
 
   /**

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -93,7 +93,7 @@ function makeCreateEnv(config: Config) {
   });
   const databaseManager = DatabaseManager.fromConfig(config, { logger: root });
   const cacheManager = CacheManager.fromConfig(config);
-  const taskScheduler = TaskScheduler.fromConfig(config);
+  const taskScheduler = TaskScheduler.fromConfig(config, { databaseManager });
   const identity = DefaultIdentityClient.create({
     discovery,
   });

--- a/packages/create-app/templates/default-app/packages/backend/src/index.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/index.ts
@@ -39,7 +39,7 @@ function makeCreateEnv(config: Config) {
   const cacheManager = CacheManager.fromConfig(config);
   const databaseManager = DatabaseManager.fromConfig(config, { logger: root });
   const tokenManager = ServerTokenManager.noop();
-  const taskScheduler = TaskScheduler.fromConfig(config);
+  const taskScheduler = TaskScheduler.fromConfig(config, { databaseManager });
 
   const identity = DefaultIdentityClient.create({
     discovery,


### PR DESCRIPTION
Found this while looking into #19863.

Now, it can be argued over whether this is better or not. In the old code, the task scheduler made an extra connection pool no matter whether you wanted it to or not. And it was always one plainly based on `fromConfig`, not respecting any additional arguments given to the shared database manager such as custom loggers and whatnot. The one benefit of that is that the task management system won't compete over the same connection pool as the regular plugin. But I feel that the risks outweigh the benefits. The task scheduler isn't that aggressive anyway.