### PR TITLE
(cli-node, repo-tools): refactor tests to avoid mock-fs

### DIFF
--- a/.changeset/violet-houses-stare.md
+++ b/.changeset/violet-houses-stare.md
@@ -1,0 +1,6 @@
+---
+'@backstage/repo-tools': patch
+'@backstage/cli-node': patch
+---
+
+Replace `mock-fs` with internal mock utility in tests

--- a/packages/cli-node/package.json
+++ b/packages/cli-node/package.json
@@ -38,8 +38,8 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
-    "@backstage/cli": "workspace:^",
-    "mock-fs": "^5.2.0"
+    "@backstage/backend-test-utils": "workspace:^",
+    "@backstage/cli": "workspace:^"
   },
   "files": [
     "dist"

--- a/packages/cli-node/src/monorepo/isMonorepo.test.ts
+++ b/packages/cli-node/src/monorepo/isMonorepo.test.ts
@@ -15,15 +15,13 @@
  */
 
 import { isMonoRepo } from './isMonoRepo';
-import mockFs from 'mock-fs';
+import { createMockDirectory } from '@backstage/backend-test-utils';
 
 describe('isMonoRepo', () => {
-  afterEach(() => {
-    mockFs.restore();
-  });
+  const mockDir = createMockDirectory();
 
   it('should detect a monorepo', async () => {
-    mockFs({
+    mockDir.setContent({
       'package.json': JSON.stringify({
         name: 'foo',
         workspaces: {
@@ -35,7 +33,7 @@ describe('isMonoRepo', () => {
   });
 
   it('should detect a non- monorepo', async () => {
-    mockFs({
+    mockDir.setContent({
       'package.json': JSON.stringify({
         name: 'foo',
       }),
@@ -44,7 +42,7 @@ describe('isMonoRepo', () => {
   });
 
   it('should return false if package.json is missing', async () => {
-    mockFs({});
+    mockDir.setContent({});
     await expect(isMonoRepo()).resolves.toBe(false);
   });
 });

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -60,12 +60,11 @@
     "yaml-diff-patch": "^2.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/is-glob": "^4.0.2",
-    "@types/mock-fs": "^4.13.0",
-    "@types/node": "^18.17.8",
-    "mock-fs": "^5.2.0"
+    "@types/node": "^18.17.8"
   },
   "peerDependencies": {
     "@microsoft/api-extractor-model": "*",

--- a/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import mockFs from 'mock-fs';
 import { normalize, resolve as resolvePath } from 'path';
 import * as pathsLib from '../../lib/paths';
 
@@ -28,6 +27,7 @@ import {
 import { buildApiReports } from './api-reports';
 import { generateTypeDeclarations } from './generateTypeDeclarations';
 import { PackageGraph } from '@backstage/cli-node';
+import { createMockDirectory } from '@backstage/backend-test-utils';
 
 jest.mock('./generateTypeDeclarations');
 // create mocks for the dependencies of the `buildApiReports` function
@@ -77,8 +77,10 @@ jest.spyOn(PackageGraph, 'listTargetPackages').mockResolvedValue([
 ]);
 
 describe('buildApiReports', () => {
+  const mockDir = createMockDirectory();
+
   beforeEach(() => {
-    mockFs({
+    mockDir.setContent({
       [projectPaths.targetRoot]: {
         'package.json': JSON.stringify({
           workspaces: { packages: ['packages/*', 'plugins/*'] },
@@ -106,11 +108,6 @@ describe('buildApiReports', () => {
         },
       },
     });
-  });
-
-  afterEach(() => {
-    mockFs.restore();
-    jest.clearAllMocks();
   });
 
   jest.spyOn(console, 'log').mockImplementation(() => {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,6 +3716,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/cli-node@workspace:packages/cli-node"
   dependencies:
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@backstage/errors": "workspace:^"
@@ -3723,7 +3724,6 @@ __metadata:
     "@manypkg/get-packages": ^1.1.3
     "@yarnpkg/parsers": ^3.0.0-rc.4
     fs-extra: 10.1.0
-    mock-fs: ^5.2.0
     semver: ^7.5.3
     zod: ^3.21.4
   languageName: unknown
@@ -10103,6 +10103,7 @@ __metadata:
   dependencies:
     "@apidevtools/swagger-parser": ^10.1.0
     "@apisyouwonthate/style-guide": ^1.4.0
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
@@ -10120,7 +10121,6 @@ __metadata:
     "@stoplight/spectral-runtime": ^1.1.2
     "@stoplight/types": ^13.14.0
     "@types/is-glob": ^4.0.2
-    "@types/mock-fs": ^4.13.0
     "@types/node": ^18.17.8
     chalk: ^4.0.0
     codeowners-utils: ^1.0.2
@@ -10131,7 +10131,6 @@ __metadata:
     js-yaml: ^4.1.0
     lodash: ^4.17.21
     minimatch: ^5.1.1
-    mock-fs: ^5.2.0
     p-limit: ^3.0.2
     ts-node: ^10.0.0
     yaml-diff-patch: ^2.0.0


### PR DESCRIPTION
Closing:  #20436 | [issue comment](https://github.com/backstage/backstage/issues/20436#issuecomment-1753340264)

Here are the changes:
- `mockFs({...})` is replaced with `mockDir.setContent({...})`
- `mockFs.restore()` is removed