### PR TITLE
🧹  one more flaky test fixed

### DIFF
--- a/plugins/techdocs-node/src/stages/publish/azureBlobStorage.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/azureBlobStorage.test.ts
@@ -398,7 +398,7 @@ describe('AzureBlobStoragePublish', () => {
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Unable to upload file(s) to Azure. Error: Upload failed for ${path.join(
+          `Error: Upload failed for ${path.join(
             directory,
             '404.html',
           )} with status code 500`,


### PR DESCRIPTION
There's actually a space separated list of files' individual errors in this string, after the "Unable to upload file(s) to Azure." prefix. So sometimes another file was before the 404 one. This should fix it well enough.