### PR TITLE
Handle gitlab namespace request properly

### DIFF
--- a/.changeset/lazy-doors-wink.md
+++ b/.changeset/lazy-doors-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Display meaningful error to the output if Gitlab namespace not found inside `publish:gitlab`.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -396,7 +396,9 @@ describe('publish:gitlab', () => {
 
   it('should show proper error message when token has insufficient permissions or namespace not found', async () => {
     mockGitlabClient.Namespaces.show.mockRejectedValue({
-      message: '404 Namespace Not Found',
+      response: {
+        statusCode: 404,
+      },
     });
     const owner = 'infrastructure/devex';
     const repoName = 'backstage';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -393,4 +393,21 @@ describe('publish:gitlab', () => {
       visibility: 'private',
     });
   });
+
+  it('should show proper error message when token has insufficient permissions or namespace not found', async () => {
+    mockGitlabClient.Namespaces.show.mockRejectedValue({
+      message: '404 Namespace Not Found',
+    });
+    const owner = 'infrastructure/devex';
+    const repoName = 'backstage';
+
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: { repoUrl: `gitlab.com?owner=${owner}&repo=${repoName}` },
+      }),
+    ).rejects.toThrow(
+      `The namespace ${owner} is not found or the user doesn't have permissions to access it`,
+    );
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -188,6 +188,7 @@ export function createPublishGitlabAction(options: {
             `The namespace ${owner} is not found or the user doesn't have permissions to access it`,
           );
         }
+        throw e;
       }
 
       const { id: userId } = (await client.Users.current()) as {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -183,9 +183,11 @@ export function createPublishGitlabAction(options: {
 
         targetNamespaceId = namespaceResponse.id;
       } catch (e) {
-        throw new InputError(
-          `The namespace ${owner} is not found or the user doesn't have permissions to access it`,
-        );
+        if (e.response && e.response.statusCode === 404) {
+          throw new InputError(
+            `The namespace ${owner} is not found or the user doesn't have permissions to access it`,
+          );
+        }
       }
 
       const { id: userId } = (await client.Users.current()) as {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -174,20 +174,30 @@ export function createPublishGitlabAction(options: {
         [tokenType]: token,
       });
 
-      let { id: targetNamespace } = (await client.Namespaces.show(owner)) as {
-        id: number;
-      };
+      let targetNamespaceId;
+
+      try {
+        const namespaceResponse = (await client.Namespaces.show(owner)) as {
+          id: number;
+        };
+
+        targetNamespaceId = namespaceResponse.id;
+      } catch (e) {
+        throw new InputError(
+          `The namespace ${owner} is not found or the user doesn't have permissions to access it`,
+        );
+      }
 
       const { id: userId } = (await client.Users.current()) as {
         id: number;
       };
 
-      if (!targetNamespace) {
-        targetNamespace = userId;
+      if (!targetNamespaceId) {
+        targetNamespaceId = userId;
       }
 
       const { id: projectId, http_url_to_repo } = await client.Projects.create({
-        namespace_id: targetNamespace,
+        namespace_id: targetNamespaceId,
         name: repo,
         visibility: repoVisibility,
         ...(topics.length ? { topics } : {}),


### PR DESCRIPTION
## This PR improves error handling for `publish:gitlab`

If the owner isn't found or current auth doesn't have permissions for the namespace, the publishing will fail with this output:

<img width="876" alt="Screenshot 2023-09-29 at 15 57 20" src="https://github.com/backstage/backstage/assets/899452/e5ab58e8-e00c-427e-851e-b97689b3590f">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
