### PR TITLE
Store GKE dashboard parameters in catalog

### DIFF
--- a/.changeset/eleven-students-brake.md
+++ b/.changeset/eleven-students-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gcp': patch
+---
+
+Allow integration with kubernetes dashboard

--- a/.changeset/fair-tools-bake.md
+++ b/.changeset/fair-tools-bake.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+---
+
+Allow storing dashboard parameters for kubernetes in catalog

--- a/plugins/catalog-backend-module-gcp/package.json
+++ b/plugins/catalog-backend-module-gcp/package.json
@@ -48,6 +48,7 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
+    "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-kubernetes-common": "workspace:^",

--- a/plugins/catalog-backend-module-gcp/src/providers/__snapshots__/GkeEntityProvider.test.ts.snap
+++ b/plugins/catalog-backend-module-gcp/src/providers/__snapshots__/GkeEntityProvider.test.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GkeEntityProvider should return clusters as Resources 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      {
+        "entities": [
+          {
+            "entity": {
+              "apiVersion": "backstage.io/v1alpha1",
+              "kind": "Resource",
+              "metadata": {
+                "annotations": {
+                  "backstage.io/managed-by-location": "gcp-gke:some-location",
+                  "backstage.io/managed-by-origin-location": "gcp-gke:some-location",
+                  "kubernetes.io/api-server": "https://127.0.0.1",
+                  "kubernetes.io/api-server-certificate-authority": "abcdefg",
+                  "kubernetes.io/auth-provider": "google",
+                  "kubernetes.io/dashboard-app": "gke",
+                  "kubernetes.io/dashboard-parameters": "{"projectId":"parent1","region":"some-location","clusterName":"some-cluster"}",
+                },
+                "name": "some-cluster",
+                "namespace": "default",
+              },
+              "spec": {
+                "owner": "unknown",
+                "type": "kubernetes-cluster",
+              },
+            },
+            "locationKey": "gcp-gke:some-location",
+          },
+          {
+            "entity": {
+              "apiVersion": "backstage.io/v1alpha1",
+              "kind": "Resource",
+              "metadata": {
+                "annotations": {
+                  "backstage.io/managed-by-location": "gcp-gke:some-other-location",
+                  "backstage.io/managed-by-origin-location": "gcp-gke:some-other-location",
+                  "kubernetes.io/api-server": "https://127.0.0.1",
+                  "kubernetes.io/api-server-certificate-authority": "",
+                  "kubernetes.io/auth-provider": "google",
+                  "kubernetes.io/dashboard-app": "gke",
+                  "kubernetes.io/dashboard-parameters": "{"projectId":"parent2","region":"some-other-location","clusterName":"some-other-cluster"}",
+                },
+                "name": "some-other-cluster",
+                "namespace": "default",
+              },
+              "spec": {
+                "owner": "unknown",
+                "type": "kubernetes-cluster",
+              },
+            },
+            "locationKey": "gcp-gke:some-other-location",
+          },
+        ],
+        "type": "full",
+      },
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.test.ts
@@ -23,7 +23,6 @@ import {
 } from '@backstage/plugin-kubernetes-common';
 import { CatalogClusterLocator } from './CatalogClusterLocator';
 import { CatalogApi } from '@backstage/catalog-client';
