### PR TITLE
Make sure a default factory badge is selected

### DIFF
--- a/.changeset/many-swans-eat.md
+++ b/.changeset/many-swans-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges-backend': patch
+---
+
+Make sure the default badge factory is used if nothing is defined

--- a/plugins/badges-backend/src/plugin.ts
+++ b/plugins/badges-backend/src/plugin.ts
@@ -20,6 +20,7 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
+import { createDefaultBadgeFactories } from './badges';
 
 /**
  * Badges backend plugin
@@ -50,6 +51,7 @@ export const badgesPlugin = createBackendPlugin({
           await createRouter({
             config,
             logger: loggerToWinstonLogger(logger),
+            badgeFactories: createDefaultBadgeFactories(),
             discovery,
             tokenManager,
             identity,

--- a/plugins/badges-backend/src/service/router.ts
+++ b/plugins/badges-backend/src/service/router.ts
@@ -32,6 +32,7 @@ import { Logger } from 'winston';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import { BadgesStore, DatabaseBadgesStore } from '../database/badgesStore';
+import { createDefaultBadgeFactories } from '../badges';
 
 /** @public */
 export interface RouterOptions {
@@ -54,7 +55,9 @@ export async function createRouter(
     options.catalog || new CatalogClient({ discoveryApi: options.discovery });
   const badgeBuilder =
     options.badgeBuilder ||
-    new DefaultBadgeBuilder(options.badgeFactories || {});
+    new DefaultBadgeBuilder(
+      options.badgeFactories || createDefaultBadgeFactories(),
+    );
   const router = Router();
 
   const { config, logger, tokenManager, discovery, identity } = options;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While doing the migration to the new backend system, we discovered that the usage of the badges plugin was impossible at the moment if you used `backend.add(import('@backstage/plugin-badges-backend'));`.

This is because the `badgesPlugin` is created without defining the `badgesFactories` property.

What I did in this PR is adding that missing field, so now we will make sure some default badges are always created (if not, you basically have no available badges, even though the documentation states these should be the default).

I guess an extension point will be needed for this plugin anyways if more things have to be added, but this is maybe a bit unrelated, since the issue was caused in the `createRouter` method. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
