### PR TITLE
stop using SingleHostDiscovery

### DIFF
--- a/plugins/auth-backend/src/service/standaloneServer.ts
+++ b/plugins/auth-backend/src/service/standaloneServer.ts
@@ -18,7 +18,7 @@ import {
   createServiceBuilder,
   loadBackendConfig,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   useHotMemoize,
 } from '@backstage/backend-common';
 import { Server } from 'http';
@@ -35,7 +35,7 @@ export async function startStandaloneServer(
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'auth-backend' });
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
 
   const database = useHotMemoize(module, () => {
     const knex = Knex({

--- a/plugins/badges-backend/src/service/router-obfuscated.test.ts
+++ b/plugins/badges-backend/src/service/router-obfuscated.test.ts
@@ -20,7 +20,7 @@ import {
   getVoidLogger,
   PluginEndpointDiscovery,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import type { Entity } from '@backstage/catalog-model';
@@ -138,7 +138,7 @@ describe('createRouter', () => {
   };
 
   beforeAll(async () => {
-    discovery = SingleHostDiscovery.fromConfig(config);
+    discovery = HostDiscovery.fromConfig(config);
     const tokenManager = ServerTokenManager.noop();
     const router = await createRouter({
       badgeBuilder,

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -20,7 +20,7 @@ import {
   getVoidLogger,
   PluginEndpointDiscovery,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import type { Entity } from '@backstage/catalog-model';
@@ -113,7 +113,7 @@ describe('createRouter', () => {
       },
     );
 
-    discovery = SingleHostDiscovery.fromConfig(config);
+    discovery = HostDiscovery.fromConfig(config);
     const tokenManager = ServerTokenManager.noop();
     const router = await createRouter({
       badgeBuilder,

--- a/plugins/badges-backend/src/service/standaloneServer.ts
+++ b/plugins/badges-backend/src/service/standaloneServer.ts
@@ -20,7 +20,7 @@ import {
   createServiceBuilder,
   loadBackendConfig,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   useHotMemoize,
 } from '@backstage/backend-common';
 import { createRouter } from './router';
@@ -39,7 +39,7 @@ export async function startStandaloneServer(
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'badges-backend' });
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const database = useHotMemoize(module, () => {
     return Knex({
       client: 'better-sqlite3',

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -19,7 +19,7 @@ import {
   DatabaseManager,
   loadBackendConfig,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   UrlReaders,
   useHotMemoize,
 } from '@backstage/backend-common';
@@ -53,7 +53,7 @@ export async function startStandaloneServer(
     );
     return manager.forPlugin('catalog');
   });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const tokenManager = ServerTokenManager.fromConfig(config, {
     logger,
   });

--- a/plugins/devtools-backend/src/service/standaloneServer.ts
+++ b/plugins/devtools-backend/src/service/standaloneServer.ts
@@ -16,7 +16,7 @@
 
 import {
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   createServiceBuilder,
   loadBackendConfig,
 } from '@backstage/backend-common';
@@ -37,7 +37,7 @@ export async function startStandaloneServer(
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'devtools-backend-backend' });
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const tokenManager = ServerTokenManager.fromConfig(config, {
     logger,
   });

--- a/plugins/entity-feedback-backend/src/service/standaloneServer.ts
+++ b/plugins/entity-feedback-backend/src/service/standaloneServer.ts
@@ -18,7 +18,7 @@ import {
   createServiceBuilder,
   DatabaseManager,
   loadBackendConfig,
-  SingleHostDiscovery,
+  HostDiscovery,
   useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
@@ -38,7 +38,7 @@ export async function startStandaloneServer(
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'entity-feedback-backend' });
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
 
   const database = useHotMemoize(module, () => {
     const manager = DatabaseManager.fromConfig(

--- a/plugins/example-todo-list-backend/src/service/standaloneServer.ts
+++ b/plugins/example-todo-list-backend/src/service/standaloneServer.ts
@@ -17,7 +17,7 @@
 import {
   createServiceBuilder,
   loadBackendConfig,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 import { Server } from 'http';
@@ -36,7 +36,7 @@ export async function startStandaloneServer(
   const logger = options.logger.child({ service: 'todo-list-backend' });
   logger.debug('Starting application server...');
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const router = await createRouter({
     logger,
     identity: DefaultIdentityClient.create({

--- a/plugins/linguist-backend/src/service/standaloneServer.ts
+++ b/plugins/linguist-backend/src/service/standaloneServer.ts
@@ -17,7 +17,7 @@
 import {
   createServiceBuilder,
   loadBackendConfig,
-  SingleHostDiscovery,
+  HostDiscovery,
   UrlReaders,
   useHotMemoize,
   ServerTokenManager,
@@ -64,7 +64,7 @@ export async function startStandaloneServer(
     { schedule: schedule, age: { days: 30 }, useSourceLocation: false },
     {
       database: { getClient: async () => db },
-      discovery: SingleHostDiscovery.fromConfig(config),
+      discovery: HostDiscovery.fromConfig(config),
       reader: UrlReaders.default({ logger, config }),
       logger,
       tokenManager: ServerTokenManager.noop(),

--- a/plugins/playlist-backend/src/service/standaloneServer.ts
+++ b/plugins/playlist-backend/src/service/standaloneServer.ts
@@ -19,7 +19,7 @@ import {
   DatabaseManager,
   loadBackendConfig,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
   useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
@@ -40,7 +40,7 @@ export async function startStandaloneServer(
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'playlist-backend' });
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
 
   const database = useHotMemoize(module, () => {
     const manager = DatabaseManager.fromConfig(

--- a/plugins/proxy-backend/src/service/router.config.test.ts
+++ b/plugins/proxy-backend/src/service/router.config.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getVoidLogger, SingleHostDiscovery } from '@backstage/backend-common';
+import { getVoidLogger, HostDiscovery } from '@backstage/backend-common';
 import {
   ConfigSources,
   MutableConfigSource,
@@ -87,7 +87,7 @@ describe('createRouter reloadable configuration', () => {
       ]),
     );
 
-    const discovery = SingleHostDiscovery.fromConfig(config);
+    const discovery = HostDiscovery.fromConfig(config);
     const router = await createRouter({
       config,
       logger,

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getVoidLogger, SingleHostDiscovery } from '@backstage/backend-common';
+import { getVoidLogger, HostDiscovery } from '@backstage/backend-common';
 import { mockServices } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { Request, Response } from 'express';
@@ -56,7 +56,7 @@ describe('createRouter', () => {
         },
       },
     });
-    const discovery = SingleHostDiscovery.fromConfig(config);
+    const discovery = HostDiscovery.fromConfig(config);
 
     beforeEach(() => {
       mockCreateProxyMiddleware.mockClear();
@@ -150,7 +150,7 @@ describe('createRouter', () => {
           },
         },
       });
-      const discovery = SingleHostDiscovery.fromConfig(config);
+      const discovery = HostDiscovery.fromConfig(config);
       await expect(
         createRouter({
           config,
@@ -185,7 +185,7 @@ describe('createRouter', () => {
           },
         },
       });
-      const discovery = SingleHostDiscovery.fromConfig(config);
+      const discovery = HostDiscovery.fromConfig(config);
       const router = await createRouter({
         config,
         logger,

--- a/plugins/proxy-backend/src/service/standaloneServer.ts
+++ b/plugins/proxy-backend/src/service/standaloneServer.ts
@@ -17,7 +17,7 @@
 import {
   createServiceBuilder,
   loadBackendConfig,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
@@ -37,7 +37,7 @@ export async function startStandaloneServer(
   logger.debug('Creating application...');
 
   const config = await loadBackendConfig({ logger, argv: process.argv });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const router = await createRouter({
     config,
     logger,

--- a/plugins/search-backend/src/service/standaloneServer.ts
+++ b/plugins/search-backend/src/service/standaloneServer.ts
@@ -18,7 +18,7 @@ import {
   createServiceBuilder,
   loadBackendConfig,
   ServerTokenManager,
-  SingleHostDiscovery,
+  HostDiscovery,
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
@@ -42,7 +42,7 @@ export async function startStandaloneServer(
   const config = await loadBackendConfig({ logger, argv: process.argv });
   const searchEngine = new LunrSearchEngine({ logger });
   const indexBuilder = new IndexBuilder({ logger, searchEngine });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const tokenManager = ServerTokenManager.fromConfig(config, {
     logger,
   });

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -18,7 +18,7 @@ import {
   CacheManager,
   createServiceBuilder,
   DockerContainerRunner,
-  SingleHostDiscovery,
+  HostDiscovery,
   UrlReader,
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
@@ -51,7 +51,7 @@ export async function startStandaloneServer(
       },
     },
   });
-  const discovery = SingleHostDiscovery.fromConfig(config);
+  const discovery = HostDiscovery.fromConfig(config);
   const mockUrlReader: jest.Mocked<UrlReader> = {
     readUrl: jest.fn(),
     readTree: jest.fn(),


### PR DESCRIPTION
It's deprecated now.

No changeset since these are all internal packages, tests, and dev-only code