### PR TITLE
feat: allow webpack configuration override

### DIFF
--- a/.changeset/slimy-toys-pay.md
+++ b/.changeset/slimy-toys-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Allow overriding default webpack configuration

--- a/docs/tutorials/overriding-webpack-config.md
+++ b/docs/tutorials/overriding-webpack-config.md
@@ -1,0 +1,36 @@
+---
+id: overriding-webpack-config
+title: Overriding webpack config
+description: Guide on how to override the default webpack configuration
+---
+
+By default, Backstage configures [webpack](https://webpack.js.org/) with sane defaults.
+In some cases, application developers might want to change this configuration and
+add for example new modules or plugins to the system.
+
+For this, it's possible to override the default configuration by providing
+`webpack.config.js` file to the root of the **packages/app/** and **packages/backend**
+directories.
+
+The configuration file must export default function that returns the overriding configuration.
+The original configuration is passed to the function as a parameter, see the example below.
+
+Example of configuration:
+
+```js
+/**
+ * Webpack configuration override
+ * @param config The original configuration from Backstage
+ * @returns webpack.Configuration
+ */
+module.exports = config => {
+  return {
+    ...config,
+    profile: config.mode === 'development' ? true : false,
+  };
+};
+```
+
+See available configuration options from [webpack documentation](https://webpack.js.org/configuration/).
+
+Default configuration is available in `/packages/cli/src/lib/bundler/config.ts`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
       - Switching Backstage from SQLite to PostgreSQL: 'tutorials/switching-sqlite-postgres.md'
       - Using the Backstage Proxy from Within a Plugin: 'tutorials/using-backstage-proxy-within-plugin.md'
       - Migration to Yarn 3: 'tutorials/yarn-migration.md'
+      - Overriding webpack configuration: 'tutorials/overriding-webpack-config.md'
   - Architecture Decision Records (ADRs):
       - Overview: 'architecture-decisions/index.md'
       - ADR001 - Architecture Decision Record (ADR) log: 'architecture-decisions/adr001-add-adr-log.md'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change allows application developers to override the default webpack configuration.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
