### PR TITLE
feat: allow prepared directory clean up for custom preparers

### DIFF
--- a/.changeset/early-toes-develop.md
+++ b/.changeset/early-toes-develop.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Allow prepared directory clean up for custom preparers
+
+When using custom preparer for TechDocs, the `preparedDir` might
+end up taking disk space. This requires all custom preparers to
+implement a new method `shouldCleanPreparedDirectory` which indicates
+whether the prepared directory should be cleaned after generation.

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import {
-  Entity,
   DEFAULT_NAMESPACE,
+  Entity,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
@@ -28,7 +28,6 @@ import {
   PreparerBase,
   PreparerBuilder,
   PublisherBase,
-  UrlPreparer,
 } from '@backstage/plugin-techdocs-node';
 import fs from 'fs-extra';
 import os from 'os';
@@ -194,7 +193,7 @@ export class DocsBuilder {
     // Remove Prepared directory since it is no longer needed.
     // Caveat: Can not remove prepared directory in case of git preparer since the
     // local git repository is used to get etag on subsequent requests.
-    if (this.preparer instanceof UrlPreparer) {
+    if (this.preparer.shouldCleanPreparedDirectory()) {
       this.logger.debug(
         `Removing prepared directory ${preparedDir} since the site has been generated`,
       );

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -21,6 +21,7 @@ import { Writable } from 'stream';
 export class DirectoryPreparer implements PreparerBase {
   static fromConfig(config: Config, options: PreparerConfig): DirectoryPreparer;
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+  shouldCleanPreparedDirectory(): boolean;
 }
 
 // @public
@@ -132,6 +133,7 @@ export const parseReferenceAnnotation: (
 // @public
 export type PreparerBase = {
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+  shouldCleanPreparedDirectory(): boolean;
 };
 
 // @public
@@ -274,5 +276,6 @@ export const transformDirLocation: (
 export class UrlPreparer implements PreparerBase {
   static fromConfig(options: PreparerConfig): UrlPreparer;
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+  shouldCleanPreparedDirectory(): boolean;
 }
 ```

--- a/plugins/techdocs-node/src/stages/prepare/dir.ts
+++ b/plugins/techdocs-node/src/stages/prepare/dir.ts
@@ -60,6 +60,11 @@ export class DirectoryPreparer implements PreparerBase {
     this.scmIntegrations = ScmIntegrations.fromConfig(config);
   }
 
+  /** {@inheritDoc PreparerBase.shouldCleanPreparedDirectory} */
+  shouldCleanPreparedDirectory() {
+    return false;
+  }
+
   /** {@inheritDoc PreparerBase.prepare} */
   async prepare(
     entity: Entity,

--- a/plugins/techdocs-node/src/stages/prepare/types.ts
+++ b/plugins/techdocs-node/src/stages/prepare/types.ts
@@ -78,6 +78,11 @@ export type PreparerBase = {
    * @throws `NotModifiedError` when the prepared directory has not been changed since the last build.
    */
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
+
+  /**
+   * Indicates whether the prepared directory should be cleaned after generation.
+   */
+  shouldCleanPreparedDirectory(): boolean;
 };
 
 /**

--- a/plugins/techdocs-node/src/stages/prepare/url.ts
+++ b/plugins/techdocs-node/src/stages/prepare/url.ts
@@ -47,6 +47,11 @@ export class UrlPreparer implements PreparerBase {
     this.reader = reader;
   }
 
+  /** {@inheritDoc PreparerBase.shouldCleanPreparedDirectory} */
+  shouldCleanPreparedDirectory() {
+    return true;
+  }
+
   /** {@inheritDoc PreparerBase.prepare} */
   async prepare(
     entity: Entity,


### PR DESCRIPTION
When using custom preparer for TechDocs, the `preparedDir` might end up taking disk space. This requires all custom preparers to implement a new method `shouldCleanPreparedDirectory` which indicates whether the prepared directory should be cleaned after generation.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
