### PR TITLE
auth-backend-module-github-provider: enable persisted scopes

### DIFF
--- a/.changeset/nice-dancers-explain.md
+++ b/.changeset/nice-dancers-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-github-provider': patch
+---
+
+Fixed a bug where the GitHub authenticator did not properly persist granted OAuth scopes.

--- a/.changeset/plenty-llamas-double.md
+++ b/.changeset/plenty-llamas-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Fix for persisted scopes not being properly restored on sign-in.

--- a/plugins/auth-backend-module-github-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-github-provider/src/authenticator.ts
@@ -28,6 +28,7 @@ const ACCESS_TOKEN_PREFIX = 'access-token.';
 export const githubAuthenticator = createOAuthAuthenticator({
   defaultProfileTransform:
     PassportOAuthAuthenticatorHelper.defaultProfileTransform,
+  shouldPersistScopes: true,
   initialize({ callbackUrl, config }) {
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -297,7 +297,7 @@ describe('createOAuthRouteHandlers', () => {
         state: encodeOAuthState({
           env: 'development',
           nonce: '123',
-          scope: 'my-scope',
+          scope: 'my-scope my-other-scope',
         } as OAuthState),
       });
 
@@ -310,7 +310,7 @@ describe('createOAuthRouteHandlers', () => {
             accessToken: 'access-token',
             expiresInSeconds: 3,
             idToken: 'id-token',
-            scope: 'my-scope',
+            scope: 'my-scope my-other-scope',
           },
           backstageIdentity: {
             identity: {
@@ -324,7 +324,9 @@ describe('createOAuthRouteHandlers', () => {
       });
 
       expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
-      expect(getGrantedScopesCookie(agent).value).toBe('my-scope');
+      expect(getGrantedScopesCookie(agent).value).toBe(
+        'my-scope%20my-other-scope',
+      );
     });
 
     it('should redirect with persisted scope', async () => {
@@ -357,7 +359,7 @@ describe('createOAuthRouteHandlers', () => {
         state: encodeOAuthState({
           env: 'development',
           nonce: '123',
-          scope: 'my-scope',
+          scope: 'my-scope my-other-scope',
           flow: 'redirect',
           redirectUrl: 'https://127.0.0.1:3000/redirect',
         } as OAuthState),
@@ -367,7 +369,9 @@ describe('createOAuthRouteHandlers', () => {
       expect(res.get('Location')).toBe('https://127.0.0.1:3000/redirect');
 
       expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
-      expect(getGrantedScopesCookie(agent).value).toBe('my-scope');
+      expect(getGrantedScopesCookie(agent).value).toBe(
+        'my-scope%20my-other-scope',
+      );
     });
 
     it('should require a valid origin', async () => {

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -214,7 +214,7 @@ export function createOAuthRouteHandlers<TProfile>(
         // the provider does not return granted scopes on refresh or if they are normalized.
         if (authenticator.shouldPersistScopes && state.scope) {
           cookieManager.setGrantedScopes(res, state.scope, appOrigin);
-          result.session.scope = state.scope;
+          response.providerInfo.scope = state.scope;
         }
 
         if (result.session.refreshToken) {

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -136,7 +136,7 @@ export function createOAuthRouteHandlers<TProfile>(
 
       // If scopes are persisted then we pass them through the state so that we
       // can set the cookie on successful auth
-      if (authenticator.shouldPersistScopes) {
+      if (authenticator.shouldPersistScopes && scope) {
         state.scope = scope;
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This was mistakenly not enabled in the initial migration, fixes #20103

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
