### PR TITLE
Move over Any* helper types from `core-plugin-api` to `frontend-plugin-api`

### DIFF
--- a/.changeset/rare-geese-film.md
+++ b/.changeset/rare-geese-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Copy over `AnyApiFactory` & `AnyApiRef` to new frontend system

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -5,9 +5,7 @@
 ```ts
 /// <reference types="react" />
 
-import { AnyApiFactory } from '@backstage/core-plugin-api';
-import { AnyApiRef } from '@backstage/core-plugin-api';
-import { ApiRef } from '@backstage/core-plugin-api';
+import { ApiRef as ApiRef_2 } from '@backstage/core-plugin-api';
 import { AppTheme } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { JsonObject } from '@backstage/types';
@@ -17,6 +15,18 @@ import { ReactNode } from 'react';
 import { z } from 'zod';
 import { ZodSchema } from 'zod';
 import { ZodTypeDef } from 'zod';
+
+// @public
+export type AnyApiFactory = ApiFactory<
+  unknown,
+  unknown,
+  {
+    [key in string]: unknown;
+  }
+>;
+
+// @public
+export type AnyApiRef = ApiRef<unknown>;
 
 // @public (undocumented)
 export type AnyExtensionDataMap = {
@@ -54,6 +64,25 @@ export type AnyRouteRefParams =
 // @public (undocumented)
 export type AnyRoutes = {
   [name in string]: RouteRef;
+};
+
+// @public
+export type ApiFactory<
+  Api,
+  Impl extends Api,
+  Deps extends {
+    [name in string]: unknown;
+  },
+> = {
+  api: ApiRef<Api>;
+  deps: TypesToApiRefs<Deps>;
+  factory(deps: Deps): Impl;
+};
+
+// @public
+export type ApiRef<T> = {
+  id: string;
+  T: T;
 };
 
 // @public
@@ -114,7 +143,7 @@ export interface AppTreeApi {
 }
 
 // @public
-export const appTreeApiRef: ApiRef<AppTreeApi>;
+export const appTreeApiRef: ApiRef_2<AppTreeApi>;
 
 // @public (undocumented)
 export interface BackstagePlugin<
@@ -544,6 +573,11 @@ export interface SubRouteRef<
   // (undocumented)
   readonly T: TParams;
 }
+
+// @public
+export type TypesToApiRefs<T> = {
+  [key in keyof T]: ApiRef<T[key]>;
+};
 
 // @public
 export function useRouteRef<

--- a/packages/frontend-plugin-api/src/extensions/createApiExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createApiExtension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AnyApiFactory, AnyApiRef } from '@backstage/core-plugin-api';
+import { AnyApiFactory, AnyApiRef } from './types';
 import { PortableSchema } from '../schema';
 import {
   ExtensionInputValues,

--- a/packages/frontend-plugin-api/src/extensions/index.ts
+++ b/packages/frontend-plugin-api/src/extensions/index.ts
@@ -18,3 +18,4 @@ export { createApiExtension } from './createApiExtension';
 export { createPageExtension } from './createPageExtension';
 export { createNavItemExtension } from './createNavItemExtension';
 export { createThemeExtension } from './createThemeExtension';
+export * from './types';

--- a/packages/frontend-plugin-api/src/extensions/types.ts
+++ b/packages/frontend-plugin-api/src/extensions/types.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * API reference.
+ *
+ * @public
+ */
+export type ApiRef<T> = {
+  id: string;
+  T: T;
+};
+
+/**
+ * Catch-all {@link ApiRef} type.
+ *
+ * @public
+ */
+export type AnyApiRef = ApiRef<unknown>;
+
+/**
+ * Wraps a type with API properties into a type holding their respective {@link ApiRef}s.
+ *
+ * @public
+ */
+export type TypesToApiRefs<T> = { [key in keyof T]: ApiRef<T[key]> };
+
+/**
+ * Describes type returning API implementations.
+ *
+ * @public
+ */
+export type ApiFactory<
+  Api,
+  Impl extends Api,
+  Deps extends { [name in string]: unknown },
+> = {
+  api: ApiRef<Api>;
+  deps: TypesToApiRefs<Deps>;
+  factory(deps: Deps): Impl;
+};
+
+/**
+ * Catch-all {@link ApiFactory} type.
+ *
+ * @public
+ */
+export type AnyApiFactory = ApiFactory<
+  unknown,
+  unknown,
+  { [key in string]: unknown }
+>;

--- a/packages/frontend-plugin-api/src/wiring/coreExtensionData.ts
+++ b/packages/frontend-plugin-api/src/wiring/coreExtensionData.ts
@@ -15,13 +15,10 @@
  */
 
 import { JSX } from 'react';
-import {
-  AnyApiFactory,
-  AppTheme,
-  IconComponent,
-} from '@backstage/core-plugin-api';
+import { AppTheme, IconComponent } from '@backstage/core-plugin-api';
 import { createExtensionDataRef } from './createExtensionDataRef';
 import { RouteRef } from '../routing';
+import { AnyApiFactory } from '../extensions';
 
 /** @public */
 export type NavTarget = {


### PR DESCRIPTION
Move over Any* helper types from `core-plugin-api` to `frontend-plugin-api` in favour of closing API Gaps mentioned in https://github.com/backstage/backstage/issues/19545

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
