### PR TITLE
fix: support button menu items text wrap

### DIFF
--- a/.changeset/popular-dots-design.md
+++ b/.changeset/popular-dots-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Changed SupportButton menuitems to support text wrap

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -46,6 +46,9 @@ const useStyles = makeStyles(
       minWidth: 260,
       maxWidth: 400,
     },
+    menuItem: {
+      whiteSpace: 'normal',
+    },
   },
   { name: 'BackstageSupportButton' },
 );
@@ -145,12 +148,16 @@ export function SupportButton(props: SupportButtonProps) {
           autoFocusItem={Boolean(anchorEl)}
         >
           {title && (
-            <MenuItem alignItems="flex-start">
+            <MenuItem alignItems="flex-start" className={classes.menuItem}>
               <Typography variant="subtitle1">{title}</Typography>
             </MenuItem>
           )}
           {React.Children.map(children, (child, i) => (
-            <MenuItem alignItems="flex-start" key={`child-${i}`}>
+            <MenuItem
+              alignItems="flex-start"
+              key={`child-${i}`}
+              className={classes.menuItem}
+            >
               {child}
             </MenuItem>
           ))}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current support button menu does not support text wrap. Yet there is a max-width defined and therefore larger menu items are not rendered correctly. To fix this I've changed the white-space property to normal.

This change is best seen in the SupportButton used at the tech-radar in the demo site:

<img width="520" alt="Screenshot 2023-09-28 at 19 07 05" src="https://github.com/backstage/backstage/assets/1516438/95fcb974-ec7c-4e72-bc24-29c4bc225f0b">

After this change the menu looks like:

<img width="543" alt="Screenshot 2023-09-28 at 17 09 33" src="https://github.com/backstage/backstage/assets/1516438/3c80f2a7-047b-4fb3-9b7f-5bcea0297a63">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
