### PR TITLE
Patch release of #20842

### DIFF
--- a/.changeset/real-pears-study.md
+++ b/.changeset/real-pears-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Reverted the `MissingAnnotationEmptyState` component changes due to the introduction of a cyclical dependency. In the next release these features will be reintroduced in a component with the same name in `@backstage/plugin-catalog-react`, while the component in `@backstage/core-components` is deprecated.

--- a/.changeset/real-pears-study.md
+++ b/.changeset/real-pears-study.md
@@ -1,5 +1,0 @@
----
-'@backstage/core-components': patch
----
-
-Reverted the `MissingAnnotationEmptyState` component changes due to the introduction of a cyclical dependency. In the next release these features will be reintroduced in a component with the same name in `@backstage/plugin-catalog-react`, while the component in `@backstage/core-components` is deprecated.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jest-haste-map@^29.4.3": "patch:jest-haste-map@npm%3A29.4.3#./.yarn/patches/jest-haste-map-npm-29.4.3-19b03fcef3.patch",
     "mock-fs@^5.2.0": "patch:mock-fs@npm%3A5.2.0#./.yarn/patches/mock-fs-npm-5.2.0-5103a7b507.patch"
   },
-  "version": "1.19.5",
+  "version": "1.19.6",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3"

--- a/packages/core-components/CHANGELOG.md
+++ b/packages/core-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/core-components
 
+## 0.13.7
+
+### Patch Changes
+
+- 7dce03bc31b4: Reverted the `MissingAnnotationEmptyState` component changes due to the introduction of a cyclical dependency. In the next release these features will be reintroduced in a component with the same name in `@backstage/plugin-catalog-react`, while the component in `@backstage/core-components` is deprecated.
+
 ## 0.13.6
 
 ### Patch Changes

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -746,16 +746,13 @@ export type MetadataTableTitleCellClassKey = 'root';
 export type MicDropClassKey = 'micDrop';
 
 // Warning: (ae-forgotten-export) The symbol "Props_3" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "MissingAnnotationEmptyState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function MissingAnnotationEmptyState(
   props: Props_3,
 ): React_2.JSX.Element;
 
-// Warning: (ae-missing-release-tag) "MissingAnnotationEmptyStateClassKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type MissingAnnotationEmptyStateClassKey = 'code';
 
 // @public

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -33,11 +33,9 @@
     "start": "backstage-cli package start"
   },
   "dependencies": {
-    "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@date-io/core": "^1.3.13",

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/core-components",
   "description": "Core components used by Backstage plugins and apps",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",

--- a/plugins/vault/src/components/EntityVaultCard/EntityVaultCard.test.tsx
+++ b/plugins/vault/src/components/EntityVaultCard/EntityVaultCard.test.tsx
@@ -46,7 +46,7 @@ describe('EntityVaultCard', () => {
       </EntityProvider>,
     );
     expect(
-      rendered.getByText(/Add the annotation to your Component YAML/),
+      rendered.getByText(/Add the annotation to your component YAML/),
     ).toBeInTheDocument();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,13 +3956,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/core-components@workspace:packages/core-components"
   dependencies:
-    "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/errors": "workspace:^"
-    "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@backstage/version-bridge": "workspace:^"


### PR DESCRIPTION
This release fixes a circular dependency across `@backstage/core-components` and `@backstage/plugin-catalog-react` that broke the ability to mock both of those packages in tests. This was fixed by reverting the changes to `MissingAnnotationEmptyState`, which will be reintroduced in `1.20.0` in a new way.