### PR TITLE
Feat/add body size limit option to code coverage backend

### DIFF
--- a/.changeset/perfect-pumas-protect.md
+++ b/.changeset/perfect-pumas-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Added option to set body size limit

--- a/plugins/code-coverage-backend/README.md
+++ b/plugins/code-coverage-backend/README.md
@@ -235,3 +235,12 @@ Example
   ]
 }
 ```
+
+### Configuration
+
+Configure the plugin in your `app-config.yaml`:
+
+```yaml
+codeCoverage:
+  bodySizeLimit: 100kb # Defaults to 100kb, see https://www.npmjs.com/package/body-parser#limit
+```

--- a/plugins/code-coverage-backend/src/service/router.ts
+++ b/plugins/code-coverage-backend/src/service/router.ts
@@ -64,10 +64,21 @@ export const makeRouter = async (
     options.catalogApi ?? new CatalogClient({ discoveryApi: discovery });
   const scm = ScmIntegrations.fromConfig(config);
 
+  const bodySizeLimit =
+    config.getOptionalString('codeCoverage.bodySizeLimit') ?? '100kb';
+
   bodyParserXml(BodyParser);
   const router = Router();
-  router.use(BodyParser.xml());
-  router.use(BodyParser.text());
+  router.use(
+    BodyParser.xml({
+      limit: bodySizeLimit,
+    }),
+  );
+  router.use(
+    BodyParser.text({
+      limit: bodySizeLimit,
+    }),
+  );
   router.use(express.json());
 
   const utils = new CoverageUtils(scm, urlReader);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The _code-coverage-backend_-plugin currently only supports sending reports up to 100kb in size, this PR adds a configuration option to override this setting.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
