### PR TITLE
bump the timeout of FactRetrieverEngine to the default of 60s

### DIFF
--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
@@ -64,14 +64,14 @@ const testFactRetriever: FactRetriever = {
     ];
   }),
 };
+
 const defaultCadence = '1 * * * *';
+
 describe('FactRetrieverEngine', () => {
   let engine: FactRetrieverEngine;
   type FactSchemaAssertionCallback = (
     factSchemaDefinition: FactSchemaDefinition,
   ) => void;
-
-  jest.setTimeout(15000);
 
   type FactInsertionAssertionCallback = ({
     facts,


### PR DESCRIPTION
There's a 60 second `setTimeout` higher up in the same file.

15s is a bit too little sometimes when database init is slow in CI.

https://github.com/backstage/backstage/actions/runs/6465043826/job/17550675999?pr=20340#step:8:13166
