### PR TITLE
backend-tasks: allow tasks to run more frequently than the default work check interval

### DIFF
--- a/.changeset/lovely-terms-search.md
+++ b/.changeset/lovely-terms-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Allow tasks to run more often that the default work check interval, which is 5 seconds.

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -51,6 +51,10 @@ export class TaskWorker {
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
 
+    const cadence = Duration.fromISO(settings.cadence);
+    const workCheckFrequency =
+      cadence < this.workCheckFrequency ? cadence : this.workCheckFrequency;
+
     let attemptNum = 1;
     (async () => {
       for (;;) {
@@ -69,7 +73,7 @@ export class TaskWorker {
               break;
             }
 
-            await sleep(this.workCheckFrequency, options?.signal);
+            await sleep(workCheckFrequency, options?.signal);
           }
 
           this.logger.info(`Task worker finished: ${this.taskId}`);

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -51,9 +51,14 @@ export class TaskWorker {
       `Task worker starting: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
 
-    const cadence = Duration.fromISO(settings.cadence);
-    const workCheckFrequency =
-      cadence < this.workCheckFrequency ? cadence : this.workCheckFrequency;
+    let workCheckFrequency = this.workCheckFrequency;
+    const isCron = !settings?.cadence.startsWith('P');
+    if (!isCron) {
+      const cadence = Duration.fromISO(settings.cadence);
+      if (cadence < workCheckFrequency) {
+        workCheckFrequency = cadence;
+      }
+    }
 
     let attemptNum = 1;
     (async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Found that the default work check interval of 5s made it impossible run to tasks more often than that on a single node. Not sure we necessarily want exactly this but at the same time it feel like we should allow for tasks to be scheduled more frequently than 5s if desired.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
