### PR TITLE
fix(catalog-backend-module-gitlab): #20891 GitlabOrgDiscoveryEntityProvider inherit members users

### DIFF
--- a/.changeset/pretty-bats-end.md
+++ b/.changeset/pretty-bats-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Resolved a bug affecting the retrieval of users from group members. By appending '/all' to the API call, we now include members from all inherited groups, as per Gitlab's API specifications. This change is reflected in the listSaaSUsers function.

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -92,7 +92,7 @@ export class GitLabClient {
     options?: CommonListOptions,
   ): Promise<PagedResponse<GitLabUser>> {
     return this.pagedRequest(
-      `/groups/${encodeURIComponent(groupPath)}/members`,
+      `/groups/${encodeURIComponent(groupPath)}/members/all`,
       {
         ...options,
         show_seat_info: true,

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -569,7 +569,7 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
           ),
         ),
       rest.get(
-        `https://gitlab.com/api/v4/groups/group1/members`,
+        `https://gitlab.com/api/v4/groups/group1/members/all`,
         (_req, res, ctx) => {
           const response = [
             {


### PR DESCRIPTION
… gets all inherited users when consulting /groups/id/members

## Hey, I just made a Pull Request!

See the error for more context #20891 

I added an `/all` to the `/gorups/id/members` API endpoint of `catalog-backend-module-gitlab`
according to [gitlab docs](https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members) 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
