### PR TITLE
Implement readTree of Gitea provider to support Techdocs

### DIFF
--- a/.changeset/sixty-houses-agree.md
+++ b/.changeset/sixty-houses-agree.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': minor
+'@backstage/integration': minor
+---
+
+Implemented readTree for Gitea provider to basically support Techdocs functionality

--- a/docs/features/techdocs/README.md
+++ b/docs/features/techdocs/README.md
@@ -68,6 +68,7 @@ See [TechDocs Architecture](architecture.md) to get an overview of where the bel
 | Gerrit                       | Yes ✅         |
 | GitLab                       | Yes ✅         |
 | GitLab Enterprise            | Yes ✅         |
+| Gitea                        | Yes ✅         |
 
 ### File storage providers
 

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -414,13 +414,18 @@ export class Git {
 
 // @public
 export class GiteaUrlReader implements UrlReader {
-  constructor(integration: GiteaIntegration);
+  constructor(
+    integration: GiteaIntegration,
+    deps: {
+      treeResponseFactory: ReadTreeResponseFactory;
+    },
+  );
   // (undocumented)
   static factory: ReaderFactory;
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(): Promise<ReadTreeResponse>;
+  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
   // (undocumented)
   readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
   // (undocumented)

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -420,7 +420,25 @@ export function getGerritRequestOptions(config: GerritIntegrationConfig): {
 };
 
 // @public
+export function getGiteaArchiveUrl(
+  config: GiteaIntegrationConfig,
+  url: string,
+): string;
+
+// @public
+export function getGiteaEditContentsUrl(
+  config: GiteaIntegrationConfig,
+  url: string,
+): string;
+
+// @public
 export function getGiteaFileContentsUrl(
+  config: GiteaIntegrationConfig,
+  url: string,
+): string;
+
+// @public
+export function getGiteaLatestCommitUrl(
   config: GiteaIntegrationConfig,
   url: string,
 ): string;
@@ -657,6 +675,18 @@ export function parseGerritGitilesUrl(
 
 // @public
 export function parseGerritJsonResponse(response: Response): Promise<unknown>;
+
+// @public
+export function parseGiteaUrl(
+  config: GiteaIntegrationConfig,
+  url: string,
+): {
+  url: string;
+  owner: string;
+  name: string;
+  ref: string;
+  path: string;
+};
 
 // @public
 export type PersonalAccessTokenCredential = AzureCredentialBase & {

--- a/packages/integration/src/gitea/index.ts
+++ b/packages/integration/src/gitea/index.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 export { GiteaIntegration } from './GiteaIntegration';
-export { getGiteaRequestOptions, getGiteaFileContentsUrl } from './core';
+export {
+  getGiteaEditContentsUrl,
+  getGiteaFileContentsUrl,
+  getGiteaArchiveUrl,
+  getGiteaLatestCommitUrl,
+  getGiteaRequestOptions,
+  parseGiteaUrl,
+} from './core';
 export { readGiteaConfig } from './config';
 export type { GiteaIntegrationConfig } from './config';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implemented the `readTree` functionality for `Gitea` provider to support TechDocs functionality.
See: #19960 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
