### PR TITLE
Add link to Octopus Deploy Project from Release Table 

### DIFF
--- a/.changeset/tender-donkeys-speak.md
+++ b/.changeset/tender-donkeys-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-octopus-deploy': minor
+---
+
+Added Deep link into Octopus Deploy project from the Release Table.

--- a/.changeset/tender-donkeys-speak.md
+++ b/.changeset/tender-donkeys-speak.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-octopus-deploy': minor
+'@backstage/plugin-octopus-deploy': patch
 ---
 
 Added Deep link into Octopus Deploy project from the Release Table.

--- a/plugins/octopus-deploy/README.md
+++ b/plugins/octopus-deploy/README.md
@@ -23,6 +23,13 @@ proxy:
       X-Octopus-ApiKey: ${OCTOPUS_API_KEY}
 ```
 
+Optionally, also add the following section to your app-config.yaml if you wish to enable linking to the Project Release page in the Octopus Deploy UI from the footer of the Backstage Release Table. Typically this will be the server URL above without the /api postfix.
+
+```
+octopusdeploy:
+  webBaseUrl: "<your-octopus-web-url>"
+```
+
 2. Add the following to `EntityPage.tsx` to display Octopus Releases
 
 ```

--- a/plugins/octopus-deploy/api-report.md
+++ b/plugins/octopus-deploy/api-report.md
@@ -65,7 +65,7 @@ export type OctopusDeployment = {
 };
 
 // @public (undocumented)
