### PR TITLE
root: disable usage of fsevents in jest

### DIFF
--- a/.yarn/patches/jest-haste-map-npm-29.4.3-19b03fcef3.patch
+++ b/.yarn/patches/jest-haste-map-npm-29.4.3-19b03fcef3.patch
@@ -1,0 +1,13 @@
+diff --git a/build/watchers/FSEventsWatcher.js b/build/watchers/FSEventsWatcher.js
+index 2273a6cbd2110ddbbd1525820289c3d93ab46cac..d637a644239ae4a7db407ce779f43b4dec9a44ed 100644
+--- a/build/watchers/FSEventsWatcher.js
++++ b/build/watchers/FSEventsWatcher.js
+@@ -103,7 +103,7 @@ function _interopRequireWildcard(obj, nodeInterop) {
+ // @ts-ignore: this is for CI which runs linux and might not have this
+ let fsevents = null;
+ try {
+-  fsevents = require('fsevents');
++  // fsevents = require('fsevents');
+ } catch {
+   // Optional dependency, only supported on Darwin.
+ }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "resolutions": {
     "@types/react": "^17",
     "@types/react-dom": "^17",
+    "jest-haste-map@^29.4.3": "patch:jest-haste-map@npm%3A29.4.3#./.yarn/patches/jest-haste-map-npm-29.4.3-19b03fcef3.patch",
     "mock-fs@^5.2.0": "patch:mock-fs@npm%3A5.2.0#./.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch"
   },
   "version": "1.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29690,7 +29690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^29.4.3":
+"jest-haste-map@npm:29.4.3":
   version: 29.4.3
   resolution: "jest-haste-map@npm:29.4.3"
   dependencies:
@@ -29710,6 +29710,29 @@ __metadata:
     fsevents:
       optional: true
   checksum: c7a83ebe6008b3fe96a96235e8153092e54b14df68e0f4205faedec57450df26b658578495a71c6d82494c01fbb44bca98c1506a6b2b9c920696dcc5d2e2bc59
+  languageName: node
+  linkType: hard
+
+"jest-haste-map@patch:jest-haste-map@npm%3A29.4.3#./.yarn/patches/jest-haste-map-npm-29.4.3-19b03fcef3.patch::locator=root%40workspace%3A.":
+  version: 29.4.3
+  resolution: "jest-haste-map@patch:jest-haste-map@npm%3A29.4.3#./.yarn/patches/jest-haste-map-npm-29.4.3-19b03fcef3.patch::version=29.4.3&hash=1e431f&locator=root%40workspace%3A."
+  dependencies:
+    "@jest/types": ^29.4.3
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.9
+    jest-regex-util: ^29.4.3
+    jest-util: ^29.4.3
+    jest-worker: ^29.4.3
+    micromatch: ^4.0.4
+    walker: ^1.0.8
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: a25fd71cc650acac4295172b2b84212872c4100a0b8e627e1f4b70a7e74d895a20274a4b0449aafdcb8273da055013fdc8765e55cbcf6dc46ae0351e974ed0c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
At least @freben and I have been having issues with extremely bad watch performance in tests. It manifests itself as hundreds of child processes spawned by the Jest main process, which use up a ton of CPU until the disappear 10-15s later. I've narrowed this down to only happening when using the `fsevents` module for file watching, but since that immediately calls out to the native MacOS APIs it's a lot trickier to continue debugging at that point.

We figured it's worth disabling `fsevents` in tests for now since this is a tricky issue to catch or even realize is happening.

This may be an issue that is specific to development on Spotify issued MacOS devices, but we're not quite sure what other options we have at this point 😅. From a bit of quick testing the performance seems alright with the node fallback API.

Also curious if anyone else has been seeing issues similar to this one.