### PR TITLE
frontend-app-api: fix for disabled nodes being filtered out from app tree

### DIFF
--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
@@ -199,14 +199,12 @@ export function resolveAppNodeSpecs(options: {
     }
   }
 
-  return configuredExtensions
-    .filter(override => !override.params.disabled)
-    .map(param => ({
-      id: param.extension.id,
-      attachTo: param.params.attachTo,
-      extension: param.extension,
-      disabled: param.params.disabled,
-      source: param.params.source,
-      config: param.params.config,
-    }));
+  return configuredExtensions.map(param => ({
+    id: param.extension.id,
+    attachTo: param.params.attachTo,
+    extension: param.extension,
+    disabled: param.params.disabled,
+    source: param.params.source,
+    config: param.params.config,
+  }));
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Disabled nodes are supposed to be part of the app tree, just not instantiated.

This check should be removed since the new check for whether a node is disabled now happens here: https://github.com/backstage/backstage/blob/4d6fa921dbdd69cf9b20acb8f6dafbcd3a6b0862/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts#L162

Skipped changeset since app tree isn't released yet and is internal for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
