### PR TITLE
fix: make entity picker more reliable with one entity

### DIFF
--- a/.changeset/little-ligers-cheat.md
+++ b/.changeset/little-ligers-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Make entity picker more reliable with only one available entity

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -123,11 +123,17 @@ export const EntityPicker = (props: EntityPickerProps) => {
     [onChange, formData, defaultKind, defaultNamespace, allowArbitraryValues],
   );
 
+  // Since free solo can be enabled, attempt to parse as a full entity ref first, then fall
+  // back to the given value.
+  const selectedEntity =
+    entities?.find(e => stringifyEntityRef(e) === formData) ??
+    (allowArbitraryValues && formData ? getLabel(formData) : '');
+
   useEffect(() => {
-    if (entities?.length === 1) {
+    if (entities?.length === 1 && selectedEntity === '') {
       onChange(stringifyEntityRef(entities[0]));
     }
-  }, [entities, onChange]);
+  }, [entities, onChange, selectedEntity]);
 
   return (
     <FormControl
@@ -138,12 +144,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
       <Autocomplete
         disabled={entities?.length === 1}
         id={idSchema?.$id}
-        value={
-          // Since free solo can be enabled, attempt to parse as a full entity ref first, then fall
-          //  back to the given value.
-          entities?.find(e => stringifyEntityRef(e) === formData) ??
-          (allowArbitraryValues && formData ? getLabel(formData) : '')
-        }
+        value={selectedEntity}
         loading={loading}
         onChange={onSelect}
         options={entities || []}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#20008 This should make entity pickers more reliable with only one entity

Not sure how I would write test's for this (or if this needs test's)

Here's a video demo of before and after:

https://github.com/backstage/backstage/assets/35847478/02f5250a-ccb3-4817-8acc-6e2d2d5590f3

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
