### PR TITLE
Fix `authenticate()` ctx properties being missing

### DIFF
--- a/.changeset/large-balloons-brush.md
+++ b/.changeset/large-balloons-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': minor
+---
+
+**BREAKING**: The recently introduced `ProxyAuthenticator.initialize()` method is no longer `async` to match the way the OAuth equivalent is implemented.

--- a/.changeset/rare-pants-reply.md
+++ b/.changeset/rare-pants-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': minor
+---
+
+**BREAKING** `gcpIapAuthenticator.initialize()` is no longer `async`

--- a/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.test.ts
@@ -29,7 +29,7 @@ jest.mock('./helpers', () => ({
 
 describe('GcpIapProvider', () => {
   it('should find default JWT header', async () => {
-    const ctx = await gcpIapAuthenticator.initialize({
+    const ctx = gcpIapAuthenticator.initialize({
       config: mockServices.rootConfig({ data: { audience: 'my-audience' } }),
     });
     await expect(
@@ -50,7 +50,7 @@ describe('GcpIapProvider', () => {
 
   it('should find custom JWT header', async () => {
     const jwtHeader = 'x-custom-header';
-    const ctx = await gcpIapAuthenticator.initialize({
+    const ctx = gcpIapAuthenticator.initialize({
       config: mockServices.rootConfig({
         data: { audience: 'my-audience', jwtHeader },
       }),
@@ -70,7 +70,7 @@ describe('GcpIapProvider', () => {
   });
 
   it('should throw if header is missing', async () => {
-    const ctx = await gcpIapAuthenticator.initialize({
+    const ctx = gcpIapAuthenticator.initialize({
       config: mockServices.rootConfig({
         data: { audience: 'my-audience' },
       }),

--- a/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.ts
@@ -29,7 +29,7 @@ export const gcpIapAuthenticator = createProxyAuthenticator({
   defaultProfileTransform: async (result: GcpIapResult) => {
     return { profile: { email: result.iapToken.email } };
   },
-  async initialize({ config }) {
+  initialize({ config }) {
     const audience = config.getString('audience');
     const jwtHeader =
       config.getOptionalString('jwtHeader') ?? DEFAULT_IAP_JWT_HEADER;

--- a/plugins/auth-node/api-report.md
+++ b/plugins/auth-node/api-report.md
@@ -550,7 +550,7 @@ export interface ProxyAuthenticator<TContext, TResult> {
   // (undocumented)
   defaultProfileTransform: ProfileTransform<TResult>;
   // (undocumented)
-  initialize(ctx: { config: Config }): Promise<TContext>;
+  initialize(ctx: { config: Config }): TContext;
 }
 
 // @public (undocumented)

--- a/plugins/auth-node/src/proxy/types.ts
+++ b/plugins/auth-node/src/proxy/types.ts
@@ -21,7 +21,7 @@ import { ProfileTransform } from '../types';
 /** @public */
 export interface ProxyAuthenticator<TContext, TResult> {
   defaultProfileTransform: ProfileTransform<TResult>;
-  initialize(ctx: { config: Config }): Promise<TContext>;
+  initialize(ctx: { config: Config }): TContext;
   authenticate(
     options: { req: Request },
     ctx: TContext,


### PR DESCRIPTION
The return value of `initialize()` is a `Promise<...>`, but it wasn't being `await`'d before being passed to `authenticator.authenticate(...)`.

This was causing the `gcpIap` provider to fail on the `/request` endpoint because `jwtHeader` was undefined.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
