### PR TITLE
Add current and defaultScopes when refreshing session

### DIFF
--- a/.changeset/red-yaks-press.md
+++ b/.changeset/red-yaks-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Add current and default scopes when refreshing session

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -44,9 +44,7 @@ describe('MicrosoftAuth', () => {
             return res(
               ctx.json({
                 providerInfo: {
-                  accessToken: scopeParam
-                    ? 'tokenForOtherResource'
-                    : 'tokenForGrantScopes',
+                  accessToken: `token:${scopeParam}`,
                   scope: scopeParam || 'grant-resource/scope',
                 },
               }),
@@ -59,7 +57,9 @@ describe('MicrosoftAuth', () => {
     it('gets access token with requested scopes for grant', async () => {
       const accessToken = await microsoftAuth.getAccessToken();
 
-      expect(accessToken).toEqual('tokenForGrantScopes');
+      expect(accessToken).toEqual(
+        'token:openid offline_access profile email User.Read',
+      );
     });
 
     it('gets access token for other consented scopes besides those directly granted', async () => {
@@ -67,7 +67,7 @@ describe('MicrosoftAuth', () => {
         'azure-resource/scope',
       );
 
-      expect(accessToken).toEqual('tokenForOtherResource');
+      expect(accessToken).toEqual('token:azure-resource/scope offline_access');
     });
 
     it('fails when requesting scopes for multiple resources at once', async () => {
@@ -86,7 +86,7 @@ describe('MicrosoftAuth', () => {
       );
 
       await expect(accessTokenPromise).resolves.toEqual(
-        'tokenForOtherResource',
+        'token:same-resource/one-scope same-resource/other-scope offline_access',
       );
     });
   });

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
@@ -47,7 +47,7 @@ describe('RefreshingAuthSessionManager', () => {
     await manager.getSession({});
     expect(createSession).toHaveBeenCalledTimes(1);
 
-    expect(refreshSession).toHaveBeenCalledWith(undefined);
+    expect(refreshSession).toHaveBeenCalledWith(new Set());
     expect(stateSubscriber.mock.calls).toEqual([
       [SessionState.SignedOut],
       [SessionState.SignedIn],
@@ -134,7 +134,7 @@ describe('RefreshingAuthSessionManager', () => {
 
     expect(await manager.getSession({ optional: true })).toBe(undefined);
     expect(createSession).toHaveBeenCalledTimes(0);
-    expect(refreshSession).toHaveBeenCalledWith(undefined);
+    expect(refreshSession).toHaveBeenCalledWith(new Set());
   });
 
   it('should forward option to instantly show auth popup and not attempt refresh', async () => {

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -137,7 +137,9 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
       return this.refreshPromise;
     }
 
-    this.refreshPromise = this.connector.refreshSession(scopes);
+    this.refreshPromise = this.connector.refreshSession(
+      this.helper.getExtendedScope(this.currentSession, scopes),
+    );
 
     try {
       const session = await this.refreshPromise;


### PR DESCRIPTION
Otherwise google auth always fails, as it lacks userinfo.profile

## Hey, I just made a Pull Request!

Was fighting with k8s plugin + google auth.
It turned out, that when refreshing session only explicitly provided scopes are taken into account.
I do not know whether this is google's quirk, or a standard.
Without this, user needs to provide auth information on every page refresh.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
