### PR TITLE
fix: max term length prevents backend to crash

### DIFF
--- a/.changeset/twelve-snakes-sell.md
+++ b/.changeset/twelve-snakes-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Set the default length limit to search query to 100. To override it, define `search.maxTermLength` in the config file.

--- a/plugins/search-backend/config.d.ts
+++ b/plugins/search-backend/config.d.ts
@@ -23,6 +23,11 @@ export interface Config {
     maxPageLimit?: number;
 
     /**
+     * Sets the maximum term length for the search string. Defaults to 100.
+     */
+    maxTermLength?: number;
+
+    /**
      * Options related to the search integration with the Backstage permissions system
      */
     permissions?: {

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -60,7 +60,7 @@ describe('createRouter', () => {
       },
       config: new ConfigReader({
         permissions: { enabled: false },
-        search: { maxPageLimit: 200 },
+        search: { maxPageLimit: 200, maxTermLength: 20 },
       }),
       permissions: mockPermissionEvaluator,
       logger,
@@ -158,6 +158,19 @@ describe('createRouter', () => {
       expect(response.body).toMatchObject({
         error: {
           message: /The page limit "twohundred" is not a number"/i,
+        },
+      });
+    });
+
+    it('should reject term length over configured max', async () => {
+      const response = await request(app).get(
+        `/query?term=HelloWorld1234567890!`,
+      );
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toMatchObject({
+        error: {
+          message: /The term length "21" is greater than "20"/i,
         },
       });
     });

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -63,6 +63,7 @@ export type RouterOptions = {
 };
 
 const defaultMaxPageLimit = 100;
+const defaultMaxTermLength = 100;
 const allowedLocationProtocols = ['http:', 'https:'];
 
 /**
@@ -77,8 +78,11 @@ export async function createRouter(
   const maxPageLimit =
     config.getOptionalNumber('search.maxPageLimit') ?? defaultMaxPageLimit;
 
+  const maxTermLength =
+    config.getOptionalNumber('search.maxTermLength') ?? defaultMaxTermLength;
+
   const requestSchema = z.object({
-    term: z.string().default(''),
+    term: z.string().max(maxTermLength).default(''),
     filters: jsonObjectSchema.optional(),
     types: z
       .array(z.string().refine(type => Object.keys(types).includes(type)))

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -82,7 +82,15 @@ export async function createRouter(
     config.getOptionalNumber('search.maxTermLength') ?? defaultMaxTermLength;
 
   const requestSchema = z.object({
-    term: z.string().max(maxTermLength).default(''),
+    term: z
+      .string()
+      .refine(
+        term => term.length <= maxTermLength,
+        term => ({
+          message: `The term length "${term.length}" is greater than "${maxTermLength}"`,
+        }),
+      )
+      .default(''),
     filters: jsonObjectSchema.optional(),
     types: z
       .array(z.string().refine(type => Object.keys(types).includes(type)))


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

- Set default maximum length of search string to 100.
- Defined `search.maxTermLength` to be configurable in config file
- Backend returns 400 and message `The term length "${term.length}" is greater than "${maxTermLength}"` if limit is reached

![image](https://github.com/backstage/backstage/assets/47827254/8c86f316-6e24-4711-b74b-a04683f23157)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Related Issue

Closes #20385 