### PR TITLE
feat(cacheService): allow cache service customization through factory options

### DIFF
--- a/.changeset/chilled-terms-breathe.md
+++ b/.changeset/chilled-terms-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Allow a default cache TTL to be set through the app config

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -149,6 +149,8 @@ export interface Config {
     cache?:
       | {
           store: 'memory';
+          /** An optional default TTL (in milliseconds). */
+          defaultTtl?: number;
         }
       | {
           store: 'redis';
@@ -157,6 +159,8 @@ export interface Config {
            * @visibility secret
            */
           connection: string;
+          /** An optional default TTL (in milliseconds). */
+          defaultTtl?: number;
         }
       | {
           store: 'memcache';
@@ -165,6 +169,8 @@ export interface Config {
            * @visibility secret
            */
           connection: string;
+          /** An optional default TTL (in milliseconds). */
+          defaultTtl?: number;
         };
 
     cors?: {

--- a/packages/backend-common/src/cache/CacheManager.ts
+++ b/packages/backend-common/src/cache/CacheManager.ts
@@ -57,6 +57,7 @@ export class CacheManager {
   private readonly connection: string;
   private readonly useRedisSets: boolean;
   private readonly errorHandler: CacheManagerOptions['onError'];
+  private readonly defaultTtl?: number;
 
   /**
    * Creates a new {@link CacheManager} instance by reading from the `backend`
@@ -71,6 +72,7 @@ export class CacheManager {
     // If no `backend.cache` config is provided, instantiate the CacheManager
     // with an in-memory cache client.
     const store = config.getOptionalString('backend.cache.store') || 'memory';
+    const defaultTtl = config.getOptionalNumber('backend.cache.defaultTtl');
     const connectionString =
       config.getOptionalString('backend.cache.connection') || '';
     const useRedisSets =
@@ -84,6 +86,7 @@ export class CacheManager {
       useRedisSets,
       logger,
       options.onError,
+      defaultTtl,
     );
   }
 
@@ -93,6 +96,7 @@ export class CacheManager {
     useRedisSets: boolean,
     logger: LoggerService,
     errorHandler: CacheManagerOptions['onError'],
+    defaultTtl?: number,
   ) {
     if (!this.storeFactories.hasOwnProperty(store)) {
       throw new Error(`Unknown cache store: ${store}`);
@@ -102,6 +106,7 @@ export class CacheManager {
     this.connection = connectionString;
     this.useRedisSets = useRedisSets;
     this.errorHandler = errorHandler;
+    this.defaultTtl = defaultTtl;
   }
 
   /**
@@ -116,7 +121,7 @@ export class CacheManager {
         const clientFactory = (options: CacheServiceOptions) => {
           const concreteClient = this.getClientWithTtl(
             pluginId,
-            options.defaultTtl,
+            options.defaultTtl ?? this.defaultTtl,
           );
 
           // Always provide an error handler to avoid stopping the process.


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Allow cache options to be customized in the new backend system service to be able to set a default TTL

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
