### PR TITLE
[Revisit] Use AzureDevOpsCredentialsProvider

### DIFF
--- a/.changeset/unlucky-clouds-build.md
+++ b/.changeset/unlucky-clouds-build.md
@@ -2,6 +2,6 @@
 '@backstage/plugin-azure-devops-backend': minor
 ---
 
-**BREAKING** New `fromConfig` static method must be used now when created an instance of the `AzureDevOpsApi`
+**BREAKING** New `fromConfig` static method must be used now when creating an instance of the `AzureDevOpsApi`
 
-Added support for using the `AzureDevOpsCredentialsProvider` and deprecated the entire `azureDevOps` configuration section
+Added support for using the `AzureDevOpsCredentialsProvider`

--- a/.changeset/unlucky-clouds-build.md
+++ b/.changeset/unlucky-clouds-build.md
@@ -1,5 +1,7 @@
 ---
-'@backstage/plugin-azure-devops-backend': patch
+'@backstage/plugin-azure-devops-backend': minor
 ---
 
-Added support for using `AzureDevOpsCredentialsProvider` and deprecated `azureDevOps.token` configuration value
+**BREAKING** New `fromConfig` static method must be used now when created an instance of the `AzureDevOpsApi`
+
+Added support for using the `AzureDevOpsCredentialsProvider` and deprecated the entire `azureDevOps` configuration section

--- a/.changeset/unlucky-clouds-build.md
+++ b/.changeset/unlucky-clouds-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Added support for using `AzureDevOpsCredentialsProvider` and deprecated `azureDevOps.token` configuration value

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -23,7 +23,14 @@ import { UrlReader } from '@backstage/backend-common';
 
 // @public (undocumented)
 export class AzureDevOpsApi {
-  constructor(logger: Logger, urlReader: UrlReader, config: Config);
+  // (undocumented)
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: Logger;
+      urlReader: UrlReader;
+    },
+  ): AzureDevOpsApi;
   // (undocumented)
   getAllTeams(): Promise<Team[]>;
   // (undocumented)

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -20,11 +20,10 @@ import { RepoBuild } from '@backstage/plugin-azure-devops-common';
 import { Team } from '@backstage/plugin-azure-devops-common';
 import { TeamMember } from '@backstage/plugin-azure-devops-common';
 import { UrlReader } from '@backstage/backend-common';
