### PR TITLE
Only show pagination controls when necessary

### DIFF
--- a/.changeset/fuzzy-pillows-remain.md
+++ b/.changeset/fuzzy-pillows-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Only show pagination controls when necessary

--- a/.changeset/fuzzy-pillows-remain.md
+++ b/.changeset/fuzzy-pillows-remain.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-Only show pagination controls when necessary
+Improved `DocsTable` to display pagination controls dynamically, appearing only when needed.

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -94,14 +94,17 @@ export const DocsTable = (props: DocsTableProps) => {
     actionFactories.createCopyDocsUrlAction(copyToClipboard),
   ];
 
+  const pageSize = 20;
+  const paging = documents && documents.length > pageSize;
+
   return (
     <>
       {loading || (documents && documents.length > 0) ? (
         <Table<DocsTableRow>
           isLoading={loading}
           options={{
-            paging: true,
-            pageSize: 20,
+            paging,
+            pageSize,
             search: true,
             actionsColumnIndex: -1,
             ...options,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I'm new to Backstage, and I noticed the TechDoc Plugin was adding Pagination controls when none were necessary. We are adopting Backstage, and I noticed this issue in our builds. I think first impressions are important, and this glitch caught my eye. Fixing it upstream will for all future adopters as well.

See also:
[🐛 Bug Report: Unnecessary Pagination Controls present on the TechDocs Page · Issue #20118 · backstage/backstage](https://github.com/backstage/backstage/issues/20118)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
