### PR TITLE
fix(#20232): load relations to get children of children

### DIFF
--- a/.changeset/cold-bees-jam.md
+++ b/.changeset/cold-bees-jam.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed the display of OwnershipCard with aggregated relations by loading relations when getting children of entity.
+This allows the already existing recursive method to work properly when children of entity have children themselves.

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -39,6 +39,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
     "@types/react": "^16.13.1 || ^17.0.0",
+    "lodash": "^4.17.21",
     "p-limit": "^3.1.0",
     "pluralize": "^8.0.0",
     "qs": "^6.10.1",

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
@@ -110,6 +110,14 @@ describe('useGetEntities', () => {
       );
     });
 
+    it('given group entity should retrieve child with their relations', async () => {
+      await whenHookIsCalledWith(givenParentGroupEntity);
+      expect(catalogApiMock.getEntitiesByRefs).toHaveBeenCalledWith({
+        entityRefs: [`group:default/${givenLeafGroup}`],
+        fields: ['kind', 'metadata.namespace', 'metadata.name', 'relations'],
+      });
+    });
+
     it('given user entity should aggregate parent ownership and direct', async () => {
       await whenHookIsCalledWith(givenUserEntity);
       expect(catalogApiMock.getEntities).toHaveBeenCalledWith(

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
@@ -90,7 +90,7 @@ const getChildOwnershipEntityRefs = async (
   if (hasChildGroups) {
     const entityRefs = childGroups.map(r => stringifyEntityRef(r));
     const childGroupResponse = await catalogApi.getEntitiesByRefs({
-      fields: ['kind', 'metadata.namespace', 'metadata.name'],
+      fields: ['kind', 'metadata.namespace', 'metadata.name', 'relations'],
       entityRefs,
     });
     const childGroupEntities = childGroupResponse.items.filter(isEntity);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8139,6 +8139,7 @@ __metadata:
     "@testing-library/react-hooks": ^8.0.1
     "@testing-library/user-event": ^14.0.0
     "@types/react": ^16.13.1 || ^17.0.0
+    lodash: ^4.17.21
     msw: ^1.0.0
     p-limit: ^3.1.0
     pluralize: ^8.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the display of OwnershipCard with aggregated relations by loading relations when getting children of entity.
This allows the already existing recursive method to work properly when children of entity have children themselves.
See [issue](https://github.com/backstage/backstage/issues/20232) for details.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] ~~Screenshots attached (for UI changes)~~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
