### PR TITLE
try to address flaky SearchModal test

### DIFF
--- a/plugins/search/src/components/SearchModal/SearchModal.test.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.test.tsx
@@ -205,6 +205,7 @@ describe('SearchModal', () => {
 
     const input = screen.getByLabelText('Search');
     await userEvent.clear(input);
+    await 'a tick';
     await userEvent.type(input, 'new term{enter}');
 
     expect(navigate).toHaveBeenCalledWith('/search?query=new term');


### PR DESCRIPTION
Just trying this naively first.

Example of build error: https://github.com/backstage/backstage/actions/runs/6365210138/job/17307707595?pr=20295

```
FAIL plugins/search/src/components/SearchModal/SearchModal.test.tsx
  ● SearchModal › Don't wait query debounce time when enter is pressed

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "/search?query=new term"
    Received: "/search?query=ew term"

    Number of calls: 1

      208 |     await userEvent.type(input, 'new term{enter}');
      209 |
    > 210 |     expect(navigate).toHaveBeenCalledWith('/search?query=new term');
          |                      ^
      211 |   });
      212 |
      213 |   it('should navigate with correct search terms to full results', async () => {

      at Object.toHaveBeenCalledWith (components/SearchModal/SearchModal.test.tsx:210:22)
```
