### PR TITLE
fix: init array with another types with one item

### DIFF
--- a/docs/features/software-templates/input-examples.md
+++ b/docs/features/software-templates/input-examples.md
@@ -110,10 +110,11 @@ parameters:
       arrayObjects:
         title: Array with custom objects
         type: array
+        minItems: 0
         ui:options:
-          addable: false
-          orderable: false
-          removable: false
+          addable: true
+          orderable: true
+          removable: true
         items:
           type: object
           properties:


### PR DESCRIPTION
## Hey, I just made a Pull Request!
#20233 Update documentation so [Array with another types](https://github.com/backstage/backstage/blob/master/docs/features/software-templates/input-examples.md#array-with-another-types) will be visible by default.
Not sure if this needed a changeset :)

![kuva](https://github.com/backstage/backstage/assets/35847478/2b44a1ea-154e-417c-a007-69859a7c41ff)

https://github.com/backstage/backstage/assets/35847478/1fa0edad-759d-4570-9bde-8785ef68b7a3

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
