### PR TITLE
Update dependency versions in default frontend plugin templates

### DIFF
--- a/.changeset/tiny-kiwis-know.md
+++ b/.changeset/tiny-kiwis-know.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Update dependencies in `defaul-plugin` template
+Updated dependencies in frontend plugin templates

--- a/.changeset/tiny-kiwis-know.md
+++ b/.changeset/tiny-kiwis-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Update dependencies in `defaul-plugin` template

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -45,8 +45,8 @@
     "@backstage/core-app-api": "{{versionQuery '@backstage/core-app-api'}}",
     "@backstage/dev-utils": "{{versionQuery '@backstage/dev-utils'}}",
     "@backstage/test-utils": "{{versionQuery '@backstage/test-utils'}}",
-    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '5.10.1'}}",
-    "@testing-library/react": "{{versionQuery '@testing-library/react' '12.1.3'}}",
+    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '6.0.0'}}",
+    "@testing-library/react": "{{versionQuery '@testing-library/react' '14.0.0'}}",
     "@testing-library/user-event": "{{versionQuery '@testing-library/user-event' '14.0.0'}}",
     "msw": "{{versionQuery 'msw' '1.0.0'}}"
   },

--- a/packages/cli/templates/default-react-plugin-package/package.json.hbs
+++ b/packages/cli/templates/default-react-plugin-package/package.json.hbs
@@ -39,8 +39,8 @@
   "devDependencies": {
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
     "@backstage/test-utils": "{{versionQuery '@backstage/test-utils'}}",
-    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '5.10.1'}}",
-    "@testing-library/react": "{{versionQuery '@testing-library/react' '12.1.3'}}"
+    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '6.0.0'}}",
+    "@testing-library/react": "{{versionQuery '@testing-library/react' '14.0.0'}}"
   },
   "files": [
     "dist"

--- a/packages/cli/templates/web-library-package/package.json.hbs
+++ b/packages/cli/templates/web-library-package/package.json.hbs
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
-    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '5.10.1'}}"
+    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '6.0.0'}}"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Creating a plugin using the `default-plugin` template created a change to the `yarn.lock` for me. As we stopped accepting new plugins in the main repository we probably missed this. This PR aligns the versions with the currently supported versions in the main repository.

**Unexpected `git diff` on `yarn.lock`**
<img width="470" alt="Screenshot 2023-11-09 at 12 07 42" src="https://github.com/backstage/backstage/assets/8904624/8e49e4fb-8c4c-425c-9963-5c6d87271974">
<img width="482" alt="Screenshot 2023-11-09 at 12 07 48" src="https://github.com/backstage/backstage/assets/8904624/1f829e60-bde3-4124-a6c7-31f7d2e17b17">
<img width="437" alt="Screenshot 2023-11-09 at 12 07 34" src="https://github.com/backstage/backstage/assets/8904624/07dacc08-3db4-46ba-8dc2-30a617007f2e">

<img width="536" alt="Screenshot 2023-11-09 at 12 07 22" src="https://github.com/backstage/backstage/assets/8904624/4ff38343-43af-442e-8686-0de0db088fd4">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
