### PR TITLE
[DI]  Improve `ExtensionBoundary` component

### DIFF
--- a/.changeset/fluffy-years-shake.md
+++ b/.changeset/fluffy-years-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Use default extensions boundary and suspense on the alpha declarative `createCatalogFilterExtension` extension factory.

--- a/.changeset/sixty-tips-argue.md
+++ b/.changeset/sixty-tips-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Improve the extension boundary component and create a default extension suspense component.

--- a/.changeset/young-days-talk.md
+++ b/.changeset/young-days-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Use default extensions boundary and suspense on the alpha declarative `createSearchResultListItem` extension factory.

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -340,7 +340,7 @@ export interface ExtensionBoundaryProps {
   // (undocumented)
   id: string;
   // (undocumented)
-  routeRef?: RouteRef;
+  routable?: boolean;
   // (undocumented)
   source?: BackstagePlugin;
 }
@@ -414,17 +414,6 @@ export interface ExtensionOverrides {
 export interface ExtensionOverridesOptions {
   // (undocumented)
   extensions: Extension<unknown>[];
-}
-
-// @public (undocumented)
-export function ExtensionSuspense(
-  props: ExtensionSuspenseProps,
-): React_2.JSX.Element;
-
-// @public (undocumented)
-export interface ExtensionSuspenseProps {
-  // (undocumented)
-  children: ReactNode;
 }
 
 // @public

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -338,6 +338,10 @@ export interface ExtensionBoundaryProps {
   // (undocumented)
   children: ReactNode;
   // (undocumented)
+  id: string;
+  // (undocumented)
+  routeRef?: RouteRef;
+  // (undocumented)
   source?: BackstagePlugin;
 }
 
@@ -410,6 +414,17 @@ export interface ExtensionOverrides {
 export interface ExtensionOverridesOptions {
   // (undocumented)
   extensions: Extension<unknown>[];
+}
+
+// @public (undocumented)
+export function ExtensionSuspense(
+  props: ExtensionSuspenseProps,
+): React_2.JSX.Element;
+
+// @public (undocumented)
+export interface ExtensionSuspenseProps {
+  // (undocumented)
+  children: ReactNode;
 }
 
 // @public

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
+    "@backstage/frontend-app-api": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
@@ -37,10 +38,11 @@
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "dependencies": {
+    "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
-    "@backstage/frontend-app-api": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
+    "@material-ui/core": "^4.12.4",
     "@types/react": "^16.13.1 || ^17.0.0",
     "lodash": "^4.17.21",
     "zod": "^3.21.4",

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "@backstage/frontend-app-api": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
@@ -39,6 +38,7 @@
   },
   "dependencies": {
     "@backstage/core-plugin-api": "workspace:^",
+    "@backstage/frontend-app-api": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/packages/frontend-plugin-api/src/components/ErrorBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ErrorBoundary.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component, PropsWithChildren } from 'react';
+import { Button } from '@material-ui/core';
+import { BackstagePlugin } from '../wiring';
+import { ErrorPanel } from '@backstage/core-components';
+
+type DefaultErrorBoundaryFallbackProps = PropsWithChildren<{
+  plugin?: BackstagePlugin;
+  error: Error;
+  resetError: () => void;
+}>;
+
+const DefaultErrorBoundaryFallback = ({
+  plugin,
+  error,
+  resetError,
+}: DefaultErrorBoundaryFallbackProps) => {
+  const title = `Error in ${plugin?.id}`;
+
+  return (
+    <ErrorPanel title={title} error={error} defaultExpanded>
+      <Button variant="outlined" onClick={resetError}>
+        Retry
+      </Button>
+    </ErrorPanel>
+  );
+};
+
+type ErrorBoundaryProps = PropsWithChildren<{ plugin?: BackstagePlugin }>;
+type ErrorBoundaryState = { error?: Error };
+
+/** @internal */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  state: ErrorBoundaryState = { error: undefined };
+
+  handleErrorReset = () => {
+    this.setState({ error: undefined });
+  };
+
+  render() {
+    const { error } = this.state;
+    const { plugin, children } = this.props;
+
+    if (error) {
+      // TODO: use a configurable error boundary fallback
+      return (
+        <DefaultErrorBoundaryFallback
+          plugin={plugin}
+          error={error}
+          resetError={this.handleErrorReset}
+        />
+      );
+    }
+
+    return children;
+  }
+}

--- a/packages/frontend-plugin-api/src/components/ErrorBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ErrorBoundary.tsx
@@ -15,9 +15,10 @@
  */
 
 import React, { Component, PropsWithChildren } from 'react';
+// TODO: Dependency on MUI should be removed from core packages
 import { Button } from '@material-ui/core';
-import { BackstagePlugin } from '../wiring';
 import { ErrorPanel } from '@backstage/core-components';
+import { BackstagePlugin } from '../wiring';
 
 type DefaultErrorBoundaryFallbackProps = PropsWithChildren<{
   plugin?: BackstagePlugin;

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import {
+  MockAnalyticsApi,
+  MockConfigApi,
+  TestApiProvider,
+  renderWithEffects,
+} from '@backstage/test-utils';
+import { ExtensionBoundary } from './ExtensionBoundary';
+import {
+  Extension,
+  coreExtensionData,
+  createExtension,
+  createPlugin,
+} from '../wiring';
+import { analyticsApiRef, useAnalytics } from '@backstage/core-plugin-api';
+import { createApp } from '@backstage/frontend-app-api';
+import { JsonObject } from '@backstage/types';
+import { createRouteRef } from '../routing';
+import { toInternalRouteRef } from '../routing/RouteRef';
+
+function renderExtensionInTestApp(
+  extension: Extension<unknown>,
+  options?: {
+    config?: JsonObject;
+  },
+) {
+  const { config = {} } = options ?? {};
+
+  const app = createApp({
+    features: [
+      createPlugin({
+        id: 'plugin',
+        extensions: [extension],
+      }),
+    ],
+    configLoader: async () => new MockConfigApi(config),
+  });
+
+  return renderWithEffects(app.createRoot());
+}
+
+const wrapInBoundaryExtension = (element: JSX.Element) => {
+  const id = 'plugin.extension';
+  const routeRef = createRouteRef();
+  toInternalRouteRef(routeRef).setId(id);
+  return createExtension({
+    id,
+    attachTo: { id: 'core.routes', input: 'routes' },
+    output: {
+      element: coreExtensionData.reactElement,
+      path: coreExtensionData.routePath,
+      routeRef: coreExtensionData.routeRef.optional(),
+    },
+    factory({ bind, source }) {
+      bind({
+        routeRef,
+        path: '/',
+        element: (
+          <ExtensionBoundary id={id} source={source} routeRef={routeRef}>
+            {element}
+          </ExtensionBoundary>
+        ),
+      });
+    },
+  });
+};
+
+describe('ExtensionBoundary', () => {
+  it('should render children when there is no error', async () => {
+    const text = 'Text Component';
+    const TextComponent = () => {
+      return <p>{text}</p>;
+    };
+    await renderExtensionInTestApp(wrapInBoundaryExtension(<TextComponent />));
+    await waitFor(() => expect(screen.getByText(text)).toBeInTheDocument());
+  });
+
+  it('should show app error component when an error is thrown', async () => {
+    const error = 'Something went wrong';
+    const ErrorComponent = () => {
+      throw new Error(error);
+    };
+    await renderExtensionInTestApp(wrapInBoundaryExtension(<ErrorComponent />));
+    await waitFor(() => expect(screen.getByText(error)).toBeInTheDocument());
+  });
+
+  it('should wrap children with analytics context', async () => {
+    const action = 'render';
+    const subject = 'analytics';
+    const analyticsApiMock = new MockAnalyticsApi();
+
+    const AnalyticsComponent = () => {
+      const analytics = useAnalytics();
+      useEffect(() => {
+        analytics.captureEvent(action, subject);
+      }, [analytics]);
+      return null;
+    };
+
+    await renderExtensionInTestApp(
+      wrapInBoundaryExtension(
+        <TestApiProvider apis={[[analyticsApiRef, analyticsApiMock]]}>
+          <AnalyticsComponent />
+        </TestApiProvider>,
+      ),
+    );
+
+    await waitFor(() =>
+      expect(analyticsApiMock.getEvents()[0]).toMatchObject({
+        action,
+        subject,
+        context: {
+          extension: 'plugin.extension',
+          routeRef: 'plugin.extension',
+        },
+      }),
+    );
+  });
+});

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
@@ -33,7 +33,6 @@ import { analyticsApiRef, useAnalytics } from '@backstage/core-plugin-api';
 import { createApp } from '@backstage/frontend-app-api';
 import { JsonObject } from '@backstage/types';
 import { createRouteRef } from '../routing';
-import { toInternalRouteRef } from '../routing/RouteRef';
 
 function renderExtensionInTestApp(
   extension: Extension<unknown>,
@@ -59,7 +58,6 @@ function renderExtensionInTestApp(
 const wrapInBoundaryExtension = (element: JSX.Element) => {
   const id = 'plugin.extension';
   const routeRef = createRouteRef();
-  toInternalRouteRef(routeRef).setId(id);
   return createExtension({
     id,
     attachTo: { id: 'core.routes', input: 'routes' },
@@ -73,7 +71,7 @@ const wrapInBoundaryExtension = (element: JSX.Element) => {
         routeRef,
         path: '/',
         element: (
-          <ExtensionBoundary id={id} source={source} routeRef={routeRef}>
+          <ExtensionBoundary id={id} source={source}>
             {element}
           </ExtensionBoundary>
         ),
@@ -128,7 +126,7 @@ describe('ExtensionBoundary', () => {
         subject,
         context: {
           extension: 'plugin.extension',
-          routeRef: 'plugin.extension',
+          routeRef: 'unknown',
         },
       }),
     );

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -14,36 +14,59 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
-import { AnalyticsContext } from '@backstage/core-plugin-api';
+import React, { PropsWithChildren, ReactNode, useEffect } from 'react';
+import { AnalyticsContext, useAnalytics } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '../wiring';
-import { RouteRef } from '../routing';
 import { ErrorBoundary } from './ErrorBoundary';
-import { toInternalRouteRef } from '../routing/RouteRef';
+import { ExtensionSuspense } from './ExtensionSuspense';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { routableExtensionRenderedEvent } from '../../../core-plugin-api/src/analytics/Tracker';
+
+type RouteTrackerProps = PropsWithChildren<{
+  disableTracking?: boolean;
+}>;
+
+const RouteTracker = (props: RouteTrackerProps) => {
+  const { disableTracking, children } = props;
+  const analytics = useAnalytics();
+
+  // This event, never exposed to end-users of the analytics API,
+  // helps inform which extension metadata gets associated with a
+  // navigation event when the route navigated to is a gathered
+  // mountpoint.
+  useEffect(() => {
+    if (disableTracking) return;
+    analytics.captureEvent(routableExtensionRenderedEvent, '');
+  }, [analytics, disableTracking]);
+
+  return <>{children}</>;
+};
 
 /** @public */
 export interface ExtensionBoundaryProps {
   id: string;
   source?: BackstagePlugin;
-  routeRef?: RouteRef;
+  routable?: boolean;
   children: ReactNode;
 }
 
 /** @public */
 export function ExtensionBoundary(props: ExtensionBoundaryProps) {
-  const { id, source, routeRef, children } = props;
+  const { id, source, routable, children } = props;
 
+  // Skipping "routeRef" attribute in the new system, the extension "id" should provide more insight
   const attributes = {
     extension: id,
     pluginId: source?.id,
-    routeRef: routeRef
-      ? toInternalRouteRef(routeRef).getDescription()
-      : undefined,
   };
 
   return (
-    <ErrorBoundary plugin={source}>
-      <AnalyticsContext attributes={attributes}>{children}</AnalyticsContext>
-    </ErrorBoundary>
+    <ExtensionSuspense>
+      <ErrorBoundary plugin={source}>
+        <AnalyticsContext attributes={attributes}>
+          <RouteTracker disableTracking={!routable}>{children}</RouteTracker>
+        </AnalyticsContext>
+      </ErrorBoundary>
+    </ExtensionSuspense>
   );
 }

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -15,15 +15,35 @@
  */
 
 import React, { ReactNode } from 'react';
+import { AnalyticsContext } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '../wiring';
+import { RouteRef } from '../routing';
+import { ErrorBoundary } from './ErrorBoundary';
+import { toInternalRouteRef } from '../routing/RouteRef';
 
 /** @public */
 export interface ExtensionBoundaryProps {
-  children: ReactNode;
+  id: string;
   source?: BackstagePlugin;
+  routeRef?: RouteRef;
+  children: ReactNode;
 }
 
 /** @public */
 export function ExtensionBoundary(props: ExtensionBoundaryProps) {
-  return <>{props.children}</>;
+  const { id, source, routeRef, children } = props;
+
+  const attributes = {
+    extension: id,
+    pluginId: source?.id,
+    routeRef: routeRef
+      ? toInternalRouteRef(routeRef).getDescription()
+      : undefined,
+  };
+
+  return (
+    <ErrorBoundary plugin={source}>
+      <AnalyticsContext attributes={attributes}>{children}</AnalyticsContext>
+    </ErrorBoundary>
+  );
 }

--- a/packages/frontend-plugin-api/src/components/ExtensionSuspense.test.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionSuspense.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { lazy } from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
+import { ExtensionSuspense } from './ExtensionSuspense';
+
+describe('ExtensionSuspense', () => {
+  it('should render the app progress component as fallback', async () => {
+    const LazyComponent = lazy(() => new Promise(() => {}));
+
+    await renderWithEffects(
+      wrapInTestApp(
+        <ExtensionSuspense>
+          <LazyComponent />
+        </ExtensionSuspense>,
+      ),
+    );
+
+    expect(screen.getByTestId('progress')).toBeInTheDocument();
+  });
+
+  it('should render the lazy loaded children component', async () => {
+    const LazyComponent = lazy(() =>
+      Promise.resolve({ default: () => <div>Lazy Component</div> }),
+    );
+
+    await renderWithEffects(
+      wrapInTestApp(
+        <ExtensionSuspense>
+          <LazyComponent />
+        </ExtensionSuspense>,
+      ),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Lazy Component')).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/frontend-plugin-api/src/components/ExtensionSuspense.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionSuspense.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-export {
-  ExtensionBoundary,
-  type ExtensionBoundaryProps,
-} from './ExtensionBoundary';
+import React, { ReactNode, Suspense } from 'react';
+import { useApp } from '@backstage/core-plugin-api';
 
-export {
-  ExtensionSuspense,
-  type ExtensionSuspenseProps,
-} from './ExtensionSuspense';
+/** @public */
+export interface ExtensionSuspenseProps {
+  children: ReactNode;
+}
+
+/** @public */
+export function ExtensionSuspense(props: ExtensionSuspenseProps) {
+  const { children } = props;
+
+  const app = useApp();
+  const { Progress } = app.getComponents();
+
+  return <Suspense fallback={<Progress />}>{children}</Suspense>;
+}

--- a/packages/frontend-plugin-api/src/components/index.ts
+++ b/packages/frontend-plugin-api/src/components/index.ts
@@ -18,8 +18,3 @@ export {
   ExtensionBoundary,
   type ExtensionBoundaryProps,
 } from './ExtensionBoundary';
-
-export {
-  ExtensionSuspense,
-  type ExtensionSuspenseProps,
-} from './ExtensionSuspense';

--- a/plugins/catalog/src/alpha.tsx
+++ b/plugins/catalog/src/alpha.tsx
@@ -98,11 +98,10 @@ export function createCatalogFilterExtension<
   loader: (options: { config: TConfig }) => Promise<JSX.Element>;
 }) {
   const id = `catalog.filter.${options.id}`;
-  const attachTo = { id: 'plugin.catalog.page.index', input: 'filters' };
 
   return createExtension({
     id,
-    attachTo,
+    attachTo: { id: 'plugin.catalog.page.index', input: 'filters' },
     inputs: options.inputs ?? {},
     configSchema: options.configSchema,
     output: {

--- a/plugins/catalog/src/alpha.tsx
+++ b/plugins/catalog/src/alpha.tsx
@@ -36,7 +36,6 @@ import {
   PortableSchema,
   ExtensionBoundary,
   createExtensionInput,
-  ExtensionSuspense,
 } from '@backstage/frontend-plugin-api';
 import {
   AsyncEntityProvider,
@@ -117,9 +116,7 @@ export function createCatalogFilterExtension<
       bind({
         element: (
           <ExtensionBoundary id={id} source={source}>
-            <ExtensionSuspense>
-              <ExtensionComponent />
-            </ExtensionSuspense>
+            <ExtensionComponent />
           </ExtensionBoundary>
         ),
       });

--- a/plugins/search-react/src/alpha.tsx
+++ b/plugins/search-react/src/alpha.tsx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import React, { lazy, Suspense } from 'react';
+import React, { lazy } from 'react';
 
 import { ListItemProps } from '@material-ui/core';
 
 import {
   ExtensionBoundary,
+  ExtensionSuspense,
   PortableSchema,
   createExtension,
   createExtensionDataRef,
   createSchemaFromZod,
 } from '@backstage/frontend-plugin-api';
-import { Progress } from '@backstage/core-components';
 import { SearchDocument, SearchResult } from '@backstage/plugin-search-common';
 
 import { SearchResultListItemExtension } from './extensions';
@@ -87,6 +87,13 @@ export type SearchResultItemExtensionOptions<
 export function createSearchResultListItemExtension<
   TConfig extends { noTrack?: boolean },
 >(options: SearchResultItemExtensionOptions<TConfig>) {
+  const id = `plugin.search.result.item.${options.id}`;
+
+  const attachTo = options.attachTo ?? {
+    id: 'plugin.search.page',
+    input: 'items',
+  };
+
   const configSchema =
     'configSchema' in options
       ? options.configSchema
@@ -95,15 +102,16 @@ export function createSearchResultListItemExtension<
             noTrack: z.boolean().default(false),
           }),
         ) as PortableSchema<TConfig>);
+
   return createExtension({
-    id: `plugin.search.result.item.${options.id}`,
-    attachTo: options.attachTo ?? { id: 'plugin.search.page', input: 'items' },
+    id,
+    attachTo,
     configSchema,
     output: {
       item: searchResultItemExtensionData,
     },
     factory({ bind, config, source }) {
-      const LazyComponent = lazy(() =>
+      const ExtensionComponent = lazy(() =>
         options
           .component({ config })
           .then(component => ({ default: component })),
@@ -113,16 +121,16 @@ export function createSearchResultListItemExtension<
         item: {
           predicate: options.predicate,
           component: props => (
-            <ExtensionBoundary source={source}>
-              <Suspense fallback={<Progress />}>
+            <ExtensionBoundary id={id} source={source}>
+              <ExtensionSuspense>
                 <SearchResultListItemExtension
                   rank={props.rank}
                   result={props.result}
                   noTrack={config.noTrack}
                 >
-                  <LazyComponent {...props} />
+                  <ExtensionComponent {...props} />
                 </SearchResultListItemExtension>
-              </Suspense>
+              </ExtensionSuspense>
             </ExtensionBoundary>
           ),
         },

--- a/plugins/search-react/src/alpha.tsx
+++ b/plugins/search-react/src/alpha.tsx
@@ -20,7 +20,6 @@ import { ListItemProps } from '@material-ui/core';
 
 import {
   ExtensionBoundary,
-  ExtensionSuspense,
   PortableSchema,
   createExtension,
   createExtensionDataRef,
@@ -120,15 +119,13 @@ export function createSearchResultListItemExtension<
           predicate: options.predicate,
           component: props => (
             <ExtensionBoundary id={id} source={source}>
-              <ExtensionSuspense>
-                <SearchResultListItemExtension
-                  rank={props.rank}
-                  result={props.result}
-                  noTrack={config.noTrack}
-                >
-                  <ExtensionComponent {...props} />
-                </SearchResultListItemExtension>
-              </ExtensionSuspense>
+              <SearchResultListItemExtension
+                rank={props.rank}
+                result={props.result}
+                noTrack={config.noTrack}
+              >
+                <ExtensionComponent {...props} />
+              </SearchResultListItemExtension>
             </ExtensionBoundary>
           ),
         },

--- a/plugins/search-react/src/alpha.tsx
+++ b/plugins/search-react/src/alpha.tsx
@@ -89,11 +89,6 @@ export function createSearchResultListItemExtension<
 >(options: SearchResultItemExtensionOptions<TConfig>) {
   const id = `plugin.search.result.item.${options.id}`;
 
-  const attachTo = options.attachTo ?? {
-    id: 'plugin.search.page',
-    input: 'items',
-  };
-
   const configSchema =
     'configSchema' in options
       ? options.configSchema
@@ -105,7 +100,10 @@ export function createSearchResultListItemExtension<
 
   return createExtension({
     id,
-    attachTo,
+    attachTo: options.attachTo ?? {
+      id: 'plugin.search.page',
+      input: 'items',
+    },
     configSchema,
     output: {
       item: searchResultItemExtensionData,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,11 +4246,13 @@ __metadata:
   resolution: "@backstage/frontend-plugin-api@workspace:packages/frontend-plugin-api"
   dependencies:
     "@backstage/cli": "workspace:^"
+    "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/frontend-app-api": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@backstage/version-bridge": "workspace:^"
+    "@material-ui/core": ^4.12.4
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0
     "@types/react": ^16.13.1 || ^17.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrate contexts and wrappers from legacy plugin context.

- [x] Use plugin error boundary
- [x] Use analytics context
- [x] Capture page navigation event
- [x] Create suspense extension component

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
