### PR TITLE
feat(techdocs): add extension for setting build strategy

### DIFF
--- a/.changeset/two-jars-melt.md
+++ b/.changeset/two-jars-melt.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Expose an extension point to set a custom build strategy and move `DocsBuildStrategy` and `ShouldBuildParameters` types to `@backstage/plugin-techdocs-node`

--- a/.changeset/two-jars-melt.md
+++ b/.changeset/two-jars-melt.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-techdocs-node': minor
 ---
 
-Expose an extension point to set a custom build strategy and move `DocsBuildStrategy` and `ShouldBuildParameters` types to `@backstage/plugin-techdocs-node`
+Expose an extension point to set a custom build strategy. Also move `DocsBuildStrategy` type to `@backstage/plugin-techdocs-node` and deprecate `ShouldBuildParameters` type.

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -7,7 +7,7 @@ import { CatalogApi } from '@backstage/catalog-client';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DefaultTechDocsCollatorFactory as DefaultTechDocsCollatorFactory_2 } from '@backstage/plugin-search-backend-module-techdocs';
-import { DocsBuildStrategy } from '@backstage/plugin-techdocs-node';
+import { DocsBuildStrategy as DocsBuildStrategy_2 } from '@backstage/plugin-techdocs-node';
 import express from 'express';
 import { GeneratorBuilder } from '@backstage/plugin-techdocs-node';
 import { Knex } from 'knex';
