### PR TITLE
Optimize document deletion query in PgSearchEngine DatabaseDocumentStore

### DIFF
--- a/.changeset/eighty-chairs-care.md
+++ b/.changeset/eighty-chairs-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-pg': patch
+---
+
+Optimize outdated documents deletion logic in PgSearchEngine DatabaseDocumentStore which significantly reduces cost on large tables


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Context 
We have encountered a similar issue as [here](https://github.com/backstage/backstage/issues/15606).

Entities in our catalog are updated automatically, including a full refresh at night. Overall, search Documents table contains > 100k rows. 

We run search collators every hour. During these runs, which lasted for 20m, backstage db cpu utilisation grew from normal ±10-15% to 70-80%. When too many entities were updated, the cpu usage would go to 100% and cause significant delays for the queue, etc.

We have discovered that deletion query in DatabaseDocumentStore's completeInsert was causing the issue. 

### Change

We replaced WHERE NOT IN condition with LEFT JOIN + NOT NULL + WHERE IN optimising the query, which is semantically equivalent to the original in the case when the field on which we join is not null - which is the case here. 

Also, added a test as existing didn't react to some of the cases.

### Impact

The transaction now runs in 3m instead of 20m. CPU utilisation says under 25% with a minor spike.

### Why it should be a part of backstage codebase

Using NOT IN for large databases is not advised, so replacing query with a good idea in general.

As a temporary workaround, we made our own DatabaseDocumentStore and use it in search.ts in backend as following:
`new PgSearchEngine(await CustomDatabaseDocumentStore.create(env.database), env.config)`

However, `new PgSearchEngine` is to be deprecated soon, so it is only a temporary solution if we want to be able to upgrade backstage further. We do not want to create our own implementations for things which already work well in backstage/backstage.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
