### PR TITLE
frontend-app-api: reject attachments to undeclared inputs

### DIFF
--- a/.changeset/five-hornets-provide.md
+++ b/.changeset/five-hornets-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+The app will now reject any extensions that attach to nonexistent inputs.

--- a/packages/frontend-app-api/src/extensions/Core.tsx
+++ b/packages/frontend-app-api/src/extensions/Core.tsx
@@ -27,6 +27,9 @@ export const Core = createExtension({
     apis: createExtensionInput({
       api: coreExtensionData.apiFactory,
     }),
+    themes: createExtensionInput({
+      theme: coreExtensionData.theme,
+    }),
   },
   output: {},
   factory() {},

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
@@ -48,7 +48,7 @@ function createTestExtension(options: {
     id: options.id,
     attachTo: options.parent
       ? { id: options.parent, input: 'children' }
-      : { id: 'core.routes', input: 'children' },
+      : { id: 'core.routes', input: 'routes' },
     output: {
       element: coreExtensionData.reactElement,
       path: coreExtensionData.routePath.optional(),
@@ -305,6 +305,7 @@ describe('discovery', () => {
       }),
       createTestExtension({
         id: 'fooEmpty',
+        parent: 'foo',
       }),
       createTestExtension({
         id: 'page3',

--- a/packages/frontend-app-api/src/wiring/createApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.test.tsx
@@ -16,6 +16,7 @@
 
 import {
   createExtension,
+  createExtensionInput,
   createPageExtension,
   createPlugin,
   createThemeExtension,
@@ -143,6 +144,9 @@ describe('createApp', () => {
       extension: createExtension({
         id: 'root',
         attachTo: { id: '', input: '' },
+        inputs: {
+          children: createExtensionInput({}),
+        },
         output: {},
         factory() {},
       }),
@@ -181,6 +185,9 @@ describe('createApp', () => {
       extension: createExtension({
         id: 'root',
         attachTo: { id: '', input: '' },
+        inputs: {
+          children: createExtensionInput({}),
+        },
         output: {},
         factory() {},
       }),

--- a/packages/frontend-app-api/src/wiring/createExtensionInstance.test.ts
+++ b/packages/frontend-app-api/src/wiring/createExtensionInstance.test.ts
@@ -289,7 +289,50 @@ describe('createExtensionInstance', () => {
         }),
       }),
     ).toThrow(
-      "Failed to instantiate extension 'core.test', received undeclared input(s) 'undeclared'",
+      "Failed to instantiate extension 'core.test', received undeclared input 'undeclared' from extension 'core.test'",
+    );
+  });
+
+  it('should refuse to create an instance with multiple undeclared inputs', () => {
+    expect(() =>
+      createExtensionInstance({
+        attachments: new Map([
+          [
+            'undeclared1',
+            [
+              createExtensionInstance({
+                attachments: new Map(),
+                config: { output: 'many1' },
+                extension: simpleExtension,
+              }),
+            ],
+          ],
+          [
+            'undeclared2',
+            [
+              createExtensionInstance({
+                attachments: new Map(),
+                config: { output: 'many1' },
+                extension: simpleExtension,
+              }),
+              createExtensionInstance({
+                attachments: new Map(),
+                config: { output: 'many1' },
+                extension: simpleExtension,
+              }),
+            ],
+          ],
+        ]),
+        config: undefined,
+        extension: createExtension({
+          id: 'core.test',
+          attachTo: { id: 'ignored', input: 'ignored' },
+          output: {},
+          factory() {},
+        }),
+      }),
+    ).toThrow(
+      "Failed to instantiate extension 'core.test', received undeclared inputs 'undeclared1' from extension 'core.test' and 'undeclared2' from extensions 'core.test', 'core.test'",
     );
   });
 

--- a/packages/frontend-app-api/src/wiring/createExtensionInstance.test.ts
+++ b/packages/frontend-app-api/src/wiring/createExtensionInstance.test.ts
@@ -250,6 +250,49 @@ describe('createExtensionInstance', () => {
     );
   });
 
+  it('should refuse to create an instance with undeclared inputs', () => {
+    expect(() =>
+      createExtensionInstance({
+        attachments: new Map([
+          [
+            'declared',
+            [
+              createExtensionInstance({
+                attachments: new Map(),
+                config: { output: 'many1' },
+                extension: simpleExtension,
+              }),
+            ],
+          ],
+          [
+            'undeclared',
+            [
+              createExtensionInstance({
+                attachments: new Map(),
+                config: { output: 'many1' },
+                extension: simpleExtension,
+              }),
+            ],
+          ],
+        ]),
+        config: undefined,
+        extension: createExtension({
+          id: 'core.test',
+          attachTo: { id: 'ignored', input: 'ignored' },
+          inputs: {
+            declared: createExtensionInput({
+              test: testDataRef,
+            }),
+          },
+          output: {},
+          factory() {},
+        }),
+      }),
+    ).toThrow(
+      "Failed to instantiate extension 'core.test', received undeclared input(s) 'undeclared'",
+    );
+  });
+
   it('should refuse to create an instance with multiple inputs for required singleton', () => {
     expect(() =>
       createExtensionInstance({

--- a/packages/frontend-app-api/src/wiring/createExtensionInstance.ts
+++ b/packages/frontend-app-api/src/wiring/createExtensionInstance.ts
@@ -60,6 +60,15 @@ function resolveInputs(
   inputMap: AnyExtensionInputMap,
   attachments: Map<string, ExtensionInstance[]>,
 ) {
+  const undeclaredAttachments = Array.from(attachments.keys()).filter(
+    name => inputMap[name] === undefined,
+  );
+  if (undeclaredAttachments.length > 0) {
+    throw new Error(
+      `received undeclared input(s) '${undeclaredAttachments.join("', '")}'`,
+    );
+  }
+
   return mapValues(inputMap, (input, inputName) => {
     const attachedInstances = attachments.get(inputName) ?? [];
     if (input.config.singleton) {

--- a/packages/frontend-app-api/src/wiring/createExtensionInstance.ts
+++ b/packages/frontend-app-api/src/wiring/createExtensionInstance.ts
@@ -60,12 +60,21 @@ function resolveInputs(
   inputMap: AnyExtensionInputMap,
   attachments: Map<string, ExtensionInstance[]>,
 ) {
-  const undeclaredAttachments = Array.from(attachments.keys()).filter(
-    name => inputMap[name] === undefined,
+  const undeclaredAttachments = Array.from(attachments.entries()).filter(
+    ([inputName]) => inputMap[inputName] === undefined,
   );
   if (undeclaredAttachments.length > 0) {
     throw new Error(
-      `received undeclared input(s) '${undeclaredAttachments.join("', '")}'`,
+      `received undeclared input${
+        undeclaredAttachments.length > 1 ? 's' : ''
+      } ${undeclaredAttachments
+        .map(
+          ([k, exts]) =>
+            `'${k}' from extension${exts.length > 1 ? 's' : ''} '${exts
+              .map(e => e.id)
+              .join("', '")}'`,
+        )
+        .join(' and ')}`,
     );
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Found some places where we were missing input declarations. I figured it's perhaps best to be very strict about this for now, and then perhaps down the line we relax this requirement a bit in favor of highlighting it in tooling or smth.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
