### PR TITLE
UserListPicker: decouple from EntityListContext

### DIFF
--- a/.changeset/shaggy-buses-beg.md
+++ b/.changeset/shaggy-buses-beg.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+The `UserListPicker` component has undergone improvements to enhance its performance.
+
+The previous implementation inferred the number of owned and starred entities based on the entities available in the `EntityListContext`. The updated version no longer relies on the `EntityListContext` for inference, allowing for better decoupling.
+
+The component now loads the entities' count asynchronously, resulting in improved performance and responsiveness. For this purpose, some of the exported filters such as `EntityTagFilter`, `EntityOwnerFilter`, `EntityLifecycleFilter` and `EntityNamespaceFilter` have now the `getCatalogFilters` method implemented.

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.test.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.test.tsx
@@ -52,6 +52,10 @@ describe('DefaultApiExplorerPage', () => {
             kind: 'API',
             metadata: {
               name: 'Entity1',
+              annotations: {
+                'backstage.io/view-url': 'viewurl',
+                'backstage.io/edit-url': 'editurl',
+              },
             },
             spec: { type: 'openapi' },
           },
@@ -62,6 +66,11 @@ describe('DefaultApiExplorerPage', () => {
     getEntitiesByRefs: () => Promise.resolve({ items: [] }),
     getEntityFacets: async () => ({
       facets: { 'relations.ownedBy': [] },
+    }),
+    queryEntities: async () => ({
+      items: [],
+      pageInfo: {},
+      totalItems: 0,
     }),
   };
 
@@ -152,37 +161,39 @@ describe('DefaultApiExplorerPage', () => {
 
   it('should render the default actions of an item in the grid', async () => {
     await renderWrapped(<DefaultApiExplorerPage />);
-    expect(await screen.findByText(/All apis \(1\)/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/View/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/View/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Edit/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Add to favorites/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/All apis \(1\)/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /view/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByTitle(/Add to favorites/)).toBeInTheDocument();
   });
 
   it('should render the custom actions of an item passed as prop', async () => {
     const actions: TableProps<CatalogTableRow>['actions'] = [
-      () => {
-        return {
-          icon: () => <DashboardIcon fontSize="small" />,
-          tooltip: 'Foo Action',
-          disabled: false,
-          onClick: () => jest.fn(),
-        };
+      {
+        icon: () => <DashboardIcon fontSize="small" />,
+        tooltip: 'Foo Action',
+        disabled: false,
+        onClick: jest.fn(),
       },
-      () => {
-        return {
-          icon: () => <DashboardIcon fontSize="small" />,
-          tooltip: 'Bar Action',
-          disabled: true,
-          onClick: () => jest.fn(),
-        };
+      {
+        icon: () => <DashboardIcon fontSize="small" />,
+        tooltip: 'Bar Action',
+        disabled: true,
+        onClick: jest.fn(),
       },
     ];
 
     await renderWrapped(<DefaultApiExplorerPage actions={actions} />);
-    expect(await screen.findByText(/All apis \(1\)/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Foo Action/)).toBeInTheDocument();
-    expect(await screen.findByTitle(/Bar Action/)).toBeInTheDocument();
-    expect((await screen.findByTitle(/Bar Action/)).firstChild).toBeDisabled();
+    await waitFor(() => {
+      expect(screen.getByText(/All apis \(1\)/)).toBeInTheDocument();
+    });
+    expect(screen.getByTitle(/Foo Action/)).toBeInTheDocument();
+    expect(screen.getByTitle(/Bar Action/)).toBeInTheDocument();
+    expect(screen.getByTitle(/Bar Action/).firstChild).toBeDisabled();
   });
 });

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -142,7 +142,7 @@ export const columnFactories: Readonly<{
 export type DefaultEntityFilters = {
   kind?: EntityKindFilter;
   type?: EntityTypeFilter;
-  user?: UserListFilter;
+  user?: UserListFilter | UserOwnersFilter;
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;
@@ -224,6 +224,8 @@ export class EntityLifecycleFilter implements EntityFilter {
   // (undocumented)
   filterEntity(entity: Entity): boolean;
   // (undocumented)
+  getCatalogFilters(): Record<string, string | string[]>;
+  // (undocumented)
   toQueryValue(): string[];
   // (undocumented)
   readonly values: string[];
@@ -275,6 +277,8 @@ export class EntityNamespaceFilter implements EntityFilter {
   // (undocumented)
   filterEntity(entity: Entity): boolean;
   // (undocumented)
+  getCatalogFilters(): Record<string, string | string[]>;
+  // (undocumented)
   toQueryValue(): string[];
   // (undocumented)
   readonly values: string[];
@@ -289,6 +293,8 @@ export class EntityOrphanFilter implements EntityFilter {
   // (undocumented)
   filterEntity(entity: Entity): boolean;
   // (undocumented)
+  getCatalogFilters(): Record<string, string | string[]>;
+  // (undocumented)
   readonly value: boolean;
 }
 
@@ -297,6 +303,8 @@ export class EntityOwnerFilter implements EntityFilter {
   constructor(values: string[]);
   // (undocumented)
   filterEntity(entity: Entity): boolean;
+  // (undocumented)
+  getCatalogFilters(): Record<string, string | string[]>;
   toQueryValue(): string[];
   // (undocumented)
   readonly values: string[];
@@ -446,6 +454,8 @@ export class EntityTagFilter implements EntityFilter {
   constructor(values: string[]);
   // (undocumented)
   filterEntity(entity: Entity): boolean;
+  // (undocumented)
+  getCatalogFilters(): Record<string, string | string[]>;
   // (undocumented)
   toQueryValue(): string[];
   // (undocumented)
@@ -620,7 +630,7 @@ export function useRelatedEntities(
   error: Error | undefined;
 };
 
-// @public
+// @public @deprecated
 export class UserListFilter implements EntityFilter {
   constructor(
     value: UserListFilterKind,
@@ -651,7 +661,28 @@ export const UserListPicker: (
 export type UserListPickerProps = {
   initialFilter?: UserListFilterKind;
   availableFilters?: UserListFilterKind[];
+  useServerSideFilters?: boolean;
 };
+
+// @public (undocumented)
+export class UserOwnersFilter implements EntityFilter {
+  // (undocumented)
+  static all(): UserOwnersFilter;
+  // (undocumented)
+  filterEntity(entity: Entity): boolean;
+  // (undocumented)
+  getCatalogFilters(): Record<string, string[]>;
+  // (undocumented)
+  static owned(ownershipEntityRefs: string[]): UserOwnersFilter;
+  // (undocumented)
+  readonly refs?: string[] | undefined;
+  // (undocumented)
+  static starred(starredEntityRefs: string[]): UserOwnersFilter;
+  // (undocumented)
+  toQueryValue(): string;
+  // (undocumented)
+  readonly value: UserListFilterKind;
+}
 
 // @public (undocumented)
 export function useStarredEntities(): {

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -142,7 +142,7 @@ export const columnFactories: Readonly<{
 export type DefaultEntityFilters = {
   kind?: EntityKindFilter;
   type?: EntityTypeFilter;
-  user?: UserListFilter | UserOwnersFilter;
+  user?: UserListFilter | EntityUserListFilter;
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;
@@ -507,6 +507,26 @@ export interface EntityTypePickerProps {
   initialFilter?: string;
 }
 
+// @public (undocumented)
+export class EntityUserListFilter implements EntityFilter {
+  // (undocumented)
+  static all(): EntityUserListFilter;
+  // (undocumented)
+  filterEntity(entity: Entity): boolean;
+  // (undocumented)
+  getCatalogFilters(): Record<string, string[]>;
+  // (undocumented)
+  static owned(ownershipEntityRefs: string[]): EntityUserListFilter;
+  // (undocumented)
+  readonly refs?: string[] | undefined;
+  // (undocumented)
+  static starred(starredEntityRefs: string[]): EntityUserListFilter;
+  // (undocumented)
+  toQueryValue(): string;
+  // (undocumented)
+  readonly value: UserListFilterKind;
+}
+
 // @public
 export const FavoriteEntity: (
   props: FavoriteEntityProps,
@@ -661,28 +681,7 @@ export const UserListPicker: (
 export type UserListPickerProps = {
   initialFilter?: UserListFilterKind;
   availableFilters?: UserListFilterKind[];
-  useServerSideFilters?: boolean;
 };
-
-// @public (undocumented)
-export class UserOwnersFilter implements EntityFilter {
-  // (undocumented)
-  static all(): UserOwnersFilter;
-  // (undocumented)
-  filterEntity(entity: Entity): boolean;
-  // (undocumented)
-  getCatalogFilters(): Record<string, string[]>;
-  // (undocumented)
-  static owned(ownershipEntityRefs: string[]): UserOwnersFilter;
-  // (undocumented)
-  readonly refs?: string[] | undefined;
-  // (undocumented)
-  static starred(starredEntityRefs: string[]): UserOwnersFilter;
-  // (undocumented)
-  toQueryValue(): string;
-  // (undocumented)
-  readonly value: UserListFilterKind;
-}
 
 // @public (undocumented)
 export function useStarredEntities(): {

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -142,7 +142,7 @@ export const columnFactories: Readonly<{
 export type DefaultEntityFilters = {
   kind?: EntityKindFilter;
   type?: EntityTypeFilter;
-  user?: UserListFilter | EntityUserListFilter;
+  user?: UserListFilter | EntityUserFilter;
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;
@@ -508,19 +508,19 @@ export interface EntityTypePickerProps {
 }
 
 // @public (undocumented)
-export class EntityUserListFilter implements EntityFilter {
+export class EntityUserFilter implements EntityFilter {
   // (undocumented)
-  static all(): EntityUserListFilter;
+  static all(): EntityUserFilter;
   // (undocumented)
   filterEntity(entity: Entity): boolean;
   // (undocumented)
   getCatalogFilters(): Record<string, string[]>;
   // (undocumented)
-  static owned(ownershipEntityRefs: string[]): EntityUserListFilter;
+  static owned(ownershipEntityRefs: string[]): EntityUserFilter;
   // (undocumented)
   readonly refs?: string[] | undefined;
   // (undocumented)
-  static starred(starredEntityRefs: string[]): EntityUserListFilter;
+  static starred(starredEntityRefs: string[]): EntityUserFilter;
   // (undocumented)
   toQueryValue(): string;
   // (undocumented)

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -16,15 +16,18 @@
 
 import React from 'react';
 import { fireEvent, render, waitFor, screen } from '@testing-library/react';
-import {
-  Entity,
-  RELATION_OWNED_BY,
-  UserEntity,
-} from '@backstage/catalog-model';
-import { UserListPicker } from './UserListPicker';
+import { Entity, UserEntity } from '@backstage/catalog-model';
+import { UserListPicker, UserListPickerProps } from './UserListPicker';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
-import { EntityTagFilter, UserListFilter } from '../../filters';
-import { CatalogApi } from '@backstage/catalog-client';
+import {
+  EntityTagFilter,
+  UserListFilter,
+  UserOwnersFilter,
+} from '../../filters';
+import {
+  CatalogApi,
+  QueryEntitiesInitialRequest,
+} from '@backstage/catalog-client';
 import { catalogApiRef } from '../../api';
 import { MockStorageApi, TestApiRegistry } from '@backstage/test-utils';
 import { ApiProvider } from '@backstage/core-app-api';
@@ -35,7 +38,7 @@ import {
   identityApiRef,
   storageApiRef,
 } from '@backstage/core-plugin-api';
-import { useEntityOwnership } from '../../hooks';
+import { MockStarredEntitiesApi, starredEntitiesApiRef } from '../../apis';
 
 const mockUser: UserEntity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -54,19 +57,22 @@ const mockConfigApi = {
 } as Partial<ConfigApi>;
 
 const mockCatalogApi = {
-  getEntityByRef: () => Promise.resolve(mockUser),
-} as Partial<CatalogApi>;
+  getEntityByRef: jest.fn(),
+  queryEntities: jest.fn(),
+} as Partial<jest.Mocked<CatalogApi>>;
 
 const mockIdentityApi = {
-  getUserId: () => 'testUser',
-  getIdToken: async () => undefined,
-} as Partial<IdentityApi>;
+  getBackstageIdentity: jest.fn(),
+} as Partial<jest.Mocked<IdentityApi>>;
+
+const mockStarredEntitiesApi = new MockStarredEntitiesApi();
 
 const apis = TestApiRegistry.from(
   [configApiRef, mockConfigApi],
   [catalogApiRef, mockCatalogApi],
   [identityApiRef, mockIdentityApi],
   [storageApiRef, MockStorageApi.create()],
+  [starredEntitiesApiRef, mockStarredEntitiesApi],
 );
 
 const mockIsOwnedEntity = jest.fn(
@@ -77,113 +83,117 @@ const mockIsStarredEntity = jest.fn(
   (entity: Entity) => entity.metadata.name === 'component-3',
 );
 
-jest.mock('../../hooks', () => {
-  const actual = jest.requireActual('../../hooks');
-  return {
-    ...actual,
-    useEntityOwnership: jest.fn(() => ({
-      isOwnedEntity: mockIsOwnedEntity,
-    })),
-    useStarredEntities: () => ({
-      isStarredEntity: mockIsStarredEntity,
-    }),
-  };
-});
-
-const backendEntities: Entity[] = [
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      namespace: 'namespace-1',
-      name: 'component-1',
-      tags: ['tag1'],
-    },
-    relations: [
-      {
-        type: RELATION_OWNED_BY,
-        targetRef: 'user:default/testuser',
-      },
-    ],
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      namespace: 'namespace-2',
-      name: 'component-2',
-      tags: ['tag1'],
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      namespace: 'namespace-2',
-      name: 'component-3',
-      tags: [],
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      namespace: 'namespace-2',
-      name: 'component-4',
-      tags: [],
-    },
-    relations: [
-      {
-        type: RELATION_OWNED_BY,
-        targetRef: 'user:default/testuser',
-      },
-    ],
-  },
-];
-
+const ownershipEntityRefs = ['user:default/testuser'];
 describe('<UserListPicker />', () => {
-  it('renders filter groups', () => {
+  const mockQueryEntitiesImplementation: CatalogApi['queryEntities'] =
+    async request => {
+      if (
+        (
+          (request as QueryEntitiesInitialRequest).filter as Record<
+            string,
+            string
+          >
+        )['relations.ownedBy']
+      ) {
+        // owned entities
+        return { items: [], totalItems: 3, pageInfo: {} };
+      }
+      if (
+        (
+          (request as QueryEntitiesInitialRequest).filter as Record<
+            string,
+            string
+          >
+        )['metadata.name']
+      ) {
+        // starred entities
+        return {
+          items: [
+            {
+              apiVersion: '1',
+              kind: 'component',
+              metadata: { name: 'e-1', namespace: 'default' },
+            },
+            {
+              apiVersion: '1',
+              kind: 'component',
+              metadata: { name: 'e-2', namespace: 'default' },
+            },
+          ],
+          totalItems: 2,
+          pageInfo: {},
+        };
+      }
+      // all items
+      return { items: [], totalItems: 10, pageInfo: {} };
+    };
+
+  beforeAll(() => {
+    mockStarredEntitiesApi.toggleStarred('component:default/e-1');
+    mockStarredEntitiesApi.toggleStarred('component:default/e-2');
+  });
+
+  beforeEach(() => {
+    mockCatalogApi.getEntityByRef?.mockResolvedValue(mockUser);
+    mockIdentityApi.getBackstageIdentity?.mockResolvedValue({
+      ownershipEntityRefs,
+      type: 'user',
+      userEntityRef: 'user:default/testuser',
+    });
+
+    mockCatalogApi.queryEntities?.mockImplementation(
+      mockQueryEntitiesImplementation,
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders filter groups', async () => {
     render(
       <ApiProvider apis={apis}>
-        <MockEntityListContextProvider value={{ backendEntities }}>
+        <MockEntityListContextProvider value={{}}>
           <UserListPicker />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
 
+    await waitFor(() =>
+      expect(mockIdentityApi.getBackstageIdentity).toHaveBeenCalled(),
+    );
+    await waitFor(() =>
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalled(),
+    );
     expect(screen.getByText('Personal')).toBeInTheDocument();
     expect(screen.getByText('Test Company')).toBeInTheDocument();
   });
 
-  it('renders filters', () => {
+  it('renders filters', async () => {
     render(
       <ApiProvider apis={apis}>
-        <MockEntityListContextProvider value={{ backendEntities }}>
+        <MockEntityListContextProvider value={{}}>
           <UserListPicker />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
 
-    expect(
-      screen.getAllByRole('menuitem').map(({ textContent }) => textContent),
-    ).toEqual(['Owned 1', 'Starred 1', 'All 4']);
-  });
-
-  it('includes counts alongside each filter', async () => {
-    render(
-      <ApiProvider apis={apis}>
-        <MockEntityListContextProvider value={{ backendEntities }}>
-          <UserListPicker />
-        </MockEntityListContextProvider>
-      </ApiProvider>,
-    );
-
-    // Material UI renders ListItemSecondaryActions outside the
-    // menuitem itself, so we pick off the next sibling.
-    await waitFor(() => {
+    await waitFor(() =>
       expect(
         screen.getAllByRole('menuitem').map(({ textContent }) => textContent),
-      ).toEqual(['Owned 1', 'Starred 1', 'All 4']);
+      ).toEqual(['Owned 3', 'Starred 2', 'All 10']),
+    );
+
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: {},
+      limit: 0,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: { 'metadata.name': ['e-1', 'e-2'] },
+      limit: 1000,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: { 'relations.ownedBy': ['user:default/testuser'] },
+      limit: 0,
     });
   });
 
@@ -192,7 +202,6 @@ describe('<UserListPicker />', () => {
       <ApiProvider apis={apis}>
         <MockEntityListContextProvider
           value={{
-            backendEntities,
             filters: { tags: new EntityTagFilter(['tag1']) },
           }}
         >
@@ -204,35 +213,104 @@ describe('<UserListPicker />', () => {
     await waitFor(() => {
       expect(
         screen.getAllByRole('menuitem').map(({ textContent }) => textContent),
-      ).toEqual(['Owned 1', 'Starred 0', 'All 2']);
+      ).toEqual(['Owned 3', 'Starred 2', 'All 10']);
+    });
+
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: { 'metadata.tags': ['tag1'] },
+      limit: 0,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: { 'metadata.name': ['e-1', 'e-2'], 'metadata.tags': ['tag1'] },
+      limit: 1000,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: {
+        'relations.ownedBy': ['user:default/testuser'],
+        'metadata.tags': ['tag1'],
+      },
+      limit: 0,
     });
   });
 
-  it('respects the query parameter filter value', () => {
+  it('respects the query parameter filter value, legacy', async () => {
     const updateFilters = jest.fn();
     const queryParameters = { user: 'owned' };
     render(
       <ApiProvider apis={apis}>
         <MockEntityListContextProvider
-          value={{ backendEntities, updateFilters, queryParameters }}
+          value={{ updateFilters, queryParameters }}
         >
           <UserListPicker />
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
 
-    expect(updateFilters).toHaveBeenLastCalledWith({
-      user: new UserListFilter('owned', mockIsOwnedEntity, mockIsStarredEntity),
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        user: new UserListFilter(
+          'owned',
+          expect.any(Function),
+          expect.any(Function),
+        ),
+      }),
+    );
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: {},
+      limit: 0,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: { 'metadata.name': ['e-1', 'e-2'] },
+      limit: 1000,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: {
+        'relations.ownedBy': ['user:default/testuser'],
+      },
+      limit: 0,
     });
   });
 
-  it('updates user filter when a menuitem is selected', () => {
+  it('respects the query parameter filter value', async () => {
     const updateFilters = jest.fn();
+    const queryParameters = { user: 'owned' };
     render(
       <ApiProvider apis={apis}>
         <MockEntityListContextProvider
-          value={{ backendEntities, updateFilters }}
+          value={{ updateFilters, queryParameters }}
         >
+          <UserListPicker useServerSideFilters />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        user: UserOwnersFilter.owned(ownershipEntityRefs),
+      }),
+    );
+
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: {},
+      limit: 0,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: { 'metadata.name': ['e-1', 'e-2'] },
+      limit: 1000,
+    });
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: {
+        'relations.ownedBy': ['user:default/testuser'],
+      },
+      limit: 0,
+    });
+  });
+
+  it('updates user filter when a menuitem is selected, legacy', async () => {
+    const updateFilters = jest.fn();
+    render(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider value={{ updateFilters }}>
           <UserListPicker />
         </MockEntityListContextProvider>
       </ApiProvider>,
@@ -240,22 +318,45 @@ describe('<UserListPicker />', () => {
 
     fireEvent.click(screen.getByText('Starred'));
 
-    expect(updateFilters).toHaveBeenLastCalledWith({
-      user: new UserListFilter(
-        'starred',
-        mockIsOwnedEntity,
-        mockIsStarredEntity,
-      ),
-    });
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        user: new UserListFilter(
+          'starred',
+          expect.any(Function),
+          expect.any(Function),
+        ),
+      }),
+    );
   });
 
-  it('responds to external queryParameters changes', () => {
+  it('updates user filter when a menuitem is selected', async () => {
+    const updateFilters = jest.fn();
+    render(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider value={{ updateFilters }}>
+          <UserListPicker useServerSideFilters />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Starred'));
+
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        user: UserOwnersFilter.starred([
+          'component:default/e-1',
+          'component:default/e-2',
+        ]),
+      }),
+    );
+  });
+
+  it('responds to external queryParameters changes, legacy', async () => {
     const updateFilters = jest.fn();
     const rendered = render(
       <ApiProvider apis={apis}>
         <MockEntityListContextProvider
           value={{
-            backendEntities,
             updateFilters,
             queryParameters: { user: ['all'] },
           }}
@@ -264,14 +365,21 @@ describe('<UserListPicker />', () => {
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
-    expect(updateFilters).toHaveBeenLastCalledWith({
-      user: new UserListFilter('all', mockIsOwnedEntity, mockIsStarredEntity),
-    });
+
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        user: new UserListFilter(
+          'all',
+          expect.any(Function),
+          expect.any(Function),
+        ),
+      }),
+    );
+
     rendered.rerender(
       <ApiProvider apis={apis}>
         <MockEntityListContextProvider
           value={{
-            backendEntities,
             updateFilters,
             queryParameters: { user: ['owned'] },
           }}
@@ -281,23 +389,59 @@ describe('<UserListPicker />', () => {
       </ApiProvider>,
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
-      user: new UserListFilter('owned', mockIsOwnedEntity, mockIsStarredEntity),
+      user: new UserListFilter(
+        'owned',
+        expect.any(Function),
+        expect.any(Function),
+      ),
     });
   });
 
-  describe.each`
-    type         | filterFn
-    ${'owned'}   | ${mockIsOwnedEntity}
-    ${'starred'} | ${mockIsStarredEntity}
-  `('filter resetting for $type entities', ({ type, filterFn }) => {
-    let updateFilters: jest.Mock;
-
-    const picker = (props: { loading: boolean }) => (
+  it('responds to external queryParameters changes', async () => {
+    const updateFilters = jest.fn();
+    const rendered = render(
       <ApiProvider apis={apis}>
         <MockEntityListContextProvider
-          value={{ backendEntities, updateFilters, loading: props.loading }}
+          value={{
+            updateFilters,
+            queryParameters: { user: ['all'] },
+          }}
         >
-          <UserListPicker initialFilter={type} />
+          <UserListPicker useServerSideFilters />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        user: UserOwnersFilter.all(),
+      }),
+    );
+
+    rendered.rerender(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            queryParameters: { user: ['owned'] },
+          }}
+        >
+          <UserListPicker useServerSideFilters />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      user: UserOwnersFilter.owned(ownershipEntityRefs),
+    });
+  });
+
+  describe('filter resetting', () => {
+    let updateFilters: jest.Mock;
+
+    const Picker = (props: UserListPickerProps) => (
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider value={{ updateFilters }}>
+          <UserListPicker {...props} />
         </MockEntityListContextProvider>
       </ApiProvider>
     );
@@ -306,57 +450,213 @@ describe('<UserListPicker />', () => {
       updateFilters = jest.fn();
     });
 
-    describe(`when there are no ${type} entities match the filter`, () => {
-      beforeEach(() => {
-        filterFn.mockReturnValue(false);
+    describe(`when there are no owned entities match the filter`, () => {
+      it('does not reset the filter while entities are loading', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(
+          () => new Promise(() => {}),
+        );
+
+        render(<Picker initialFilter="owned" />);
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalled(),
+        );
+        expect(updateFilters).not.toHaveBeenCalled();
       });
 
-      it('does not reset the filter while entities are loading', () => {
-        render(picker({ loading: true }));
+      it('does not reset the filter while owned entities are loading', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['relations.ownedBy']
+          ) {
+            return new Promise(() => {});
+          }
+          return mockQueryEntitiesImplementation(request);
+        });
 
+        render(<Picker initialFilter="owned" />);
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
+        );
         expect(updateFilters).not.toHaveBeenCalledWith({
-          user: new UserListFilter(
-            'all',
-            mockIsOwnedEntity,
-            mockIsStarredEntity,
-          ),
+          user: expect.any(Object),
         });
       });
 
-      it('does not reset the filter while owned entities are loading', () => {
-        const isOwnedEntity = jest.fn(() => false);
-        (useEntityOwnership as jest.Mock).mockReturnValueOnce({
-          loading: true,
-          isOwnedEntity,
+      it('resets the filter to "all" when entities are loaded, legacy', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(async request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['relations.ownedBy']
+          ) {
+            return { items: [], totalItems: 0, pageInfo: {} };
+          }
+          return mockQueryEntitiesImplementation(request);
         });
 
-        render(picker({ loading: false }));
-        expect(updateFilters).not.toHaveBeenCalledWith({
-          user: new UserListFilter('all', isOwnedEntity, mockIsStarredEntity),
-        });
+        render(<Picker initialFilter="owned" />);
+
+        await waitFor(() =>
+          expect(updateFilters).toHaveBeenLastCalledWith({
+            user: new UserListFilter(
+              'all',
+              expect.any(Function),
+              expect.any(Function),
+            ),
+          }),
+        );
       });
 
-      it('resets the filter to "all" when entities are loaded', () => {
-        render(picker({ loading: false }));
-
-        expect(updateFilters).toHaveBeenLastCalledWith({
-          user: new UserListFilter(
-            'all',
-            mockIsOwnedEntity,
-            mockIsStarredEntity,
-          ),
+      it('resets the filter to "all" when entities are loaded', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(async request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['relations.ownedBy']
+          ) {
+            return { items: [], totalItems: 0, pageInfo: {} };
+          }
+          return mockQueryEntitiesImplementation(request);
         });
+
+        render(<Picker initialFilter="owned" useServerSideFilters />);
+
+        await waitFor(() =>
+          expect(updateFilters).toHaveBeenLastCalledWith({
+            user: UserOwnersFilter.all(),
+          }),
+        );
       });
     });
 
-    describe(`when there are some ${type} entities present`, () => {
-      beforeEach(() => {
-        filterFn.mockReturnValue(true);
+    describe(`when there are no starred entities match the filter`, () => {
+      it('does not reset the filter while entities are loading', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(
+          () => new Promise(() => {}),
+        );
+
+        render(<Picker initialFilter="starred" />);
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalled(),
+        );
+        expect(updateFilters).not.toHaveBeenCalled();
       });
 
-      it('does not reset the filter while entities are loading', () => {
-        render(picker({ loading: true }));
+      it('does not reset the filter while starred entities are loading', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['metadata.name']
+          ) {
+            return new Promise(() => {});
+          }
+          return mockQueryEntitiesImplementation(request);
+        });
 
+        render(<Picker initialFilter="starred" />);
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
+        );
+        expect(updateFilters).not.toHaveBeenCalledWith({
+          user: expect.any(Object),
+        });
+      });
+
+      it('resets the filter to "all" when entities are loaded, legacy', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(async request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['metadata.name']
+          ) {
+            return { items: [], totalItems: 0, pageInfo: {} };
+          }
+          return mockQueryEntitiesImplementation(request);
+        });
+
+        render(<Picker initialFilter="starred" />);
+
+        await waitFor(() =>
+          expect(updateFilters).toHaveBeenLastCalledWith({
+            user: new UserListFilter(
+              'all',
+              expect.any(Function),
+              expect.any(Function),
+            ),
+          }),
+        );
+      });
+
+      it('resets the filter to "all" when entities are loaded', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(async request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['metadata.name']
+          ) {
+            return { items: [], totalItems: 0, pageInfo: {} };
+          }
+          return mockQueryEntitiesImplementation(request);
+        });
+
+        render(<Picker initialFilter="starred" useServerSideFilters />);
+
+        await waitFor(() =>
+          expect(updateFilters).toHaveBeenLastCalledWith({
+            user: UserOwnersFilter.all(),
+          }),
+        );
+      });
+    });
+
+    describe(`when there are some owned entities present`, () => {
+      it('does not reset the filter while entities are loading', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['relations.ownedBy']
+          ) {
+            return new Promise(() => {});
+          }
+          return mockQueryEntitiesImplementation(request);
+        });
+
+        render(
+          <Picker initialFilter="owned" />,
+        ); /*  picker({ loading: true })*/
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
+        );
         expect(updateFilters).not.toHaveBeenCalledWith({
           user: new UserListFilter(
             'all',
@@ -366,16 +666,73 @@ describe('<UserListPicker />', () => {
         });
       });
 
-      it('does not reset the filter when entities are loaded', () => {
-        render(picker({ loading: false }));
+      it('does not reset the filter when entities are loaded', async () => {
+        render(<Picker initialFilter="owned" />);
 
-        expect(updateFilters).toHaveBeenLastCalledWith({
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
+        );
+
+        await waitFor(() =>
+          expect(updateFilters).toHaveBeenLastCalledWith({
+            user: new UserListFilter(
+              'owned',
+              expect.any(Function),
+              expect.any(Function),
+            ),
+          }),
+        );
+      });
+    });
+
+    describe(`when there are some starred entities present`, () => {
+      it('does not reset the filter while entities are loading', async () => {
+        mockCatalogApi.queryEntities?.mockImplementation(request => {
+          if (
+            (
+              (request as QueryEntitiesInitialRequest).filter as Record<
+                string,
+                string
+              >
+            )['metadata.name']
+          ) {
+            return new Promise(() => {});
+          }
+          return mockQueryEntitiesImplementation(request);
+        });
+
+        render(
+          <Picker initialFilter="starred" />,
+        ); /*  picker({ loading: true })*/
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
+        );
+        expect(updateFilters).not.toHaveBeenCalledWith({
           user: new UserListFilter(
-            type,
+            'all',
             mockIsOwnedEntity,
             mockIsStarredEntity,
           ),
         });
+      });
+
+      it('does not reset the filter when entities are loaded', async () => {
+        render(<Picker initialFilter="starred" />);
+
+        await waitFor(() =>
+          expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
+        );
+
+        await waitFor(() =>
+          expect(updateFilters).toHaveBeenLastCalledWith({
+            user: new UserListFilter(
+              'starred',
+              expect.any(Function),
+              expect.any(Function),
+            ),
+          }),
+        );
       });
     });
   });

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -22,7 +22,7 @@ import { MockEntityListContextProvider } from '../../testUtils/providers';
 import {
   EntityTagFilter,
   UserListFilter,
-  UserOwnersFilter,
+  EntityUserListFilter,
 } from '../../filters';
 import {
   CatalogApi,
@@ -286,7 +286,7 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() =>
       expect(updateFilters).toHaveBeenLastCalledWith({
-        user: UserOwnersFilter.owned(ownershipEntityRefs),
+        user: EntityUserListFilter.owned(ownershipEntityRefs),
       }),
     );
 
@@ -343,7 +343,7 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() =>
       expect(updateFilters).toHaveBeenLastCalledWith({
-        user: UserOwnersFilter.starred([
+        user: EntityUserListFilter.starred([
           'component:default/e-1',
           'component:default/e-2',
         ]),
@@ -414,7 +414,7 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() =>
       expect(updateFilters).toHaveBeenLastCalledWith({
-        user: UserOwnersFilter.all(),
+        user: EntityUserListFilter.all(),
       }),
     );
 
@@ -431,7 +431,7 @@ describe('<UserListPicker />', () => {
       </ApiProvider>,
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
-      user: UserOwnersFilter.owned(ownershipEntityRefs),
+      user: EntityUserListFilter.owned(ownershipEntityRefs),
     });
   });
 
@@ -536,7 +536,7 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: UserOwnersFilter.all(),
+            user: EntityUserListFilter.all(),
           }),
         );
       });
@@ -628,7 +628,7 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: UserOwnersFilter.all(),
+            user: EntityUserListFilter.all(),
           }),
         );
       });

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -523,9 +523,7 @@ describe('<UserListPicker />', () => {
           return mockQueryEntitiesImplementation(request);
         });
 
-        render(
-          <Picker initialFilter="owned" />,
-        ); /*  picker({ loading: true })*/
+        render(<Picker initialFilter="owned" />);
 
         await waitFor(() =>
           expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
@@ -566,9 +564,7 @@ describe('<UserListPicker />', () => {
           return mockQueryEntitiesImplementation(request);
         });
 
-        render(
-          <Picker initialFilter="starred" />,
-        ); /*  picker({ loading: true })*/
+        render(<Picker initialFilter="starred" />);
 
         await waitFor(() =>
           expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
@@ -587,7 +583,10 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserListFilter.starred(expect.any(Array)),
+            user: EntityUserListFilter.starred([
+              'component:default/e-1',
+              'component:default/e-2',
+            ]),
           }),
         );
       });

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -142,6 +142,7 @@ describe('<UserListPicker />', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
+
   it('renders filter groups', async () => {
     render(
       <ApiProvider apis={apis}>
@@ -357,7 +358,7 @@ describe('<UserListPicker />', () => {
   });
 
   describe('filter resetting', () => {
-    let updateFilters: jest.Mock;
+    const updateFilters = jest.fn();
 
     const Picker = ({ ...props }: UserListPickerProps) => (
       <ApiProvider apis={apis}>
@@ -372,15 +373,9 @@ describe('<UserListPicker />', () => {
       </ApiProvider>
     );
 
-    beforeEach(() => {
-      updateFilters = jest.fn();
-    });
-
     describe(`when there are no owned entities matching the filter`, () => {
       it('does not reset the filter while entities are loading', async () => {
-        mockCatalogApi.queryEntities?.mockImplementation(
-          () => new Promise(() => {}),
-        );
+        mockCatalogApi.queryEntities?.mockReturnValue(new Promise(() => {}));
 
         render(<Picker initialFilter="owned" />);
 
@@ -388,7 +383,7 @@ describe('<UserListPicker />', () => {
           expect(mockCatalogApi.queryEntities).toHaveBeenCalled(),
         );
 
-        await expect(
+        await expect(() =>
           waitFor(() => expect(updateFilters).toHaveBeenCalled()),
         ).rejects.toThrow();
       });

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -23,7 +23,7 @@ import {
   EntityKindFilter,
   EntityNamespaceFilter,
   EntityTagFilter,
-  EntityUserListFilter,
+  EntityUserFilter,
 } from '../../filters';
 import {
   CatalogApi,
@@ -263,7 +263,7 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() =>
       expect(updateFilters).toHaveBeenLastCalledWith({
-        user: EntityUserListFilter.owned(ownershipEntityRefs),
+        user: EntityUserFilter.owned(ownershipEntityRefs),
       }),
     );
 
@@ -298,7 +298,7 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() =>
       expect(updateFilters).toHaveBeenLastCalledWith({
-        user: EntityUserListFilter.starred([
+        user: EntityUserFilter.starred([
           'component:default/e-1',
           'component:default/e-2',
         ]),
@@ -331,7 +331,7 @@ describe('<UserListPicker />', () => {
 
     await waitFor(() =>
       expect(updateFilters).toHaveBeenLastCalledWith({
-        user: EntityUserListFilter.all(),
+        user: EntityUserFilter.all(),
       }),
     );
 
@@ -352,7 +352,7 @@ describe('<UserListPicker />', () => {
       </ApiProvider>,
     );
     expect(updateFilters).toHaveBeenLastCalledWith({
-      user: EntityUserListFilter.owned(ownershipEntityRefs),
+      user: EntityUserFilter.owned(ownershipEntityRefs),
     });
   });
 
@@ -437,7 +437,7 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserListFilter.all(),
+            user: EntityUserFilter.all(),
           }),
         );
       });
@@ -501,7 +501,7 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserListFilter.all(),
+            user: EntityUserFilter.all(),
           }),
         );
       });
@@ -529,7 +529,7 @@ describe('<UserListPicker />', () => {
           expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
         );
         expect(updateFilters).not.toHaveBeenCalledWith({
-          user: EntityUserListFilter.all(),
+          user: EntityUserFilter.all(),
         });
       });
 
@@ -542,7 +542,7 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserListFilter.owned(expect.any(Array)),
+            user: EntityUserFilter.owned(expect.any(Array)),
           }),
         );
       });
@@ -570,7 +570,7 @@ describe('<UserListPicker />', () => {
           expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3),
         );
         expect(updateFilters).not.toHaveBeenCalledWith({
-          user: EntityUserListFilter.all(),
+          user: EntityUserFilter.all(),
         });
       });
 
@@ -583,7 +583,7 @@ describe('<UserListPicker />', () => {
 
         await waitFor(() =>
           expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserListFilter.starred([
+            user: EntityUserFilter.starred([
               'component:default/e-1',
               'component:default/e-2',
             ]),

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -32,16 +32,14 @@ import {
 } from '@material-ui/core';
 import SettingsIcon from '@material-ui/icons/Settings';
 import StarIcon from '@material-ui/icons/Star';
-import { compact } from 'lodash';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { UserListFilter } from '../../filters';
-import {
-  useEntityList,
-  useStarredEntities,
-  useEntityOwnership,
-} from '../../hooks';
+import { UserListFilter, UserOwnersFilter } from '../../filters';
+import { useEntityList, useStarredEntities } from '../../hooks';
 import { UserListFilterKind } from '../../types';
-import { reduceEntityFilters } from '../../utils';
+import { useOwnedEntitiesCount } from './useOwnedEntitiesCount';
+import { useAllEntitiesCount } from './useAllEntitiesCount';
+import { useStarredEntitiesCount } from './useStarredEntitiesCount';
+import { useIsOwnedEntity } from '../../hooks/useEntityOwnership';
 
 /** @public */
 export type CatalogReactUserListPickerClassKey =
@@ -122,20 +120,19 @@ function getFilterGroups(orgName: string | undefined): ButtonGroup[] {
 export type UserListPickerProps = {
   initialFilter?: UserListFilterKind;
   availableFilters?: UserListFilterKind[];
+  useServerSideFilters?: boolean;
 };
 
 /** @public */
 export const UserListPicker = (props: UserListPickerProps) => {
-  const { initialFilter, availableFilters } = props;
+  const { initialFilter, availableFilters, useServerSideFilters } = props;
   const classes = useStyles();
   const configApi = useApi(configApiRef);
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
   const {
     filters,
     updateFilters,
-    backendEntities,
     queryParameters: { kind: kindParameter, user: userParameter },
-    loading: loadingBackendEntities,
   } = useEntityList();
 
   // Remove group items that aren't in availableFilters and exclude
@@ -153,21 +150,18 @@ export const UserListPicker = (props: UserListPickerProps) => {
     }))
     .filter(({ items }) => !!items.length);
 
-  const { isStarredEntity } = useStarredEntities();
-  const { isOwnedEntity, loading: loadingEntityOwnership } =
-    useEntityOwnership();
-
-  const loading = loadingBackendEntities || loadingEntityOwnership;
-
-  // Static filters; used for generating counts of potentially unselected kinds
-  const ownedFilter = useMemo(
-    () => new UserListFilter('owned', isOwnedEntity, isStarredEntity),
-    [isOwnedEntity, isStarredEntity],
-  );
-  const starredFilter = useMemo(
-    () => new UserListFilter('starred', isOwnedEntity, isStarredEntity),
-    [isOwnedEntity, isStarredEntity],
-  );
+  const {
+    count: ownedEntitiesCount,
+    loading: loadingOwnedEntities,
+    filter: ownedEntitiesFilter,
+    ownershipEntityRefs,
+  } = useOwnedEntitiesCount();
+  const { count: allCount } = useAllEntitiesCount();
+  const {
+    count: starredEntitiesCount,
+    filter: starredEntitiesFilter,
+    loading: loadingStarredEntities,
+  } = useStarredEntitiesCount();
 
   const queryParamUserFilter = useMemo(
     () => [userParameter].flat()[0],
@@ -175,33 +169,19 @@ export const UserListPicker = (props: UserListPickerProps) => {
   );
 
   const [selectedUserFilter, setSelectedUserFilter] = useState(
-    queryParamUserFilter ?? initialFilter,
+    (queryParamUserFilter as UserListFilterKind) ?? initialFilter,
   );
 
-  // To show proper counts for each section, apply all other frontend filters _except_ the user
-  // filter that's controlled by this picker.
-  const entitiesWithoutUserFilter = useMemo(
-    () =>
-      backendEntities.filter(
-        reduceEntityFilters(
-          compact(Object.values({ ...filters, user: undefined })),
-        ),
-      ),
-    [filters, backendEntities],
-  );
+  const filterCounts = useMemo(() => {
+    return {
+      all: allCount,
+      starred: starredEntitiesCount,
+      owned: ownedEntitiesCount,
+    };
+  }, [starredEntitiesCount, ownedEntitiesCount, allCount]);
 
-  const filterCounts = useMemo<Record<string, number>>(
-    () => ({
-      all: entitiesWithoutUserFilter.length,
-      starred: entitiesWithoutUserFilter.filter(entity =>
-        starredFilter.filterEntity(entity),
-      ).length,
-      owned: entitiesWithoutUserFilter.filter(entity =>
-        ownedFilter.filterEntity(entity),
-      ).length,
-    }),
-    [entitiesWithoutUserFilter, starredFilter, ownedFilter],
-  );
+  const { isStarredEntity } = useStarredEntities();
+  const isOwnedEntity = useIsOwnedEntity(ownershipEntityRefs);
 
   // Set selected user filter on query parameter updates; this happens at initial page load and from
   // external updates to the page location.
@@ -210,6 +190,8 @@ export const UserListPicker = (props: UserListPickerProps) => {
       setSelectedUserFilter(queryParamUserFilter as UserListFilterKind);
     }
   }, [queryParamUserFilter]);
+
+  const loading = loadingOwnedEntities || loadingStarredEntities;
 
   useEffect(() => {
     if (
@@ -223,16 +205,46 @@ export const UserListPicker = (props: UserListPickerProps) => {
   }, [loading, filterCounts, selectedUserFilter, setSelectedUserFilter]);
 
   useEffect(() => {
-    updateFilters({
-      user: selectedUserFilter
-        ? new UserListFilter(
-            selectedUserFilter as UserListFilterKind,
-            isOwnedEntity,
-            isStarredEntity,
-          )
-        : undefined,
-    });
-  }, [selectedUserFilter, isOwnedEntity, isStarredEntity, updateFilters]);
+    if (!selectedUserFilter) {
+      return;
+    }
+    if (loading) {
+      return;
+    }
+    if (useServerSideFilters) {
+      const getFilter = () => {
+        if (selectedUserFilter === 'owned') {
+          return ownedEntitiesFilter;
+        }
+        if (selectedUserFilter === 'starred') {
+          return starredEntitiesFilter;
+        }
+        return UserOwnersFilter.all();
+      };
+
+      updateFilters({ user: getFilter() });
+    } else {
+      // legacy
+      updateFilters({
+        user: selectedUserFilter
+          ? new UserListFilter(
+              selectedUserFilter as UserListFilterKind,
+              isOwnedEntity,
+              isStarredEntity,
+            )
+          : undefined,
+      });
+    }
+  }, [
+    selectedUserFilter,
+    starredEntitiesFilter,
+    ownedEntitiesFilter,
+    updateFilters,
+    useServerSideFilters,
+    isOwnedEntity,
+    isStarredEntity,
+    loading,
+  ]);
 
   return (
     <Card className={classes.root}>

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -33,7 +33,7 @@ import {
 import SettingsIcon from '@material-ui/icons/Settings';
 import StarIcon from '@material-ui/icons/Star';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { UserListFilter, UserOwnersFilter } from '../../filters';
+import { UserListFilter, EntityUserListFilter } from '../../filters';
 import { useEntityList, useStarredEntities } from '../../hooks';
 import { UserListFilterKind } from '../../types';
 import { useOwnedEntitiesCount } from './useOwnedEntitiesCount';
@@ -219,7 +219,7 @@ export const UserListPicker = (props: UserListPickerProps) => {
         if (selectedUserFilter === 'starred') {
           return starredEntitiesFilter;
         }
-        return UserOwnersFilter.all();
+        return EntityUserListFilter.all();
       };
 
       updateFilters({ user: getFilter() });

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -33,7 +33,7 @@ import {
 import SettingsIcon from '@material-ui/icons/Settings';
 import StarIcon from '@material-ui/icons/Star';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { EntityUserListFilter } from '../../filters';
+import { EntityUserFilter } from '../../filters';
 import { useEntityList } from '../../hooks';
 import { UserListFilterKind } from '../../types';
 import { useOwnedEntitiesCount } from './useOwnedEntitiesCount';
@@ -213,7 +213,7 @@ export const UserListPicker = (props: UserListPickerProps) => {
       if (selectedUserFilter === 'starred') {
         return starredEntitiesFilter;
       }
-      return EntityUserListFilter.all();
+      return EntityUserFilter.all();
     };
 
     updateFilters({ user: getFilter() });

--- a/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { PropsWithChildren } from 'react';
+import { CatalogApi } from '@backstage/catalog-client';
+import { useAllEntitiesCount } from './useAllEntitiesCount';
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { EntityListProvider, useEntityList } from '../../hooks';
+import { catalogApiRef } from '../../api';
+import { ApiRef } from '@backstage/core-plugin-api';
+import { MemoryRouter } from 'react-router-dom';
+import { EntityOwnerFilter } from '../../filters';
+import { useMountEffect } from '@react-hookz/web';
+
+const mockQueryEntities: jest.MockedFn<CatalogApi['queryEntities']> = jest.fn();
+const mockCatalogApi: jest.Mocked<Partial<CatalogApi>> = {
+  queryEntities: mockQueryEntities,
+};
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: (ref: ApiRef<any>) =>
+      ref === catalogApiRef ? mockCatalogApi : actual.useApi(ref),
+  };
+});
+
+describe('useAllEntitiesCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the count', async () => {
+    mockQueryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    function WrapFilters(props: PropsWithChildren<{}>) {
+      const { updateFilters } = useEntityList();
+
+      useMountEffect(() => {
+        updateFilters({
+          owners: new EntityOwnerFilter(['user:default/owner']),
+        });
+      });
+      return <>{props.children}</>;
+    }
+
+    const { result } = renderHook(() => useAllEntitiesCount(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <EntityListProvider>
+            <WrapFilters>{children}</WrapFilters>
+          </EntityListProvider>
+        </MemoryRouter>
+      ),
+    });
+
+    await waitFor(() =>
+      expect(mockQueryEntities).toHaveBeenCalledWith({
+        filter: {
+          'relations.ownedBy': ['user:default/owner'],
+        },
+        limit: 0,
+      }),
+    );
+    expect(result.current).toEqual({ count: 10, loading: false });
+  });
+
+  it(`shouldn't invoke the endpoint at startup, when filters are missing`, async () => {
+    mockQueryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    const { result } = renderHook(() => useAllEntitiesCount(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <EntityListProvider>{children}</EntityListProvider>
+        </MemoryRouter>
+      ),
+    });
+
+    await expect(
+      waitFor(() => expect(mockQueryEntities).toHaveBeenCalled()),
+    ).rejects.toThrow();
+    expect(result.current).toEqual({ count: 0, loading: false });
+  });
+});

--- a/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.test.tsx
@@ -16,7 +16,6 @@
 import React, { PropsWithChildren } from 'react';
 import { CatalogApi } from '@backstage/catalog-client';
 import { useAllEntitiesCount } from './useAllEntitiesCount';
-import { waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { EntityListProvider, useEntityList } from '../../hooks';
 import { catalogApiRef } from '../../api';
@@ -62,7 +61,7 @@ describe('useAllEntitiesCount', () => {
       return <>{props.children}</>;
     }
 
-    const { result } = renderHook(() => useAllEntitiesCount(), {
+    const { result, waitFor } = renderHook(() => useAllEntitiesCount(), {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <EntityListProvider>
@@ -90,7 +89,7 @@ describe('useAllEntitiesCount', () => {
       pageInfo: {},
     });
 
-    const { result } = renderHook(() => useAllEntitiesCount(), {
+    const { result, waitFor } = renderHook(() => useAllEntitiesCount(), {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <EntityListProvider>{children}</EntityListProvider>

--- a/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.test.tsx
@@ -16,7 +16,7 @@
 import React, { PropsWithChildren } from 'react';
 import { CatalogApi } from '@backstage/catalog-client';
 import { useAllEntitiesCount } from './useAllEntitiesCount';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { EntityListProvider, useEntityList } from '../../hooks';
 import { catalogApiRef } from '../../api';
 import { ApiRef } from '@backstage/core-plugin-api';
@@ -61,7 +61,7 @@ describe('useAllEntitiesCount', () => {
       return <>{props.children}</>;
     }
 
-    const { result, waitFor } = renderHook(() => useAllEntitiesCount(), {
+    const { result } = renderHook(() => useAllEntitiesCount(), {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <EntityListProvider>
@@ -89,7 +89,7 @@ describe('useAllEntitiesCount', () => {
       pageInfo: {},
     });
 
-    const { result, waitFor } = renderHook(() => useAllEntitiesCount(), {
+    const { result } = renderHook(() => useAllEntitiesCount(), {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <EntityListProvider>{children}</EntityListProvider>

--- a/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.ts
@@ -36,6 +36,11 @@ export function useAllEntitiesCount() {
       limit: 0,
     };
 
+    if (Object.keys(filter).length === 0) {
+      prevRequest.current = undefined;
+      return prevRequest.current;
+    }
+
     if (isEqual(newRequest, prevRequest.current)) {
       return prevRequest.current;
     }
@@ -44,6 +49,9 @@ export function useAllEntitiesCount() {
   }, [filters]);
 
   const { value: count, loading } = useAsync(async () => {
+    if (request === undefined) {
+      return 0;
+    }
     const { totalItems } = await catalogApi.queryEntities(request);
 
     return totalItems;

--- a/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useAllEntitiesCount.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryEntitiesInitialRequest } from '@backstage/catalog-client';
+import { useApi } from '@backstage/core-plugin-api';
+import { compact, isEqual } from 'lodash';
+import { useMemo, useRef } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { catalogApiRef } from '../../api';
+import { useEntityList } from '../../hooks';
+import { reduceCatalogFilters } from '../../utils';
+
+/**
+ * TODO(vinzscam): we need to find a better way
+ * for retrieving this value. One possible way, could be to use
+ * the /entities endpoint: since this method is paginated,
+ * it should also return how many items matching the provided filters
+ *  are in the catalog
+ */
+export function useAllEntitiesCount() {
+  const catalogApi = useApi(catalogApiRef);
+  const { filters } = useEntityList();
+
+  const refRequest = useRef<QueryEntitiesInitialRequest>();
+  useMemo(() => {
+    const { user, ...allFilters } = filters;
+    const compacted = compact(Object.values(allFilters));
+    const filter = reduceCatalogFilters(compacted);
+    const request: QueryEntitiesInitialRequest = {
+      filter,
+      limit: 0,
+    };
+
+    if (isEqual(request, refRequest.current)) {
+      return refRequest.current;
+    }
+    refRequest.current = request;
+
+    return request;
+  }, [filters]);
+
+  const { value: count, loading } = useAsync(async () => {
+    const { totalItems } = await catalogApi.queryEntities(refRequest.current);
+
+    return totalItems;
+  }, [refRequest.current]);
+
+  return { count, loading };
+}

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { PropsWithChildren } from 'react';
+import { CatalogApi } from '@backstage/catalog-client';
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  DefaultEntityFilters,
+  EntityListProvider,
+  useEntityList,
+} from '../../hooks';
+import { catalogApiRef } from '../../api';
+import {
+  ApiRef,
+  IdentityApi,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { MemoryRouter } from 'react-router-dom';
+import { useOwnedEntitiesCount } from './useOwnedEntitiesCount';
+import {
+  EntityNamespaceFilter,
+  EntityOwnerFilter,
+  EntityUserListFilter,
+} from '../../filters';
+import { useMountEffect } from '@react-hookz/web';
+
+const mockQueryEntities: jest.MockedFn<CatalogApi['queryEntities']> = jest.fn();
+const mockCatalogApi: jest.Mocked<Partial<CatalogApi>> = {
+  queryEntities: mockQueryEntities,
+};
+
+const mockGetBackstageIdentity: jest.MockedFn<
+  IdentityApi['getBackstageIdentity']
+> = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: (ref: ApiRef<any>) => {
+      if (ref === catalogApiRef) {
+        return mockCatalogApi;
+      }
+      if (ref === identityApiRef) {
+        return {
+          getBackstageIdentity: mockGetBackstageIdentity,
+        };
+      }
+
+      return actual.useApi(ref);
+    },
+  };
+});
+
+describe('useOwnedEntitiesCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetBackstageIdentity.mockResolvedValue({
+      ownershipEntityRefs: ['user:default/spiderman', 'user:group/a-group'],
+      userEntityRef: 'user:default/spiderman',
+      type: 'user',
+    });
+  });
+
+  it(`shouldn't invoke queryEntities when filters are loading`, async () => {
+    mockQueryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+      wrapper: createWrapperWithInitialFilters({}),
+    });
+
+    await waitFor(() => expect(mockGetBackstageIdentity).toHaveBeenCalled());
+
+    await expect(
+      waitFor(() => expect(mockQueryEntities).toHaveBeenCalled()),
+    ).rejects.toThrow();
+
+    expect(result.current).toEqual({
+      count: 0,
+      loading: false,
+      filter: EntityUserListFilter.owned([
+        'user:default/spiderman',
+        'user:group/a-group',
+      ]),
+      ownershipEntityRefs: ['user:default/spiderman', 'user:group/a-group'],
+    });
+  });
+
+  it(`should properly apply the filters`, async () => {
+    mockQueryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+      wrapper: createWrapperWithInitialFilters({
+        namespace: new EntityNamespaceFilter(['a-namespace']),
+      }),
+    });
+
+    await waitFor(() => expect(mockGetBackstageIdentity).toHaveBeenCalled());
+
+    await waitFor(() =>
+      expect(mockQueryEntities).toHaveBeenCalledWith({
+        filter: {
+          'metadata.namespace': ['a-namespace'],
+          'relations.ownedBy': ['user:default/spiderman', 'user:group/a-group'],
+        },
+        limit: 0,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      count: 10,
+      loading: false,
+      filter: EntityUserListFilter.owned([
+        'user:default/spiderman',
+        'user:group/a-group',
+      ]),
+      ownershipEntityRefs: ['user:default/spiderman', 'user:group/a-group'],
+    });
+  });
+
+  it(`should return count 0 without invoking queryEntities if owners filter doesn't have claims on common with logged in user`, async () => {
+    mockQueryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+      wrapper: createWrapperWithInitialFilters({
+        namespace: new EntityNamespaceFilter(['a-namespace']),
+        owners: new EntityOwnerFilter(['group:default/monsters']),
+      }),
+    });
+
+    await waitFor(() => expect(mockGetBackstageIdentity).toHaveBeenCalled());
+
+    await expect(
+      waitFor(() => expect(mockQueryEntities).toHaveBeenCalled()),
+    ).rejects.toThrow();
+
+    expect(result.current).toEqual({
+      count: 0,
+      loading: false,
+      filter: EntityUserListFilter.owned([
+        'user:default/spiderman',
+        'user:group/a-group',
+      ]),
+      ownershipEntityRefs: ['user:default/spiderman', 'user:group/a-group'],
+    });
+  });
+
+  it(`should send claims in common between owners filter and logged in user`, async () => {
+    mockQueryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+      wrapper: createWrapperWithInitialFilters({
+        namespace: new EntityNamespaceFilter(['a-namespace']),
+        owners: new EntityOwnerFilter([
+          'group:default/monsters',
+          'user:group/a-group',
+        ]),
+      }),
+    });
+
+    await waitFor(() => expect(mockGetBackstageIdentity).toHaveBeenCalled());
+
+    await waitFor(() =>
+      expect(mockQueryEntities).toHaveBeenCalledWith({
+        filter: {
+          'metadata.namespace': ['a-namespace'],
+          'relations.ownedBy': ['user:group/a-group'],
+        },
+        limit: 0,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      count: 10,
+      loading: false,
+      filter: EntityUserListFilter.owned([
+        'user:default/spiderman',
+        'user:group/a-group',
+      ]),
+      ownershipEntityRefs: ['user:default/spiderman', 'user:group/a-group'],
+    });
+  });
+});
+
+function createWrapperWithInitialFilters(
+  filters: Partial<DefaultEntityFilters>,
+) {
+  function WrapFilters(props: PropsWithChildren<{}>) {
+    const { updateFilters } = useEntityList();
+
+    useMountEffect(() => {
+      updateFilters(filters);
+    });
+    return <>{props.children}</>;
+  }
+
+  return function Wrapper(props: PropsWithChildren<{}>) {
+    return (
+      <MemoryRouter>
+        <EntityListProvider>
+          <WrapFilters>{props.children}</WrapFilters>
+        </EntityListProvider>
+      </MemoryRouter>
+    );
+  };
+}

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -32,7 +32,7 @@ import { useOwnedEntitiesCount } from './useOwnedEntitiesCount';
 import {
   EntityNamespaceFilter,
   EntityOwnerFilter,
-  EntityUserListFilter,
+  EntityUserFilter,
 } from '../../filters';
 import { useMountEffect } from '@react-hookz/web';
 
@@ -95,7 +95,7 @@ describe('useOwnedEntitiesCount', () => {
     expect(result.current).toEqual({
       count: 0,
       loading: false,
-      filter: EntityUserListFilter.owned([
+      filter: EntityUserFilter.owned([
         'user:default/spiderman',
         'user:group/a-group',
       ]),
@@ -131,7 +131,7 @@ describe('useOwnedEntitiesCount', () => {
     expect(result.current).toEqual({
       count: 10,
       loading: false,
-      filter: EntityUserListFilter.owned([
+      filter: EntityUserFilter.owned([
         'user:default/spiderman',
         'user:group/a-group',
       ]),
@@ -162,7 +162,7 @@ describe('useOwnedEntitiesCount', () => {
     expect(result.current).toEqual({
       count: 0,
       loading: false,
-      filter: EntityUserListFilter.owned([
+      filter: EntityUserFilter.owned([
         'user:default/spiderman',
         'user:group/a-group',
       ]),
@@ -202,7 +202,7 @@ describe('useOwnedEntitiesCount', () => {
     expect(result.current).toEqual({
       count: 10,
       loading: false,
-      filter: EntityUserListFilter.owned([
+      filter: EntityUserFilter.owned([
         'user:default/spiderman',
         'user:group/a-group',
       ]),

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -15,7 +15,7 @@
  */
 import React, { PropsWithChildren } from 'react';
 import { CatalogApi } from '@backstage/catalog-client';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import {
   DefaultEntityFilters,
   EntityListProvider,
@@ -82,7 +82,7 @@ describe('useOwnedEntitiesCount', () => {
       pageInfo: {},
     });
 
-    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+    const { result } = renderHook(() => useOwnedEntitiesCount(), {
       wrapper: createWrapperWithInitialFilters({}),
     });
 
@@ -110,7 +110,7 @@ describe('useOwnedEntitiesCount', () => {
       pageInfo: {},
     });
 
-    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+    const { result } = renderHook(() => useOwnedEntitiesCount(), {
       wrapper: createWrapperWithInitialFilters({
         namespace: new EntityNamespaceFilter(['a-namespace']),
       }),
@@ -139,14 +139,14 @@ describe('useOwnedEntitiesCount', () => {
     });
   });
 
-  it(`should return count 0 without invoking queryEntities if owners filter doesn't have claims on common with logged in user`, async () => {
+  it(`should return count 0 without invoking queryEntities if owners filter doesn't have claims in common with logged in user`, async () => {
     mockQueryEntities.mockResolvedValue({
       items: [],
       totalItems: 10,
       pageInfo: {},
     });
 
-    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+    const { result } = renderHook(() => useOwnedEntitiesCount(), {
       wrapper: createWrapperWithInitialFilters({
         namespace: new EntityNamespaceFilter(['a-namespace']),
         owners: new EntityOwnerFilter(['group:default/monsters']),
@@ -177,7 +177,7 @@ describe('useOwnedEntitiesCount', () => {
       pageInfo: {},
     });
 
-    const { result, waitFor } = renderHook(() => useOwnedEntitiesCount(), {
+    const { result } = renderHook(() => useOwnedEntitiesCount(), {
       wrapper: createWrapperWithInitialFilters({
         namespace: new EntityNamespaceFilter(['a-namespace']),
         owners: new EntityOwnerFilter([

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
@@ -29,9 +29,10 @@ export function useOwnedEntitiesCount() {
   const catalogApi = useApi(catalogApiRef);
 
   const { filters } = useEntityList();
-  // Trigger load only on mount
+
   const { value: ownershipEntityRefs, loading: loadingEntityRefs } = useAsync(
     async () => (await identityApi.getBackstageIdentity()).ownershipEntityRefs,
+    // load only on mount
     [],
   );
 

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryEntitiesInitialRequest } from '@backstage/catalog-client';
+import { identityApiRef, useApi } from '@backstage/core-plugin-api';
+import { compact, intersection, isEqual } from 'lodash';
+import { useMemo, useRef } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { catalogApiRef } from '../../api';
+import { UserOwnersFilter } from '../../filters';
+import { useEntityList } from '../../hooks';
+import { reduceCatalogFilters } from '../../utils';
+
+export function useOwnedEntitiesCount() {
+  const identityApi = useApi(identityApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const { filters } = useEntityList();
+  // Trigger load only on mount
+  const { value: ownershipEntityRefs, loading: loadingEntityRefs } = useAsync(
+    async () => (await identityApi.getBackstageIdentity()).ownershipEntityRefs,
+
+    [],
+  );
+
+  const refRequest = useRef<QueryEntitiesInitialRequest>();
+
+  useMemo(async () => {
+    const compacted = compact(Object.values(filters));
+    const allFilter = reduceCatalogFilters(compacted);
+    const { ['metadata.name']: metadata, ...filter } = allFilter;
+
+    const facet = 'relations.ownedBy';
+
+    const ownedByFilter = Array.isArray(filter[facet])
+      ? (filter[facet] as string[])
+      : [];
+
+    const commonOwnedBy = intersection(ownedByFilter, ownershipEntityRefs);
+
+    const ownedBy =
+      ownedByFilter.length > 0 ? ownedByFilter : ownershipEntityRefs;
+    if (ownedByFilter.length > 0 && commonOwnedBy.length === 0) {
+      // don't send any request if another filter sets
+      // totally different values for relations.ownedBy filter.
+      // TODO(vinzscam): check conflicts between UserOwnersFilter and EntityOwnerFilter.
+      // both set filters on the same relations.ownedBy key, so the conflicts need
+      // to be addressed properly.
+      refRequest.current = undefined;
+      return null;
+    }
+    const request: QueryEntitiesInitialRequest = {
+      filter: {
+        ...filter,
+        'relations.ownedBy': ownedBy ?? [],
+      },
+      limit: 0,
+    };
+
+    if (isEqual(request, refRequest.current)) {
+      return refRequest.current;
+    }
+
+    refRequest.current = request;
+
+    return request;
+  }, [filters, ownershipEntityRefs]);
+
+  const { value: count, loading: loadingEntityOwnership } =
+    useAsync(async () => {
+      if (!ownershipEntityRefs?.length) {
+        return 0;
+      }
+      if (!refRequest.current) {
+        return 0;
+      }
+      const { totalItems } = await catalogApi.queryEntities(refRequest.current);
+
+      return totalItems;
+    }, [refRequest.current]);
+
+  const loading = loadingEntityRefs || loadingEntityOwnership;
+  const filter = useMemo(
+    () => UserOwnersFilter.owned(ownershipEntityRefs ?? []),
+    [ownershipEntityRefs],
+  );
+
+  return {
+    count,
+    loading,
+    filter,
+    ownershipEntityRefs,
+  };
+}

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
@@ -20,7 +20,7 @@ import { compact, intersection, isEqual } from 'lodash';
 import { useMemo, useRef } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../../api';
-import { UserOwnersFilter } from '../../filters';
+import { EntityUserListFilter } from '../../filters';
 import { useEntityList } from '../../hooks';
 import { reduceCatalogFilters } from '../../utils';
 
@@ -94,7 +94,7 @@ export function useOwnedEntitiesCount() {
 
   const loading = loadingEntityRefs || loadingEntityOwnership;
   const filter = useMemo(
-    () => UserOwnersFilter.owned(ownershipEntityRefs ?? []),
+    () => EntityUserListFilter.owned(ownershipEntityRefs ?? []),
     [ownershipEntityRefs],
   );
 

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
@@ -20,7 +20,7 @@ import { compact, intersection, isEqual } from 'lodash';
 import { useMemo, useRef } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../../api';
-import { EntityOwnerFilter, EntityUserListFilter } from '../../filters';
+import { EntityOwnerFilter, EntityUserFilter } from '../../filters';
 import { useEntityList } from '../../hooks';
 import { reduceCatalogFilters } from '../../utils';
 
@@ -82,7 +82,7 @@ export function useOwnedEntitiesCount() {
 
   const loading = loadingEntityRefs || loadingEntityOwnership;
   const filter = useMemo(
-    () => EntityUserListFilter.owned(ownershipEntityRefs ?? []),
+    () => EntityUserFilter.owned(ownershipEntityRefs ?? []),
     [ownershipEntityRefs],
   );
 

--- a/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { CatalogApi } from '@backstage/catalog-client';
+import { EntityListProvider, useStarredEntities } from '../../hooks';
+import { catalogApiRef } from '../../api';
+import { ApiRef } from '@backstage/core-plugin-api';
+import { MemoryRouter } from 'react-router-dom';
+import { useStarredEntitiesCount } from './useStarredEntitiesCount';
+import { renderHook } from '@testing-library/react-hooks';
+
+const mockQueryEntities: jest.MockedFn<CatalogApi['queryEntities']> = jest.fn();
+const mockCatalogApi: jest.Mocked<Partial<CatalogApi>> = {
+  queryEntities: mockQueryEntities,
+};
+
+const mockStarredEntities: jest.MockedFn<() => Set<string>> = jest.fn();
+
+const mockUseStarredEntities: ReturnType<typeof useStarredEntities> = {
+  get starredEntities() {
+    return mockStarredEntities();
+  },
+} as ReturnType<typeof useStarredEntities>;
+
+jest.mock('../../hooks', () => {
+  const actual = jest.requireActual('../../hooks');
+  return { ...actual, useStarredEntities: () => mockUseStarredEntities };
+});
+
+jest.mock('@backstage/core-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/core-plugin-api');
+  return {
+    ...actual,
+    useApi: (ref: ApiRef<any>) =>
+      ref === catalogApiRef ? mockCatalogApi : actual.useApi(ref),
+  };
+});
+
+describe('useStarredEntitiesCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the count', async () => {
+    mockStarredEntities.mockReturnValue(
+      new Set(['component:default/favourite1', 'component:default/favourite2']),
+    );
+    mockQueryEntities.mockResolvedValue({
+      items: [
+        {
+          apiVersion: '1',
+          kind: 'component',
+          metadata: { name: 'favourite1' },
+        },
+        {
+          apiVersion: '1',
+          kind: 'component',
+          metadata: { name: 'favourite2' },
+        },
+      ],
+      totalItems: 2,
+      pageInfo: {},
+    });
+
+    const { result, waitFor } = renderHook(() => useStarredEntitiesCount(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <EntityListProvider>{children}</EntityListProvider>
+        </MemoryRouter>
+      ),
+    });
+
+    await waitFor(() =>
+      expect(mockQueryEntities).toHaveBeenCalledWith({
+        filter: {
+          'metadata.name': ['favourite1', 'favourite2'],
+        },
+        limit: 1000,
+      }),
+    );
+    expect(result.current).toEqual({
+      count: 2,
+      loading: false,
+      filter: {
+        refs: ['component:default/favourite1', 'component:default/favourite2'],
+        value: 'starred',
+      },
+    });
+  });
+
+  it(`shouldn't invoke the endpoint if there are no starred entities`, async () => {
+    mockStarredEntities.mockReturnValue(new Set());
+
+    const { result, waitFor } = renderHook(() => useStarredEntitiesCount(), {
+      wrapper: ({ children }) => (
+        <MemoryRouter>
+          <EntityListProvider>{children}</EntityListProvider>
+        </MemoryRouter>
+      ),
+    });
+
+    await expect(
+      waitFor(() => expect(mockQueryEntities).toHaveBeenCalled()),
+    ).rejects.toThrow();
+    expect(result.current).toEqual({
+      count: 0,
+      loading: false,
+      filter: { refs: [], value: 'starred' },
+    });
+  });
+});

--- a/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.test.tsx
@@ -20,7 +20,7 @@ import { catalogApiRef } from '../../api';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { MemoryRouter } from 'react-router-dom';
 import { useStarredEntitiesCount } from './useStarredEntitiesCount';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 
 const mockQueryEntities: jest.MockedFn<CatalogApi['queryEntities']> = jest.fn();
 const mockCatalogApi: jest.Mocked<Partial<CatalogApi>> = {
@@ -75,7 +75,7 @@ describe('useStarredEntitiesCount', () => {
       pageInfo: {},
     });
 
-    const { result, waitFor } = renderHook(() => useStarredEntitiesCount(), {
+    const { result } = renderHook(() => useStarredEntitiesCount(), {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <EntityListProvider>{children}</EntityListProvider>
@@ -83,28 +83,31 @@ describe('useStarredEntitiesCount', () => {
       ),
     });
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(mockQueryEntities).toHaveBeenCalledWith({
         filter: {
           'metadata.name': ['favourite1', 'favourite2'],
         },
         limit: 1000,
-      }),
-    );
-    expect(result.current).toEqual({
-      count: 2,
-      loading: false,
-      filter: {
-        refs: ['component:default/favourite1', 'component:default/favourite2'],
-        value: 'starred',
-      },
+      });
+      expect(result.current).toEqual({
+        count: 2,
+        loading: false,
+        filter: {
+          refs: [
+            'component:default/favourite1',
+            'component:default/favourite2',
+          ],
+          value: 'starred',
+        },
+      });
     });
   });
 
   it(`shouldn't invoke the endpoint if there are no starred entities`, async () => {
     mockStarredEntities.mockReturnValue(new Set());
 
-    const { result, waitFor } = renderHook(() => useStarredEntitiesCount(), {
+    const { result } = renderHook(() => useStarredEntitiesCount(), {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <EntityListProvider>{children}</EntityListProvider>

--- a/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
@@ -21,7 +21,7 @@ import { compact, isEqual } from 'lodash';
 import { useMemo, useRef } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../../api';
-import { UserOwnersFilter } from '../../filters';
+import { EntityUserListFilter } from '../../filters';
 import { useEntityList, useStarredEntities } from '../../hooks';
 import { reduceCatalogFilters } from '../../utils';
 
@@ -72,7 +72,7 @@ export function useStarredEntitiesCount() {
   }, [refRequest.current, starredEntities]);
 
   const filter = useMemo(
-    () => UserOwnersFilter.starred(Array.from(starredEntities)),
+    () => EntityUserListFilter.starred(Array.from(starredEntities)),
     [starredEntities],
   );
 

--- a/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryEntitiesInitialRequest } from '@backstage/catalog-client';
+import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
+import { useApi } from '@backstage/core-plugin-api';
+import { compact, isEqual } from 'lodash';
+import { useMemo, useRef } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { catalogApiRef } from '../../api';
+import { UserOwnersFilter } from '../../filters';
+import { useEntityList, useStarredEntities } from '../../hooks';
+import { reduceCatalogFilters } from '../../utils';
+
+export function useStarredEntitiesCount() {
+  const catalogApi = useApi(catalogApiRef);
+  const { filters } = useEntityList();
+  const { starredEntities } = useStarredEntities();
+
+  const refRequest = useRef<QueryEntitiesInitialRequest>();
+  useMemo(async () => {
+    const { user, ...allFilters } = filters;
+    const compacted = compact(Object.values(allFilters));
+    const filter = reduceCatalogFilters(compacted);
+
+    const facet = 'metadata.name';
+
+    const request: QueryEntitiesInitialRequest = {
+      filter: {
+        ...filter,
+        [facet]: Array.from(starredEntities).map(e => parseEntityRef(e).name),
+      },
+      limit: 1000,
+    };
+    if (isEqual(request, refRequest.current)) {
+      return refRequest.current;
+    }
+    refRequest.current = request;
+
+    return request;
+  }, [filters, starredEntities]);
+
+  const { value: count, loading } = useAsync(async () => {
+    if (!starredEntities.size) {
+      return 0;
+    }
+
+    const response = await catalogApi.queryEntities(refRequest.current);
+
+    return response.items
+      .map(e =>
+        stringifyEntityRef({
+          kind: e.kind,
+          namespace: e.metadata.namespace,
+          name: e.metadata.name,
+        }),
+      )
+      .filter(e => starredEntities.has(e)).length;
+  }, [refRequest.current, starredEntities]);
+
+  const filter = useMemo(
+    () => UserOwnersFilter.starred(Array.from(starredEntities)),
+    [starredEntities],
+  );
+
+  return { count, loading, filter };
+}

--- a/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
@@ -41,8 +41,17 @@ export function useStarredEntitiesCount() {
     const newRequest: QueryEntitiesInitialRequest = {
       filter: {
         ...filter,
+        /**
+         * here we are filtering entities by `name`. Given this filter,
+         * the response might contain more entities than expected, in case multiple entities
+         * of different kind or namespace share the same name. Those extra entities are filtered out
+         * client side by `EntityUserFilter`, so they won't be visible to the user.
+         */
         [facet]: Array.from(starredEntities).map(e => parseEntityRef(e).name),
       },
+      /**
+       * limit is set to a high value as we are not expecting many starred entities
+       */
       limit: 1000,
     };
     if (isEqual(newRequest, prevRequest.current)) {
@@ -58,6 +67,12 @@ export function useStarredEntitiesCount() {
       return 0;
     }
 
+    /**
+     * given a list of starred entity refs and some filters coming from CatalogPage,
+     * it reduces the list of starred entities, to a list of entities that matches the
+     * provided filters. It won't be possible to getEntitiesByRefs
+     * as the method doesn't accept any filter.
+     */
     const response = await catalogApi.queryEntities(request);
 
     return response.items

--- a/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useStarredEntitiesCount.ts
@@ -21,7 +21,7 @@ import { compact, isEqual } from 'lodash';
 import { useMemo, useRef } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../../api';
-import { EntityUserListFilter } from '../../filters';
+import { EntityUserFilter } from '../../filters';
 import { useEntityList, useStarredEntities } from '../../hooks';
 import { reduceCatalogFilters } from '../../utils';
 
@@ -72,7 +72,7 @@ export function useStarredEntitiesCount() {
   }, [request, starredEntities]);
 
   const filter = useMemo(
-    () => EntityUserListFilter.starred(Array.from(starredEntities)),
+    () => EntityUserFilter.starred(Array.from(starredEntities)),
     [starredEntities],
   );
 

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -237,6 +237,15 @@ export class EntityUserListFilter implements EntityFilter {
     if (this.value === 'starred') {
       return this.refs?.includes(stringifyEntityRef(entity)) ?? true;
     }
+    if (this.value === 'owned') {
+      return (
+        this.refs?.some(v =>
+          getEntityRelations(entity, RELATION_OWNED_BY).some(
+            o => stringifyEntityRef(o) === v,
+          ),
+        ) ?? false
+      );
+    }
     return true;
   }
 

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -72,6 +72,10 @@ export class EntityTagFilter implements EntityFilter {
     return this.values.every(v => (entity.metadata.tags ?? []).includes(v));
   }
 
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { 'metadata.tags': this.values };
+  }
+
   toQueryValue(): string[] {
     return this.values;
   }
@@ -136,6 +140,10 @@ export class EntityOwnerFilter implements EntityFilter {
     }, [] as string[]);
   }
 
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { 'relations.ownedBy': this.values };
+  }
+
   filterEntity(entity: Entity): boolean {
     return this.values.some(v =>
       getEntityRelations(entity, RELATION_OWNED_BY).some(
@@ -160,6 +168,10 @@ export class EntityOwnerFilter implements EntityFilter {
 export class EntityLifecycleFilter implements EntityFilter {
   constructor(readonly values: string[]) {}
 
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { 'spec.lifecycle': this.values };
+  }
+
   filterEntity(entity: Entity): boolean {
     return this.values.some(v => entity.spec?.lifecycle === v);
   }
@@ -176,6 +188,9 @@ export class EntityLifecycleFilter implements EntityFilter {
 export class EntityNamespaceFilter implements EntityFilter {
   constructor(readonly values: string[]) {}
 
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { 'spec.lifecycle': this.values };
+  }
   filterEntity(entity: Entity): boolean {
     return this.values.some(v => entity.metadata.namespace === v);
   }
@@ -218,6 +233,11 @@ export class UserListFilter implements EntityFilter {
  */
 export class EntityOrphanFilter implements EntityFilter {
   constructor(readonly value: boolean) {}
+
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { 'metadata.annotations.backstage.io/orphan': String(this.value) };
+  }
+
   filterEntity(entity: Entity): boolean {
     const orphan = entity.metadata.annotations?.['backstage.io/orphan'];
     return orphan !== undefined && this.value.toString() === orphan;
@@ -230,6 +250,10 @@ export class EntityOrphanFilter implements EntityFilter {
  */
 export class EntityErrorFilter implements EntityFilter {
   constructor(readonly value: boolean) {}
+
+  // TODO(vinzscam): is it possible to implement
+  // getCatalogFilters? ask mammals
+
   filterEntity(entity: Entity): boolean {
     const error =
       ((entity as AlphaEntity)?.status?.items?.length as number) > 0;

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -203,22 +203,22 @@ export class EntityNamespaceFilter implements EntityFilter {
 /**
  * @public
  */
-export class UserOwnersFilter implements EntityFilter {
+export class EntityUserListFilter implements EntityFilter {
   private constructor(
     readonly value: UserListFilterKind,
     readonly refs?: string[],
   ) {}
 
   static owned(ownershipEntityRefs: string[]) {
-    return new UserOwnersFilter('owned', ownershipEntityRefs);
+    return new EntityUserListFilter('owned', ownershipEntityRefs);
   }
 
   static all() {
-    return new UserOwnersFilter('all');
+    return new EntityUserListFilter('all');
   }
 
   static starred(starredEntityRefs: string[]) {
-    return new UserOwnersFilter('starred', starredEntityRefs);
+    return new EntityUserListFilter('starred', starredEntityRefs);
   }
 
   getCatalogFilters(): Record<string, string[]> {
@@ -247,7 +247,7 @@ export class UserOwnersFilter implements EntityFilter {
 
 /**
  * Filters entities based on whatever the user has starred or owns them.
- * @deprecated use UserOwnersFilter
+ * @deprecated use EntityUserListFilter
  * @public
  */
 export class UserListFilter implements EntityFilter {

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -237,10 +237,9 @@ export class EntityUserListFilter implements EntityFilter {
     if (this.value === 'starred') {
       return this.refs?.includes(stringifyEntityRef(entity)) ?? true;
     }
-    // used only for retro-compatibility with the old
-    // non paginated table. This is supposed to return always true
-    // for paginated owned entities, since the filters are applied
-    // server side.
+    // used only for retro-compatibility with non paginated data.
+    // This is supposed to return always true for paginated
+    // owned entities, since the filters are applied server side.
     if (this.value === 'owned') {
       return (
         this.refs?.some(v =>

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -201,7 +201,53 @@ export class EntityNamespaceFilter implements EntityFilter {
 }
 
 /**
+ * @public
+ */
+export class UserOwnersFilter implements EntityFilter {
+  private constructor(
+    readonly value: UserListFilterKind,
+    readonly refs?: string[],
+  ) {}
+
+  static owned(ownershipEntityRefs: string[]) {
+    return new UserOwnersFilter('owned', ownershipEntityRefs);
+  }
+
+  static all() {
+    return new UserOwnersFilter('all');
+  }
+
+  static starred(starredEntityRefs: string[]) {
+    return new UserOwnersFilter('starred', starredEntityRefs);
+  }
+
+  getCatalogFilters(): Record<string, string[]> {
+    if (this.value === 'owned') {
+      return { 'relations.ownedBy': this.refs ?? [] };
+    }
+    if (this.value === 'starred') {
+      return {
+        'metadata.name': this.refs?.map(e => parseEntityRef(e).name) ?? [],
+      };
+    }
+    return {};
+  }
+
+  filterEntity(entity: Entity) {
+    if (this.value === 'starred') {
+      return this.refs?.includes(stringifyEntityRef(entity)) ?? true;
+    }
+    return true;
+  }
+
+  toQueryValue(): string {
+    return this.value;
+  }
+}
+
+/**
  * Filters entities based on whatever the user has starred or owns them.
+ * @deprecated use UserOwnersFilter
  * @public
  */
 export class UserListFilter implements EntityFilter {

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -189,7 +189,7 @@ export class EntityNamespaceFilter implements EntityFilter {
   constructor(readonly values: string[]) {}
 
   getCatalogFilters(): Record<string, string | string[]> {
-    return { 'spec.lifecycle': this.values };
+    return { 'metadata.namespace': this.values };
   }
   filterEntity(entity: Entity): boolean {
     return this.values.some(v => entity.metadata.namespace === v);

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -237,6 +237,10 @@ export class EntityUserListFilter implements EntityFilter {
     if (this.value === 'starred') {
       return this.refs?.includes(stringifyEntityRef(entity)) ?? true;
     }
+    // used only for retro-compatibility with the old
+    // non paginated table. This is supposed to return always true
+    // for paginated owned entities, since the filters are applied
+    // server side.
     if (this.value === 'owned') {
       return (
         this.refs?.some(v =>

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -293,7 +293,10 @@ export class EntityOrphanFilter implements EntityFilter {
   constructor(readonly value: boolean) {}
 
   getCatalogFilters(): Record<string, string | string[]> {
-    return { 'metadata.annotations.backstage.io/orphan': String(this.value) };
+    if (this.value) {
+      return { 'metadata.annotations.backstage.io/orphan': String(this.value) };
+    }
+    return {};
   }
 
   filterEntity(entity: Entity): boolean {

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -241,11 +241,11 @@ export class EntityUserListFilter implements EntityFilter {
     // This is supposed to return always true for paginated
     // owned entities, since the filters are applied server side.
     if (this.value === 'owned') {
+      const relations = getEntityRelations(entity, RELATION_OWNED_BY);
+
       return (
         this.refs?.some(v =>
-          getEntityRelations(entity, RELATION_OWNED_BY).some(
-            o => stringifyEntityRef(o) === v,
-          ),
+          relations.some(o => stringifyEntityRef(o) === v),
         ) ?? false
       );
     }
@@ -308,9 +308,6 @@ export class EntityOrphanFilter implements EntityFilter {
  */
 export class EntityErrorFilter implements EntityFilter {
   constructor(readonly value: boolean) {}
-
-  // TODO(vinzscam): is it possible to implement
-  // getCatalogFilters? ask mammals
 
   filterEntity(entity: Entity): boolean {
     const error =

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -203,22 +203,22 @@ export class EntityNamespaceFilter implements EntityFilter {
 /**
  * @public
  */
-export class EntityUserListFilter implements EntityFilter {
+export class EntityUserFilter implements EntityFilter {
   private constructor(
     readonly value: UserListFilterKind,
     readonly refs?: string[],
   ) {}
 
   static owned(ownershipEntityRefs: string[]) {
-    return new EntityUserListFilter('owned', ownershipEntityRefs);
+    return new EntityUserFilter('owned', ownershipEntityRefs);
   }
 
   static all() {
-    return new EntityUserListFilter('all');
+    return new EntityUserFilter('all');
   }
 
   static starred(starredEntityRefs: string[]) {
-    return new EntityUserListFilter('starred', starredEntityRefs);
+    return new EntityUserFilter('starred', starredEntityRefs);
   }
 
   getCatalogFilters(): Record<string, string[]> {
@@ -259,7 +259,7 @@ export class EntityUserListFilter implements EntityFilter {
 
 /**
  * Filters entities based on whatever the user has starred or owns them.
- * @deprecated use EntityUserListFilter
+ * @deprecated use EntityUserFilter
  * @public
  */
 export class UserListFilter implements EntityFilter {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -32,7 +32,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { catalogApiRef } from '../api';
 import { starredEntitiesApiRef, MockStarredEntitiesApi } from '../apis';
 import { EntityKindPicker, UserListPicker } from '../components';
-import { EntityKindFilter, EntityTypeFilter, UserListFilter } from '../filters';
+import {
+  EntityKindFilter,
+  EntityTypeFilter,
+  EntityUserListFilter,
+} from '../filters';
 import { UserListFilterKind } from '../types';
 import { EntityListProvider, useEntityList } from './useEntityListProvider';
 
@@ -62,11 +66,14 @@ const entities: Entity[] = [
 const mockConfigApi = {
   getOptionalString: () => '',
 } as Partial<ConfigApi>;
+
+const ownershipEntityRefs = ['user:default/guest'];
+
 const mockIdentityApi: Partial<IdentityApi> = {
   getBackstageIdentity: async () => ({
     type: 'user',
     userEntityRef: 'user:default/guest',
-    ownershipEntityRefs: [],
+    ownershipEntityRefs,
   }),
   getCredentials: async () => ({ token: undefined }),
 };
@@ -148,11 +155,7 @@ describe('<EntityListProvider />', () => {
 
     act(() =>
       result.current.updateFilters({
-        user: new UserListFilter(
-          'owned',
-          entity => entity.metadata.name === 'component-1',
-          () => true,
-        ),
+        user: EntityUserListFilter.owned(ownershipEntityRefs),
       }),
     );
 
@@ -193,11 +196,7 @@ describe('<EntityListProvider />', () => {
 
     act(() =>
       result.current.updateFilters({
-        user: new UserListFilter(
-          'owned',
-          entity => entity.metadata.name === 'component-1',
-          () => true,
-        ),
+        user: EntityUserListFilter.owned(ownershipEntityRefs),
       }),
     );
 

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -35,7 +35,7 @@ import { EntityKindPicker, UserListPicker } from '../components';
 import {
   EntityKindFilter,
   EntityTypeFilter,
-  EntityUserListFilter,
+  EntityUserFilter,
 } from '../filters';
 import { UserListFilterKind } from '../types';
 import { EntityListProvider, useEntityList } from './useEntityListProvider';
@@ -155,7 +155,7 @@ describe('<EntityListProvider />', () => {
 
     act(() =>
       result.current.updateFilters({
-        user: EntityUserListFilter.owned(ownershipEntityRefs),
+        user: EntityUserFilter.owned(ownershipEntityRefs),
       }),
     );
 
@@ -196,7 +196,7 @@ describe('<EntityListProvider />', () => {
 
     act(() =>
       result.current.updateFilters({
-        user: EntityUserListFilter.owned(ownershipEntityRefs),
+        user: EntityUserFilter.owned(ownershipEntityRefs),
       }),
     );
 

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -41,16 +41,17 @@ import {
   EntityTypeFilter,
   UserListFilter,
   EntityNamespaceFilter,
+  UserOwnersFilter,
 } from '../filters';
 import { EntityFilter } from '../types';
-import { reduceCatalogFilters, reduceEntityFilters } from '../utils';
+import { reduceBackendCatalogFilters, reduceEntityFilters } from '../utils';
 import { useApi } from '@backstage/core-plugin-api';
 
 /** @public */
 export type DefaultEntityFilters = {
   kind?: EntityKindFilter;
   type?: EntityTypeFilter;
-  user?: UserListFilter;
+  user?: UserListFilter | UserOwnersFilter;
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;
@@ -156,8 +157,8 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
     async () => {
       const compacted = compact(Object.values(requestedFilters));
       const entityFilter = reduceEntityFilters(compacted);
-      const backendFilter = reduceCatalogFilters(compacted);
-      const previousBackendFilter = reduceCatalogFilters(
+      const backendFilter = reduceBackendCatalogFilters(compacted);
+      const previousBackendFilter = reduceBackendCatalogFilters(
         compact(Object.values(outputState.appliedFilters)),
       );
 

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -41,7 +41,7 @@ import {
   EntityTypeFilter,
   UserListFilter,
   EntityNamespaceFilter,
-  UserOwnersFilter,
+  EntityUserListFilter,
 } from '../filters';
 import { EntityFilter } from '../types';
 import { reduceBackendCatalogFilters, reduceEntityFilters } from '../utils';
@@ -51,7 +51,7 @@ import { useApi } from '@backstage/core-plugin-api';
 export type DefaultEntityFilters = {
   kind?: EntityKindFilter;
   type?: EntityTypeFilter;
-  user?: UserListFilter | UserOwnersFilter;
+  user?: UserListFilter | EntityUserListFilter;
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -41,7 +41,7 @@ import {
   EntityTypeFilter,
   UserListFilter,
   EntityNamespaceFilter,
-  EntityUserListFilter,
+  EntityUserFilter,
 } from '../filters';
 import { EntityFilter } from '../types';
 import { reduceBackendCatalogFilters, reduceEntityFilters } from '../utils';
@@ -51,7 +51,7 @@ import { useApi } from '@backstage/core-plugin-api';
 export type DefaultEntityFilters = {
   kind?: EntityKindFilter;
   type?: EntityTypeFilter;
-  user?: UserListFilter | EntityUserListFilter;
+  user?: UserListFilter | EntityUserFilter;
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.ts
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.ts
@@ -41,10 +41,14 @@ export function useEntityOwnership(): {
   const identityApi = useApi(identityApiRef);
 
   // Trigger load only on mount
-  const { loading, value: refs } = useAsync(async () => {
-    const { ownershipEntityRefs } = await identityApi.getBackstageIdentity();
-    return ownershipEntityRefs;
-  }, []);
+  const { loading, value: refs } = useAsync(
+    async () => {
+      const { ownershipEntityRefs } = await identityApi.getBackstageIdentity();
+      return ownershipEntityRefs;
+    },
+    // load only on mount
+    [],
+  );
 
   const isOwnedEntity = useMemo(() => {
     const myOwnerRefs = new Set(refs ?? []);

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.ts
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.ts
@@ -46,15 +46,10 @@ export function useEntityOwnership(): {
     return ownershipEntityRefs;
   }, []);
 
-  const isOwnedEntity = useIsOwnedEntity(refs);
-
-  return useMemo(() => ({ loading, isOwnedEntity }), [loading, isOwnedEntity]);
-}
-
-export function useIsOwnedEntity(refs?: string[]) {
-  return useMemo(() => {
+  const isOwnedEntity = useMemo(() => {
     const myOwnerRefs = new Set(refs ?? []);
-    const isOwnedEntity = (entity: Entity) => {
+
+    return (entity: Entity) => {
       const entityOwnerRefs = getEntityRelations(entity, RELATION_OWNED_BY).map(
         stringifyEntityRef,
       );
@@ -65,6 +60,7 @@ export function useIsOwnedEntity(refs?: string[]) {
       }
       return false;
     };
-    return isOwnedEntity;
   }, [refs]);
+
+  return { loading, isOwnedEntity };
 }

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.ts
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.ts
@@ -46,9 +46,15 @@ export function useEntityOwnership(): {
     return ownershipEntityRefs;
   }, []);
 
-  const isOwnedEntity = useMemo(() => {
+  const isOwnedEntity = useIsOwnedEntity(refs);
+
+  return useMemo(() => ({ loading, isOwnedEntity }), [loading, isOwnedEntity]);
+}
+
+export function useIsOwnedEntity(refs?: string[]) {
+  return useMemo(() => {
     const myOwnerRefs = new Set(refs ?? []);
-    return (entity: Entity) => {
+    const isOwnedEntity = (entity: Entity) => {
       const entityOwnerRefs = getEntityRelations(entity, RELATION_OWNED_BY).map(
         stringifyEntityRef,
       );
@@ -59,7 +65,6 @@ export function useEntityOwnership(): {
       }
       return false;
     };
+    return isOwnedEntity;
   }, [refs]);
-
-  return useMemo(() => ({ loading, isOwnedEntity }), [loading, isOwnedEntity]);
 }

--- a/plugins/catalog-react/src/hooks/useStarredEntities.test.tsx
+++ b/plugins/catalog-react/src/hooks/useStarredEntities.test.tsx
@@ -16,7 +16,8 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { TestApiProvider } from '@backstage/test-utils';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import React, { PropsWithChildren } from 'react';
 import {
   starredEntitiesApiRef,

--- a/plugins/catalog-react/src/hooks/useStarredEntity.test.tsx
+++ b/plugins/catalog-react/src/hooks/useStarredEntity.test.tsx
@@ -16,7 +16,8 @@
 
 import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
 import { TestApiProvider } from '@backstage/test-utils';
-import { renderHook, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import React, { PropsWithChildren } from 'react';
 import Observable from 'zen-observable';
 import { StarredEntitiesApi, starredEntitiesApiRef } from '../apis';

--- a/plugins/catalog-react/src/utils/filters.ts
+++ b/plugins/catalog-react/src/utils/filters.ts
@@ -16,6 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { EntityFilter } from '../types';
+import { EntityKindFilter, EntityTypeFilter } from '../filters';
 
 export function reduceCatalogFilters(
   filters: EntityFilter[],
@@ -26,6 +27,24 @@ export function reduceCatalogFilters(
       ...(filter.getCatalogFilters ? filter.getCatalogFilters() : {}),
     };
   }, {} as Record<string, string | symbol | (string | symbol)[]>);
+}
+
+export function reduceBackendCatalogFilters(filters: EntityFilter[]) {
+  const backendCatalogFilters: Record<
+    string,
+    string | symbol | (string | symbol)[]
+  > = {};
+
+  filters.forEach(filter => {
+    if (
+      filter instanceof EntityKindFilter ||
+      filter instanceof EntityTypeFilter
+    ) {
+      Object.assign(backendCatalogFilters, filter.getCatalogFilters());
+    }
+  });
+
+  return backendCatalogFilters;
 }
 
 export function reduceEntityFilters(

--- a/plugins/catalog-react/src/utils/filters.ts
+++ b/plugins/catalog-react/src/utils/filters.ts
@@ -16,7 +16,16 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { EntityFilter } from '../types';
-import { EntityKindFilter, EntityTypeFilter } from '../filters';
+import {
+  EntityLifecycleFilter,
+  EntityNamespaceFilter,
+  EntityOrphanFilter,
+  EntityOwnerFilter,
+  EntityTagFilter,
+  EntityTextFilter,
+  EntityUserListFilter,
+  UserListFilter,
+} from '../filters';
 
 export function reduceCatalogFilters(
   filters: EntityFilter[],
@@ -29,6 +38,13 @@ export function reduceCatalogFilters(
   }, {} as Record<string, string | symbol | (string | symbol)[]>);
 }
 
+/**
+ * This function computes and returns an object containing the filters to be sent
+ * to the backend. Any filter coming from `EntityKindFilter` and `EntityTypeFilter`, together
+ * with custom filter set by the adopters is allowed. This function is used by `EntityListProvider`
+ * and it won't be needed anymore in the future once pagination is implemented, as all the filters
+ * will be applied backend-side.
+ */
 export function reduceBackendCatalogFilters(filters: EntityFilter[]) {
   const backendCatalogFilters: Record<
     string,
@@ -37,11 +53,18 @@ export function reduceBackendCatalogFilters(filters: EntityFilter[]) {
 
   filters.forEach(filter => {
     if (
-      filter instanceof EntityKindFilter ||
-      filter instanceof EntityTypeFilter
+      filter instanceof EntityTagFilter ||
+      filter instanceof EntityOwnerFilter ||
+      filter instanceof EntityLifecycleFilter ||
+      filter instanceof EntityNamespaceFilter ||
+      filter instanceof EntityUserListFilter ||
+      filter instanceof EntityOrphanFilter ||
+      filter instanceof EntityTextFilter ||
+      filter instanceof UserListFilter
     ) {
-      Object.assign(backendCatalogFilters, filter.getCatalogFilters());
+      return;
     }
+    Object.assign(backendCatalogFilters, filter.getCatalogFilters?.() || {});
   });
 
   return backendCatalogFilters;

--- a/plugins/catalog-react/src/utils/filters.ts
+++ b/plugins/catalog-react/src/utils/filters.ts
@@ -23,7 +23,7 @@ import {
   EntityOwnerFilter,
   EntityTagFilter,
   EntityTextFilter,
-  EntityUserListFilter,
+  EntityUserFilter,
   UserListFilter,
 } from '../filters';
 
@@ -57,7 +57,7 @@ export function reduceBackendCatalogFilters(filters: EntityFilter[]) {
       filter instanceof EntityOwnerFilter ||
       filter instanceof EntityLifecycleFilter ||
       filter instanceof EntityNamespaceFilter ||
-      filter instanceof EntityUserListFilter ||
+      filter instanceof EntityUserFilter ||
       filter instanceof EntityOrphanFilter ||
       filter instanceof EntityTextFilter ||
       filter instanceof UserListFilter

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -83,6 +83,7 @@ describe('DefaultCatalogPage', () => {
             kind: 'Component',
             metadata: {
               name: 'Entity2',
+              namespace: 'default',
             },
             spec: {
               owner: 'not-tools',

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -117,43 +117,31 @@ describe('DefaultCatalogPage', () => {
         ],
       },
     })),
-    queryEntities: jest.fn().mockImplementation(async request => {
-      if (
-        (
-          (request as QueryEntitiesInitialRequest).filter as Record<
-            string,
-            string
-          >
-        )['relations.ownedBy']
-      ) {
-        // owned entities
-        return { items: [], totalItems: 3, pageInfo: {} };
-      }
+    queryEntities: jest
+      .fn()
+      .mockImplementation(async (request: QueryEntitiesInitialRequest) => {
+        if ((request.filter as any)['relations.ownedBy']) {
+          // owned entities
+          return { items: [], totalItems: 3, pageInfo: {} };
+        }
 
-      if (
-        (
-          (request as QueryEntitiesInitialRequest).filter as Record<
-            string,
-            string
-          >
-        )['metadata.name']
-      ) {
-        // starred entities
-        return {
-          items: [
-            {
-              apiVersion: '1',
-              kind: 'component',
-              metadata: { name: 'Entity1', namespace: 'default' },
-            },
-          ],
-          totalItems: 1,
-          pageInfo: {},
-        };
-      }
-      // all items
-      return { items: [], totalItems: 2, pageInfo: {} };
-    }),
+        if ((request.filter as any)['metadata.name']) {
+          // starred entities
+          return {
+            items: [
+              {
+                apiVersion: '1',
+                kind: 'component',
+                metadata: { name: 'Entity1', namespace: 'default' },
+              },
+            ],
+            totalItems: 1,
+            pageInfo: {},
+          };
+        }
+        // all items
+        return { items: [], totalItems: 2, pageInfo: {} };
+      }),
   };
 
   const testProfile: Partial<ProfileInfo> = {

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { CatalogApi } from '@backstage/catalog-client';
+import {
+  CatalogApi,
+  QueryEntitiesInitialRequest,
+} from '@backstage/catalog-client';
 import { RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { TableColumn, TableProps } from '@backstage/core-components';
 import {
@@ -36,7 +39,7 @@ import {
   renderInTestApp,
 } from '@backstage/test-utils';
 import DashboardIcon from '@material-ui/icons/Dashboard';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { createComponentRouteRef } from '../../routes';
 import { CatalogTableRow } from '../CatalogTable';
@@ -49,10 +52,12 @@ describe('DefaultCatalogPage', () => {
   });
   afterEach(() => {
     window.history.replaceState = origReplaceState;
+
+    jest.clearAllMocks();
   });
 
-  const catalogApi: Partial<CatalogApi> = {
-    getEntities: () =>
+  const catalogApi: jest.Mocked<Partial<CatalogApi>> = {
+    getEntities: jest.fn().mockImplementation(() =>
       Promise.resolve({
         items: [
           {
@@ -97,17 +102,59 @@ describe('DefaultCatalogPage', () => {
           },
         ],
       }),
-    getLocationByRef: () =>
-      Promise.resolve({ id: 'id', type: 'url', target: 'url' }),
-    getEntityFacets: async () => ({
+    ),
+    getLocationByRef: jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ id: 'id', type: 'url', target: 'url' }),
+      ),
+    getEntityFacets: jest.fn().mockImplementation(async () => ({
       facets: {
         'relations.ownedBy': [
           { count: 1, value: 'group:default/not-tools' },
           { count: 1, value: 'group:default/tools' },
         ],
       },
+    })),
+    queryEntities: jest.fn().mockImplementation(async request => {
+      if (
+        (
+          (request as QueryEntitiesInitialRequest).filter as Record<
+            string,
+            string
+          >
+        )['relations.ownedBy']
+      ) {
+        // owned entities
+        return { items: [], totalItems: 3, pageInfo: {} };
+      }
+
+      if (
+        (
+          (request as QueryEntitiesInitialRequest).filter as Record<
+            string,
+            string
+          >
+        )['metadata.name']
+      ) {
+        // starred entities
+        return {
+          items: [
+            {
+              apiVersion: '1',
+              kind: 'component',
+              metadata: { name: 'Entity1', namespace: 'default' },
+            },
+          ],
+          totalItems: 1,
+          pageInfo: {},
+        };
+      }
+      // all items
+      return { items: [], totalItems: 2, pageInfo: {} };
     }),
   };
+
   const testProfile: Partial<ProfileInfo> = {
     displayName: 'Display Name',
   };
@@ -183,6 +230,8 @@ describe('DefaultCatalogPage', () => {
 
   it('should render the default actions of an item in the grid', async () => {
     await renderWrapped(<DefaultCatalogPage />);
+    await waitFor(() => expect(catalogApi.queryEntities).toHaveBeenCalled());
+
     fireEvent.click(screen.getByTestId('user-picker-owned'));
     await expect(
       screen.findByText(/Owned components \(1\)/),
@@ -215,6 +264,8 @@ describe('DefaultCatalogPage', () => {
     ];
 
     await renderWrapped(<DefaultCatalogPage actions={actions} />);
+    await waitFor(() => expect(catalogApi.queryEntities).toHaveBeenCalled());
+
     fireEvent.click(screen.getByTestId('user-picker-owned'));
     await expect(
       screen.findByText(/Owned components \(1\)/),
@@ -231,7 +282,10 @@ describe('DefaultCatalogPage', () => {
   // https://github.com/mbrn/material-table/issues/1293
   it('should render', async () => {
     await renderWrapped(<DefaultCatalogPage />);
+    await waitFor(() => expect(catalogApi.queryEntities).toHaveBeenCalled());
+
     fireEvent.click(screen.getByTestId('user-picker-owned'));
+
     await expect(
       screen.findByText(/Owned components \(1\)/),
     ).resolves.toBeInTheDocument();
@@ -252,6 +306,8 @@ describe('DefaultCatalogPage', () => {
   // entities defaulting to "owned" filter and not based on the selected filter
   it('should render the correct entities filtered on the selected filter', async () => {
     await renderWrapped(<DefaultCatalogPage />);
+    await waitFor(() => expect(catalogApi.queryEntities).toHaveBeenCalled());
+
     fireEvent.click(screen.getByTestId('user-picker-owned'));
     await expect(
       screen.findByText(/Owned components \(1\)/),

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -320,10 +320,9 @@ describe('DefaultCatalogPage', () => {
 
     // Now that we've starred an entity, the "Starred" menu option should be
     // enabled.
-    expect(screen.getByTestId('user-picker-starred')).not.toHaveAttribute(
-      'aria-disabled',
-      'true',
-    );
+    expect(
+      await screen.findByTestId('user-picker-starred'),
+    ).not.toHaveAttribute('aria-disabled', 'true');
     fireEvent.click(screen.getByTestId('user-picker-starred'));
     await expect(
       screen.findByText(/Starred components \(1\)/),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Following up from #18285

This PR makes `UserListPicker` load the data asynchronously, removing its dependency from the entities stored in `EntityListContext`.
The work on this PR is part of #12247.

Since the data displayed in `UserListPicker` relies on which filters are applied in `EntityListContext`, some work was needed on how the filters are applied. The number of available entities is returned by invoking the `queryEntities` method, passing all the selected filters, gathered together by using the existing `reduceCatalogFilters`. This is the reason why I had to implement the `getCatalogFilters` method in all the filters.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