-import { WebApi } from 'azure-devops-node-api';
 
 // @public (undocumented)
 export class AzureDevOpsApi {
-  constructor(logger: Logger, webApi: WebApi, urlReader: UrlReader);
+  constructor(logger: Logger, urlReader: UrlReader, config: Config);
   // (undocumented)
   getAllTeams(): Promise<Team[]>;
   // (undocumented)

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -15,10 +15,15 @@
  */
 
 export interface Config {
-  /** Configuration options for the azure-devops-backend plugin */
+  /** Configuration options for the azure-devops-backend plugin
+   * @deprecated Use `integrations.azure` instead.
+   * @see https://backstage.io/docs/integrations/azure/locations
+   */
   azureDevOps: {
     /**
      * The hostname of the given Azure instance
+     * @deprecated Use `integrations.azure` instead.
+     * @see https://backstage.io/docs/integrations/azure/locations
      */
     host: string;
     /**
@@ -30,6 +35,8 @@ export interface Config {
     token: string;
     /**
      * The organization of the given Azure instance
+     * @deprecated Use `integrations.azure` instead.
+     * @see https://backstage.io/docs/integrations/azure/locations
      */
     organization: string;
   };

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -24,6 +24,8 @@ export interface Config {
     /**
      * Token used to authenticate requests.
      * @visibility secret
+     * @deprecated Use `integrations.azure` instead.
+     * @see https://backstage.io/docs/integrations/azure/locations
      */
     token: string;
     /**

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -15,28 +15,21 @@
  */
 
 export interface Config {
-  /** Configuration options for the azure-devops-backend plugin
-   * @deprecated Use `integrations.azure` instead.
-   * @see https://backstage.io/docs/integrations/azure/locations
+  /**
+   * Configuration options for the azure-devops-backend plugin
    */
   azureDevOps: {
     /**
      * The hostname of the given Azure instance
-     * @deprecated Use `integrations.azure` instead.
-     * @see https://backstage.io/docs/integrations/azure/locations
      */
     host: string;
     /**
      * Token used to authenticate requests.
      * @visibility secret
-     * @deprecated Use `integrations.azure` instead.
-     * @see https://backstage.io/docs/integrations/azure/locations
      */
     token: string;
     /**
      * The organization of the given Azure instance
-     * @deprecated Use `integrations.azure` instead.
-     * @see https://backstage.io/docs/integrations/azure/locations
      */
     organization: string;
   };

--- a/plugins/azure-devops-backend/package.json
+++ b/plugins/azure-devops-backend/package.json
@@ -31,6 +31,7 @@
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/integration": "workspace:^",
     "@backstage/plugin-azure-devops-common": "workspace:^",
     "@types/express": "^4.17.6",
     "azure-devops-node-api": "^11.0.1",

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
@@ -1,0 +1,764 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('azure-devops-node-api', () => ({
+  WebApi: jest.fn(),
+  getHandlerFromToken: jest.fn().mockReturnValue(() => {}),
+}));
+
+import { UrlReader, getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import { AzureDevOpsApi } from './AzureDevOpsApi';
+import { WebApi } from 'azure-devops-node-api';
+import { TeamProjectReference } from 'azure-devops-node-api/interfaces/CoreInterfaces';
+import { GitRepository } from 'azure-devops-node-api/interfaces/TfvcInterfaces';
+import {
+  Build,
+  BuildResult,
+  BuildStatus,
+} from 'azure-devops-node-api/interfaces/BuildInterfaces';
+import {
+  GitPullRequest,
+  GitRef,
+  PullRequestStatus,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { PullRequestOptions } from '@backstage/plugin-azure-devops-common';
+
+describe('AzureDevOpsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockConfig = new ConfigReader({
+    azureDevOps: {
+      host: 'dev.azure.com',
+      token: 'token',
+      organization: 'org',
+    },
+    integrations: {
+      azure: [
+        {
+          host: 'dev.azure.com',
+          credentials: [
+            {
+              personalAccessToken: 'pat',
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  const mockLogger = getVoidLogger();
+
+  const mockUrlReader: UrlReader = {
+    readUrl: url =>
+      Promise.resolve({
+        buffer: async () => Buffer.from(url),
+        etag: 'buffer',
+        stream: jest.fn(),
+      }),
+    readTree: jest.fn(),
+    search: jest.fn(),
+  };
+
+  it('should get projects', async () => {
+    const mockProjects: TeamProjectReference[] = [
+      {
+        id: 'one',
+        name: 'one',
+        description: 'one',
+      },
+      {
+        id: 'two',
+        name: 'two',
+        description: 'two',
+      },
+      {
+        id: 'three',
+        name: 'three',
+        description: 'three',
+      },
+    ];
+
+    const mockCoreApiClient = {
+      getProjects: jest.fn().mockResolvedValue(mockProjects),
+    };
+
+    const mockCoreApi = {
+      getCoreApi: jest.fn().mockResolvedValue(mockCoreApiClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockCoreApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getProjects();
+
+    expect(result).toEqual([
+      {
+        id: 'one',
+        name: 'one',
+        description: 'one',
+      },
+      {
+        id: 'three',
+        name: 'three',
+        description: 'three',
+      },
+      {
+        id: 'two',
+        name: 'two',
+        description: 'two',
+      },
+    ]);
+  });
+
+  it('should get git repository', async () => {
+    const mockGitRepository: GitRepository = {
+      id: 'repo',
+    };
+
+    const mockGitClient = {
+      getRepository: jest.fn().mockResolvedValue(mockGitRepository),
+    };
+    const mockGitApi = {
+      getGitApi: jest.fn().mockReturnValue(mockGitClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockGitApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getGitRepository('project', 'repo');
+
+    expect(result).toEqual({ id: 'repo' });
+  });
+
+  it('should get build list', async () => {
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+      },
+    ];
+
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue(mockBuilds),
+    };
+    const mockBuildApi = {
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockBuildApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuildList('project', 'repo', 10);
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('should get repo builds', async () => {
+    const mockGitRepository: GitRepository = {
+      id: 'repo',
+    };
+
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+        buildNumber: 'Build-1',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+      {
+        id: 2,
+        buildNumber: 'Build-2',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+      {
+        id: 3,
+        buildNumber: 'Build-3',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+    ];
+
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue(mockBuilds),
+    };
+    const mockGitClient = {
+      getRepository: jest.fn().mockResolvedValue(mockGitRepository),
+    };
+    const mockApi = {
+      getGitApi: jest.fn().mockReturnValue(mockGitClient),
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getRepoBuilds('project', 'repo', 10);
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        title: 'Build-1',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+      {
+        id: 2,
+        title: 'Build-2',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+      {
+        id: 3,
+        title: 'Build-3',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+    ]);
+  });
+
+  it('should get git tags', async () => {
+    const mockGitRepository: GitRepository = {
+      id: 'repo',
+    };
+
+    const mockGitRefs: GitRef[] = [
+      {
+        objectId: '1.0',
+        peeledObjectId: '1.0',
+        name: 'v1.0',
+      },
+      {
+        objectId: '2.0',
+        peeledObjectId: '2.0',
+        name: 'v2.0',
+      },
+      {
+        objectId: '3.0',
+        peeledObjectId: '3.0',
+        name: 'v3.0',
+      },
+    ];
+
+    const mockGitClient = {
+      getRepository: jest.fn().mockResolvedValue(mockGitRepository),
+      getRefs: jest.fn().mockResolvedValue(mockGitRefs),
+    };
+    const mockApi = {
+      getGitApi: jest.fn().mockReturnValue(mockGitClient),
+      serverUrl: 'serverUrl',
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getGitTags('project', 'repo');
+
+    expect(result).toEqual([
+      {
+        objectId: '1.0',
+        peeledObjectId: '1.0',
+        name: 'v1.0',
+        commitLink: 'serverUrl/project/_git/repo/commit/1.0',
+        createdBy: 'N/A',
+        link: 'serverUrl/project/_git/repo?version=GTv1.0',
+      },
+      {
+        objectId: '2.0',
+        peeledObjectId: '2.0',
+        name: 'v2.0',
+        commitLink: 'serverUrl/project/_git/repo/commit/2.0',
+        createdBy: 'N/A',
+        link: 'serverUrl/project/_git/repo?version=GTv2.0',
+      },
+      {
+        objectId: '3.0',
+        peeledObjectId: '3.0',
+        name: 'v3.0',
+        commitLink: 'serverUrl/project/_git/repo/commit/3.0',
+        createdBy: 'N/A',
+        link: 'serverUrl/project/_git/repo?version=GTv3.0',
+      },
+    ]);
+  });
+
+  it('should get pull requests', async () => {
+    const mockGitRepository: GitRepository = {
+      id: 'repo',
+      name: 'repo',
+    };
+
+    const mockGitPullRequests: GitPullRequest[] = [
+      {
+        pullRequestId: 1,
+        repository: mockGitRepository,
+        title: 'PR1',
+        creationDate: new Date('2020-09-12T06:10:23.932Z'),
+        sourceRefName: 'refs/heads/topic/pr1',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+      },
+      {
+        pullRequestId: 2,
+        repository: mockGitRepository,
+        title: 'PR2',
+        creationDate: new Date('2020-09-12T06:10:23.932Z'),
+        sourceRefName: 'refs/heads/topic/pr2',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+      },
+      {
+        pullRequestId: 3,
+        repository: mockGitRepository,
+        title: 'PR3',
+        creationDate: new Date('2020-09-12T06:10:23.932Z'),
+        sourceRefName: 'refs/heads/topic/pr3',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+      },
+    ];
+
+    const mockGitClient = {
+      getRepository: jest.fn().mockResolvedValue(mockGitRepository),
+      getPullRequests: jest.fn().mockResolvedValue(mockGitPullRequests),
+    };
+    const mockApi = {
+      getGitApi: jest.fn().mockReturnValue(mockGitClient),
+      serverUrl: 'serverUrl',
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const pullRequestOptions: PullRequestOptions = {
+      top: 10,
+      status: PullRequestStatus.Active,
+    };
+
+    const result = await api.getPullRequests(
+      'project',
+      'repo',
+      pullRequestOptions,
+    );
+
+    expect(result).toEqual([
+      {
+        pullRequestId: 1,
+        repoName: 'repo',
+        title: 'PR1',
+        uniqueName: 'N/A',
+        createdBy: 'N/A',
+        creationDate: '2020-09-12T06:10:23.932Z',
+        sourceRefName: 'refs/heads/topic/pr1',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+        link: 'serverUrl/project/_git/repo/pullrequest/1',
+      },
+      {
+        pullRequestId: 2,
+        repoName: 'repo',
+        title: 'PR2',
+        uniqueName: 'N/A',
+        createdBy: 'N/A',
+        creationDate: '2020-09-12T06:10:23.932Z',
+        sourceRefName: 'refs/heads/topic/pr2',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+        link: 'serverUrl/project/_git/repo/pullrequest/2',
+      },
+      {
+        pullRequestId: 3,
+        repoName: 'repo',
+        title: 'PR3',
+        uniqueName: 'N/A',
+        createdBy: 'N/A',
+        creationDate: '2020-09-12T06:10:23.932Z',
+        sourceRefName: 'refs/heads/topic/pr3',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+        link: 'serverUrl/project/_git/repo/pullrequest/3',
+      },
+    ]);
+  });
+
+  it('should get build definitions', async () => {
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+      },
+    ];
+
+    const mockBuildClient = {
+      getDefinitions: jest.fn().mockResolvedValue(mockBuilds),
+    };
+    const mockBuildApi = {
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockBuildApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuildDefinitions('project', 'definition');
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('should get build builds with repoId', async () => {
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+      },
+    ];
+
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue(mockBuilds),
+    };
+    const mockBuildApi = {
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockBuildApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuilds('project', 10, 'repo', undefined);
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('should get build builds with definitions', async () => {
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+      },
+    ];
+
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue(mockBuilds),
+    };
+    const mockBuildApi = {
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockBuildApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuilds('project', 10, undefined, [1, 2, 3]);
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('should get build runs with repoName', async () => {
+    const mockGitRepository: GitRepository = {
+      id: 'repo',
+    };
+
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+        buildNumber: 'Build-1',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+      {
+        id: 2,
+        buildNumber: 'Build-2',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+      {
+        id: 3,
+        buildNumber: 'Build-3',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+    ];
+
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue(mockBuilds),
+    };
+    const mockGitClient = {
+      getRepository: jest.fn().mockResolvedValue(mockGitRepository),
+    };
+    const mockApi = {
+      getGitApi: jest.fn().mockReturnValue(mockGitClient),
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuildRuns('project', 10, 'repo', undefined);
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        title: 'Build-1',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+      {
+        id: 2,
+        title: 'Build-2',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+      {
+        id: 3,
+        title: 'Build-3',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+    ]);
+  });
+
+  it('should get build runs with definitionName', async () => {
+    const mockBuilds: Build[] = [
+      {
+        id: 1,
+        buildNumber: 'Build-1',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+      {
+        id: 2,
+        buildNumber: 'Build-2',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+      {
+        id: 3,
+        buildNumber: 'Build-3',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: new Date('2020-09-12T06:10:23.932Z'),
+        startTime: new Date('2020-09-12T06:15:23.932Z'),
+        finishTime: new Date('2020-09-12T06:20:23.932Z'),
+        sourceBranch: 'main',
+        sourceVersion: 'abcd',
+      },
+    ];
+
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue(mockBuilds),
+      getDefinitions: jest.fn().mockResolvedValue(mockBuilds),
+    };
+
+    const mockApi = {
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuildRuns(
+      'project',
+      10,
+      undefined,
+      'definition',
+    );
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        title: 'Build-1',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+      {
+        id: 2,
+        title: 'Build-2',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+      {
+        id: 3,
+        title: 'Build-3',
+        link: '',
+        status: BuildStatus.Completed,
+        result: BuildResult.Succeeded,
+        queueTime: '2020-09-12T06:10:23.932Z',
+        startTime: '2020-09-12T06:15:23.932Z',
+        finishTime: '2020-09-12T06:20:23.932Z',
+        source: 'main (abcd)',
+        uniqueName: 'N/A',
+      },
+    ]);
+  });
+});

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -67,11 +67,22 @@ import {
 
 /** @public */
 export class AzureDevOpsApi {
-  public constructor(
-    private readonly logger: Logger,
-    private readonly urlReader: UrlReader,
-    private readonly config: Config,
-  ) {}
+  private readonly logger: Logger;
+  private readonly urlReader: UrlReader;
+  private readonly config: Config;
+
+  private constructor(logger: Logger, urlReader: UrlReader, config: Config) {
+    this.logger = logger;
+    this.urlReader = urlReader;
+    this.config = config;
+  }
+
+  static fromConfig(
+    config: Config,
+    options: { logger: Logger; urlReader: UrlReader },
+  ) {
+    return new AzureDevOpsApi(options.logger, options.urlReader, config);
+  }
 
   private async getWebApi(host?: string, org?: string): Promise<WebApi> {
     const validHost = host ?? this.config.getString('azureDevOps.host');

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -19,9 +19,7 @@ import {
   BuildDefinitionReference,
 } from 'azure-devops-node-api/interfaces/BuildInterfaces';
 import {
-  BuildResult,
   BuildRun,
-  BuildStatus,
   DashboardPullRequest,
   GitTag,
   Policy,
@@ -65,6 +63,12 @@ import {
   DefaultAzureDevOpsCredentialsProvider,
   ScmIntegrations,
 } from '@backstage/integration';
+import {
+  mappedBuildRun,
+  mappedGitTag,
+  mappedPullRequest,
+  mappedRepoBuild,
+} from './mappers';
 
 /** @public */
 export class AzureDevOpsApi {
@@ -493,76 +497,4 @@ export class AzureDevOpsApi {
     );
     return { url, content };
   }
-}
-
-export function mappedRepoBuild(build: Build): RepoBuild {
-  return {
-    id: build.id,
-    title: [build.definition?.name, build.buildNumber]
-      .filter(Boolean)
-      .join(' - '),
-    link: build._links?.web.href ?? '',
-    status: build.status ?? BuildStatus.None,
-    result: build.result ?? BuildResult.None,
-    queueTime: build.queueTime?.toISOString(),
-    startTime: build.startTime?.toISOString(),
-    finishTime: build.finishTime?.toISOString(),
-    source: `${build.sourceBranch} (${build.sourceVersion?.slice(0, 8)})`,
-    uniqueName: build.requestedFor?.uniqueName ?? 'N/A',
-  };
-}
-
-export function mappedGitTag(
-  gitRef: GitRef,
-  linkBaseUrl: string,
-  commitBaseUrl: string,
-): GitTag {
-  return {
-    objectId: gitRef.objectId,
-    peeledObjectId: gitRef.peeledObjectId,
-    name: gitRef.name?.replace('refs/tags/', ''),
-    createdBy: gitRef.creator?.displayName ?? 'N/A',
-    link: `${linkBaseUrl}${encodeURIComponent(
-      gitRef.name?.replace('refs/tags/', '') ?? '',
-    )}`,
-    commitLink: `${commitBaseUrl}/${encodeURIComponent(
-      gitRef.peeledObjectId ?? '',
-    )}`,
-  };
-}
-
-export function mappedPullRequest(
-  pullRequest: GitPullRequest,
-  linkBaseUrl: string,
-): PullRequest {
-  return {
-    pullRequestId: pullRequest.pullRequestId,
-    repoName: pullRequest.repository?.name,
-    title: pullRequest.title,
-    uniqueName: pullRequest.createdBy?.uniqueName ?? 'N/A',
-    createdBy: pullRequest.createdBy?.displayName ?? 'N/A',
-    creationDate: pullRequest.creationDate?.toISOString(),
-    sourceRefName: pullRequest.sourceRefName,
-    targetRefName: pullRequest.targetRefName,
-    status: pullRequest.status,
-    isDraft: pullRequest.isDraft,
-    link: `${linkBaseUrl}/${pullRequest.pullRequestId}`,
-  };
-}
-
-export function mappedBuildRun(build: Build): BuildRun {
-  return {
-    id: build.id,
-    title: [build.definition?.name, build.buildNumber]
-      .filter(Boolean)
-      .join(' - '),
-    link: build._links?.web.href ?? '',
-    status: build.status ?? BuildStatus.None,
-    result: build.result ?? BuildResult.None,
-    queueTime: build.queueTime?.toISOString(),
-    startTime: build.startTime?.toISOString(),
-    finishTime: build.finishTime?.toISOString(),
-    source: `${build.sourceBranch} (${build.sourceVersion?.slice(0, 8)})`,
-    uniqueName: build.requestedFor?.uniqueName ?? 'N/A',
-  };
 }

--- a/plugins/azure-devops-backend/src/api/mappers.test.ts
+++ b/plugins/azure-devops-backend/src/api/mappers.test.ts
@@ -40,7 +40,7 @@ import {
 
 import { IdentityRef } from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
 
-describe('AzureDevOpsApi', () => {
+describe('mappers', () => {
   describe('mappedRepoBuild', () => {
     describe('mappedRepoBuild happy path', () => {
       it('should return RepoBuild from Build', () => {

--- a/plugins/azure-devops-backend/src/api/mappers.test.ts
+++ b/plugins/azure-devops-backend/src/api/mappers.test.ts
@@ -36,7 +36,7 @@ import {
   mappedGitTag,
   mappedPullRequest,
   mappedRepoBuild,
-} from './AzureDevOpsApi';
+} from './mappers';
 
 import { IdentityRef } from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
 

--- a/plugins/azure-devops-backend/src/api/mappers.ts
+++ b/plugins/azure-devops-backend/src/api/mappers.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  RepoBuild,
+  BuildStatus,
+  BuildResult,
+  GitTag,
+  PullRequest,
+  BuildRun,
+} from '@backstage/plugin-azure-devops-common';
+import { Build } from 'azure-devops-node-api/interfaces/BuildInterfaces';
+import {
+  GitRef,
+  GitPullRequest,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+
+export function mappedRepoBuild(build: Build): RepoBuild {
+  return {
+    id: build.id,
+    title: [build.definition?.name, build.buildNumber]
+      .filter(Boolean)
+      .join(' - '),
+    link: build._links?.web.href ?? '',
+    status: build.status ?? BuildStatus.None,
+    result: build.result ?? BuildResult.None,
+    queueTime: build.queueTime?.toISOString(),
+    startTime: build.startTime?.toISOString(),
+    finishTime: build.finishTime?.toISOString(),
+    source: `${build.sourceBranch} (${build.sourceVersion?.slice(0, 8)})`,
+    uniqueName: build.requestedFor?.uniqueName ?? 'N/A',
+  };
+}
+
+export function mappedGitTag(
+  gitRef: GitRef,
+  linkBaseUrl: string,
+  commitBaseUrl: string,
+): GitTag {
+  return {
+    objectId: gitRef.objectId,
+    peeledObjectId: gitRef.peeledObjectId,
+    name: gitRef.name?.replace('refs/tags/', ''),
+    createdBy: gitRef.creator?.displayName ?? 'N/A',
+    link: `${linkBaseUrl}${encodeURIComponent(
+      gitRef.name?.replace('refs/tags/', '') ?? '',
+    )}`,
+    commitLink: `${commitBaseUrl}/${encodeURIComponent(
+      gitRef.peeledObjectId ?? '',
+    )}`,
+  };
+}
+
+export function mappedPullRequest(
+  pullRequest: GitPullRequest,
+  linkBaseUrl: string,
+): PullRequest {
+  return {
+    pullRequestId: pullRequest.pullRequestId,
+    repoName: pullRequest.repository?.name,
+    title: pullRequest.title,
+    uniqueName: pullRequest.createdBy?.uniqueName ?? 'N/A',
+    createdBy: pullRequest.createdBy?.displayName ?? 'N/A',
+    creationDate: pullRequest.creationDate?.toISOString(),
+    sourceRefName: pullRequest.sourceRefName,
+    targetRefName: pullRequest.targetRefName,
+    status: pullRequest.status,
+    isDraft: pullRequest.isDraft,
+    link: `${linkBaseUrl}/${pullRequest.pullRequestId}`,
+  };
+}
+
+export function mappedBuildRun(build: Build): BuildRun {
+  return {
+    id: build.id,
+    title: [build.definition?.name, build.buildNumber]
+      .filter(Boolean)
+      .join(' - '),
+    link: build._links?.web.href ?? '',
+    status: build.status ?? BuildStatus.None,
+    result: build.result ?? BuildResult.None,
+    queueTime: build.queueTime?.toISOString(),
+    startTime: build.startTime?.toISOString(),
+    finishTime: build.finishTime?.toISOString(),
+    source: `${build.sourceBranch} (${build.sourceVersion?.slice(0, 8)})`,
+    uniqueName: build.requestedFor?.uniqueName ?? 'N/A',
+  };
+}

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -19,7 +19,6 @@ import {
   PullRequestOptions,
   PullRequestStatus,
 } from '@backstage/plugin-azure-devops-common';
-import { WebApi, getPersonalAccessTokenHandler } from 'azure-devops-node-api';
 
 import { AzureDevOpsApi } from '../api';
 import { Config } from '@backstage/config';
@@ -43,18 +42,10 @@ export interface RouterOptions {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, reader } = options;
-  const config = options.config.getConfig('azureDevOps');
-
-  const token = config.getString('token');
-  const host = config.getString('host');
-  const organization = config.getString('organization');
-
-  const authHandler = getPersonalAccessTokenHandler(token);
-  const webApi = new WebApi(`https://${host}/${organization}`, authHandler);
+  const { logger, reader, config } = options;
 
   const azureDevOpsApi =
-    options.azureDevOpsApi || new AzureDevOpsApi(logger, webApi, reader);
+    options.azureDevOpsApi || new AzureDevOpsApi(logger, reader, config);
 
   const pullRequestsDashboardProvider =
     await PullRequestsDashboardProvider.create(logger, azureDevOpsApi);
@@ -195,6 +186,8 @@ export async function createRouter(
   });
 
   router.get('/readme/:projectName/:repoName', async (req, res) => {
+    const host = config.getString('azureDevOps.host');
+    const organization = config.getString('azureDevOps.organization');
     const { projectName, repoName } = req.params;
     const readme = await azureDevOpsApi.getReadme(
       host,

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -45,7 +45,8 @@ export async function createRouter(
   const { logger, reader, config } = options;
 
   const azureDevOpsApi =
-    options.azureDevOpsApi || new AzureDevOpsApi(logger, reader, config);
+    options.azureDevOpsApi ||
+    AzureDevOpsApi.fromConfig(config, { logger, urlReader: reader });
 
   const pullRequestsDashboardProvider =
     await PullRequestsDashboardProvider.create(logger, azureDevOpsApi);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5077,6 +5077,7 @@ __metadata:
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/integration": "workspace:^"
     "@backstage/plugin-azure-devops-common": "workspace:^"
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.8


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for using `AzureDevOpsCredentialsProvider` and deprecated `azureDevOps.token` configuration value.

This lays the foundation along with https://github.com/backstage/backstage/pull/19616 towards adding multi-org support to the Azure DevOps plugin

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
