### PR TITLE
feat: support strings for fontSize in BackstageTypography

### DIFF
--- a/.changeset/smooth-rings-mate.md
+++ b/.changeset/smooth-rings-mate.md
@@ -2,4 +2,4 @@
 '@backstage/theme': patch
 ---
 
-Fixed a bug to support string fontSize values (`"2.5rem"`) instead of forcing numeric-only values & requiring casts. In addition, added an optional fontFamily prop for h1-h6 BackstageTypography variants to allow further customization.
+Added support for string `fontSize` values (e.g. `"2.5rem"`) in themes in addition to numbers. Also added an optional `fontFamily` prop for header typography variants to allow further customization.

--- a/.changeset/smooth-rings-mate.md
+++ b/.changeset/smooth-rings-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Fixed a bug to support string fontSize values (`"2.5rem"`) instead of forcing numeric-only values & requiring casts. In addition, added an optional fontFamily prop for h1-h6 BackstageTypography variants to allow further customization.

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -178,42 +178,7 @@ export function createBaseThemeOptions<PaletteOptions>(
   options: BaseThemeOptionsInput<PaletteOptions>,
 ): {
   palette: PaletteOptions;
-  typography:
-    | BackstageTypography
-    | {
-        htmlFontSize: number;
-        fontFamily: string;
-        h1: {
-          fontSize: number;
-          fontWeight: number;
-          marginBottom: number;
-        };
-        h2: {
-          fontSize: number;
-          fontWeight: number;
-          marginBottom: number;
-        };
-        h3: {
-          fontSize: number;
-          fontWeight: number;
-          marginBottom: number;
-        };
-        h4: {
-          fontWeight: number;
-          fontSize: number;
-          marginBottom: number;
-        };
-        h5: {
-          fontWeight: number;
-          fontSize: number;
-          marginBottom: number;
-        };
-        h6: {
-          fontWeight: number;
-          fontSize: number;
-          marginBottom: number;
-        };
-      };
+  typography: BackstageTypography;
   page: PageTheme;
   getPageTheme: ({ themeId }: PageThemeSelector) => PageTheme;
 };

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -117,32 +117,38 @@ export type BackstageTypography = {
   htmlFontSize: number;
   fontFamily: string;
   h1: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h2: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h3: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h4: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h5: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h6: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
@@ -172,7 +178,42 @@ export function createBaseThemeOptions<PaletteOptions>(
   options: BaseThemeOptionsInput<PaletteOptions>,
 ): {
   palette: PaletteOptions;
-  typography: BackstageTypography;
+  typography:
+    | BackstageTypography
+    | {
+        htmlFontSize: number;
+        fontFamily: string;
+        h1: {
+          fontSize: number;
+          fontWeight: number;
+          marginBottom: number;
+        };
+        h2: {
+          fontSize: number;
+          fontWeight: number;
+          marginBottom: number;
+        };
+        h3: {
+          fontSize: number;
+          fontWeight: number;
+          marginBottom: number;
+        };
+        h4: {
+          fontWeight: number;
+          fontSize: number;
+          marginBottom: number;
+        };
+        h5: {
+          fontWeight: number;
+          fontSize: number;
+          marginBottom: number;
+        };
+        h6: {
+          fontWeight: number;
+          fontSize: number;
+          marginBottom: number;
+        };
+      };
   page: PageTheme;
   getPageTheme: ({ themeId }: PageThemeSelector) => PageTheme;
 };

--- a/packages/theme/src/base/createBaseThemeOptions.ts
+++ b/packages/theme/src/base/createBaseThemeOptions.ts
@@ -57,7 +57,7 @@ export function createBaseThemeOptions<PaletteOptions>(
     throw new Error(`${defaultPageTheme} is not defined in pageTheme.`);
   }
 
-  const defaultTypography = {
+  const defaultTypography: BackstageTypography = {
     htmlFontSize,
     fontFamily,
     h1: {

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -124,32 +124,38 @@ export type BackstageTypography = {
   htmlFontSize: number;
   fontFamily: string;
   h1: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h2: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h3: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h4: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h5: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };
   h6: {
-    fontSize: number;
+    fontFamily?: string;
+    fontSize: number | string;
     fontWeight: number;
     marginBottom: number;
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi - looking to fix #20093. Please note I'm not well-versed in front-end so some tweaks are likely needed. I also didn't see any existing tests associated to this type or its use in setting the default light & dark themes.

Changes to `BackstageTypography`:

- convert `fontSize` props on h1-h6 variants to support string-based values in addition to numbers such as `"2.5rem"`
- added optional `fontFamily`* prop on headers to support further customization (mentioned in issue)
- ~convert `htmlFontSize` to string + number type for [htmlFontSize to support changing the `<html>` default size](https://mui.com/material-ui/customization/typography/#html-font-size)~ This isn't supported in mui and fails to compile. I've reverted this change.

*__Question__: If `typography.h1.fontFamily === undefined`, will the default font set via `typography.fontFamily` be used? Is there any potential conflicts?

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Manual Testing

1. Apply the below patch:
    ```diff
    diff --git a/packages/theme/src/unified/themes.ts b/packages/theme/src/unified/themes.ts
    index 197a5cbbd0d1..0ffae3f670cb 100644
    --- a/packages/theme/src/unified/themes.ts
    +++ b/packages/theme/src/unified/themes.ts
    @@ -22,7 +22,54 @@ import { createUnifiedTheme } from './UnifiedTheme';
      *
      * @public
      */
    +
    +// Taken from packages/theme/src/base/createBaseThemeOptions.ts
    +const DEFAULT_HTML_FONT_SIZE = 16;
    +const DEFAULT_FONT_FAMILY =
    +  '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif';
    +
    +const light = createUnifiedTheme(
    +  {
    +    palette: palettes.light,
    +    typography: {
    +      htmlFontSize: DEFAULT_HTML_FONT_SIZE,
    +      fontFamily: DEFAULT_FONT_FAMILY,
    +      h1: {
    +        fontFamily: 'sans-serif',
    +        fontSize: '2.5rem',
    +        fontWeight: 700,
    +        marginBottom: 10,
    +      },
    +      h2: {
    +        fontSize: '2.5rem',
    +        fontWeight: 700,
    +        marginBottom: 8,
    +      },
    +      h3: {
    +        fontSize: '1.125rem',
    +        fontWeight: 700,
    +        marginBottom: 6,
    +      },
    +      h4: {
    +        fontWeight: 700,
    +        fontSize: '2.5rem',
    +        marginBottom: 6,
    +      },
    +      h5: {
    +        fontWeight: 700,
    +        fontSize: '2.5rem',
    +        marginBottom: 4,
    +      },
    +      h6: {
    +        fontWeight: 700,
    +        fontSize: '2.5rem',
    +        marginBottom: 2,
    +      },
    +    },
    +  }
    +);
    +
     export const themes = {
    -  light: createUnifiedTheme({ palette: palettes.light }),
    +  light: light,
       dark: createUnifiedTheme({ palette: palettes.dark }),
     };
    ````
2. Run the default sample app via `yarn dev`.

Screenshots below.

![Screenshot_20231002_161050](https://github.com/backstage/backstage/assets/57812123/2628ee96-6645-4e67-806f-f94ab290fe4f)

![Screenshot_20231002_160300](https://github.com/backstage/backstage/assets/57812123/1533d6a0-bbbe-4c35-8be1-a9b4801cfd0d)
