### PR TITLE
(kubernetes-react): Make sure types are exported

### DIFF
--- a/.changeset/old-coats-doubt.md
+++ b/.changeset/old-coats-doubt.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Make sure types exported by other `kubernetes` plugins in the past are exported again after the creation
+of the react package.
+
+Some types have been moved to this new package but the export was missing, so they were not available anymore for developers.

--- a/plugins/kubernetes-react/api-report.md
+++ b/plugins/kubernetes-react/api-report.md
@@ -22,6 +22,7 @@ import { IContainerStatus } from 'kubernetes-models/v1';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { IIoK8sApimachineryPkgApisMetaV1ObjectMeta } from '@kubernetes-models/apimachinery/apis/meta/v1/ObjectMeta';
 import { IObjectMeta } from '@kubernetes-models/apimachinery/apis/meta/v1/ObjectMeta';
+import type { JsonObject } from '@backstage/types';
 import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { OAuthApi } from '@backstage/core-plugin-api';
 import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
@@ -58,6 +59,26 @@ export const Cluster: ({
 
 // @public (undocumented)
 export const ClusterContext: React_2.Context<ClusterAttributes>;
+
+// @public (undocumented)
+export type ClusterLinksFormatter = (
+  options: ClusterLinksFormatterOptions,
+) => URL;
+
+// @public (undocumented)
+export interface ClusterLinksFormatterOptions {
+  // (undocumented)
+  dashboardParameters?: JsonObject;
+  // (undocumented)
+  dashboardUrl?: URL;
+  // (undocumented)
+  kind: string;
+  // (undocumented)
+  object: any;
+}
+
+// @public (undocumented)
+export const clusterLinksFormatters: Record<string, ClusterLinksFormatter>;
 
 // @public
 export type ClusterProps = {
@@ -206,6 +227,20 @@ export interface FixDialogProps {
   // (undocumented)
   pod: Pod_2;
 }
+
+// @public (undocumented)
+export function formatClusterLink(
+  options: FormatClusterLinkOptions,
+): string | undefined;
+
+// @public (undocumented)
+export type FormatClusterLinkOptions = {
+  dashboardUrl?: string;
+  dashboardApp?: string;
+  dashboardParameters?: JsonObject;
+  object: any;
+  kind: string;
+};
 
 // @public (undocumented)
 export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {

--- a/plugins/kubernetes-react/src/index.ts
+++ b/plugins/kubernetes-react/src/index.ts
@@ -27,3 +27,5 @@ export * from './hooks';
 export * from './api';
 export * from './kubernetes-auth-provider';
 export * from './components';
+export * from './utils';
+export * from './types';

--- a/plugins/kubernetes-react/src/types/types.ts
+++ b/plugins/kubernetes-react/src/types/types.ts
@@ -16,6 +16,9 @@
 
 import type { JsonObject } from '@backstage/types';
 
+/**
+ * @public
+ */
 export interface ClusterLinksFormatterOptions {
   dashboardUrl?: URL;
   dashboardParameters?: JsonObject;
@@ -23,6 +26,9 @@ export interface ClusterLinksFormatterOptions {
   kind: string;
 }
 
+/**
+ * @public
+ */
 export type ClusterLinksFormatter = (
   options: ClusterLinksFormatterOptions,
 ) => URL;

--- a/plugins/kubernetes-react/src/utils/clusterLinks/formatClusterLink.ts
+++ b/plugins/kubernetes-react/src/utils/clusterLinks/formatClusterLink.ts
@@ -17,7 +17,9 @@
 import type { JsonObject } from '@backstage/types';
 import { defaultFormatterName, clusterLinksFormatters } from './formatters';
 
-// @Deprecated use import { FormatClusterLinkOptions } from '@backstage/kubernetes-react'
+/**
+ * @public
+ */
 export type FormatClusterLinkOptions = {
   dashboardUrl?: string;
   dashboardApp?: string;
@@ -26,7 +28,9 @@ export type FormatClusterLinkOptions = {
   kind: string;
 };
 
-// @Deprecated use import { formatClusterLink } from '@backstage/kubernetes-react'
+/**
+ * @public
+ */
 export function formatClusterLink(options: FormatClusterLinkOptions) {
   if (!options.dashboardUrl && !options.dashboardParameters) {
     return undefined;

--- a/plugins/kubernetes-react/src/utils/clusterLinks/formatters/index.ts
+++ b/plugins/kubernetes-react/src/utils/clusterLinks/formatters/index.ts
@@ -21,6 +21,9 @@ import { aksFormatter } from './aks';
 import { eksFormatter } from './eks';
 import { gkeFormatter } from './gke';
 
+/**
+ * @public
+ */
 export const clusterLinksFormatters: Record<string, ClusterLinksFormatter> = {
   standard: standardFormatter,
   rancher: rancherFormatter,

--- a/plugins/kubernetes-react/src/utils/clusterLinks/index.ts
+++ b/plugins/kubernetes-react/src/utils/clusterLinks/index.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { formatClusterLink } from './formatClusterLink';
+export {
+  formatClusterLink,
+  type FormatClusterLinkOptions,
+} from './formatClusterLink';
 export { clusterLinksFormatters } from './formatters';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After the upgrade to Backstage 1.19.2, we noticed some types that we were using from the `kubernetes-backend` plugin were not available anymore. In the source code we saw they were moved to the newly created `kubernetes-react` library, but looks like they were forgotten to be exported.

In this PR I'm exporting all those types again and updating the api report, as well as the messages for some of those types.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
