### PR TITLE
Export `MissingAnnotationEmptyState` from `@backstage/plugin-catalog-react` instead

### DIFF
--- a/.changeset/real-pears-study.md
+++ b/.changeset/real-pears-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Reverting the `MissingAnnotationEmptyState` component due to cyclical dependency. This component is now deprecated, please use the import from `@backstage/plugin-catalog-react` instead to use the new functionality

--- a/.changeset/stale-horses-obey.md
+++ b/.changeset/stale-horses-obey.md
@@ -1,0 +1,32 @@
+---
+'@backstage/plugin-github-deployments': patch
+'@backstage/plugin-kubernetes-cluster': patch
+'@backstage/plugin-newrelic-dashboard': patch
+'@backstage/plugin-github-actions': patch
+'@backstage/plugin-splunk-on-call': patch
+'@backstage/plugin-code-coverage': patch
+'@backstage/plugin-code-climate': patch
+'@backstage/plugin-azure-sites': patch
+'@backstage/plugin-cloudbuild': patch
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-lighthouse': patch
+'@backstage/plugin-dynatrace': patch
+'@backstage/plugin-sonarqube': patch
+'@backstage/plugin-airbrake': patch
+'@backstage/plugin-circleci': patch
+'@backstage/plugin-puppetdb': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-bitrise': patch
+'@backstage/plugin-jenkins': patch
+'@backstage/plugin-rollbar': patch
+'@backstage/plugin-allure': patch
+'@backstage/plugin-sentry': patch
+'@backstage/plugin-fossa': patch
+'@backstage/plugin-kafka': patch
+'@backstage/plugin-nomad': patch
+'@backstage/plugin-vault': patch
+'@backstage/plugin-gocd': patch
+'@backstage/plugin-adr': patch
+---
+
+Import `MissingAnnotationEmptyState` from `@backstage/plugin-catalog-react` to remove the cyclical dependency

--- a/.changeset/wet-shrimps-approve.md
+++ b/.changeset/wet-shrimps-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Export `MissingAnnotationEmptyState` from `@backstage/plugin-catalog-react`

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -746,16 +746,13 @@ export type MetadataTableTitleCellClassKey = 'root';
 export type MicDropClassKey = 'micDrop';
 
 // Warning: (ae-forgotten-export) The symbol "Props_3" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "MissingAnnotationEmptyState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function MissingAnnotationEmptyState(
   props: Props_3,
 ): React_2.JSX.Element;
 
