### PR TITLE
core-app-api: wrap entire app in Suspense

### DIFF
--- a/.changeset/fresh-badgers-study.md
+++ b/.changeset/fresh-badgers-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Wrap entire app in `<Suspense>`, enabling support for using translations outside plugins.

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -18,6 +18,7 @@ import { Config } from '@backstage/config';
 import React, {
   ComponentType,
   PropsWithChildren,
+  Suspense,
   useMemo,
   useRef,
 } from 'react';
@@ -341,7 +342,7 @@ export class AppManager implements BackstageApp {
         }
       }
 
-      const { ThemeProvider = AppThemeProvider } = this.components;
+      const { ThemeProvider = AppThemeProvider, Progress } = this.components;
 
       return (
         <ApiProvider apis={this.getApiHolder()}>
@@ -360,7 +361,7 @@ export class AppManager implements BackstageApp {
                     appIdentityProxy: this.appIdentityProxy,
                   }}
                 >
-                  {children}
+                  <Suspense fallback={<Progress />}>{children}</Suspense>
                 </InternalAppContext.Provider>
               </RoutingProvider>
             </ThemeProvider>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We currently only wrap each plugin in `<Suspense>`. This adds it to the entire app, which in turn adds support for using async translations anywhere in the app. [Discord thread](https://discord.com/channels/687207715902193673/1158717808608284712)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
