### PR TITLE
fix dagda1 github link in OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -129,7 +129,7 @@ Scope: The Scaffolder frontend and backend plugins, and related tooling.
 | Name                | Organization   | GitHub                                | Discord          |
 | ------------------- | -------------- | ------------------------------------- | ---------------- |
 | Bogdan Nechyporenko | Bol.com        | [acierto](https://github.com/acierto) | `bogdan_haarlem` |
-| Paul Cowan          | frontendrescue | [dagda1](https://github.com/dadga1)   | `dagda1`         |
+| Paul Cowan          | frontendrescue | [dagda1](https://github.com/dagda1)   | `dagda1`         |
 
 ## Sponsors
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1 character PR!  Fixes the link to my GitHub profile in OWNERS.md.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