-// Warning: (ae-missing-release-tag) "MissingAnnotationEmptyStateClassKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type MissingAnnotationEmptyStateClassKey = 'code';
 
 // @public

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -33,11 +33,9 @@
     "start": "backstage-cli package start"
   },
   "dependencies": {
-    "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@date-io/core": "^1.3.13",

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -43,7 +43,7 @@ const ANNOTATION_LINE = COMPONENT_YAML_TEMPLATE.split('\n').findIndex(line =>
   ANNOTATION_REGEXP.test(line),
 );
 
-type Props = {
+export type Props = {
   annotation: string | string[];
   readMoreUrl?: string;
 };

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -47,7 +47,13 @@ type Props = {
   annotation: string | string[];
   readMoreUrl?: string;
 };
+
+/**
+ * @public
+ * @deprecated This component is deprecated, please use {@link @backstage/plugin-catalog-react#MissingAnnotationEmptyStateClassKey} instead
+ */
 export type MissingAnnotationEmptyStateClassKey = 'code';
+
 const useStyles = makeStyles<BackstageTheme>(
   theme => ({
     code: {
@@ -92,7 +98,7 @@ function generateDescription(annotations: string[]) {
 
 /**
  * @public
- * @deprecated This component is deprecated, please use {@link @backstage/plugin-catalog-react#MissingAnnotationEmptyuseState} instead
+ * @deprecated This component is deprecated, please use {@link @backstage/plugin-catalog-react#MissingAnnotationEmptyState} instead
  */
 export function MissingAnnotationEmptyState(props: Props) {
   const { annotation, readMoreUrl } = props;

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -25,16 +25,29 @@ import { CodeSnippet } from '../CodeSnippet';
 import { Link } from '../Link';
 import { EmptyState } from './EmptyState';
 
-import { useEntity } from '@backstage/plugin-catalog-react';
-import { Entity } from '@backstage/catalog-model';
+const COMPONENT_YAML_TEMPLATE = `apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: example
+  description: example.com
+  annotations:
+    ANNOTATION: value
+spec:
+  type: website
+  lifecycle: production
+  owner: user:guest`;
+
+const ANNOTATION_REGEXP = /^.*ANNOTATION.*$/m;
+const ANNOTATION_YAML = COMPONENT_YAML_TEMPLATE.match(ANNOTATION_REGEXP)![0];
+const ANNOTATION_LINE = COMPONENT_YAML_TEMPLATE.split('\n').findIndex(line =>
+  ANNOTATION_REGEXP.test(line),
+);
 
 type Props = {
   annotation: string | string[];
   readMoreUrl?: string;
 };
-
 export type MissingAnnotationEmptyStateClassKey = 'code';
-
 const useStyles = makeStyles<BackstageTheme>(
   theme => ({
     code: {
@@ -47,38 +60,18 @@ const useStyles = makeStyles<BackstageTheme>(
   { name: 'BackstageMissingAnnotationEmptyState' },
 );
 
-function generateYamlExample(
-  annotations: string[],
-  entity?: Entity,
-): { yamlText: string; lineNumbers: number[] } {
-  const kind = entity?.kind || 'Component';
-  const name = entity?.metadata.name || 'example';
-  const type = entity?.spec?.type || 'website';
-  const owner = entity?.spec?.owner || 'user:default/guest';
-
-  const yamlText = `apiVersion: backstage.io/v1alpha1
-kind: ${kind}
-metadata:
-  name: ${name}
-  annotations:${annotations.map(ann => `\n    ${ann}: value`).join('')}
-spec:
-  type: ${type}
-  owner: ${owner}`;
-
-  let line = 6; // Line 6 is the line number that annotations are added to.
-  const lineNumbers: number[] = [];
-  annotations.forEach(() => {
-    lineNumbers.push(line);
-    line++;
-  });
-
-  return {
-    yamlText,
-    lineNumbers,
-  };
+function generateLineNumbers(lineCount: number) {
+  return Array.from(Array(lineCount + 1).keys(), i => i + ANNOTATION_LINE);
 }
 
-function generateDescription(annotations: string[], entityKind = 'Component') {
+function generateComponentYaml(annotations: string[]) {
+  const annotationYaml = annotations
+    .map(ann => ANNOTATION_YAML.replace('ANNOTATION', ann))
+    .join('\n');
+  return COMPONENT_YAML_TEMPLATE.replace(ANNOTATION_YAML, annotationYaml);
+}
+
+function generateDescription(annotations: string[]) {
   const isSingular = annotations.length <= 1;
   return (
     <>
@@ -91,21 +84,17 @@ function generateDescription(annotations: string[], entityKind = 'Component') {
           </>
         ))}{' '}
       {isSingular ? 'is' : 'are'} missing. You need to add the{' '}
-      {isSingular ? 'annotation' : 'annotations'} to your {entityKind} if you
-      want to enable this tool.
+      {isSingular ? 'annotation' : 'annotations'} to your component if you want
+      to enable this tool.
     </>
   );
 }
 
+/**
+ * @public
+ * @deprecated This component is deprecated, please use {@link @backstage/plugin-catalog-react#MissingAnnotationEmptyuseState} instead
+ */
 export function MissingAnnotationEmptyState(props: Props) {
-  let entity: Entity | undefined;
-  try {
-    const entityContext = useEntity();
-    entity = entityContext.entity;
-  } catch (err) {
-    // ignore when entity context doesnt exist
-  }
-
   const { annotation, readMoreUrl } = props;
   const annotations = Array.isArray(annotation) ? annotation : [annotation];
   const url =
@@ -113,25 +102,23 @@ export function MissingAnnotationEmptyState(props: Props) {
     'https://backstage.io/docs/features/software-catalog/well-known-annotations';
   const classes = useStyles();
 
-  const entityKind = entity?.kind || 'Component';
-  const { yamlText, lineNumbers } = generateYamlExample(annotations, entity);
   return (
     <EmptyState
       missing="field"
       title="Missing Annotation"
-      description={generateDescription(annotations, entityKind)}
+      description={generateDescription(annotations)}
       action={
         <>
           <Typography variant="body1">
-            Add the annotation to your {entityKind} YAML as shown in the
+            Add the annotation to your component YAML as shown in the
             highlighted example below:
           </Typography>
           <Box className={classes.code}>
             <CodeSnippet
-              text={yamlText}
+              text={generateComponentYaml(annotations)}
               language="yaml"
               showLineNumbers
-              highlightedNumbers={lineNumbers}
+              highlightedNumbers={generateLineNumbers(annotations.length)}
               customStyle={{ background: 'inherit', fontSize: '115%' }}
             />
           </Box>

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -43,7 +43,7 @@ const ANNOTATION_LINE = COMPONENT_YAML_TEMPLATE.split('\n').findIndex(line =>
   ANNOTATION_REGEXP.test(line),
 );
 
-export type Props = {
+type Props = {
   annotation: string | string[];
   readMoreUrl?: string;
 };

--- a/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
+++ b/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
@@ -24,7 +24,6 @@ import {
   Content,
   ContentHeader,
   InfoCard,
-  MissingAnnotationEmptyState,
   Progress,
   SupportButton,
   WarningPanel,
@@ -38,7 +37,10 @@ import {
   isAdrAvailable,
   madrFilePathFilter,
 } from '@backstage/plugin-adr-common';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import {
   Box,
   Chip,

--- a/plugins/airbrake/src/components/EntityAirbrakeWidget/EntityAirbrakeWidget.tsx
+++ b/plugins/airbrake/src/components/EntityAirbrakeWidget/EntityAirbrakeWidget.tsx
@@ -19,7 +19,6 @@ import {
   EmptyState,
   ErrorPanel,
   InfoCard,
-  MissingAnnotationEmptyState,
   Progress,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
@@ -29,6 +28,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { airbrakeApiRef } from '../../api';
+import { MissingAnnotationEmptyState } from '@backstage/plugin-catalog-react';
 import { AIRBRAKE_PROJECT_ID_ANNOTATION, useProjectId } from '../useProjectId';
 
 const useStyles = makeStyles<BackstageTheme>(() => ({

--- a/plugins/allure/src/components/AllureReportComponent/AllureReportComponent.tsx
+++ b/plugins/allure/src/components/AllureReportComponent/AllureReportComponent.tsx
@@ -16,16 +16,16 @@
 import React from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import { allureApiRef } from '../../api';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import {
   ALLURE_PROJECT_ID_ANNOTATION,
   isAllureReportAvailable,
   getAllureProjectId,
 } from '../annotationHelpers';
-import {
-  MissingAnnotationEmptyState,
-  Progress,
-} from '@backstage/core-components';
+import { Progress } from '@backstage/core-components';
 import useAsync from 'react-use/lib/useAsync';
 import { Entity } from '@backstage/catalog-model';
 

--- a/plugins/azure-sites/src/components/AzureSitesOverviewComponent/AzureSitesOverview.tsx
+++ b/plugins/azure-sites/src/components/AzureSitesOverviewComponent/AzureSitesOverview.tsx
@@ -21,12 +21,11 @@ import {
   AZURE_WEB_SITE_NAME_ANNOTATION,
   useServiceEntityAnnotations,
 } from '../../hooks/useServiceEntityAnnotations';
+import { ErrorBoundary, ResponseErrorPanel } from '@backstage/core-components';
 import {
-  ErrorBoundary,
+  useEntity,
   MissingAnnotationEmptyState,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
-import { useEntity } from '@backstage/plugin-catalog-react';
+} from '@backstage/plugin-catalog-react';
 import { AzureSitesOverviewTable } from '../AzureSitesOverviewTableComponent/AzureSitesOverviewTable';
 
 /** @public */

--- a/plugins/bitrise/src/components/BitriseBuildsComponent/BitriseBuildsComponent.test.tsx
+++ b/plugins/bitrise/src/components/BitriseBuildsComponent/BitriseBuildsComponent.test.tsx
@@ -31,6 +31,7 @@ jest.mock('../../hooks/useBitriseBuildWorkflows', () => ({
 }));
 
 jest.mock('@backstage/plugin-catalog-react', () => ({
+  ...jest.requireActual('@backstage/plugin-catalog-react'),
   useEntity: () => {
     return entityValue;
   },

--- a/plugins/bitrise/src/components/BitriseBuildsComponent/BitriseBuildsComponent.tsx
+++ b/plugins/bitrise/src/components/BitriseBuildsComponent/BitriseBuildsComponent.tsx
@@ -15,18 +15,16 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import React, { useState } from 'react';
 import { useBitriseBuildWorkflows } from '../../hooks/useBitriseBuildWorkflows';
 import { AsyncState } from 'react-use/lib/useAsync';
 import { BitriseBuildsTable } from '../BitriseBuildsTableComponent';
 import { Item, Select } from '../Select';
-import {
-  Content,
-  ContentHeader,
-  MissingAnnotationEmptyState,
-  Page,
-} from '@backstage/core-components';
+import { Content, ContentHeader, Page } from '@backstage/core-components';
 
 export type Props = {
   entity: Entity;

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -616,6 +616,15 @@ export function InspectEntityDialog(props: {
   onClose: () => void;
 }): React_2.JSX.Element | null;
 
+// @public
+export function MissingAnnotationEmptyState(props: {
+  annotation: string | string[];
+  readMoreUrl?: string;
+}): React_2.JSX.Element;
+
+// @public (undocumented)
+export type MissingAnnotationEmptyStateClassKey = 'code';
+
 // @public (undocumented)
 export function MockEntityListContextProvider<
   T extends DefaultEntityFilters = DefaultEntityFilters,

--- a/plugins/catalog-react/src/components/MissingAnnotationEmptyState/MissingAnnotationEmptyState.tsx
+++ b/plugins/catalog-react/src/components/MissingAnnotationEmptyState/MissingAnnotationEmptyState.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackstageTheme } from '@backstage/theme';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import React from 'react';
+import { CodeSnippet, Link, EmptyState } from '@backstage/core-components';
+import { Entity } from '@backstage/catalog-model';
+import { useEntity } from '../../hooks';
+
+type Props = {
+  annotation: string | string[];
+  readMoreUrl?: string;
+};
+
+/** @public */
+export type MissingAnnotationEmptyStateClassKey = 'code';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    code: {
+      borderRadius: 6,
+      margin: theme.spacing(2, 0),
+      background:
+        theme.palette.type === 'dark' ? '#444' : theme.palette.common.white,
+    },
+  }),
+  { name: 'BackstageMissingAnnotationEmptyState' },
+);
+
+function generateYamlExample(
+  annotations: string[],
+  entity?: Entity,
+): { yamlText: string; lineNumbers: number[] } {
+  const kind = entity?.kind || 'Component';
+  const name = entity?.metadata.name || 'example';
+  const type = entity?.spec?.type || 'website';
+  const owner = entity?.spec?.owner || 'user:default/guest';
+
+  const yamlText = `apiVersion: backstage.io/v1alpha1
+kind: ${kind}
+metadata:
+  name: ${name}
+  annotations:${annotations.map(ann => `\n    ${ann}: value`).join('')}
+spec:
+  type: ${type}
+  owner: ${owner}`;
+
+  let line = 6; // Line 6 is the line number that annotations are added to.
+  const lineNumbers: number[] = [];
+  annotations.forEach(() => {
+    lineNumbers.push(line);
+    line++;
+  });
+
+  return {
+    yamlText,
+    lineNumbers,
+  };
+}
+
+function generateDescription(annotations: string[], entityKind = 'Component') {
+  const isSingular = annotations.length <= 1;
+  return (
+    <>
+      The {isSingular ? 'annotation' : 'annotations'}{' '}
+      {annotations
+        .map(ann => <code>{ann}</code>)
+        .reduce((prev, curr) => (
+          <>
+            {prev}, {curr}
+          </>
+        ))}{' '}
+      {isSingular ? 'is' : 'are'} missing. You need to add the{' '}
+      {isSingular ? 'annotation' : 'annotations'} to your {entityKind} if you
+      want to enable this tool.
+    </>
+  );
+}
+
+/**
+ * @public
+ * Renders an empty state when an annotation is missing from an entity.
+ */
+export function MissingAnnotationEmptyState(props: Props) {
+  let entity: Entity | undefined;
+  try {
+    const entityContext = useEntity();
+    entity = entityContext.entity;
+  } catch (err) {
+    // ignore when entity context doesnt exist
+  }
+
+  const { annotation, readMoreUrl } = props;
+  const annotations = Array.isArray(annotation) ? annotation : [annotation];
+  const url =
+    readMoreUrl ||
+    'https://backstage.io/docs/features/software-catalog/well-known-annotations';
+  const classes = useStyles();
+
+  const entityKind = entity?.kind || 'Component';
+  const { yamlText, lineNumbers } = generateYamlExample(annotations, entity);
+  return (
+    <EmptyState
+      missing="field"
+      title="Missing Annotation"
+      description={generateDescription(annotations, entityKind)}
+      action={
+        <>
+          <Typography variant="body1">
+            Add the annotation to your {entityKind} YAML as shown in the
+            highlighted example below:
+          </Typography>
+          <Box className={classes.code}>
+            <CodeSnippet
+              text={yamlText}
+              language="yaml"
+              showLineNumbers
+              highlightedNumbers={lineNumbers}
+              customStyle={{ background: 'inherit', fontSize: '115%' }}
+            />
+          </Box>
+          <Button color="primary" component={Link} to={url}>
+            Read more
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/plugins/catalog-react/src/components/MissingAnnotationEmptyState/MissingAnnotationEmptyState.tsx
+++ b/plugins/catalog-react/src/components/MissingAnnotationEmptyState/MissingAnnotationEmptyState.tsx
@@ -24,11 +24,6 @@ import { CodeSnippet, Link, EmptyState } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useEntity } from '../../hooks';
 
-type Props = {
-  annotation: string | string[];
-  readMoreUrl?: string;
-};
-
 /** @public */
 export type MissingAnnotationEmptyStateClassKey = 'code';
 
@@ -98,7 +93,10 @@ function generateDescription(annotations: string[], entityKind = 'Component') {
  * @public
  * Renders an empty state when an annotation is missing from an entity.
  */
-export function MissingAnnotationEmptyState(props: Props) {
+export function MissingAnnotationEmptyState(props: {
+  annotation: string | string[];
+  readMoreUrl?: string;
+}) {
   let entity: Entity | undefined;
   try {
     const entityContext = useEntity();

--- a/plugins/catalog-react/src/components/MissingAnnotationEmptyState/index.ts
+++ b/plugins/catalog-react/src/components/MissingAnnotationEmptyState/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './MissingAnnotationEmptyState';

--- a/plugins/catalog-react/src/components/index.ts
+++ b/plugins/catalog-react/src/components/index.ts
@@ -32,3 +32,4 @@ export * from './UserListPicker';
 export * from './EntityProcessingStatusPicker';
 export * from './EntityNamespacePicker';
 export * from './EntityAutocompletePicker';
+export * from './MissingAnnotationEmptyState';

--- a/plugins/circleci/src/components/Router.tsx
+++ b/plugins/circleci/src/components/Router.tsx
@@ -21,8 +21,10 @@ import { BuildWithStepsPage } from './BuildWithStepsPage/';
 import { BuildsPage } from './BuildsPage';
 import { CIRCLECI_ANNOTATION } from '../constants';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 
 /** @public */
 export const isCircleCIAvailable = (entity: Entity) =>

--- a/plugins/cloudbuild/src/components/Router.tsx
+++ b/plugins/cloudbuild/src/components/Router.tsx
@@ -15,13 +15,15 @@
  */
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { Routes, Route } from 'react-router-dom';
 import { buildRouteRef } from '../routes';
 import { WorkflowRunDetails } from './WorkflowRunDetails';
 import { WorkflowRunsTable } from './WorkflowRunsTable';
 import { CLOUDBUILD_ANNOTATION } from './useProjectName';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 /** @public */
 export const isCloudbuildAvailable = (entity: Entity) =>

--- a/plugins/code-climate/src/components/CodeClimateCardContents/CodeClimateCardContents.tsx
+++ b/plugins/code-climate/src/components/CodeClimateCardContents/CodeClimateCardContents.tsx
@@ -19,13 +19,11 @@ import useAsync from 'react-use/lib/useAsync';
 import { codeClimateApiRef } from '../../api';
 import { CodeClimateTable } from '../CodeClimateTable';
 import { CODECLIMATE_REPO_ID_ANNOTATION } from '../../plugin';
-import { useEntity } from '@backstage/plugin-catalog-react';
 import {
-  EmptyState,
-  ErrorPanel,
+  useEntity,
   MissingAnnotationEmptyState,
-  Progress,
-} from '@backstage/core-components';
+} from '@backstage/plugin-catalog-react';
+import { EmptyState, ErrorPanel, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
 export const CodeClimateCardContents = () => {

--- a/plugins/code-coverage/src/components/Router.tsx
+++ b/plugins/code-coverage/src/components/Router.tsx
@@ -16,9 +16,11 @@
 
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { CodeCoveragePage } from './CodeCoveragePage';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 /**
  * Returns true if the given entity has code coverage enabled.

--- a/plugins/dynatrace/src/components/DynatraceTab/DynatraceTab.tsx
+++ b/plugins/dynatrace/src/components/DynatraceTab/DynatraceTab.tsx
@@ -15,12 +15,11 @@
  */
 import React from 'react';
 import { Grid } from '@material-ui/core';
+import { Page, Content } from '@backstage/core-components';
 import {
-  Page,
-  Content,
+  useEntity,
   MissingAnnotationEmptyState,
-} from '@backstage/core-components';
-import { useEntity } from '@backstage/plugin-catalog-react';
+} from '@backstage/plugin-catalog-react';
 import { ProblemsList } from '../Problems/ProblemsList';
 import { SyntheticsCard } from '../Synthetics/SyntheticsCard';
 import { isDynatraceAvailable } from '../../plugin';

--- a/plugins/fossa/src/components/FossaCard/FossaCard.tsx
+++ b/plugins/fossa/src/components/FossaCard/FossaCard.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { Grid, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -31,7 +34,6 @@ import {
   EmptyState,
   InfoCard,
   InfoCardVariants,
-  MissingAnnotationEmptyState,
   Progress,
   ResponseErrorPanel,
 } from '@backstage/core-components';

--- a/plugins/github-actions/src/components/Router.tsx
+++ b/plugins/github-actions/src/components/Router.tsx
@@ -16,13 +16,15 @@
 
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { Routes, Route } from 'react-router-dom';
 import { buildRouteRef } from '../routes';
 import { WorkflowRunDetails } from './WorkflowRunDetails';
 import { WorkflowRunsTable } from './WorkflowRunsTable';
 import { GITHUB_ACTIONS_ANNOTATION } from './getProjectNameFromEntity';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 /** @public */
 export const isGithubActionsAvailable = (entity: Entity) =>

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.tsx
@@ -17,7 +17,10 @@
 import React from 'react';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
 import { GithubDeployment, githubDeploymentsApiRef } from '../api';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import {
   GITHUB_PROJECT_SLUG_ANNOTATION,
   isGithubDeploymentsAvailable,
@@ -28,11 +31,7 @@ import {
   ANNOTATION_SOURCE_LOCATION,
 } from '@backstage/catalog-model';
 
-import {
-  MissingAnnotationEmptyState,
-  ResponseErrorPanel,
-  TableColumn,
-} from '@backstage/core-components';
+import { ResponseErrorPanel, TableColumn } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
 const GithubDeploymentsComponent = ({

--- a/plugins/gocd/src/components/GoCdBuildsComponent/GoCdBuildsComponent.tsx
+++ b/plugins/gocd/src/components/GoCdBuildsComponent/GoCdBuildsComponent.tsx
@@ -15,11 +15,13 @@
  */
 import React, { useState } from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import {
   Content,
   ContentHeader,
-  MissingAnnotationEmptyState,
   EmptyState,
   Page,
 } from '@backstage/core-components';

--- a/plugins/jenkins/src/components/Router.tsx
+++ b/plugins/jenkins/src/components/Router.tsx
@@ -15,11 +15,11 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
+import { TableColumn } from '@backstage/core-components';
 import {
+  useEntity,
   MissingAnnotationEmptyState,
-  TableColumn,
-} from '@backstage/core-components';
-import { useEntity } from '@backstage/plugin-catalog-react';
+} from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { JENKINS_ANNOTATION, LEGACY_JENKINS_ANNOTATION } from '../constants';

--- a/plugins/kafka/src/Router.tsx
+++ b/plugins/kafka/src/Router.tsx
@@ -17,10 +17,12 @@
 import { Entity } from '@backstage/catalog-model';
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { KAFKA_CONSUMER_GROUP_ANNOTATION } from './constants';
 import { KafkaTopicsForConsumer } from './components/ConsumerGroupOffsets/ConsumerGroupOffsets';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 /** @public */
 export const isPluginApplicableToEntity = (entity: Entity) =>

--- a/plugins/kubernetes-cluster/src/Router.tsx
+++ b/plugins/kubernetes-cluster/src/Router.tsx
@@ -16,9 +16,11 @@
 
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { Route, Routes } from 'react-router-dom';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 import { ANNOTATION_KUBERNETES_API_SERVER } from '@backstage/plugin-kubernetes-common';
 import { KubernetesClusterContent } from './components/KubernetesClusterContent';
 

--- a/plugins/kubernetes/src/Router.tsx
+++ b/plugins/kubernetes/src/Router.tsx
@@ -16,11 +16,13 @@
 
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { Route, Routes } from 'react-router-dom';
 import { KubernetesContent } from './KubernetesContent';
 import { Button } from '@material-ui/core';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 const KUBERNETES_ANNOTATION = 'backstage.io/kubernetes-id';
 const KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION =

--- a/plugins/lighthouse/src/Router.tsx
+++ b/plugins/lighthouse/src/Router.tsx
@@ -16,14 +16,16 @@
 
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import AuditList from './components/AuditList';
 import AuditView, { AuditViewContent } from './components/AuditView';
 import CreateAudit, { CreateAuditContent } from './components/CreateAudit';
 import { Entity } from '@backstage/catalog-model';
 import { LIGHTHOUSE_WEBSITE_URL_ANNOTATION } from '../constants';
 import { AuditListForEntity } from './components/AuditList/AuditListForEntity';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 /** @public */
 export const isLighthouseAvailable = (entity: Entity) =>

--- a/plugins/newrelic-dashboard/src/Router.tsx
+++ b/plugins/newrelic-dashboard/src/Router.tsx
@@ -15,10 +15,12 @@
  */
 import { Entity } from '@backstage/catalog-model';
 import React from 'react';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 import { Button } from '@material-ui/core';
 import { NewRelicDashboard } from './components/NewRelicDashboard';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { NEWRELIC_GUID_ANNOTATION } from './constants';
 
 /** @public */

--- a/plugins/nomad/src/Router.tsx
+++ b/plugins/nomad/src/Router.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { useEntity } from '@backstage/plugin-catalog-react';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { Route, Routes } from 'react-router-dom';
 import { EntityNomadAllocationListTable } from './components/EntityNomadAllocationListTable/EntityNomadAllocationListTable';
 import {

--- a/plugins/nomad/src/components/EntityNomadAllocationListTable/EntityNomadAllocationListTable.tsx
+++ b/plugins/nomad/src/components/EntityNomadAllocationListTable/EntityNomadAllocationListTable.tsx
@@ -17,7 +17,6 @@
 import { DateTime } from 'luxon';
 import {
   Link,
-  MissingAnnotationEmptyState,
   ResponseErrorPanel,
   StatusError,
   StatusOK,
@@ -26,7 +25,10 @@ import {
   Table,
   TableColumn,
 } from '@backstage/core-components';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import React, { useState } from 'react';
 import { Allocation, nomadApiRef } from '../../api';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';

--- a/plugins/nomad/src/components/EntityNomadJobVersionListCard/EntityNomadJobVersionListCard.tsx
+++ b/plugins/nomad/src/components/EntityNomadJobVersionListCard/EntityNomadJobVersionListCard.tsx
@@ -17,12 +17,14 @@
 import { DateTime } from 'luxon';
 import {
   InfoCard,
-  MissingAnnotationEmptyState,
   ResponseErrorPanel,
   Table,
   TableColumn,
 } from '@backstage/core-components';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import React, { useEffect, useState } from 'react';
 import { Version, nomadApiRef } from '../../api';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';

--- a/plugins/puppetdb/src/components/Router.tsx
+++ b/plugins/puppetdb/src/components/Router.tsx
@@ -19,8 +19,10 @@ import { Routes, Route } from 'react-router-dom';
 import { puppetDbReportRouteRef } from '../routes';
 import { ANNOTATION_PUPPET_CERTNAME } from '../constants';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { ReportsPage } from './ReportsPage';
 import { ReportDetailsPage } from './ReportDetailsPage';
 

--- a/plugins/rollbar/src/components/Router.tsx
+++ b/plugins/rollbar/src/components/Router.tsx
@@ -15,12 +15,14 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { ROLLBAR_ANNOTATION } from '../constants';
 import { EntityPageRollbar } from './EntityPageRollbar/EntityPageRollbar';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 /** @public */
 export const isPluginApplicableToEntity = (entity: Entity) =>

--- a/plugins/sentry/src/components/SentryIssuesWidget/SentryIssuesWidget.tsx
+++ b/plugins/sentry/src/components/SentryIssuesWidget/SentryIssuesWidget.tsx
@@ -20,12 +20,12 @@ import useAsync from 'react-use/lib/useAsync';
 import { sentryApiRef } from '../../api';
 import SentryIssuesTable from '../SentryIssuesTable/SentryIssuesTable';
 import { SENTRY_PROJECT_SLUG_ANNOTATION, useProjectSlug } from '../hooks';
+import { MissingAnnotationEmptyState } from '@backstage/plugin-catalog-react';
 
 import {
   EmptyState,
   InfoCard,
   InfoCardVariants,
-  MissingAnnotationEmptyState,
   Progress,
 } from '@backstage/core-components';
 

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import {
   sonarQubeApiRef,
   useProjectInfo,
@@ -38,7 +41,6 @@ import {
   EmptyState,
   InfoCard,
   InfoCardVariants,
-  MissingAnnotationEmptyState,
   Progress,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';

--- a/plugins/sonarqube/src/components/SonarQubeContentPage/SonarQubeContentPage.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeContentPage/SonarQubeContentPage.tsx
@@ -19,8 +19,10 @@ import {
   ContentHeader,
   SupportButton,
 } from '@backstage/core-components';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { SonarQubeCard } from '../SonarQubeCard';
 import {

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -16,7 +16,10 @@
 import React, { useCallback, useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import {
   Card,
   CardContent,
@@ -40,7 +43,6 @@ import {
   EmptyState,
   HeaderIconLinkRow,
   IconLinkVerticalProps,
-  MissingAnnotationEmptyState,
   Progress,
 } from '@backstage/core-components';
 

--- a/plugins/techdocs/src/Router.tsx
+++ b/plugins/techdocs/src/Router.tsx
@@ -19,10 +19,12 @@ import { Route, Routes, useRoutes } from 'react-router-dom';
 
 import { Entity } from '@backstage/catalog-model';
 import { EntityPageDocs } from './EntityPageDocs';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 import { TechDocsIndexPage } from './home/components/TechDocsIndexPage';
 import { TechDocsReaderPage } from './reader/components/TechDocsReaderPage';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 
 const TECHDOCS_ANNOTATION = 'backstage.io/techdocs-ref';
 

--- a/plugins/vault/src/components/EntityVaultCard/EntityVaultCard.tsx
+++ b/plugins/vault/src/components/EntityVaultCard/EntityVaultCard.tsx
@@ -15,11 +15,13 @@
  */
 
 import React from 'react';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  MissingAnnotationEmptyState,
+} from '@backstage/plugin-catalog-react';
 import { isVaultAvailable } from '../../conditions';
 import { VAULT_SECRET_PATH_ANNOTATION } from '../../constants';
 import { EntityVaultTable } from '../EntityVaultTable';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 export const EntityVaultCard = () => {
   const { entity } = useEntity();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,13 +4159,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/core-components@workspace:packages/core-components"
   dependencies:
-    "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/errors": "workspace:^"
-    "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@backstage/version-bridge": "workspace:^"


### PR DESCRIPTION
We ended up hitting this internally too so wanted to get this fix out as a patch for all affected :tada:

This is caused by a cyclical dependency in `core-components` on the `catalog` packages. So i've done the following:

- Copy and export `MissingAnnotationEmptyState` from `@backstage/plugin-catalog-react`
- Update all usages of `MissingAnnotationEmptyState` in the main repo to import it from `@backstage/plugin-catalog-react`
- Deprecate `MissingAnnotationEmptyState` in `@backstage/core-components` and point to the new one
- Remove `useEntity` from `MissingAnnotationEmptyState` in `@backstage/core-components` and remove the dependencies on `@backstage/plugins-catalog-react` and `@backstage/catalog-model`


Fixes #20713