### PR TITLE
catalog: add basic support for default and configured filters for entity page content

### DIFF
--- a/packages/app-next/app-config.yaml
+++ b/packages/app-next/app-config.yaml
@@ -10,10 +10,15 @@ app:
     - apis.plugin.graphiql.browse.gitlab: true
 
     # Entity page cards
-    - 'entity.cards.about'
+    - entity.cards.about
+    - entity.cards.labels
+    - entity.cards.links:
+        config:
+          filter:
+            - isKind: component
 
     # Entity page content
-    - 'entity.content.techdocs'
+    - entity.content.techdocs
 
   # scmAuthExtension: >-
   #   createScmAuthExtension({

--- a/plugins/catalog-react/alpha-api-report.md
+++ b/plugins/catalog-react/alpha-api-report.md
@@ -10,13 +10,11 @@ import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { Extension } from '@backstage/frontend-plugin-api';
 import { ExtensionInputValues } from '@backstage/frontend-plugin-api';
-import { PortableSchema } from '@backstage/frontend-plugin-api';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 
 // @alpha (undocumented)
 export function createEntityCardExtension<
-  TConfig,
   TInputs extends AnyExtensionInputMap,
 >(options: {
   id: string;
@@ -26,48 +24,57 @@ export function createEntityCardExtension<
   };
   disabled?: boolean;
   inputs?: TInputs;
-  configSchema?: PortableSchema<TConfig>;
+  filter?: (ctx: { entity: Entity }) => boolean;
   loader: (options: {
-    config: TConfig;
     inputs: Expand<ExtensionInputValues<TInputs>>;
   }) => Promise<JSX.Element>;
-}): Extension<TConfig>;
+}): Extension<{
+  filter?:
+    | {
+        isKind?: string | undefined;
+        isType?: string | undefined;
+      }[]
+    | undefined;
+}>;
 
 // @alpha (undocumented)
 export function createEntityContentExtension<
-  TConfig extends {
-    path: string;
-    title: string;
-  },
   TInputs extends AnyExtensionInputMap,
->(
-  options: (
-    | {
-        defaultPath: string;
-        defaultTitle: string;
-      }
-    | {
-        configSchema: PortableSchema<TConfig>;
-      }
-  ) & {
+>(options: {
+  id: string;
+  attachTo?: {
     id: string;
-    attachTo?: {
-      id: string;
-      input: string;
-    };
-    disabled?: boolean;
-    inputs?: TInputs;
-    routeRef?: RouteRef;
-    loader: (options: {
-      config: TConfig;
-      inputs: Expand<ExtensionInputValues<TInputs>>;
-    }) => Promise<JSX.Element>;
-  },
-): Extension<TConfig>;
+    input: string;
+  };
+  disabled?: boolean;
+  inputs?: TInputs;
+  routeRef?: RouteRef;
+  defaultPath: string;
+  defaultTitle: string;
+  filter?: (ctx: { entity: Entity }) => boolean;
+  loader: (options: {
+    inputs: Expand<ExtensionInputValues<TInputs>>;
+  }) => Promise<JSX.Element>;
+}): Extension<{
+  title: string;
+  path: string;
+  filter?:
+    | {
+        isKind?: string | undefined;
+        isType?: string | undefined;
+      }[]
+    | undefined;
+}>;
 
 // @alpha (undocumented)
 export const entityContentTitleExtensionDataRef: ConfigurableExtensionDataRef<
   string,
+  {}
+>;
+
+// @alpha (undocumented)
+export const entityFilterExtensionDataRef: ConfigurableExtensionDataRef<
+  (ctx: { entity: Entity }) => boolean,
   {}
 >;
 

--- a/plugins/catalog/src/alpha/EntityOverviewPage.tsx
+++ b/plugins/catalog/src/alpha/EntityOverviewPage.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
+import Grid from '@material-ui/core/Grid';
+
+interface EntityOverviewPageProps {
+  cards: Array<{
+    element: React.JSX.Element;
+    filter: (ctx: { entity: Entity }) => boolean;
+  }>;
+}
+
+export function EntityOverviewPage(props: EntityOverviewPageProps) {
+  const { entity } = useEntity();
+  return (
+    <Grid container spacing={3} alignItems="stretch">
+      {props.cards
+        .filter(card => card.filter({ entity }))
+        .map(card => (
+          <Grid item md={6} xs={12}>
+            {card.element}
+          </Grid>
+        ))}
+    </Grid>
+  );
+}

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -27,6 +27,7 @@ export const EntityAboutCard = createEntityCardExtension({
 
 export const EntityLinksCard = createEntityCardExtension({
   id: 'links',
+  filter: ({ entity }) => Boolean(entity.metadata.links),
   loader: async () =>
     import('../components/EntityLinksCard').then(m => {
       return <m.EntityLinksCard variant="gridItem" />;
@@ -35,6 +36,7 @@ export const EntityLinksCard = createEntityCardExtension({
 
 export const EntityLabelsCard = createEntityCardExtension({
   id: 'labels',
+  filter: ({ entity }) => Boolean(entity.metadata.labels),
   loader: async () =>
     import('../components/EntityLabelsCard').then(m => (
       <m.EntityLabelsCard variant="gridItem" />

--- a/plugins/catalog/src/alpha/entityContents.tsx
+++ b/plugins/catalog/src/alpha/entityContents.tsx
@@ -15,12 +15,14 @@
  */
 
 import React from 'react';
-import { Grid } from '@material-ui/core';
 import {
   coreExtensionData,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
-import { createEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
+import {
+  createEntityContentExtension,
+  entityFilterExtensionDataRef,
+} from '@backstage/plugin-catalog-react/alpha';
 
 export const OverviewEntityContent = createEntityContentExtension({
   id: 'overview',
@@ -30,17 +32,13 @@ export const OverviewEntityContent = createEntityContentExtension({
   inputs: {
     cards: createExtensionInput({
       element: coreExtensionData.reactElement,
+      filter: entityFilterExtensionDataRef,
     }),
   },
-  loader: async ({ inputs }) => (
-    <Grid container spacing={3} alignItems="stretch">
-      {inputs.cards.map(card => (
-        <Grid item md={6} xs={12}>
-          {card.element}
-        </Grid>
-      ))}
-    </Grid>
-  ),
+  loader: async ({ inputs }) =>
+    import('./EntityOverviewPage').then(m => (
+      <m.EntityOverviewPage cards={inputs.cards} />
+    )),
 });
 
 export default [OverviewEntityContent];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just the initial building blocks really. We had to remove the config schema from entity page contents as our config merging isn't built out enough yet.

The `isKind` and `isType` filter format is just *something* to get us started, not set in stone at all.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
