### PR TITLE
Allow user-defined scopes for Okta auth in config yaml

### DIFF
--- a/.changeset/sharp-wombats-speak.md
+++ b/.changeset/sharp-wombats-speak.md
@@ -1,0 +1,28 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Allow user-defined scopes for Okta auth in config yaml
+
+Example `app-config.yaml` excerpt
+
+```yml
+auth:
+  environment: development
+  providers:
+    okta:
+      development:
+        clientId: ${AUTH_OKTA_CLIENT_ID}
+        clientSecret: ${AUTH_OKTA_CLIENT_SECRET}
+        audience: ${AUTH_OKTA_DOMAIN}
+        authServerId: ${AUTH_OKTA_AUTH_SERVER_ID} # Optional
+        idp: ${AUTH_OKTA_IDP} # Optional
+        # https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned
+        scope: openid profile email offline_access groups # Optional
+```
+
+- Accept a new scope option during okta creation with `createAuthProviderIntegration`
+- Pass the user-defined `scope` as an option to `OktaAuthProvider`
+- Add `scope` as an option for `OktaAuthProvider`
+- Set `scope` in `OktaAuthProvider` to the `scope` passed as an `option` or a default of `'openid email profile offline_access'` if a user-defined option is not provided
+- Update the `start` and `refresh` methods to use `scope` from `OktaAuthProvider` rather than `scope` from the request

--- a/.changeset/sharp-wombats-speak.md
+++ b/.changeset/sharp-wombats-speak.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-auth-backend': patch
 ---
 
 Allow additional user-defined scopes for Okta auth in config yaml

--- a/.changeset/sharp-wombats-speak.md
+++ b/.changeset/sharp-wombats-speak.md
@@ -22,7 +22,7 @@ auth:
 ```
 
 - Accept a new ` additionalScopes`` option during okta creation with  `createAuthProviderIntegration`
-- Passes the the user-defined `additionalScopes` as an option to `OktaAuthProvider`
+- Passes the user-defined `additionalScopes` as an option to `OktaAuthProvider`
 - Add `additionalScopes` as an option for `OktaAuthProvider`
 - Set `scope` in `OktaAuthProvider` to the combined value of current scopes combined with the user-defined `additionalScopes` passed as an `option`
 - Update the `start` and `refresh` methods to use the new combined `scope` from `OktaAuthProvider` rather than `scope` from the request

--- a/.changeset/sharp-wombats-speak.md
+++ b/.changeset/sharp-wombats-speak.md
@@ -21,8 +21,8 @@ auth:
         additionalScopes: groups # Optional
 ```
 
-- Accept a new additionalScope option during okta creation with `createAuthProviderIntegration`
+- Accept a new ` additionalScopes`` option during okta creation with  `createAuthProviderIntegration`
 - Passes the the user-defined `additionalScopes` as an option to `OktaAuthProvider`
 - Add `additionalScopes` as an option for `OktaAuthProvider`
 - Set `scope` in `OktaAuthProvider` to the combined value of current scopes combined with the user-defined `additionalScopes` passed as an `option`
-- Update the `start` and `refresh` methods to use the new combiend `scope` from `OktaAuthProvider` rather than `scope` from the request
+- Update the `start` and `refresh` methods to use the new combined `scope` from `OktaAuthProvider` rather than `scope` from the request

--- a/.changeset/sharp-wombats-speak.md
+++ b/.changeset/sharp-wombats-speak.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-auth-backend': minor
 ---
 
-Allow user-defined scopes for Okta auth in config yaml
+Allow additional user-defined scopes for Okta auth in config yaml
 
 Example `app-config.yaml` excerpt
 
@@ -18,11 +18,11 @@ auth:
         authServerId: ${AUTH_OKTA_AUTH_SERVER_ID} # Optional
         idp: ${AUTH_OKTA_IDP} # Optional
         # https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned
