### PR TITLE
Updates the techdocs instructions to not fail when using zsh

### DIFF
--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -29,7 +29,7 @@ cd repo
 
 # Install @techdocs/cli, mkdocs and mkdocs plugins
 npm install -g @techdocs/cli
-pip install mkdocs-techdocs-core==1.*
+pip install "mkdocs-techdocs-core==1.*"
 
 # Generate
 techdocs-cli generate --no-docker


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using zsh, the pip install fails due to the `*` getting expanded. This fixes that.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
