### PR TITLE
[scaffolder] Fix form re-rendering

### DIFF
--- a/plugins/scaffolder-react/src/next/components/Form/Form.tsx
+++ b/plugins/scaffolder-react/src/next/components/Form/Form.tsx
@@ -32,27 +32,34 @@ const WrappedForm = withTheme(MuiTheme);
 export const Form = (props: PropsWithChildren<ScaffolderRJSFFormProps>) => {
   // This is where we unbreak the changes from RJSF, and make it work with our custom fields so we don't pass on this
   // breaking change to our users. We will look more into a better API for this in scaffolderv2.
-  const wrappedFields = Object.fromEntries(
-    Object.entries(props.fields ?? {}).map(([key, Component]) => [
-      key,
-      (wrapperProps: FieldProps) => {
-        return (
-          <Component
-            {...wrapperProps}
-            uiSchema={wrapperProps.uiSchema ?? {}}
-            formData={wrapperProps.formData}
-            rawErrors={wrapperProps.rawErrors ?? []}
-          />
-        );
-      },
-    ]),
+  const wrappedFields = React.useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(props.fields ?? {}).map(([key, Component]) => [
+          key,
+          (wrapperProps: FieldProps) => {
+            return (
+              <Component
+                {...wrapperProps}
+                uiSchema={wrapperProps.uiSchema ?? {}}
+                formData={wrapperProps.formData}
+                rawErrors={wrapperProps.rawErrors ?? []}
+              />
+            );
+          },
+        ]),
+      ),
+    [props.fields],
   );
 
-  const templates = {
-    FieldTemplate,
-    DescriptionFieldTemplate,
-    ...props.templates,
-  };
+  const templates = React.useMemo(
+    () => ({
+      FieldTemplate,
+      DescriptionFieldTemplate,
+      ...props.templates,
+    }),
+    [props.templates],
+  );
 
   return (
     <WrappedForm {...props} templates={templates} fields={wrappedFields} />

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -115,6 +115,11 @@ export const Stepper = (stepperProps: StepperProps) => {
     );
   }, [props.extensions]);
 
+  const fields = useMemo(
+    () => ({ ...FieldOverrides, ...extensions }),
+    [extensions],
+  );
+
   const validators = useMemo(() => {
     return Object.fromEntries(
       props.extensions.map(({ name, validation }) => [name, validation]),
@@ -197,7 +202,7 @@ export const Stepper = (stepperProps: StepperProps) => {
             schema={currentStep.schema}
             uiSchema={currentStep.uiSchema}
             onSubmit={handleNext}
-            fields={{ ...FieldOverrides, ...extensions }}
+            fields={fields}
             showErrorList={false}
             onChange={handleChange}
             {...(props.formProps ?? {})}


### PR DESCRIPTION
Due to the nature of these things in the `Form`, gets re-rendered to agressively causing loss of state and being refocused to the first input element everytime.

This wraps things in `useMemo` to avoid creating new objects and breaking the react diffing to stop re-renders of the form.

Skipping a changeset here in favour of the other one for the scaffolder next work which hasn't been released yet.