### PR TITLE
kubernetesProxy invoke AuthenticationStrategies

### DIFF
--- a/.changeset/two-dingos-dream.md
+++ b/.changeset/two-dingos-dream.md
@@ -1,6 +1,7 @@
 ---
 '@backstage/plugin-kubernetes-backend': patch
 '@backstage/plugin-kubernetes-react': patch
+'@backstage/plugin-kubernetes-common': patch
 ---
 
 The kubernetes APIs invokes Authentication Strategies when Backstage-Kubernetes-Authorization-X-X headers are provided, this enable the possibility to invoke strategies that executes additional steps to get a kubernetes token like on pinniped or custom strategies

--- a/.changeset/two-dingos-dream.md
+++ b/.changeset/two-dingos-dream.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-react': patch
+---
+
+The kubernetes APIs invokes Authentication Strategies when Backstage-Kubernetes-Authorization-X-X headers are provided, this enable the possibility to invoke strategies that executes additional steps to get a kubernetes token like on pinniped or custom strategies

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -520,6 +520,26 @@ metadata:
 
       expect(response.body).toStrictEqual({ items: [] });
     });
+
+    it('should not permit custom auth strategies with dashes', async () => {
+      const throwError = () =>
+        KubernetesBuilder.createBuilder({
+          logger: getVoidLogger(),
+          config,
+          catalogApi,
+          permissions,
+        }).addAuthStrategy('custom-strategy', {
+          getCredential: jest
+            .fn<
+              Promise<KubernetesCredential>,
+              [ClusterDetails, KubernetesRequestAuth]
+            >()
+            .mockResolvedValue({ type: 'anonymous' }),
+          validateCluster: jest.fn().mockReturnValue([]),
+        });
+
+      expect(throwError).toThrow('Strategy name can not include dashes');
+    });
   });
   describe('get /.well-known/backstage/permissions/metadata', () => {
     it('lists permissions supported by the kubernetes plugin', async () => {

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -205,6 +205,9 @@ export class KubernetesBuilder {
   }
 
   public addAuthStrategy(key: string, strategy: AuthenticationStrategy) {
+    if (key.includes('-')) {
+      throw new Error('Strategy name can not include dashes');
+    }
     this.getAuthStrategyMap()[key] = strategy;
     return this;
   }

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -7,6 +7,7 @@ import { BasicPermission } from '@backstage/plugin-permission-common';
 import { Entity } from '@backstage/catalog-model';
 import { FetchResponse as FetchResponse_2 } from '@backstage/plugin-kubernetes-common';
 import type { JsonObject } from '@backstage/types';
+import type { JsonValue } from '@backstage/types';
 import { ObjectsByEntityResponse as ObjectsByEntityResponse_2 } from '@backstage/plugin-kubernetes-common';
 import { PodStatus } from '@kubernetes/client-node';
 import { V1ConfigMap } from '@kubernetes/client-node';
@@ -319,7 +320,9 @@ export const kubernetesPermissions: BasicPermission[];
 export const kubernetesProxyPermission: BasicPermission;
 
 // @public (undocumented)
-export type KubernetesRequestAuth = JsonObject;
+export type KubernetesRequestAuth = {
+  [providerKey: string]: JsonValue | undefined;
+};
 
 // @public (undocumented)
 export interface KubernetesRequestBody {

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { JsonObject } from '@backstage/types';
+import type { JsonObject, JsonValue } from '@backstage/types';
 import {
   PodStatus,
   V1ConfigMap,
@@ -33,7 +33,9 @@ import {
 import { Entity } from '@backstage/catalog-model';
 
 /** @public */
-export type KubernetesRequestAuth = JsonObject;
+export type KubernetesRequestAuth = {
+  [providerKey: string]: JsonValue | undefined;
+};
 
 /** @public */
 export interface CustomResourceMatcher {

--- a/plugins/kubernetes-react/src/api/KubernetesBackendClient.test.ts
+++ b/plugins/kubernetes-react/src/api/KubernetesBackendClient.test.ts
@@ -398,9 +398,26 @@ describe('KubernetesBackendClient', () => {
       identityApi.getCredentials.mockResolvedValue({ token: 'idToken' });
     });
 
-    it('hits the /proxy API', async () => {
+    it('hits the /proxy API with oidc as protocol and okta as auth provider', async () => {
+      worker.use(
+        rest.get(
+          'http://localhost:1234/api/kubernetes/clusters',
+          (_, res, ctx) =>
+            res(
+              ctx.json({
+                items: [
+                  {
+                    name: 'cluster-a',
+                    authProvider: 'oidc',
+                    oidcTokenProvider: 'okta',
+                  },
+                ],
+              }),
+            ),
+        ),
+      );
       kubernetesAuthProvidersApi.getCredentials.mockResolvedValue({
-        token: 'k8-token',
+        token: 'k8-token3',
       });
       const nsResponse = {
         kind: 'Namespace',
@@ -414,8 +431,56 @@ describe('KubernetesBackendClient', () => {
           'http://localhost:1234/api/kubernetes/proxy/api/v1/namespaces',
           (req, res, ctx) =>
             res(
-              req.headers.get('Backstage-Kubernetes-Authorization') ===
-                'Bearer k8-token'
+              req.headers.get(
+                'Backstage-Kubernetes-Authorization-oidc-okta',
+              ) === 'k8-token3'
+                ? ctx.json(nsResponse)
+                : ctx.status(403),
+            ),
+        ),
+      );
+
+      const request = {
+        clusterName: 'cluster-a',
+        path: '/api/v1/namespaces',
+      };
+
+      const response = await backendClient.proxy(request);
+
+      await expect(response.json()).resolves.toStrictEqual(nsResponse);
+    });
+
+    it('hits the /proxy API with serviceAccount as auth provider', async () => {
+      worker.use(
+        rest.get(
+          'http://localhost:1234/api/kubernetes/clusters',
+          (_, res, ctx) =>
+            res(
+              ctx.json({
+                items: [
+                  {
+                    name: 'cluster-a',
+                    authProvider: 'serviceAccount',
+                  },
+                ],
+              }),
+            ),
+        ),
+      );
+
+      const nsResponse = {
+        kind: 'Namespace',
+        apiVersion: 'v1',
+        metadata: {
+          name: 'new-ns',
+        },
+      };
+      worker.use(
+        rest.get(
+          'http://localhost:1234/api/kubernetes/proxy/api/v1/namespaces',
+          (req, res, ctx) =>
+            res(
+              req.headers.get('Authorization') === 'Bearer idToken'
                 ? ctx.json(nsResponse)
                 : ctx.status(403),
             ),
@@ -450,8 +515,8 @@ describe('KubernetesBackendClient', () => {
           'http://localhost:1234/api/kubernetes/proxy/api/v1/namespaces',
           (req, res, ctx) =>
             res(
-              req.headers.get('Backstage-Kubernetes-Authorization') ===
-                'Bearer k8-token'
+              req.headers.get('Backstage-Kubernetes-Authorization-aws') ===
+                'k8-token'
                 ? ctx.json(nsResponse)
                 : ctx.status(403),
             ),

--- a/plugins/kubernetes-react/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes-react/src/api/KubernetesBackendClient.ts
@@ -75,9 +75,11 @@ export class KubernetesBackendClient implements KubernetesApi {
     return this.handleResponse(response);
   }
 
-  private async getCluster(
-    clusterName: string,
-  ): Promise<{ name: string; authProvider: string }> {
+  private async getCluster(clusterName: string): Promise<{
+    name: string;
+    authProvider: string;
+    oidcTokenProvider?: string;
+  }> {
     const cluster = await this.getClusters().then(clusters =>
       clusters.find(c => c.name === clusterName),
     );
@@ -140,23 +142,62 @@ export class KubernetesBackendClient implements KubernetesApi {
     path: string;
     init?: RequestInit;
   }): Promise<Response> {
-    const { authProvider } = await this.getCluster(options.clusterName);
-    const { token: k8sToken } = await this.getCredentials(authProvider);
+    const { authProvider, oidcTokenProvider } = await this.getCluster(
+      options.clusterName,
+    );
+    const kubernetesCredentials = await this.getCredentials(authProvider);
     const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}/proxy${
       options.path
     }`;
     const identityResponse = await this.identityApi.getCredentials();
-    const headers = {
+    const headers = KubernetesBackendClient.getKubernetesHeaders(
+      options,
+      kubernetesCredentials?.token,
+      identityResponse,
+      authProvider,
+      oidcTokenProvider,
+    );
+    return await fetch(url, { ...options.init, headers });
+  }
+
+  private static getKubernetesHeaders(
+    options: {
+      clusterName: string;
+      path: string;
+      init?: RequestInit;
+    },
+    k8sToken: string | undefined,
+    identityResponse: { token?: string },
+    authProvider: string,
+    oidcTokenProvider: string | undefined,
+  ) {
+    const kubernetesAuthHeader =
+      KubernetesBackendClient.getKubernetesAuthHeaderByAuthProvider(
+        authProvider,
+        oidcTokenProvider,
+      );
+    return {
       ...options.init?.headers,
       [`Backstage-Kubernetes-Cluster`]: options.clusterName,
       ...(k8sToken && {
-        [`Backstage-Kubernetes-Authorization`]: `Bearer ${k8sToken}`,
+        [kubernetesAuthHeader]: k8sToken,
       }),
       ...(identityResponse.token && {
         Authorization: `Bearer ${identityResponse.token}`,
       }),
     };
+  }
 
-    return await fetch(url, { ...options.init, headers });
+  private static getKubernetesAuthHeaderByAuthProvider(
+    authProvider: string,
+    oidcTokenProvider: string | undefined,
+  ): string {
+    let header: string = 'Backstage-Kubernetes-Authorization';
+
+    header = header.concat('-', authProvider);
+
+    if (oidcTokenProvider) header = header.concat('-', oidcTokenProvider);
+
+    return header;
   }
 }


### PR DESCRIPTION
This PR resolves #19999 

kubernetes-backend proxy API invoke Authentication Strategies when Backstage-Kubernetes-Authorization-X-X are provided

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
