### PR TITLE
[DI] Migrate catalog entity cards

### DIFF
--- a/.changeset/fast-bears-lick.md
+++ b/.changeset/fast-bears-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Migrate catalog entity cards to new frontend system extension format.

--- a/plugins/catalog/src/alpha/apis.tsx
+++ b/plugins/catalog/src/alpha/apis.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createApiFactory,
+  discoveryApiRef,
+  fetchApiRef,
+  storageApiRef,
+} from '@backstage/core-plugin-api';
+import { CatalogClient } from '@backstage/catalog-client';
+import { createApiExtension } from '@backstage/frontend-plugin-api';
+import {
+  catalogApiRef,
+  starredEntitiesApiRef,
+} from '@backstage/plugin-catalog-react';
+import { DefaultStarredEntitiesApi } from '../apis';
+
+export const CatalogApi = createApiExtension({
+  factory: createApiFactory({
+    api: catalogApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      fetchApi: fetchApiRef,
+    },
+    factory: ({ discoveryApi, fetchApi }) =>
+      new CatalogClient({ discoveryApi, fetchApi }),
+  }),
+});
+
+export const StarredEntitiesApi = createApiExtension({
+  factory: createApiFactory({
+    api: starredEntitiesApiRef,
+    deps: { storageApi: storageApiRef },
+    factory: ({ storageApi }) => new DefaultStarredEntitiesApi({ storageApi }),
+  }),
+});
+
+export default [CatalogApi, StarredEntitiesApi];

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { createEntityCardExtension } from '@backstage/plugin-catalog-react/alpha';
+import { createSchemaFromZod } from '@backstage/frontend-plugin-api';
+
+export const EntityAboutCard = createEntityCardExtension({
+  id: 'about',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/AboutCard').then(m => (
+      <m.AboutCard variant={config.variant} />
+    )),
+});
+
+export const EntityLinksCard = createEntityCardExtension({
+  id: 'links',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).optional(),
+      cols: z
+        .union([
+          z.number(),
+          z.object({
+            xs: z.number(),
+            sm: z.number(),
+            md: z.number(),
+            lg: z.number(),
+            xl: z.number(),
+          }),
+        ])
+        .optional(),
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/EntityLinksCard').then(m => {
+      return <m.EntityLinksCard variant={config.variant} cols={config.cols} />;
+    }),
+});
+
+export const EntityLabelsCard = createEntityCardExtension({
+  id: 'labels',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).optional(),
+      title: z.string().optional(),
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/EntityLabelsCard').then(m => (
+      <m.EntityLabelsCard variant={config.variant} title={config.title} />
+    )),
+});
+
+export const EntityDependsOnComponentsCard = createEntityCardExtension({
+  id: 'dependsOn.components',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+      title: z.string().optional(),
+      // TODO: columns, tableOptions
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/DependsOnComponentsCard').then(m => (
+      <m.DependsOnComponentsCard
+        variant={config.variant}
+        title={config.title}
+      />
+    )),
+});
+
+export const EntityDependsOnResourcesCard = createEntityCardExtension({
+  id: 'dependsOn.resources',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+      title: z.string().optional(),
+      // TODO: columns, tableOptions
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/DependsOnResourcesCard').then(m => (
+      <m.DependsOnResourcesCard variant={config.variant} title={config.title} />
+    )),
+});
+
+export const EntityHasComponentsCard = createEntityCardExtension({
+  id: 'has.components',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+      title: z.string().optional(),
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/HasComponentsCard').then(m => (
+      <m.HasComponentsCard variant={config.variant} title={config.title} />
+    )),
+});
+
+export const EntityHasResourcesCard = createEntityCardExtension({
+  id: 'has.resources',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+      title: z.string().optional(),
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/HasResourcesCard').then(m => (
+      <m.HasResourcesCard variant={config.variant} title={config.title} />
+    )),
+});
+
+export const EntityHasSubcomponentsCard = createEntityCardExtension({
+  id: 'has.subcomponents',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+      title: z.string().optional(),
+      // TODO: tableOptions
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/HasSubcomponentsCard').then(m => (
+      <m.HasSubcomponentsCard variant={config.variant} title={config.title} />
+    )),
+});
+
+export const EntityHasSystemsCard = createEntityCardExtension({
+  id: 'has.systems',
+  configSchema: createSchemaFromZod(z =>
+    z.object({
+      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
+      title: z.string().optional(),
+    }),
+  ),
+  loader: async ({ config }) =>
+    import('../components/HasSystemsCard').then(m => (
+      <m.HasSystemsCard variant={config.variant} title={config.title} />
+    )),
+});
+
+export default [
+  EntityAboutCard,
+  EntityLinksCard,
+  EntityLabelsCard,
+  EntityDependsOnComponentsCard,
+  EntityDependsOnResourcesCard,
+  EntityHasComponentsCard,
+  EntityHasResourcesCard,
+  EntityHasSubcomponentsCard,
+  EntityHasSystemsCard,
+];

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -16,147 +16,76 @@
 
 import React from 'react';
 import { createEntityCardExtension } from '@backstage/plugin-catalog-react/alpha';
