### PR TITLE
e2e-test: fix hanging backend process on Windows

### DIFF
--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -427,6 +427,8 @@ async function dropClientDatabases(client: string) {
 async function testBackendStart(appDir: string, ...args: string[]) {
   const child = spawnPiped(['yarn', 'workspace', 'backend', 'start', ...args], {
     cwd: appDir,
+    // Windows does not like piping stdin here, the child process will hang when requiring the 'process' module
+    stdio: ['ignore', 'pipe', 'pipe'],
     env: {
       ...process.env,
       GITHUB_TOKEN: 'abc',


### PR DESCRIPTION
This seems to me like a bug in Node.js, the backend process will hang on the first `require('process')`. Digging into it a bit further it happens when assigning the `stdin` ESM export of the process module [here](https://github.com/nodejs/node/blob/f73650ea52a2b9750f49e5bed02f94b5b8f99847/lib/internal/bootstrap/realm.js#L371). I'm assuming the actual issue is trying to access the `stdin` property at all, rather than the ESM compatibility layer. At that point I believe we're entering native code and I don't really want to dig deeper 😅 Seems like this has been a hard to track down bug in the past: https://github.com/nodejs/node/issues/10836