### PR TITLE
config-loader: retry empty files

### DIFF
--- a/.changeset/shy-clouds-reflect.md
+++ b/.changeset/shy-clouds-reflect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+The `FileConfigSource` will now retry file reading after a short delay if it reads an empty file. This is to avoid flakiness during watch mode where change events can trigger before the file content has been written.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is to fix the flaky tests, but it's not impossible that this could happen in production setups either as far as I can find. For example https://stackoverflow.com/questions/34750158/chokidar-onchange-event-for-a-file-is-possibly-triggered-to-fast. We don't want to use the `awaitWriteFinish` option though imo, it introduces too much delay and we're not dealing with large files. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
