### PR TITLE
core-app-api: Fixed bug in AppRouter to determine the correct signOutTargetUrl if app.baseUrl contains a basePath

### DIFF
--- a/.changeset/empty-clocks-argue.md
+++ b/.changeset/empty-clocks-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed bug in AppRouter to determine the correct signOutTargetUrl if app.baseUrl contains a basePath

--- a/.changeset/empty-clocks-argue.md
+++ b/.changeset/empty-clocks-argue.md
@@ -2,4 +2,4 @@
 '@backstage/core-app-api': patch
 ---
 
-Fixed bug in AppRouter to determine the correct signOutTargetUrl if app.baseUrl contains a basePath
+Fixed bug in `AppRouter` to determine the correct `signOutTargetUrl` if `app.baseUrl` contains a `basePath`

--- a/packages/core-app-api/src/app/AppRouter.tsx
+++ b/packages/core-app-api/src/app/AppRouter.tsx
@@ -70,7 +70,7 @@ function SignInPageWrapper({
 }) {
   const [identityApi, setIdentityApi] = useState<IdentityApi>();
   const configApi = useApi(configApiRef);
-  const basePath = getBasePath(configApi);
+  const basePath = readBasePath(configApi);
 
   if (!identityApi) {
     return <Component onSignInSuccess={setIdentityApi} />;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: #20473 

If you sign out from Backstage without the fix, you will be redirected to the baseUrl without a path.

For example if backstage is deployed in a kubernetes cluster and the baseUrl is configured with the following value:
app.baseUrl: http://mykubernetes.installation.de/subpath/to/backstage

The Logout within the "Settings" Page will lead to the Url http://mykubernetes.installation.de/ instead of http://mykubernetes.installation.de/subpath/to/backstage.

With the fix, the logout will lead to the Url http://mykubernetes.installation.de/subpath/to/backstage

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
