### PR TITLE
backend-next: fixes for development on Windows

### DIFF
--- a/.changeset/itchy-monkeys-reply.md
+++ b/.changeset/itchy-monkeys-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-dev-utils': patch
+---
+
+Fix an issue where early IPC responses would be lost.

--- a/.changeset/red-bees-try.md
+++ b/.changeset/red-bees-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue where the new backend start command would not gracefully shut down the backend process on Windows.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,6 +78,7 @@
     "cross-fetch": "^3.1.5",
     "cross-spawn": "^7.0.3",
     "css-loader": "^6.5.1",
+    "ctrlc-windows": "^2.1.0",
     "diff": "^5.0.0",
     "esbuild": "^0.19.0",
     "esbuild-loader": "^2.18.0",

--- a/packages/cli/src/lib/experimental/startBackendExperimental.ts
+++ b/packages/cli/src/lib/experimental/startBackendExperimental.ts
@@ -18,6 +18,7 @@ import { FSWatcher, watch } from 'chokidar';
 
 import { BackendServeOptions } from '../bundler/types';
 import type { ChildProcess } from 'child_process';
+import { ctrlc } from 'ctrlc-windows';
 import { IpcServer } from './IpcServer';
 import { ServerDataStore } from './ServerDataStore';
 import debounce from 'lodash/debounce';
@@ -57,7 +58,11 @@ export async function startBackendExperimental(options: BackendServeOptions) {
     if (child && !child.killed && child.exitCode === null) {
       // We always wait for the existing process to exit, to make sure we don't get IPC conflicts
       shutdownPromise = new Promise(resolve => child!.once('exit', resolve));
-      child.kill();
+      if (process.platform === 'win32' && child.pid) {
+        ctrlc(child.pid);
+      } else {
+        child.kill();
+      }
       await shutdownPromise;
       shutdownPromise = undefined;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3795,6 +3795,7 @@ __metadata:
     cross-fetch: ^3.1.5
     cross-spawn: ^7.0.3
     css-loader: ^6.5.1
+    ctrlc-windows: ^2.1.0
     del: ^7.0.0
     diff: ^5.0.0
     esbuild: ^0.19.0
@@ -23045,6 +23046,13 @@ __metadata:
     csv-stringify: ^5.6.5
     stream-transform: ^2.1.3
   checksum: 0decc2d0d7a0abf127f4556d6f3cef5a54015b78d348608b5e8f42256c2bd0a021f34f1efc9723b2cd162680917de4c0b3967bfb65a07305eca0827654ca727e
+  languageName: node
+  linkType: hard
+
+"ctrlc-windows@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "ctrlc-windows@npm:2.1.0"
+  checksum: 0f0582ba9516290d3e90ea7b91710f8b9b110e1ed29b7c84ebd44c16368b2553722b86a17226120ca3ea0ef679ac3596f48104cc113cfb7c3d07260f6c92e38b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns out that the new development setup for backends doesn't work very well on Windows. This switches to using a graceful shutdown method for the backend child process on Windows, as well as fixes a bug where fast IPC responses would be lost on Windows, because we registered the message handler too late.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
