### PR TITLE
frontend-app-api: add support for existing routing system

### DIFF
--- a/.changeset/unlucky-experts-breathe.md
+++ b/.changeset/unlucky-experts-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Added support for the existing routing system.

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -42,6 +42,7 @@
     "@backstage/plugin-graphiql": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@backstage/version-bridge": "workspace:^",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
@@ -1,0 +1,467 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { RouteRef, createRouteRef } from '@backstage/core-plugin-api';
+import { extractRouteInfoFromInstanceTree } from './extractRouteInfoFromInstanceTree';
+import {
+  coreExtensionData,
+  createExtensionInput,
+  createPageExtension,
+  createPlugin,
+} from '@backstage/frontend-plugin-api';
+import { createInstances } from '../wiring/createApp';
+import { MockConfigApi } from '@backstage/test-utils';
+
+const ref1 = createRouteRef({ id: 'page1' });
+const ref2 = createRouteRef({ id: 'page2' });
+const ref3 = createRouteRef({ id: 'page3' });
+const ref4 = createRouteRef({ id: 'page4' });
+const ref5 = createRouteRef({ id: 'page5' });
+const refOrder = [ref1, ref2, ref3, ref4, ref5];
+
+function sortedEntries<T>(map: Map<RouteRef, T>): [RouteRef, T][] {
+  return Array.from(map).sort(
+    ([a], [b]) => refOrder.indexOf(a) - refOrder.indexOf(b),
+  );
+}
+
+// async function routeObj(
+//   path: string,
+//   refs: RouteRef[],
+//   children: any[] = [],
+//   type: 'mounted' | 'gathered' = 'mounted',
+//   backstagePlugin?: BackstagePlugin,
+// ) {
+//   return {
+//     path: path,
+//     caseSensitive: false,
+//     element: type,
+//     routeRefs: new Set(refs),
+//     children: [
+//       {
+//         path: '*',
+//         caseSensitive: false,
+//         element: 'match-all',
+//         routeRefs: new Set(),
+//         plugins: new Set(),
+//       },
+//       ...children,
+//     ],
+//     plugins: backstagePlugin ? new Set([backstagePlugin]) : new Set(),
+//   };
+// }
+
+const emptyLoader = () => Promise.resolve(React.createElement('div'));
+
+describe('discovery', () => {
+  it('should collect routes', () => {
+    const extensions = [
+      createPageExtension({
+        id: 'nothing',
+        defaultPath: 'nothing',
+        loader: emptyLoader,
+      }),
+      createPageExtension({
+        id: 'page1',
+        defaultPath: 'foo',
+        routeRef: ref1,
+        inputs: {
+          routes: createExtensionInput({
+            element: coreExtensionData.reactElement,
+          }),
+        },
+        loader: emptyLoader,
+      }),
+      createPageExtension({
+        id: 'page2',
+        at: 'page1/routes',
+        defaultPath: 'bar/:id',
+        routeRef: ref2,
+        inputs: {
+          routes: createExtensionInput({
+            element: coreExtensionData.reactElement,
+          }),
+        },
+        loader: emptyLoader,
+      }),
+      createPageExtension({
+        id: 'page3',
+        at: 'page2/routes',
+        defaultPath: 'baz',
+        routeRef: ref3,
+        loader: emptyLoader,
+      }),
+      createPageExtension({
+        id: 'page4',
+        defaultPath: 'divsoup',
+        routeRef: ref4,
+        loader: emptyLoader,
+      }),
+      createPageExtension({
+        id: 'page5',
+        at: 'page1/routes',
+        defaultPath: 'blop',
+        routeRef: ref5,
+        loader: emptyLoader,
+      }),
+    ];
+
+    const { rootInstances } = createInstances({
+      config: new MockConfigApi({}),
+      plugins: [
+        createPlugin({
+          id: 'test',
+          extensions,
+        }),
+      ],
+    });
+
+    const info = extractRouteInfoFromInstanceTree(rootInstances);
+
+    expect(sortedEntries(info.routePaths)).toEqual([
+      [ref1, 'foo'],
+      [ref2, 'bar/:id'],
+      [ref3, 'baz'],
+      [ref4, 'divsoup'],
+      [ref5, 'blop'],
+    ]);
+    expect(sortedEntries(info.routeParents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+      [ref3, ref2],
+      [ref4, undefined],
+      [ref5, ref1],
+    ]);
+    // expect(routing.objects).toEqual([
+    //   routeObj(
+    //     'foo',
+    //     [ref1],
+    //     [
+    //       routeObj(
+    //         'bar/:id',
+    //         [ref2],
+    //         [routeObj('baz', [ref3], undefined, undefined, plugin)],
+    //         undefined,
+    //         plugin,
+    //       ),
+    //       routeObj('blop', [ref5], undefined, undefined, plugin),
+    //     ],
+    //     undefined,
+    //     plugin,
+    //   ),
+    //   routeObj('divsoup', [ref4], undefined, undefined, plugin),
+    // ]);
+  });
+
+  // it('should handle all react router Route patterns', () => {
+  //   const root = (
+  //     <MemoryRouter>
+  //       <Routes>
+  //         <Route path="foo" element={<Extension1 />}>
+  //           <Routes>
+  //             <Route path="bar/:id" element={<Extension2 />} />
+  //           </Routes>
+  //         </Route>
+  //         <Route path="baz" element={<Extension3 />}>
+  //           <Route path="divsoup" element={<Extension4 />} />
+  //           <Route path="blop" element={<Extension5 />} />
+  //         </Route>
+  //       </Routes>
+  //     </MemoryRouter>
+  //   );
+
+  //   const { routing } = traverseElementTree({
+  //     root,
+  //     discoverers: [childDiscoverer, routeElementDiscoverer],
+  //     collectors: {
+  //       routing: routingV2Collector,
+  //     },
+  //   });
+  //   expect(sortedEntries(routing.paths)).toEqual([
+  //     [ref1, 'foo'],
+  //     [ref2, 'bar/:id'],
+  //     [ref3, 'baz'],
+  //     [ref4, 'divsoup'],
+  //     [ref5, 'blop'],
+  //   ]);
+  //   expect(sortedEntries(routing.parents)).toEqual([
+  //     [ref1, undefined],
+  //     [ref2, ref1],
+  //     [ref3, undefined],
+  //     [ref4, ref3],
+  //     [ref5, ref3],
+  //   ]);
+  // });
+
+  // it('should handle absolute route paths', () => {
+  //   const root = (
+  //     <MemoryRouter>
+  //       <Routes>
+  //         <Route path="/foo" element={<Extension1 />}>
+  //           <Routes>
+  //             <Route path="/bar/:id" element={<Extension2 />} />
+  //           </Routes>
+  //         </Route>
+  //         <Route path="/baz" element={<Extension3 />}>
+  //           <Route path="/divsoup" element={<Extension4 />} />
+  //           <Route path="/blop" element={<Extension5 />} />
+  //         </Route>
+  //       </Routes>
+  //     </MemoryRouter>
+  //   );
+
+  //   const { routing } = traverseElementTree({
+  //     root,
+  //     discoverers: [childDiscoverer, routeElementDiscoverer],
+  //     collectors: {
+  //       routing: routingV2Collector,
+  //     },
+  //   });
+  //   expect(sortedEntries(routing.paths)).toEqual([
+  //     [ref1, 'foo'],
+  //     [ref2, 'bar/:id'],
+  //     [ref3, 'baz'],
+  //     [ref4, 'divsoup'],
+  //     [ref5, 'blop'],
+  //   ]);
+  //   expect(sortedEntries(routing.parents)).toEqual([
+  //     [ref1, undefined],
+  //     [ref2, ref1],
+  //     [ref3, undefined],
+  //     [ref4, ref3],
+  //     [ref5, ref3],
+  //   ]);
+  // });
+
+  // it('should use the route aggregator key to bind child routes to the same path', () => {
+  //   const root = (
+  //     <MemoryRouter>
+  //       <Routes>
+  //         <AggregationComponent path="foo">
+  //           <Extension1 />
+  //           <div>
+  //             <Extension2 />
+  //           </div>
+  //           HELLO
+  //         </AggregationComponent>
+  //         <Route path="bar" element={<Extension3 />}>
+  //           <AggregationComponent path="">
+  //             <Extension4>
+  //               <Extension5 />
+  //             </Extension4>
+  //           </AggregationComponent>
+  //         </Route>
+  //       </Routes>
+  //     </MemoryRouter>
+  //   );
+
+  //   const { routing } = traverseElementTree({
+  //     root,
+  //     discoverers: [childDiscoverer, routeElementDiscoverer],
+  //     collectors: {
+  //       routing: routingV2Collector,
+  //     },
+  //   });
+  //   expect(sortedEntries(routing.paths)).toEqual([
+  //     [ref1, 'foo'],
+  //     [ref2, 'foo'],
+  //     [ref3, 'bar'],
+  //     [ref4, ''],
+  //     [ref5, ''],
+  //   ]);
+  //   expect(sortedEntries(routing.parents)).toEqual([
+  //     [ref1, undefined],
+  //     [ref2, undefined],
+  //     [ref3, undefined],
+  //     [ref4, ref3],
+  //     [ref5, ref3],
+  //   ]);
+  //   expect(routing.objects).toEqual([
+  //     routeObj('foo', [ref1, ref2], [], 'gathered', plugin),
+  //     routeObj(
+  //       'bar',
+  //       [ref3],
+  //       [routeObj('', [ref4, ref5], [], 'gathered', plugin)],
+  //       undefined,
+  //       plugin,
+  //     ),
+  //   ]);
+  // });
+
+  // it('should use the route aggregator but stop when encountering explicit path', () => {
+  //   const root = (
+  //     <MemoryRouter>
+  //       <Routes>
+  //         <Route path="foo" element={<Extension1 />}>
+  //           <AggregationComponent path="/bar">
+  //             <Extension2>
+  //               <Routes>
+  //                 <Route path="baz" element={<Extension3 />}>
+  //                   <Route path="/blop" element={<Extension4 />} />
+  //                 </Route>
+  //               </Routes>
+  //               <Extension5 />
+  //             </Extension2>
+  //           </AggregationComponent>
+  //         </Route>
+  //       </Routes>
+  //     </MemoryRouter>
+  //   );
+
+  //   const { routing } = traverseElementTree({
+  //     root,
+  //     discoverers: [childDiscoverer, routeElementDiscoverer],
+  //     collectors: {
+  //       routing: routingV2Collector,
+  //     },
+  //   });
+  //   expect(sortedEntries(routing.paths)).toEqual([
+  //     [ref1, 'foo'],
+  //     [ref2, 'bar'],
+  //     [ref3, 'baz'],
+  //     [ref4, 'blop'],
+  //     [ref5, 'bar'],
+  //   ]);
+  //   expect(sortedEntries(routing.parents)).toEqual([
+  //     [ref1, undefined],
+  //     [ref2, ref1],
+  //     [ref3, ref2],
+  //     [ref4, ref3],
+  //     [ref5, ref1],
+  //   ]);
+  //   expect(routing.objects).toEqual([
+  //     routeObj(
+  //       'foo',
+  //       [ref1],
+  //       [
+  //         routeObj(
+  //           'bar',
+  //           [ref2, ref5],
+  //           [
+  //             routeObj(
+  //               'baz',
+  //               [ref3],
+  //               [routeObj('blop', [ref4], undefined, undefined, plugin)],
+  //               undefined,
+  //               plugin,
+  //             ),
+  //           ],
+  //           'gathered',
+  //           plugin,
+  //         ),
+  //       ],
+  //       undefined,
+  //       plugin,
+  //     ),
+  //   ]);
+  // });
+
+  // it('should throw when you provide path property on an extension', () => {
+  //   expect(() => {
+  //     traverseElementTree({
+  //       root: <Extension1 path="/foo" />,
+  //       discoverers: [childDiscoverer, routeElementDiscoverer],
+  //       collectors: {
+  //         routing: routingV2Collector,
+  //       },
+  //     });
+  //   }).toThrow(
+  //     'Path property may not be set directly on a routable extension "Extension(Extension1)"',
+  //   );
+  // });
+
+  // it('should throw when element prop is not a string', () => {
+  //   const Div = 'div' as unknown as ComponentType<{ path: boolean }>;
+  //   expect(() => {
+  //     traverseElementTree({
+  //       root: <Div path />,
+  //       discoverers: [childDiscoverer, routeElementDiscoverer],
+  //       collectors: {
+  //         routing: routingV2Collector,
+  //       },
+  //     });
+  //   }).toThrow('Element path must be a string at "div"');
+  // });
+
+  // it('should throw when the mount point gatherers have an element prop', () => {
+  //   const AnyAggregationComponent = AggregationComponent as any;
+  //   expect(() => {
+  //     traverseElementTree({
+  //       root: <AnyAggregationComponent path="test" element={<Extension3 />} />,
+  //       discoverers: [childDiscoverer, routeElementDiscoverer],
+  //       collectors: {
+  //         routing: routingV2Collector,
+  //       },
+  //     });
+  //   }).toThrow(
+  //     'Mount point gatherers may not have an element prop "AggregationComponent"',
+  //   );
+  // });
+
+  // it('should ignore path props within route elements', () => {
+  //   const { routing } = traverseElementTree({
+  //     root: <Route path="foo" element={<Extension1 path="bar" />} />,
+  //     discoverers: [childDiscoverer, routeElementDiscoverer],
+  //     collectors: {
+  //       routing: routingV2Collector,
+  //     },
+  //   });
+  //   expect(sortedEntries(routing.paths)).toEqual([[ref1, 'foo']]);
+  //   expect(sortedEntries(routing.parents)).toEqual([[ref1, undefined]]);
+  //   expect(routing.objects).toEqual([
+  //     routeObj('foo', [ref1], [], undefined, plugin),
+  //   ]);
+  // });
+
+  // it('should throw when a routable extension does not have a path set', () => {
+  //   expect(() => {
+  //     traverseElementTree({
+  //       root: <Extension3 />,
+  //       discoverers: [childDiscoverer, routeElementDiscoverer],
+  //       collectors: {
+  //         routing: routingV2Collector,
+  //       },
+  //     });
+  //   }).toThrow(
+  //     'Routable extension "Extension(Extension3)" with mount point "routeRef{type=absolute,id=ref3}" must be assigned a path',
+  //   );
+  // });
+
+  // it('should throw when Route elements contain multiple routable extensions', () => {
+  //   expect(() => {
+  //     traverseElementTree({
+  //       root: (
+  //         <Route
+  //           path="foo"
+  //           element={
+  //             <>
+  //               <Extension1 />
+  //               <Extension2 />
+  //             </>
+  //           }
+  //         />
+  //       ),
+  //       discoverers: [childDiscoverer, routeElementDiscoverer],
+  //       collectors: {
+  //         routing: routingV2Collector,
+  //       },
+  //     });
+  //   }).toThrow(
+  //     'Route element with path "foo" may not contain multiple routable extensions',
+  //   );
+  // });
+});

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
@@ -233,53 +233,53 @@ describe('discovery', () => {
     ]);
   });
 