-export const octopusDeployPlugin: BackstagePlugin<{}, {}, {}>;
+export const octopusDeployPlugin: BackstagePlugin<{}, {}>;
 
 // @public (undocumented)
 export type OctopusEnvironment = {

--- a/plugins/octopus-deploy/api-report.md
+++ b/plugins/octopus-deploy/api-report.md
@@ -7,6 +7,7 @@
 
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { ConfigApi } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { FetchApi } from '@backstage/core-plugin-api';
@@ -26,6 +27,10 @@ export const OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION = 'octopus.com/project-id';
 // @public (undocumented)
 export interface OctopusDeployApi {
   // (undocumented)
+  getConfig(): Promise<OctopusPluginConfig>;
+  // (undocumented)
+  getProjectInfo(projectReference: ProjectReference): Promise<OctopusProject>;
+  // (undocumented)
   getReleaseProgression(opts: {
     projectReference: ProjectReference;
     releaseHistoryCount: number;
@@ -38,10 +43,15 @@ export const octopusDeployApiRef: ApiRef<OctopusDeployApi>;
 // @public (undocumented)
 export class OctopusDeployClient implements OctopusDeployApi {
   constructor(options: {
+    configApi: ConfigApi;
     discoveryApi: DiscoveryApi;
     fetchApi: FetchApi;
     proxyPathBase?: string;
   });
+  // (undocumented)
+  getConfig(): Promise<OctopusPluginConfig>;
+  // (undocumented)
+  getProjectInfo(projectReference: ProjectReference): Promise<OctopusProject>;
   // (undocumented)
   getReleaseProgression(opts: {
     projectReference: ProjectReference;
@@ -55,7 +65,7 @@ export type OctopusDeployment = {
 };
 
 // @public (undocumented)
-export const octopusDeployPlugin: BackstagePlugin<{}, {}>;
+export const octopusDeployPlugin: BackstagePlugin<{}, {}, {}>;
 
 // @public (undocumented)
 export type OctopusEnvironment = {
@@ -64,9 +74,27 @@ export type OctopusEnvironment = {
 };
 
 // @public (undocumented)
+export type OctopusLinks = {
+  Self: string;
+  Web: string;
+};
+
+// @public (undocumented)
+export type OctopusPluginConfig = {
+  WebUiBaseUrl: string;
+};
+
+// @public (undocumented)
 export type OctopusProgression = {
   Environments: OctopusEnvironment[];
   Releases: OctopusReleaseProgression[];
+};
+
+// @public (undocumented)
+export type OctopusProject = {
+  Name: string;
+  Slug: string;
+  Links: OctopusLinks;
 };
 
 // @public (undocumented)

--- a/plugins/octopus-deploy/config.d.ts
+++ b/plugins/octopus-deploy/config.d.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Config {
+  octopusdeploy?: {
+    /**
+     * Frontend Web UI Base URL for deep links to UI
+     * @visibility frontend
+     */
+    webBaseUrl?: string;
+  };
+}

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -1,8 +1,14 @@
 {
   "name": "@backstage/plugin-octopus-deploy",
+<<<<<<< HEAD
   "version": "0.2.8-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
+=======
+  "version": "0.2.7",
+  "main": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+>>>>>>> e7e3614866b7 (Added deep link to Octopus Deploy Project from release table for Octopus Deploy plugin)
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
@@ -57,6 +63,8 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -1,14 +1,8 @@
 {
   "name": "@backstage/plugin-octopus-deploy",
-<<<<<<< HEAD
   "version": "0.2.8-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
-=======
-  "version": "0.2.7",
-  "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
->>>>>>> e7e3614866b7 (Added deep link to Octopus Deploy Project from release table for Octopus Deploy plugin)
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",

--- a/plugins/octopus-deploy/src/components/EntityPageOctopusDeploy/EntityPageOctopusDeploy.tsx
+++ b/plugins/octopus-deploy/src/components/EntityPageOctopusDeploy/EntityPageOctopusDeploy.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useConfig } from '../../hooks/useConfig';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { useProject } from '../../hooks/useProject';
 import { useReleases } from '../../hooks/useReleases';
 import { getProjectReferenceAnnotationFromEntity } from '../../utils/getAnnotationFromEntity';
 import React from 'react';
@@ -30,12 +32,22 @@ export const EntityPageOctopusDeploy = (props: { defaultLimit?: number }) => {
     projectReference.spaceId,
   );
 
+  const {
+    project,
+    loading: projectLoading,
+    error: projectError,
+  } = useProject(projectReference.projectId, projectReference.spaceId);
+
+  const { config, loading: configLoading, error: configError } = useConfig();
+
   return (
     <ReleaseTable
       environments={environments}
       releases={releases}
-      loading={loading}
-      error={error}
+      project={project}
+      config={config}
+      loading={loading || projectLoading || configLoading}
+      error={error || projectError || configError}
     />
   );
 };

--- a/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
+++ b/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 import { Box, Typography } from '@material-ui/core';
-import { OctopusEnvironment, OctopusReleaseProgression } from '../../api';
+import {
+  OctopusEnvironment,
+  OctopusProject,
+  OctopusReleaseProgression,
+  OctopusPluginConfig,
+} from '../../api';
 
 import React from 'react';
 import {
+  BottomLink,
+  BottomLinkProps,
   ResponseErrorPanel,
   StatusAborted,
   StatusError,
@@ -33,6 +40,8 @@ import { OctopusDeployIcon } from '../OctopusDeployIcon';
 type ReleaseTableProps = {
   environments?: OctopusEnvironment[];
   releases?: OctopusReleaseProgression[];
+  project?: OctopusProject;
+  config?: OctopusPluginConfig;
   loading: boolean;
   error?: Error;
 };
@@ -93,6 +102,8 @@ export const getDeploymentStatusComponent = (state: string | undefined) => {
 export const ReleaseTable = ({
   environments,
   releases,
+  project,
+  config,
   loading,
   error,
 }: ReleaseTableProps) => {
@@ -130,24 +141,39 @@ export const ReleaseTable = ({
     })) ?? []),
   ];
 
+  const deepLink: BottomLinkProps | null =
+    project?.Links?.Web && config?.WebUiBaseUrl
+      ? {
+          link: `${config.WebUiBaseUrl}${project.Links.Web}`,
+          title: 'Go to project',
+          onClick: e => {
+            e.preventDefault();
+            window.open(`${config?.WebUiBaseUrl}${project?.Links.Web}`);
+          },
+        }
+      : null;
+
   return (
-    <Table
-      isLoading={loading}
-      columns={columns}
-      options={{
-        search: true,
-        paging: true,
-        pageSize: 5,
-        showEmptyDataSourceMessage: !loading,
-      }}
-      title={
-        <Box display="flex" alignItems="center">
-          <OctopusDeployIcon style={{ fontSize: 30 }} />
-          <Box mr={1} />
-          Octopus Deploy - Releases ({releases ? releases.length : 0})
-        </Box>
-      }
-      data={releases ?? []}
-    />
+    <Box>
+      <Table
+        isLoading={loading}
+        columns={columns}
+        options={{
+          search: true,
+          paging: true,
+          pageSize: 5,
+          showEmptyDataSourceMessage: !loading,
+        }}
+        title={
+          <Box display="flex" alignItems="center">
+            <OctopusDeployIcon style={{ fontSize: 30 }} />
+            <Box mr={1} />
+            Octopus Deploy - Releases ({releases ? releases.length : 0})
+          </Box>
+        }
+        data={releases ?? []}
+      />
+      {deepLink !== null && <BottomLink {...deepLink} />}
+    </Box>
   );
 };

--- a/plugins/octopus-deploy/src/hooks/useConfig.ts
+++ b/plugins/octopus-deploy/src/hooks/useConfig.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+import { octopusDeployApiRef, OctopusPluginConfig } from '../api';
+
+export function useConfig(): {
+  config?: OctopusPluginConfig;
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(octopusDeployApiRef);
+
+  const { value, loading, error } = useAsync(() => {
+    return api.getConfig();
+  }, [api]);
+
+  return {
+    config: value,
+    loading,
+    error,
+  };
+}

--- a/plugins/octopus-deploy/src/hooks/useProject.ts
+++ b/plugins/octopus-deploy/src/hooks/useProject.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+import { octopusDeployApiRef, OctopusProject } from '../api';
+
+export function useProject(
+  projectId: string,
+  spaceId?: string,
+): {
+  project?: OctopusProject;
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(octopusDeployApiRef);
+
+  const { value, loading, error } = useAsync(() => {
+    return api.getProjectInfo({ projectId: projectId, spaceId: spaceId });
+  }, [api, projectId, spaceId]);
+
+  return {
+    project: value,
+    loading,
+    error,
+  };
+}

--- a/plugins/octopus-deploy/src/plugin.ts
+++ b/plugins/octopus-deploy/src/plugin.ts
@@ -24,6 +24,7 @@ import {
   createRoutableExtension,
   discoveryApiRef,
   fetchApiRef,
+  configApiRef,
 } from '@backstage/core-plugin-api';
 
 import { Entity } from '@backstage/catalog-model';
@@ -38,9 +39,13 @@ export const octopusDeployPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: octopusDeployApiRef,
-      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
-      factory: ({ discoveryApi, fetchApi }) =>
-        new OctopusDeployClient({ discoveryApi, fetchApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi, configApi }) =>
+        new OctopusDeployClient({ discoveryApi, fetchApi, configApi }),
     }),
   ],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a deep link into the octopus deploy UI for a  project from the Release Table in line with other similar plugins.

![image](https://github.com/backstage/backstage/assets/1361894/1d033229-0127-405f-b988-91f2820848fd)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
