### PR TITLE
Bug/18436 entity unregister redirect

### DIFF
--- a/.changeset/lucky-kids-cough.md
+++ b/.changeset/lucky-kids-cough.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-fixes bug where after unregistering an entity you are redirected to "/". Adds an optional externalRoute "unregisterRedirect" into the catalog plugin which when bound will be navigated to on successfull removal of an entity. If the external route is not bound it will default to using the catalog rootRouteRef "/catalog".
+fixes bug where after unregistering an entity you are redirected to "/". Adds an optional external route "unregisterRedirect" into the catalog plugin which when bound will be navigated to on successful removal of an entity. If the external route is not bound it will default to using the catalog rootRouteRef "/catalog".

--- a/.changeset/lucky-kids-cough.md
+++ b/.changeset/lucky-kids-cough.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-refactors redirection after successfully unregistering an entity to use the catalog rootRouteRef "/catalog" instead of "/"
+fixes bug where after unregistering an entity you are redirected to "/". Adds an optional externalRoute "unregisterRedirect" into the catalog plugin which when bound will be navigated to on successfull removal of an entity. If the external route is not bound it will default to using the catalog rootRouteRef "/catalog".

--- a/.changeset/lucky-kids-cough.md
+++ b/.changeset/lucky-kids-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+refactors redirection after successfully unregistering an entity to use the catalog rootRouteRef "/catalog" instead of "/"

--- a/.changeset/lucky-kids-cough.md
+++ b/.changeset/lucky-kids-cough.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-catalog': patch
 ---
 
-fixes bug where after unregistering an entity you are redirected to "/". Adds an optional external route "unregisterRedirect" into the catalog plugin which when bound will be navigated to on successful removal of an entity. If the external route is not bound it will default to using the catalog rootRouteRef "/catalog".
+- Fixes bug where after unregistering an entity you are redirected to `/`.
+- Adds an optional external route `unregisterRedirect` to override this behaviour to another route.

