### PR TITLE
fix: watch now button and year in footer

### DIFF
--- a/microsite/docusaurus.config.js
+++ b/microsite/docusaurus.config.js
@@ -276,7 +276,7 @@ module.exports = {
           },
         ],
         copyright:
-          '<p style="text-align:center"><a href="https://spotify.github.io/">Made with ❤️ at Spotify</a></p><p class="copyright">Copyright © 2022 Backstage Project Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage</p>',
+          '<p style="text-align:center"><a href="https://spotify.github.io/">Made with ❤️ at Spotify</a></p><p class="copyright">Copyright © 2023 Backstage Project Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage</p>',
       },
       algolia: {
         apiKey: '1f0ba86672ccfc3576faa94583e5b318',

--- a/microsite/src/pages/demos/index.tsx
+++ b/microsite/src/pages/demos/index.tsx
@@ -175,12 +175,16 @@ const Demos = () => {
             <BannerSectionGrid>
               <ContentBlock
                 title={<h1>{demoItem.title}</h1>}
-                actionButtons={[
-                  {
-                    link: demoItem.actionItemLink,
-                    label: 'WATCH NOW',
-                  },
-                ]}
+                actionButtons={
+                  demoItem.actionItemLink
+                    ? [
+                        {
+                          link: demoItem.actionItemLink,
+                          label: 'WATCH NOW',
+                        },
+                      ]
+                    : []
+                }
               >
                 {demoItem.content}
               </ContentBlock>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

- updated year to 2023 in the footer 
<img width="1313" alt="image" src="https://github.com/backstage/backstage/assets/47827254/b27cde23-cdf1-4f39-9682-374661b7f3a4">

- If `demoItem.actionItemLink` is undefined, we do not show the `Watch Now` button

<img width="1335" alt="image" src="https://github.com/backstage/backstage/assets/47827254/863dca0e-3dc7-48a0-95ab-2d95499fcad3">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Related Issue

Closes #20222 
Closes #20223
