### PR TITLE
auth-node: Refresh handler not returning persisted scope in response

### DIFF
--- a/.changeset/stale-stingrays-explode.md
+++ b/.changeset/stale-stingrays-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Fixed cookie persisted scope not returned in OAuth refresh handler response.

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -320,7 +320,9 @@ export function createOAuthRouteHandlers<TProfile>(
           providerInfo: {
             idToken: result.session.idToken,
             accessToken: result.session.accessToken,
-            scope: result.session.scope,
+            scope: authenticator.shouldPersistScopes
+              ? scope
+              : result.session.scope,
             expiresInSeconds: result.session.expiresInSeconds,
           },
         };


### PR DESCRIPTION
## Fix OAuth refresh handler in auth-node prompting for re-login on page reload.

The refresh handler is returning an empty scope if scope was previously saved in a cookie. The session is successfully refreshed but the client receives a response without the scope it requested, prompting a new login.

This should also be backported to 1.18.x

Resolves #20322

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
