### PR TITLE
[DI] Create `Catalog` search result item extension

### DIFF
--- a/.changeset/eight-melons-cough.md
+++ b/.changeset/eight-melons-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Create an experimental `CatalogSearchResultItemExtension` for declarative integration with Backstage; it can be accessed via the `/alpha` import.

--- a/plugins/catalog/alpha-api-report.md
+++ b/plugins/catalog/alpha-api-report.md
@@ -5,19 +5,14 @@
 ```ts
 import { BackstagePlugin } from '@backstage/frontend-plugin-api';
 import { Extension } from '@backstage/frontend-plugin-api';
-import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
 // @alpha (undocumented)
 export const CatalogApi: Extension<{}>;
 
 // @alpha (undocumented)
-export const catalogTranslationRef: TranslationRef<
-  'catalog',
-  {
-    readonly catalog_page_title: '{{orgName}} Catalog';
-    readonly catalog_page_create_button_title: 'Create';
-  }
->;
+export const CatalogSearchResultListItemExtension: Extension<{
+  noTrack?: boolean | undefined;
+}>;
 
 // @alpha (undocumented)
 const _default: BackstagePlugin;

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -10,13 +10,13 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./alpha": "./src/alpha.ts",
+    "./alpha": "./src/alpha.tsx",
     "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
       "alpha": [
-        "src/alpha.ts"
+        "src/alpha.tsx"
       ],
       "package.json": [
         "package.json"

--- a/plugins/catalog/src/alpha.tsx
+++ b/plugins/catalog/src/alpha.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-export * from './translation';
-
 import {
   createApiFactory,
   discoveryApiRef,
@@ -31,6 +29,7 @@ import {
   catalogApiRef,
   starredEntitiesApiRef,
 } from '@backstage/plugin-catalog-react';
+import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
 import { DefaultStarredEntitiesApi } from './apis';
 
 /** @alpha */
@@ -56,7 +55,22 @@ export const StarredEntitiesApi = createApiExtension({
 });
 
 /** @alpha */
+export const CatalogSearchResultListItemExtension =
+  createSearchResultListItemExtension({
+    id: 'catalog',
+    predicate: result => result.type === 'software-catalog',
+    component: () =>
+      import('./components/CatalogSearchResultListItem').then(
+        m => m.CatalogSearchResultListItem,
+      ),
+  });
+
+/** @alpha */
 export default createPlugin({
   id: 'catalog',
-  extensions: [CatalogApi, StarredEntitiesApi],
+  extensions: [
+    CatalogApi,
+    StarredEntitiesApi,
+    CatalogSearchResultListItemExtension,
+  ],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrate the `CatalogSearchResultItemExtension` to the declarative integration format.

### Known limitations:

- It doesn't support icon customization for now.

### Usage example:

> [!Note]
> Currently, it is in an experimental stage and is not recommended for production

For frontend applications that support declarative integration, it is only necessary to install the following packages:

```sh
# install the catalog and search plugins packages
yarn add @backstage/plugin-catalog @backstage/plugin-search
```

Optionally you can customize the search results via `app-config.yaml` file:

```yaml
# app-config.yaml
# example disabling analytics tracking
app:
  experimental:
    packages: 'all' # ✨

  extensions:
    - plugin.search.result.item.catalog:
        config:
          noTrack: true
```
### Testing

Install the branch dependencies and start both frontend and backend declarative applications:

```sh
# Installing branch dependencies
yarn install

# Starting the backend application
cd packages/backend-next
yarn start

# Starting the frontend application
cd packages/app-next
yarn start
```
After that, navigate to http://locahost:3000 and click on the `Search` sidebar item:

![image](https://github.com/backstage/backstage/assets/6290749/dd2d0ad9-d8c4-4d5b-a695-8c343f748551)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
