### PR TITLE
Changed color of the overlay components to match navigation color

### DIFF
--- a/.changeset/violet-beers-cross.md
+++ b/.changeset/violet-beers-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Change overlay header colors in the mobile menu to use navigation color from the theme

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -79,14 +79,14 @@ const useStyles = makeStyles<BackstageTheme, { sidebarConfig: SidebarConfig }>(
 
     overlayHeader: {
       display: 'flex',
-      color: theme.palette.text.primary,
+      color: theme.palette.navigation.color,
       alignItems: 'center',
       justifyContent: 'space-between',
       padding: theme.spacing(2, 3),
     },
 
     overlayHeaderClose: {
-      color: theme.palette.text.primary,
+      color: theme.palette.navigation.color,
     },
 
     marginMobileSidebar: props => ({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The overlay components in the drawer menu uses the primary text color. I think it's better to use the navigation color instead. Even in the demo app the label is hardly visible due to the lack of contrast in the colors.

<img width="414" alt="Screenshot 2023-09-25 at 14 28 22" src="https://github.com/backstage/backstage/assets/1516438/3acdb901-f3ad-4f24-ab65-4036eb6df3b8">

With the current change the demo app will look like:

<img width="412" alt="Screenshot 2023-09-25 at 14 38 26" src="https://github.com/backstage/backstage/assets/1516438/a551d24b-f381-49f2-9da3-7c64838a5d2e">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
