### PR TITLE
Clarified docker node and Bebian version

### DIFF
--- a/.changeset/small-pugs-build.md
+++ b/.changeset/small-pugs-build.md
@@ -2,6 +2,6 @@
 '@backstage/create-app': patch
 ---
 
-Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build.
+Bump Docker base images to `node:18-bookworm-slim` to fix node compatibility issues raised during image build.
 
-You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bullseye-slim`
+You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bookworm-slim`

--- a/docs/releases/v1.19.0-next.0-changelog.md
+++ b/docs/releases/v1.19.0-next.0-changelog.md
@@ -297,9 +297,9 @@
 
 - de42eebaaf: Bumped dev dependencies `@types/node` and `mock-fs`.
 
-- 04a3f65e15: Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build.
+- 04a3f65e15: Bump Docker base images to `node:18-bookworm-slim` to fix node compatibility issues raised during image build.
 
-  You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bullseye-slim`
+  You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bookworm-slim`
 
 - 5eacd5d213: The E2E test setup based on Cypress has been replaced with one based on [Playwright](https://playwright.dev/). Migrating existing apps is not required as this is a standalone setup, only do so if you also want to switch from Cypress to Playwright.
 

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -12,9 +12,9 @@
 
 - deed089a3d: Bump `cypress` to fix the end-to-end tests
 - de42eebaaf: Bumped dev dependencies `@types/node` and `mock-fs`.
-- 04a3f65e15: Bump Docker base images to `node:18-bullseye-slim` to fix compatibility issues raised during image build.
+- 04a3f65e15: Bump Docker base images to `node:18-bookworm-slim` to fix node compatibility issues raised during image build.
 
-  You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bullseye-slim`
+  You can apply these change to your own `Dockerfile` by replacing `node:16-bullseye-slim` with `node:18-bookworm-slim`
 
 - 5eacd5d213: The E2E test setup based on Cypress has been replaced with one based on [Playwright](https://playwright.dev/). Migrating existing apps is not required as this is a standalone setup, only do so if you also want to switch from Cypress to Playwright.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current @backstage/create-app changelog is fairly confusing around what node and Debian version currently being used in the dockerfile:

<img width="1026" alt="Screenshot 2023-09-28 at 2 26 43 PM copy" src="https://github.com/backstage/backstage/assets/67169551/fdddbd6b-6448-416d-8b04-5055bad31a61">

This PR attempts to clarify this, very open to feedback though

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
