### PR TITLE
Bump lerna version on the create-app's template

### DIFF
--- a/.changeset/tiny-suns-deny.md
+++ b/.changeset/tiny-suns-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Bump dev dependencies `lerna@7.3.0` on the template

--- a/packages/create-app/templates/default-app/lerna.json
+++ b/packages/create-app/templates/default-app/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*", "plugins/*"],
   "npmClient": "yarn",
-  "useWorkspaces": true,
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -36,7 +36,7 @@
     "@playwright/test": "^1.32.3",
     "@spotify/prettier-config": "^12.0.0",
     "concurrently": "^8.0.0",
-    "lerna": "^4.0.0",
+    "lerna": "^7.3.0",
     "node-gyp": "^9.0.0",
     "prettier": "^2.3.2",
     "typescript": "~5.2.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As raised on https://github.com/backstage/backstage/issues/20484, the new apps generated with `create-app` are being delivered with an old version of lerna. 

This PR just bumps that lerna version on the template for new apps. I used `lerna repair` to adapt the file `lerna.json` to the new version.


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
