### PR TITLE
[catalog/unprocessed-entities] add sort and filter

### DIFF
--- a/.changeset/new-kangaroos-train.md
+++ b/.changeset/new-kangaroos-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+---
+
+Added filtering and sorting to unprocessed entities tables.

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   ErrorPanel,
@@ -91,6 +91,7 @@ export const FailedEntities = () => {
     error,
     value: data,
   } = useAsync(async () => await unprocessedApi.failed());
+  const [, setSelectedSearchTerm] = useState<string>('');
 
   if (loading) {
     return <Progress />;
@@ -102,22 +103,33 @@ export const FailedEntities = () => {
   const columns: TableColumn[] = [
     {
       title: <Typography>entityRef</Typography>,
+      sorting: true,
+      field: 'entity_ref',
+      customFilterAndSearch: (query, row: any) =>
+        row.entity_ref
+          .toLocaleUpperCase('en-US')
+          .includes(query.toLocaleUpperCase('en-US')),
       render: (rowData: UnprocessedEntity | {}) =>
         (rowData as UnprocessedEntity).entity_ref,
     },
     {
       title: <Typography>Kind</Typography>,
+      sorting: true,
+      field: 'kind',
       render: (rowData: UnprocessedEntity | {}) =>
         (rowData as UnprocessedEntity).unprocessed_entity.kind,
     },
     {
       title: <Typography>Owner</Typography>,
+      sorting: true,
+      field: 'unprocessed_entity.spec.owner',
       render: (rowData: UnprocessedEntity | {}) =>
         (rowData as UnprocessedEntity).unprocessed_entity.spec?.owner ||
         'unknown',
     },
     {
       title: <Typography>Raw</Typography>,
+      sorting: false,
       render: (rowData: UnprocessedEntity | {}) => (
         <EntityDialog entity={rowData as UnprocessedEntity} />
       ),
@@ -133,6 +145,9 @@ export const FailedEntities = () => {
           <Typography className={classes.successMessage}>
             No failed entities found
           </Typography>
+        }
+        onSearchChange={(searchTerm: string) =>
+          setSelectedSearchTerm(searchTerm)
         }
         detailPanel={({ rowData }) => {
           const errors = (rowData as UnprocessedEntity).errors;

--- a/plugins/catalog-unprocessed-entities/src/components/PendingEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/PendingEntities.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   ErrorPanel,
@@ -46,6 +46,7 @@ export const PendingEntities = () => {
     error,
     value: data,
   } = useAsync(async () => await unprocessedApi.pending());
+  const [, setSelectedSearchTerm] = useState<string>('');
 
   if (loading) {
     return <Progress />;
@@ -57,22 +58,33 @@ export const PendingEntities = () => {
   const columns: TableColumn[] = [
     {
       title: <Typography>entityRef</Typography>,
+      sorting: true,
+      field: 'entity_ref',
+      customFilterAndSearch: (query, row: any) =>
+        row.entity_ref
+          .toLocaleUpperCase('en-US')
+          .includes(query.toLocaleUpperCase('en-US')),
       render: (rowData: UnprocessedEntity | {}) =>
         (rowData as UnprocessedEntity).entity_ref,
     },
     {
       title: <Typography>Kind</Typography>,
+      sorting: true,
+      field: 'kind',
       render: (rowData: UnprocessedEntity | {}) =>
         (rowData as UnprocessedEntity).unprocessed_entity.kind,
     },
     {
       title: <Typography>Owner</Typography>,
+      sorting: true,
+      field: 'unprocessed_entity.spec.owner',
       render: (rowData: UnprocessedEntity | {}) =>
         (rowData as UnprocessedEntity).unprocessed_entity.spec?.owner ||
         'unknown',
     },
     {
       title: <Typography>Raw</Typography>,
+      sorting: false,
       render: (rowData: UnprocessedEntity | {}) => (
         <EntityDialog entity={rowData as UnprocessedEntity} />
       ),
@@ -84,6 +96,9 @@ export const PendingEntities = () => {
         options={{ pageSize: 20 }}
         columns={columns}
         data={data?.entities || []}
+        onSearchChange={(searchTerm: string) =>
+          setSelectedSearchTerm(searchTerm)
+        }
         emptyContent={
           <Typography className={classes.successMessage}>
             No pending entities found


### PR DESCRIPTION
Implement sorting and filtering to unprocessed entities tables.

Sorting added to entity-ref, owner and kind columns.

Filtering/searching added to entity-ref column.

Fixes #18694

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