-import { createSchemaFromZod } from '@backstage/frontend-plugin-api';
 
 export const EntityAboutCard = createEntityCardExtension({
   id: 'about',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/AboutCard').then(m => (
-      <m.AboutCard variant={config.variant} />
+      <m.AboutCard variant="gridItem" />
     )),
 });
 
 export const EntityLinksCard = createEntityCardExtension({
   id: 'links',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).optional(),
-      cols: z
-        .union([
-          z.number(),
-          z.object({
-            xs: z.number(),
-            sm: z.number(),
-            md: z.number(),
-            lg: z.number(),
-            xl: z.number(),
-          }),
-        ])
-        .optional(),
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/EntityLinksCard').then(m => {
-      return <m.EntityLinksCard variant={config.variant} cols={config.cols} />;
+      return <m.EntityLinksCard variant="gridItem" />;
     }),
 });
 
 export const EntityLabelsCard = createEntityCardExtension({
   id: 'labels',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).optional(),
-      title: z.string().optional(),
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/EntityLabelsCard').then(m => (
-      <m.EntityLabelsCard variant={config.variant} title={config.title} />
+      <m.EntityLabelsCard variant="gridItem" />
     )),
 });
 
 export const EntityDependsOnComponentsCard = createEntityCardExtension({
   id: 'dependsOn.components',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-      title: z.string().optional(),
-      // TODO: columns, tableOptions
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/DependsOnComponentsCard').then(m => (
-      <m.DependsOnComponentsCard
-        variant={config.variant}
-        title={config.title}
-      />
+      <m.DependsOnComponentsCard variant="gridItem" />
     )),
 });
 
 export const EntityDependsOnResourcesCard = createEntityCardExtension({
   id: 'dependsOn.resources',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-      title: z.string().optional(),
-      // TODO: columns, tableOptions
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/DependsOnResourcesCard').then(m => (
-      <m.DependsOnResourcesCard variant={config.variant} title={config.title} />
+      <m.DependsOnResourcesCard variant="gridItem" />
     )),
 });
 
 export const EntityHasComponentsCard = createEntityCardExtension({
   id: 'has.components',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-      title: z.string().optional(),
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/HasComponentsCard').then(m => (
-      <m.HasComponentsCard variant={config.variant} title={config.title} />
+      <m.HasComponentsCard variant="gridItem" />
     )),
 });
 
 export const EntityHasResourcesCard = createEntityCardExtension({
   id: 'has.resources',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-      title: z.string().optional(),
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/HasResourcesCard').then(m => (
-      <m.HasResourcesCard variant={config.variant} title={config.title} />
+      <m.HasResourcesCard variant="gridItem" />
     )),
 });
 
 export const EntityHasSubcomponentsCard = createEntityCardExtension({
   id: 'has.subcomponents',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-      title: z.string().optional(),
-      // TODO: tableOptions
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/HasSubcomponentsCard').then(m => (
-      <m.HasSubcomponentsCard variant={config.variant} title={config.title} />
+      <m.HasSubcomponentsCard variant="gridItem" />
     )),
 });
 
 export const EntityHasSystemsCard = createEntityCardExtension({
   id: 'has.systems',
-  configSchema: createSchemaFromZod(z =>
-    z.object({
-      variant: z.enum(['gridItem', 'flex', 'fullHeight']).default('gridItem'),
-      title: z.string().optional(),
-    }),
-  ),
-  loader: async ({ config }) =>
+  loader: async () =>
     import('../components/HasSystemsCard').then(m => (
-      <m.HasSystemsCard variant={config.variant} title={config.title} />
+      <m.HasSystemsCard variant="gridItem" />
     )),
 });
 

