### PR TITLE
use named exports in cjs builds

### DIFF
--- a/.changeset/tasty-doors-switch.md
+++ b/.changeset/tasty-doors-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Explicitly set `exports: 'named'` for CJS builds, ensuring that they have e.g. `exports["default"] = catalogPlugin;`

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -90,6 +90,7 @@ export async function makeRollupConfigs(
         chunkFileNames: `cjs/[name]-[hash].cjs.js`,
         format: 'commonjs',
         sourcemap: true,
+        exports: 'named',
       });
     }
     if (options.outputs.has(Output.esm)) {


### PR DESCRIPTION
As a matter of fact, this doesn't change anything as far as I know, it just gets rid of the warnings and establishes that this is the intended way of working.