### PR TITLE
fix(adr): align icon in AdrSearchResultListItem

### DIFF
--- a/.changeset/many-pianos-bow.md
+++ b/.changeset/many-pianos-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+Fix icon alignment in `AdrSearchResultListItem`

--- a/plugins/adr/src/search/AdrSearchResultListItem.tsx
+++ b/plugins/adr/src/search/AdrSearchResultListItem.tsx
@@ -33,6 +33,9 @@ import { ResultHighlight } from '@backstage/plugin-search-common';
 import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
 
 const useStyles = makeStyles({
+  item: {
+    display: 'flex',
+  },
   flexContainer: {
     flexWrap: 'wrap',
   },
@@ -66,59 +69,63 @@ export function AdrSearchResultListItem(props: AdrSearchResultListItemProps) {
 
   return (
     <>
-      <ListItem alignItems="flex-start" className={classes.flexContainer}>
+      <ListItem alignItems="flex-start" className={classes.item}>
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
-        <ListItemText
-          className={classes.itemText}
-          primaryTypographyProps={{ variant: 'h6' }}
-          primary={
-            <Link noTrack to={result.location}>
-              {highlight?.fields.title ? (
-                <HighlightedSearchResultText
-                  text={highlight?.fields.title || ''}
-                  preTag={highlight?.preTag || ''}
-                  postTag={highlight?.postTag || ''}
-                />
-              ) : (
-                result.title
-              )}
-            </Link>
-          }
-          secondary={
-            <Typography
-              component="span"
-              style={{
-                display: '-webkit-box',
-                WebkitBoxOrient: 'vertical',
-                WebkitLineClamp: lineClamp,
-                overflow: 'hidden',
-              }}
-            >
-              {highlight?.fields.text ? (
-                <HighlightedSearchResultText
-                  text={highlight.fields.text}
-                  preTag={highlight.preTag}
-                  postTag={highlight.postTag}
-                />
-              ) : (
-                result.text
-              )}
-            </Typography>
-          }
-        />
-        <Box>
-          <Chip
-            label={`Entity: ${
-              result.entityTitle ??
-              humanizeEntityRef(parseEntityRef(result.entityRef))
-            }`}
-            size="small"
+        <div className={classes.flexContainer}>
+          <ListItemText
+            className={classes.itemText}
+            primaryTypographyProps={{ variant: 'h6' }}
+            primary={
+              <Link noTrack to={result.location}>
+                {highlight?.fields.title ? (
+                  <HighlightedSearchResultText
+                    text={highlight?.fields.title || ''}
+                    preTag={highlight?.preTag || ''}
+                    postTag={highlight?.postTag || ''}
+                  />
+                ) : (
+                  result.title
+                )}
+              </Link>
+            }
+            secondary={
+              <Typography
+                component="span"
+                style={{
+                  display: '-webkit-box',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: lineClamp,
+                  overflow: 'hidden',
+                }}
+              >
+                {highlight?.fields.text ? (
+                  <HighlightedSearchResultText
+                    text={highlight.fields.text}
+                    preTag={highlight.preTag}
+                    postTag={highlight.postTag}
+                  />
+                ) : (
+                  result.text
+                )}
+              </Typography>
+            }
           />
-          {result.status && (
-            <Chip label={`Status: ${result.status}`} size="small" />
-          )}
-          {result.date && <Chip label={`Date: ${result.date}`} size="small" />}
-        </Box>
+          <Box>
+            <Chip
+              label={`Entity: ${
+                result.entityTitle ??
+                humanizeEntityRef(parseEntityRef(result.entityRef))
+              }`}
+              size="small"
+            />
+            {result.status && (
+              <Chip label={`Status: ${result.status}`} size="small" />
+            )}
+            {result.date && (
+              <Chip label={`Date: ${result.date}`} size="small" />
+            )}
+          </Box>
+        </div>
       </ListItem>
       <Divider component="li" />
     </>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
The icon's alignment in `AdrSearchResultListItem` differs from `CatalogSearchResultListItem`. Fixing alignment in `AdrSearchResultListItem` to other search result list items.

Before: 
![image](https://github.com/backstage/backstage/assets/8716372/b82e91ef-ec90-4d6e-b200-7cfd26409083)

After:
![image](https://github.com/backstage/backstage/assets/8716372/ce130927-a183-4ada-8d94-d9de247831d5)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
