### PR TITLE
fix(create-app): Logic bug about suggesting Yarn install

### DIFF
--- a/.changeset/real-jars-yawn.md
+++ b/.changeset/real-jars-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+If create app installs dependencies, don't suggest to user that they also need to do it.

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -131,7 +131,7 @@ export default async (opts: OptionValues): Promise<void> => {
     );
     Task.log();
     Task.section('All set! Now you might want to');
-    if (!opts.skipInstall) {
+    if (opts.skipInstall) {
       Task.log(
         `  Install the dependencies: ${chalk.cyan(
           `cd ${opts.path ?? answers.name} && yarn install`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When using the Create App, I realized it suggested to me that I should install dependencies when I had just watched it do so. I thought I'd go in to add a way to skip that message, and realized that skip code was already there. But I think it was just a minor negative logic bug? So quick fix here.

Here's what I see currently with `npx @backstage/create-app` with the defaults:

```
Installing dependencies:
  init          git repository ✔ 
  determining   yarn version ✔ 
  executing     yarn install ✔ 
  executing     yarn tsc ✔ 

🥇  Successfully created backstage-adam-created


 All set! Now you might want to:
  Install the dependencies: cd backstage-adam-created && yarn install
  Run the app: cd backstage-adam-created && yarn dev
  Set up the software catalog: https://backstage.io/docs/features/software-catalog/configuration
  Add authentication: https://backstage.io/docs/auth/
```

And when I run `npx @backstage/create-app --skip-install`,

```
  copying       EntityPage.tsx ✔ 
  copying       SearchPage.tsx ✔ 

 Moving to final location:
  moving        backstage-adam-skip-install ✔ 
  init          git repository ◜ 
🥇  Successfully created backstage-adam-skip-install


 All set! Now you might want to:
  Run the app: cd backstage-adam-skip-install && yarn dev
  Set up the software catalog: https://backstage.io/docs/features/software-catalog/configuration
  Add authentication: https://backstage.io/docs/auth/
```

No reminder to install. 

As a first time user, I'd hope the create does it all for me, and then doesn't need to remind me to install the dependencies. Sort of my short circuit to getting started. But a more advanced user might want to skip the dependency install, and that's where we'd want to remind them I believe.

So this fixes that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
