### PR TITLE
.github/workflows: limit sync VP fetch

### DIFF
--- a/.github/workflows/sync_version-packages.yml
+++ b/.github/workflows/sync_version-packages.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 20000
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
       - name: Install Dependencies
         run: yarn --immutable


### PR DESCRIPTION
Fetching with depth 0 causes all branches and tags to be fetched as well, so I figured we could just fetch with a large depth instead, but only default branch. Should hopefully speed up the quite slow Version Packages builds.