### PR TITLE
Scale `EntityMembersListCard` children based on thier container's width instead of the page width

### DIFF
--- a/.changeset/fresh-seahorses-glow.md
+++ b/.changeset/fresh-seahorses-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fix issue where members inside of `<EntityMembersListCard>` would be rendered as squished when the card itself was shrunk down.

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -61,13 +61,6 @@ const useStyles = makeStyles((theme: Theme) =>
       flex: '1',
       minWidth: '0px',
     },
-    cardGrid: {
-      display: 'grid',
-      gap: theme.spacing(1.5),
-      gridTemplateColumns: `repeat(auto-fit, minmax(auto, ${theme.spacing(
-        34,
-      )}px))`,
-    },
   }),
 );
 
@@ -124,12 +117,19 @@ const MemberComponent = (props: { member: UserEntity }) => {
   );
 };
 
-const useListStyles = makeStyles(() => ({
+const useListStyles = makeStyles(theme => ({
   root: {
     height: '100%',
   },
   cardContent: {
     overflow: 'auto',
+  },
+  memberList: {
+    display: 'grid',
+    gap: theme.spacing(1.5),
+    gridTemplateColumns: `repeat(auto-fit, minmax(auto, ${theme.spacing(
+      34,
+    )}px))`,
   },
 }));
 
@@ -139,7 +139,6 @@ export const MembersListCard = (props: {
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
 }) => {
-  const classes = useStyles();
   const {
     memberDisplayTitle = 'Members',
     pageSize = 50,
@@ -228,7 +227,7 @@ export const MembersListCard = (props: {
   let memberList: React.JSX.Element;
   if (members && members.length > 0) {
     memberList = (
-      <Box className={classes.cardGrid}>
+      <Box className={classes.memberList}>
         {members.slice(pageSize * (page - 1), pageSize * page).map(member => (
           <MemberComponent member={member} key={member.metadata.uid} />
         ))}

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -61,6 +61,13 @@ const useStyles = makeStyles((theme: Theme) =>
       flex: '1',
       minWidth: '0px',
     },
+    cardGrid: {
+      display: 'grid',
+      gap: theme.spacing(1.5),
+      gridTemplateColumns: `repeat(auto-fit, minmax(auto, ${theme.spacing(
+        34,
+      )}px))`,
+    },
   }),
 );
 
@@ -73,49 +80,47 @@ const MemberComponent = (props: { member: UserEntity }) => {
   const displayName = profile?.displayName ?? metaName;
 
   return (
-    <Grid item container xs={12} sm={6} md={4} xl={2}>
-      <Box className={classes.card}>
+    <Box className={classes.card}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        m={3}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Avatar
+          displayName={displayName}
+          picture={profile?.picture}
+          customStyles={{
+            position: 'absolute',
+            top: '-2rem',
+          }}
+        />
         <Box
-          display="flex"
-          flexDirection="column"
-          m={3}
-          alignItems="center"
-          justifyContent="center"
+          pt={2}
+          sx={{
+            width: '100%',
+          }}
+          textAlign="center"
         >
-          <Avatar
-            displayName={displayName}
-            picture={profile?.picture}
-            customStyles={{
-              position: 'absolute',
-              top: '-2rem',
-            }}
-          />
-          <Box
-            pt={2}
-            sx={{
-              width: '100%',
-            }}
-            textAlign="center"
-          >
-            <Typography variant="h6">
-              <EntityRefLink
-                data-testid="user-link"
-                entityRef={props.member}
-                title={displayName}
-              />
-            </Typography>
-            {profile?.email && (
-              <Link to={`mailto:${profile.email}`}>
-                <OverflowTooltip text={profile.email} />
-              </Link>
-            )}
-            {description && (
-              <Typography variant="subtitle2">{description}</Typography>
-            )}
-          </Box>
+          <Typography variant="h6">
+            <EntityRefLink
+              data-testid="user-link"
+              entityRef={props.member}
+              title={displayName}
+            />
+          </Typography>
+          {profile?.email && (
+            <Link to={`mailto:${profile.email}`}>
+              <OverflowTooltip text={profile.email} />
+            </Link>
+          )}
+          {description && (
+            <Typography variant="subtitle2">{description}</Typography>
+          )}
         </Box>
       </Box>
-    </Grid>
+    </Box>
   );
 };
 
@@ -134,6 +139,7 @@ export const MembersListCard = (props: {
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
 }) => {
+  const classes = useStyles();
   const {
     memberDisplayTitle = 'Members',
     pageSize = 50,
@@ -219,6 +225,25 @@ export const MembersListCard = (props: {
     />
   );
 
+  let memberList: React.JSX.Element;
+  if (members && members.length > 0) {
+    memberList = (
+      <Box className={classes.cardGrid}>
+        {members.slice(pageSize * (page - 1), pageSize * page).map(member => (
+          <MemberComponent member={member} key={member.metadata.uid} />
+        ))}
+      </Box>
+    );
+  } else {
+    memberList = (
+      <Box p={2}>
+        <Typography>
+          This group has no {memberDisplayTitle.toLocaleLowerCase()}.
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
     <Grid item className={classes.root}>
       <InfoCard
@@ -247,21 +272,7 @@ export const MembersListCard = (props: {
         {showAggregateMembers && loadingDescendantMembers ? (
           <Progress />
         ) : (
-          <Grid container spacing={3}>
-            {members && members.length > 0 ? (
-              members
-                .slice(pageSize * (page - 1), pageSize * page)
-                .map(member => (
-                  <MemberComponent member={member} key={member.metadata.uid} />
-                ))
-            ) : (
-              <Box p={2}>
-                <Typography>
-                  This group has no {memberDisplayTitle.toLocaleLowerCase()}.
-                </Typography>
-              </Box>
-            )}
-          </Grid>
+          memberList
         )}
       </InfoCard>
     </Grid>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The `<EntityMembersListCard />` component renders incorrectly when its width is shrunk. This happens when trying to make the card take less space than the full width of a page using `<Grid item ...>`. For example, the following renders incorrectly:

```ts
<Grid item xs={3}>
  <EntityMembersListCard />
</Grid>
```

![image](https://github.com/backstage/backstage/assets/1874242/91b2ae16-4e76-4424-b6d8-387e6c8250a4)

I believe that this happens because under the hood, `<EntityMembersListCard />` is implemented using `<Grid>` which is relative to the screen size and not relative to whatever container it's in.

I have resolved this issue by replacing the use of `<Grid>` with CSS Grid which does scale based on its container.

### Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/backstage/backstage/assets/1874242/18abc5b1-3b63-49a3-a5ac-4ebe16b5e327) | ![image](https://github.com/backstage/backstage/assets/1874242/80e50606-cc76-4019-8831-838177aeedde) |

Note that these examples were generated with the following changes to the example app. While looking at [`team-b`](http://localhost:3000/catalog/default/group/team-b)

```patch
diff --git a/packages/app/src/components/catalog/EntityPage.tsx b/packages/app/src/components/catalog/EntityPage.tsx
index ecc1f008b59a..5581604de883 100644
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -801,6 +801,15 @@ const groupPage = (
         <Grid item xs={12}>
           <EntityMembersListCard />
         </Grid>
+        <Grid item xs={9}>
+          <EntityMembersListCard />
+        </Grid>
+        <Grid item xs={6}>
+          <EntityMembersListCard />
+        </Grid>
+        <Grid item xs={3}>
+          <EntityMembersListCard />
+        </Grid>
         <Grid item xs={12}>
           <EntityLikeDislikeRatingsCard />
         </Grid>

```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
