### PR TITLE
hotfix: absolute url for matomo icon in microsite

### DIFF
--- a/microsite/data/plugins/analytics-module-matomo.yaml
+++ b/microsite/data/plugins/analytics-module-matomo.yaml
@@ -5,6 +5,6 @@ authorUrl: https://redhat.com
 category: Monitoring
 description: Track usage of your Backstage instance using Matomo Analytics.
 documentation: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-module-matomo/README.md
-iconUrl: img/matomo.png
+iconUrl: /img/matomo.png
 npmPackageName: '@janus-idp/backstage-plugin-analytics-module-matomo'
 addedDate: '2023-10-17'


### PR DESCRIPTION
> Closes #20902 

## Hey, I just made a Pull Request!

The icon for matomo was not defined as an absolute path, which caused the icon to not be displayed correctly on https://backstage.io/plugins/

Screenshot:

![image](https://github.com/backstage/backstage/assets/19623278/28909d67-9f07-40f4-b138-35f81ef27b99)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
