### PR TITLE
frontend-app-api: move root extension to be an input on core instead

### DIFF
--- a/.changeset/slow-cameras-grab.md
+++ b/.changeset/slow-cameras-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+The hidden `'root'` extension has been removed and has instead been made an input of the `'core'` extension. The checks for rejecting configuration of the `'root'` extension to rejects configuration of the `'core'` extension instead.

--- a/packages/frontend-app-api/src/extensions/Core.tsx
+++ b/packages/frontend-app-api/src/extensions/Core.tsx
@@ -30,7 +30,19 @@ export const Core = createExtension({
     themes: createExtensionInput({
       theme: coreExtensionData.theme,
     }),
+    root: createExtensionInput(
+      {
+        element: coreExtensionData.reactElement,
+      },
+      { singleton: true },
+    ),
   },
-  output: {},
-  factory() {},
+  output: {
+    root: coreExtensionData.reactElement,
+  },
+  factory({ bind, inputs }) {
+    bind({
+      root: inputs.root.element,
+    });
+  },
 });

--- a/packages/frontend-app-api/src/extensions/CoreLayout.tsx
+++ b/packages/frontend-app-api/src/extensions/CoreLayout.tsx
@@ -24,7 +24,7 @@ import { SidebarPage } from '@backstage/core-components';
 
 export const CoreLayout = createExtension({
   id: 'core.layout',
-  attachTo: { id: 'root', input: 'default' },
+  attachTo: { id: 'core', input: 'root' },
   inputs: {
     nav: createExtensionInput(
       {

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.test.ts
@@ -74,12 +74,12 @@ function routeInfoFromExtensions(extensions: Extension<unknown>[]) {
     id: 'test',
     extensions,
   });
-  const { rootInstances } = createInstances({
+  const { coreInstance } = createInstances({
     config: new MockConfigApi({}),
     features: [plugin],
   });
 
-  return extractRouteInfoFromInstanceTree(rootInstances);
+  return extractRouteInfoFromInstanceTree(coreInstance);
 }
 
 function sortedEntries<T>(map: Map<RouteRef, T>): [RouteRef, T][] {

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromInstanceTree.ts
@@ -42,7 +42,7 @@ export function joinPaths(...paths: string[]): string {
   return normalized;
 }
 
-export function extractRouteInfoFromInstanceTree(roots: ExtensionInstance[]): {
+export function extractRouteInfoFromInstanceTree(core: ExtensionInstance): {
   routePaths: Map<RouteRef, string>;
   routeParents: Map<RouteRef, RouteRef | undefined>;
   routeObjects: BackstageRouteObject[];
@@ -151,9 +151,7 @@ export function extractRouteInfoFromInstanceTree(roots: ExtensionInstance[]): {
     }
   }
 
-  for (const root of roots) {
-    visit(root);
-  }
+  visit(core);
 
   return { routePaths, routeParents, routeObjects };
 }

--- a/packages/frontend-app-api/src/wiring/parameters.ts
+++ b/packages/frontend-app-api/src/wiring/parameters.ts
@@ -235,13 +235,13 @@ export function mergeExtensionParameters(options: {
     override => toInternalExtensionOverrides(override).extensions,
   );
 
-  // Prevent root override
-  if (pluginExtensions.some(({ id }) => id === 'root')) {
-    const rootPluginIds = pluginExtensions
-      .filter(({ id }) => id === 'root')
+  // Prevent core override
+  if (pluginExtensions.some(({ id }) => id === 'core')) {
+    const pluginIds = pluginExtensions
+      .filter(({ id }) => id === 'core')
       .map(({ source }) => source.id);
     throw new Error(
-      `The following plugin(s) are overriding the 'root' extension which is forbidden: ${rootPluginIds.join(
+      `The following plugin(s) are overriding the 'core' extension which is forbidden: ${pluginIds.join(
         ',',
       )}`,
     );
@@ -352,10 +352,10 @@ export function mergeExtensionParameters(options: {
   for (const overrideParam of parameters) {
     const extensionId = overrideParam.id;
 
-    // Prevent root parametrization
-    if (extensionId === 'root') {
+    // Prevent core parametrization
+    if (extensionId === 'core') {
       throw new Error(
-        "A 'root' extension configuration was detected, but the root extension is not configurable",
+        "A 'core' extension configuration was detected, but the core extension is not configurable",
       );
     }
 

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -85,7 +85,7 @@ const TechDocsPage = createExtension({
 
 const outputExtension = createExtension({
   id: 'test.output',
-  attachTo: { id: 'root', input: 'default' },
+  attachTo: { id: 'core', input: 'root' },
   inputs: {
     names: createExtensionInput({
       name: nameExtensionDataRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This shuffles things around so that the React root of the app is now instead the `root` input of the `core` extension, rather than a magic `root` extension that doesn't exist in practice. With this we're able to guarantee a single root extension as well, simplifying the code in a couple of places.

If we want to add more ways to wrap the react root in additional elements etc then I figured we can take care of that in the implementation of the core extension itself.

The react root is consumed via the output of the core extension. I didn't do the same change for themes and APIs, because that'd require a separate extension data type that is an array of those types. It's something we can consider though in order to make the consumptions of those a bit less magic.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
