### PR TITLE
kubernetes: more lazy use of TextEncoder

### DIFF
--- a/.changeset/light-clocks-listen.md
+++ b/.changeset/light-clocks-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Avoid eager use of `TextEncoder` in order not to break tests.

--- a/plugins/kubernetes/src/components/PodExecTerminal/PodExecTerminal.test.tsx
+++ b/plugins/kubernetes/src/components/PodExecTerminal/PodExecTerminal.test.tsx
@@ -27,6 +27,8 @@ import React from 'react';
 import './matchMedia.mock';
 import { PodExecTerminal } from './PodExecTerminal';
 
+global.TextEncoder = require('util').TextEncoder;
+
 const textEncoder = new TextEncoder();
 
 describe('PodExecTerminal', () => {

--- a/plugins/kubernetes/src/components/PodExecTerminal/PodExecTerminalAttachAddon.ts
+++ b/plugins/kubernetes/src/components/PodExecTerminal/PodExecTerminalAttachAddon.ts
@@ -15,9 +15,9 @@
  */
 import { AttachAddon, IAttachOptions } from 'xterm-addon-attach';
 
-const textEncoder = new TextEncoder();
-
 export class PodExecTerminalAttachAddon extends AttachAddon {
+  #textEncoder = new TextEncoder();
+
   constructor(socket: WebSocket, options?: IAttachOptions) {
     super(socket, options);
 
@@ -30,7 +30,7 @@ export class PodExecTerminalAttachAddon extends AttachAddon {
         return;
       }
 
-      const buffer = Uint8Array.from([0, ...textEncoder.encode(data)]);
+      const buffer = Uint8Array.from([0, ...this.#textEncoder.encode(data)]);
 
       thisAddon._socket.send(buffer);
     };

--- a/plugins/kubernetes/src/setupTests.ts
+++ b/plugins/kubernetes/src/setupTests.ts
@@ -13,15 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';
-// eslint-disable-next-line no-restricted-imports
-import { TextDecoder, TextEncoder } from 'util';
-
-// These are missing from jest-node, so not available on global.
-Object.defineProperty(global, 'TextEncoder', {
-  value: TextEncoder,
-});
-
-Object.defineProperty(global, 'TextDecoder', {
-  value: TextDecoder,
-});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Yet another fix for #19925 🎉 😁 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
