### PR TITLE
Fail gracefully on fetching users from gitlab groups

### DIFF
--- a/.changeset/fresh-schools-thank.md
+++ b/.changeset/fresh-schools-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Added try catch arround fetching gitlab group users to prevent refresh from failing completely while only a select number of groups might not be able to load correctly.

--- a/.changeset/fresh-schools-thank.md
+++ b/.changeset/fresh-schools-thank.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-Added try catch arround fetching gitlab group users to prevent refresh from failing completely while only a select number of groups might not be able to load correctly.
+Added try catch around fetching gitlab group users to prevent refresh from failing completely while only a select number of groups might not be able to load correctly.

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import fetch from 'node-fetch';
 import {
   getGitLabRequestOptions,
   GitLabIntegrationConfig,
 } from '@backstage/integration';
+import fetch from 'node-fetch';
 import { Logger } from 'winston';
+
 import {
-  GitLabGroup,
   GitLabDescendantGroupsResponse,
+  GitLabGroup,
   GitLabGroupMembersResponse,
   GitLabUser,
+  PagedResponse,
 } from './types';
 
 export type CommonListOptions = {
@@ -43,11 +44,6 @@ interface UserListOptions extends CommonListOptions {
   without_project_bots?: boolean | undefined;
   exclude_internal?: boolean | undefined;
 }
-
-export type PagedResponse<T> = {
-  items: T[];
-  nextPage?: number;
-};
 
 export class GitLabClient {
   private readonly config: GitLabIntegrationConfig;

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -236,11 +236,7 @@ export class GitLabClient {
         },
       ).then(r => r.json());
       if (response.errors) {
-        throw new Error(
-          `GraphQL errors: ${JSON.stringify(
-            response.errors,
-          )}, for group: ${groupPath}`,
-        );
+        throw new Error(`GraphQL errors: ${JSON.stringify(response.errors)}`);
       }
 
       if (!response.data.group?.groupMembers?.nodes) {

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -236,7 +236,11 @@ export class GitLabClient {
         },
       ).then(r => r.json());
       if (response.errors) {
-        throw new Error(`GraphQL errors: ${JSON.stringify(response.errors)}`);
+        throw new Error(
+          `GraphQL errors: ${JSON.stringify(
+            response.errors,
+          )}, for group: ${groupPath}`,
+        );
       }
 
       if (!response.data.group?.groupMembers?.nodes) {

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
+
+export type PagedResponse<T> = {
+  items: T[];
+  nextPage?: number;
+};
 
 export type GitlabGroupDescription = {
   id: number;

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -13,31 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { PluginTaskScheduler, TaskRunner } from '@backstage/backend-tasks';
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+  Entity,
+  GroupEntity,
+  UserEntity,
+} from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { GitLabIntegration, ScmIntegrations } from '@backstage/integration';
 import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
+import { merge } from 'lodash';
 import * as uuid from 'uuid';
 import { Logger } from 'winston';
+
 import {
   GitLabClient,
   GitlabProviderConfig,
   paginated,
   readGitlabConfigs,
 } from '../lib';
-import { GitLabGroup, GitLabUser } from '../lib/types';
-import {
-  ANNOTATION_LOCATION,
-  ANNOTATION_ORIGIN_LOCATION,
-  Entity,
-  UserEntity,
-  GroupEntity,
-} from '@backstage/catalog-model';
-import { merge } from 'lodash';
+import { GitLabGroup, GitLabUser, PagedResponse } from '../lib/types';
 
 type Result = {
   scanned: number;
@@ -245,9 +245,12 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       groupRes.scanned++;
       groupRes.matches.push(group);
 
-      const groupUsers = await client.getGroupMembers(group.full_path, [
-        'DIRECT',
-      ]);
+      let groupUsers: PagedResponse<GitLabUser> = { items: [] };
+      try {
+        groupUsers = await client.getGroupMembers(group.full_path, ['DIRECT']);
+      } catch {
+        logger.error(`Failed fetching user for group: ${group.full_path}`);
+      }
 
       for (const groupUser of groupUsers.items) {
         const user = idMappedUser[groupUser.id];

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -249,7 +249,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       try {
         groupUsers = await client.getGroupMembers(group.full_path, ['DIRECT']);
       } catch {
-        logger.error(`Failed fetching user for group: ${group.full_path}`);
+        logger.error(`Failed fetching users for group: ${group.full_path}`);
       }
 
       for (const groupUser of groupUsers.items) {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -248,8 +248,10 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       let groupUsers: PagedResponse<GitLabUser> = { items: [] };
       try {
         groupUsers = await client.getGroupMembers(group.full_path, ['DIRECT']);
-      } catch {
-        logger.error(`Failed fetching users for group: ${group.full_path}`);
+      } catch (e) {
+        logger.error(
+          `Failed fetching users for group '${group.full_path}': ${e}`,
+        );
       }
 
       for (const groupUser of groupUsers.items) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull requests makes it easier to see what is going wrong while fetching users from gitlab groups.
Currently the complete refresh of data fails while only a selected number of groups could give an error.
This MR should handle errors like https://github.com/backstage/backstage/issues/20274 more graceful.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
