### PR TITLE
rename plugin listing page to directory

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -162,9 +162,9 @@ APIs in TypeScript, but aren't forcing it on individual plugins.
 ### How do I find out if a plugin already exists?
 
 You can browse and search for all available plugins in the
-[Plugin Marketplace](https://backstage.io/plugins).
+[Plugin Directory](https://backstage.io/plugins).
 
-If you can't find it in the marketplace, before you write a plugin
+If you can't find it in the directory, before you write a plugin
 [search the plugin issues](https://github.com/backstage/backstage/issues?q=is%3Aissue+label%3Aplugin+)
 to see if is in the works. If no one's thought of it yet, great! Open a new
 issue as

--- a/docs/dls/design.md
+++ b/docs/dls/design.md
@@ -86,7 +86,7 @@ building it up with your help!
 ### Core Backstage User Experience
 
 This is the universal user experience that is shared amongst all Backstage
-users. From more concrete aspects like the plugins marketplace to more abstract
+users. From more concrete aspects like the plugins directory to more abstract
 ones like end-to-end workflows on Backstage, we’ll be working with the community
 to create a core user experience that best serves you and your organization.
 

--- a/docs/getting-started/configure-app-with-plugins.md
+++ b/docs/getting-started/configure-app-with-plugins.md
@@ -5,7 +5,7 @@ description: Documentation on How Configuring App with plugins
 ---
 
 Backstage plugins customize the app for your needs. There is a
-[plugin marketplace](https://backstage.io/plugins) with plugins for many common
+[plugin directory](https://backstage.io/plugins) with plugins for many common
 infrastructure needs - CI/CD, monitoring, auditing, and more.
 
 ## Adding existing plugins to your app

--- a/docs/getting-started/project-structure.md
+++ b/docs/getting-started/project-structure.md
@@ -186,7 +186,7 @@ a dash-suffix. `-backend` means it’s a backend plugin and so on.
 One reason for splitting a plugin is because of its dependencies. Another reason
 is for clear separation of concerns.
 
-Take a look at our [Plugin Marketplace](https://backstage.io/plugins) or browse
+Take a look at our [Plugin Directory](https://backstage.io/plugins) or browse
 through the
 [`plugins/`](https://github.com/backstage/backstage/tree/master/plugins) folder.
 

--- a/docs/plugins/add-to-directory.md
+++ b/docs/plugins/add-to-directory.md
@@ -4,7 +4,7 @@ title: Add to Directory
 description: Documentation on Adding Plugin to Plugin Directory
 ---
 
-## Adding a Plugin to the Marketplace
+## Adding a Plugin to the Directory
 
 To add a new plugin to the [plugin directory](https://backstage.io/plugins)
 create a file in
@@ -23,5 +23,5 @@ iconUrl: # Used as the src attribute for your logo.
 # You can provide an external url or add your logo under static/img and provide a path
 # relative to static/ e.g. img/my-logo.png
 npmPackageName: # Your npm package name E.g. '@backstage/plugin-<etc>' quotes are required
-addedDate: # The date plugin added to marketplace E.g. '2022-10-01' quotes are required
+addedDate: # The date plugin added to directory E.g. '2022-10-01' quotes are required
 ```

--- a/docs/plugins/add-to-directory.md
+++ b/docs/plugins/add-to-directory.md
@@ -1,12 +1,12 @@
 ---
-id: add-to-marketplace
-title: Add to Marketplace
-description: Documentation on Adding Plugin to Marketplace
+id: add-to-directory
+title: Add to Directory
+description: Documentation on Adding Plugin to Plugin Directory
 ---
 
 ## Adding a Plugin to the Marketplace
 
-To add a new plugin to the [plugin marketplace](https://backstage.io/plugins)
+To add a new plugin to the [plugin directory](https://backstage.io/plugins)
 create a file in
 [`microsite/data/plugins`](https://github.com/backstage/backstage/tree/master/microsite/data/plugins)
 with your plugin's information. Example:

--- a/docs/plugins/existing-plugins.md
+++ b/docs/plugins/existing-plugins.md
@@ -4,7 +4,7 @@ title: Existing plugins
 description: Lists of existing open source plugins
 ---
 
-## The Plugin Marketplace
+## The Plugin Directory
 
 Open source plugins that you can add to your Backstage deployment can be found
 at:
@@ -15,4 +15,4 @@ https://backstage.io/plugins
 
 ## Links
 
-- [[blog] The Plugin Marketplace is open](https://backstage.io/blog/2020/09/30/plugin-marketplace)
+- [[blog] The Plugin Directory is open](https://backstage.io/blog/2020/09/30/plugin-marketplace)

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -267,7 +267,7 @@
         "label": "Publishing",
         "items": [
           "plugins/publish-private",
-          "plugins/add-to-marketplace",
+          "plugins/add-to-directory",
           "plugins/observability"
         ]
       }

--- a/microsite/src/pages/on-demand/index.tsx
+++ b/microsite/src/pages/on-demand/index.tsx
@@ -36,8 +36,8 @@ const Plugins = () => (
     <div
       className={clsx('container', 'padding--lg', pluginsStyles.onDemandPage)}
     >
-      <div className="marketplaceBanner">
-        <div className="marketplaceContent">
+      <div className="communityBanner">
+        <div className="communityContent">
           <h2>Community sessions</h2>
 
           <p>

--- a/microsite/src/pages/on-demand/onDemand.module.scss
+++ b/microsite/src/pages/on-demand/onDemand.module.scss
@@ -1,10 +1,10 @@
 .onDemandPage {
-  :global(.marketplaceBanner) {
+  :global(.communityBanner) {
     display: flex;
     align-items: center;
   }
 
-  :global(.marketplaceContent) {
+  :global(.communityContent) {
     flex: 1;
   }
 

--- a/microsite/src/pages/plugins/index.tsx
+++ b/microsite/src/pages/plugins/index.tsx
@@ -102,9 +102,9 @@ const Plugins = () => {
       <div
         className={clsx('container', 'padding--lg', pluginsStyles.pluginsPage)}
       >
-        <div className="marketplaceBanner">
-          <div className="marketplaceContent">
-            <h2>Plugin Marketplace</h2>
+        <div className="directoryBanner">
+          <div className="directoryContent">
+            <h2>Plugin directory</h2>
 
             <p>
               Open source plugins that you can add to your Backstage deployment.
@@ -113,10 +113,10 @@ const Plugins = () => {
           </div>
 
           <Link
-            to="/docs/plugins/add-to-marketplace"
+            to="/docs/plugins/add-to-directory"
             className="button button--outline button--primary"
           >
-            Add to Marketplace
+            Add to Directory
           </Link>
         </div>
 

--- a/microsite/src/pages/plugins/plugins.module.scss
+++ b/microsite/src/pages/plugins/plugins.module.scss
@@ -1,10 +1,10 @@
 .pluginsPage {
-  :global(.marketplaceBanner) {
+  :global(.directoryBanner) {
     display: flex;
     align-items: center;
   }
 
-  :global(.marketplaceContent) {
+  :global(.directoryContent) {
     flex: 1;
   }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,7 @@ nav:
           - Testing with Jest: 'plugins/testing.md'
       - Publishing:
           - Publish private: 'plugins/publish-private.md'
-          - Add to Marketplace: 'plugins/add-to-marketplace.md'
+          - Add to Directory: 'plugins/add-to-directory.md'
           - Observability: 'plugins/observability.md'
   - Configuration:
       - Static Configuration in Backstage: 'conf/index.md'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adjusting the name of the open source plugin listing to directory to prevent clashing with Spotify's marketplace.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
