### PR TITLE
docs: tweak docs for splitting into multiple backends

### DIFF
--- a/docs/backend-system/building-backends/01-index.md
+++ b/docs/backend-system/building-backends/01-index.md
@@ -103,8 +103,6 @@ This example touches on the fact that services can have different scopes, being 
 
 ## Split Into Multiple Backends
 
-> NOTE: Splitting into multiple backends is an advanced deployment pattern that requires significant effort and there are not yet many built-in tools in the framework to help you out. Only use this if necessary.
-
 A more advanced way to deploy Backstage is to split the backend plugins into multiple different backend deployments. Both the [deployment documentation](../../deployment/scaling.md) and [Threat Model](../../overview/threat-model.md#trust-model) explain the benefits of this, so here we'll focus on how to do it.
 
 To create a separate backend we need to create an additional backend package. This package will be built and deployed separately from your existing backend. There is currently no template to create a backend via `yarn new`, so the quickest way is to copy the new package and modify. The naming is up to you and it depends on how you are splitting things and up. For this example we'll just use a simple suffix. You might end up with a directory structure like this:

--- a/docs/deployment/scaling.md
+++ b/docs/deployment/scaling.md
@@ -17,7 +17,7 @@ into multiple different services, each running a different set of plugins. This
 is a more advanced approach and requires you to be able to route requests to
 the appropriate backends based on the plugin ID. Both for ingress, but also
 internal traffic between Backstage backends, which is done by creating a custom
-implementation of the [DiscoveryService](../reference/backend-plugin-api.discoveryservice.md) interface.
+implementation of the [DiscoveryService](../reference/backend-plugin-api.discoveryservice.md) interface. See the [backend system docs](../backend-system/building-backends/01-index.md#split-into-multiple-backends) for more details on how to separate your deployment into multiple backend instances.
 
 Lastly, you can also replicate the Backstage deployments across multiple regions.
 This is not a pattern that there is built-in support for and typically only makes


### PR DESCRIPTION
🧹  We now have the discovery API implementation that makes it simple to configure different discovery targets, so let's remove the note about splitting into multiple backends not being recommended since it's a pattern I think we should encourage.