### PR TITLE
Github actions: sort workflow runs by status

### DIFF
--- a/.changeset/twelve-donkeys-smash.md
+++ b/.changeset/twelve-donkeys-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Fixed an issue that was preventing the sorting of workflow runs by their status.

--- a/plugins/github-actions/src/components/WorkflowRunStatus/WorkflowRunStatus.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunStatus/WorkflowRunStatus.tsx
@@ -24,59 +24,74 @@ import {
   StatusError,
 } from '@backstage/core-components';
 
-export const WorkflowRunStatus = ({
+export const WorkflowRunStatus = (props: {
+  status?: string;
+  conclusion?: string;
+}) => {
+  return (
+    <>
+      <WorkflowIcon {...props} />
+      {getStatusDescription(props)}
+    </>
+  );
+};
+
+export function WorkflowIcon({
   status,
   conclusion,
 }: {
   status?: string;
   conclusion?: string;
-}) => {
+}) {
   if (status === undefined) return null;
   switch (status.toLocaleLowerCase('en-US')) {
     case 'queued':
-      return (
-        <>
-          <StatusPending /> Queued
-        </>
-      );
+      return <StatusPending />;
+
     case 'in_progress':
-      return (
-        <>
-          <StatusRunning /> In progress
-        </>
-      );
+      return <StatusRunning />;
     case 'completed':
       switch (conclusion?.toLocaleLowerCase('en-US')) {
         case 'skipped' || 'canceled':
-          return (
-            <>
-              <StatusAborted /> Aborted
-            </>
-          );
+          return <StatusAborted />;
+
         case 'timed_out':
-          return (
-            <>
-              <StatusWarning /> Timed out
-            </>
-          );
+          return <StatusWarning />;
         case 'failure':
-          return (
-            <>
-              <StatusError /> Error
-            </>
-          );
+          return <StatusError />;
         default:
-          return (
-            <>
-              <StatusOK /> Completed
-            </>
-          );
+          return <StatusOK />;
       }
     default:
-      return (
-        <>
-          <StatusPending /> Pending
-        </>
-      );
+      return <StatusPending />;
   }
-};
+}
+
+export function getStatusDescription({
+  status,
+  conclusion,
+}: {
+  status?: string;
+  conclusion?: string;
+}) {
+  if (status === undefined) return '';
+  switch (status.toLocaleLowerCase('en-US')) {
+    case 'queued':
+      return 'Queued';
+    case 'in_progress':
+      return 'In progress';
+    case 'completed':
+      switch (conclusion?.toLocaleLowerCase('en-US')) {
+        case 'skipped' || 'canceled':
+          return 'Aborted';
+        case 'timed_out':
+          return 'Timed out';
+        case 'failure':
+          return 'Error';
+        default:
+          return 'Completed';
+      }
+    default:
+      return 'Pending';
+  }
+}

--- a/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -39,8 +39,9 @@ import {
 } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { getHostnameFromEntity } from '../getHostnameFromEntity';
+import { getStatusDescription } from '../WorkflowRunStatus/WorkflowRunStatus';
 
-const generatedColumns: TableColumn[] = [
+const generatedColumns: TableColumn<Partial<WorkflowRun>>[] = [
   {
     title: 'ID',
     field: 'id',
@@ -51,7 +52,7 @@ const generatedColumns: TableColumn[] = [
     title: 'Message',
     field: 'message',
     highlight: true,
-    render: (row: Partial<WorkflowRun>) => {
+    render: row => {
       const LinkWrapper = () => {
         const routeLink = useRouteRef(buildRouteRef);
         return (
@@ -66,7 +67,7 @@ const generatedColumns: TableColumn[] = [
   },
   {
     title: 'Source',
-    render: (row: Partial<WorkflowRun>) => (
+    render: row => (
       <Typography variant="body2" noWrap>
         <Typography paragraph variant="body2">
           {row.source?.branchName}
@@ -83,9 +84,10 @@ const generatedColumns: TableColumn[] = [
   },
   {
     title: 'Status',
-    width: '150px',
-
-    render: (row: Partial<WorkflowRun>) => (
+    customSort: (d1, d2) => {
+      return getStatusDescription(d1).localeCompare(getStatusDescription(d2));
+    },
+    render: row => (
       <Box display="flex" alignItems="center">
         <WorkflowRunStatus status={row.status} conclusion={row.conclusion} />
       </Box>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed #20779 which was preventing the sorting of workflow runs by their status.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
