### PR TITLE
[DI] Export `TechDocs` routes and nav item extension

### DIFF
--- a/.changeset/giant-cars-walk.md
+++ b/.changeset/giant-cars-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Export alpha routes and nav item extension, only available for applications that uses the new Frontend system.

--- a/plugins/techdocs/alpha-api-report.md
+++ b/plugins/techdocs/alpha-api-report.md
@@ -16,6 +16,7 @@ const _default: BackstagePlugin<
       kind: string;
       namespace: string;
     }>;
+    entityContent: RouteRef<undefined>;
   },
   {}
 >;

--- a/plugins/techdocs/src/alpha.tsx
+++ b/plugins/techdocs/src/alpha.tsx
@@ -15,89 +15,33 @@
  */
 
 import React from 'react';
+import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import {
   createPlugin,
   createSchemaFromZod,
   createApiExtension,
   createPageExtension,
+  createNavItemExtension,
 } from '@backstage/frontend-plugin-api';
 import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
 import {
   configApiRef,
   createApiFactory,
-  createRouteRef,
   discoveryApiRef,
   fetchApiRef,
   identityApiRef,
 } from '@backstage/core-plugin-api';
+import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
 import {
   techdocsApiRef,
   techdocsStorageApiRef,
 } from '@backstage/plugin-techdocs-react';
 import { TechDocsClient, TechDocsStorageClient } from './client';
-import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
-
-const rootRouteRef = createRouteRef({
-  id: 'plugin.techdocs.indexPage',
-});
-
-const rootDocsRouteRef = createRouteRef({
-  id: 'plugin.techdocs.readerPage',
-  params: ['namespace', 'kind', 'name'],
-});
-
-/** @alpha */
-export const TechDocsSearchResultListItemExtension =
-  createSearchResultListItemExtension({
-    id: 'techdocs',
-    configSchema: createSchemaFromZod(z =>
-      z.object({
-        // TODO: Define how the icon can be configurable
-        title: z.string().optional(),
-        lineClamp: z.number().default(5),
-        asLink: z.boolean().default(true),
-        asListItem: z.boolean().default(true),
-        noTrack: z.boolean().default(false),
-      }),
-    ),
-    predicate: result => result.type === 'techdocs',
-    component: async ({ config }) => {
-      const { TechDocsSearchResultListItem } = await import(
-        './search/components/TechDocsSearchResultListItem'
-      );
-      return props => <TechDocsSearchResultListItem {...props} {...config} />;
-    },
-  });
-
-/**
- * Responsible for rendering the provided router element
- *
- * @alpha
- */
-const TechDocsIndexPage = createPageExtension({
-  id: 'plugin.techdocs.indexPage',
-  defaultPath: '/docs',
-  routeRef: convertLegacyRouteRef(rootRouteRef),
-  loader: () =>
-    import('./home/components/TechDocsIndexPage').then(m => (
-      <m.TechDocsIndexPage />
-    )),
-});
-
-/**
- * Component responsible for composing a TechDocs reader page experience
- *
- * @alpha
- */
-const TechDocsReaderPage = createPageExtension({
-  id: 'plugin.techdocs.readerPage',
-  loader: () =>
-    import('./reader/components/TechDocsReaderPage').then(m => (
-      <m.TechDocsReaderPage />
-    )),
-  routeRef: convertLegacyRouteRef(rootDocsRouteRef),
-  defaultPath: '/docs/:namespace/:kind/:name/*',
-});
+import {
+  rootCatalogDocsRouteRef,
+  rootDocsRouteRef,
+  rootRouteRef,
+} from './routes';
 
 /** @alpha */
 const techDocsStorage = createApiExtension({
@@ -145,17 +89,80 @@ const techDocsClient = createApiExtension({
 });
 
 /** @alpha */
+export const TechDocsSearchResultListItemExtension =
+  createSearchResultListItemExtension({
+    id: 'techdocs',
+    configSchema: createSchemaFromZod(z =>
+      z.object({
+        // TODO: Define how the icon can be configurable
+        title: z.string().optional(),
+        lineClamp: z.number().default(5),
+        asLink: z.boolean().default(true),
+        asListItem: z.boolean().default(true),
+        noTrack: z.boolean().default(false),
+      }),
+    ),
+    predicate: result => result.type === 'techdocs',
+    component: async ({ config }) => {
+      const { TechDocsSearchResultListItem } = await import(
+        './search/components/TechDocsSearchResultListItem'
+      );
+      return props => <TechDocsSearchResultListItem {...props} {...config} />;
+    },
+  });
+
+/**
+ * Responsible for rendering the provided router element
+ *
+ * @alpha
+ */
+const TechDocsIndexPage = createPageExtension({
+  id: 'plugin.techdocs.indexPage',
+  defaultPath: '/docs',
+  routeRef: convertLegacyRouteRef(rootRouteRef),
+  loader: () =>
+    import('./home/components/TechDocsIndexPage').then(m => (
+      <m.TechDocsIndexPage />
+    )),
+});
+
+/**
+ * Component responsible for composing a TechDocs reader page experience
+ *
+ * @alpha
+ */
+const TechDocsReaderPage = createPageExtension({
+  id: 'plugin.techdocs.readerPage',
+  defaultPath: '/docs/:namespace/:kind/:name',
+  routeRef: convertLegacyRouteRef(rootDocsRouteRef),
+  loader: () =>
+    import('./reader/components/TechDocsReaderPage').then(m => (
+      <m.TechDocsReaderPage />
+    )),
+});
+
+/** @alpha */
+const TechDocsNavItem = createNavItemExtension({
+  id: 'plugin.techdocs.nav.index',
+  icon: LibraryBooks,
+  title: 'Docs',
+  routeRef: convertLegacyRouteRef(rootRouteRef),
+});
+
+/** @alpha */
 export default createPlugin({
   id: 'techdocs',
   extensions: [
-    TechDocsIndexPage,
-    TechDocsReaderPage,
     techDocsClient,
     techDocsStorage,
+    TechDocsNavItem,
+    TechDocsIndexPage,
+    TechDocsReaderPage,
     TechDocsSearchResultListItemExtension,
   ],
   routes: {
     root: convertLegacyRouteRef(rootRouteRef),
     docRoot: convertLegacyRouteRef(rootDocsRouteRef),
+    entityContent: convertLegacyRouteRef(rootCatalogDocsRouteRef),
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Export `TechDocs` routes to be used by external `Catalog` plugin routes in this other pull request: https://github.com/backstage/backstage/pull/20355/files#diff-9f1faf3645c1286627892aa7c28e4a89ce08134719b54cebfd8c492f9c618e7dR81.

Additionally, some minor adjustments were made:
- fix `techdocs` reader route paths and references
- create a `techdocs` nav item extension

https://github.com/backstage/backstage/assets/6290749/c96a55fb-5c7d-4a12-83d7-a90da899b4a3

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
