### PR TITLE
bugfix(catalog-backend-module-gitlab): Make sure archived repos are skipped

### DIFF
--- a/.changeset/shy-seas-sip.md
+++ b/.changeset/shy-seas-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Make sure the archived projects are skipped with the Gitlab API

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
@@ -238,14 +238,6 @@ describe('GitlabDiscoveryProcessor', () => {
                   path_with_namespace: '3',
                 },
                 {
-                  id: 4,
-                  archived: true, // ARCHIVED
-                  default_branch: 'master',
-                  last_activity_at: '2021-08-05T11:03:05.774Z',
-                  web_url: 'https://gitlab.fake/4',
-                  path_with_namespace: '4',
-                },
-                {
                   id: 5,
                   archived: false,
                   default_branch: undefined, // MISSING DEFAULT BRANCH

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -309,7 +309,7 @@ export class GitLabClient {
   ): Promise<PagedResponse<T>> {
     const request = new URL(`${this.config.apiBaseUrl}${endpoint}`);
     for (const key in options) {
-      if (options[key]) {
+      if (options[key] !== undefined && options[key] !== '') {
         request.searchParams.append(key, options[key]!.toString());
       }
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This error appeared since the archived repos are filtered via the GitLab API in the PR https://github.com/backstage/backstage/pull/18816. However, this never worked properly.

For some time we noticed a bunch of archived repos were fetched again by Backstage, and after investigating the reason, we discovered what is the reason:

In the `pagedRequest` function _only_ the values that passed the `options[key]` were accepted.  The `archived` parameter was always set to `false` so this check never passed and the generated URL would look like this: `<GITLAB_URL>/groups/<GROUP>/projects?group=<GROUP>&page=1&per_page=50&include_subgroups=true`. When this is called, the GitLab API is also returning the archived repos. 

Therefore, we have to make sure that _only_ the empty options are skipped (the ones that are an empty string). Once this is done, the URL will be like the following: `<GITLAB_URL>/groups/<GROUP>/projects?archived=false&group=<GROUP>&page=1&per_page=50&include_subgroups=true`. Which is now skipping the archived repos.

I also needed to update a test, because an archived repo was returned and it was causing the test to fail. Removing that archived repo fixed it.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
