### PR TITLE
Adding descending sort (Z-A) in a bazaar plugin 

### DIFF
--- a/.changeset/heavy-rings-play.md
+++ b/.changeset/heavy-rings-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Adding decending sort in a bazaar plugin

--- a/.changeset/heavy-rings-play.md
+++ b/.changeset/heavy-rings-play.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-bazaar': patch
 ---
 
-Adding decending sort in a bazaar plugin
+Adding descending sort in a bazaar plugin

--- a/plugins/bazaar/src/components/SortMethodSelector/SortMethodSelector.tsx
+++ b/plugins/bazaar/src/components/SortMethodSelector/SortMethodSelector.tsx
@@ -50,7 +50,8 @@ export const SortMethodSelector = ({
       >
         <MenuItem value={0}>Latest updated</MenuItem>
         <MenuItem value={1}>A-Z</MenuItem>
-        <MenuItem value={2}>Most members</MenuItem>
+        <MenuItem value={2}>Z-A</MenuItem>
+        <MenuItem value={3}>Most members</MenuItem>
       </Select>
     </FormControl>
   );

--- a/plugins/bazaar/src/components/SortView/SortView.tsx
+++ b/plugins/bazaar/src/components/SortView/SortView.tsx
@@ -31,7 +31,7 @@ import {
   sortByDate,
   sortByMembers,
   sortByTitle,
-  sortByDecendingTitle,
+  sortByTitleDescending,
 } from '../../util/sortMethods';
 import { SortMethodSelector } from '../SortMethodSelector';
 import { fetchCatalogItems } from '../../util/fetchMethods';
@@ -86,7 +86,7 @@ export const SortView = (props: SortViewProps) => {
   const sortMethods = [
     sortByDate,
     sortByTitle,
-    sortByDecendingTitle,
+    sortByTitleDescending,
     sortByMembers,
   ];
   const [sortMethodNbr, setSortMethodNbr] = useState(0);

--- a/plugins/bazaar/src/components/SortView/SortView.tsx
+++ b/plugins/bazaar/src/components/SortView/SortView.tsx
@@ -27,7 +27,12 @@ import { BazaarProject } from '../../types';
 import { bazaarApiRef } from '../../api';
 import { Alert } from '@material-ui/lab';
 import SearchBar from 'material-ui-search-bar';
-import { sortByDate, sortByMembers, sortByTitle } from '../../util/sortMethods';
+import {
+  sortByDate,
+  sortByMembers,
+  sortByTitle,
+  sortByDecendingTitle,
+} from '../../util/sortMethods';
 import { SortMethodSelector } from '../SortMethodSelector';
 import { fetchCatalogItems } from '../../util/fetchMethods';
 import { parseBazaarProject } from '../../util/parseMethods';
@@ -78,7 +83,12 @@ export const SortView = (props: SortViewProps) => {
   const bazaarApi = useApi(bazaarApiRef);
   const catalogApi = useApi(catalogApiRef);
   const classes = useStyles();
-  const sortMethods = [sortByDate, sortByTitle, sortByMembers];
+  const sortMethods = [
+    sortByDate,
+    sortByTitle,
+    sortByDecendingTitle,
+    sortByMembers,
+  ];
   const [sortMethodNbr, setSortMethodNbr] = useState(0);
   const [openAdd, setOpenAdd] = useState(false);
   const [searchValue, setSearchValue] = useState('');

--- a/plugins/bazaar/src/util/sortMethods.ts
+++ b/plugins/bazaar/src/util/sortMethods.ts
@@ -35,6 +35,15 @@ export const sortByTitle = (a: BazaarProject, b: BazaarProject) => {
   return 0;
 };
 
+export const sortByDecendingTitle = (a: BazaarProject, b: BazaarProject) => {
+  if (a.title < b.title) {
+    return 1;
+  } else if (a.title > b.title) {
+    return -1;
+  }
+  return 0;
+};
+
 export const sortByMembers = (a: BazaarProject, b: BazaarProject) => {
   return b.membersCount - a.membersCount;
 };

--- a/plugins/bazaar/src/util/sortMethods.ts
+++ b/plugins/bazaar/src/util/sortMethods.ts
@@ -27,21 +27,11 @@ export const sortByDate = (a: BazaarProject, b: BazaarProject): number => {
 };
 
 export const sortByTitle = (a: BazaarProject, b: BazaarProject) => {
-  if (a.title < b.title) {
-    return -1;
-  } else if (a.title > b.title) {
-    return 1;
-  }
-  return 0;
+  return a.title.localeCompare(b.title);
 };
 
 export const sortByDecendingTitle = (a: BazaarProject, b: BazaarProject) => {
-  if (a.title < b.title) {
-    return 1;
-  } else if (a.title > b.title) {
-    return -1;
-  }
-  return 0;
+  return b.title.localeCompare(a.title);
 };
 
 export const sortByMembers = (a: BazaarProject, b: BazaarProject) => {

--- a/plugins/bazaar/src/util/sortMethods.ts
+++ b/plugins/bazaar/src/util/sortMethods.ts
@@ -30,7 +30,7 @@ export const sortByTitle = (a: BazaarProject, b: BazaarProject) => {
   return a.title.localeCompare(b.title);
 };
 
-export const sortByDecendingTitle = (a: BazaarProject, b: BazaarProject) => {
+export const sortByTitleDescending = (a: BazaarProject, b: BazaarProject) => {
   return b.title.localeCompare(a.title);
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By default bazaar plugin project have sorting 

![Default sort](https://github.com/backstage/backstage/assets/133481507/e15e95d2-bd21-4269-9e4e-11365a6ea299)

Adding  descending sort (Z-A) will help some users and improve user experience

![Z-A sort](https://github.com/backstage/backstage/assets/133481507/03e0f236-e45f-4329-8218-97b451633872)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
