### PR TITLE
Feat/add entitypicker nunjucks template support

### DIFF
--- a/.changeset/cyan-pugs-rescue.md
+++ b/.changeset/cyan-pugs-rescue.md
@@ -1,0 +1,32 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added nunjucks templates support for EntityPicker catalogFilter ui:options property.
+
+This change will allow to use values of another parameters to restrict results of EntityPicker dropdowns, for example
+
+```
+parameters:
+  - title: Service Settings
+    properties:
+      system:
+        title: System
+        type: string
+        ui:field: EntityPicker
+        ui:options:
+          catalogFilter:
+            - kind: Domain
+          defaultKind: Domain
+          allowArbitraryValues: false
+      product:
+        title: Product
+        type: string
+        ui:field: EntityPicker
+        ui:options:
+          catalogFilter:
+            - kind: System
+              spec.domain: '{{ parameters.system }}'
+          defaultKind: System
+          allowArbitraryValues: false
+```

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -38,6 +38,7 @@ describe('<EntityPicker />', () => {
   let uiSchema: EntityPickerProps['uiSchema'];
   const rawErrors: string[] = [];
   const formData = undefined;
+  const formContext = { formData: {} };
 
   let props: FieldProps;
 
@@ -76,6 +77,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -117,6 +119,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -160,6 +163,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -240,6 +244,62 @@ describe('<EntityPicker />', () => {
     });
   });
 
+  describe('with catalogFilter dependency on formContext', () => {
+    beforeEach(() => {
+      uiSchema = {
+        'ui:options': {
+          catalogFilter: [
+            {
+              kind: ['Group'],
+              'metadata.name': '{{ parameters.group }}',
+            },
+            {
+              kind: ['User'],
+              'metadata.name': '{{ parameters.user }}',
+            },
+          ],
+        },
+      };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+        formContext: {
+          formData: {
+            group: 'test-group',
+            user: 'user-group',
+          },
+        },
+      } as unknown as FieldProps<any>;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+    });
+
+    it('searches for a specific group based on form context data', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        filter: [
+          {
+            kind: ['Group'],
+            'metadata.name': 'test-group',
+          },
+          {
+            kind: ['User'],
+            'metadata.name': 'user-group',
+          },
+        ],
+      });
+    });
+  });
+
   describe('catalogFilter should take precedence over allowedKinds', () => {
     beforeEach(() => {
       uiSchema = {
@@ -260,6 +320,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -297,6 +358,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -356,6 +418,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -453,6 +516,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -551,6 +615,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -649,6 +714,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -44,6 +44,7 @@ describe('<OwnerPicker />', () => {
   };
   const rawErrors: string[] = [];
   const formData = undefined;
+  const formContext = { formData: {} };
 
   let props: FieldProps;
 
@@ -82,6 +83,7 @@ describe('<OwnerPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -112,6 +114,7 @@ describe('<OwnerPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -151,6 +154,7 @@ describe('<OwnerPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });
@@ -196,6 +200,7 @@ describe('<OwnerPicker />', () => {
         uiSchema,
         rawErrors,
         formData,
+        formContext,
       } as unknown as FieldProps<any>;
 
       catalogApi.getEntities.mockResolvedValue({ items: entities });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added ability to use nunjucks templates in EntityPicker catalogFilter property, as per proposal https://github.com/backstage/backstage/issues/20533.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
