### PR TITLE
Handle decimals in k8s resource usage calculation

### DIFF
--- a/.changeset/rare-glasses-play.md
+++ b/.changeset/rare-glasses-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Handle mixed decimals and bigint when calculating k8s resource usage

--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -25,6 +25,7 @@ backend's
 backported
 backporting
 BEPs
+bigint
 Bigtable
 Billett
 bitbucket

--- a/plugins/kubernetes-react/src/utils/pod.test.tsx
+++ b/plugins/kubernetes-react/src/utils/pod.test.tsx
@@ -24,18 +24,18 @@ import { SubvalueCell } from '@backstage/core-components';
 
 describe('pod', () => {
   describe('currentToDeclaredResourceToPerc', () => {
-    it('10%', () => {
-      const tests: (number | string)[][] = [
-        [10, 100],
-        [10, '100'],
-        ['10', 100],
-        ['10', '100'],
-      ];
-      tests.forEach(([a, b]) => {
-        const result = currentToDeclaredResourceToPerc(a, b);
-        expect(result).toBe('10%');
-      });
-    });
+    it.each([
+      [10, 100],
+      [10, '100'],
+      ['10', 100],
+      ['10', '100'],
+      ['10', 100.0],
+      [10.0, '100'],
+      [10.1, '100'],
+      ['10', 100.1],
+    ])('%p out of %p gives 10%%', (current, resource) =>
+      expect(currentToDeclaredResourceToPerc(current, resource)).toBe('10%'),
+    );
   });
   describe('podStatusToCpuUtil', () => {
     it('does use correct units', () => {

--- a/plugins/kubernetes-react/src/utils/pod.tsx
+++ b/plugins/kubernetes-react/src/utils/pod.tsx
@@ -126,8 +126,12 @@ export const currentToDeclaredResourceToPerc = (
     return `${Math.round((current / resource) * 100)}%`;
   }
 
-  const numerator: bigint = BigInt(current);
-  const denominator: bigint = BigInt(resource);
+  const numerator: bigint = BigInt(
+    typeof current === 'number' ? Math.round(current) : current,
+  );
+  const denominator: bigint = BigInt(
+    typeof resource === 'number' ? Math.round(resource) : resource,
+  );
 
   return `${(numerator * BigInt(100)) / denominator}%`;
 };


### PR DESCRIPTION
When one of the numerator/denominator is a number and other is bigint this was failing. decimals cannot be converted to bigints

## Hey, I just made a Pull Request!

This does include some loss of precision, but I assume it's negligible enough to disregard it

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
