### PR TITLE
backend-common: added DB creation retries and lowered pool limits

### DIFF
--- a/.changeset/sour-rules-press.md
+++ b/.changeset/sour-rules-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added retries for initial database creation, as well as set minimum connection pool size for the database creation client to 0 and lowered the connection acquisition timeout.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Having dug into the DB creation errors quite deeply I'm still not sure why the actual failures in #19299 and #19863 happen. But especially for CI I've observed a few things:

- The client used for creating the DB is separate from the one used for the rest of the connections and is not affected by config, so setting pool sizes and acquisition timeouts in config has no effect on this initial client.
- When hitting the connection limit on the PostgreSQL end you get a very different error message than the one we're seeing. This means that it's likely not related to either pool or connection limit starvation.
- When tests fail because due to the acquisition timeout, it's extremely local. I tends to be just a single test in the suite, and the rest of them succeed.
- Adding logging to the tests before the DB creation may fix the issue, meaning this might be some sort of race.

@freben also found that the default minimum pool size is 2, which we should lower to 0 for the initial creation to avoid creating extra connections.

The idea with this change is that the acquisition of the initial connection and creation of the DB should be a very fast operation. If it isn't then something likely stuck and we should simply try again with a reasonably short timeout.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
