### PR TITLE
frontend-plugin-api: draft TS-configurable extensions

### DIFF
--- a/packages/frontend-plugin-api/src/wiring/coreExtensionData.ts
+++ b/packages/frontend-plugin-api/src/wiring/coreExtensionData.ts
@@ -31,9 +31,20 @@ export type NavTarget = {
 
 /** @public */
 export const coreExtensionData = {
-  reactElement: createExtensionDataRef<JSX.Element>('core.reactElement'),
-  routePath: createExtensionDataRef<string>('core.routing.path'),
-  apiFactory: createExtensionDataRef<AnyApiFactory>('core.api.factory'),
-  routeRef: createExtensionDataRef<RouteRef>('core.routing.ref'),
-  navTarget: createExtensionDataRef<NavTarget>('core.nav.target'),
+  // TODO: We'd want to figure out if we can better structure extension data ref declarations to avoid the ID duplication
+  reactElement: createExtensionDataRef<JSX.Element, 'core.reactElement'>(
+    'core.reactElement',
+  ),
+  routePath: createExtensionDataRef<string, 'core.routing.path'>(
+    'core.routing.path',
+  ),
+  apiFactory: createExtensionDataRef<AnyApiFactory, 'core.api.factory'>(
+    'core.api.factory',
+  ),
+  routeRef: createExtensionDataRef<RouteRef, 'core.routing.ref'>(
+    'core.routing.ref',
+  ),
+  navTarget: createExtensionDataRef<NavTarget, 'core.nav.target'>(
+    'core.nav.target',
+  ),
 };

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -15,13 +15,14 @@
  */
 
 import { PortableSchema } from '../schema';
+import { coreExtensionData } from './coreExtensionData';
 import { ExtensionDataRef } from './createExtensionDataRef';
-import { ExtensionInput } from './createExtensionInput';
+import { ExtensionInput, createExtensionInput } from './createExtensionInput';
 import { BackstagePlugin } from './createPlugin';
 
 /** @public */
 export type AnyExtensionDataMap = {
-  [name in string]: ExtensionDataRef<unknown, { optional?: true }>;
+  [name in string]: ExtensionDataRef<unknown, string, { optional?: true }>;
 };
 
 /** @public */
@@ -94,13 +95,17 @@ export interface CreateExtensionOptions<
 }
 
 /** @public */
