### PR TITLE
chore: fix spacing of header labels for entity layout

### DIFF
--- a/.changeset/famous-plums-sit.md
+++ b/.changeset/famous-plums-sit.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog': patch
+---
+
+Fix spacing inconsistency with links and labels in headers

--- a/packages/core-components/src/layout/HeaderLabel/HeaderLabel.test.tsx
+++ b/packages/core-components/src/layout/HeaderLabel/HeaderLabel.test.tsx
@@ -51,4 +51,29 @@ describe('<HeaderLabel />', () => {
     expect(rendered.getByText('Value')).toBeInTheDocument();
     expect(anchor.href).toBe('http://localhost/test');
   });
+
+  it('should use a `p` tag if the provided value is a string', async () => {
+    const rendered = await renderInTestApp(
+      <HeaderLabel label="Label" value="Value" />,
+    );
+    expect(rendered.getByText('Value').tagName).toBe('P');
+  });
+
+  it('should use a `span` tag if the provided value is not a string', async () => {
+    const rendered = await renderInTestApp(
+      <HeaderLabel label="Label" value={<>Value</>} />,
+    );
+    expect(rendered.getByText('Value').tagName).toBe('SPAN');
+  });
+
+  it('should use the correct custom typography root component', async () => {
+    const rendered = await renderInTestApp(
+      <HeaderLabel
+        label="Label"
+        value="Value"
+        contentTypograpyRootComponent="tr"
+      />,
+    );
+    expect(rendered.container.querySelector('tr')).toBeInTheDocument();
+  });
 });

--- a/packages/core-components/src/layout/HeaderLabel/HeaderLabel.tsx
+++ b/packages/core-components/src/layout/HeaderLabel/HeaderLabel.tsx
@@ -49,12 +49,19 @@ const useStyles = makeStyles<BackstageTheme>(
 type HeaderLabelContentProps = PropsWithChildren<{
   value: React.ReactNode;
   className: string;
+  typographyRootComponent?: keyof JSX.IntrinsicElements;
 }>;
 
-const HeaderLabelContent = ({ value, className }: HeaderLabelContentProps) => {
+const HeaderLabelContent = ({
+  value,
+  className,
+  typographyRootComponent,
+}: HeaderLabelContentProps) => {
   return (
     <Typography
-      component={typeof value === 'string' ? 'p' : 'span'}
+      component={
+        typographyRootComponent ?? (typeof value === 'string' ? 'p' : 'span')
+      }
       className={className}
     >
       {value}
@@ -65,6 +72,7 @@ const HeaderLabelContent = ({ value, className }: HeaderLabelContentProps) => {
 type HeaderLabelProps = {
   label: string;
   value?: HeaderLabelContentProps['value'];
+  contentTypograpyRootComponent?: HeaderLabelContentProps['typographyRootComponent'];
   url?: string;
 };
 
@@ -75,12 +83,13 @@ type HeaderLabelProps = {
  *
  */
 export function HeaderLabel(props: HeaderLabelProps) {
-  const { label, value, url } = props;
+  const { label, value, url, contentTypograpyRootComponent } = props;
   const classes = useStyles();
   const content = (
     <HeaderLabelContent
       className={classes.value}
       value={value || '<Unknown>'}
+      typographyRootComponent={contentTypograpyRootComponent}
     />
   );
   return (

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -233,4 +233,35 @@ describe('EntityLayout', () => {
     expect(screen.queryByText('tabbed-test-title-2')).not.toBeInTheDocument();
     expect(screen.getByText('tabbed-test-title-3')).toBeInTheDocument();
   });
+
+  it('renders the owner links inside `p` tags', async () => {
+    const mockTargetRef = 'my:target/ref';
+    const ownerEntity = {
+      ...mockEntity,
+      relations: [{ type: 'ownedBy', targetRef: mockTargetRef }],
+    };
+    await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <EntityProvider entity={ownerEntity}>
+          <EntityLayout>
+            <EntityLayout.Route path="/" title="tabbed-test-title">
+              <div>tabbed-test-content</div>
+            </EntityLayout.Route>
+          </EntityLayout>
+        </EntityProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const ownerLink = screen.getByText(mockTargetRef);
+    expect(ownerLink).toBeInTheDocument();
+    expect(ownerLink.nodeName).toBe('A');
+    const linkParent = ownerLink.parentElement;
+    expect(linkParent).toBeInTheDocument();
+    expect(linkParent?.nodeName).toBe('P');
+  });
 });

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -257,11 +257,11 @@ describe('EntityLayout', () => {
       },
     );
 
-    const ownerLink = screen.getByText(mockTargetRef);
+    const ownerLink = screen.getByText(mockTargetRef).closest('a');
     expect(ownerLink).toBeInTheDocument();
-    expect(ownerLink.nodeName).toBe('A');
-    const linkParent = ownerLink.parentElement;
+    expect(ownerLink?.tagName).toBe('A');
+    const linkParent = ownerLink?.parentElement;
     expect(linkParent).toBeInTheDocument();
-    expect(linkParent?.nodeName).toBe('P');
+    expect(linkParent?.tagName).toBe('P');
   });
 });

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -119,6 +119,7 @@ function EntityLabels(props: { entity: Entity }) {
       {ownedByRelations.length > 0 && (
         <HeaderLabel
           label="Owner"
+          contentTypograpyRootComponent="p"
           value={
             <EntityRefLinks
               entityRefs={ownedByRelations}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR adds an optional prop to the `HeaderLabel` component to specify the component type used in the content's parent `Typography` component.

This was done because this component is used in multiple places and in multiple conditions. When passed a string the `Typography` component used is `p`, for anything else we use `span`. The spacing between the component's label's `p` and content is different depending on if it is a `span` or another `p`.
In practice, any links passed into this component will have more spacing between the label and content. This is fine when the component is used elsewhere, and where that spacing is consistent. But when used in the header, and when right next to non-link sibling components, the spacing difference is obvious. 

By specifying that we want to use a `p` tag in this specific use for owner links inside `EntityLayout`, we can have the link and non-link items in the header have consistent spacing. 


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
### Changes
- add optional prop to `HeaderLabel` that sets `Typography` `component` prop
- use new prop in `EntityLayout`
- add tests

### Before (note spacing between label and content)
![SCR-20231023-l8s](https://github.com/backstage/backstage/assets/30599893/92ba7dcc-b8a6-499c-8a98-192e557ce126)

### After
![SCR-20231023-l8i](https://github.com/backstage/backstage/assets/30599893/fb163d01-e464-4212-a2c2-8e690ebf6313)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
