### PR TITLE
just a few small windows build fixes

### DIFF
--- a/.changeset/sharp-chefs-attend.md
+++ b/.changeset/sharp-chefs-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Ensure recursive deletion of temporary directories in tests

--- a/packages/app-next/src/App.test.tsx
+++ b/packages/app-next/src/App.test.tsx
@@ -21,6 +21,10 @@ jest.mock('@backstage/plugin-graphiql', () => ({
   GraphiQLIcon: () => null,
 }));
 
+// Rarely, and only in windows CI, do these tests take slightly more than the
+// default five seconds
+jest.setTimeout(15_000);
+
 describe('App', () => {
   it('should render', async () => {
     process.env = {

--- a/packages/backend-test-utils/src/filesystem/MockDirectory.ts
+++ b/packages/backend-test-utils/src/filesystem/MockDirectory.ts
@@ -311,7 +311,7 @@ class MockDirectoryImpl {
   };
 
   remove = (): void => {
-    fs.removeSync(this.#root);
+    fs.rmSync(this.#root, { recursive: true, force: true, maxRetries: 10 });
   };
 
   #transformInput(input: MockDirectoryContent[string]): MockEntry[] {

--- a/packages/config-loader/src/sources/ConfigSources.test.ts
+++ b/packages/config-loader/src/sources/ConfigSources.test.ts
@@ -93,7 +93,7 @@ describe('ConfigSources', () => {
           targets: [{ type: 'path', target: '/config.yaml' }],
         }),
       ),
-    ).toEqual([{ name: 'FileConfigSource', path: '/config.yaml' }]);
+    ).toEqual([{ name: 'FileConfigSource', path: `${root}config.yaml` }]);
 
     expect(
       mergeSources(
@@ -201,9 +201,9 @@ describe('ConfigSources', () => {
         ]),
       ),
     ).toEqual([
-      { name: 'FileConfigSource', path: '/a.yaml' },
-      { name: 'FileConfigSource', path: '/b.yaml' },
-      { name: 'FileConfigSource', path: '/c.yaml' },
+      { name: 'FileConfigSource', path: `${root}a.yaml` },
+      { name: 'FileConfigSource', path: `${root}b.yaml` },
+      { name: 'FileConfigSource', path: `${root}c.yaml` },
     ]);
   });
 


### PR DESCRIPTION
The removal change should deal with the ENOTEMPTY errors, but there may still remain EBUSY/EPERM errors due to files being locked, let's deal with that separately. I did add a retry counter which may deal with short lived (up to a second; the delay is 100ms by default) errors.