### PR TITLE
frontend-app-api: make app initialization async

### DIFF
--- a/.changeset/polite-cooks-perform.md
+++ b/.changeset/polite-cooks-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+The `createApp` config option has been replaced by a new `configLoader` option. There is now also a `pluginLoader` option that can be used to dynamically load plugins into the app.

--- a/packages/frontend-app-api/api-report.md
+++ b/packages/frontend-app-api/api-report.md
@@ -12,7 +12,8 @@ import { JSX as JSX_2 } from 'react';
 // @public (undocumented)
 export function createApp(options: {
   plugins: BackstagePlugin[];
-  config?: ConfigApi;
+  configLoader?: () => Promise<ConfigApi>;
+  pluginLoader?: (ctx: { config: ConfigApi }) => Promise<BackstagePlugin[]>;
 }): {
   createRoot(): JSX_2.Element;
 };

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -282,7 +282,11 @@ export function createApp(options: {
     const appContext = createLegacyAppContext(allPlugins);
 
     const rootElements = rootInstances
-      .map(e => e.getData(coreExtensionData.reactElement))
+      .map(e => (
+        <React.Fragment key={e.id}>
+          {e.getData(coreExtensionData.reactElement)}
+        </React.Fragment>
+      ))
       .filter((x): x is JSX.Element => !!x);
 
     const App = () => (

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -247,50 +247,67 @@ export function createInstances(options: {
 /** @public */
 export function createApp(options: {
   plugins: BackstagePlugin[];
-  config?: ConfigApi;
+  configLoader?: () => Promise<ConfigApi>;
+  pluginLoader?: (ctx: { config: ConfigApi }) => Promise<BackstagePlugin[]>;
 }): {
   createRoot(): JSX.Element;
 } {
-  const discoveredPlugins = getAvailablePlugins();
-  const allPlugins = Array.from(
-    new Set([...discoveredPlugins, ...options.plugins]),
-  );
-  const appConfig =
-    options?.config ??
-    ConfigReader.fromConfigs(overrideBaseUrlConfigs(defaultConfigLoaderSync()));
+  async function appLoader() {
+    const config =
+      (await options?.configLoader?.()) ??
+      ConfigReader.fromConfigs(
+        overrideBaseUrlConfigs(defaultConfigLoaderSync()),
+      );
 
-  const { rootInstances } = createInstances({
-    plugins: allPlugins,
-    config: appConfig,
-  });
+    const discoveredPlugins = getAvailablePlugins();
+    const loadedPlugins = (await options.pluginLoader?.({ config })) ?? [];
+    const allPlugins = Array.from(
+      new Set([...discoveredPlugins, ...options.plugins, ...loadedPlugins]),
+    );
 
-  const routePaths = extractRouteInfoFromInstanceTree(rootInstances);
+    const { rootInstances } = createInstances({
+      plugins: allPlugins,
+      config,
+    });
 
-  const coreInstance = rootInstances.find(({ id }) => id === 'core');
-  if (!coreInstance) {
-    throw Error('Unable to find core extension instance');
+    const routePaths = extractRouteInfoFromInstanceTree(rootInstances);
+
+    const coreInstance = rootInstances.find(({ id }) => id === 'core');
+    if (!coreInstance) {
+      throw Error('Unable to find core extension instance');
+    }
+
+    const apiHolder = createApiHolder(coreInstance, config);
+
+    const appContext = createLegacyAppContext(allPlugins);
+
+    const rootElements = rootInstances
+      .map(e => e.getData(coreExtensionData.reactElement))
+      .filter((x): x is JSX.Element => !!x);
+
+    const App = () => (
+      <ApiProvider apis={apiHolder}>
+        <AppContextProvider appContext={appContext}>
+          <AppThemeProvider>
+            <RoutingProvider routePaths={routePaths}>
+              {/* TODO: set base path using the logic from AppRouter */}
+              <BrowserRouter>{rootElements}</BrowserRouter>
+            </RoutingProvider>
+          </AppThemeProvider>
+        </AppContextProvider>
+      </ApiProvider>
+    );
+
+    return { default: App };
   }
-
-  const apiHolder = createApiHolder(coreInstance, appConfig);
-
-  const appContext = createLegacyAppContext(allPlugins);
 
   return {
     createRoot() {
-      const rootElements = rootInstances
-        .map(e => e.getData(coreExtensionData.reactElement))
-        .filter((x): x is JSX.Element => !!x);
+      const LazyApp = React.lazy(appLoader);
       return (
-        <ApiProvider apis={apiHolder}>
-          <AppContextProvider appContext={appContext}>
-            <AppThemeProvider>
-              <RoutingProvider routePaths={routePaths}>
-                {/* TODO: set base path using the logic from AppRouter */}
-                <BrowserRouter>{rootElements}</BrowserRouter>
-              </RoutingProvider>
-            </AppThemeProvider>
-          </AppContextProvider>
-        </ApiProvider>
+        <React.Suspense fallback="Loading...">
+          <LazyApp />
+        </React.Suspense>
       );
     },
   };


### PR DESCRIPTION
Figured we're likely gonna end up needing the app initialization to be async in the end. Initially to make config loading easier, but down the line also to be able to load in feature dynamically. I did also throw in a quick and dirty was to do that for now so we can experiment with that bit.
