### PR TITLE
Fix/correct coverage statistics

### DIFF
--- a/.changeset/cold-seas-repeat.md
+++ b/.changeset/cold-seas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage': patch
+---
+
+Fixed the coverage history statistics to compare newest with oldest record

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -113,8 +113,8 @@ export const CoverageHistoryChart = () => {
     );
   }
 
-  const oldestCoverage = valueHistory.history[0];
-  const [latestCoverage] = valueHistory.history.slice(-1);
+  const [oldestCoverage] = valueHistory.history.slice(-1);
+  const latestCoverage = valueHistory.history[0];
 
   const getTrendForCoverage = (type: Coverage) => {
     if (!oldestCoverage[type].percentage) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As [suggested](https://github.com/backstage/backstage/pull/20064#discussion_r1335803076) in [this](https://github.com/backstage/backstage/pull/20064) PR, the bug fix with the coverage history was moved to a separate PR.

This PR fixes an issue where the history statistics (current line/branch) compare the oldest record against the newest, often resulting in a negative trend when it's actually a positive.

The mock data used in the dev server is the actual API response for a test project that I have.

Before the change:

<img width="1418" alt="Screenshot 2023-09-26 at 11 43 53" src="https://github.com/backstage/backstage/assets/3415645/7b6a80a3-558d-4f77-a080-d2a2761691e9">

After the change:

<img width="1415" alt="Screenshot 2023-09-26 at 11 44 06" src="https://github.com/backstage/backstage/assets/3415645/de1e6b09-9d46-45f6-a5f7-fb4601fb176b">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
