### PR TITLE
auth-backend(oidc-provider): Use requested scope if the refresh token request response has none

### DIFF
--- a/.changeset/five-spiders-listen.md
+++ b/.changeset/five-spiders-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed bug in oidc refresh handler, if token endpoints response on refresh request does not contain a scope, the requested scope is used.

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -130,6 +130,9 @@ export class OidcAuthProvider implements OAuthHandlers {
     if (!tokenset.access_token) {
       throw new Error('Refresh failed');
     }
+    if (!tokenset.scope) {
+      tokenset.scope = req.scope;
+    }
     const userinfo = await client.userinfo(tokenset.access_token);
 
     return {


### PR DESCRIPTION
## Fix the refresh token request response has no scope - oidc provider

fixes: #19836

While using the kubernetes plugin with AWS cognito as oidc provider, we had an issue where backstage was requesting a new login for AWS cognito everytime we reloaded the kubernetes page. We found out, that a missing scope in the providerInfo of the ```/api/auth/.../refresh``` response was the cause of this behaviour.

After tracing this down to the oidc-client, we found out that cognito wasn't sending the scope on refresh token calls.

After reading the oidc documentation, an empty scope in the refresh token call means that the requested scope is returned. If this is the case, backstage should use the requested scope.


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation - not necessary
- [ ] Tests for new functionality and regression tests for bug fixes - affecting no tests
- [ ] Screenshots attached (for UI changes) - not necessary
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
