### PR TITLE
deprecate the GraphQL packages

### DIFF
--- a/.changeset/light-squids-deny.md
+++ b/.changeset/light-squids-deny.md
@@ -1,3 +1,6 @@
-# Catalog GraphQL Plugin
+---
+'@backstage/plugin-catalog-graphql': minor
+'@backstage/plugin-graphql-backend': minor
+---
 
 This package has been deprecated, consider using [@frontside/backstage-plugin-graphql-backend](https://www.npmjs.com/package/@frontside/backstage-plugin-graphql-backend) instead.

--- a/plugins/catalog-graphql/package.json
+++ b/plugins/catalog-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-graphql",
-  "description": "An experimental Backstage catalog GraphQL module",
+  "description": "Deprecated, consider using @frontside/backstage-plugin-graphql-backend instead",
   "version": "0.3.24-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/graphql-backend/README.md
+++ b/plugins/graphql-backend/README.md
@@ -1,28 +1,3 @@
 # GraphQL Backend
 
-## Getting Started
-
-This is the GraphQL Backend plugin.
-
-It is responsible for merging different `graphql-plugins` together to provide the end schema.
-
-To run it within the backend do:
-
-1. Register the router in `packages/backend/src/index.ts`:
-
-```ts
-const graphqlEnv = useHotMemoize(module, () => createEnv('graphql'));
-
-const service = createServiceBuilder(module)
-  .loadConfig(configReader)
-  /** several different routers */
-  .addRouter('/graphql', await graphql(graphqlEnv));
-```
-
-2. Start the backend
-
-```bash
-yarn workspace example-backend start
-```
-
-This will launch the full example backend.
+This package has been deprecated, consider using [@frontside/backstage-plugin-graphql-backend](https://www.npmjs.com/package/@frontside/backstage-plugin-graphql-backend) instead.

--- a/plugins/graphql-backend/package.json
+++ b/plugins/graphql-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-graphql-backend",
-  "description": "An experimental Backstage backend plugin for GraphQL",
+  "description": "Deprecated, consider using @frontside/backstage-plugin-graphql-backend instead",
   "version": "0.1.44-next.2",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

According to the discussion in #15519 we're deprecating the GraphQL plugin and related packages. Instead we point users to https://www.npmjs.com/package/@frontside/backstage-plugin-graphql-backend

@taras @cowboyd @wKich 👀 please, just to double check this all looks good 😁 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
