### PR TITLE
[CLI] avoid api report warning for @packageDocumentation comment

### DIFF
--- a/packages/cli/templates/default-backend-module/src/index.ts.hbs
+++ b/packages/cli/templates/default-backend-module/src/index.ts.hbs
@@ -1,4 +1,3 @@
-/***/
 /**
  * The {{moduleId}} backend module for the {{pluginId}} plugin.
  *

--- a/packages/cli/templates/default-common-plugin-package/src/index.ts.hbs
+++ b/packages/cli/templates/default-common-plugin-package/src/index.ts.hbs
@@ -1,4 +1,3 @@
-/***/
 /**
  * Common functionalities for the {{id}} plugin.
  *

--- a/packages/cli/templates/default-node-plugin-package/src/index.ts.hbs
+++ b/packages/cli/templates/default-node-plugin-package/src/index.ts.hbs
@@ -1,4 +1,3 @@
-/***/
 /**
  * Node.js library for the {{id}} plugin.
  *

--- a/packages/cli/templates/default-react-plugin-package/src/index.ts.hbs
+++ b/packages/cli/templates/default-react-plugin-package/src/index.ts.hbs
@@ -1,4 +1,3 @@
-/***/
 /**
  * Web library for the {{id}} plugin.
  *

--- a/packages/cli/templates/scaffolder-module/src/index.ts.hbs
+++ b/packages/cli/templates/scaffolder-module/src/index.ts.hbs
@@ -1,4 +1,3 @@
-/***/
 /**
  * The {{id}} module for @backstage/plugin-scaffolder-backend.
  *


### PR DESCRIPTION
## Hey, I just made a Pull Request!

created a new module using the backstage cli and when I was going to generate the api report I got the following warning

```
// Warnings were encountered during analysis:
//
// src/index.d.ts:2:1 - (ae-misplaced-package-tag) The @packageDocumentation comment must appear at the top of entry point *.d.ts file

// (No @packageDocumentation comment for this package)
```

Since the template index files starts with `/***/` I had to remove that line and then re-generate the report to get rid of the warning. Here is a PR removing that line from the templates that originally had this in place. If there is a reason to why this line is there, feel free to close this PR! 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
