### PR TITLE
fix(configLoader): properly resolve targets into absolute paths

### DIFF
--- a/.changeset/chatty-cobras-cheer.md
+++ b/.changeset/chatty-cobras-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Correctly resolve config targets into absolute paths

--- a/packages/config-loader/src/sources/ConfigSources.test.ts
+++ b/packages/config-loader/src/sources/ConfigSources.test.ts
@@ -95,6 +95,14 @@ describe('ConfigSources', () => {
       ),
     ).toEqual([{ name: 'FileConfigSource', path: '/config.yaml' }]);
 
+    expect(
+      mergeSources(
+        ConfigSources.defaultForTargets({
+          targets: [{ type: 'path', target: 'config.yaml' }],
+        }),
+      ),
+    ).toEqual([{ name: 'FileConfigSource', path: resolvePath('config.yaml') }]);
+
     const subFunc = async () => undefined;
     expect(
       mergeSources(
@@ -172,8 +180,8 @@ describe('ConfigSources', () => {
         }),
       ),
     ).toEqual([
-      { name: 'FileConfigSource', path: 'a.yaml' },
-      { name: 'FileConfigSource', path: 'b.yaml' },
+      { name: 'FileConfigSource', path: resolvePath('a.yaml') },
+      { name: 'FileConfigSource', path: resolvePath('b.yaml') },
       { name: 'EnvConfigSource', env: { HOME: '/' } },
     ]);
   });

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -161,7 +161,7 @@ export class ConfigSources {
       }
       return FileConfigSource.create({
         watch: options.watch,
-        path: arg.target,
+        path: resolvePath(arg.target),
         substitutionFunc: options.substitutionFunc,
       });
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue with loading custom configs in the new backend system setup supplied through command line args eg. `--config my-app-config.yaml`.

In the old setup, configs are loaded via calling `loadBackendConfig`:
https://github.com/backstage/backstage/blob/4996c0d0c35cb14654b60b36984454d7c7939d5b/packages/backend/src/index.ts#L135-L138
and when passed an app config through args it will correctly resolve them into absolute paths and load correctly:
https://github.com/backstage/backstage/blob/4996c0d0c35cb14654b60b36984454d7c7939d5b/packages/backend-app-api/src/config/config.ts#L77-L81


In the new system, config loading is handled by the `rootConfig` service which calls `ConfigSources.default` directly:
https://github.com/backstage/backstage/blob/4996c0d0c35cb14654b60b36984454d7c7939d5b/packages/backend-app-api/src/services/implementations/config/rootConfigServiceFactory.ts#L45-L48

`ConfigSources.default` will parse `process.argv` by default and eventually creates `FileConfigSource` objects:
https://github.com/backstage/backstage/blob/4996c0d0c35cb14654b60b36984454d7c7939d5b/packages/config-loader/src/sources/ConfigSources.ts#L208-L212
https://github.com/backstage/backstage/blob/4996c0d0c35cb14654b60b36984454d7c7939d5b/packages/config-loader/src/sources/ConfigSources.ts#L162-L166
which at this point passes raw non-absolute path targets eg. `my-app-config.yaml` and causes `FileConfigSource` to throw:
https://github.com/backstage/backstage/blob/4996c0d0c35cb14654b60b36984454d7c7939d5b/packages/config-loader/src/sources/FileConfigSource.ts#L88-L91


This fix ensures that paths given via command args are always resolved as absolute paths to avoid the `FileConfigSource` error. Also side note that this bug seemed like it would've been caught in existing unit test but `FileConfigSource` was stubbed out which hide the issue. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
