### PR TITLE
🧹 hopefully fix zip archive flakiness

### DIFF
--- a/packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
@@ -196,12 +196,14 @@ describe('ZipArchiveResponse', () => {
     const fileSize = 1000 * 1000;
     const filePath = await new Promise<string>((resolve, reject) => {
       const outFile = targetDir.resolve('large-archive.zip');
-      const archive = createArchive('zip');
 
+      const outStream = fs.createWriteStream(outFile);
+      outStream.on('close', () => resolve(outFile));
+
+      const archive = createArchive('zip');
       archive.on('error', reject);
-      archive.on('end', () => resolve(outFile));
-      archive.pipe(fs.createWriteStream(outFile));
       archive.on('warning', w => console.warn('WARN', w));
+      archive.pipe(outStream);
 
       for (let i = 0; i < fileCount; i++) {
         // Workaround for https://github.com/archiverjs/node-archiver/issues/542


### PR DESCRIPTION
Following https://www.archiverjs.com/docs/quickstart and using the file stream `close` event instead of the archive `end` event to mark completion. This should hopefully end the following flakiness which seems to happen because the data wasn't completely written at the time of starting to read it back.

```
PASS @backstage/plugin-kubernetes-backend plugins/kubernetes-backend/src/index.test.ts

Summary of all failing tests
FAIL packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
  ● ZipArchiveResponse › should extract a large archive

    end of central directory record signature not found

      at ../../../node_modules/yauzl/index.js:187:14
      at ../../../node_modules/yauzl/index.js:631:5
      at ../../../node_modules/fd-slicer/index.js:32:7
```