### PR TITLE
cli: make the new backend start command the default

### DIFF
--- a/.changeset/itchy-rabbits-exist.md
+++ b/.changeset/itchy-rabbits-exist.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli': minor
+---
+
+The new backend start command that used to be enabled by setting `EXPERIMENTAL_BACKEND_START` is now the default. To revert to the old behavior, set `LEGACY_BACKEND_START` instead.
+
+This new command is no longer based on Webpack, but instead uses Node.js loaders to transpile on the fly. Rather than hot reloading modules the entire backend is now restarted on change, but the SQLite database state is still maintained across restarts via a parent process.

--- a/.changeset/wet-timers-chew.md
+++ b/.changeset/wet-timers-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+The `useHotCleanup` and `useHotMemoize` helpers are now deprecated, since hot module reloads for backend are being phased out.

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -401,6 +401,7 @@ tooltip
 tooltips
 touchpoint
 transpilation
+transpile
 transpiled
 transpiler
 transpilers

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -785,12 +785,12 @@ export type UrlReadersOptions = {
   factories?: ReaderFactory[];
 };
 
-// @public
+// @public @deprecated
 export function useHotCleanup(
   _module: NodeModule,
   cancelEffect: () => void,
 ): void;
 
-// @public
+// @public @deprecated
 export function useHotMemoize<T>(_module: NodeModule, valueFactory: () => T): T;
 ```

--- a/packages/backend-common/src/hot.ts
+++ b/packages/backend-common/src/hot.ts
@@ -47,6 +47,7 @@ function findAllAncestors(_module: NodeModule): NodeModule[] {
  * Useful for cleaning intervals, timers, requests etc
  *
  * @public
+ * @deprecated Hot module reloading is no longer supported for backends.
  * @example
  * ```ts
  * const intervalId = setInterval(doStuff, 1000);
@@ -80,6 +81,7 @@ const CURRENT_HOT_MEMOIZE_INDEX_KEY = 'backstage.io/hmr-memoize-key';
  * stateful parts of the backend, e.g. to retain a database.
  *
  * @public
+ * @deprecated Hot module reloading is no longer supported for backends.
  * @example
  * ```ts
  * const db = useHotMemoize(module, () => createDB(dbParams));

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -18,7 +18,7 @@
     "backstage"
   ],
   "scripts": {
-    "start": "EXPERIMENTAL_BACKEND_START=1 backstage-cli package start",
+    "start": "backstage-cli package start",
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",

--- a/packages/cli/src/commands/start/startBackend.ts
+++ b/packages/cli/src/commands/start/startBackend.ts
@@ -36,7 +36,7 @@ export async function startBackend(options: StartBackendOptions) {
     });
 
     await waitForExit();
-  } else if (process.env.EXPERIMENTAL_BACKEND_START) {
+  } else if (!process.env.LEGACY_BACKEND_START) {
     const waitForExit = await startBackendExperimental({
       entry: 'src/index',
       checksEnabled: false, // not supported

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -463,6 +463,10 @@ async function testBackendStart(appDir: string, ...args: string[]) {
           !l.includes('check the migration guide at https://a.co/7PzMCcy') &&
           !l.includes(
             '(Use `node --trace-warnings ...` to show where the warning was created)',
+          ) &&
+          !l.includes('Custom ESM Loaders is an experimental feature') &&
+          !l.includes(
+            'ExperimentalWarning: `globalPreload` is planned for removal',
           ),
       ).length !== 0
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Switching over to using the new backend start command by default.

Docs not updated yet as it'd be a bit early

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
