### PR TITLE
Fix google auth provider

### DIFF
--- a/.changeset/selfish-pots-beam.md
+++ b/.changeset/selfish-pots-beam.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend-module-google-provider': patch
+---
+
+Fix google auth provider
+
+Do not pass scopes when refreshing token, as this will limit scopes returned to only those provided

--- a/plugins/auth-backend-module-google-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-google-provider/src/authenticator.ts
@@ -66,6 +66,7 @@ export const googleAuthenticator = createOAuthAuthenticator({
     return helper.start(input, {
       accessType: 'offline',
       prompt: 'consent',
+      includeGrantedScopes: 'true',
     });
   },
 
@@ -74,7 +75,7 @@ export const googleAuthenticator = createOAuthAuthenticator({
   },
 
   async refresh(input, helper) {
-    return helper.refresh(input);
+    return helper.refresh({ ...input, scope: '' });
   },
 
   async logout(input) {

--- a/plugins/auth-backend-module-google-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-google-provider/src/module.test.ts
@@ -67,6 +67,7 @@ describe('authModuleGoogleProvider', () => {
       prompt: 'consent',
       response_type: 'code',
       client_id: 'my-client-id',
+      include_granted_scopes: 'true',
       redirect_uri: `http://localhost:${server.port()}/api/auth/google/handler/frame`,
       state: expect.any(String),
     });


### PR DESCRIPTION
When token is refreshed with google oauth, it gets only scopes explicitly provided, and backstage silently needs more. Pass no scopes (lacking scopes will get handled by frontend if it happens) and support incremental auth.

This supersedes https://github.com/backstage/backstage/pull/20653

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