-import { ClusterDetails } from '../types/types';
 
 const mockCatalogApi = {
   getEntityByRef: jest.fn(),
@@ -93,25 +92,7 @@ describe('CatalogClusterLocator', () => {
     const result = await clusterSupplier.getClusters();
 
     expect(result).toHaveLength(2);
-    expect(result[0]).toStrictEqual<ClusterDetails>({
-      name: 'owned',
-      url: 'https://apiserver.com',
-      caData: 'caData',
-      authMetadata: {
-        'kubernetes.io/api-server': 'https://apiserver.com',
-        'kubernetes.io/api-server-certificate-authority': 'caData',
-        [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'oidc',
-        [ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER]: 'google',
-        'kubernetes.io/skip-metrics-lookup': 'true',
-        'kubernetes.io/skip-tls-verify': 'true',
-        'kubernetes.io/dashboard-url': 'my-url',
-        'kubernetes.io/dashboard-app': 'my-app',
-      },
-      skipMetricsLookup: true,
-      skipTLSVerify: true,
-      dashboardUrl: 'my-url',
-      dashboardApp: 'my-app',
-    });
+    expect(result[0]).toMatchSnapshot();
   });
 
   it('returns the aws cluster details provided by annotations', async () => {
@@ -120,24 +101,6 @@ describe('CatalogClusterLocator', () => {
     const result = await clusterSupplier.getClusters();
 
     expect(result).toHaveLength(2);
-    expect(result[1]).toStrictEqual<ClusterDetails>({
-      name: 'owned',
-      url: 'https://apiserver.com',
-      caData: 'caData',
-      authMetadata: {
-        'kubernetes.io/api-server': 'https://apiserver.com',
-        'kubernetes.io/api-server-certificate-authority': 'caData',
-        [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
-        [ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE]: 'my-role',
-        [ANNOTATION_KUBERNETES_AWS_EXTERNAL_ID]: 'my-id',
-        [ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER]: 'google',
-        'kubernetes.io/dashboard-url': 'my-url',
-        'kubernetes.io/dashboard-app': 'my-app',
-      },
-      skipMetricsLookup: false,
-      skipTLSVerify: false,
-      dashboardUrl: 'my-url',
-      dashboardApp: 'my-app',
-    });
+    expect(result[1]).toMatchSnapshot();
   });
 });

--- a/plugins/kubernetes-backend/src/cluster-locator/__snapshots__/CatalogClusterLocator.test.ts.snap
+++ b/plugins/kubernetes-backend/src/cluster-locator/__snapshots__/CatalogClusterLocator.test.ts.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CatalogClusterLocator returns the aws cluster details provided by annotations 1`] = `
+{
+  "authMetadata": {
+    "kubernetes.io/api-server": "https://apiserver.com",
+    "kubernetes.io/api-server-certificate-authority": "caData",
+    "kubernetes.io/auth-provider": "aws",
+    "kubernetes.io/aws-assume-role": "my-role",
+    "kubernetes.io/aws-external-id": "my-id",
+    "kubernetes.io/dashboard-app": "my-app",
+    "kubernetes.io/dashboard-url": "my-url",
+    "kubernetes.io/oidc-token-provider": "google",
+  },
+  "caData": "caData",
+  "dashboardApp": "my-app",
+  "dashboardParameters": undefined,
+  "dashboardUrl": "my-url",
+  "name": "owned",
+  "skipMetricsLookup": false,
+  "skipTLSVerify": false,
+  "url": "https://apiserver.com",
+}
+`;
+
+exports[`CatalogClusterLocator returns the cluster details provided by annotations 1`] = `
+{
+  "authMetadata": {
+    "kubernetes.io/api-server": "https://apiserver.com",
+    "kubernetes.io/api-server-certificate-authority": "caData",
+    "kubernetes.io/auth-provider": "oidc",
+    "kubernetes.io/dashboard-app": "my-app",
+    "kubernetes.io/dashboard-url": "my-url",
+    "kubernetes.io/oidc-token-provider": "google",
+    "kubernetes.io/skip-metrics-lookup": "true",
+    "kubernetes.io/skip-tls-verify": "true",
+  },
+  "caData": "caData",
+  "dashboardApp": "my-app",
+  "dashboardParameters": undefined,
+  "dashboardUrl": "my-url",
+  "name": "owned",
+  "skipMetricsLookup": true,
+  "skipTLSVerify": true,
+  "url": "https://apiserver.com",
+}
+`;

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -47,6 +47,10 @@ export const ANNOTATION_KUBERNETES_DASHBOARD_APP =
   'kubernetes.io/dashboard-app';
 
 // @public
+export const ANNOTATION_KUBERNETES_DASHBOARD_PARAMETERS =
+  'kubernetes.io/dashboard-parameters';
+
+// @public
 export const ANNOTATION_KUBERNETES_DASHBOARD_URL =
   'kubernetes.io/dashboard-url';
 

--- a/plugins/kubernetes-common/src/catalog-entity-constants.ts
+++ b/plugins/kubernetes-common/src/catalog-entity-constants.ts
@@ -78,6 +78,13 @@ export const ANNOTATION_KUBERNETES_DASHBOARD_APP =
   'kubernetes.io/dashboard-app';
 
 /**
+ * Annotation for specifying the dashboard app parameters for a Kubernetes cluster.
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_DASHBOARD_PARAMETERS =
+  'kubernetes.io/dashboard-parameters';
+/**
  * Annotation for specifying the assume role use to authenticate with AWS.
  *
  * @public

--- a/yarn.lock
+++ b/yarn.lock
@@ -5432,6 +5432,7 @@ __metadata:
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-tasks": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
+    "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add possibility to fill dashboardParamaters in k8s from catalog.
Also add implementation in gcp catalog module.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
