### PR TITLE
backend-app-api: double default wrapping workaround

### DIFF
--- a/.changeset/strong-taxis-wait.md
+++ b/.changeset/strong-taxis-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Added a workaround for double `default` wrapping when dynamically importing CommonJS modules with default exports.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a workaround for the issue reported here: https://github.com/backstage/backstage/issues/20680#issuecomment-1772708801

The proper solution for this issue is to move to using ESM instead of CommonJS for backend, i.e. #12218, since you can't really support mixed default and named exports with transpiled CommonJS.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
