### PR TITLE
e2e-test: ignore all experimental warnings

### DIFF
--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -465,9 +465,7 @@ async function testBackendStart(appDir: string, ...args: string[]) {
             '(Use `node --trace-warnings ...` to show where the warning was created)',
           ) &&
           !l.includes('Custom ESM Loaders is an experimental feature') &&
-          !l.includes(
-            'ExperimentalWarning: `globalPreload` is planned for removal',
-          ),
+          !l.includes('ExperimentalWarning'),
       ).length !== 0
     );
   };


### PR DESCRIPTION
🧹 

They keep changing, and we see them while running locally anyway