### PR TITLE
stop using `useHotMemoize`

### DIFF
--- a/.changeset/hungry-radios-play.md
+++ b/.changeset/hungry-radios-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings-backend': patch
+---
+
+Added dependency on `@backstage/config`

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -21,7 +21,6 @@ import {
   ServerTokenManager,
   HostDiscovery,
   UrlReaders,
-  useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { ServerPermissionClient } from '@backstage/plugin-permission-node';
@@ -43,16 +42,14 @@ export async function startStandaloneServer(
   const logger = options.logger.child({ service: 'catalog-backend' });
   const config = await loadBackendConfig({ logger, argv: process.argv });
   const reader = UrlReaders.default({ logger, config });
-  const database = useHotMemoize(module, () => {
-    const manager = DatabaseManager.fromConfig(
-      new ConfigReader({
-        backend: {
-          database: { client: 'better-sqlite3', connection: ':memory:' },
-        },
-      }),
-    );
-    return manager.forPlugin('catalog');
-  });
+  const manager = DatabaseManager.fromConfig(
+    new ConfigReader({
+      backend: {
+        database: { client: 'better-sqlite3', connection: ':memory:' },
+      },
+    }),
+  );
+  const database = manager.forPlugin('catalog');
   const discovery = HostDiscovery.fromConfig(config);
   const tokenManager = ServerTokenManager.fromConfig(config, {
     logger,

--- a/plugins/entity-feedback-backend/src/service/standaloneServer.ts
+++ b/plugins/entity-feedback-backend/src/service/standaloneServer.ts
@@ -19,7 +19,6 @@ import {
   DatabaseManager,
   loadBackendConfig,
   HostDiscovery,
-  useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
@@ -40,16 +39,14 @@ export async function startStandaloneServer(
   const config = await loadBackendConfig({ logger, argv: process.argv });
   const discovery = HostDiscovery.fromConfig(config);
 
-  const database = useHotMemoize(module, () => {
-    const manager = DatabaseManager.fromConfig(
-      new ConfigReader({
-        backend: {
-          database: { client: 'better-sqlite3', connection: ':memory:' },
-        },
-      }),
-    );
-    return manager.forPlugin('entity-feedback');
-  });
+  const manager = DatabaseManager.fromConfig(
+    new ConfigReader({
+      backend: {
+        database: { client: 'better-sqlite3', connection: ':memory:' },
+      },
+    }),
+  );
+  const database = manager.forPlugin('entity-feedback');
 
   const identity = DefaultIdentityClient.create({
     discovery,

--- a/plugins/playlist-backend/src/service/standaloneServer.ts
+++ b/plugins/playlist-backend/src/service/standaloneServer.ts
@@ -20,7 +20,6 @@ import {
   loadBackendConfig,
   ServerTokenManager,
   HostDiscovery,
-  useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
@@ -42,16 +41,14 @@ export async function startStandaloneServer(
   const config = await loadBackendConfig({ logger, argv: process.argv });
   const discovery = HostDiscovery.fromConfig(config);
 
-  const database = useHotMemoize(module, () => {
-    const manager = DatabaseManager.fromConfig(
-      new ConfigReader({
-        backend: {
-          database: { client: 'better-sqlite3', connection: ':memory:' },
-        },
-      }),
-    );
-    return manager.forPlugin('playlist');
-  });
+  const manager = DatabaseManager.fromConfig(
+    new ConfigReader({
+      backend: {
+        database: { client: 'better-sqlite3', connection: ':memory:' },
+      },
+    }),
+  );
+  const database = manager.forPlugin('playlist');
 
   const identity = DefaultIdentityClient.create({
     discovery,

--- a/plugins/user-settings-backend/package.json
+++ b/plugins/user-settings-backend/package.json
@@ -33,6 +33,7 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
+    "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/types": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9948,6 +9948,7 @@ __metadata:
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
+    "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/types": "workspace:^"


### PR DESCRIPTION
It's deprecated now.

No changesets for the dev-only code.

Couldn't quite muster up the energy to make a convenient dev helper for this stuff. Using the database manager directly is pretty OK, and when we migrate to the new backend system this becomes a non-issue anyway.