### PR TITLE
docs: mention flag for using software templates on Node 20

### DIFF
--- a/docs/features/software-templates/index.md
+++ b/docs/features/software-templates/index.md
@@ -20,6 +20,11 @@ locations like GitHub or GitLab.
 > Be sure to have covered
 > [Getting Started with Backstage](../../getting-started) before proceeding.
 
+> Note: if you're running Backstage with Node 20 or later, you'll need to pass the flag `--no-node-snapshot` to Node in order to
+> use the templates feature.
+> One way to do this is to specify the `NODE_OPTIONS` environment variable before starting Backstage:
+> `export NODE_OPTIONS=--no-node-snapshot`
+
 The Software Templates are available under `/create`. For local development you
 should be able to reach them at `http://localhost:3000/create`.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a brief note to the docs about a required flag (`--no-node-snapshot`) for using the software templates with Node 20. There's a bit more detail on the issue in #20661

Closes #20661

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
