### PR TITLE
fix(github-issues): fixes bug where entities that did not belong to the configured github instance were trying to be fetched

### DIFF
--- a/.changeset/two-terms-play.md
+++ b/.changeset/two-terms-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-issues': patch
+---
+
+Filters out entities that belonged to a different github instance other than the one configured by the plugin

--- a/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -21,9 +21,14 @@ jest.mock('octokit', () => ({
 
 import { ConfigApi, ErrorApi } from '@backstage/core-plugin-api';
 import { ForwardedError } from '@backstage/errors';
-import { createFilterByClause, githubIssuesApi } from './githubIssuesApi';
-import type { GithubIssuesFilters } from './githubIssuesApi';
+import { createFilterByClause, githubIssuesApi, Repository, GithubIssuesFilters } from './githubIssuesApi';
 
+function entityRepository(name: string, locationHostname: string = "github.com"): Repository {
+  return {
+    locationHostname,
+    name
+  }
+}
 function getFragment(
   filterBy = '',
   orderBy = 'field: UPDATED_AT, direction: DESC',
@@ -110,7 +115,26 @@ describe('githubIssuesApi', () => {
 
     it('should call GitHub API with correct query with fragment for each repo', async () => {
       await api.fetchIssuesByRepoFromGithub(
-        ['mrwolny/yo-yo', 'mrwolny/yoyo', 'mrwolny/yo.yo'],
+        [
+          entityRepository('mrwolny/yo-yo'),
+          entityRepository('mrwolny/yoyo'),
+          entityRepository('mrwolny/yo.yo'),
+        ],
+        10,
+      );
+
+      expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
+      expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
+    });
+
+    it("should only fetch data for entities hosted in the same GitHub instance as the plugin's config", async () => {
+      await api.fetchIssuesByRepoFromGithub(
+        [
+          entityRepository('mrwolny/yo-yo'),
+          entityRepository('mrwolny/yoyo'),
+          entityRepository('mrwolny/yo.yo'),
+          entityRepository('mrwolny/another-repo', "enterprise.github.com"), // This one should be filtered out
+        ],
         10,
       );
 
@@ -120,7 +144,11 @@ describe('githubIssuesApi', () => {
 
     it('should call Github API with the correct filterBy and orderBy clauses', async () => {
       await api.fetchIssuesByRepoFromGithub(
-        ['mrwolny/yo-yo', 'mrwolny/yoyo', 'mrwolny/yo.yo'],
+        [
+          entityRepository('mrwolny/yo-yo'),
+          entityRepository('mrwolny/yoyo'),
+          entityRepository('mrwolny/yo.yo')
+        ],
         10,
         {
           filterBy: {
@@ -231,7 +259,7 @@ describe('githubIssuesApi', () => {
     );
 
     const data = await api.fetchIssuesByRepoFromGithub(
-      ['mrwolny/yo-yo', 'mrwolny/notfound'],
+      [entityRepository('mrwolny/yo-yo'), entityRepository('mrwolny/notfound')],
       10,
     );
 
@@ -301,7 +329,7 @@ describe('githubIssuesApi', () => {
     );
 
     const data = await api.fetchIssuesByRepoFromGithub(
-      ['mrwolny/notfound'],
+      [entityRepository('mrwolny/notfound')],
       10,
     );
 
@@ -341,7 +369,7 @@ describe('githubIssuesApi', () => {
       mockErrorApi as unknown as ErrorApi,
     );
 
-    await api.fetchIssuesByRepoFromGithub(['mrwolny/notfound'], 10);
+    await api.fetchIssuesByRepoFromGithub([entityRepository('mrwolny/notfound')], 10);
 
     expect(mockErrorApi.post).toHaveBeenCalledTimes(1);
     expect(mockErrorApi.post).toHaveBeenCalledWith(

--- a/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -21,13 +21,21 @@ jest.mock('octokit', () => ({
 
 import { ConfigApi, ErrorApi } from '@backstage/core-plugin-api';
 import { ForwardedError } from '@backstage/errors';
-import { createFilterByClause, githubIssuesApi, Repository, GithubIssuesFilters } from './githubIssuesApi';
+import {
+  createFilterByClause,
+  githubIssuesApi,
+  Repository,
+  GithubIssuesFilters,
+} from './githubIssuesApi';
 
-function entityRepository(name: string, locationHostname: string = "github.com"): Repository {
+function entityRepository(
+  name: string,
+  locationHostname: string = 'github.com',
+): Repository {
   return {
     locationHostname,
-    name
-  }
+    name,
+  };
 }
 function getFragment(
   filterBy = '',
@@ -133,7 +141,7 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/yo-yo'),
           entityRepository('mrwolny/yoyo'),
           entityRepository('mrwolny/yo.yo'),
-          entityRepository('mrwolny/another-repo', "enterprise.github.com"), // This one should be filtered out
+          entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
         ],
         10,
       );
@@ -147,7 +155,7 @@ describe('githubIssuesApi', () => {
         [
           entityRepository('mrwolny/yo-yo'),
           entityRepository('mrwolny/yoyo'),
-          entityRepository('mrwolny/yo.yo')
+          entityRepository('mrwolny/yo.yo'),
         ],
         10,
         {
@@ -369,7 +377,10 @@ describe('githubIssuesApi', () => {
       mockErrorApi as unknown as ErrorApi,
     );
 
-    await api.fetchIssuesByRepoFromGithub([entityRepository('mrwolny/notfound')], 10);
+    await api.fetchIssuesByRepoFromGithub(
+      [entityRepository('mrwolny/notfound')],
+      10,
+    );
 
     expect(mockErrorApi.post).toHaveBeenCalledTimes(1);
     expect(mockErrorApi.post).toHaveBeenCalledWith(

--- a/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -25,6 +25,11 @@ import { readGithubIntegrationConfigs } from '@backstage/integration';
 import { ForwardedError } from '@backstage/errors';
 
 /** @internal */
+export type Repository = {
+  name: string;
+  locationHostname: string;
+}
+/** @internal */
 export type Assignee = {
   avatarUrl: string;
   login: string;
@@ -116,9 +121,10 @@ export const githubIssuesApi = (
   let octokit: Octokit;
 
   const getOctokit = async () => {
-    const baseUrl = readGithubIntegrationConfigs(
+    const githubConfig = readGithubIntegrationConfigs(
       configApi.getOptionalConfigArray('integrations.github') ?? [],
-    )[0].apiBaseUrl;
+    )[0]
+    const baseUrl = githubConfig.apiBaseUrl;
 
     const token = await githubAuthApi.getAccessToken(['repo']);
 
@@ -126,11 +132,11 @@ export const githubIssuesApi = (
       octokit = new Octokit({ auth: token, ...(baseUrl && { baseUrl }) });
     }
 
-    return octokit.graphql;
+    return { graphql: octokit.graphql, hostname: githubConfig.host };
   };
 
   const fetchIssuesByRepoFromGithub = async (
-    repos: Array<string>,
+    repos: Array<Repository>,
     itemsPerRepo: number,
     {
       filterBy,
@@ -140,30 +146,35 @@ export const githubIssuesApi = (
       },
     }: GithubIssuesByRepoOptions = {},
   ): Promise<IssuesByRepo> => {
-    const graphql = await getOctokit();
+    const { graphql, hostname } = await getOctokit();
     const safeNames: Array<string> = [];
+    const repositories = repos
+      // only tries to fetch issues from repositories that are hosted on the same GitHub instance as the octokit
+      .filter(repo => repo.locationHostname === hostname)
+      .map(repo => {
+        const [owner, name] = repo.name.split('/');
 
-    const repositories = repos.map(repo => {
-      const [owner, name] = repo.split('/');
+        const safeNameRegex = /-|\./gi;
+        let safeName = name.replace(safeNameRegex, '');
 
-      const safeNameRegex = /-|\./gi;
-      let safeName = name.replace(safeNameRegex, '');
+        while (safeNames.includes(safeName)) {
+          safeName += 'x';
+        }
 
-      while (safeNames.includes(safeName)) {
-        safeName += 'x';
-      }
+        safeNames.push(safeName);
 
-      safeNames.push(safeName);
-
-      return {
-        safeName,
-        name,
-        owner,
-      };
-    });
+        return {
+          safeName,
+          name,
+          owner,
+        };
+      });
 
     let issuesByRepo: IssuesByRepo = {};
     try {
+      if(repositories.length === 0) {
+        throw new Error(`No repositories found for ${hostname}`)
+      }
       issuesByRepo = await graphql(
         createIssueByRepoQuery(repositories, itemsPerRepo, {
           filterBy,
@@ -273,12 +284,12 @@ function createIssueByRepoQuery(
 
     query {
       ${repositories.map(
-        ({ safeName, name, owner }) => `
+    ({ safeName, name, owner }) => `
         ${safeName}: repository(name: "${name}", owner: "${owner}") {
           ...issues
         }
       `,
-      )}
+  )}
     }
   `;
 

--- a/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -28,7 +28,7 @@ import { ForwardedError } from '@backstage/errors';
 export type Repository = {
   name: string;
   locationHostname: string;
-}
+};
 /** @internal */
 export type Assignee = {
   avatarUrl: string;
@@ -123,7 +123,7 @@ export const githubIssuesApi = (
   const getOctokit = async () => {
     const githubConfig = readGithubIntegrationConfigs(
       configApi.getOptionalConfigArray('integrations.github') ?? [],
-    )[0]
+    )[0];
     const baseUrl = githubConfig.apiBaseUrl;
 
     const token = await githubAuthApi.getAccessToken(['repo']);
@@ -172,8 +172,8 @@ export const githubIssuesApi = (
 
     let issuesByRepo: IssuesByRepo = {};
     try {
-      if(repositories.length === 0) {
-        throw new Error(`No repositories found for ${hostname}`)
+      if (repositories.length === 0) {
+        throw new Error(`No repositories found for ${hostname}`);
       }
       issuesByRepo = await graphql(
         createIssueByRepoQuery(repositories, itemsPerRepo, {
@@ -284,12 +284,12 @@ function createIssueByRepoQuery(
 
     query {
       ${repositories.map(
-    ({ safeName, name, owner }) => `
+        ({ safeName, name, owner }) => `
         ${safeName}: repository(name: "${name}", owner: "${owner}") {
           ...issues
         }
       `,
-  )}
+      )}
     }
   `;
 

--- a/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
@@ -68,6 +68,7 @@ const entityComponent = {
   metadata: {
     annotations: {
       'github.com/project-slug': 'backstage/backstage',
+      'backstage.io/source-location': "url:https://github.com/backstage/backstage"
     },
     name: 'backstage',
   },

--- a/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
@@ -68,7 +68,8 @@ const entityComponent = {
   metadata: {
     annotations: {
       'github.com/project-slug': 'backstage/backstage',
-      'backstage.io/source-location': "url:https://github.com/backstage/backstage"
+      'backstage.io/source-location':
+        'url:https://github.com/backstage/backstage',
     },
     name: 'backstage',
   },

--- a/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
+++ b/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity, stringifyEntityRef, getEntitySourceLocation } from '@backstage/catalog-model';
+import {
+  Entity,
+  stringifyEntityRef,
+  getEntitySourceLocation,
+} from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef, useEntity } from '@backstage/plugin-catalog-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -27,9 +31,9 @@ export const getProjectNameFromEntity = (entity: Entity): string => {
 };
 
 export const getHostnameFromEntity = (entity: Entity): string => {
-  const { target } = getEntitySourceLocation(entity)
-  return new URL(target).hostname
-}
+  const { target } = getEntitySourceLocation(entity);
+  return new URL(target).hostname;
+};
 
 export function useEntityGithubRepositories() {
   const { entity } = useEntity();
@@ -40,12 +44,14 @@ export function useEntityGithubRepositories() {
   const getRepositoriesNames = useCallback(async () => {
     if (entity.kind === 'Component' || entity.kind === 'API') {
       const entityName = getProjectNameFromEntity(entity);
-      const locationHostname = getHostnameFromEntity(entity)
+      const locationHostname = getHostnameFromEntity(entity);
       if (entityName) {
-        setRepositories([{
-          name: entityName,
-          locationHostname
-        }]);
+        setRepositories([
+          {
+            name: entityName,
+            locationHostname,
+          },
+        ]);
       }
 
       return;
@@ -58,14 +64,24 @@ export function useEntityGithubRepositories() {
       },
     });
 
-    const repositoryEntities: Repository[] = entitiesList.items.reduce((acc: Repository[], componentEntity: Entity) => {
-      const entityName = getProjectNameFromEntity(componentEntity);
-      const entityLocationHostname = getHostnameFromEntity(componentEntity);
-      if (entityName && !acc.some((it: Repository) => it.name === entityName) && entityName.length) {
-        acc.push({ name: entityName, locationHostname: entityLocationHostname });
-      }
-      return acc;
-    }, []);
+    const repositoryEntities: Repository[] = entitiesList.items.reduce(
+      (acc: Repository[], componentEntity: Entity) => {
+        const entityName = getProjectNameFromEntity(componentEntity);
+        const entityLocationHostname = getHostnameFromEntity(componentEntity);
+        if (
+          entityName &&
+          !acc.some((it: Repository) => it.name === entityName) &&
+          entityName.length
+        ) {
+          acc.push({
+            name: entityName,
+            locationHostname: entityLocationHostname,
+          });
+        }
+        return acc;
+      },
+      [],
+    );
 
     setRepositories(repositoryEntities);
   }, [catalogApi, entity]);

--- a/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
+++ b/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef, getEntitySourceLocation } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef, useEntity } from '@backstage/plugin-catalog-react';
 import { useCallback, useEffect, useState } from 'react';
+import { Repository } from '../api';
 
 const GITHUB_PROJECT_SLUG_ANNOTATION = 'github.com/project-slug';
 
@@ -25,18 +26,26 @@ export const getProjectNameFromEntity = (entity: Entity): string => {
   return entity?.metadata.annotations?.[GITHUB_PROJECT_SLUG_ANNOTATION] ?? '';
 };
 
+export const getHostnameFromEntity = (entity: Entity): string => {
+  const { target } = getEntitySourceLocation(entity)
+  return new URL(target).hostname
+}
+
 export function useEntityGithubRepositories() {
   const { entity } = useEntity();
 
   const catalogApi = useApi(catalogApiRef);
-  const [repositories, setRepositories] = useState<string[]>([]);
+  const [repositories, setRepositories] = useState<Repository[]>([]);
 
   const getRepositoriesNames = useCallback(async () => {
     if (entity.kind === 'Component' || entity.kind === 'API') {
       const entityName = getProjectNameFromEntity(entity);
-
+      const locationHostname = getHostnameFromEntity(entity)
       if (entityName) {
-        setRepositories([entityName]);
+        setRepositories([{
+          name: entityName,
+          locationHostname
+        }]);
       }
 
       return;
@@ -49,11 +58,16 @@ export function useEntityGithubRepositories() {
       },
     });
 
-    const entitiesNames: string[] = entitiesList.items.map(componentEntity =>
-      getProjectNameFromEntity(componentEntity),
-    );
+    const repositoryEntities: Repository[] = entitiesList.items.reduce((acc: Repository[], componentEntity: Entity) => {
+      const entityName = getProjectNameFromEntity(componentEntity);
+      const entityLocationHostname = getHostnameFromEntity(componentEntity);
+      if (entityName && !acc.some((it: Repository) => it.name === entityName) && entityName.length) {
+        acc.push({ name: entityName, locationHostname: entityLocationHostname });
+      }
+      return acc;
+    }, []);
 
-    setRepositories([...new Set(entitiesNames)].filter(name => name.length));
+    setRepositories(repositoryEntities);
   }, [catalogApi, entity]);
 
   useEffect(() => {

--- a/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
+++ b/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
@@ -16,7 +16,11 @@
 
 import { useApi } from '@backstage/core-plugin-api';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
-import { Repository, githubIssuesApiRef, GithubIssuesByRepoOptions } from '../api';
+import {
+  Repository,
+  githubIssuesApiRef,
+  GithubIssuesByRepoOptions,
+} from '../api';
 
 export const useGetIssuesByRepoFromGithub = (
   repos: Array<Repository>,

--- a/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
+++ b/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
@@ -16,10 +16,10 @@
 
 import { useApi } from '@backstage/core-plugin-api';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
-import { githubIssuesApiRef, GithubIssuesByRepoOptions } from '../api';
+import { Repository, githubIssuesApiRef, GithubIssuesByRepoOptions } from '../api';
 
 export const useGetIssuesByRepoFromGithub = (
-  repos: Array<string>,
+  repos: Array<Repository>,
   itemsPerRepo: number,
   options?: GithubIssuesByRepoOptions,
 ) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The **github-issues** plugin currently has a problem because it is hardcoded to always use the **first** GitHub integration config

https://github.com/backstage/backstage/blob/0507326be65fc2059cc2f042322ecc5125ebc476/plugins/github-issues/src/api/githubIssuesApi.ts#L121

Considering a scenario where a Backstage instance can be connected to multiple GitHub Instances, this plugin will fail.

Ideally, the plugin should be refactored to use an **scmAuthApi** in a way that i could fetch Issues from Multiple GitHub instances. But I didn't want to do that right now, as it would be a fairly large refactor.

So this PR is at least implementing a little bit more consistency, by allowing the plugin to Filter out entities that are not hosted in the same GitHub of the Octokit.

Without this fix, whenever we try to render the **Issues** table for a **Group** that owns entities across multiple GitHubs, we would have errors popup on the screen, complaining about repository-A not existing in that GitHub.

I'm open to discussing, weather we want to merge this first as a patch, and then create a new PR later as a minor that allows the plugin to work with multiple GitHub Instances, or if we want to implement support to multiple GitHub instances first.


### Current Error

![image](https://github.com/backstage/backstage/assets/11502789/1d66aebb-ae86-4b34-9ff1-f6fc513163af)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
