### PR TITLE
.github/workflows: disable Node 20 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
 
     env:
       CI: true
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
 
     env:
       CI: true
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
 
     name: Test ${{ matrix.node-version }}
     services:

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
 
     services:
       postgres13:


### PR DESCRIPTION
The `20.8.0` Node.js release broke tests due to further updates that in turn break `mock-fs`. While we work to replace usage of `mock-fs` we've decided to temporarily disable the Node.js v20 tests in order to smooth out PR reviews and today's release. Ideally we'll have this change reverted within a day or two, and we will also be ready to handle any issues that may arise from releasing without explicit tests for Node.js v20.