### PR TITLE
make `coreServices.httpRouter` configurable, add `notFound`

### DIFF
--- a/.changeset/flat-papayas-film.md
+++ b/.changeset/flat-papayas-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Ensure that a `notFound` router is always present on plugin routes. Also makes `coreServices.httpRouter` configurable in the same way as the `rootHttpRouter`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -33,6 +33,7 @@ import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { RootLoggerService } from '@backstage/backend-plugin-api';
+import { Router } from 'express';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceFactoryOrFunction } from '@backstage/backend-plugin-api';
@@ -143,7 +144,25 @@ export class HostDiscovery implements DiscoveryService {
 }
 
 // @public (undocumented)
+export interface HttpRouterConfigureContext {
+  // (undocumented)
+  lifecycle: LifecycleService;
+  // (undocumented)
+  logger: LoggerService;
+  // (undocumented)
+  middleware: MiddlewareFactory;
+  // (undocumented)
+  pluginRouter: Router;
+  // (undocumented)
+  rootConfig: RootConfigService;
+  // (undocumented)
+  routes: RequestHandler;
+}
+
+// @public (undocumented)
 export interface HttpRouterFactoryOptions {
+  basePath?: string;
+  configure?(context: HttpRouterConfigureContext): void;
   getPath?(pluginId: string): string;
 }
 

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
@@ -15,21 +15,59 @@
  */
 
 import {
+  LifecycleService,
+  LoggerService,
+  RootConfigService,
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
-import { Handler } from 'express';
+import { Handler, RequestHandler, Router } from 'express';
 import PromiseRouter from 'express-promise-router';
+import { MiddlewareFactory } from '../../../http';
 import { createLifecycleMiddleware } from './createLifecycleMiddleware';
+
+/**
+ * @public
+ */
+export interface HttpRouterConfigureContext {
+  pluginRouter: Router;
+  middleware: MiddlewareFactory;
+  routes: RequestHandler;
+  rootConfig: RootConfigService;
+  logger: LoggerService;
+  lifecycle: LifecycleService;
+}
+
+function defaultConfigure(context: HttpRouterConfigureContext): void {
+  const { pluginRouter, routes, middleware, lifecycle } = context;
+  pluginRouter.use(createLifecycleMiddleware({ lifecycle }));
+  pluginRouter.use(routes);
+  pluginRouter.use(middleware.notFound());
+}
 
 /**
  * @public
  */
 export interface HttpRouterFactoryOptions {
   /**
-   * A callback used to generate the path for each plugin, defaults to `/api/{pluginId}`.
+   * The base path under which plugins are installed, defaults to `/api`.
+   */
+  basePath?: string;
+
+  /**
+   * A callback used to generate the path for each plugin, defaults to
+   * `${basePath}/{pluginId}`. This is a power user option and normally you'll
+   * do well to just add a base path or leave them both unset.
    */
   getPath?(pluginId: string): string;
+
+  /**
+   * Allows you to customize the creation of the plugin router, by attaching a
+   * set of middleware and the given routes in the desired order. If no
+   * configure callback is given, a default set of middleware are added around
+   * the routes, e.g. for 404 handling.
+   */
+  configure?(context: HttpRouterConfigureContext): void;
 }
 
 /** @public */
@@ -37,24 +75,95 @@ export const httpRouterServiceFactory = createServiceFactory(
   (options?: HttpRouterFactoryOptions) => ({
     service: coreServices.httpRouter,
     deps: {
+      config: coreServices.rootConfig,
+      logger: coreServices.rootLogger,
       plugin: coreServices.pluginMetadata,
       lifecycle: coreServices.lifecycle,
       rootHttpRouter: coreServices.rootHttpRouter,
     },
-    async factory({ plugin, rootHttpRouter, lifecycle }) {
-      const getPath = options?.getPath ?? (id => `/api/${id}`);
+    createRootContext({ config, logger, rootHttpRouter }) {
+      const { notFoundHandlerPath } = getOptions(options);
+      const middleware = MiddlewareFactory.create({ config, logger });
+
+      const pluginsRouter = PromiseRouter();
+      rootHttpRouter.use('', pluginsRouter);
+
+      if (notFoundHandlerPath) {
+        rootHttpRouter.use(notFoundHandlerPath, middleware.notFound());
+      }
+
+      return {
+        pluginsRouter,
+        middleware,
+      };
+    },
+    async factory(
+      { config, logger, plugin, lifecycle },
+      { pluginsRouter, middleware },
+    ) {
+      const { getPath, configure } = getOptions(options);
+
       const path = getPath(plugin.getId());
+      const pluginRouter = PromiseRouter();
+      const routes = PromiseRouter();
 
-      const router = PromiseRouter();
-      rootHttpRouter.use(path, router);
+      pluginsRouter.use(path, pluginRouter);
 
-      router.use(createLifecycleMiddleware({ lifecycle }));
+      configure({
+        pluginRouter,
+        middleware,
+        routes,
+        rootConfig: config,
+        logger,
+        lifecycle,
+      });
 
       return {
         use(handler: Handler) {
-          router.use(handler);
+          routes.use(handler);
         },
       };
     },
   }),
 );
+
+function getOptions(options?: HttpRouterFactoryOptions): {
+  notFoundHandlerPath?: string;
+  getPath(pluginId: string): string;
+  configure(context: HttpRouterConfigureContext): void;
+} {
+  let basePath = options?.basePath;
+  if (basePath !== undefined) {
+    basePath = adjustSlashes(basePath);
+  }
+
+  // Specifically if the user passed in a getPath but no base path, we cannot be
+  // sure on what path to place a notFound handler since in theory
+  const notFoundHandlerPath: string | undefined =
+    !basePath && options?.getPath ? undefined : basePath ?? '/api';
+
+  const getPath =
+    options?.getPath ??
+    ((pluginId: string) => `${basePath ?? '/api'}/${pluginId}`);
+
+  const configure = options?.configure ?? defaultConfigure;
+
+  return {
+    notFoundHandlerPath,
+    getPath,
+    configure,
+  };
+}
+
+function adjustSlashes(path: string): string {
+  let result = path;
+
+  if (result !== '/' && result.endsWith('/')) {
+    result = result.slice(0, -1);
+  }
+  if (!result.startsWith('/')) {
+    result = `/${result}`;
+  }
+
+  return result;
+}

--- a/packages/backend-app-api/src/services/implementations/httpRouter/index.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/index.ts
@@ -15,6 +15,9 @@
  */
 
 export { httpRouterServiceFactory } from './httpRouterServiceFactory';
-export type { HttpRouterFactoryOptions } from './httpRouterServiceFactory';
+export type {
+  HttpRouterFactoryOptions,
+  HttpRouterConfigureContext,
+} from './httpRouterServiceFactory';
 export { createLifecycleMiddleware } from './createLifecycleMiddleware';
 export type { LifecycleMiddlewareOptions } from './createLifecycleMiddleware';

--- a/packages/backend-app-api/src/services/implementations/rootHttpRouter/DefaultRootHttpRouter.ts
+++ b/packages/backend-app-api/src/services/implementations/rootHttpRouter/DefaultRootHttpRouter.ts
@@ -72,16 +72,17 @@ export class DefaultRootHttpRouter implements RootHttpRouterService {
   }
 
   use(path: string, handler: Handler) {
-    if (path.match(/^[/\s]*$/)) {
-      throw new Error(`Root router path may not be empty`);
+    // It's still permitted to register empty paths, as route wrappers
+    if (path !== '') {
+      const conflictingPath = this.#findConflictingPath(path);
+      if (conflictingPath) {
+        throw new Error(
+          `Path ${path} conflicts with the existing path ${conflictingPath}`,
+        );
+      }
+      this.#existingPaths.push(path);
     }
-    const conflictingPath = this.#findConflictingPath(path);
-    if (conflictingPath) {
-      throw new Error(
-        `Path ${path} conflicts with the existing path ${conflictingPath}`,
-      );
-    }
-    this.#existingPaths.push(path);
+
     this.#namedRoutes.use(path, handler);
 
     if (this.#indexPath === path) {

--- a/packages/backend-app-api/src/services/implementations/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -51,6 +51,12 @@ export type RootHttpRouterFactoryOptions = {
    */
   indexPath?: string | false;
 
+  /**
+   * Allows you to customize the creation of the express app, by attaching a set
+   * of middleware and the given routes in the desired order. If no configure
+   * callback is given, a default set of middleware for error handling, logging
+   * etc are added around the routes.
+   */
   configure?(context: RootHttpRouterConfigureContext): void;
 };
 
@@ -61,7 +67,6 @@ function defaultConfigure(context: RootHttpRouterConfigureContext) {
   app.use(middleware.compression());
   app.use(middleware.logging());
   app.use(routes);
-  app.use(middleware.notFound());
   app.use(middleware.error());
 }
 


### PR DESCRIPTION
Fixes #20742

Went a bit farther than just the bare minimum - the plugin router is now configurable in exactly the same way as the root router, if you want to change out the middleware.