### PR TITLE
chore: add matomo to analytics supported tools doc

### DIFF
--- a/docs/plugins/analytics.md
+++ b/docs/plugins/analytics.md
@@ -39,6 +39,7 @@ choice below.
 | [Google Analytics][ga]                | Yes ✅         |
 | [Google Analytics 4][ga4]             | Yes ✅         |
 | [New Relic Browser][newrelic-browser] | Community ✅   |
+| [Matomo][matomo]                      | Community ✅   |
 
 To suggest an integration, please [open an issue][add-tool] for the analytics
 tool your organization uses. Or jump to [Writing Integrations][int-howto] to
@@ -47,6 +48,7 @@ learn how to contribute the integration yourself!
 [ga]: https://github.com/backstage/backstage/blob/master/plugins/analytics-module-ga/README.md
 [ga4]: https://github.com/backstage/backstage/blob/master/plugins/analytics-module-ga4/README.md
 [newrelic-browser]: https://github.com/backstage/backstage/blob/master/plugins/analytics-module-newrelic-browser/README.md
+[matomo]: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/analytics-module-matomo/README.md
 [add-tool]: https://github.com/backstage/backstage/issues/new?assignees=&labels=plugin&template=plugin_template.md&title=%5BAnalytics+Module%5D+THE+ANALYTICS+TOOL+TO+INTEGRATE
 [int-howto]: #writing-integrations
 [analytics-api-type]: https://backstage.io/docs/reference/core-plugin-api.analyticsapi


### PR DESCRIPTION
> Closes #20904 

## Hey, I just made a Pull Request!

Added the Matomo Analytics Module to the Supported Tools table in the Plugin Analytics Documentations.

<img width="290" alt="image" src="https://github.com/backstage/backstage/assets/19623278/a05369d0-237f-4eb9-a018-f267dc44dff5">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
