### PR TITLE
[SupportButton] allow custom icon for SupportItem

### DIFF
--- a/.changeset/hip-donuts-heal.md
+++ b/.changeset/hip-donuts-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add support for custom icons on SupportButton items

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1280,7 +1280,7 @@ export type SupportConfig = {
 // @public (undocumented)
 export type SupportItem = {
   title: string;
-  icon?: string;
+  icon?: string | JSX.Element;
   links: SupportItemLink[];
 };
 

--- a/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.test.tsx
@@ -23,6 +23,7 @@ import {
 import { act, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { SupportButton } from './SupportButton';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
 const configApi = new MockConfigApi({
   app: {
@@ -56,6 +57,31 @@ describe('<SupportButton />', () => {
     expect(screen.getByText('Custom title')).toBeInTheDocument();
   });
 
+  it('supports passing an icon object', async () => {
+    const CustomIcon = (props: SvgIconProps) =>
+      React.createElement(
+        SvgIcon,
+        props,
+        <path d="M9 7H4a2 2 0 1 0 0 4h5a2 2 0 1 0 0-4zm2-3v2H9a2 2 0 1 1 2-2zM7 14v5a2 2 0 1 0 4 0v-5a2 2 0 1 0-4 0zm-3-2h2v2a2 2 0 1 1-2-2zm10 4h5a2 2 0 1 0 0-4h-5a2 2 0 1 0 0 4zm-2 3v-2h2a2 2 0 1 1-2 2zm4-10V4a2 2 0 1 0-4 0v5a2 2 0 1 0 4 0zm3 2h-2V9a2 2 0 1 1 2 2z" />,
+      );
+
+    await renderInTestApp(
+      <SupportButton
+        items={[
+          {
+            title: 'Documentation',
+            icon: <CustomIcon data-testid="custom-icon" />,
+            links: [{ title: 'Show docs', url: '/docs' }],
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId(SUPPORT_BUTTON_ID));
+
+    const customIcon = screen.getByTestId('custom-icon');
+    expect(customIcon).toBeInTheDocument();
+  });
+
   it('supports passing link items through props', async () => {
     await renderInTestApp(
       <SupportButton
@@ -76,6 +102,9 @@ describe('<SupportButton />', () => {
 
     const documentationItem = screen.getByText('Documentation');
     expect(documentationItem).toBeInTheDocument();
+
+    const descriptionIcon = screen.getByTestId('description');
+    expect(descriptionIcon).toBeInTheDocument();
   });
 
   it('shows items from support config', async () => {

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -53,10 +53,16 @@ const useStyles = makeStyles(
   { name: 'BackstageSupportButton' },
 );
 
-const SupportIcon = ({ icon }: { icon: string | undefined }) => {
+const SupportIcon = ({ icon }: { icon: string | JSX.Element | undefined }) => {
   const app = useApp();
-  const Icon = icon ? app.getSystemIcon(icon) ?? HelpIcon : HelpIcon;
-  return <Icon />;
+  if (!icon) {
+    return <HelpIcon />;
+  }
+  if (typeof icon === 'string') {
+    const Icon = app.getSystemIcon(icon) || HelpIcon;
+    return <Icon data-testid={icon} />;
+  }
+  return <>{icon}</>;
 };
 
 const SupportLink = ({ link }: { link: SupportItemLink }) => (

--- a/packages/core-components/src/hooks/useSupportConfig.ts
+++ b/packages/core-components/src/hooks/useSupportConfig.ts
@@ -23,7 +23,7 @@ export type SupportItemLink = {
 
 export type SupportItem = {
   title: string;
-  icon?: string;
+  icon?: string | JSX.Element;
   links: SupportItemLink[];
 };
 


### PR DESCRIPTION
Allow the usage of non-predefined icons for SupportItem list.

Part of the reason SupportItems can be supplied to modify the SupportButton entries is to provide links to the users support tool of choice. Allowing the usage of custom icons and not just the pre-defined set will make it possible to make this experience nicer, by using icons the users may more readily associate with that tool.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