-export interface Extension<TConfig> {
+export interface Extension<
+  TOutput extends AnyExtensionDataMap,
+  TInputs extends AnyExtensionInputMap,
+  TConfig,
+> {
   $$type: '@backstage/Extension';
   id: string;
   at: string;
   disabled: boolean;
-  inputs: AnyExtensionInputMap;
-  output: AnyExtensionDataMap;
+  inputs: TInputs;
+  output: TOutput;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
     source?: BackstagePlugin;
@@ -114,25 +119,146 @@ export interface Extension<TConfig> {
 }
 
 /** @public */
+export interface ExtensionConfiguration<
+  TOutput extends { [id in string]: true },
+> {
+  id: string;
+  outputIds: TOutput;
+
+  config?: unknown;
+  disabled?: boolean;
+  attachments?: { [inputName in string]: string[] };
+}
+
+export type ExtensionConfigurer<
+  TOutput extends AnyExtensionDataMap,
+  TInputs extends AnyExtensionInputMap,
+  TConfig,
+> = (options?: {
+  config?: TConfig;
+  disabled?: boolean;
+  attachments?: {
+    [inputName in keyof TInputs]: TInputs[inputName]['config']['singleton'] extends true
+      ? ExtensionConfiguration<{
+          [name in keyof TInputs[inputName]['extensionData'] as TInputs[inputName]['extensionData'][name]['id']]: true;
+        }>
+      : Array<
+          ExtensionConfiguration<{
+            [name in keyof TInputs[inputName]['extensionData'] as TInputs[inputName]['extensionData'][name]['id']]: true;
+          }>
+        >;
+  };
+}) => ExtensionConfiguration<{
+  [name in keyof TOutput as TOutput[name]['id']]: true;
+}>;
+
+/** @public */
 export function createExtension<
   TOutput extends AnyExtensionDataMap,
   TInputs extends AnyExtensionInputMap,
   TConfig = never,
 >(
   options: CreateExtensionOptions<TOutput, TInputs, TConfig>,
-): Extension<TConfig> {
-  return {
-    ...options,
-    disabled: options.disabled ?? false,
-    $$type: '@backstage/Extension',
-    inputs: options.inputs ?? {},
-    factory({ bind, config, inputs }) {
-      // TODO: Simplify this, but TS wouldn't infer the input type for some reason
-      return options.factory({
-        bind,
-        config,
-        inputs: inputs as Expand<ExtensionInputValues<TInputs>>,
-      });
+): Extension<TOutput, TInputs, TConfig> &
+  ExtensionConfigurer<TOutput, TInputs, TConfig> {
+  return Object.assign<
+    ExtensionConfigurer<TOutput, TInputs, TConfig>,
+    Extension<TOutput, TInputs, TConfig>
+  >(
+    configuredOptions => {
+      const attachmentIds =
+        configuredOptions?.attachments &&
+        Object.fromEntries(
+          Object.entries(configuredOptions?.attachments).map(
+            ([inputName, attachments]) => [
+              inputName,
+              [attachments].flat().map(attachment => attachment.id),
+            ],
+          ),
+        );
+      return {
+        id: options.id,
+        outputIds: null as any, // Only used for type safety, ignored at runtime
+        config: configuredOptions?.config,
+        disabled: configuredOptions?.disabled,
+        output: options.output,
+        attachments: attachmentIds,
+      };
     },
-  };
+    {
+      $$type: '@backstage/Extension',
+      id: options.id,
+      at: options.at,
+      disabled: options.disabled ?? false,
+      inputs: options.inputs ?? ({} as TInputs),
+      output: options.output,
+      configSchema: options.configSchema,
+      factory({ bind, config, inputs }) {
+        // TODO: Simplify this, but TS wouldn't infer the input type for some reason
+        return options.factory({
+          bind,
+          config,
+          inputs: inputs as Expand<ExtensionInputValues<TInputs>>,
+        });
+      },
+    },
+  );
 }
+
+const a = createExtension({
+  id: 'a',
+  at: 'root/default',
+  inputs: {
+    one: createExtensionInput(
+      {
+        a: coreExtensionData.reactElement,
+      },
+      { singleton: true },
+    ),
+    many: createExtensionInput({
+      a: coreExtensionData.reactElement,
+    }),
+  },
+  output: {
+    a: coreExtensionData.navTarget,
+  },
+  factory() {},
+});
+
+const b = createExtension({
+  id: 'b',
+  at: 'root/default',
+  output: {
+    b: coreExtensionData.reactElement,
+  },
+  factory() {},
+});
+const c = createExtension({
+  id: 'c',
+  at: 'root/default',
+  output: {
+    c: coreExtensionData.routePath,
+  },
+  factory() {},
+});
+
+a({
+  attachments: {
+    one: b(),
+    many: [b()],
+  },
+});
+
+a({
+  attachments: {
+    one: [b()], // error, expects a single extension
+    many: b(), // error, expects an array of extensions
+  },
+});
+
+a({
+  attachments: {
+    one: c(), // error, extension data mismatch
+    many: [c()], // error, extension data mismatch
+  },
+});

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -17,9 +17,10 @@
 /** @public */
 export type ExtensionDataRef<
   TData,
+  TId extends string = string,
   TConfig extends { optional?: true } = {},
 > = {
-  id: string;
+  id: TId;
   T: TData;
   config: TConfig;
   $$type: '@backstage/ExtensionDataRef';
@@ -28,16 +29,21 @@ export type ExtensionDataRef<
 /** @public */
 export interface ConfigurableExtensionDataRef<
   TData,
+  TId extends string,
   TConfig extends { optional?: true } = {},
-> extends ExtensionDataRef<TData, TConfig> {
-  optional(): ConfigurableExtensionDataRef<TData, TData & { optional: true }>;
+> extends ExtensionDataRef<TData, TId, TConfig> {
+  optional(): ConfigurableExtensionDataRef<
+    TData,
+    TId,
+    TConfig & { optional: true }
+  >;
 }
 
 // TODO: change to options object with ID.
 /** @public */
-export function createExtensionDataRef<TData>(
-  id: string,
-): ConfigurableExtensionDataRef<TData> {
+export function createExtensionDataRef<TData, const TId extends string>(
+  id: TId,
+): ConfigurableExtensionDataRef<TData, TId> {
   return {
     id,
     $$type: '@backstage/ExtensionDataRef',
@@ -45,5 +51,5 @@ export function createExtensionDataRef<TData>(
     optional() {
       return { ...this, config: { ...this.config, optional: true } };
     },
-  } as ConfigurableExtensionDataRef<TData>;
+  } as ConfigurableExtensionDataRef<TData, TId>;
 }


### PR DESCRIPTION
Just a bit of early exploration into a TypeScript API for configuration extensions, for those that prefer the upfront checks or syntax compared to YAML.

Example usage:

```ts
createApp({
  extensionConfig: [
    graphiqlBrowseApi({
      attachments: {
        endpoints: [
          gitlabGraphiQLBrowseExtension({ // enabled by mention without explicit disabled: false
            config: {
              title: 'GitLab GraphQL',
            }
          })
        ]
      }
    })
  ],
})
```

This only generates configuration, so the same rules as app-config apply where you only need to list things that you want to reconfigure. This in itself does not install the extension into the app.