### PR TITLE
fix: bitbucket server edit url resolves correctly

### DIFF
--- a/.changeset/bright-lies-compare.md
+++ b/.changeset/bright-lies-compare.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/integration': patch
+'@backstage/plugin-techdocs-node': patch
 ---
 
 Fixed the method `resolveEditUrl` of `BitbucketServerIntegration` to return the entire url instead of cutting the query parameters

--- a/.changeset/bright-lies-compare.md
+++ b/.changeset/bright-lies-compare.md
@@ -3,4 +3,5 @@
 '@backstage/plugin-techdocs-node': patch
 ---
 
-Fixed the method `resolveEditUrl` of `BitbucketServerIntegration` to return the entire url instead of cutting the query parameters
+Fixed the method `resolveEditUrl` of `BitbucketServerIntegration` to return the entire url instead of cutting the query parameters.
+`mkdocsPatcher` removes query params from the `edit_uri` in bitbucket server integration in order not to break the edit button in tech docs

--- a/.changeset/bright-lies-compare.md
+++ b/.changeset/bright-lies-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixed the method `resolveEditUrl` of `BitbucketServerIntegration` to return the entire url instead of cutting the query parameters

--- a/packages/integration/src/bitbucketServer/BitbucketServerIntegration.ts
+++ b/packages/integration/src/bitbucketServer/BitbucketServerIntegration.ts
@@ -20,6 +20,7 @@ import {
   BitbucketServerIntegrationConfig,
   readBitbucketServerIntegrationConfigs,
 } from './config';
+import parseGitUrl from 'git-url-parse';
 
 /**
  * A Bitbucket Server based integration.
@@ -75,6 +76,13 @@ export class BitbucketServerIntegration implements ScmIntegration {
 
   resolveEditUrl(url: string): string {
     // Bitbucket Server doesn't support deep linking to edit mode, therefore there's nothing to do here.
-    return url;
+    const urlData = parseGitUrl(url);
+    const editUrl = new URL(url);
+
+    // TODO: Not sure what spa=0 does, at least bitbucket.org doesn't support it
+    // but this is taken over from the initial implementation.
+    editUrl.searchParams.set('spa', '0');
+    editUrl.searchParams.set('at', urlData.ref);
+    return editUrl.toString();
   }
 }

--- a/packages/integration/src/bitbucketServer/BitbucketServerIntegration.ts
+++ b/packages/integration/src/bitbucketServer/BitbucketServerIntegration.ts
@@ -75,10 +75,6 @@ export class BitbucketServerIntegration implements ScmIntegration {
 
   resolveEditUrl(url: string): string {
     // Bitbucket Server doesn't support deep linking to edit mode, therefore there's nothing to do here.
-    // We just remove query parameters since they cause issues with TechDocs edit button.
-    if (url.includes('?')) {
-      return url.substring(0, url.indexOf('?'));
-    }
     return url;
   }
 }

--- a/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
+++ b/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
@@ -119,6 +119,16 @@ export const patchMkdocsYmlPreBuild = async (
       );
 
       if (result.repo_url || result.edit_uri) {
+        if (
+          result.edit_uri &&
+          scmIntegrations.byUrl(result.edit_uri)?.type === 'bitbucketServer' &&
+          result.edit_uri.includes('?')
+        ) {
+          result.edit_uri = result.edit_uri.substring(
+            0,
+            result.edit_uri.indexOf('?'),
+          );
+        }
         mkdocsYml.repo_url = result.repo_url;
         mkdocsYml.edit_uri = result.edit_uri;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

from this:
<img width="910" alt="image" src="https://user-images.githubusercontent.com/47827254/269287284-31ac37d7-64b9-4944-9734-1b054f07c4c0.png">

to this:
<img width="910" alt="image" src="https://github.com/backstage/backstage/assets/47827254/5849e6de-1b97-45c8-a4f3-b47ce587c253">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Closes #20042 
