### PR TITLE
add i18n to some components in scaffolder plugin

### DIFF
--- a/docs/plugins/internationalization.md
+++ b/docs/plugins/internationalization.md
@@ -58,8 +58,11 @@ In an app you can both override the default messages, as well as register transl
 +      }),
 +      createTranslationResource({
 +        ref: myPluginTranslationRef,
-+        messages: {
++        translations: {
 +          zh: () => import('./translations/zh'),
++          pt: () => Promise.resolve({ default:  {
++            create_component_button_label: 'Criar nova entidade',
++          }})
 +        },
 +      }),
 +    ],

--- a/plugins/scaffolder/src/alpha.ts
+++ b/plugins/scaffolder/src/alpha.ts
@@ -21,3 +21,4 @@ export {
   type TemplateListPageProps,
   type TemplateWizardPageProps,
 } from './next';
+export * from './translation';

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -52,6 +52,8 @@ import {
   Progress,
 } from '@backstage/core-components';
 import Chip from '@material-ui/core/Chip';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../translation';
 
 const useStyles = makeStyles(theme => ({
   code: {
@@ -108,6 +110,7 @@ const ExamplesTable = (props: { examples: ActionExample[] }) => {
 };
 
 export const ActionsPage = () => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const api = useApi(scaffolderApiRef);
   const classes = useStyles();
   const { loading, value, error } = useAsync(async () => {
@@ -122,7 +125,7 @@ export const ActionsPage = () => {
   if (error) {
     return (
       <ErrorPage
-        statusMessage="Failed to load installed actions"
+        statusMessage={t('failed_to_load_installed_actions')}
         status="500"
       />
     );
@@ -130,17 +133,17 @@ export const ActionsPage = () => {
 
   const renderTable = (rows?: JSX.Element[]) => {
     if (!rows || rows.length < 1) {
-      return <Typography>No schema defined</Typography>;
+      return <Typography>{t('no_schema_defined')}</Typography>;
     }
     return (
       <TableContainer component={Paper}>
         <Table size="small">
           <TableHead>
             <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Title</TableCell>
-              <TableCell>Description</TableCell>
-              <TableCell>Type</TableCell>
+              <TableCell>{t('name')}</TableCell>
+              <TableCell>{t('title')}</TableCell>
+              <TableCell>{t('description')}</TableCell>
+              <TableCell>{t('type')}</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>{rows}</TableBody>
@@ -160,7 +163,7 @@ export const ActionsPage = () => {
 
     return [
       `${properties.type}(${
-        (properties.items as JSONSchema7 | undefined)?.type ?? 'unknown'
+        (properties.items as JSONSchema7 | undefined)?.type ?? t('unknown')
       })`,
     ];
   };
@@ -284,7 +287,7 @@ export const ActionsPage = () => {
         {action.schema?.input && (
           <Box pb={2}>
             <Typography variant="h5" component="h3">
-              Input
+              {t('input')}
             </Typography>
             {renderTable(
               formatRows(`${action.id}.input`, action?.schema?.input),
@@ -295,7 +298,7 @@ export const ActionsPage = () => {
         {action.schema?.output && (
           <Box pb={2}>
             <Typography variant="h5" component="h3">
-              Output
+              {t('output')}
             </Typography>
             {renderTable(
               formatRows(`${action.id}.output`, action?.schema?.output),
@@ -306,7 +309,7 @@ export const ActionsPage = () => {
           <Accordion>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <Typography variant="h5" component="h3">
-                Examples
+                {t('examples')}
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
@@ -323,9 +326,9 @@ export const ActionsPage = () => {
   return (
     <Page themeId="home">
       <Header
-        pageTitleOverride="Create a New Component"
-        title="Installed actions"
-        subtitle="This is the collection of all installed actions"
+        pageTitleOverride={t('create_a_new_component')}
+        title={t('installed_actions')}
+        subtitle={t('this_is_the_collection_of_all_installed_actions')}
       />
       <Content>{items}</Content>
     </Page>

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -40,6 +40,9 @@ import { usePermission } from '@backstage/plugin-permission-react';
 import { ScaffolderPageContextMenu } from './ScaffolderPageContextMenu';
 import { registerComponentRouteRef } from '../../routes';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../translation';
+
 export type ScaffolderPageProps = {
   TemplateCardComponent?:
     | ComponentType<{ template: TemplateEntityV1beta3 }>
@@ -68,9 +71,11 @@ export const ScaffolderPageContents = ({
   contextMenu,
   headerOptions,
 }: ScaffolderPageProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
   const otherTemplatesGroup = {
-    title: groups ? 'Other Templates' : 'Templates',
+    title: groups ? t('other_templates') : t('templates'),
     filter: (entity: TemplateEntityV1beta3) => {
       const filtered = (groups ?? []).map(group => group.filter(entity));
       return !filtered.some(result => result === true);
@@ -84,26 +89,22 @@ export const ScaffolderPageContents = ({
   return (
     <Page themeId="home">
       <Header
-        pageTitleOverride="Create a New Component"
-        title="Create a New Component"
-        subtitle="Create new software components using standard templates"
+        pageTitleOverride={t('create_a_new_component')}
+        title={t('create_a_new_component')}
+        subtitle={t('create_new_software_components_using_standard_templates')}
         {...headerOptions}
       >
         <ScaffolderPageContextMenu {...contextMenu} />
       </Header>
       <Content>
-        <ContentHeader title="Available Templates">
+        <ContentHeader title={t('available_templates')}>
           {allowed && (
             <CreateButton
-              title="Register Existing Component"
+              title={t('register_existing_component')}
               to={registerComponentLink && registerComponentLink()}
             />
           )}
-          <SupportButton>
-            Create new software components using standard templates. Different
-            templates create different kinds of components (services, websites,
-            documentation, ...).
-          </SupportButton>
+          <SupportButton>{t('scaffolder_page_support_button')}</SupportButton>
         </ContentHeader>
 
         <CatalogFilterLayout>

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -18,15 +18,21 @@ import { EntityNamePickerProps } from './schema';
 import { TextField } from '@material-ui/core';
 
 export { EntityNamePickerSchema } from './schema';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
 
 /**
  * EntityName Picker
  */
 export const EntityNamePicker = (props: EntityNamePickerProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const {
     onChange,
     required,
-    schema: { title = 'Name', description = 'Unique name of the component' },
+    schema: {
+      title = t('name'),
+      description = t('unique_name_of_the_component'),
+    },
     rawErrors,
     formData,
     uiSchema: { 'ui:autofocus': autoFocus },

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.ts
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.ts
@@ -22,6 +22,7 @@ export const entityNamePickerValidation = (
   validation: FieldValidation,
 ) => {
   if (!KubernetesValidatorFunctions.isValidObjectName(value)) {
+    // TODO I need access to i18n object to translate this. Hooks can't be called outside a Component Lifecycle
     validation.addError(
       'Must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
     );

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -42,6 +42,8 @@ import {
 } from './schema';
 
 export { EntityPickerSchema } from './schema';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
 
 /**
  * The underlying component that is rendered in the form for the `EntityPicker`
@@ -50,9 +52,14 @@ export { EntityPickerSchema } from './schema';
  * @public
  */
 export const EntityPicker = (props: EntityPickerProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
   const {
     onChange,
-    schema: { title = 'Entity', description = 'An entity from the catalog' },
+    schema: {
+      title = t('entity'),
+      description = t('an_entity_from_the_catalog'),
+    },
     required,
     uiSchema,
     rawErrors,

--- a/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
@@ -26,6 +26,9 @@ import { EntityTagsPickerProps } from './schema';
 
 export { EntityTagsPickerSchema } from './schema';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 /**
  * The underlying component that is rendered in the form for the `EntityTagsPicker`
  * field extension.
@@ -33,6 +36,8 @@ export { EntityTagsPickerSchema } from './schema';
  * @public
  */
 export const EntityTagsPicker = (props: EntityTagsPickerProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
   const { formData, onChange, uiSchema } = props;
   const catalogApi = useApi(catalogApiRef);
   const [tagOptions, setTagOptions] = useState<string[]>([]);
@@ -108,13 +113,10 @@ export const EntityTagsPicker = (props: EntityTagsPickerProps) => {
         renderInput={params => (
           <TextField
             {...params}
-            label="Tags"
+            label={t('tags')}
             onChange={e => setInputValue(e.target.value)}
             error={inputError}
-            helperText={
-              helperText ??
-              "Add any relevant tags, hit 'Enter' to add new tags. Valid format: [a-z0-9+#] separated by [-], at most 63 characters"
-            }
+            helperText={helperText ?? t('entity_tags_picker_helper_text')}
           />
         )}
       />

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -15,11 +15,11 @@
  */
 
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { CatalogApi } from '@backstage/catalog-client';
 import { FieldProps } from '@rjsf/core';
 import { MyGroupsPicker } from './MyGroupsPicker';
-import { TestApiProvider } from '@backstage/test-utils';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
 import {
@@ -111,7 +111,7 @@ describe('<MyGroupsPicker />', () => {
       required,
     } as unknown as FieldProps<any>;
 
-    render(
+    renderInTestApp(
       <TestApiProvider
         apis={[
           [identityApiRef, mockIdentityApi],
@@ -183,7 +183,7 @@ describe('<MyGroupsPicker />', () => {
       required,
     } as unknown as FieldProps<any>;
 
-    const { queryByText, getByRole } = render(
+    const { queryByText, getByRole } = await renderInTestApp(
       <TestApiProvider
         apis={[
           [identityApiRef, mockIdentityApi],
@@ -212,7 +212,7 @@ describe('<MyGroupsPicker />', () => {
       expect(group2Element).toBeInTheDocument();
     });
 
-    // Assert that 'group3' is not rendered in the component
+    // Assert that 'group3' is not renderInTestApped in the component
     expect(queryByText('group3')).not.toBeInTheDocument();
   });
 
@@ -240,7 +240,7 @@ describe('<MyGroupsPicker />', () => {
       required,
     } as unknown as FieldProps<any>;
 
-    const { getByRole } = render(
+    const { getByRole } = await renderInTestApp(
       <TestApiProvider
         apis={[
           [identityApiRef, mockIdentityApi],

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -30,7 +30,11 @@ import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 
 export { MyGroupsPickerSchema };
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const {
     schema: { title, description },
     required,
@@ -56,7 +60,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
     const { userEntityRef } = await identityApi.getBackstageIdentity();
 
     if (!userEntityRef) {
-      errorApi.post(new NotFoundError('No user entity ref found'));
+      errorApi.post(new NotFoundError(t('no_user_entity_ref_found')));
       return;
     }
 

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -26,6 +26,9 @@ import { EntityPickerProps } from '../EntityPicker/schema';
 
 export { OwnedEntityPickerSchema } from './schema';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 /**
  * The underlying component that is rendered in the form for the `OwnedEntityPicker`
  * field extension.
@@ -33,8 +36,12 @@ export { OwnedEntityPickerSchema } from './schema';
  * @public
  */
 export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const {
-    schema: { title = 'Entity', description = 'An entity from the catalog' },
+    schema: {
+      title = t('entity'),
+      description = t('an_entity_from_the_catalog'),
+    },
     uiSchema,
     required,
   } = props;

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -19,6 +19,9 @@ import { OwnerPickerProps } from './schema';
 
 export { OwnerPickerSchema } from './schema';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 /**
  * The underlying component that is rendered in the form for the `OwnerPicker`
  * field extension.
@@ -26,8 +29,13 @@ export { OwnerPickerSchema } from './schema';
  * @public
  */
 export const OwnerPicker = (props: OwnerPickerProps) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
   const {
-    schema: { title = 'Owner', description = 'The owner of the component' },
+    schema: {
+      title = t('owner'),
+      description = t('the_owner_of_the_component'),
+    },
     uiSchema,
     ...restProps
   } = props;

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.test.tsx
@@ -16,11 +16,12 @@
 
 import React from 'react';
 import { AzureRepoPicker } from './AzureRepoPicker';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('AzureRepoPicker', () => {
   it('renders the two input fields', async () => {
-    const { getAllByRole } = render(
+    const { getAllByRole } = await renderInTestApp(
       <AzureRepoPicker onChange={jest.fn()} rawErrors={[]} state={{}} />,
     );
 
@@ -30,9 +31,9 @@ describe('AzureRepoPicker', () => {
   });
 
   describe('org field', () => {
-    it('calls onChange when the organisation changes', () => {
+    it('calls onChange when the organisation changes', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <AzureRepoPicker onChange={onChange} rawErrors={[]} state={{}} />,
       );
 
@@ -45,9 +46,9 @@ describe('AzureRepoPicker', () => {
   });
 
   describe('owner field', () => {
-    it('calls onChange when the owner changes', () => {
+    it('calls onChange when the owner changes', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <AzureRepoPicker onChange={onChange} rawErrors={[]} state={{}} />,
       );
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
@@ -22,6 +22,9 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { RepoUrlPickerState } from './types';
 import { Select, SelectItem } from '@backstage/core-components';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const AzureRepoPicker = (props: {
   allowedOrganizations?: string[];
   allowedOwners?: string[];
@@ -29,6 +32,8 @@ export const AzureRepoPicker = (props: {
   state: RepoUrlPickerState;
   onChange: (state: RepoUrlPickerState) => void;
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
   const {
     allowedOrganizations = [],
     allowedOwners = [],
@@ -39,11 +44,11 @@ export const AzureRepoPicker = (props: {
 
   const organizationItems: SelectItem[] = allowedOrganizations
     ? allowedOrganizations.map(i => ({ label: i, value: i }))
-    : [{ label: 'Loading...', value: 'loading' }];
+    : [{ label: t('loading'), value: 'loading' }];
 
   const ownerItems: SelectItem[] = allowedOwners
     ? allowedOwners.map(i => ({ label: i, value: i }))
-    : [{ label: 'Loading...', value: 'loading' }];
+    : [{ label: t('loading'), value: 'loading' }];
 
   const { organization, owner } = state;
 
@@ -57,7 +62,7 @@ export const AzureRepoPicker = (props: {
         {allowedOrganizations?.length ? (
           <Select
             native
-            label="Organization"
+            label={t('organization')}
             onChange={s =>
               onChange({ organization: String(Array.isArray(s) ? s[0] : s) })
             }
@@ -67,7 +72,7 @@ export const AzureRepoPicker = (props: {
           />
         ) : (
           <>
-            <InputLabel htmlFor="orgInput">Organization</InputLabel>
+            <InputLabel htmlFor="orgInput">{t('organization')}</InputLabel>
             <Input
               id="orgInput"
               onChange={e => onChange({ organization: e.target.value })}
@@ -76,7 +81,7 @@ export const AzureRepoPicker = (props: {
           </>
         )}
         <FormHelperText>
-          The Organization that this repo will belong to
+          {t('repo_picker_organization_help_text')}
         </FormHelperText>
       </FormControl>
       <FormControl
@@ -87,7 +92,7 @@ export const AzureRepoPicker = (props: {
         {allowedOwners?.length ? (
           <Select
             native
-            label="Owner"
+            label={t('owner')}
             onChange={s =>
               onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
             }
@@ -97,7 +102,7 @@ export const AzureRepoPicker = (props: {
           />
         ) : (
           <>
-            <InputLabel htmlFor="ownerInput">Project</InputLabel>
+            <InputLabel htmlFor="ownerInput">{t('project')}</InputLabel>
             <Input
               id="ownerInput"
               onChange={e => onChange({ owner: e.target.value })}
@@ -105,9 +110,7 @@ export const AzureRepoPicker = (props: {
             />
           </>
         )}
-        <FormHelperText>
-          The Project that this repo will belong to
-        </FormHelperText>
+        <FormHelperText>{t('repo_picker_project_help_text')}</FormHelperText>
       </FormControl>
     </>
   );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
@@ -16,12 +16,13 @@
 
 import React from 'react';
 import { BitbucketRepoPicker } from './BitbucketRepoPicker';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('BitbucketRepoPicker', () => {
   it('renders a select if there is a list of allowed owners', async () => {
     const allowedOwners = ['owner1', 'owner2'];
-    const { findByText } = render(
+    const { findByText } = await renderInTestApp(
       <BitbucketRepoPicker
         onChange={jest.fn()}
         rawErrors={[]}
@@ -34,10 +35,10 @@ describe('BitbucketRepoPicker', () => {
     expect(await findByText('owner2')).toBeInTheDocument();
   });
 
-  it('renders workspace input when host is bitbucket.org', () => {
+  it('renders workspace input when host is bitbucket.org', async () => {
     const state = { host: 'bitbucket.org', workspace: 'lolsWorkspace' };
 
-    const { getAllByRole } = render(
+    const { getAllByRole } = await renderInTestApp(
       <BitbucketRepoPicker onChange={jest.fn()} rawErrors={[]} state={state} />,
     );
 
@@ -45,12 +46,12 @@ describe('BitbucketRepoPicker', () => {
     expect(getAllByRole('textbox')[0]).toHaveValue('lolsWorkspace');
   });
 
-  it('hides the workspace input when the host is not bitbucket.org', () => {
+  it('hides the workspace input when the host is not bitbucket.org', async () => {
     const state = {
       host: 'mycustom.domain.bitbucket.org',
     };
 
-    const { getAllByRole } = render(
+    const { getAllByRole } = await renderInTestApp(
       <BitbucketRepoPicker onChange={jest.fn()} rawErrors={[]} state={state} />,
     );
 
@@ -58,9 +59,9 @@ describe('BitbucketRepoPicker', () => {
   });
 
   describe('workspace field', () => {
-    it('calls onChange when the workspace changes', () => {
+    it('calls onChange when the workspace changes', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <BitbucketRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -77,9 +78,9 @@ describe('BitbucketRepoPicker', () => {
   });
 
   describe('project field', () => {
-    it('calls onChange when the project changes', () => {
+    it('calls onChange when the project changes', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <BitbucketRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -95,7 +96,7 @@ describe('BitbucketRepoPicker', () => {
     });
 
     it('Does not render a select if the list of allowed projects does not exist', async () => {
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <BitbucketRepoPicker
           onChange={jest.fn()}
           rawErrors={[]}
@@ -108,7 +109,7 @@ describe('BitbucketRepoPicker', () => {
     });
 
     it('Does not render a select if the list of allowed projects is empty', async () => {
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <BitbucketRepoPicker
           onChange={jest.fn()}
           rawErrors={[]}
@@ -123,7 +124,7 @@ describe('BitbucketRepoPicker', () => {
 
     it('Does render a select if there is a list of allowed projects', async () => {
       const allowedProjects = ['project1', 'project2'];
-      const { findByText } = render(
+      const { findByText } = await renderInTestApp(
         <BitbucketRepoPicker
           onChange={jest.fn()}
           rawErrors={[]}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -21,6 +21,9 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 /**
  * The underlying component that is rendered in the form for the `BitbucketRepoPicker`
  * field extension.
@@ -37,6 +40,8 @@ export const BitbucketRepoPicker = (props: {
   state: RepoUrlPickerState;
   rawErrors: string[];
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
   const {
     allowedOwners = [],
     allowedProjects = [],
@@ -69,7 +74,7 @@ export const BitbucketRepoPicker = (props: {
           {allowedOwners?.length ? (
             <Select
               native
-              label="Allowed Workspaces"
+              label={t('allowed_workspaces')}
               onChange={s =>
                 onChange({ workspace: String(Array.isArray(s) ? s[0] : s) })
               }
@@ -79,7 +84,7 @@ export const BitbucketRepoPicker = (props: {
             />
           ) : (
             <>
-              <InputLabel htmlFor="workspaceInput">Workspace</InputLabel>
+              <InputLabel htmlFor="workspaceInput">{t('workspace')}</InputLabel>
               <Input
                 id="workspaceInput"
                 onChange={e => onChange({ workspace: e.target.value })}
@@ -88,7 +93,7 @@ export const BitbucketRepoPicker = (props: {
             </>
           )}
           <FormHelperText>
-            The Workspace that this repo will belong to
+            {t('repo_picker_workspace_helper_text')}
           </FormHelperText>
         </FormControl>
       )}
@@ -100,7 +105,7 @@ export const BitbucketRepoPicker = (props: {
         {allowedProjects?.length ? (
           <Select
             native
-            label="Allowed Projects"
+            label={t('allowed_projects')}
             onChange={s =>
               onChange({ project: String(Array.isArray(s) ? s[0] : s) })
             }
@@ -110,7 +115,7 @@ export const BitbucketRepoPicker = (props: {
           />
         ) : (
           <>
-            <InputLabel htmlFor="projectInput">Project</InputLabel>
+            <InputLabel htmlFor="projectInput">{t('project')}</InputLabel>
             <Input
               id="projectInput"
               onChange={e => onChange({ project: e.target.value })}
@@ -118,9 +123,7 @@ export const BitbucketRepoPicker = (props: {
             />
           </>
         )}
-        <FormHelperText>
-          The Project that this repo will belong to
-        </FormHelperText>
+        <FormHelperText>{t('repo_picker_project_help_text')}</FormHelperText>
       </FormControl>
     </>
   );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.test.tsx
@@ -16,13 +16,14 @@
 
 import React from 'react';
 import { GerritRepoPicker } from './GerritRepoPicker';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('GerritRepoPicker', () => {
   describe('owner input field', () => {
-    it('calls onChange when the owner input changes', () => {
+    it('calls onChange when the owner input changes', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <GerritRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -39,9 +40,9 @@ describe('GerritRepoPicker', () => {
   });
 
   describe('parent field', () => {
-    it('calls onChange when the parent changes', () => {
+    it('calls onChange when the parent changes', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <GerritRepoPicker
           onChange={onChange}
           rawErrors={[]}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
@@ -20,37 +20,43 @@ import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import { RepoUrlPickerState } from './types';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const GerritRepoPicker = (props: {
   onChange: (state: RepoUrlPickerState) => void;
   state: RepoUrlPickerState;
   rawErrors: string[];
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const { onChange, rawErrors, state } = props;
   const { workspace, owner } = state;
   return (
     <>
       <FormControl margin="normal" error={rawErrors?.length > 0 && !workspace}>
-        <InputLabel htmlFor="ownerInput">Owner</InputLabel>
+        <InputLabel htmlFor="ownerInput">{t('owner')}</InputLabel>
         <Input
           id="ownerInput"
           onChange={e => onChange({ owner: e.target.value })}
           value={owner}
         />
-        <FormHelperText>The owner of the project (optional)</FormHelperText>
+        <FormHelperText>
+          {t('repo_picker_project_help_text_optional')}
+        </FormHelperText>
       </FormControl>
       <FormControl
         margin="normal"
         required
         error={rawErrors?.length > 0 && !workspace}
       >
-        <InputLabel htmlFor="parentInput">Parent</InputLabel>
+        <InputLabel htmlFor="parentInput">{t('parent')}</InputLabel>
         <Input
           id="parentInput"
           onChange={e => onChange({ workspace: e.target.value })}
           value={workspace}
         />
         <FormHelperText>
-          The project parent that the repo will belong to
+          {t('repo_picker_project_parent_help_text')}
         </FormHelperText>
       </FormControl>
     </>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.test.tsx
@@ -16,13 +16,14 @@
 
 import React from 'react';
 import { GithubRepoPicker } from './GithubRepoPicker';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('GithubRepoPicker', () => {
   describe('owner field', () => {
     it('renders a select if there is a list of allowed owners', async () => {
       const allowedOwners = ['owner1', 'owner2'];
-      const { findByText } = render(
+      const { findByText } = await renderInTestApp(
         <GithubRepoPicker
           onChange={jest.fn()}
           rawErrors={[]}
@@ -38,7 +39,7 @@ describe('GithubRepoPicker', () => {
     it('calls onChange when the owner is changed to a different owner', async () => {
       const onChange = jest.fn();
       const allowedOwners = ['owner1', 'owner2'];
-      const { getByRole } = render(
+      const { getByRole } = await renderInTestApp(
         <GithubRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -54,10 +55,10 @@ describe('GithubRepoPicker', () => {
       expect(onChange).toHaveBeenCalledWith({ owner: 'owner2' });
     });
 
-    it('is disabled picked when only one allowed owner', () => {
+    it('is disabled picked when only one allowed owner', async () => {
       const onChange = jest.fn();
       const allowedOwners = ['owner1'];
-      const { getByRole } = render(
+      const { getByRole } = await renderInTestApp(
         <GithubRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -71,7 +72,7 @@ describe('GithubRepoPicker', () => {
 
     it('should display free text if no allowed owners are passed', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <GithubRepoPicker
           onChange={onChange}
           rawErrors={[]}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -21,16 +21,20 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const GithubRepoPicker = (props: {
   allowedOwners?: string[];
   rawErrors: string[];
   state: RepoUrlPickerState;
   onChange: (state: RepoUrlPickerState) => void;
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const { allowedOwners = [], rawErrors, state, onChange } = props;
   const ownerItems: SelectItem[] = allowedOwners
     ? allowedOwners.map(i => ({ label: i, value: i }))
-    : [{ label: 'Loading...', value: 'loading' }];
+    : [{ label: t('loading'), value: 'loading' }];
 
   const { owner } = state;
 
@@ -44,7 +48,7 @@ export const GithubRepoPicker = (props: {
         {allowedOwners?.length ? (
           <Select
             native
-            label="Owner Available"
+            label={t('owner_available')}
             onChange={s =>
               onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
             }
@@ -54,7 +58,7 @@ export const GithubRepoPicker = (props: {
           />
         ) : (
           <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
+            <InputLabel htmlFor="ownerInput">{t('owner')}</InputLabel>
             <Input
               id="ownerInput"
               onChange={e => onChange({ owner: e.target.value })}
@@ -62,9 +66,7 @@ export const GithubRepoPicker = (props: {
             />
           </>
         )}
-        <FormHelperText>
-          The organization, user or project that this repo will belong to
-        </FormHelperText>
+        <FormHelperText>{t('repo_picker_github_help_text')}</FormHelperText>
       </FormControl>
     </>
   );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.test.tsx
@@ -16,13 +16,14 @@
 
 import React from 'react';
 import { GitlabRepoPicker } from './GitlabRepoPicker';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('GitlabRepoPicker', () => {
   describe('owner field', () => {
     it('renders a select if there is a list of allowed owners', async () => {
       const allowedOwners = ['owner1', 'owner2'];
-      const { findByText } = render(
+      const { findByText } = await renderInTestApp(
         <GitlabRepoPicker
           onChange={jest.fn()}
           rawErrors={[]}
@@ -38,7 +39,7 @@ describe('GitlabRepoPicker', () => {
     it('calls onChange when the owner is changed to a different owner', async () => {
       const onChange = jest.fn();
       const allowedOwners = ['owner1', 'owner2'];
-      const { getByRole } = render(
+      const { getByRole } = await renderInTestApp(
         <GitlabRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -54,10 +55,10 @@ describe('GitlabRepoPicker', () => {
       expect(onChange).toHaveBeenCalledWith({ owner: 'owner2' });
     });
 
-    it('is disabled picked when only one allowed owner', () => {
+    it('is disabled picked when only one allowed owner', async () => {
       const onChange = jest.fn();
       const allowedOwners = ['owner1'];
-      const { getByRole } = render(
+      const { getByRole } = await renderInTestApp(
         <GitlabRepoPicker
           onChange={onChange}
           rawErrors={[]}
@@ -71,7 +72,7 @@ describe('GitlabRepoPicker', () => {
 
     it('should display free text if no allowed owners are passed', async () => {
       const onChange = jest.fn();
-      const { getAllByRole } = render(
+      const { getAllByRole } = await renderInTestApp(
         <GitlabRepoPicker
           onChange={onChange}
           rawErrors={[]}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -21,6 +21,9 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { Select, SelectItem } from '@backstage/core-components';
 import { RepoUrlPickerState } from './types';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const GitlabRepoPicker = (props: {
   allowedOwners?: string[];
   allowedRepos?: string[];
@@ -28,10 +31,11 @@ export const GitlabRepoPicker = (props: {
   onChange: (state: RepoUrlPickerState) => void;
   rawErrors: string[];
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const { allowedOwners = [], state, onChange, rawErrors } = props;
   const ownerItems: SelectItem[] = allowedOwners
     ? allowedOwners.map(i => ({ label: i, value: i }))
-    : [{ label: 'Loading...', value: 'loading' }];
+    : [{ label: t('loading'), value: 'loading' }];
 
   const { owner } = state;
 
@@ -45,7 +49,7 @@ export const GitlabRepoPicker = (props: {
         {allowedOwners?.length ? (
           <Select
             native
-            label="Owner Available"
+            label={t('owner_available')}
             onChange={selected =>
               onChange({
                 owner: String(Array.isArray(selected) ? selected[0] : selected),
@@ -57,7 +61,7 @@ export const GitlabRepoPicker = (props: {
           />
         ) : (
           <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
+            <InputLabel htmlFor="ownerInput">{t('owner')}</InputLabel>
             <Input
               id="ownerInput"
               onChange={e => onChange({ owner: e.target.value })}
@@ -65,10 +69,7 @@ export const GitlabRepoPicker = (props: {
             />
           </>
         )}
-        <FormHelperText>
-          GitLab namespace where this repository will belong to. It can be the
-          name of organization, group, subgroup, user, or the project.
-        </FormHelperText>
+        <FormHelperText>{t('repo_picker_gitlab_help_text')}</FormHelperText>
       </FormControl>
     </>
   );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
@@ -21,12 +21,16 @@ import { useApi } from '@backstage/core-plugin-api';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import useAsync from 'react-use/lib/useAsync';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const RepoUrlPickerHost = (props: {
   host?: string;
   hosts?: string[];
   onChange: (host: string) => void;
   rawErrors: string[];
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const { host, hosts, onChange, rawErrors } = props;
   const scaffolderApi = useApi(scaffolderApiRef);
 
@@ -57,7 +61,7 @@ export const RepoUrlPickerHost = (props: {
     ? integrations
         .filter(i => (hosts?.length ? hosts?.includes(i.host) : true))
         .map(i => ({ label: i.title, value: i.host }))
-    : [{ label: 'Loading...', value: 'loading' }];
+    : [{ label: t('loading'), value: 'loading' }];
 
   if (loading) {
     return <Progress />;
@@ -73,7 +77,7 @@ export const RepoUrlPickerHost = (props: {
         <Select
           native
           disabled={hosts?.length === 1 ?? false}
-          label="Host"
+          label={t('host')}
           onChange={s => onChange(String(Array.isArray(s) ? s[0] : s))}
           selected={host}
           items={hostsOptions}
@@ -81,7 +85,7 @@ export const RepoUrlPickerHost = (props: {
         />
 
         <FormHelperText>
-          The host where the repository will be created
+          {t('the_host_where_the_repository_will_be_created')}
         </FormHelperText>
       </FormControl>
     </>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.test.tsx
@@ -15,13 +15,14 @@
  */
 import React from 'react';
 import { RepoUrlPickerRepoName } from './RepoUrlPickerRepoName';
-import { render, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('RepoUrlPickerRepoName', () => {
   it('should call onChange with the first allowed repo if there is none set already', async () => {
     const onChange = jest.fn();
 
-    render(
+    await renderInTestApp(
       <RepoUrlPickerRepoName
         onChange={onChange}
         allowedRepos={['foo', 'bar']}
@@ -37,7 +38,7 @@ describe('RepoUrlPickerRepoName', () => {
 
     const onChange = jest.fn();
 
-    const { getByRole } = render(
+    const { getByRole } = await renderInTestApp(
       <RepoUrlPickerRepoName
         onChange={onChange}
         allowedRepos={allowedRepos}
@@ -57,7 +58,7 @@ describe('RepoUrlPickerRepoName', () => {
   it('should render a normal text area when no options are passed', async () => {
     const onChange = jest.fn();
 
-    const { getByRole } = render(
+    const { getByRole } = await renderInTestApp(
       <RepoUrlPickerRepoName
         onChange={onChange}
         allowedRepos={[]}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -20,12 +20,16 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { scaffolderTranslationRef } from '../../../translation';
+
 export const RepoUrlPickerRepoName = (props: {
   repoName?: string;
   allowedRepos?: string[];
   onChange: (host: string) => void;
   rawErrors: string[];
 }) => {
+  const { t } = useTranslationRef(scaffolderTranslationRef);
   const { repoName, allowedRepos, onChange, rawErrors } = props;
 
   useEffect(() => {
@@ -40,7 +44,7 @@ export const RepoUrlPickerRepoName = (props: {
 
   const repoItems: SelectItem[] = allowedRepos
     ? allowedRepos.map(i => ({ label: i, value: i }))
-    : [{ label: 'Loading...', value: 'loading' }];
+    : [{ label: t('loading'), value: 'loading' }];
 
   return (
     <>
@@ -52,7 +56,7 @@ export const RepoUrlPickerRepoName = (props: {
         {allowedRepos?.length ? (
           <Select
             native
-            label="Repositories Available"
+            label={t('repositories_available')}
             onChange={selected =>
               String(Array.isArray(selected) ? selected[0] : selected)
             }
@@ -62,7 +66,7 @@ export const RepoUrlPickerRepoName = (props: {
           />
         ) : (
           <>
-            <InputLabel htmlFor="repoNameInput">Repository</InputLabel>
+            <InputLabel htmlFor="repoNameInput">{t('repository')}</InputLabel>
             <Input
               id="repoNameInput"
               onChange={e => onChange(String(e.target.value))}
@@ -70,7 +74,7 @@ export const RepoUrlPickerRepoName = (props: {
             />
           </>
         )}
-        <FormHelperText>The name of the repository</FormHelperText>
+        <FormHelperText>{t('the_name_of_the_repository')}</FormHelperText>
       </FormControl>
     </>
   );

--- a/plugins/scaffolder/src/translation.ts
+++ b/plugins/scaffolder/src/translation.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+export const scaffolderTranslationRef = createTranslationRef({
+  id: 'scaffolder',
+  messages: {
+    failed_to_load_installed_actions: 'Failed to load installed actions',
+    no_schema_defined: 'No schema defined',
+    name: 'Name',
+    title: 'Title',
+    description: 'Description',
+    type: 'Type',
+    unknown: 'unknown',
+    create_a_new_component: 'Create a New Component',
+    installed_actions: 'Installed actions',
+    this_is_the_collection_of_all_installed_actions:
+      'This is the collection of all installed actions',
+    examples: 'Examples',
+    output: 'Output',
+    input: 'Input',
+    unique_name_of_the_component: 'Unique name of the component from here',
+    entity_name_picker_validation_message:
+      'Must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
+    entity: 'Entity',
+    an_entity_from_the_catalog: 'An entity from the catalog',
+    tags: 'Tags',
+    entity_tags_picker_helper_text:
+      "Add any relevant tags, hit 'Enter' to add new tags. Valid format: [a-z0-9+#] separated by [-], at most 63 characters",
+    no_user_entity_ref_found: 'No user entity ref found',
+    owner: 'Owner',
+    the_owner_of_the_component: 'The owner of the component',
+    loading: 'Loading...',
+    organization: 'Organization',
+    repo_picker_organization_help_text:
+      'The Organization that this repo will belong to',
+    project: 'Project',
+    repo_picker_project_help_text: 'The Project that this repo will belong to',
+    allowed_workspaces: 'Allowed Workspaces',
+    workspace: 'Workspace',
+    repo_picker_workspace_helper_text:
+      'The Workspace that this repo will belong to',
+    allowed_projects: 'Allowed Projects',
+    repo_picker_project_help_text_optional:
+      'The owner of the project (optional)',
+    parent: 'Parent',
+    repo_picker_project_parent_help_text:
+      'The project parent that the repo will belong to',
+    owner_available: 'Owner Available',
+    repo_picker_github_help_text:
+      'The organization, user or project that this repo will belong to',
+    repo_picker_gitlab_help_text:
+      'GitLab namespace where this repository will belong to. It can be the name of organization, group, subgroup, user, or the project.',
+    host: 'Host',
+    the_host_where_the_repository_will_be_created:
+      'The host where the repository will be created',
+    repositories_available: 'Repositories Available',
+    repository: 'Repository',
+    the_name_of_the_repository: 'The name of the repository',
+    other_templates: 'Other Templates',
+    templates: 'Templates',
+    create_new_software_components_using_standard_templates:
+      'Create new software components using standard templates',
+    available_templates: 'Available Templates',
+    register_existing_component: 'Register Existing Component',
+    scaffolder_page_support_button:
+      'Create new software components using standard templates. Different templates create different kinds of components (services, websites, documentation, ...).',
+  },
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was playing a little with the new i18n system so we can boost this in Hacktoberfest (Great ideia from @ahhhndre ), but I think could be nice talk a little about this. So I raise this draft and will send some points to discussion:


### 1. Should a Plugin be full moved to I18N before first merge?
I started to move some strings from components and... OMG threre is a lot of words here 😅 
So my first suggestion is to be clear about this: We want all or nothing?

**Suggestion:** I prefer not wait for the full translation, so we can wave small PRs

### 2. Flat keys vs Deep Keys
I started to translate looking using the User Settings as reference.
But this plugin, like many others have so many components I got a little confused about to stay flat.

Juts to get context, [we have two](https://www.i18next.com/translation-function/essentials#accessing-keys) options here:
```js
{
    "component_name": "My Component",
    "component": {
        "name": "My Component"
    }
}

t('component_name') 
t('component.name')
```
I stayed using flat keys, but after walk a little in the translation ref I got some doubts.
Flat keys will provide a simple way to reuse words and phrases, but can get a little messy.
Deep keys could provide a more organized approach, but we can got a big file because of that.

**Suggestion:** Stay flat and things got messy we can refactor and provide a migration path (maybe a tool too)

### 3. Semantic Keys vs Plain text keys
We have a lot of work to change those hard coded words. So I started to use [this plugin](https://github.com/lokalise/i18n-ally) to help me. It's really fast extract the word to a json and after that put in TS. But the fast way to do that is using a approach more "your key is your text", like [here](https://github.com/backstage/backstage/pull/20130/files#diff-f878076e8e66396eb54ab2b3aa53912df1704b7c79399e4a737b62fd8e1c68c6R68). We can use more semantic text like [here](https://github.com/backstage/backstage/pull/20130/files#diff-f878076e8e66396eb54ab2b3aa53912df1704b7c79399e4a737b62fd8e1c68c6R65) too, it's just more slow because we need to get context and understand a little about the component.

**Suggestion:** Stay using plain text keys for most cases and when some is really specific change the approach (like [here](https://github.com/backstage/backstage/pull/20130/files#diff-f878076e8e66396eb54ab2b3aa53912df1704b7c79399e4a737b62fd8e1c68c6R48))

### 4. Provide a No-React way to access the I18N instance
We have some cases where text is outside a component (like [here](https://github.com/backstage/backstage/pull/20130/files#diff-4787c2c98e4f01f6a65f5c0310eb34dce0e3d3b5453ad7e9dd9ecdce89b5739cR27)) so we need to put a way to grab the I18N instance so we can call the translate method.

**Suggestion:** Maybe I am missing how to do that, we can provide a doc or maybe put this in a singleton so we can grab that in a simple import

### 5. Be explicit about the Non Translate out-of-box
I was trying to find new languages in the project when I see we don't have a standard way to do that. I can translate may Backstage instance to Portuguese, but just in my code. Could be nice if we give some pointers about next steps about that so we don't get people frustated or expecting to contribuite for a thing and got another.

**Suggestion:** Create a issue with the next steps (and missing points) about the current i18n state in Backstage


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
