### PR TITLE
remove main master build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CNCF Status](https://img.shields.io/badge/cncf%20status-incubation-blue.svg)](https://www.cncf.io/projects)
-[![Main CI Build](https://github.com/backstage/backstage/workflows/Main%20Master%20Build/badge.svg)](https://github.com/backstage/backstage/actions?query=workflow%3A%22Main+Master+Build%22)
 [![Discord](https://img.shields.io/discord/687207715902193673)](https://discord.gg/backstage-687207715902193673)
 ![Code style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 [![Codecov](https://img.shields.io/codecov/c/github/backstage/backstage)](https://codecov.io/gh/backstage/backstage)


### PR DESCRIPTION
Since we renamed the workflows this has been a broken image

![Screenshot 2023-10-24 at 09 33 31](https://github.com/backstage/backstage/assets/3097461/da2a6922-d3da-4e5c-a95f-c2b386a5f285)

And I opted to just remove it, the value seems extremely low. What should we otherwise have put here?