### PR TITLE
docs(auth): fix links to repository in `README.md`

### DIFF
--- a/.changeset/forty-monkeys-lay.md
+++ b/.changeset/forty-monkeys-lay.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+---
+
+Fix link to the repository in `README.md`.

--- a/plugins/auth-backend-module-gitlab-provider/README.md
+++ b/plugins/auth-backend-module-gitlab-provider/README.md
@@ -4,5 +4,5 @@ This module provides an GitLab auth provider implementation for `@backstage/plug
 
 ## Links
 
-- [Repository](https://gitlab.com/backstage/backstage/tree/master/plugins/auth-backend-module-gitlab-provider)
+- [Repository](https://github.com/backstage/backstage/tree/master/plugins/auth-backend-module-gitlab-provider)
 - [Backstage Project Homepage](https://backstage.io)

--- a/plugins/auth-backend-module-microsoft-provider/README.md
+++ b/plugins/auth-backend-module-microsoft-provider/README.md
@@ -1,8 +1,8 @@
 # Auth Module: Microsoft Provider
 
-This module provides an Microsoft auth provider implementation for `@backstage/plugin-auth-backend`.
+This module provides a Microsoft auth provider implementation for `@backstage/plugin-auth-backend`.
 
 ## Links
 
-- [Repository](https://gitlab.com/backstage/backstage/tree/master/plugins/auth-backend-module-microsoft-provider)
+- [Repository](https://github.com/backstage/backstage/tree/master/plugins/auth-backend-module-microsoft-provider)
 - [Backstage Project Homepage](https://backstage.io)

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -32,7 +32,7 @@ import {
 } from '@backstage/plugin-auth-backend-module-microsoft-provider';
 
 /**
- * Auth provider integration for GitLab auth
+ * Auth provider integration for Microsoft auth
  *
  * @public
  */


### PR DESCRIPTION
Fix links at the `README.md` files
of the GitLab auth provider and Microsoft auth provider.

Additionally, the wrong provider name was used at auth-backend within code documentation related to the Microsoft provider.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