-        scope: openid profile email offline_access groups # Optional
+        additionalScopes: groups # Optional
 ```
 
-- Accept a new scope option during okta creation with `createAuthProviderIntegration`
-- Pass the user-defined `scope` as an option to `OktaAuthProvider`
-- Add `scope` as an option for `OktaAuthProvider`
-- Set `scope` in `OktaAuthProvider` to the `scope` passed as an `option` or a default of `'openid email profile offline_access'` if a user-defined option is not provided
-- Update the `start` and `refresh` methods to use `scope` from `OktaAuthProvider` rather than `scope` from the request
+- Accept a new additionalScope option during okta creation with `createAuthProviderIntegration`
+- Passes the the user-defined `additionalScopes` as an option to `OktaAuthProvider`
+- Add `additionalScopes` as an option for `OktaAuthProvider`
+- Set `scope` in `OktaAuthProvider` to the combined value of current scopes combined with the user-defined `additionalScopes` passed as an `option`
+- Update the `start` and `refresh` methods to use the new combiend `scope` from `OktaAuthProvider` rather than `scope` from the request

--- a/.changeset/sharp-wombats-speak.md
+++ b/.changeset/sharp-wombats-speak.md
@@ -2,27 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Allow additional user-defined scopes for Okta auth in config yaml
-
-Example `app-config.yaml` excerpt
-
-```yml
-auth:
-  environment: development
-  providers:
-    okta:
-      development:
-        clientId: ${AUTH_OKTA_CLIENT_ID}
-        clientSecret: ${AUTH_OKTA_CLIENT_SECRET}
-        audience: ${AUTH_OKTA_DOMAIN}
-        authServerId: ${AUTH_OKTA_AUTH_SERVER_ID} # Optional
-        idp: ${AUTH_OKTA_IDP} # Optional
-        # https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned
-        additionalScopes: groups # Optional
-```
-
-- Accept a new ` additionalScopes`` option during okta creation with  `createAuthProviderIntegration`
-- Passes the user-defined `additionalScopes` as an option to `OktaAuthProvider`
-- Add `additionalScopes` as an option for `OktaAuthProvider`
-- Set `scope` in `OktaAuthProvider` to the combined value of current scopes combined with the user-defined `additionalScopes` passed as an `option`
-- Update the `start` and `refresh` methods to use the new combined `scope` from `OktaAuthProvider` rather than `scope` from the request
+Added an optional `additionalScopes` configuration parameter to `okta` providers, that lets you add additional scopes on top of the default ones.

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -44,7 +44,7 @@ auth:
         authServerId: ${AUTH_OKTA_AUTH_SERVER_ID} # Optional
         idp: ${AUTH_OKTA_IDP} # Optional
         # https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned
-        scope: ${AUTH_OKTA_SCOPE} # Optional
+        additionalScopes: ${AUTH_OKTA_ADDITIONAL_SCOPES} # Optional
 ```
 
 The values referenced are found on the Application page on your Okta site.
@@ -57,7 +57,7 @@ The values referenced are found on the Application page on your Okta site.
 - `authServerId`: The authorization server ID for the Application
 - `idp`: The identity provider for the application, e.g. `0oaulob4BFVa4zQvt0g3`
 
-`scope` is an optional value to change the `scope` value sent to Okta during OAuth. The default value is `openid profile email offline_access`. Changing the `scope` will have an impact on [the dependent claims returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned). For example, adding `groups` to the `scope` by setting the value to `openid profile email offline_access groups` will result in the claim returning a list of the groups that the user is a member of that also match the ID token group filter of the client app.
+`additionalScopes` is an optional value, a string of space separated scopes, that will be combined with the default `scope` value of `openid profile email offline_access` to adjust the `scope` sent to Okta during OAuth. This will have an impact on [the dependent claims returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned). For example, setting the `additionalScopes` value to `groups` will result in the claim returning a list of the groups that the user is a member of that also match the ID token group filter of the client app.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -57,7 +57,7 @@ The values referenced are found on the Application page on your Okta site.
 - `authServerId`: The authorization server ID for the Application
 - `idp`: The identity provider for the application, e.g. `0oaulob4BFVa4zQvt0g3`
 
-`scope` is an optional value to change the `scope` value sent to Okta during OAuth. The default value is `openid profile email offline_access`. Chaning the `scope` will have an impact on [the dependent claims returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned). For example, adding `groups` to the `scope` by setting the value to `openid profile email offline_access groups` will result in the claim returning a list of the groups that the user is a member of that also match the ID token group filter of the client app.
+`scope` is an optional value to change the `scope` value sent to Okta during OAuth. The default value is `openid profile email offline_access`. Changing the `scope` will have an impact on [the dependent claims returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned). For example, adding `groups` to the `scope` by setting the value to `openid profile email offline_access groups` will result in the claim returning a list of the groups that the user is a member of that also match the ID token group filter of the client app.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -43,6 +43,8 @@ auth:
         audience: ${AUTH_OKTA_DOMAIN}
         authServerId: ${AUTH_OKTA_AUTH_SERVER_ID} # Optional
         idp: ${AUTH_OKTA_IDP} # Optional
+        # https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned
+        scope: ${AUTH_OKTA_SCOPE} # Optional
 ```
 
 The values referenced are found on the Application page on your Okta site.
