### PR TITLE
add longer timeout to some db based tests

### DIFF
--- a/plugins/badges-backend/src/database/badgeStore.test.ts
+++ b/plugins/badges-backend/src/database/badgeStore.test.ts
@@ -19,6 +19,8 @@ import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
 import { Knex } from 'knex';
 import { Entity } from '@backstage/catalog-model';
 
+jest.setTimeout(60_000);
+
 describe('DatabaseBadgesStore', () => {
   const entity: Entity = {
     apiVersion: 'v1',

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.test.ts
@@ -21,6 +21,8 @@ import { ConfigReader } from '@backstage/config';
 import { IncrementalEntityProvider } from '../types';
 import { WrapperProviders } from './WrapperProviders';
 
+jest.setTimeout(60_000);
+
 describe('WrapperProviders', () => {
   const applyDatabaseMigrations = jest.fn();
   const databases = TestDatabases.create({


### PR DESCRIPTION
When running tests with `CI=1` locally, sometimes these take a bit longer than 5 seconds