### PR TITLE
Replaced mock-fs in scaffolder rails

### DIFF
--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -39,13 +39,12 @@
     "fs-extra": "^10.0.1"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^9.0.1",
-    "@types/mock-fs": "^4.13.0",
     "@types/node": "^18.17.8",
-    "jest-when": "^3.1.0",
-    "mock-fs": "^5.2.0"
+    "jest-when": "^3.1.0"
   },
   "files": [
     "dist"

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
@@ -73,9 +73,6 @@ describe('fetch:rails', () => {
     createTemporaryDirectory: jest.fn().mockResolvedValue(mockTmpDir),
   };
 
-  mockDir.clear();
-  mockDir.addContent({ template: {} });
-
   const mockReader: UrlReader = {
     readUrl: jest.fn(),
     readTree: jest.fn(),
@@ -93,7 +90,7 @@ describe('fetch:rails', () => {
   });
 
   beforeEach(() => {
-    mockDir.addContent({
+    mockDir.setContent({
       result: '{}',
     });
     jest.clearAllMocks();

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
@@ -34,14 +34,14 @@ import {
 } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { ScmIntegrations } from '@backstage/integration';
-import mockFs from 'mock-fs';
-import os from 'os';
 import { resolve as resolvePath } from 'path';
 import { PassThrough } from 'stream';
 import { createFetchRailsAction } from './index';
 import { fetchContents } from '@backstage/plugin-scaffolder-node';
+import { createMockDirectory } from '@backstage/backend-test-utils';
 
 describe('fetch:rails', () => {
+  const mockDir = createMockDirectory();
   const integrations = ScmIntegrations.fromConfig(
     new ConfigReader({
       integrations: {
@@ -53,7 +53,7 @@ describe('fetch:rails', () => {
     }),
   );
 
-  const mockTmpDir = os.tmpdir();
+  const mockTmpDir = mockDir.path;
   const mockContext = {
     input: {
       url: 'https://rubyonrails.org/generator',
@@ -73,6 +73,9 @@ describe('fetch:rails', () => {
     createTemporaryDirectory: jest.fn().mockResolvedValue(mockTmpDir),
   };
 
+  mockDir.clear();
+  mockDir.addContent({ template: {} });
+
   const mockReader: UrlReader = {
     readUrl: jest.fn(),
     readTree: jest.fn(),
@@ -90,12 +93,10 @@ describe('fetch:rails', () => {
   });
 
   beforeEach(() => {
-    mockFs({ [`${mockContext.workspacePath}/result`]: {} });
+    mockDir.addContent({
+      result: '{}',
+    });
     jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    mockFs.restore();
   });
 
   it('should call fetchContents with the correct values', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8494,6 +8494,7 @@ __metadata:
   resolution: "@backstage/plugin-scaffolder-backend-module-rails@workspace:plugins/scaffolder-backend-module-rails"
   dependencies:
     "@backstage/backend-common": "workspace:^"
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
@@ -8502,12 +8503,10 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@types/command-exists": ^1.2.0
     "@types/fs-extra": ^9.0.1
-    "@types/mock-fs": ^4.13.0
     "@types/node": ^18.17.8
     command-exists: ^1.2.9
     fs-extra: ^10.0.1
     jest-when: ^3.1.0
-    mock-fs: ^5.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Removes usage of mock-fs from the tests in the "plugin-scaffolder-backend-module-rails" package. See https://github.com/backstage/backstage/issues/20436.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