@@ -17,9 +17,9 @@ import { PluginCacheManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { PreparerBuilder } from '@backstage/plugin-techdocs-node';
 import { PublisherBase } from '@backstage/plugin-techdocs-node';
-import { ShouldBuildParameters } from '@backstage/plugin-techdocs-node';
+import { ShouldBuildParameters as ShouldBuildParameters_2 } from '@backstage/plugin-techdocs-node';
 import type { TechDocsCollatorFactoryOptions as TechDocsCollatorFactoryOptions_2 } from '@backstage/plugin-search-backend-module-techdocs';
-import { TechDocsDocument } from '@backstage/plugin-techdocs-node';
+import { TechDocsDocument as TechDocsDocument_2 } from '@backstage/plugin-techdocs-node';
 import { TokenManager } from '@backstage/backend-common';
 import * as winston from 'winston';
 
@@ -34,7 +34,7 @@ export class DefaultTechDocsCollator {
     args: Record<string, string>,
   ): string;
   // (undocumented)
-  execute(): Promise<TechDocsDocument[]>;
+  execute(): Promise<TechDocsDocument_2[]>;
   // (undocumented)
   static fromConfig(
     config: Config,
@@ -49,7 +49,8 @@ export class DefaultTechDocsCollator {
 // @public @deprecated (undocumented)
 export const DefaultTechDocsCollatorFactory: typeof DefaultTechDocsCollatorFactory_2;
 
-export { DocsBuildStrategy };
+// @public @deprecated (undocumented)
+export type DocsBuildStrategy = DocsBuildStrategy_2;
 
 // @public
 export type OutOfTheBoxDeploymentOptions = {
@@ -61,7 +62,7 @@ export type OutOfTheBoxDeploymentOptions = {
   database?: Knex;
   config: Config;
   cache: PluginCacheManager;
-  docsBuildStrategy?: DocsBuildStrategy;
+  docsBuildStrategy?: DocsBuildStrategy_2;
   buildLogTransport?: winston.transport;
   catalogClient?: CatalogClient;
 };
@@ -73,7 +74,7 @@ export type RecommendedDeploymentOptions = {
   discovery: PluginEndpointDiscovery;
   config: Config;
   cache: PluginCacheManager;
-  docsBuildStrategy?: DocsBuildStrategy;
+  docsBuildStrategy?: DocsBuildStrategy_2;
   buildLogTransport?: winston.transport;
   catalogClient?: CatalogClient;
 };
@@ -83,7 +84,8 @@ export type RouterOptions =
   | RecommendedDeploymentOptions
   | OutOfTheBoxDeploymentOptions;
 
-export { ShouldBuildParameters };
+// @public @deprecated (undocumented)
+export type ShouldBuildParameters = ShouldBuildParameters_2;
 
 // @public @deprecated (undocumented)
 export type TechDocsCollatorFactoryOptions = TechDocsCollatorFactoryOptions_2;
@@ -99,7 +101,8 @@ export type TechDocsCollatorOptions = {
   legacyPathCasing?: boolean;
 };
 
-export { TechDocsDocument };
+// @public @deprecated (undocumented)
+export type TechDocsDocument = TechDocsDocument_2;
 
 export * from '@backstage/plugin-techdocs-node';
 ```

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -8,6 +8,7 @@ import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DefaultTechDocsCollatorFactory as DefaultTechDocsCollatorFactory_2 } from '@backstage/plugin-search-backend-module-techdocs';
 import { DocsBuildStrategy as DocsBuildStrategy_2 } from '@backstage/plugin-techdocs-node';
+import { Entity } from '@backstage/catalog-model';
 import express from 'express';
 import { GeneratorBuilder } from '@backstage/plugin-techdocs-node';
 import { Knex } from 'knex';
@@ -17,7 +18,6 @@ import { PluginCacheManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { PreparerBuilder } from '@backstage/plugin-techdocs-node';
 import { PublisherBase } from '@backstage/plugin-techdocs-node';
-import { ShouldBuildParameters as ShouldBuildParameters_2 } from '@backstage/plugin-techdocs-node';
 import type { TechDocsCollatorFactoryOptions as TechDocsCollatorFactoryOptions_2 } from '@backstage/plugin-search-backend-module-techdocs';
 import { TechDocsDocument as TechDocsDocument_2 } from '@backstage/plugin-techdocs-node';
 import { TokenManager } from '@backstage/backend-common';
@@ -85,7 +85,9 @@ export type RouterOptions =
   | OutOfTheBoxDeploymentOptions;
 
 // @public @deprecated (undocumented)
-export type ShouldBuildParameters = ShouldBuildParameters_2;
+export type ShouldBuildParameters = {
+  entity: Entity;
+};
 
 // @public @deprecated (undocumented)
 export type TechDocsCollatorFactoryOptions = TechDocsCollatorFactoryOptions_2;

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -7,7 +7,7 @@ import { CatalogApi } from '@backstage/catalog-client';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DefaultTechDocsCollatorFactory as DefaultTechDocsCollatorFactory_2 } from '@backstage/plugin-search-backend-module-techdocs';
-import { Entity } from '@backstage/catalog-model';
+import { DocsBuildStrategy } from '@backstage/plugin-techdocs-node';
 import express from 'express';
 import { GeneratorBuilder } from '@backstage/plugin-techdocs-node';
 import { Knex } from 'knex';
@@ -17,6 +17,7 @@ import { PluginCacheManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { PreparerBuilder } from '@backstage/plugin-techdocs-node';
 import { PublisherBase } from '@backstage/plugin-techdocs-node';
+import { ShouldBuildParameters } from '@backstage/plugin-techdocs-node';
 import type { TechDocsCollatorFactoryOptions as TechDocsCollatorFactoryOptions_2 } from '@backstage/plugin-search-backend-module-techdocs';
 import { TechDocsDocument } from '@backstage/plugin-techdocs-node';
 import { TokenManager } from '@backstage/backend-common';
@@ -48,11 +49,7 @@ export class DefaultTechDocsCollator {
 // @public @deprecated (undocumented)
 export const DefaultTechDocsCollatorFactory: typeof DefaultTechDocsCollatorFactory_2;
 
-// @public
-export interface DocsBuildStrategy {
-  // (undocumented)
-  shouldBuild(params: ShouldBuildParameters): Promise<boolean>;
-}
+export { DocsBuildStrategy };
 
 // @public
 export type OutOfTheBoxDeploymentOptions = {
@@ -86,10 +83,7 @@ export type RouterOptions =
   | RecommendedDeploymentOptions
   | OutOfTheBoxDeploymentOptions;
 
-// @public
-export type ShouldBuildParameters = {
-  entity: Entity;
-};
+export { ShouldBuildParameters };
 
 // @public @deprecated (undocumented)
 export type TechDocsCollatorFactoryOptions = TechDocsCollatorFactoryOptions_2;

--- a/plugins/techdocs-backend/src/index.ts
+++ b/plugins/techdocs-backend/src/index.ts
@@ -20,9 +20,9 @@
  * @packageDocumentation
  */
 
+import { Entity } from '@backstage/catalog-model';
 import {
   DocsBuildStrategy as _DocsBuildStrategy,
-  ShouldBuildParameters as _ShouldBuildParameters,
   TechDocsDocument as _TechDocsDocument,
 } from '@backstage/plugin-techdocs-node';
 
@@ -49,9 +49,11 @@ export type {
 export type DocsBuildStrategy = _DocsBuildStrategy;
 /**
  * @public
- * @deprecated import from `@backstage/plugin-techdocs-node` instead
+ * @deprecated use direct type definition instead
  */
-export type ShouldBuildParameters = _ShouldBuildParameters;
+export type ShouldBuildParameters = {
+  entity: Entity;
+};
 /**
  * @public
  * @deprecated import from `@backstage/plugin-techdocs-node` instead

--- a/plugins/techdocs-backend/src/index.ts
+++ b/plugins/techdocs-backend/src/index.ts
@@ -20,6 +20,12 @@
  * @packageDocumentation
  */
 
+import {
+  DocsBuildStrategy as _DocsBuildStrategy,
+  ShouldBuildParameters as _ShouldBuildParameters,
+  TechDocsDocument as _TechDocsDocument,
+} from '@backstage/plugin-techdocs-node';
+
 export { createRouter } from './service';
 export type {
   RouterOptions,
@@ -37,12 +43,19 @@ export type {
 } from './search';
 
 /**
- * @deprecated Use directly from @backstage/plugin-techdocs-node
+ * @public
+ * @deprecated import from `@backstage/plugin-techdocs-node` instead
  */
-export type {
-  DocsBuildStrategy,
-  ShouldBuildParameters,
-  TechDocsDocument,
-} from '@backstage/plugin-techdocs-node';
+export type DocsBuildStrategy = _DocsBuildStrategy;
+/**
+ * @public
+ * @deprecated import from `@backstage/plugin-techdocs-node` instead
+ */
+export type ShouldBuildParameters = _ShouldBuildParameters;
+/**
+ * @public
+ * @deprecated import from `@backstage/plugin-techdocs-node` instead
+ */
+export type TechDocsDocument = _TechDocsDocument;
 
 export * from '@backstage/plugin-techdocs-node';

--- a/plugins/techdocs-backend/src/index.ts
+++ b/plugins/techdocs-backend/src/index.ts
@@ -25,8 +25,6 @@ export type {
   RouterOptions,
   RecommendedDeploymentOptions,
   OutOfTheBoxDeploymentOptions,
-  DocsBuildStrategy,
-  ShouldBuildParameters,
 } from './service';
 
 export {
@@ -41,6 +39,10 @@ export type {
 /**
  * @deprecated Use directly from @backstage/plugin-techdocs-node
  */
-export type { TechDocsDocument } from '@backstage/plugin-techdocs-node';
+export type {
+  DocsBuildStrategy,
+  ShouldBuildParameters,
+  TechDocsDocument,
+} from '@backstage/plugin-techdocs-node';
 
 export * from '@backstage/plugin-techdocs-node';

--- a/plugins/techdocs-backend/src/plugin.ts
+++ b/plugins/techdocs-backend/src/plugin.ts
@@ -25,9 +25,11 @@ import {
 } from '@backstage/backend-plugin-api';
 
 import {
+  DocsBuildStrategy,
   Preparers,
   Generators,
   Publisher,
+  techdocsBuildStrategyExtensionPoint,
 } from '@backstage/plugin-techdocs-node';
 import Docker from 'dockerode';
 import { createRouter } from '@backstage/plugin-techdocs-backend';
@@ -39,6 +41,16 @@ import { createRouter } from '@backstage/plugin-techdocs-backend';
 export const techdocsPlugin = createBackendPlugin({
   pluginId: 'techdocs',
   register(env) {
+    let docsBuildStrategy: DocsBuildStrategy | undefined;
+    env.registerExtensionPoint(techdocsBuildStrategyExtensionPoint, {
+      setBuildStrategy(buildStrategy: DocsBuildStrategy) {
+        if (docsBuildStrategy) {
+          throw new Error('DocsBuildStrategy may only be set once');
+        }
+        docsBuildStrategy = buildStrategy;
+      },
+    });
+
     env.registerInit({
       deps: {
         config: coreServices.rootConfig,
@@ -82,6 +94,7 @@ export const techdocsPlugin = createBackendPlugin({
           await createRouter({
             logger: winstonLogger,
             cache: cacheManager,
+            docsBuildStrategy,
             preparers,
             generators,
             publisher,

--- a/plugins/techdocs-backend/src/plugin.ts
+++ b/plugins/techdocs-backend/src/plugin.ts
@@ -29,7 +29,7 @@ import {
   Preparers,
   Generators,
   Publisher,
-  techdocsBuildStrategyExtensionPoint,
+  techdocsBuildsExtensionPoint,
 } from '@backstage/plugin-techdocs-node';
 import Docker from 'dockerode';
 import { createRouter } from '@backstage/plugin-techdocs-backend';
@@ -42,7 +42,7 @@ export const techdocsPlugin = createBackendPlugin({
   pluginId: 'techdocs',
   register(env) {
     let docsBuildStrategy: DocsBuildStrategy | undefined;
-    env.registerExtensionPoint(techdocsBuildStrategyExtensionPoint, {
+    env.registerExtensionPoint(techdocsBuildsExtensionPoint, {
       setBuildStrategy(buildStrategy: DocsBuildStrategy) {
         if (docsBuildStrategy) {
           throw new Error('DocsBuildStrategy may only be set once');

--- a/plugins/techdocs-backend/src/service/DefaultDocsBuildStrategy.test.ts
+++ b/plugins/techdocs-backend/src/service/DefaultDocsBuildStrategy.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DefaultDocsBuildStrategy } from './DocsBuildStrategy';
+import { DefaultDocsBuildStrategy } from './DefaultDocsBuildStrategy';
 import { ConfigReader } from '@backstage/config';
 
 const MockedConfigReader = ConfigReader as jest.MockedClass<

--- a/plugins/techdocs-backend/src/service/DefaultDocsBuildStrategy.ts
+++ b/plugins/techdocs-backend/src/service/DefaultDocsBuildStrategy.ts
@@ -13,28 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
+import {
+  DocsBuildStrategy,
+  ShouldBuildParameters,
+} from '@backstage/plugin-techdocs-node';
 
-/**
- * Parameters passed to the shouldBuild method on the DocsBuildStrategy interface
- *
- * @public
- */
-export type ShouldBuildParameters = {
-  entity: Entity;
-};
-
-/**
- * A strategy for when to build TechDocs locally, and when to skip building TechDocs (allowing for an external build)
- *
- * @public
- */
-export interface DocsBuildStrategy {
-  shouldBuild(params: ShouldBuildParameters): Promise<boolean>;
-}
-
-export class DefaultDocsBuildStrategy {
+export class DefaultDocsBuildStrategy implements DocsBuildStrategy {
   private readonly config: Config;
 
   private constructor(config: Config) {

--- a/plugins/techdocs-backend/src/service/DefaultDocsBuildStrategy.ts
+++ b/plugins/techdocs-backend/src/service/DefaultDocsBuildStrategy.ts
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import {
-  DocsBuildStrategy,
-  ShouldBuildParameters,
-} from '@backstage/plugin-techdocs-node';
+import { DocsBuildStrategy } from '@backstage/plugin-techdocs-node';
 
 export class DefaultDocsBuildStrategy implements DocsBuildStrategy {
   private readonly config: Config;
@@ -30,7 +28,7 @@ export class DefaultDocsBuildStrategy implements DocsBuildStrategy {
     return new DefaultDocsBuildStrategy(config);
   }
 
-  async shouldBuild(_: ShouldBuildParameters): Promise<boolean> {
+  async shouldBuild(_: { entity: Entity }): Promise<boolean> {
     return this.config.getString('techdocs.builder') === 'local';
   }
 }

--- a/plugins/techdocs-backend/src/service/index.ts
+++ b/plugins/techdocs-backend/src/service/index.ts
@@ -20,7 +20,3 @@ export type {
   RecommendedDeploymentOptions,
   OutOfTheBoxDeploymentOptions,
 } from './router';
-export type {
-  DocsBuildStrategy,
-  ShouldBuildParameters,
-} from './DocsBuildStrategy';

--- a/plugins/techdocs-backend/src/service/router.test.ts
+++ b/plugins/techdocs-backend/src/service/router.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import {
+  DocsBuildStrategy,
   GeneratorBuilder,
   PreparerBuilder,
   PublisherBase,
@@ -32,7 +33,6 @@ import { DocsSynchronizer, DocsSynchronizerSyncOpts } from './DocsSynchronizer';
 import { CachedEntityLoader } from './CachedEntityLoader';
 import { createEventStream, createRouter, RouterOptions } from './router';
 import { TechDocsCache } from '../cache';
-import { DocsBuildStrategy } from './DocsBuildStrategy';
 
 jest.mock('@backstage/catalog-client');
 jest.mock('@backstage/config');

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -22,6 +22,7 @@ import { stringifyEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
 import {
+  DocsBuildStrategy,
   GeneratorBuilder,
   getLocationForEntity,
   PreparerBuilder,
@@ -34,10 +35,7 @@ import { ScmIntegrations } from '@backstage/integration';
 import { DocsSynchronizer, DocsSynchronizerSyncOpts } from './DocsSynchronizer';
 import { createCacheMiddleware, TechDocsCache } from '../cache';
 import { CachedEntityLoader } from './CachedEntityLoader';
-import {
-  DefaultDocsBuildStrategy,
-  DocsBuildStrategy,
-} from './DocsBuildStrategy';
+import { DefaultDocsBuildStrategy } from './DefaultDocsBuildStrategy';
 import * as winston from 'winston';
 import { PassThrough } from 'stream';
 

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -242,13 +242,13 @@ export type ShouldBuildParameters = {
 export type SupportedGeneratorKey = 'techdocs' | string;
 
 // @public
-export interface TechdocsBuildStrategyExtensionPoint {
+export interface TechdocsBuildsExtensionPoint {
   // (undocumented)
   setBuildStrategy(buildStrategy: DocsBuildStrategy): void;
 }
 
 // @public
-export const techdocsBuildStrategyExtensionPoint: ExtensionPoint<TechdocsBuildStrategyExtensionPoint>;
+export const techdocsBuildsExtensionPoint: ExtensionPoint<TechdocsBuildsExtensionPoint>;
 
 // @public
 export interface TechDocsDocument extends IndexableDocument {

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -10,6 +10,7 @@ import { Config } from '@backstage/config';
 import { ContainerRunner } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
+import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -22,6 +23,12 @@ export class DirectoryPreparer implements PreparerBase {
   static fromConfig(config: Config, options: PreparerConfig): DirectoryPreparer;
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
   shouldCleanPreparedDirectory(): boolean;
+}
+
+// @public
+export interface DocsBuildStrategy {
+  // (undocumented)
+  shouldBuild(params: ShouldBuildParameters): Promise<boolean>;
 }
 
 // @public
@@ -227,7 +234,21 @@ export type ReadinessResponse = {
 export type RemoteProtocol = 'url' | 'dir';
 
 // @public
+export type ShouldBuildParameters = {
+  entity: Entity;
+};
+
+// @public
 export type SupportedGeneratorKey = 'techdocs' | string;
+
+// @public
+export interface TechdocsBuildStrategyExtensionPoint {
+  // (undocumented)
+  setBuildStrategy(buildStrategy: DocsBuildStrategy): void;
+}
+
+// @public
+export const techdocsBuildStrategyExtensionPoint: ExtensionPoint<TechdocsBuildStrategyExtensionPoint>;
 
 // @public
 export interface TechDocsDocument extends IndexableDocument {

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -28,7 +28,7 @@ export class DirectoryPreparer implements PreparerBase {
 // @public
 export interface DocsBuildStrategy {
   // (undocumented)
-  shouldBuild(params: ShouldBuildParameters): Promise<boolean>;
+  shouldBuild(params: { entity: Entity }): Promise<boolean>;
 }
 
 // @public
@@ -232,11 +232,6 @@ export type ReadinessResponse = {
 
 // @public
 export type RemoteProtocol = 'url' | 'dir';
-
-// @public
-export type ShouldBuildParameters = {
-  entity: Entity;
-};
 
 // @public
 export type SupportedGeneratorKey = 'techdocs' | string;

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -47,6 +47,7 @@
     "@azure/identity": "^3.2.1",
     "@azure/storage-blob": "^12.5.0",
     "@backstage/backend-common": "workspace:^",
+    "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createExtensionPoint } from '@backstage/backend-plugin-api';
+import { DocsBuildStrategy } from './techdocsTypes';
+
+/**
+ * Extension point type for setting a custom build strategy.
+ *
+ * @public
+ */
+export interface TechdocsBuildStrategyExtensionPoint {
+  setBuildStrategy(buildStrategy: DocsBuildStrategy): void;
+}
+
+/**
+ * Extension point for setting a custom build strategy.
+ *
+ * @public
+ */
+export const techdocsBuildStrategyExtensionPoint =
+  createExtensionPoint<TechdocsBuildStrategyExtensionPoint>({
+    id: 'techdocs.buildStrategy',
+  });

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -17,20 +17,20 @@ import { createExtensionPoint } from '@backstage/backend-plugin-api';
 import { DocsBuildStrategy } from './techdocsTypes';
 
 /**
- * Extension point type for setting a custom build strategy.
+ * Extension point type for configuring Techdocs builds.
  *
  * @public
  */
-export interface TechdocsBuildStrategyExtensionPoint {
+export interface TechdocsBuildsExtensionPoint {
   setBuildStrategy(buildStrategy: DocsBuildStrategy): void;
 }
 
 /**
- * Extension point for setting a custom build strategy.
+ * Extension point for configuring Techdocs builds.
  *
  * @public
  */
-export const techdocsBuildStrategyExtensionPoint =
-  createExtensionPoint<TechdocsBuildStrategyExtensionPoint>({
-    id: 'techdocs.buildStrategy',
+export const techdocsBuildsExtensionPoint =
+  createExtensionPoint<TechdocsBuildsExtensionPoint>({
+    id: 'techdocs.builds',
   });

--- a/plugins/techdocs-node/src/index.ts
+++ b/plugins/techdocs-node/src/index.ts
@@ -24,6 +24,6 @@ export * from './stages';
 export * from './helpers';
 export * from './techdocsTypes';
 export {
-  techdocsBuildStrategyExtensionPoint,
-  type TechdocsBuildStrategyExtensionPoint,
+  techdocsBuildsExtensionPoint,
+  type TechdocsBuildsExtensionPoint,
 } from './extensions';

--- a/plugins/techdocs-node/src/index.ts
+++ b/plugins/techdocs-node/src/index.ts
@@ -23,3 +23,7 @@
 export * from './stages';
 export * from './helpers';
 export * from './techdocsTypes';
+export {
+  techdocsBuildStrategyExtensionPoint,
+  type TechdocsBuildStrategyExtensionPoint,
+} from './extensions';

--- a/plugins/techdocs-node/src/techdocsTypes.ts
+++ b/plugins/techdocs-node/src/techdocsTypes.ts
@@ -49,19 +49,10 @@ export interface TechDocsDocument extends IndexableDocument {
 }
 
 /**
- * Parameters passed to the shouldBuild method on the DocsBuildStrategy interface
- *
- * @public
- */
-export type ShouldBuildParameters = {
-  entity: Entity;
-};
-
-/**
  * A strategy for when to build TechDocs locally, and when to skip building TechDocs (allowing for an external build)
  *
  * @public
  */
 export interface DocsBuildStrategy {
-  shouldBuild(params: ShouldBuildParameters): Promise<boolean>;
+  shouldBuild(params: { entity: Entity }): Promise<boolean>;
 }

--- a/plugins/techdocs-node/src/techdocsTypes.ts
+++ b/plugins/techdocs-node/src/techdocsTypes.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Entity } from '@backstage/catalog-model';
 import { IndexableDocument } from '@backstage/plugin-search-common';
 
 /**
@@ -45,4 +46,22 @@ export interface TechDocsDocument extends IndexableDocument {
    * Entity path
    */
   path: string;
+}
+
+/**
+ * Parameters passed to the shouldBuild method on the DocsBuildStrategy interface
+ *
+ * @public
+ */
+export type ShouldBuildParameters = {
+  entity: Entity;
+};
+
+/**
+ * A strategy for when to build TechDocs locally, and when to skip building TechDocs (allowing for an external build)
+ *
+ * @public
+ */
+export interface DocsBuildStrategy {
+  shouldBuild(params: ShouldBuildParameters): Promise<boolean>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9770,6 +9770,7 @@ __metadata:
     "@azure/identity": ^3.2.1
     "@azure/storage-blob": ^12.5.0
     "@backstage/backend-common": "workspace:^"
+    "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Expose an extension point to be able to set a custom docs build strategy on the techdocs plugin. Also moving related types to the `-node` package and deprecating them in the `-backend` package. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
