### PR TITLE
Patch release of #20052

### DIFF
--- a/.changeset/quick-weeks-explode.md
+++ b/.changeset/quick-weeks-explode.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-test-utils': patch
----
-
-Remove third type parameter used for `MockInstance`, in order to be compatible with older versions of `@types/jest`.

--- a/.changeset/quick-weeks-explode.md
+++ b/.changeset/quick-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Remove third type parameter used for `MockInstance`, in order to be compatible with older versions of `@types/jest`.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.18.0",
+  "version": "1.18.1",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3"

--- a/packages/backend-test-utils/CHANGELOG.md
+++ b/packages/backend-test-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/backend-test-utils
 
+## 0.2.4
+
+### Patch Changes
+
+- dbeb822f4c09: Remove third type parameter used for `MockInstance`, in order to be compatible with older versions of `@types/jest`.
+- Updated dependencies
+  - @backstage/backend-app-api@0.5.3
+  - @backstage/backend-common@0.19.5
+  - @backstage/plugin-auth-node@0.3.0
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -210,10 +210,9 @@ export type ServiceMock<TService> = {
   factory: ServiceFactory<TService>;
 } & {
   [Key in keyof TService]: TService[Key] extends (
-    this: infer This,
     ...args: infer Args
   ) => infer Return
-    ? TService[Key] & jest.MockInstance<Return, Args, This>
+    ? TService[Key] & jest.MockInstance<Return, Args>
     : TService[Key];
 };
 

--- a/packages/backend-test-utils/package.json
+++ b/packages/backend-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-test-utils",
   "description": "Test helpers library for Backstage backends",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -64,10 +64,9 @@ export type ServiceMock<TService> = {
   factory: ServiceFactory<TService>;
 } & {
   [Key in keyof TService]: TService[Key] extends (
-    this: infer This,
     ...args: infer Args
   ) => infer Return
-    ? TService[Key] & jest.MockInstance<Return, Args, This>
+    ? TService[Key] & jest.MockInstance<Return, Args>
     : TService[Key];
 };
 


### PR DESCRIPTION
This release fixes an issue in `@backstage/backend-test-utils` where some existing versions of Jest would cause a type error because `MockInstance` only accepts two type arguments.