--- a/plugins/catalog/src/alpha/entityContents.tsx
+++ b/plugins/catalog/src/alpha/entityContents.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Grid } from '@material-ui/core';
+import {
+  coreExtensionData,
+  createExtensionInput,
+} from '@backstage/frontend-plugin-api';
+import { createEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
+
+export const OverviewEntityContent = createEntityContentExtension({
+  id: 'overview',
+  defaultPath: '/',
+  defaultTitle: 'Overview',
+  disabled: false,
+  inputs: {
+    cards: createExtensionInput({
+      element: coreExtensionData.reactElement,
+    }),
+  },
+  loader: async ({ inputs }) => (
+    <Grid container spacing={3} alignItems="stretch">
+      {inputs.cards.map(card => (
+        <Grid item md={6} xs={12}>
+          {card.element}
+        </Grid>
+      ))}
+    </Grid>
+  ),
+});
+
+export default [OverviewEntityContent];

--- a/plugins/catalog/src/alpha/filters.tsx
+++ b/plugins/catalog/src/alpha/filters.tsx
@@ -109,7 +109,7 @@ const CatalogUserListFilter = createCatalogFilterExtension({
   },
 });
 
-export const builtInFilterExtensions = [
+export default [
   CatalogEntityTagFilter,
   CatalogEntityKindFilter,
   CatalogEntityTypeFilter,

--- a/plugins/catalog/src/alpha/navItems.tsx
+++ b/plugins/catalog/src/alpha/navItems.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import HomeIcon from '@material-ui/icons/Home';
+import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
+import { createNavItemExtension } from '@backstage/frontend-plugin-api';
+import { rootRouteRef } from '../routes';
+
+export const CatalogIndexNavItem = createNavItemExtension({
+  id: 'catalog.nav.index',
+  routeRef: convertLegacyRouteRef(rootRouteRef),
+  title: 'Catalog',
+  icon: HomeIcon,
+});
+
+export default [CatalogIndexNavItem];

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
+import {
+  createPageExtension,
+  coreExtensionData,
+  createExtensionInput,
+} from '@backstage/frontend-plugin-api';
+import {
+  AsyncEntityProvider,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
+import { entityContentTitleExtensionDataRef } from '@backstage/plugin-catalog-react/alpha';
+import { rootRouteRef } from '../routes';
+import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
+
+export const CatalogIndexPage = createPageExtension({
+  id: 'plugin.catalog.page.index',
+  defaultPath: '/catalog',
+  routeRef: convertLegacyRouteRef(rootRouteRef),
+  inputs: {
+    filters: createExtensionInput({
+      element: coreExtensionData.reactElement,
+    }),
+  },
+  loader: async ({ inputs }) => {
+    const { BaseCatalogPage } = await import('../components/CatalogPage');
+    const filters = inputs.filters.map(filter => filter.element);
+    return <BaseCatalogPage filters={<>{filters}</>} />;
+  },
+});
+
+export const CatalogEntityPage = createPageExtension({
+  id: 'plugin.catalog.page.entity',
+  defaultPath: '/catalog/:namespace/:kind/:name',
+  routeRef: convertLegacyRouteRef(entityRouteRef),
+  inputs: {
+    contents: createExtensionInput({
+      element: coreExtensionData.reactElement,
+      path: coreExtensionData.routePath,
+      routeRef: coreExtensionData.routeRef.optional(),
+      title: entityContentTitleExtensionDataRef,
+    }),
+  },
+  loader: async ({ inputs }) => {
+    const { EntityLayout } = await import('../components/EntityLayout');
+    const Component = () => {
+      return (
+        <AsyncEntityProvider {...useEntityFromUrl()}>
+          <EntityLayout>
+            {inputs.contents.map(content => (
+              <EntityLayout.Route
+                key={content.path}
+                path={content.path}
+                title={content.title}
+              >
+                {content.element}
+              </EntityLayout.Route>
+            ))}
+          </EntityLayout>
+        </AsyncEntityProvider>
+      );
+    };
+    return <Component />;
+  },
+});
+
+export default [CatalogIndexPage, CatalogEntityPage];

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -26,7 +26,6 @@ import {
 
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { createEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
-import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
 
 import {
   createComponentRouteRef,
@@ -40,17 +39,7 @@ import pages from './pages';
 import filters from './filters';
 import navItems from './navItems';
 import entityCards from './entityCards';
-
-/** @alpha */
-export const CatalogSearchResultListItemExtension =
-  createSearchResultListItemExtension({
-    id: 'catalog',
-    predicate: result => result.type === 'software-catalog',
-    component: () =>
-      import('../components/CatalogSearchResultListItem').then(
-        m => m.CatalogSearchResultListItem,
-      ),
-  });
+import searchResultItems from './searchResultItems';
 
 const OverviewEntityContent = createEntityContentExtension({
   id: 'overview',
@@ -91,7 +80,7 @@ export default createPlugin({
     ...filters,
     ...navItems,
     ...entityCards,
-    CatalogSearchResultListItemExtension,
+    ...searchResultItems,
     OverviewEntityContent,
   ],
 });

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
+import Grid from '@material-ui/core/Grid';
 import HomeIcon from '@material-ui/icons/Home';
+
 import {
   createApiFactory,
   discoveryApiRef,
@@ -23,7 +25,6 @@ import {
   storageApiRef,
 } from '@backstage/core-plugin-api';
 import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
-import { CatalogClient } from '@backstage/catalog-client';
 import {
   createApiExtension,
   createPageExtension,
@@ -32,6 +33,8 @@ import {
   coreExtensionData,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
+
+import { CatalogClient } from '@backstage/catalog-client';
 import {
   AsyncEntityProvider,
   catalogApiRef,
@@ -44,6 +47,7 @@ import {
   entityContentTitleExtensionDataRef,
 } from '@backstage/plugin-catalog-react/alpha';
 import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
+
 import { DefaultStarredEntitiesApi } from '../apis';
 import {
   createComponentRouteRef,
@@ -51,9 +55,9 @@ import {
   rootRouteRef,
   viewTechDocRouteRef,
 } from '../routes';
-import { builtInFilterExtensions } from './builtInFilterExtensions';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
-import Grid from '@material-ui/core/Grid';
+
+import filters from './filters';
 
 /** @alpha */
 export const CatalogApi = createApiExtension({
@@ -99,8 +103,11 @@ const CatalogIndexPage = createPageExtension({
   },
   loader: async ({ inputs }) => {
     const { BaseCatalogPage } = await import('../components/CatalogPage');
-    const filters = inputs.filters.map(filter => filter.element);
-    return <BaseCatalogPage filters={<>{filters}</>} />;
+    return (
+      <BaseCatalogPage
+        filters={<>{inputs.filters.map(filter => filter.element)}</>}
+      />
+    );
   },
 });
 
@@ -188,6 +195,7 @@ export default createPlugin({
     createFromTemplate: convertLegacyRouteRef(createFromTemplateRouteRef),
   },
   extensions: [
+    ...filters,
     CatalogApi,
     StarredEntitiesApi,
     CatalogSearchResultListItemExtension,
@@ -196,6 +204,5 @@ export default createPlugin({
     CatalogNavItem,
     OverviewEntityContent,
     EntityAboutCard,
-    ...builtInFilterExtensions,
   ],
 });

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -18,15 +18,8 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import HomeIcon from '@material-ui/icons/Home';
 
-import {
-  createApiFactory,
-  discoveryApiRef,
-  fetchApiRef,
-  storageApiRef,
-} from '@backstage/core-plugin-api';
 import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
 import {
-  createApiExtension,
   createPageExtension,
   createPlugin,
   createNavItemExtension,
@@ -34,12 +27,9 @@ import {
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 
-import { CatalogClient } from '@backstage/catalog-client';
 import {
   AsyncEntityProvider,
-  catalogApiRef,
   entityRouteRef,
-  starredEntitiesApiRef,
 } from '@backstage/plugin-catalog-react';
 import {
   createEntityContentExtension,
@@ -48,7 +38,6 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
 
-import { DefaultStarredEntitiesApi } from '../apis';
 import {
   createComponentRouteRef,
   createFromTemplateRouteRef,
@@ -57,29 +46,8 @@ import {
 } from '../routes';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 
+import apis from './apis';
 import filters from './filters';
-
-/** @alpha */
-export const CatalogApi = createApiExtension({
-  factory: createApiFactory({
-    api: catalogApiRef,
-    deps: {
-      discoveryApi: discoveryApiRef,
-      fetchApi: fetchApiRef,
-    },
-    factory: ({ discoveryApi, fetchApi }) =>
-      new CatalogClient({ discoveryApi, fetchApi }),
-  }),
-});
-
-/** @alpha */
-export const StarredEntitiesApi = createApiExtension({
-  factory: createApiFactory({
-    api: starredEntitiesApiRef,
-    deps: { storageApi: storageApiRef },
-    factory: ({ storageApi }) => new DefaultStarredEntitiesApi({ storageApi }),
-  }),
-});
 
 /** @alpha */
 export const CatalogSearchResultListItemExtension =
@@ -195,9 +163,8 @@ export default createPlugin({
     createFromTemplate: convertLegacyRouteRef(createFromTemplateRouteRef),
   },
   extensions: [
+    ...apis,
     ...filters,
-    CatalogApi,
-    StarredEntitiesApi,
     CatalogSearchResultListItemExtension,
     CatalogIndexPage,
     CatalogEntityPage,

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -16,12 +16,10 @@
 
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
-import HomeIcon from '@material-ui/icons/Home';
 
 import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
 import {
   createPlugin,
-  createNavItemExtension,
   coreExtensionData,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
@@ -40,6 +38,7 @@ import {
 import apis from './apis';
 import pages from './pages';
 import filters from './filters';
+import navItems from './navItems';
 import entityCards from './entityCards';
 
 /** @alpha */
@@ -74,13 +73,6 @@ const OverviewEntityContent = createEntityContentExtension({
   ),
 });
 
-const CatalogNavItem = createNavItemExtension({
-  id: 'catalog.nav.index',
-  routeRef: convertLegacyRouteRef(rootRouteRef),
-  title: 'Catalog',
-  icon: HomeIcon,
-});
-
 /** @alpha */
 export default createPlugin({
   id: 'catalog',
@@ -97,9 +89,9 @@ export default createPlugin({
     ...apis,
     ...pages,
     ...filters,
+    ...navItems,
     ...entityCards,
     CatalogSearchResultListItemExtension,
-    CatalogNavItem,
     OverviewEntityContent,
   ],
 });

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -20,21 +20,16 @@ import HomeIcon from '@material-ui/icons/Home';
 
 import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
 import {
-  createPageExtension,
   createPlugin,
   createNavItemExtension,
   coreExtensionData,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 
-import {
-  AsyncEntityProvider,
-  entityRouteRef,
-} from '@backstage/plugin-catalog-react';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import {
   createEntityContentExtension,
   createEntityCardExtension,
-  entityContentTitleExtensionDataRef,
 } from '@backstage/plugin-catalog-react/alpha';
 import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
 
@@ -44,9 +39,9 @@ import {
   rootRouteRef,
   viewTechDocRouteRef,
 } from '../routes';
-import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 
 import apis from './apis';
+import pages from './pages';
 import filters from './filters';
 
 /** @alpha */
@@ -59,60 +54,6 @@ export const CatalogSearchResultListItemExtension =
         m => m.CatalogSearchResultListItem,
       ),
   });
-
-const CatalogIndexPage = createPageExtension({
-  id: 'plugin.catalog.page.index',
-  defaultPath: '/catalog',
-  routeRef: convertLegacyRouteRef(rootRouteRef),
-  inputs: {
-    filters: createExtensionInput({
-      element: coreExtensionData.reactElement,
-    }),
-  },
-  loader: async ({ inputs }) => {
-    const { BaseCatalogPage } = await import('../components/CatalogPage');
-    return (
-      <BaseCatalogPage
-        filters={<>{inputs.filters.map(filter => filter.element)}</>}
-      />
-    );
-  },
-});
-
-const CatalogEntityPage = createPageExtension({
-  id: 'plugin.catalog.page.entity',
-  defaultPath: '/catalog/:namespace/:kind/:name',
-  routeRef: convertLegacyRouteRef(entityRouteRef),
-  inputs: {
-    contents: createExtensionInput({
-      element: coreExtensionData.reactElement,
-      path: coreExtensionData.routePath,
-      routeRef: coreExtensionData.routeRef.optional(),
-      title: entityContentTitleExtensionDataRef,
-    }),
-  },
-  loader: async ({ inputs }) => {
-    const { EntityLayout } = await import('../components/EntityLayout');
-    const Component = () => {
-      return (
-        <AsyncEntityProvider {...useEntityFromUrl()}>
-          <EntityLayout>
-            {inputs.contents.map(content => (
-              <EntityLayout.Route
-                key={content.path}
-                path={content.path}
-                title={content.title}
-              >
-                {content.element}
-              </EntityLayout.Route>
-            ))}
-          </EntityLayout>
-        </AsyncEntityProvider>
-      );
-    };
-    return <Component />;
-  },
-});
 
 const EntityAboutCard = createEntityCardExtension({
   id: 'about',
@@ -164,10 +105,9 @@ export default createPlugin({
   },
   extensions: [
     ...apis,
+    ...pages,
     ...filters,
     CatalogSearchResultListItemExtension,
-    CatalogIndexPage,
-    CatalogEntityPage,
     CatalogNavItem,
     OverviewEntityContent,
     EntityAboutCard,

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -27,10 +27,7 @@ import {
 } from '@backstage/frontend-plugin-api';
 
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
-import {
-  createEntityContentExtension,
-  createEntityCardExtension,
-} from '@backstage/plugin-catalog-react/alpha';
+import { createEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
 import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
 
 import {
@@ -43,6 +40,7 @@ import {
 import apis from './apis';
 import pages from './pages';
 import filters from './filters';
+import entityCards from './entityCards';
 
 /** @alpha */
 export const CatalogSearchResultListItemExtension =
@@ -54,14 +52,6 @@ export const CatalogSearchResultListItemExtension =
         m => m.CatalogSearchResultListItem,
       ),
   });
-
-const EntityAboutCard = createEntityCardExtension({
-  id: 'about',
-  loader: async () =>
-    import('../components/AboutCard').then(m => (
-      <m.AboutCard variant="gridItem" />
-    )),
-});
 
 const OverviewEntityContent = createEntityContentExtension({
   id: 'overview',
@@ -107,9 +97,9 @@ export default createPlugin({
     ...apis,
     ...pages,
     ...filters,
+    ...entityCards,
     CatalogSearchResultListItemExtension,
     CatalogNavItem,
     OverviewEntityContent,
-    EntityAboutCard,
   ],
 });

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import Grid from '@material-ui/core/Grid';
-
 import { convertLegacyRouteRef } from '@backstage/core-plugin-api/alpha';
-import {
-  createPlugin,
-  coreExtensionData,
-  createExtensionInput,
-} from '@backstage/frontend-plugin-api';
+import { createPlugin } from '@backstage/frontend-plugin-api';
 
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
-import { createEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
 
 import {
   createComponentRouteRef,
@@ -39,28 +31,8 @@ import pages from './pages';
 import filters from './filters';
 import navItems from './navItems';
 import entityCards from './entityCards';
+import entityContents from './entityContents';
 import searchResultItems from './searchResultItems';
-
-const OverviewEntityContent = createEntityContentExtension({
-  id: 'overview',
-  defaultPath: '/',
-  defaultTitle: 'Overview',
-  disabled: false,
-  inputs: {
-    cards: createExtensionInput({
-      element: coreExtensionData.reactElement,
-    }),
-  },
-  loader: async ({ inputs }) => (
-    <Grid container spacing={3} alignItems="stretch">
-      {inputs.cards.map(card => (
-        <Grid item md={6} xs={12}>
-          {card.element}
-        </Grid>
-      ))}
-    </Grid>
-  ),
-});
 
 /** @alpha */
 export default createPlugin({
@@ -80,7 +52,7 @@ export default createPlugin({
     ...filters,
     ...navItems,
     ...entityCards,
+    ...entityContents,
     ...searchResultItems,
-    OverviewEntityContent,
   ],
 });

--- a/plugins/catalog/src/alpha/searchResultItems.tsx
+++ b/plugins/catalog/src/alpha/searchResultItems.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSearchResultListItemExtension } from '@backstage/plugin-search-react/alpha';
+
+export const CatalogSearchResultListItemExtension =
+  createSearchResultListItemExtension({
+    id: 'catalog',
+    predicate: result => result.type === 'software-catalog',
+    component: () =>
+      import('../components/CatalogSearchResultListItem').then(
+        m => m.CatalogSearchResultListItem,
+      ),
+  });
+
+export default [CatalogSearchResultListItemExtension];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up of: https://github.com/backstage/backstage/pull/20686

Migrate catalog entity cards to new extension format:

> [!Note]
> Table options and columns are not configurable in this initial migration.

- [x] EntityAboutCard
- [x] EntityLinksCard
- [x] EntityLabelsCard
- [x] EntityDependsOnComponentsCard
- [x] EntityDependsOnResourcesCard
- [x] EntityHasComponentsCard
- [x] EntityHasResourcesCard
- [x] EntityHasSubcomponentsCard
- [x] EntityHasSystemsCard

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
