### PR TITLE
fix: CommonJSModuleLoader returning uncomplete list

### DIFF
--- a/packages/backend-plugin-manager/src/loader/CommonJSModuleLoader.ts
+++ b/packages/backend-plugin-manager/src/loader/CommonJSModuleLoader.ts
@@ -24,8 +24,8 @@ export class CommonJSModuleLoader implements ModuleLoader {
     backstageRoot: string,
     dynamicPluginsPaths: string[],
   ): Promise<void> {
-    const allowedNodeModulesPaths = [
-      `${backstageRoot}/node_modules`,
+    const backstageRootNodeModulesPath = `${backstageRoot}/node_modules`;
+    const dynamicNodeModulesPaths = [
       ...dynamicPluginsPaths.map(p => path.resolve(p, 'node_modules')),
     ];
     const Module = require('module');
@@ -35,8 +35,12 @@ export class CommonJSModuleLoader implements ModuleLoader {
       if (!dynamicPluginsPaths.some(p => from.startsWith(p))) {
         return result;
       }
-
-      const filtered = result.filter(p => allowedNodeModulesPaths.includes(p));
+      const filtered = result.filter(nodeModulePath => {
+        return (
+          nodeModulePath === backstageRootNodeModulesPath ||
+          dynamicNodeModulesPaths.some(p => nodeModulePath.startsWith(p))
+        );
+      });
       this.logger.debug(
         `Overriding node_modules search path for dynamic plugin ${from} to: ${filtered}`,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `CommonJSModuleLoader` default module loader of the `backend-plugin-manager` package does not support loading modules from embedded `node_modules` folders of private packages located in the plugin `node_modules` folder.

Typical example is the backstage `kubernetes` plugin, which transitively imports the `tar` module, which itself imports version `5.0.0` of the `minipass` module.
In the main backstage `node_modules`, there is another, older, version of `minipass` (version `3.3.5`), which is incompatible with the `tar` module, so the `tar`-required `minipass` module ends up being available in a `tar`-private `node_modules` folder: in `node_modules/tar/node_modules/minipass`.

This PR fixes issue #20762

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
