### PR TITLE
feat(catalog) small change to expand exposed parameters to enable more customisation to defaultcatalog

### DIFF
--- a/.changeset/beige-mangos-hear.md
+++ b/.changeset/beige-mangos-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Expand the exposed properties to enable more customisation of the default catalog so you can do things like splitting the catalogs for corporate and software catalog

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -216,13 +216,27 @@ export interface DefaultCatalogPageProps {
   // (undocumented)
   emptyContent?: ReactNode;
   // (undocumented)
+  entityKindPickerAllowedKinds?: string[];
+  // (undocumented)
+  entityKindPickerHidden?: boolean;
+  // (undocumented)
+  entityLifecyclePickerInitialFilter?: string[];
+  // (undocumented)
+  entityTypePickerHidden?: boolean;
+  // (undocumented)
   initialKind?: string;
   // (undocumented)
   initiallySelectedFilter?: UserListFilterKind;
   // (undocumented)
+  initialType?: string;
+  // (undocumented)
   ownerPickerMode?: EntityOwnerPickerProps['mode'];
   // (undocumented)
+  showTagCounts?: boolean;
+  // (undocumented)
   tableOptions?: TableProps<CatalogTableRow>['options'];
+  // (undocumented)
+  userListFilters?: UserListFilterKind[];
 }
 
 // @public

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -15,6 +15,21 @@
  */
 
 import {
+  CatalogFilterLayout,
+  EntityKindPicker,
+  EntityLifecyclePicker,
+  EntityListProvider,
+  EntityNamespacePicker,
+  EntityOwnerPicker,
+  EntityOwnerPickerProps,
+  EntityProcessingStatusPicker,
+  EntityTagPicker,
+  EntityTypePicker,
+  UserListFilterKind,
+  UserListPicker,
+} from '@backstage/plugin-catalog-react';
+import { CatalogTable, CatalogTableRow } from '../CatalogTable';
+import {
   Content,
   ContentHeader,
   CreateButton,
@@ -23,24 +38,10 @@ import {
   TableColumn,
   TableProps,
 } from '@backstage/core-components';
-import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
-import {
-  CatalogFilterLayout,
-  EntityLifecyclePicker,
-  EntityListProvider,
-  EntityProcessingStatusPicker,
-  EntityOwnerPicker,
-  EntityTagPicker,
-  EntityTypePicker,
-  UserListFilterKind,
-  UserListPicker,
-  EntityKindPicker,
-  EntityNamespacePicker,
-  EntityOwnerPickerProps,
-} from '@backstage/plugin-catalog-react';
 import React, { ReactNode } from 'react';
+import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
+
 import { createComponentRouteRef } from '../../routes';
-import { CatalogTable, CatalogTableRow } from '../CatalogTable';
 import { useCatalogPluginOptions } from '../../options';
 
 /**
@@ -56,6 +57,13 @@ export interface DefaultCatalogPageProps {
   tableOptions?: TableProps<CatalogTableRow>['options'];
   emptyContent?: ReactNode;
   ownerPickerMode?: EntityOwnerPickerProps['mode'];
+  entityKindPickerAllowedKinds?: string[];
+  entityKindPickerHidden?: boolean;
+  entityTypePickerHidden?: boolean;
+  initialType?: string;
+  showTagCounts?: boolean;
+  entityLifecyclePickerInitialFilter?: string[];
+  userListFilters?: UserListFilterKind[];
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
@@ -67,6 +75,13 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     tableOptions = {},
     emptyContent,
     ownerPickerMode,
+    entityKindPickerAllowedKinds,
+    entityKindPickerHidden,
+    initialType,
+    entityTypePickerHidden,
+    showTagCounts,
+    entityLifecyclePickerInitialFilter,
+    userListFilters,
   } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
@@ -87,12 +102,24 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
         <EntityListProvider>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
-              <EntityKindPicker initialFilter={initialKind} />
-              <EntityTypePicker />
-              <UserListPicker initialFilter={initiallySelectedFilter} />
+              <EntityKindPicker
+                initialFilter={initialKind}
+                allowedKinds={entityKindPickerAllowedKinds}
+                hidden={entityKindPickerHidden}
+              />
+              <EntityTypePicker
+                hidden={entityTypePickerHidden}
+                initialFilter={initialType}
+              />
+              <UserListPicker
+                initialFilter={initiallySelectedFilter}
+                availableFilters={userListFilters}
+              />
               <EntityOwnerPicker mode={ownerPickerMode} />
-              <EntityLifecyclePicker />
-              <EntityTagPicker />
+              <EntityLifecyclePicker
+                initialFilter={entityLifecyclePickerInitialFilter}
+              />
+              <EntityTagPicker showCounts={showTagCounts} />
               <EntityProcessingStatusPicker />
               <EntityNamespacePicker />
             </CatalogFilterLayout.Filters>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Small update to expand the parameters on the Default Catalog pages to enable more customisation without having to create a brand new catalog page. 

just exposes the subcomponent parameters

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
