### PR TITLE
.github/workflows: remove runner hardening from test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,11 +196,6 @@ jobs:
       INTEGRATION_TEST_AZURE_TOKEN: ${{ secrets.INTEGRATION_TEST_AZURE_TOKEN }}
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@v3.6.0
       - name: fetch branch master
         run: git fetch origin master

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -60,11 +60,6 @@ jobs:
       INTEGRATION_TEST_AZURE_TOKEN: ${{ secrets.INTEGRATION_TEST_AZURE_TOKEN }}
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@v3.6.0
 
       - name: use node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Unfortunately test have been consistently broken since #20090 was merged. Starting by removing the runner hardening only for full test runs on Linux to see if that fixes it.