### PR TITLE
feat: add entityRef to Entity Inspector view

### DIFF
--- a/.changeset/cool-bulldogs-itch.md
+++ b/.changeset/cool-bulldogs-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Add EntityRef to Entity Inspector UI

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
@@ -21,6 +21,7 @@ import {
   List,
   ListItem,
   ListItemIcon,
+  ListItemSecondaryAction,
   makeStyles,
   Typography,
 } from '@material-ui/core';
@@ -37,6 +38,7 @@ import {
 } from './common';
 import { EntityKindIcon } from './EntityKindIcon';
 import { stringifyEntityRef } from '@backstage/catalog-model';
+import { CopyTextButton } from '@backstage/core-components';
 
 const useStyles = makeStyles({
   root: {
@@ -61,6 +63,7 @@ export function OverviewPage(props: { entity: AlphaEntity }) {
     'type',
   );
 
+  const entityRef = stringifyEntityRef(props.entity);
   return (
     <>
       <DialogContentText variant="h2">Overview</DialogContentText>
@@ -84,18 +87,24 @@ export function OverviewPage(props: { entity: AlphaEntity }) {
             {metadata.uid && (
               <ListItem>
                 <ListItemText primary="uid" secondary={metadata.uid} />
+                <ListItemSecondaryAction>
+                  <CopyTextButton text={metadata.uid} />
+                </ListItemSecondaryAction>
               </ListItem>
             )}
             {metadata.etag && (
               <ListItem>
                 <ListItemText primary="etag" secondary={metadata.etag} />
+                <ListItemSecondaryAction>
+                  <CopyTextButton text={metadata.etag} />
+                </ListItemSecondaryAction>
               </ListItem>
             )}
             <ListItem>
-              <ListItemText
-                primary="entityRef"
-                secondary={stringifyEntityRef(props.entity)}
-              />
+              <ListItemText primary="entityRef" secondary={entityRef} />
+              <ListItemSecondaryAction>
+                <CopyTextButton text={entityRef} />
+              </ListItemSecondaryAction>
             </ListItem>
           </List>
         </Container>

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
@@ -36,6 +36,7 @@ import {
   ListSubheader,
 } from './common';
 import { EntityKindIcon } from './EntityKindIcon';
+import { stringifyEntityRef } from '@backstage/catalog-model';
 
 const useStyles = makeStyles({
   root: {
@@ -90,6 +91,12 @@ export function OverviewPage(props: { entity: AlphaEntity }) {
                 <ListItemText primary="etag" secondary={metadata.etag} />
               </ListItem>
             )}
+            <ListItem>
+              <ListItemText
+                primary="entityRef"
+                secondary={stringifyEntityRef(props.entity)}
+              />
+            </ListItem>
           </List>
         </Container>
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Occasionally, I would like to get an entity ref, but the UI has no place to copy it from. The Entity Inspector seems like a nice place for it. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
<img width="641" alt="image" src="https://github.com/backstage/backstage/assets/5969237/b212af6c-b3e1-4ece-90cb-1b0ff2d97988">

new screenshot with copy buttons:
<img width="1695" alt="image" src="https://github.com/backstage/backstage/assets/5969237/54bee9c5-fef5-4e75-af5e-1e0ca0e74dd1">

