### PR TITLE
Allow manual docker image build

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -1,5 +1,7 @@
 name: Build and push Docker image
 on:
+  workflow_dispatch:
+
   repository_dispatch:
     types: [release-published]
 
@@ -59,7 +61,7 @@ jobs:
         with:
           context: './example-app'
           file: ./example-app/packages/backend/Dockerfile
-          push: true
+          push: ${{ github.event_name == "repository_dispatch" && github.event.action == "release-published" }}
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/backstage:latest


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently you can't run `deploy_docker-image.yml` manually to validate fixes to this workflow. As you can see it's been failing for some time now with effort put in to fix it but no easy way to validate the fixes: https://github.com/backstage/backstage/actions/workflows/deploy_docker-image.yml

This change adds on `workflow_dispatch` and does a check to see if it should push or not. This should give us a bit more flexibility should we have issue with this workflow.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
