### PR TITLE
[Catalog] Update content Items key on default import page

### DIFF
--- a/.changeset/silver-yaks-bow.md
+++ b/.changeset/silver-yaks-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Fix missing children key warning on the default catalog import page.

--- a/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
+++ b/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
@@ -39,11 +39,11 @@ export const DefaultImportPage = () => {
   const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
 
   const contentItems = [
-    <Grid item xs={12} md={4} lg={6} xl={8}>
+    <Grid key={0} item xs={12} md={4} lg={6} xl={8}>
       <ImportInfoCard />
     </Grid>,
 
-    <Grid item xs={12} md={8} lg={6} xl={4}>
+    <Grid key={1} item xs={12} md={8} lg={6} xl={4}>
       <ImportStepper />
     </Grid>,
   ];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up on [this](https://github.com/backstage/backstage/pull/20632#issuecomment-1793763820) comment for adding a changeset file, thanks for the contribution [@iegik](https://github.com/iegik) 🎉 .

---

Fixes 'Warning: Each child in a list should have a unique "key" prop.'

![image](https://github.com/backstage/backstage/assets/6290749/00439fe3-8987-4c92-9da9-bddd09780efe)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
