### PR TITLE
Update Custom Auth Provider Documentation to Work Properly

### DIFF
--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -371,6 +371,7 @@ createApiFactory({
       configApi,
       discoveryApi,
       oauthRequestApi,
+      provider: { id: 'ghe', title: 'GitHub Enterprise', icon: () => null },
       defaultScopes: ['read:user'],
       environment: configApi.getOptionalString('auth.environment'),
     }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Docs: [https://backstage.io/docs/auth/#custom-scmauthapi-implementation](https://backstage.io/docs/auth/#custom-scmauthapi-implementation)

The provider.id is used as the backend auth endpoint, which is added in this same guide. The default provider id is `github`, which will point to the wrong auth endpoint. Without modifying the core package code, this guide will not work without this additional configuration line.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
