### PR TITLE
fix(backend-tasks): prevent immediately triggering tasks out of band

### DIFF
--- a/.changeset/nine-garlics-attend.md
+++ b/.changeset/nine-garlics-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Fix bug where backend tasks that are defined with HumanDuration are immediately triggered on application startup

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -165,27 +165,26 @@ export class TaskWorker {
 
     const isCron = !settings?.cadence.startsWith('P');
 
-    let startAt: Knex.Raw;
+    let startAt: Knex.Raw | undefined;
+    let nextStartAt: Knex.Raw | undefined;
     if (settings.initialDelayDuration) {
       startAt = nowPlus(
         Duration.fromISO(settings.initialDelayDuration),
         this.knex,
       );
-    } else if (isCron) {
+    }
+
+    if (isCron) {
       const time = new CronTime(settings.cadence)
         .sendAt()
         .minus({ seconds: 1 }) // immediately, if "* * * * * *"
         .toUTC();
 
-      if (this.knex.client.config.client.includes('sqlite3')) {
-        startAt = this.knex.raw('datetime(?)', [time.toISO()]);
-      } else if (this.knex.client.config.client.includes('mysql')) {
-        startAt = this.knex.raw(`?`, [time.toSQL({ includeOffset: false })]);
-      } else {
-        startAt = this.knex.raw(`?`, [time.toISO()]);
-      }
+      nextStartAt = this.nextRunAtRaw(time);
+      startAt ||= nextStartAt;
     } else {
-      startAt = this.knex.fn.now();
+      startAt ||= this.knex.fn.now();
+      nextStartAt = nowPlus(Duration.fromISO(settings.cadence), this.knex);
     }
 
     this.logger.debug(`task: ${this.taskId} configured to run at: ${startAt}`);
@@ -206,7 +205,12 @@ export class TaskWorker {
               settings_json: settingsJson,
               next_run_start_at: this.knex.raw(
                 `CASE WHEN ?? < ?? THEN ?? ELSE ?? END`,
-                [startAt, 'next_run_start_at', startAt, 'next_run_start_at'],
+                [
+                  nextStartAt,
+                  'next_run_start_at',
+                  nextStartAt,
+                  'next_run_start_at',
+                ],
               ),
             }
           : {
@@ -214,9 +218,9 @@ export class TaskWorker {
               next_run_start_at: this.knex.raw(
                 `CASE WHEN ?? < ?? THEN ?? ELSE ?? END`,
                 [
-                  'excluded.next_run_start_at',
+                  nextStartAt,
                   `${DB_TASKS_TABLE}.next_run_start_at`,
-                  'excluded.next_run_start_at',
+                  nextStartAt,
                   `${DB_TASKS_TABLE}.next_run_start_at`,
                 ],
               ),
@@ -308,13 +312,7 @@ export class TaskWorker {
       const time = new CronTime(settings.cadence).sendAt().toUTC();
       this.logger.debug(`task: ${this.taskId} will next occur around ${time}`);
 
-      if (this.knex.client.config.client.includes('sqlite3')) {
-        nextRun = this.knex.raw('datetime(?)', [time.toISO()]);
-      } else if (this.knex.client.config.client.includes('mysql')) {
-        nextRun = this.knex.raw(`?`, [time.toSQL({ includeOffset: false })]);
-      } else {
-        nextRun = this.knex.raw(`?`, [time.toISO()]);
-      }
+      nextRun = this.nextRunAtRaw(time);
     } else {
       const dt = Duration.fromISO(settings.cadence).as('seconds');
       this.logger.debug(
@@ -350,5 +348,14 @@ export class TaskWorker {
       });
 
     return rows === 1;
+  }
+
+  private nextRunAtRaw(time: DateTime): Knex.Raw {
+    if (this.knex.client.config.client.includes('sqlite3')) {
+      return this.knex.raw('datetime(?)', [time.toISO()]);
+    } else if (this.knex.client.config.client.includes('mysql')) {
+      return this.knex.raw(`?`, [time.toSQL({ includeOffset: false })]);
+    }
+    return this.knex.raw(`?`, [time.toISO()]);
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves https://github.com/backstage/backstage/issues/20239

Pre-calculates what the _next_ task run time should be when persisting tasks. This value is only used on the UPSERT conflict resolution part of the query.

This prevents tasks from being immediately requeued when `HumanDuration` cadences or start delays have been provided as the current code effectively uses the current time to update the `next_run_start_at` value on insert conflicts

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation **N/A**
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) **N/A**
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