@@ -54,6 +56,8 @@ The values referenced are found on the Application page on your Okta site.
   `https://company.okta.com`
 - `authServerId`: The authorization server ID for the Application
 - `idp`: The identity provider for the application, e.g. `0oaulob4BFVa4zQvt0g3`
+
+`scope` is an optional value to change the `scope` value sent to Okta during OAuth. The default value is `openid profile email offline_access`. Chaning the `scope` will have an impact on [the dependent claims returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned). For example, adding `groups` to the `scope` by setting the value to `openid profile email offline_access groups` will result in the claim returning a list of the groups that the user is a member of that also match the ID token group filter of the client app.
 
 ## Adding the provider to the Backstage frontend
 

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -131,6 +131,7 @@ export interface Config {
           authServerId?: string;
           idp?: string;
           callbackUrl?: string;
+          additionalScopes?: string;
         };
       };
       /** @visibility frontend */

--- a/plugins/auth-backend/src/providers/okta/provider.test.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.test.ts
@@ -106,8 +106,8 @@ describe('createOktaProvider', () => {
 
   it('should pass a custom scope to start and refresh requests', async () => {
     const additionalScopes = 'groups';
-    const mockScope = 'openid profile email offline_access groups';
     const reqScope = 'openid profile email offline_access';
+    const combinedScope = `${reqScope} ${additionalScopes}`;
     const provider = new OktaAuthProvider({
       resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
@@ -138,6 +138,6 @@ describe('createOktaProvider', () => {
     await provider.start(req);
     const mockCallScope = (mockRedirectStrategy.mock.calls[0] as any)?.[2]
       ?.scope;
-    expect(mockCallScope).toBe(mockScope);
+    expect(mockCallScope).toBe(combinedScope);
   });
 });

--- a/plugins/auth-backend/src/providers/okta/provider.test.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.test.ts
@@ -105,6 +105,7 @@ describe('createOktaProvider', () => {
   });
 
   it('should pass a custom scope to start and refresh requests', async () => {
+    const additionalScopes = 'groups';
     const mockScope = 'openid profile email offline_access groups';
     const reqScope = 'openid profile email offline_access';
     const provider = new OktaAuthProvider({
@@ -119,7 +120,7 @@ describe('createOktaProvider', () => {
       clientId: 'mock',
       clientSecret: 'mock',
       callbackUrl: 'mock',
-      scope: mockScope,
+      additionalScopes,
     });
 
     mockRedirectStrategy.mockResolvedValueOnce({


### PR DESCRIPTION
## Background Info

I am getting into Backstage and loving it so far! I will be using Okta for authentication. My end goal is to assign users to a group in Okta and have them mapped to a corresponding group in Backstage for RBAC.

Tackling this goal one piece at a time I started with getting a user's group information from Okta when authenticating. Allowing [scope dependent claims to be returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned)

This requires an additional `groups` scope to be added to the requests sent to Okta during authentication. Currently, there is no way to modify the scopes send to Okta in Backstage; they are alway `openid email profile offline_access `.

This PR allows users to add additional scopes in addition to the default scopes in the config yaml along with other fields such as `clientId` and `clientSecret`.

With this approach, using an `additionalScopes` field in my config of `groups`, I am able to get the following response from `info.result.fullProfile._json` in the Okta resolvers.

```json
{
  "sub": "REDACTED",
  "name": "Andrew Taylor",
  "locale": "US",
  "email": "REDACTED",
  "preferred_username": "REDACTED",
  "given_name": "Andrew",
  "middle_name": "",
  "family_name": "Taylor",
  "zoneinfo": "America/Los_Angeles",
  "updated_at": 1696427831,
  "email_verified": true,
  "groups": [ "Backstage - Users", "Backstage - Admins" ]
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~ Not applicable
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
