### PR TITLE
Add a way to bypass user modification for TechDocs CLI docs generation in Docker

### DIFF
--- a/.changeset/spotty-olives-share.md
+++ b/.changeset/spotty-olives-share.md
@@ -1,0 +1,7 @@
+---
+'@techdocs/cli': minor
+'@backstage/plugin-techdocs-node': minor
+'@backstage/backend-common': patch
+---
+
+Add command `--runAsDefaultUser` for `@techdocs/cli generate` to bypass running the docker builds as host user for macOS and Linux.

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -147,6 +147,7 @@ Options:
                                   Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
   --legacyCopyReadmeMdToIndexMd   Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md
                                   in case a default <docs-dir>/index.md is not provided. (default: false)
+  --runAsDefaultUser              Bypass setting the container user as the same user and group id as host for Linux and MacOS (default: false)
   -v --verbose                    Enable verbose output. (default: false)
   -h, --help                      display help for command
 ```

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -683,6 +683,7 @@ export type RunContainerOptions = {
   workingDir?: string;
   envVars?: Record<string, string>;
   pullImage?: boolean;
+  defaultUser?: boolean;
 };
 
 export { SearchOptions };

--- a/packages/backend-common/src/util/ContainerRunner.ts
+++ b/packages/backend-common/src/util/ContainerRunner.ts
@@ -30,6 +30,7 @@ export type RunContainerOptions = {
   workingDir?: string;
   envVars?: Record<string, string>;
   pullImage?: boolean;
+  defaultUser?: boolean;
 };
 
 /**

--- a/packages/backend-common/src/util/DockerContainerRunner.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.ts
@@ -46,7 +46,7 @@ export class DockerContainerRunner implements ContainerRunner {
       workingDir,
       envVars = {},
       pullImage = true,
-      defaultUser = false
+      defaultUser = false,
     } = options;
 
     // Show a better error message when Docker is unavailable.
@@ -72,7 +72,7 @@ export class DockerContainerRunner implements ContainerRunner {
     }
 
     const userOptions: UserOptions = {};
-    if (!defaultUser && (process.getuid && process.getgid)) {
+    if (!defaultUser && process.getuid && process.getgid) {
       // Files that are created inside the Docker container will be owned by
       // root on the host system on non Mac systems, because of reasons. Mainly the fact that
       // volume sharing is done using NFS on Mac and actual mounts in Linux world.

--- a/packages/backend-common/src/util/DockerContainerRunner.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.ts
@@ -46,6 +46,7 @@ export class DockerContainerRunner implements ContainerRunner {
       workingDir,
       envVars = {},
       pullImage = true,
+      defaultUser = false
     } = options;
 
     // Show a better error message when Docker is unavailable.
@@ -71,7 +72,7 @@ export class DockerContainerRunner implements ContainerRunner {
     }
 
     const userOptions: UserOptions = {};
-    if (process.getuid && process.getgid) {
+    if (!defaultUser && (process.getuid && process.getgid)) {
       // Files that are created inside the Docker container will be owned by
       // root on the host system on non Mac systems, because of reasons. Mainly the fact that
       // volume sharing is done using NFS on Mac and actual mounts in Linux world.

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -38,6 +38,7 @@ Options:
   --omitTechdocsCoreMkdocsPlugin
   --legacyCopyReadmeMdToIndexMd
   --defaultPlugin [defaultPlugins...]
+  --runAsDefaultUser
   -h, --help
 ```
 

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -114,7 +114,7 @@ export default async function generate(opts: OptionValues) {
     etag: opts.etag,
     logStream: getLogStream(logger),
     siteOptions: { name: opts.siteName },
-    runAsDefaultUser: opts.runAsDefaultUser
+    runAsDefaultUser: opts.runAsDefaultUser,
   });
 
   if (configIsTemporary) {

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -114,6 +114,7 @@ export default async function generate(opts: OptionValues) {
     etag: opts.etag,
     logStream: getLogStream(logger),
     siteOptions: { name: opts.siteName },
+    runAsDefaultUser: opts.runAsDefaultUser
   });
 
   if (configIsTemporary) {

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -75,6 +75,11 @@ export function registerCommands(program: Command) {
       'Plugins which should be added automatically to the mkdocs.yaml file',
       [],
     )
+    .option(
+      '--runAsDefaultUser',
+      'Bypass setting the container user as the same user and group id as host for Linux and MacOS',
+      false
+    )
     .alias('build')
     .action(lazy(() => import('./generate/generate').then(m => m.default)));
 

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -78,7 +78,7 @@ export function registerCommands(program: Command) {
     .option(
       '--runAsDefaultUser',
       'Bypass setting the container user as the same user and group id as host for Linux and MacOS',
-      false
+      false,
     )
     .alias('build')
     .action(lazy(() => import('./generate/generate').then(m => m.default)));

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -55,6 +55,7 @@ export type GeneratorRunOptions = {
   siteOptions?: {
     name?: string;
   };
+  runAsDefaultUser?: boolean;
 };
 
 // @public

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -97,7 +97,7 @@ export class TechdocsGenerator implements GeneratorBase {
       logger: childLogger,
       logStream,
       siteOptions,
-      runAsDefaultUser
+      runAsDefaultUser,
     } = options;
 
     // Do some updates to mkdocs.yml before generating docs e.g. adding repo_url
@@ -172,7 +172,7 @@ export class TechdocsGenerator implements GeneratorBase {
             // write to, otherwise they will just fail trying to write to /
             envVars: { HOME: '/tmp' },
             pullImage: this.options.pullImage,
-            defaultUser: runAsDefaultUser
+            defaultUser: runAsDefaultUser,
           });
           childLogger.info(
             `Successfully generated docs from ${inputDir} into ${outputDir} using techdocs-container`,

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -97,6 +97,7 @@ export class TechdocsGenerator implements GeneratorBase {
       logger: childLogger,
       logStream,
       siteOptions,
+      runAsDefaultUser
     } = options;
 
     // Do some updates to mkdocs.yml before generating docs e.g. adding repo_url
@@ -171,6 +172,7 @@ export class TechdocsGenerator implements GeneratorBase {
             // write to, otherwise they will just fail trying to write to /
             envVars: { HOME: '/tmp' },
             pullImage: this.options.pullImage,
+            defaultUser: runAsDefaultUser
           });
           childLogger.info(
             `Successfully generated docs from ${inputDir} into ${outputDir} using techdocs-container`,

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -64,6 +64,7 @@ export type GeneratorRunOptions = {
   logger: Logger;
   logStream?: Writable;
   siteOptions?: { name?: string };
+  runAsDefaultUser?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

To resolve https://github.com/backstage/backstage/issues/19948

Containerised TechDocs generation via `techdocs/cli` runs the container user as the host user via a system check that can't be bypassed. This PR adds a new command  `runAsDefaultUser` to `techdocs/cli generate` which will bypass this magic when set. 

I've added the new parameter across dependencies as an optional parameter that is false by default to avoid any regression in functionality. 
Let me know if there's anything missing on this PR since the issue has been open for a while 🙇 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
