### PR TITLE
Create `scaffolder` Incubating Project Area

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -122,9 +122,10 @@ Team: @backstage/scaffolder-maintainers
 
 Scope: The Scaffolder frontend and backend plugins, and related tooling.
 
-| Name       | Organization | GitHub                              | Discord  |
-| ---------- | ------------ | ----------------------------------- | -------- |
-| Paul Cowan |              | [dagda1](https://github.com/dadga1) | `dagda1` |
+| Name                | Organization   | GitHub                                | Discord          |
+| ------------------- | -------------- | ------------------------------------- | ---------------- |
+| Bogdan Nechyporenko | Bol.com        | [acierto](https://github.com/acierto) | `bogdan_haarlem` |
+| Paul Cowan          | frontendrescue | [dagda1](https://github.com/dadga1)   | `dagda1`         |
 
 ## Sponsors
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -116,6 +116,16 @@ Scope: Tooling for frontend and backend schema-first OpenAPI development.
 | -------------- | ------------ | --------------------------------------- | ------------- |
 | Aramis Sennyey | Spotify      | [sennyeya](https://github.com/sennyeya) | `Aramis#7984` |
 
+### Scaffolder
+
+Team: @backstage/scaffolder-maintainers
+
+Scope: The Scaffolder frontend and backend plugins, and related tooling.
+
+| Name       | Organization | GitHub                              | Discord  |
+| ---------- | ------------ | ----------------------------------- | -------- |
+| Paul Cowan |              | [dagda1](https://github.com/dadga1) | `dagda1` |
+
 ## Sponsors
 
 | Name              | Organization | GitHub                                      | Email              |


### PR DESCRIPTION
Hey :wave:

So this has been a long time in the making, but we think we're ready to start moving the `scaffolder` to it's own dedicated project area.  Right now, we're looking to start it off as an incubating project area, supported initially by the @backstage/maintainers, with the intention to share some of the reviewing load and ownership of the scaffolder and related plugins.

We're looking to add some more people to this group too, so feel free to reach out here or on Discord if you're interested in becoming a project area maintainer! :pray:

~Welcome to the first member @dagda1 :tada:~

Welcome to the first two members @dagda1 and @acierto :tada: