### PR TITLE
Backport HAS_REACT_DOM_CLIENT support to previous minor CLI version

### DIFF
--- a/.changeset/eleven-hounds-invent.md
+++ b/.changeset/eleven-hounds-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+In frontend builds and tests `process.env.HAS_REACT_DOM_CLIENT` will now be defined if `react-dom/client` is present, i.e. if using React 18. This allows for conditional imports of `react-dom/client`.

--- a/.changeset/eleven-hounds-invent.md
+++ b/.changeset/eleven-hounds-invent.md
@@ -1,5 +1,0 @@
----
-'@backstage/cli': patch
----
-
-In frontend builds and tests `process.env.HAS_REACT_DOM_CLIENT` will now be defined if `react-dom/client` is present, i.e. if using React 18. This allows for conditional imports of `react-dom/client`.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.18.4",
+  "version": "1.18.5",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/cli
 
+## 0.22.14
+
+### Patch Changes
+
+- 48c94f8309ec: In frontend builds and tests `process.env.HAS_REACT_DOM_CLIENT` will now be defined if `react-dom/client` is present, i.e. if using React 18. This allows for conditional imports of `react-dom/client`.
+
 ## 0.22.13
 
 ### Patch Changes

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -24,6 +24,13 @@ const envOptions = {
   oldTests: Boolean(process.env.BACKSTAGE_OLD_TESTS),
 };
 
+try {
+  require.resolve('react-dom/client');
+  process.env.HAS_REACT_DOM_CLIENT = true;
+} catch {
+  /* ignored */
+}
+
 const transformIgnorePattern = [
   '@material-ui',
   'ajv',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "0.22.13",
+  "version": "0.22.14",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -81,6 +81,15 @@ async function readBuildInfo() {
   };
 }
 
+function hasReactDomClient() {
+  try {
+    require.resolve('react-dom/client');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function createConfig(
   paths: BundlingPaths,
   options: BundlingOptions,
@@ -136,6 +145,9 @@ export async function createConfig(
         () => JSON.stringify(options.getFrontendAppConfigs()),
         true,
       ),
+      // This allows for conditional imports of react-dom/client, since there's no way
+      // to check for presence of it in source code without module resolution errors.
+      'process.env.HAS_REACT_DOM_CLIENT': JSON.stringify(hasReactDomClient()),
     }),
   );
 


### PR DESCRIPTION
This release introduces support for the conditional `process.env.HAS_REACT_DOM_CLIENT` to older versions of the Backstage CLI. Allowing it to work with newer versions of the TechDocs plugin.