### PR TITLE
Add optional additional search query for pg search

### DIFF
--- a/plugins/search-backend-module-pg/src/database/types.ts
+++ b/plugins/search-backend-module-pg/src/database/types.ts
@@ -22,6 +22,7 @@ export interface PgSearchQuery {
   fields?: Record<string, string | string[]>;
   types?: string[];
   pgTerm?: string;
+  fallbackSearchQuery?: string;
   offset: number;
   limit: number;
   options: PgSearchHighlightOptions;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added option to specify an additional search query. This can be added when creating a custom translator for things like searching using `LIKE` or other pattern matching queries.

This would also somewhat resolve [this requested feature](https://github.com/backstage/backstage/issues/17423)

**Example using posix regular expression**:
```
translator(
    query: SearchQuery,
    options: PgSearchQueryTranslatorOptions,
  ): ConcretePgSearchQuery {
    const pageSize = query.pageLimit || 25;
    const { page } = decodePageCursor(query.pageCursor);
    const offset = page * pageSize;
    // We request more result to know whether there is another page
    const limit = pageSize + 1;

    const words = query.term
      .split(/\s/)
      .map(p => p.replace(/[\0()|&:*!]/g, '').trim())
      .filter(p => p !== '');

    return {
      pgQuery: {
        pgTerm: words
          .map(p => `(${JSON.stringify(p)} | ${JSON.stringify(p)}:*)`)
          .join('&'),
        fields: query.filters as Record<string, string | string[]>,
        fallbackSearchQuery: `documents.document->>'title' ~* '${words
          .join('|')}'`,
        types: query.types,
        offset,
        limit,
        options: options.highlightOptions,
      },
      pageSize,
    };
  }
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
