### PR TITLE
fix: Tidy up i18nextTranslationApi change handling

### DIFF
--- a/.changeset/shiny-birds-melt.md
+++ b/.changeset/shiny-birds-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed a bug in i18nextTranslationApi where in some cases it wouldn't notify subscribers of language changes

--- a/.changeset/shiny-birds-melt.md
+++ b/.changeset/shiny-birds-melt.md
@@ -2,4 +2,4 @@
 '@backstage/core-app-api': patch
 ---
 
-Fixed a bug in i18nextTranslationApi where in some cases it wouldn't notify subscribers of language changes
+Fixed a bug in `TranslationApi` implementation where in some cases it wouldn't notify subscribers of language changes.

--- a/packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi.test.ts
+++ b/packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi.test.ts
@@ -377,8 +377,7 @@ describe('I18nextTranslationApi', () => {
         },
       });
     });
-
-    expect(translations).toEqual(['foo', null, 'Föö', null, 'Føø']);
+    expect(translations).toEqual(['foo', 'Föö', 'Føø']);
   });
 
   describe('formatting', () => {

--- a/packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi.ts
+++ b/packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi.ts
@@ -241,7 +241,6 @@ export class I18nextTranslationApi implements TranslationApi {
 
     return new ObservableImpl<TranslationSnapshot<TMessages>>(subscriber => {
       let loadTicket = {}; // To check for stale loads
-      let lastSnapshotWasReady = false;
 
       const loadResource = () => {
         loadTicket = {};
@@ -250,8 +249,7 @@ export class I18nextTranslationApi implements TranslationApi {
           () => {
             if (ticket === loadTicket) {
               const snapshot = this.#createSnapshot(internalRef);
-              if (snapshot.ready || lastSnapshotWasReady) {
-                lastSnapshotWasReady = snapshot.ready;
+              if (snapshot.ready) {
                 subscriber.next(snapshot);
               }
             }
@@ -266,12 +264,9 @@ export class I18nextTranslationApi implements TranslationApi {
 
       const onChange = () => {
         const snapshot = this.#createSnapshot(internalRef);
-        if (lastSnapshotWasReady && !snapshot.ready) {
-          lastSnapshotWasReady = snapshot.ready;
+        if (snapshot.ready) {
           subscriber.next(snapshot);
-        }
-
-        if (!snapshot.ready) {
+        } else {
           loadResource();
         }
       };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This change removes some extra logic in i18NextTranslationApi's change handling to ensure it always updates subscribers when a language change is handled.  The relevant test was updated so it doesn't expect snapshots that aren't loaded.  Fixes #20381

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
