### PR TITLE
TechInsight plugin - Export ScorecardInfo and ScorecardsList Components

### DIFF
--- a/.changeset/twenty-bags-sin.md
+++ b/.changeset/twenty-bags-sin.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-insights': patch
 ---
 
-Export ScorecardInfo and ScorecardsList Components to be able to use manually queried CheckResults directly.
+Export `ScorecardInfo` and `ScorecardsList` components to be able to use manually queried check results directly.

--- a/.changeset/twenty-bags-sin.md
+++ b/.changeset/twenty-bags-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Export ScorecardInfo and ScorecardsList Components to be able to use manually queried CheckResults directly.

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -68,6 +68,18 @@ export interface InsightFacts {
 // @public
 export const jsonRulesEngineCheckResultRenderer: CheckResultRenderer;
 
+// @public (undocumented)
+export const ScorecardInfo: (props: {
+  checkResults: CheckResult[];
+  title: string;
+  description?: string | undefined;
+}) => JSX_2.Element;
+
+// @public (undocumented)
+export const ScorecardsList: (props: {
+  checkResults: CheckResult[];
+}) => JSX_2.Element;
+
 // @public
 export interface TechInsightsApi {
   // (undocumented)

--- a/plugins/tech-insights/src/index.ts
+++ b/plugins/tech-insights/src/index.ts
@@ -17,6 +17,8 @@ export {
   techInsightsPlugin,
   EntityTechInsightsScorecardContent,
   EntityTechInsightsScorecardCard,
+  ScorecardInfo,
+  ScorecardsList,
 } from './plugin';
 
 export { techInsightsApiRef, TechInsightsClient } from './api';

--- a/plugins/tech-insights/src/plugin.ts
+++ b/plugins/tech-insights/src/plugin.ts
@@ -45,6 +45,30 @@ export const techInsightsPlugin = createPlugin({
 /**
  * @public
  */
+export const ScorecardInfo = techInsightsPlugin.provide(
+  createRoutableExtension({
+    name: 'ScorecardInfo',
+    component: () =>
+      import('./components/ScorecardsInfo').then(m => m.ScorecardInfo),
+    mountPoint: rootRouteRef,
+  }),
+);
+
+/**
+ * @public
+ */
+export const ScorecardsList = techInsightsPlugin.provide(
+  createRoutableExtension({
+    name: 'ScorecardsList',
+    component: () =>
+      import('./components/ScorecardsList').then(m => m.ScorecardsList),
+    mountPoint: rootRouteRef,
+  }),
+);
+
+/**
+ * @public
+ */
 export const EntityTechInsightsScorecardContent = techInsightsPlugin.provide(
   createRoutableExtension({
     name: 'EntityTechInsightsScorecardContent',


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Fixes : https://github.com/backstage/backstage/issues/19993

This PR aim to export ScorecardInfo and ScorecardsList Component to be able to use CheckResults directly without having to pass `checksId` to `EntityTechInsightsScorecardContent`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
