### PR TITLE
backend-test-utils: remove last type parameter for MockInstance

### DIFF
--- a/.changeset/quick-weeks-explode.md
+++ b/.changeset/quick-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Remove third type parameter used for `MockInstance`, in order to be compatible with older versions of `@types/jest`.

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -210,10 +210,9 @@ export type ServiceMock<TService> = {
   factory: ServiceFactory<TService>;
 } & {
   [Key in keyof TService]: TService[Key] extends (
-    this: infer This,
     ...args: infer Args
   ) => infer Return
-    ? TService[Key] & jest.MockInstance<Return, Args, This>
+    ? TService[Key] & jest.MockInstance<Return, Args>
     : TService[Key];
 };
 

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -64,10 +64,9 @@ export type ServiceMock<TService> = {
   factory: ServiceFactory<TService>;
 } & {
   [Key in keyof TService]: TService[Key] extends (
-    this: infer This,
     ...args: infer Args
   ) => infer Return
-    ? TService[Key] & jest.MockInstance<Return, Args, This>
+    ? TService[Key] & jest.MockInstance<Return, Args>
     : TService[Key];
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reported on Discord by @drodil, this fixes an issue where older versions of `@types/jest` only accepts two type parameters. We don't really need the `This` parameter in practice (afaik), so let's get rid of it to avoid that breakage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
