### PR TITLE
Ignore maintainer thanks on changelogs

### DIFF
--- a/.changeset/backstage-changelog.js
+++ b/.changeset/backstage-changelog.js
@@ -32,7 +32,24 @@ async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
   return ['- Updated dependencies', ...updatedDependenciesList].join('\n');
 }
 
+async function getReleaseLine(changeset, type, options) {
+  const { ignoreUserThanks: users = [] } = options ?? {};
+  const releaseLine = await defaultChangelogFunctions.getReleaseLine(
+    changeset,
+    type,
+    options,
+  );
+  return releaseLine.replace(/Thanks\s(.*)!\s/g, (_, group) => {
+    const links = group
+      .split(', ')
+      .filter(link =>
+        users.every(user => `[@${user}](https://github.com/${user})` !== link),
+      );
+    return links.length ? `Thanks ${links.join(', ')}! ` : '';
+  });
+}
+
 module.exports = {
-  getReleaseLine: defaultChangelogFunctions.getReleaseLine,
+  getReleaseLine,
   getDependencyReleaseLine,
 };

--- a/.changeset/backstage-changelog.js
+++ b/.changeset/backstage-changelog.js
@@ -34,17 +34,16 @@ async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
 
 async function getReleaseLine(changeset, type, options) {
   const { ignoreUserThanks: users = [] } = options ?? {};
+  const ignoredLinks = new Set(
+    users.map(user => `[@${user}](https://github.com/${user})`),
+  );
   const releaseLine = await defaultChangelogFunctions.getReleaseLine(
     changeset,
     type,
     options,
   );
   return releaseLine.replace(/Thanks\s(.*)!\s/g, (_, group) => {
-    const links = group
-      .split(', ')
-      .filter(link =>
-        users.every(user => `[@${user}](https://github.com/${user})` !== link),
-      );
+    const links = group.split(', ').filter(link => !ignoredLinks.has(link));
     return links.length ? `Thanks ${links.join(', ')}! ` : '';
   });
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.3.0/schema.json",
-  "changelog": ["./backstage-changelog.js", { "repo": "backstage/backstage" }],
+  "changelog": [
+    "./backstage-changelog.js",
+    {
+      "repo": "backstage/backstage",
+      "ignoreUserThanks": ["benjdlambert", "freben", "jhaals", "Rugvip"]
+    }
+  ],
   "commit": false,
   "linked": [],
   "access": "public",


### PR DESCRIPTION
Signed-off-by: Camila Belo <camilaibs@gmail.com>

## Hey, I just made a Pull Request!
Ignore maintainer users in changelog thank you mentions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
