### PR TITLE
serialize test db shutdown

### DIFF
--- a/.changeset/silver-bananas-kick.md
+++ b/.changeset/silver-bananas-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Serialize test database shutdown, and add logging


### PR DESCRIPTION
Also try to contain the fake timers of the `FactRetrieverEngine` test.

This is part of the hunt for the cause of https://github.com/backstage/backstage/issues/19299 and https://github.com/backstage/backstage/issues/19863