-  // it('should handle absolute route paths', () => {
-  //   const info = routeInfoFromExtensions([
-  //     createTestExtension({
-  //       id: 'page1',
-  //       path: '/foo',
-  //       routeRef: ref1,
-  //     }),
-  //     createTestExtension({
-  //       id: 'page2',
-  //       at: 'page1/children',
-  //       path: '/bar/:id',
-  //       routeRef: ref2,
-  //     }),
-  //     createTestExtension({
-  //       id: 'page3',
-  //       path: '/baz',
-  //       routeRef: ref3,
-  //     }),
-  //     createTestExtension({
-  //       id: 'page4',
-  //       at: 'page3/children',
-  //       path: '/divsoup',
-  //       routeRef: ref4,
-  //     }),
-  //     createTestExtension({
-  //       id: 'page5',
-  //       at: 'page3/children',
-  //       path: '/blop',
-  //       routeRef: ref5,
-  //     }),
-  //   ]);
+  it('should strip leading slashes in route paths', () => {
+    const info = routeInfoFromExtensions([
+      createTestExtension({
+        id: 'page1',
+        path: '/foo',
+        routeRef: ref1,
+      }),
+      createTestExtension({
+        id: 'page2',
+        at: 'page1/children',
+        path: '/bar/:id',
+        routeRef: ref2,
+      }),
+      createTestExtension({
+        id: 'page3',
+        path: '/baz',
+        routeRef: ref3,
+      }),
+      createTestExtension({
+        id: 'page4',
+        at: 'page3/children',
+        path: '/divsoup',
+        routeRef: ref4,
+      }),
+      createTestExtension({
+        id: 'page5',
+        at: 'page3/children',
+        path: '/blop',
+        routeRef: ref5,
+      }),
+    ]);
 
-  //   expect(sortedEntries(info.routePaths)).toEqual([
-  //     [ref1, 'foo'],
-  //     [ref2, 'bar/:id'],
-  //     [ref3, 'baz'],
-  //     [ref4, 'divsoup'],
-  //     [ref5, 'blop'],
-  //   ]);
-  //   expect(sortedEntries(info.routeParents)).toEqual([
-  //     [ref1, undefined],
-  //     [ref2, ref1],
-  //     [ref3, undefined],
-  //     [ref4, ref3],
-  //     [ref5, ref3],
-  //   ]);
-  // });
+    expect(sortedEntries(info.routePaths)).toEqual([
+      [ref1, 'foo'],
+      [ref2, 'bar/:id'],
+      [ref3, 'baz'],
+      [ref4, 'divsoup'],
+      [ref5, 'blop'],
+    ]);
+    expect(sortedEntries(info.routeParents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+      [ref3, undefined],
+      [ref4, ref3],
+      [ref5, ref3],
+    ]);
+  });
 
   it('should use the route aggregator key to bind child routes to the same path', () => {
     const info = routeInfoFromExtensions([
@@ -338,7 +338,7 @@ describe('discovery', () => {
       [ref2, undefined],
       [ref3, undefined],
       [ref4, ref3],
-      [ref5, ref4],
+      [ref5, ref3],
     ]);
     expect(info.routeObjects).toEqual([
       routeObj('foo', [ref1, ref2], [], 'mounted', expect.any(Object)),
@@ -352,166 +352,177 @@ describe('discovery', () => {
     ]);
   });
 
-  // it('should use the route aggregator but stop when encountering explicit path', () => {
-  //   const root = (
-  //     <MemoryRouter>
-  //       <Routes>
-  //         <Route path="foo" element={<Extension1 />}>
-  //           <AggregationComponent path="/bar">
-  //             <Extension2>
-  //               <Routes>
-  //                 <Route path="baz" element={<Extension3 />}>
-  //                   <Route path="/blop" element={<Extension4 />} />
-  //                 </Route>
-  //               </Routes>
-  //               <Extension5 />
-  //             </Extension2>
-  //           </AggregationComponent>
-  //         </Route>
-  //       </Routes>
-  //     </MemoryRouter>
-  //   );
+  it('should use the route aggregator but stop when encountering explicit path', () => {
+    const info = routeInfoFromExtensions([
+      createTestExtension({
+        id: 'page1',
+        path: 'foo',
+        routeRef: ref1,
+      }),
+      createTestExtension({
+        id: 'page1Child',
+        at: 'page1/children',
+        path: 'bar',
+      }),
+      createTestExtension({
+        id: 'page2',
+        at: 'page1Child/children',
+        routeRef: ref2,
+      }),
+      createTestExtension({
+        id: 'page3',
+        at: 'page2/children',
+        path: 'baz',
+        routeRef: ref3,
+      }),
+      createTestExtension({
+        id: 'page4',
+        at: 'page3/children',
+        path: '/blop',
+        routeRef: ref4,
+      }),
+      createTestExtension({
+        id: 'page5',
+        at: 'page2/children',
+        routeRef: ref5,
+      }),
+    ]);
 
-  //   const { routing } = traverseElementTree({
-  //     root,
-  //     discoverers: [childDiscoverer, routeElementDiscoverer],
-  //     collectors: {
-  //       routing: routingV2Collector,
-  //     },
-  //   });
-  //   expect(sortedEntries(routing.paths)).toEqual([
-  //     [ref1, 'foo'],
-  //     [ref2, 'bar'],
-  //     [ref3, 'baz'],
-  //     [ref4, 'blop'],
-  //     [ref5, 'bar'],
-  //   ]);
-  //   expect(sortedEntries(routing.parents)).toEqual([
-  //     [ref1, undefined],
-  //     [ref2, ref1],
-  //     [ref3, ref2],
-  //     [ref4, ref3],
-  //     [ref5, ref1],
-  //   ]);
-  //   expect(routing.objects).toEqual([
-  //     routeObj(
-  //       'foo',
-  //       [ref1],
-  //       [
-  //         routeObj(
-  //           'bar',
-  //           [ref2, ref5],
-  //           [
-  //             routeObj(
-  //               'baz',
-  //               [ref3],
-  //               [routeObj('blop', [ref4], undefined, undefined, plugin)],
-  //               undefined,
-  //               plugin,
-  //             ),
-  //           ],
-  //           'gathered',
-  //           plugin,
-  //         ),
-  //       ],
-  //       undefined,
-  //       plugin,
-  //     ),
-  //   ]);
-  // });
+    expect(sortedEntries(info.routePaths)).toEqual([
+      [ref1, 'foo'],
+      [ref2, 'bar'],
+      [ref3, 'baz'],
+      [ref4, 'blop'],
+      [ref5, 'bar'],
+    ]);
+    expect(sortedEntries(info.routeParents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+      [ref3, ref2],
+      [ref4, ref3],
+      [ref5, ref1],
+    ]);
+    expect(info.routeObjects).toEqual([
+      routeObj(
+        'foo',
+        [ref1],
+        [
+          routeObj(
+            'bar',
+            [ref2, ref5],
+            [
+              routeObj(
+                'baz',
+                [ref3],
+                [
+                  routeObj(
+                    'blop',
+                    [ref4],
+                    undefined,
+                    undefined,
+                    expect.any(Object),
+                  ),
+                ],
+                undefined,
+                expect.any(Object),
+              ),
+            ],
+            'mounted',
+            expect.any(Object),
+          ),
+        ],
+        undefined,
+        expect.any(Object),
+      ),
+    ]);
+  });
 
-  // it('should throw when you provide path property on an extension', () => {
-  //   expect(() => {
-  //     traverseElementTree({
-  //       root: <Extension1 path="/foo" />,
-  //       discoverers: [childDiscoverer, routeElementDiscoverer],
-  //       collectors: {
-  //         routing: routingV2Collector,
-  //       },
-  //     });
-  //   }).toThrow(
-  //     'Path property may not be set directly on a routable extension "Extension(Extension1)"',
-  //   );
-  // });
+  it('should account for loose route paths', () => {
+    const info = routeInfoFromExtensions([
+      createTestExtension({
+        id: 'r',
+        path: 'r',
+      }),
+      createTestExtension({
+        id: 'page1',
+        at: 'r/children',
+        path: 'x',
+        routeRef: ref1,
+      }),
+      createTestExtension({
+        id: 'y',
+        path: 'y',
+        at: 'r/children',
+      }),
+      createTestExtension({
+        id: 'page2',
+        at: 'y/children',
+        path: '1',
+        routeRef: ref2,
+      }),
+      createTestExtension({
+        id: 'page3',
+        at: 'page2/children',
+        path: 'a',
+        routeRef: ref3,
+      }),
+      createTestExtension({
+        id: 'page4',
+        at: 'page2/children',
+        path: 'b',
+        routeRef: ref4,
+      }),
+    ]);
 
-  // it('should throw when element prop is not a string', () => {
-  //   const Div = 'div' as unknown as ComponentType<{ path: boolean }>;
-  //   expect(() => {
-  //     traverseElementTree({
-  //       root: <Div path />,
-  //       discoverers: [childDiscoverer, routeElementDiscoverer],
-  //       collectors: {
-  //         routing: routingV2Collector,
-  //       },
-  //     });
-  //   }).toThrow('Element path must be a string at "div"');
-  // });
-
-  // it('should throw when the mount point gatherers have an element prop', () => {
-  //   const AnyAggregationComponent = AggregationComponent as any;
-  //   expect(() => {
-  //     traverseElementTree({
-  //       root: <AnyAggregationComponent path="test" element={<Extension3 />} />,
-  //       discoverers: [childDiscoverer, routeElementDiscoverer],
-  //       collectors: {
-  //         routing: routingV2Collector,
-  //       },
-  //     });
-  //   }).toThrow(
-  //     'Mount point gatherers may not have an element prop "AggregationComponent"',
-  //   );
-  // });
-
-  // it('should ignore path props within route elements', () => {
-  //   const { routing } = traverseElementTree({
-  //     root: <Route path="foo" element={<Extension1 path="bar" />} />,
-  //     discoverers: [childDiscoverer, routeElementDiscoverer],
-  //     collectors: {
-  //       routing: routingV2Collector,
-  //     },
-  //   });
-  //   expect(sortedEntries(routing.paths)).toEqual([[ref1, 'foo']]);
-  //   expect(sortedEntries(routing.parents)).toEqual([[ref1, undefined]]);
-  //   expect(routing.objects).toEqual([
-  //     routeObj('foo', [ref1], [], undefined, plugin),
-  //   ]);
-  // });
-
-  // it('should throw when a routable extension does not have a path set', () => {
-  //   expect(() => {
-  //     traverseElementTree({
-  //       root: <Extension3 />,
-  //       discoverers: [childDiscoverer, routeElementDiscoverer],
-  //       collectors: {
-  //         routing: routingV2Collector,
-  //       },
-  //     });
-  //   }).toThrow(
-  //     'Routable extension "Extension(Extension3)" with mount point "routeRef{type=absolute,id=ref3}" must be assigned a path',
-  //   );
-  // });
-
-  // it('should throw when Route elements contain multiple routable extensions', () => {
-  //   expect(() => {
-  //     traverseElementTree({
-  //       root: (
-  //         <Route
-  //           path="foo"
-  //           element={
-  //             <>
-  //               <Extension1 />
-  //               <Extension2 />
-  //             </>
-  //           }
-  //         />
-  //       ),
-  //       discoverers: [childDiscoverer, routeElementDiscoverer],
-  //       collectors: {
-  //         routing: routingV2Collector,
-  //       },
-  //     });
-  //   }).toThrow(
-  //     'Route element with path "foo" may not contain multiple routable extensions',
-  //   );
-  // });
+    expect(sortedEntries(info.routePaths)).toEqual([
+      [ref1, 'r/x'],
+      [ref2, 'r/y/1'],
+      [ref3, 'a'],
+      [ref4, 'b'],
+    ]);
+    expect(sortedEntries(info.routeParents)).toEqual([
+      [ref1, undefined],
+      [ref2, undefined],
+      [ref3, ref2],
+      [ref4, ref2],
+    ]);
+    expect(info.routeObjects).toEqual([
+      routeObj(
+        'r',
+        [],
+        [
+          routeObj('x', [ref1], [], 'mounted', expect.any(Object)),
+          routeObj(
+            'y',
+            [],
+            [
+              routeObj(
+                '1',
+                [ref2],
+                [
+                  routeObj(
+                    'a',
+                    [ref3],
+                    undefined,
+                    'mounted',
+                    expect.any(Object),
+                  ),
+                  routeObj(
+                    'b',
+                    [ref4],
+                    undefined,
+                    'mounted',
+                    expect.any(Object),
+                  ),
+                ],
+                'mounted',
+                expect.any(Object),
+              ),
+            ],
+            'mounted',
+          ),
+        ],
+      ),
+    ]);
+  });
 });

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
@@ -27,7 +27,7 @@ import {
   createPageExtension,
   createPlugin,
 } from '@backstage/frontend-plugin-api';
-import { createInstances, toLegacyPlugin } from '../wiring/createApp';
+import { createInstances } from '../wiring/createApp';
 import { MockConfigApi } from '@backstage/test-utils';
 
 const ref1 = createRouteRef({ id: 'page1' });
@@ -36,6 +36,28 @@ const ref3 = createRouteRef({ id: 'page3' });
 const ref4 = createRouteRef({ id: 'page4' });
 const ref5 = createRouteRef({ id: 'page5' });
 const refOrder = [ref1, ref2, ref3, ref4, ref5];
+
+const emptyLoader = () => Promise.resolve(React.createElement('div'));
+
+function createTestExtension(options: {
+  id: string;
+  at?: string;
+  path: string;
+  routeRef?: RouteRef;
+}) {
+  return createPageExtension({
+    id: options.id,
+    at: options.at,
+    defaultPath: options.path,
+    routeRef: options.routeRef,
+    inputs: {
+      routes: createExtensionInput({
+        element: coreExtensionData.reactElement,
+      }),
+    },
+    loader: emptyLoader,
+  });
+}
 
 function sortedEntries<T>(map: Map<RouteRef, T>): [RouteRef, T][] {
   return Array.from(map).sort(
@@ -69,58 +91,40 @@ function routeObj(
   };
 }
 
-const emptyLoader = () => Promise.resolve(React.createElement('div'));
-
 describe('discovery', () => {
   it('should collect routes', () => {
     const extensions = [
-      createPageExtension({
+      createTestExtension({
         id: 'nothing',
-        defaultPath: 'nothing',
-        loader: emptyLoader,
+        path: 'nothing',
       }),
-      createPageExtension({
+      createTestExtension({
         id: 'page1',
-        defaultPath: 'foo',
+        path: 'foo',
         routeRef: ref1,
-        inputs: {
-          routes: createExtensionInput({
-            element: coreExtensionData.reactElement,
-          }),
-        },
-        loader: emptyLoader,
       }),
-      createPageExtension({
+      createTestExtension({
         id: 'page2',
         at: 'page1/routes',
-        defaultPath: 'bar/:id',
+        path: 'bar/:id',
         routeRef: ref2,
-        inputs: {
-          routes: createExtensionInput({
-            element: coreExtensionData.reactElement,
-          }),
-        },
-        loader: emptyLoader,
       }),
-      createPageExtension({
+      createTestExtension({
         id: 'page3',
         at: 'page2/routes',
-        defaultPath: 'baz',
+        path: 'baz',
         routeRef: ref3,
-        loader: emptyLoader,
       }),
-      createPageExtension({
+      createTestExtension({
         id: 'page4',
-        defaultPath: 'divsoup',
+        path: 'divsoup',
         routeRef: ref4,
-        loader: emptyLoader,
       }),
-      createPageExtension({
+      createTestExtension({
         id: 'page5',
         at: 'page1/routes',
-        defaultPath: 'blop',
+        path: 'blop',
         routeRef: ref5,
-        loader: emptyLoader,
       }),
     ];
 

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouteRef } from '@backstage/core-plugin-api';
+import { coreExtensionData } from '@backstage/frontend-plugin-api';
+import { ExtensionInstance } from '../wiring/createExtensionInstance';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { BackstageRouteObject } from '../../../core-app-api/src/routing/types';
+
+// Joins a list of paths together, avoiding trailing and duplicate slashes
+export function joinPaths(...paths: string[]): string {
+  const normalized = paths.join('/').replace(/\/\/+/g, '/');
+  if (normalized !== '/' && normalized.endsWith('/')) {
+    return normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+export function extractRouteInfoFromInstanceTree(roots: ExtensionInstance[]): {
+  routePaths: Map<RouteRef, string>;
+  routeParents: Map<RouteRef, RouteRef | undefined>;
+  routeObjects: BackstageRouteObject[];
+} {
+  const routePaths = new Map<RouteRef, string>();
+  const routeParents = new Map<RouteRef, RouteRef | undefined>();
+
+  function visit(current: ExtensionInstance, parent?: RouteRef) {
+    const routePath = current.getData(coreExtensionData.routePath) ?? '';
+    const routeRef = current.getData(coreExtensionData.routeRef);
+
+    if (routeRef) {
+      const routeRefId = (routeRef as any).id; // TODO: properly
+      if (routeRefId !== current.id) {
+        throw new Error(
+          `Route ref '${routeRefId}' must have the same ID as extension '${current.id}'`,
+        );
+      }
+      routePaths.set(routeRef, routePath);
+      routeParents.set(routeRef, parent);
+    }
+
+    for (const children of current.attachments.values()) {
+      for (const child of children) {
+        visit(child, routeRef ?? parent);
+      }
+    }
+  }
+
+  for (const root of roots) {
+    visit(root);
+  }
+
+  return { routePaths, routeParents, routeObjects: [] };
+}

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -336,7 +336,7 @@ export function createApp(options: {
   };
 }
 
-function toLegacyPlugin(plugin: BackstagePlugin): LegacyBackstagePlugin {
+export function toLegacyPlugin(plugin: BackstagePlugin): LegacyBackstagePlugin {
   const errorMsg = 'Not implemented in legacy plugin compatibility layer';
   const notImplemented = () => {
     throw new Error(errorMsg);

--- a/packages/frontend-app-api/src/wiring/createExtensionInstance.ts
+++ b/packages/frontend-app-api/src/wiring/createExtensionInstance.ts
@@ -36,6 +36,8 @@ export interface ExtensionInstance {
    * Maps input names to the actual instances given to them.
    */
   readonly attachments: Map<string, ExtensionInstance[]>;
+
+  readonly source?: BackstagePlugin;
 }
 
 function resolveInputData(
@@ -141,7 +143,7 @@ export function createExtensionInstance(options: {
     getData<T>(ref: ExtensionDataRef<T>): T | undefined {
       return extensionData.get(ref.id) as T | undefined;
     },
-
+    source,
     attachments,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,6 +4311,7 @@ __metadata:
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@backstage/version-bridge": "workspace:^"
     "@material-ui/core": ^4.12.4
     "@material-ui/icons": ^4.11.3
     "@testing-library/jest-dom": ^5.10.1


### PR DESCRIPTION
Adds support for the existing routing system in apps built on top of the new frontend app API.