--- a/packages/app/src/components/catalog/EntityPage.test.tsx
+++ b/packages/app/src/components/catalog/EntityPage.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EntityLayout } from '@backstage/plugin-catalog';
+import { EntityLayout, catalogPlugin } from '@backstage/plugin-catalog';
 import {
   EntityProvider,
   starredEntitiesApiRef,
@@ -51,6 +51,7 @@ describe('EntityPage Test', () => {
     listWorkflowRuns: jest.fn().mockResolvedValue([]),
   };
   const mockPermissionApi = new MockPermissionApi();
+  const rootRouteRef = catalogPlugin.routes.catalogIndex;
 
   describe('cicdContent', () => {
     it('Should render GitHub Actions View', async () => {
@@ -70,6 +71,11 @@ describe('EntityPage Test', () => {
             </EntityLayout>
           </EntityProvider>
         </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/catalog': rootRouteRef,
+          },
+        },
       );
 
       expect(rendered.getByText('ExampleComponent')).toBeInTheDocument();

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -122,6 +122,7 @@ export const catalogPlugin: BackstagePlugin<
       },
       true
     >;
+    unregisterRedirect: ExternalRouteRef<undefined, true>;
   }
 >;
 

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -77,7 +77,8 @@
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
+    "react-router": "6.17.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -77,8 +77,7 @@
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
-    "react-router": "6.17.0"
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -41,7 +41,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { EntityLayout } from './EntityLayout';
 import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
-import * as router from 'react-router';
+import { Route, Routes } from 'react-router-dom';
 
 describe('EntityLayout', () => {
   const mockEntity = {
@@ -326,15 +326,6 @@ describe('EntityLayout - CleanUpAfterRemoval', () => {
     },
   };
 
-  const navigate = jest.fn();
-  beforeEach(() => {
-    jest.spyOn(router, 'useNavigate').mockImplementation(() => navigate);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('redirects to externalRouteRef when unregisterRedirectRouteRef is bound', async () => {
     await renderInTestApp(
       <TestApiProvider
@@ -360,12 +351,16 @@ describe('EntityLayout - CleanUpAfterRemoval', () => {
             </EntityLayout.Route>
           </EntityLayout>
         </EntityProvider>
+        <Routes>
+          <Route path="/catalog" element={<p>catalog-page</p>} />
+          <Route path="/testRoute" element={<p>external-page</p>} />
+        </Routes>
       </TestApiProvider>,
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
           '/catalog': rootRouteRef,
-          '/testExternalRouteRef': unregisterRedirectRouteRef,
+          '/testRoute': unregisterRedirectRouteRef,
         },
       },
     );
@@ -386,7 +381,7 @@ describe('EntityLayout - CleanUpAfterRemoval', () => {
     });
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('/testExternalRouteRef');
+      expect(screen.getByText('external-page')).toBeInTheDocument();
     });
   });
 
@@ -415,6 +410,10 @@ describe('EntityLayout - CleanUpAfterRemoval', () => {
             </EntityLayout.Route>
           </EntityLayout>
         </EntityProvider>
+        <Routes>
+          <Route path="/catalog" element={<p>catalog-page</p>} />
+          <Route path="/testRoute" element={<p>external-page</p>} />
+        </Routes>
       </TestApiProvider>,
       {
         mountedRoutes: {
@@ -440,7 +439,7 @@ describe('EntityLayout - CleanUpAfterRemoval', () => {
     });
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('/catalog');
+      expect(screen.getByText('catalog-page')).toBeInTheDocument();
     });
   });
 });

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -266,6 +266,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -15,7 +15,11 @@
  */
 
 import { CatalogApi } from '@backstage/catalog-client';
-import { Entity } from '@backstage/catalog-model';
+import {
+  ANNOTATION_ORIGIN_LOCATION,
+  Entity,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
 import { ApiProvider } from '@backstage/core-app-api';
 import { AlertApi, alertApiRef } from '@backstage/core-plugin-api';
 import {
@@ -30,28 +34,30 @@ import { permissionApiRef } from '@backstage/plugin-permission-react';
 import {
   MockPermissionApi,
   renderInTestApp,
+  TestApiProvider,
   TestApiRegistry,
 } from '@backstage/test-utils';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { EntityLayout } from './EntityLayout';
-import { rootRouteRef } from '../../routes';
-
-const mockEntity = {
-  kind: 'MyKind',
-  metadata: {
-    name: 'my-entity',
-  },
-} as Entity;
-
-const mockApis = TestApiRegistry.from(
-  [catalogApiRef, {} as CatalogApi],
-  [alertApiRef, {} as AlertApi],
-  [starredEntitiesApiRef, new MockStarredEntitiesApi()],
-  [permissionApiRef, new MockPermissionApi()],
-);
+import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
+import * as router from 'react-router';
 
 describe('EntityLayout', () => {
+  const mockEntity = {
+    kind: 'MyKind',
+    metadata: {
+      name: 'my-entity',
+    },
+  } as Entity;
+
+  const mockApis = TestApiRegistry.from(
+    [catalogApiRef, {} as CatalogApi],
+    [alertApiRef, {} as AlertApi],
+    [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+    [permissionApiRef, new MockPermissionApi()],
+  );
+
   it('renders simplest case', async () => {
     await renderInTestApp(
       <ApiProvider apis={mockApis}>
@@ -270,5 +276,171 @@ describe('EntityLayout', () => {
     const linkParent = ownerLink?.parentElement;
     expect(linkParent).toBeInTheDocument();
     expect(linkParent?.tagName).toBe('P');
+  });
+});
+
+describe('EntityLayout - CleanUpAfterRemoval', () => {
+  const entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'n',
+      namespace: 'ns',
+      annotations: {
+        [ANNOTATION_ORIGIN_LOCATION]: 'url:http://example.com',
+      },
+    },
+    spec: {
+      owner: 'tools',
+      type: 'service',
+    },
+    relations: [
+      {
+        type: RELATION_OWNED_BY,
+        targetRef: 'group:default/tools',
+      },
+    ],
+  };
+  const getLocationByRef: jest.MockedFunction<CatalogApi['getLocationByRef']> =
+    jest.fn();
+  const getEntities: jest.MockedFunction<CatalogApi['getEntities']> = jest.fn();
+  const removeEntityByUid: jest.MockedFunction<
+    CatalogApi['removeEntityByUid']
+  > = jest.fn();
+  const getEntityFacets: jest.MockedFunction<CatalogApi['getEntityFacets']> =
+    jest.fn();
+  getLocationByRef.mockResolvedValue(undefined);
+  getEntities.mockResolvedValue({ items: [{ ...entity }] });
+  getEntityFacets.mockResolvedValue({
+    facets: {
+      'relations.ownedBy': [{ count: 1, value: 'group:default/tools' }],
+    },
+  });
+
+  const alertApi: AlertApi = {
+    post() {
+      return undefined;
+    },
+    alert$() {
+      throw new Error('not implemented');
+    },
+  };
+
+  const navigate = jest.fn();
+  beforeEach(() => {
+    jest.spyOn(router, 'useNavigate').mockImplementation(() => navigate);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to externalRouteRef when unregisterRedirectRouteRef is bound', async () => {
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            catalogApiRef,
+            {
+              getLocationByRef,
+              getEntities,
+              removeEntityByUid,
+              getEntityFacets,
+            },
+          ],
+          [alertApiRef, alertApi],
+          [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+          [permissionApiRef, new MockPermissionApi()],
+        ]}
+      >
+        <EntityProvider entity={entity}>
+          <EntityLayout>
+            <EntityLayout.Route path="/" title="tabbed-test-title">
+              <div>tabbed-test-content</div>
+            </EntityLayout.Route>
+          </EntityLayout>
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
+          '/testExternalRouteRef': unregisterRedirectRouteRef,
+        },
+      },
+    );
+
+    const menuButton = screen.queryAllByTestId('menu-button')[0];
+    fireEvent.click(menuButton);
+    const listItemUnregister = screen.queryAllByRole('menuitem', {
+      name: /Unregister entity/i,
+    })[0];
+    fireEvent.click(listItemUnregister);
+    await waitFor(() => {
+      const deleteEntityButton = screen.getByRole('button', {
+        name: /Delete Entity/i,
+      });
+      act(() => {
+        fireEvent.click(deleteEntityButton);
+      });
+    });
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('/testExternalRouteRef');
+    });
+  });
+
+  it('redirects to rootRouteRef when unregisterRedirectRouteRef is not bound', async () => {
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            catalogApiRef,
+            {
+              getLocationByRef,
+              getEntities,
+              removeEntityByUid,
+              getEntityFacets,
+            },
+          ],
+          [alertApiRef, alertApi],
+          [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+          [permissionApiRef, new MockPermissionApi()],
+        ]}
+      >
+        <EntityProvider entity={entity}>
+          <EntityLayout>
+            <EntityLayout.Route path="/" title="tabbed-test-title">
+              <div>tabbed-test-content</div>
+            </EntityLayout.Route>
+          </EntityLayout>
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
+        },
+      },
+    );
+
+    const menuButton = screen.queryAllByTestId('menu-button')[0];
+    fireEvent.click(menuButton);
+    const listItemUnregister = screen.queryAllByRole('menuitem', {
+      name: /Unregister entity/i,
+    })[0];
+    fireEvent.click(listItemUnregister);
+    await waitFor(() => {
+      const deleteEntityButton = screen.getByRole('button', {
+        name: /Delete Entity/i,
+      });
+      act(() => {
+        fireEvent.click(deleteEntityButton);
+      });
+    });
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('/catalog');
+    });
   });
 });

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -35,6 +35,7 @@ import {
 import { act, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { EntityLayout } from './EntityLayout';
+import { rootRouteRef } from '../../routes';
 
 const mockEntity = {
   kind: 'MyKind',
@@ -65,6 +66,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -97,6 +99,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -120,6 +123,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -146,6 +150,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -178,6 +183,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -225,6 +231,7 @@ describe('EntityLayout', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -33,6 +33,7 @@ import {
   attachComponentData,
   IconComponent,
   useElementFilter,
+  useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
 import {
@@ -50,6 +51,7 @@ import { Alert } from '@material-ui/lab';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
+import { rootRouteRef } from '../../routes';
 
 /** @public */
 export type EntityLayoutRouteProps = {
@@ -229,10 +231,11 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
   const [inspectionDialogOpen, setInspectionDialogOpen] = useState(false);
   const navigate = useNavigate();
+  const catalogRoute = useRouteRef(rootRouteRef);
   const cleanUpAfterRemoval = async () => {
     setConfirmationDialogOpen(false);
     setInspectionDialogOpen(false);
-    navigate('/');
+    navigate(catalogRoute());
   };
 
   // Make sure to close the dialog if the user clicks links in it that navigate

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -51,7 +51,7 @@ import { Alert } from '@material-ui/lab';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
-import { rootRouteRef } from '../../routes';
+import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
 
 /** @public */
 export type EntityLayoutRouteProps = {
@@ -232,10 +232,14 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   const [inspectionDialogOpen, setInspectionDialogOpen] = useState(false);
   const navigate = useNavigate();
   const catalogRoute = useRouteRef(rootRouteRef);
+  const unregisterRedirectRoute = useRouteRef(unregisterRedirectRouteRef);
+
   const cleanUpAfterRemoval = async () => {
     setConfirmationDialogOpen(false);
     setInspectionDialogOpen(false);
-    navigate(catalogRoute());
+    navigate(
+      unregisterRedirectRoute ? unregisterRedirectRoute() : catalogRoute(),
+    );
   };
 
   // Make sure to close the dialog if the user clicks links in it that navigate

--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -25,6 +25,7 @@ import {
 import {
   createComponentRouteRef,
   createFromTemplateRouteRef,
+  unregisterRedirectRouteRef,
   viewTechDocRouteRef,
 } from './routes';
 import {
@@ -89,6 +90,7 @@ export const catalogPlugin = createPlugin({
     createComponent: createComponentRouteRef,
     viewTechDoc: viewTechDocRouteRef,
     createFromTemplate: createFromTemplateRouteRef,
+    unregisterRedirect: unregisterRedirectRouteRef,
   },
 });
 

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -36,6 +36,11 @@ export const createFromTemplateRouteRef = createExternalRouteRef({
   params: ['namespace', 'templateName'],
 });
 
+export const unregisterRedirectRouteRef = createExternalRouteRef({
+  id: 'unregister-redirect',
+  optional: true,
+});
+
 export const rootRouteRef = createRouteRef({
   id: 'catalog',
 });

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -37,7 +37,7 @@ export const createFromTemplateRouteRef = createExternalRouteRef({
 });
 
 export const unregisterRedirectRouteRef = createExternalRouteRef({
-  id: 'unregister-redirect',
+  id: 'catalog:unregister-redirect',
   optional: true,
 });
 

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -31,7 +31,7 @@ import {
   mockedCatalogApiSupportingGroups,
 } from '../../../../__testUtils__/catalogMocks';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
-import { EntityLayout } from '@backstage/plugin-catalog';
+import { EntityLayout, catalogPlugin } from '@backstage/plugin-catalog';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Observable } from '@backstage/types';
@@ -62,6 +62,8 @@ const mockedStarredEntitiesApi: Partial<StarredEntitiesApi> = {
     } as Observable<Set<string>>;
   },
 };
+
+const rootRouteRef = catalogPlugin.routes.catalogIndex;
 
 describe('MemberTab Test', () => {
   const groupEntity: GroupEntity = {
@@ -122,6 +124,7 @@ describe('MemberTab Test', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -151,6 +154,7 @@ describe('MemberTab Test', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -179,6 +183,7 @@ describe('MemberTab Test', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
+            '/catalog': rootRouteRef,
           },
         },
       );
@@ -206,6 +211,7 @@ describe('MemberTab Test', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
+            '/catalog': rootRouteRef,
           },
         },
       );
@@ -231,6 +237,7 @@ describe('MemberTab Test', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
+            '/catalog': rootRouteRef,
           },
         },
       );
@@ -265,6 +272,7 @@ describe('MemberTab Test', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
+            '/catalog': rootRouteRef,
           },
         },
       );
@@ -299,6 +307,7 @@ describe('MemberTab Test', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
+            '/catalog': rootRouteRef,
           },
         },
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes #18436 navigates to catalog root using rootRouteRef after successfully unregistering an entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
