### PR TITLE
feat: exported SecureTemplater and createDefaultFilters

### DIFF
--- a/.changeset/sour-roses-rest.md
+++ b/.changeset/sour-roses-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Exported `SecureTemplater` and `createDefaultFilters` in the `index.ts`

--- a/.changeset/sour-roses-rest.md
+++ b/.changeset/sour-roses-rest.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Exported `SecureTemplater` and `createDefaultFilters` in the `index.ts`
+Exported `SecureTemplater`, `SecureTemplaterOptions`, `SecureTemplateRenderer` and `createDefaultFilters` in the `index.ts`

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -116,8 +116,6 @@ export function createDebugLogAction(): TemplateAction_2<
   JsonObject
 >;
 
-// Warning: (ae-missing-release-tag) "createDefaultFilters" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const createDefaultFilters: ({
   integrations,
@@ -920,17 +918,28 @@ export type RunCommandOptions = ExecuteShellCommandOptions;
 // @public @deprecated
 export const ScaffolderEntitiesProcessor: typeof ScaffolderEntitiesProcessor_2;
 
-// Warning: (ae-missing-release-tag) "SecureTemplater" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export class SecureTemplater {
-  // Warning: (ae-forgotten-export) The symbol "SecureTemplaterOptions" needs to be exported by the entry point index.d.ts
-  // Warning: (ae-forgotten-export) The symbol "SecureTemplateRenderer" needs to be exported by the entry point index.d.ts
-  //
   // (undocumented)
   static loadRenderer(
     options?: SecureTemplaterOptions,
   ): Promise<SecureTemplateRenderer>;
+}
+
+// @public (undocumented)
+export type SecureTemplateRenderer = (
+  template: string,
+  values: unknown,
+) => string;
+
+// @public (undocumented)
+export interface SecureTemplaterOptions {
+  // (undocumented)
+  cookiecutterCompat?: boolean;
+  // (undocumented)
+  templateFilters?: Record<string, TemplateFilter>;
+  // (undocumented)
+  templateGlobals?: Record<string, TemplateGlobal>;
 }
 
 // @public @deprecated

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -116,6 +116,15 @@ export function createDebugLogAction(): TemplateAction_2<
   JsonObject
 >;
 
+// Warning: (ae-missing-release-tag) "createDefaultFilters" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const createDefaultFilters: ({
+  integrations,
+}: {
+  integrations: ScmIntegrations;
+}) => Record<string, TemplateFilter>;
+
 // @public
 export function createFetchCatalogEntityAction(options: {
   catalogClient: CatalogApi;
@@ -161,8 +170,8 @@ export function createFetchPlainFileAction(options: {
 export function createFetchTemplateAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
-  additionalTemplateFilters?: Record<string, TemplateFilter>;
-  additionalTemplateGlobals?: Record<string, TemplateGlobal>;
+  additionalTemplateFilters?: Record<string, TemplateFilter_2>;
+  additionalTemplateGlobals?: Record<string, TemplateGlobal_2>;
 }): TemplateAction_2<
   {
     url: string;
@@ -910,6 +919,19 @@ export type RunCommandOptions = ExecuteShellCommandOptions;
 
 // @public @deprecated
 export const ScaffolderEntitiesProcessor: typeof ScaffolderEntitiesProcessor_2;
+
+// Warning: (ae-missing-release-tag) "SecureTemplater" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class SecureTemplater {
+  // Warning: (ae-forgotten-export) The symbol "SecureTemplaterOptions" needs to be exported by the entry point index.d.ts
+  // Warning: (ae-forgotten-export) The symbol "SecureTemplateRenderer" needs to be exported by the entry point index.d.ts
+  //
+  // (undocumented)
+  static loadRenderer(
+    options?: SecureTemplaterOptions,
+  ): Promise<SecureTemplateRenderer>;
+}
 
 // @public @deprecated
 export type SerializedTask = SerializedTask_2;

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.ts
@@ -102,6 +102,9 @@ export type TemplateFilter = _TemplateFilter;
  */
 export type TemplateGlobal = _TemplateGlobal;
 
+/**
+ * @public
+ */
 export interface SecureTemplaterOptions {
   /* Enables jinja compatibility and the "jsonify" filter */
   cookiecutterCompat?: boolean;
@@ -111,11 +114,17 @@ export interface SecureTemplaterOptions {
   templateGlobals?: Record<string, TemplateGlobal>;
 }
 
+/**
+ * @public
+ */
 export type SecureTemplateRenderer = (
   template: string,
   values: unknown,
 ) => string;
 
+/**
+ * @public
+ */
 export class SecureTemplater {
   static async loadRenderer(options: SecureTemplaterOptions = {}) {
     const {

--- a/plugins/scaffolder-backend/src/lib/templating/filters.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/filters.ts
@@ -20,6 +20,9 @@ import { TemplateFilter } from '..';
 import { parseRepoUrl } from '../../scaffolder/actions/builtin/publish/util';
 import get from 'lodash/get';
 
+/**
+ * @public
+ */
 export const createDefaultFilters = ({
   integrations,
 }: {

--- a/plugins/scaffolder-backend/src/lib/templating/index.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/index.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
-export type { TemplateFilter, TemplateGlobal } from './SecureTemplater';
+export type {
+  TemplateFilter,
+  TemplateGlobal,
+  SecureTemplaterOptions,
+  SecureTemplateRenderer,
+} from './SecureTemplater';
 export { SecureTemplater } from './SecureTemplater';
 export { createDefaultFilters } from './filters';

--- a/plugins/scaffolder-backend/src/lib/templating/index.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/index.ts
@@ -15,3 +15,5 @@
  */
 
 export type { TemplateFilter, TemplateGlobal } from './SecureTemplater';
+export { SecureTemplater } from './SecureTemplater';
+export { createDefaultFilters } from './filters';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -21,16 +21,14 @@ import { ScmIntegrations } from '@backstage/integration';
 import {
   createTemplateAction,
   fetchContents,
+  TemplateFilter,
+  TemplateGlobal,
 } from '@backstage/plugin-scaffolder-node';
 import globby from 'globby';
 import fs from 'fs-extra';
 import { isBinaryFile } from 'isbinaryfile';
-import {
-  TemplateFilter,
-  SecureTemplater,
-  TemplateGlobal,
-} from '../../../../lib/templating/SecureTemplater';
-import { createDefaultFilters } from '../../../../lib/templating/filters';
+import { SecureTemplater } from '../../../../lib';
+import { createDefaultFilters } from '../../../../lib';
 import { examples } from './template.examples';
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- `SecureTemplater`, `SecureTemplaterOptions`, `SecureTemplateRenderer` and `createDefaultFilters` are now exported in the `index.ts`
- Refactored `template.ts` imports

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Related Issue

Closes #20529 
