### PR TITLE
Allow passing undefined labelSelector to KubernetesFetcher

### DIFF
--- a/.changeset/silent-years-marry.md
+++ b/.changeset/silent-years-marry.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+---
+
+**BREAKING** Allow passing undefined `labelSelector` to `KubernetesFetcher`
+
+`KubernetesFetch` no longer auto-adds `labelSelector` when empty string was passed.
+This is only applicable if you have custom ObjectProvider implementation, as build-in `KubernetesFanOutHandler` already does this

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -391,7 +391,7 @@ export interface ObjectFetchParams {
   // (undocumented)
   customResources: CustomResource[];
   // (undocumented)
-  labelSelector: string;
+  labelSelector?: string;
   // (undocumented)
   namespace?: string;
   // (undocumented)

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -165,7 +165,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'pod-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -226,7 +226,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'pod-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -237,7 +237,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'service-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -289,7 +289,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'service-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -339,7 +339,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'pod-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -350,7 +350,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'service-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -420,7 +420,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'pod-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -431,7 +431,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'service-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -443,7 +443,7 @@ describe('KubernetesFetcher', () => {
                 kind: 'Thing',
                 metadata: {
                   name: 'something-else',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -511,7 +511,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'pod-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -861,7 +861,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'pod-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -872,7 +872,7 @@ describe('KubernetesFetcher', () => {
               {
                 metadata: {
                   name: 'service-name',
-                  labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                  labels: {},
                 },
               },
             ],
@@ -956,7 +956,7 @@ describe('KubernetesFetcher', () => {
                 {
                   metadata: {
                     name: 'pod-name',
-                    labels: { 'backstage.io/kubernetes-id': 'some-service' },
+                    labels: {},
                   },
                 },
               ],

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -101,8 +101,7 @@ export class KubernetesClientBasedFetcher implements KubernetesFetcher {
           apiVersion,
           plural,
           params.namespace,
-          params.labelSelector ||
-            `backstage.io/kubernetes-id=${params.serviceId}`,
+          params.labelSelector,
         ).then(
           (r: Response): Promise<FetchResult> =>
             r.ok

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -35,7 +35,7 @@ export interface ObjectFetchParams {
   clusterDetails: ClusterDetails;
   credential: KubernetesCredential;
   objectTypesToFetch: Set<ObjectToFetch>;
-  labelSelector: string;
+  labelSelector?: string;
   customResources: CustomResource[];
   namespace?: string;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

labelSelectors do not work in our environment.
We use namespace per service, and by passing  undefined labelSelector we can now get all objects in a namespace, without filtering.
This labelSelector was also superfluous, as [KubernetesFanOutHandler](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts#L255) already sets it to default value.
This allows us to only have company-specific version objectsProvider.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
