### PR TITLE
add parseJSON function

### DIFF
--- a/plugins/scaffolder-backend/src/lib/templating/filters.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/filters.ts
@@ -17,7 +17,7 @@ import { parseEntityRef } from '@backstage/catalog-model';
 import { ScmIntegrations } from '@backstage/integration';
 import type { JsonObject, JsonValue } from '@backstage/types';
 import { TemplateFilter } from '..';
-import { parseRepoUrl } from '../../scaffolder/actions/builtin/publish/util';
+import { parseJSON, parseRepoUrl } from '../../scaffolder/actions/builtin/publish/util';
 import get from 'lodash/get';
 
 export const createDefaultFilters = ({
@@ -34,5 +34,6 @@ export const createDefaultFilters = ({
       const { owner, repo } = parseRepoUrl(repoUrl as string, integrations);
       return `${owner}/${repo}`;
     },
+    parseJSON: objString => parseJSON(objString as string),
   };
 };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.test.ts
@@ -18,6 +18,8 @@ import path from 'path';
 import { getRepoSourceDirectory, isExecutable, parseRepoUrl } from './util';
 import { ScmIntegrations } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
+import { parseJSON, JsonSpec } from './util';
+import { InputError } from '@backstage/errors';
 
 describe('getRepoSourceDirectory', () => {
   it('should return workspace root if no sub folder is given', () => {
@@ -177,5 +179,31 @@ describe('parseRepoUrl', () => {
     ).toThrow(
       'Invalid repo URL passed to publisher: https://www.bitbucket.org/?project=project&repo=repo, missing workspace',
     );
+  });
+});
+
+describe('parseJSON', () => {
+  it('should parse a valid JSON string and return a JsonSpec object', () => {
+    const jsonString = '{"key1": "value1", "key2": "value2"}';
+    const expected: JsonSpec = { key1: 'value1', key2: 'value2' };
+
+    const result = parseJSON(jsonString);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should throw an InputError for an invalid JSON string', () => {
+    const invalidJsonString = 'invalid_json_string';
+
+    expect(() => parseJSON(invalidJsonString)).toThrowError(InputError);
+  });
+
+  it('should handle an empty JSON string and return an empty JsonSpec object', () => {
+    const emptyJsonString = '{}';
+    const expected: JsonSpec = {};
+
+    const result = parseJSON(emptyJsonString);
+
+    expect(result).toEqual(expected);
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts
@@ -127,3 +127,47 @@ function checkRequiredParams(repoUrl: URL, ...params: string[]) {
     }
   }
 }
+
+/**
+ *  This function receives an object transformed into a string and returns it parsed, 
+     unstructured, so it can easily be used to obtain values in the template.
+ *
+ * @param objString - the object transformed into a string
+ *
+ * @throws
+ * An InputError exception is thrown..
+ *
+ * @public
+ */
+
+     export type Props = {
+      [key:string]: string
+  }
+  
+  export type JsonSpec = Props;
+  
+  export const parseJSON = (
+    objString: string,
+  ): JsonSpec => {
+    let parsed;
+    try {
+      parsed = JSON.parse(objString);
+    } catch (error) {
+      throw new InputError(
+        `Invalid object passed to publisher, ${error}`,
+      );
+    }
+  
+    let results: JsonSpec = {};
+  
+    if (parsed) {
+      for (const key in parsed) {
+        if (parsed.hasOwnProperty(key)) {
+          results[key] = parsed[key];
+        }
+      }
+    }
+  
+    return {...results};
+  };
+  


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello...👋

I have a small suggestion to add to the scaffolder-backend plugin.

In the company where I work, we are implementing the backstage and also creating some internal modifications.
The last one was to reuse information from a customized kind, called Cluster, in the generation of other projects using our own templates.
To make sense of this, internally I extended the "EntityPicker" field and created it under the name "ResourcePicker". It scans my catalog and returns entities that I filter when designing the template, using the catalogFilter (which already existed in the EntityPicker), as an example, I added it so that it returns all the Kinds Clusters... 


![i1](https://github.com/backstage/backstage/assets/84424883/129db170-86f7-43b5-8431-61f1afebcf1c)

And in the same "ResourcePicker", I will treat this object and use JSON.stringify to transform it into a string;

The pull request presented would be an additional feature so that we could parse objects like the case described above, objects transformed into strings.

I've seen that there's parseRepoUrl, where we can extract fragments from the "RepoUrl" step, and reuse them in the next steps of the template, as well as in the "skeleton" that will generate our new project (via the template).

The idea is to have a dynamic function to parse as many objects as we need, and to be able to use these values freely in the construction of our templates, and we need something very generic that can be adapted to any abstraction we need, hence the name "parseJSON".

Screen prints:

![i2](https://github.com/backstage/backstage/assets/84424883/2a96f663-73da-4104-aa3d-843e9bddc256)

ℹ️ This field is not included in pullRequest, it is an internal component, which in this case is being used as an example.

![i3](https://github.com/backstage/backstage/assets/84424883/4a5b9a2e-272e-4e21-b945-a9c947f560f9)

🙏 The chosen property is expected to replace this placeholder in the template's skeleton.
![i4](https://github.com/backstage/backstage/assets/84424883/01a5d964-9b3f-4788-9e76-12a1ab330924)

✅ output:
![i5](https://github.com/backstage/backstage/assets/84424883/2c3e4045-d2e1-4f80-a3a7-200263a0c10b)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
- [ ✅] Tests for new functionality and regression tests for bug fixes
- [✅ ] Screenshots attached (for UI changes)
- [✅ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
