### PR TITLE
Set base node image to node:18-bookworm-slim

### DIFF
--- a/.changeset/dull-laws-camp.md
+++ b/.changeset/dull-laws-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye. Ref Discord thread: https://discord.com/channels/687207715902193673/687235481154617364/1154020909871550525

--- a/.changeset/dull-laws-camp.md
+++ b/.changeset/dull-laws-camp.md
@@ -2,4 +2,6 @@
 '@backstage/create-app': patch
 ---
 
-Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye. Ref Discord thread: https://discord.com/channels/687207715902193673/687235481154617364/1154020909871550525
+Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye.
+
+You can apply these change to your own `Dockerfile` by replacing `node:18-bullseye-slim` with `node:18-bookworm-slim`

--- a/.changeset/witty-buttons-admire.md
+++ b/.changeset/witty-buttons-admire.md
@@ -1,0 +1,5 @@
+---
+'example-backend': patch
+---
+
+Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye. Ref Discord thread: https://discord.com/channels/687207715902193673/687235481154617364/1154020909871550525

--- a/.changeset/witty-buttons-admire.md
+++ b/.changeset/witty-buttons-admire.md
@@ -1,7 +1,0 @@
----
-'example-backend': patch
----
-
-Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye.
-
-You can apply these change to your own `Dockerfile` by replacing `node:18-bullseye-slim` with `node:18-bookworm-slim`

--- a/.changeset/witty-buttons-admire.md
+++ b/.changeset/witty-buttons-admire.md
@@ -2,4 +2,6 @@
 'example-backend': patch
 ---
 
-Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye. Ref Discord thread: https://discord.com/channels/687207715902193673/687235481154617364/1154020909871550525
+Change base node image from node:18-bullseye-slim to node:18-bookworm-slim due to Docker build error on bullseye.
+
+You can apply these change to your own `Dockerfile` by replacing `node:18-bullseye-slim` with `node:18-bookworm-slim`

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -54,7 +54,7 @@ Once the host build is complete, we are ready to build our image. The following
 `Dockerfile` is included when creating a new app with `@backstage/create-app`:
 
 ```Dockerfile
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -160,7 +160,7 @@ the repo root:
 
 ```Dockerfile
 # Stage 1 - Create yarn install skeleton layer
-FROM node:18-bullseye-slim AS packages
+FROM node:18-bookworm-slim AS packages
 
 WORKDIR /app
 COPY package.json yarn.lock ./
@@ -173,7 +173,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM node:18-bullseye-slim AS build
+FROM node:18-bookworm-slim AS build
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -211,7 +211,7 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docs/local-dev/cli-build-system.md
+++ b/docs/local-dev/cli-build-system.md
@@ -418,7 +418,7 @@ The following is an example of a `Dockerfile` that can be used to package the
 output of building a package with role `'backend'` into an image:
 
 ```Dockerfile
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 WORKDIR /app
 
 COPY yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -18,9 +18,15 @@ FROM node:18-bookworm-slim
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
-    apt-get install -y --no-install-recommends libsqlite3-dev python3 python3-pip build-essential && \
-    yarn config set python /usr/bin/python3 && \
-    pip3 install mkdocs-techdocs-core==1.1.7
+    apt-get install -y --no-install-recommends libsqlite3-dev python3 python3-pip python3-venv build-essential && \
+    yarn config set python /usr/bin/python3
+
+# Set up a virtual environment for mkdocs-techdocs-core.
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip3 install mkdocs-techdocs-core==1.1.7
 
 # From here on we use the least-privileged `node` user to run the backend.
 WORKDIR /app

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Looks like the node image node:18-bullseye-slim is breaking on new builds. See Discord thread:
https://discord.com/channels/687207715902193673/687235481154617364/1154020909871550525

This PR is simply updating references from node:18-bullseye-slim to node:18-bookworm-slim
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
