### PR TITLE
Remove `button` prop from used MaterialUI `MenuItem` component

### DIFF
--- a/.changeset/odd-scissors-eat.md
+++ b/.changeset/odd-scissors-eat.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-cost-insights': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-playlist': patch
+'@backstage/plugin-bazaar': patch
+---
+
+Remove `button` prop from used MaterialUI `MenuItem` component fixing incompatibility with MaterialUI v5.

--- a/plugins/bazaar/src/components/InputSelector/InputSelector.tsx
+++ b/plugins/bazaar/src/components/InputSelector/InputSelector.tsx
@@ -60,7 +60,7 @@ export const InputSelector = ({ name, options, control, error }: Props) => {
           >
             {options.map(option => {
               return (
-                <MenuItem button key={option} value={option}>
+                <MenuItem key={option} value={option}>
                   {option}
                 </MenuItem>
               );

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -243,7 +243,6 @@ export const UserListPicker = (props: UserListPickerProps) => {
                 <MenuItem
                   role="none presentation"
                   key={item.id}
-                  button
                   divider
                   onClick={() => setSelectedUserFilter(item.id)}
                   selected={item.id === filters.user?.value}

--- a/plugins/cost-insights/src/components/CostInsightsNavigation/CostInsightsNavigation.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsNavigation/CostInsightsNavigation.tsx
@@ -44,7 +44,6 @@ const NavigationMenuItem = ({ navigation, icon, title }: NavigationItem) => {
   const [, setScroll] = useScroll();
   return (
     <MenuItem
-      button
       data-testid={`menu-item-${navigation}`}
       className={classes.menuItem}
       onClick={() => setScroll(navigation)}

--- a/plugins/playlist/src/components/PersonalListPicker/PersonalListPicker.tsx
+++ b/plugins/playlist/src/components/PersonalListPicker/PersonalListPicker.tsx
@@ -261,7 +261,6 @@ export const PersonalListPicker = () => {
                 <MenuItem
                   role="none presentation"
                   key={item.id}
-                  button
                   divider
                   onClick={() => setSelectedPersonalFilter(item.id)}
                   selected={item.id === selectedPersonalFilter}

--- a/plugins/scaffolder/src/components/ListTasksPage/OwnerListPicker.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/OwnerListPicker.tsx
@@ -111,7 +111,6 @@ export const OwnerListPicker = (props: {
               {group.items.map(item => (
                 <MenuItem
                   key={item.id}
-                  button
                   divider
                   ContainerProps={{ role: 'menuitem' }}
                   onClick={() => onSelectOwner(item.id as 'owned' | 'all')}


### PR DESCRIPTION
Closes #18020

**Context:** 

Material UI v5 removed the `button` prop from the `MenuItem` component as the component inself now inhertiates from the `ButtonBase` & thereby always is a button (https://mui.com/material-ui/api/menu-item/#inheritance). In v4 `MenuItem` was a `ListItem` & therefor had a `button` prob (https://v4.mui.com/api/menu-item/). 

Due to the `UnifiedThemeProvider` we have the style overrides of `v5` (giving the `MenuItem` the `BaseButton` style) already in the application. There for this should not have any visual impact (https://github.com/backstage/backstage/blob/master/packages/theme/src/unified/UnifiedTheme.tsx#L78-L82)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
