### PR TITLE
add openapi maintainers to openapi utils in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /docs/features/techdocs                           @backstage/techdocs-maintainers
 /docs/plugins/integrating-search-into-plugins.md  @backstage/discoverability-maintainers
 /packages/cli/src/commands/onboard                @backstage/sharks
-/packages/backend-openapi-utils                   @backstage/maintainers @backstage/openapi-tooling-maintainers
+/packages/backend-openapi-utils                   @backstage/maintainers @backstage/reviewers @backstage/openapi-tooling-maintainers
 /packages/techdocs-cli                            @backstage/techdocs-maintainers
 /packages/techdocs-cli-embedded-app               @backstage/techdocs-maintainers
 /plugins/adr                                      @backstage/maintainers @backstage/reviewers @kuangp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /docs/features/techdocs                           @backstage/techdocs-maintainers
 /docs/plugins/integrating-search-into-plugins.md  @backstage/discoverability-maintainers
 /packages/cli/src/commands/onboard                @backstage/sharks
-/packages/backend-openapi-utils                   @backstage/openapi-tooling-maintainers @backstage/maintainers
+/packages/backend-openapi-utils                   @backstage/maintainers @backstage/openapi-tooling-maintainers
 /packages/techdocs-cli                            @backstage/techdocs-maintainers
 /packages/techdocs-cli-embedded-app               @backstage/techdocs-maintainers
 /plugins/adr                                      @backstage/maintainers @backstage/reviewers @kuangp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /docs/features/techdocs                           @backstage/techdocs-maintainers
 /docs/plugins/integrating-search-into-plugins.md  @backstage/discoverability-maintainers
 /packages/cli/src/commands/onboard                @backstage/sharks
+/packages/backend-openapi-utils                   @backstage/openapi-tooling-maintainers @backstage/maintainers
 /packages/techdocs-cli                            @backstage/techdocs-maintainers
 /packages/techdocs-cli-embedded-app               @backstage/techdocs-maintainers
 /plugins/adr                                      @backstage/maintainers @backstage/reviewers @kuangp

--- a/packages/backend-openapi-utils/catalog-info.yaml
+++ b/packages/backend-openapi-utils/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: openapi-tooling-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds OpenAPI tooling maintainers as codeowner for `backend-openapi-utils`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
