### PR TITLE
Bump Docker base image from 'node:16-bullseye-slim' to 'node:18-bulls…

### DIFF
--- a/.changeset/small-pugs-build.md
+++ b/.changeset/small-pugs-build.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/create-app': patch
-'example-backend': patch
 ---
 
 Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build. This update aligns with the recent Github Actions update to Node 18x [#19563](https://github.com/backstage/backstage/pull/19563).

--- a/.changeset/small-pugs-build.md
+++ b/.changeset/small-pugs-build.md
@@ -2,4 +2,6 @@
 '@backstage/create-app': patch
 ---
 
-Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build. This update aligns with the recent Github Actions update to Node 18x [#19563](https://github.com/backstage/backstage/pull/19563).
+Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build.
+
+You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bullseye-slim`

--- a/.changeset/small-pugs-build.md
+++ b/.changeset/small-pugs-build.md
@@ -1,0 +1,6 @@
+---
+'@backstage/create-app': major
+'example-backend': major
+---
+
+- [#19974](https://github.com/backstage/backstage/issues/19974) Bump Docker base images to "node:18-bullseye-slim" in order to resolve compatiblity issue raised when running `yarn build-image` with Node.JS 16.x. This update follows the Docker CI update to Node 18x [#19563](https://github.com/backstage/backstage/pull/19563).

--- a/.changeset/small-pugs-build.md
+++ b/.changeset/small-pugs-build.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/create-app': major
-'example-backend': major
+'@backstage/create-app': patch
+'example-backend': patch
 ---
 
-- [#19974](https://github.com/backstage/backstage/issues/19974) Bump Docker base images to "node:18-bullseye-slim" in order to resolve compatiblity issue raised when running `yarn build-image` with Node.JS 16.x. This update follows the Docker CI update to Node 18x [#19563](https://github.com/backstage/backstage/pull/19563).
+Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build. This update aligns with the recent Github Actions update to Node 18x [#19563](https://github.com/backstage/backstage/pull/19563).

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -54,7 +54,7 @@ Once the host build is complete, we are ready to build our image. The following
 `Dockerfile` is included when creating a new app with `@backstage/create-app`:
 
 ```Dockerfile
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -160,7 +160,7 @@ the repo root:
 
 ```Dockerfile
 # Stage 1 - Create yarn install skeleton layer
-FROM node:16-bullseye-slim AS packages
+FROM node:18-bullseye-slim AS packages
 
 WORKDIR /app
 COPY package.json yarn.lock ./
@@ -173,7 +173,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM node:16-bullseye-slim AS build
+FROM node:18-bullseye-slim AS build
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -211,7 +211,7 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docs/local-dev/cli-build-system.md
+++ b/docs/local-dev/cli-build-system.md
@@ -418,7 +418,7 @@ The following is an example of a `Dockerfile` that can be used to package the
 output of building a package with role `'backend'` into an image:
 
 ```Dockerfile
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 WORKDIR /app
 
 COPY yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update Docker base image from `node:16-bullseye-slim` to `node:18-bullseye-slim` in to align to align with the node version recently update in the Github Action workflow. #19974

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
