### PR TITLE
remove duplicate app icon link

### DIFF
--- a/.changeset/big-spies-beam.md
+++ b/.changeset/big-spies-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed duplicate `apple-touch-icon` link from `packages/app/public/index.html` that linked to nonexistent icon.

--- a/packages/app-next/public/index.html
+++ b/packages/app-next/public/index.html
@@ -8,7 +8,6 @@
       name="description"
       content="Backstage is an open platform for building developer portals"
     />
-    <link rel="apple-touch-icon" href="<%= publicPath %>/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -8,7 +8,6 @@
       name="description"
       content="Backstage is an open platform for building developer portals"
     />
-    <link rel="apple-touch-icon" href="<%= publicPath %>/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/create-app/templates/default-app/packages/app/public/index.html
+++ b/packages/create-app/templates/default-app/packages/app/public/index.html
@@ -8,7 +8,6 @@
       name="description"
       content="Backstage is an open platform for building developer portals"
     />
-    <link rel="apple-touch-icon" href="<%= publicPath %>/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/techdocs-cli-embedded-app/public/index.html
+++ b/packages/techdocs-cli-embedded-app/public/index.html
@@ -8,7 +8,6 @@
       name="description"
       content="Backstage is an open platform for building developer portals"
     />
-    <link rel="apple-touch-icon" href="<%= publicPath %>/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
🧹 

Fixes #20000, figured we just remove it since as reported there's an 180x180 icon already.