### PR TITLE
fix: copy entity URL support insecure contexts

### DIFF
--- a/.changeset/empty-dingos-grow.md
+++ b/.changeset/empty-dingos-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix copy entity url function in http contexts.

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -28,12 +28,13 @@ import { Theme, makeStyles } from '@material-ui/core/styles';
 import BugReportIcon from '@material-ui/icons/BugReport';
 import MoreVert from '@material-ui/icons/MoreVert';
 import FileCopyTwoToneIcon from '@material-ui/icons/FileCopyTwoTone';
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useEntityPermission } from '@backstage/plugin-catalog-react/alpha';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common/alpha';
 import { UnregisterEntity, UnregisterEntityOptions } from './UnregisterEntity';
 import { useApi, alertApiRef } from '@backstage/core-plugin-api';
+import useCopyToClipboard from 'react-use/lib/useCopyToClipboard';
 
 /** @public */
 export type EntityContextMenuClassKey = 'button';
@@ -87,16 +88,16 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
   };
 
   const alertApi = useApi(alertApiRef);
-
-  const copyToClipboard = useCallback(() => {
-    window.navigator.clipboard.writeText(window.location.toString()).then(() =>
+  const [copyState, copyToClipboard] = useCopyToClipboard();
+  useEffect(() => {
+    if (!copyState.error && copyState.value) {
       alertApi.post({
         message: 'Copied!',
         severity: 'info',
         display: 'transient',
-      }),
-    );
-  }, [alertApi]);
+      });
+    }
+  }, [copyState, alertApi]);
 
   const extraItems = UNSTABLE_extraContextMenuItems && [
     ...UNSTABLE_extraContextMenuItems.map(item => (
@@ -163,7 +164,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
           <MenuItem
             onClick={() => {
               onClose();
-              copyToClipboard();
+              copyToClipboard(window.location.toString());
             }}
           >
             <ListItemIcon>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Copy entity URL function does not work when Backstage is deployed with HTTP (not HTTPS). This PR fixed that issue.
<img width="423" alt="image" src="https://github.com/backstage/backstage/assets/18688410/690783c9-c460-4f23-b57e-8905cc5b74d9">

reference: https://stackoverflow.com/questions/71873824/copy-text-to-clipboard-cannot-read-properties-of-undefined-reading-writetext

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
