### PR TITLE
Limit the use of the duplicate bazaar project title when adding a project

### DIFF
--- a/.changeset/little-clocks-yell.md
+++ b/.changeset/little-clocks-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Limit the use of the duplicate bazaar project title when adding a project

--- a/plugins/bazaar/src/components/InputField/InputField.tsx
+++ b/plugins/bazaar/src/components/InputField/InputField.tsx
@@ -36,6 +36,7 @@ type Props = {
   helperText?: string;
   placeholder?: string;
   rules?: Rules | undefined;
+  customValidation?: (value: string) => true | string;
 };
 
 export const InputField = ({
@@ -45,6 +46,7 @@ export const InputField = ({
   helperText,
   placeholder,
   rules,
+  customValidation,
 }: Props) => {
   const label =
     inputType.charAt(0).toLocaleUpperCase('en-US') + inputType.slice(1);
@@ -53,7 +55,10 @@ export const InputField = ({
     <Controller
       name={inputType}
       control={control}
-      rules={rules}
+      rules={{
+        ...rules,
+        validate: customValidation,
+      }}
       render={({ field }) => (
         <TextField
           {...field}

--- a/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
+++ b/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
@@ -128,7 +128,7 @@ export const ProjectDialog = ({
             control={control}
             rules={{
               required: true,
-              validate: titleIsUnique,
+              customValidation: titleIsUnique,
             }}
             inputType="title"
             helperText={helperText}

--- a/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
+++ b/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
@@ -128,8 +128,8 @@ export const ProjectDialog = ({
             control={control}
             rules={{
               required: true,
-              customValidation: titleIsUnique,
             }}
+            customValidation={titleIsUnique}
             inputType="title"
             helperText={helperText}
           />

--- a/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
+++ b/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
@@ -75,7 +75,9 @@ export const ProjectDialog = ({
   const titleIsUnique = (name: string) => {
     if (
       name !== defaultValues.title &&
-      bazaarProject.value.data.some(bazaarTitle => bazaarTitle.title === name)
+      bazaarProject.value.data.some(
+        (bazaarTitle: { title: string }) => bazaarTitle.title === name,
+      )
     ) {
       return 'A Bazaar project with this title already exists';
     }
@@ -100,7 +102,8 @@ export const ProjectDialog = ({
     if (errors.title.type === 'required') {
       helperText = 'Please enter a title for your project';
     } else {
-      helperText = errors.title.message;
+      helperText =
+        errors.title.message ?? 'Please enter a title for your project';
     }
   }
 


### PR DESCRIPTION

## Hey, I just made a Pull Request!

When adding a project in a bazaar plugin its should not accept the duplicate project name (which already exist)

limiting the duplicate bazaar project title will help user to avoid the confusions 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
