### PR TITLE
frontend-app-api: two small fixes

### DIFF
--- a/.changeset/healthy-dancers-dream.md
+++ b/.changeset/healthy-dancers-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+The options parameter of `createApp` is now optional.

--- a/.changeset/selfish-flies-kneel.md
+++ b/.changeset/selfish-flies-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+No longer throw error on invalid input if the child is disabled.

--- a/packages/frontend-app-api/api-report.md
+++ b/packages/frontend-app-api/api-report.md
@@ -27,7 +27,7 @@ export type AppRouteBinder = <
 ) => void;
 
 // @public (undocumented)
-export function createApp(options: {
+export function createApp(options?: {
   features?: (BackstagePlugin | ExtensionOverrides)[];
   configLoader?: () => Promise<ConfigApi>;
   bindRoutes?(context: { bind: AppRouteBinder }): void;

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -167,7 +167,8 @@ describe('instantiateAppNodeTree', () => {
       {
         ...makeSpec(simpleExtension),
         id: 'child-node',
-        attachTo: { id: 'root-node', input: 'test' },
+        // Using an invalid input should not be an error when disabled
+        attachTo: { id: 'root-node', input: 'invalid' },
         disabled: true,
       },
     ]);

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -176,7 +176,9 @@ export function instantiateAppNodeTree(rootNode: AppNode): void {
         }
         return [{ id: child.spec.id, instance: childInstance }];
       });
-      instantiatedAttachments.set(input, instantiatedChildren);
+      if (instantiatedChildren.length > 0) {
+        instantiatedAttachments.set(input, instantiatedChildren);
+      }
     }
 
     (node as Mutable<AppNode>).instance = createAppNodeInstance({

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -222,7 +222,7 @@ function deduplicateFeatures(
 }
 
 /** @public */
-export function createApp(options: {
+export function createApp(options?: {
   features?: (BackstagePlugin | ExtensionOverrides)[];
   configLoader?: () => Promise<ConfigApi>;
   bindRoutes?(context: { bind: AppRouteBinder }): void;
@@ -240,11 +240,11 @@ export function createApp(options: {
       );
 
     const discoveredFeatures = getAvailableFeatures(config);
-    const loadedFeatures = (await options.featureLoader?.({ config })) ?? [];
+    const loadedFeatures = (await options?.featureLoader?.({ config })) ?? [];
     const allFeatures = deduplicateFeatures([
       ...discoveredFeatures,
       ...loadedFeatures,
-      ...(options.features ?? []),
+      ...(options?.features ?? []),
     ]);
 
     const tree = createAppTree({
@@ -268,7 +268,7 @@ export function createApp(options: {
             <RoutingProvider
               {...extractRouteInfoFromAppNode(tree.root)}
               routeBindings={resolveRouteBindings(
-                options.bindRoutes,
+                options?.bindRoutes,
                 config,
                 routeIds,
               )}


### PR DESCRIPTION
Optional options for `createApp` + fix input validation when child extensions are disabled