### PR TITLE
Enable addition of permission rules for Catalog plugin through CatalogPermissionExtensionPoint

### DIFF
--- a/.changeset/wild-knives-wait.md
+++ b/.changeset/wild-knives-wait.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-catalog-node': minor
 ---
 
-Permission rules can now be added for the Catalog plugin through the `CatalogProcessingExtensionPoint` interface.
+Permission rules can now be added for the Catalog plugin through the `CatalogPermissionExtensionPoint` interface.

--- a/.changeset/wild-knives-wait.md
+++ b/.changeset/wild-knives-wait.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-node': minor
+---
+
+Permission rules can now be added for the Catalog plugin through the `CatalogProcessingExtensionPoint` interface.

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -17,7 +17,7 @@ import {
   createBackendPlugin,
   coreServices,
 } from '@backstage/backend-plugin-api';
-import { CatalogBuilder } from './CatalogBuilder';
+import { CatalogBuilder, CatalogPermissionRuleInput } from './CatalogBuilder';
 import {
   CatalogAnalysisExtensionPoint,
   catalogAnalysisExtensionPoint,
@@ -38,6 +38,7 @@ class CatalogProcessingExtensionPointImpl
   #processors = new Array<CatalogProcessor>();
   #entityProviders = new Array<EntityProvider>();
   #placeholderResolvers: Record<string, PlaceholderResolver> = {};
+  #permissionRules = new Array<CatalogPermissionRuleInput>();
 
   addProcessor(
     ...processors: Array<CatalogProcessor | Array<CatalogProcessor>>
@@ -59,6 +60,14 @@ class CatalogProcessingExtensionPointImpl
     this.#placeholderResolvers[key] = resolver;
   }
 
+  addPermissionRules(
+    ...rules: Array<
+      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
+    >
+  ): void {
+    this.#permissionRules.push(...rules.flat());
+  }
+
   get processors() {
     return this.#processors;
   }
@@ -69,6 +78,10 @@ class CatalogProcessingExtensionPointImpl
 
   get placeholderResolvers() {
     return this.#placeholderResolvers;
+  }
+
+  get permissionRules() {
+    return this.#permissionRules;
   }
 }
 
@@ -142,6 +155,7 @@ export const catalogPlugin = createBackendPlugin({
           ([key, resolver]) => builder.setPlaceholderResolver(key, resolver),
         );
         builder.addLocationAnalyzers(...analysisExtensions.locationAnalyzers);
+        builder.addPermissionRules(...processingExtensions.permissionRules);
 
         const { processingEngine, router } = await builder.build();
 

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogPermissionRuleInput } from '@backstage/plugin-catalog-backend';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
@@ -25,6 +26,12 @@ export interface CatalogProcessingExtensionPoint {
   // (undocumented)
   addEntityProvider(
     ...providers: Array<EntityProvider | Array<EntityProvider>>
+  ): void;
+  // (undocumented)
+  addPermissionRules(
+    ...rules: Array<
+      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
+    >
   ): void;
   // (undocumented)
   addPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -24,6 +24,19 @@ export interface CatalogAnalysisExtensionPoint {
 export const catalogAnalysisExtensionPoint: ExtensionPoint<CatalogAnalysisExtensionPoint>;
 
 // @alpha (undocumented)
+export interface CatalogPermissionExtensionPoint {
+  // (undocumented)
+  addPermissionRules(
+    ...rules: Array<
+      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
+    >
+  ): void;
+}
+
+// @alpha (undocumented)
+export const catalogPermissionExtensionPoint: ExtensionPoint<CatalogPermissionExtensionPoint>;
+
+// @alpha (undocumented)
 export type CatalogPermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
@@ -33,12 +46,6 @@ export interface CatalogProcessingExtensionPoint {
   // (undocumented)
   addEntityProvider(
     ...providers: Array<EntityProvider | Array<EntityProvider>>
-  ): void;
-  // (undocumented)
-  addPermissionRules(
-    ...rules: Array<
-      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
-    >
   ): void;
   // (undocumented)
   addPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -4,10 +4,12 @@
 
 ```ts
 import { CatalogApi } from '@backstage/catalog-client';
-import { CatalogPermissionRuleInput } from '@backstage/plugin-catalog-backend';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
+import { PermissionRule } from '@backstage/plugin-permission-node';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaceholderResolver } from '@backstage/plugin-catalog-node';
 import { ScmLocationAnalyzer } from '@backstage/plugin-catalog-node';
 import { ServiceRef } from '@backstage/backend-plugin-api';
@@ -20,6 +22,11 @@ export interface CatalogAnalysisExtensionPoint {
 
 // @alpha (undocumented)
 export const catalogAnalysisExtensionPoint: ExtensionPoint<CatalogAnalysisExtensionPoint>;
+
+// @alpha (undocumented)
+export type CatalogPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 // @alpha (undocumented)
 export interface CatalogProcessingExtensionPoint {
@@ -46,6 +53,12 @@ export const catalogProcessingExtensionPoint: ExtensionPoint<CatalogProcessingEx
 
 // @alpha
 export const catalogServiceRef: ServiceRef<CatalogApi, 'plugin'>;
+
+// @alpha (undocumented)
+export type EntitiesSearchFilter = {
+  key: string;
+  values?: string[];
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -46,6 +46,7 @@
     "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
+    "@backstage/plugin-catalog-backend": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/types": "workspace:^"
   },

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -47,6 +47,8 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
+    "@backstage/plugin-permission-common": "workspace:^",
+    "@backstage/plugin-permission-node": "workspace:^",
     "@backstage/types": "workspace:^"
   },
   "devDependencies": {

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -46,7 +46,6 @@
     "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/plugin-catalog-backend": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/types": "workspace:^"
   },

--- a/plugins/catalog-node/src/alpha.ts
+++ b/plugins/catalog-node/src/alpha.ts
@@ -19,3 +19,7 @@ export type { CatalogProcessingExtensionPoint } from './extensions';
 export { catalogProcessingExtensionPoint } from './extensions';
 export type { CatalogAnalysisExtensionPoint } from './extensions';
 export { catalogAnalysisExtensionPoint } from './extensions';
+export type {
+  EntitiesSearchFilter,
+  CatalogPermissionRuleInput,
+} from './extensions';

--- a/plugins/catalog-node/src/alpha.ts
+++ b/plugins/catalog-node/src/alpha.ts
@@ -23,3 +23,5 @@ export type {
   EntitiesSearchFilter,
   CatalogPermissionRuleInput,
 } from './extensions';
+export type { CatalogPermissionExtensionPoint } from './extensions';
+export { catalogPermissionExtensionPoint } from './extensions';

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -24,11 +24,18 @@ import {
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
 
-type EntitiesSearchFilter = {
+/**
+ * @alpha
+ */
+export type EntitiesSearchFilter = {
   key: string;
   values?: string[];
 };
-type CatalogPermissionRuleInput<
+
+/**
+ * @alpha
+ */
+export type CatalogPermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -14,30 +14,15 @@
  * limitations under the License.
  */
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
-import { Entity } from '@backstage/catalog-model';
-import { PermissionRuleParams } from '@backstage/plugin-permission-common';
-import { PermissionRule } from '@backstage/plugin-permission-node';
 import {
   EntityProvider,
   CatalogProcessor,
   PlaceholderResolver,
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
-
-/**
- * @alpha
- */
-export type EntitiesSearchFilter = {
-  key: string;
-  values?: string[];
-};
-
-/**
- * @alpha
- */
-export type CatalogPermissionRuleInput<
-  TParams extends PermissionRuleParams = PermissionRuleParams,
-> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
+import { Entity } from '@backstage/catalog-model';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
+import { PermissionRule } from '@backstage/plugin-permission-node';
 
 /**
  * @alpha
@@ -50,11 +35,6 @@ export interface CatalogProcessingExtensionPoint {
     ...providers: Array<EntityProvider | Array<EntityProvider>>
   ): void;
   addPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;
-  addPermissionRules(
-    ...rules: Array<
-      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
-    >
-  ): void;
 }
 
 /**
@@ -78,4 +58,38 @@ export interface CatalogAnalysisExtensionPoint {
 export const catalogAnalysisExtensionPoint =
   createExtensionPoint<CatalogAnalysisExtensionPoint>({
     id: 'catalog.analysis',
+  });
+
+/**
+ * @alpha
+ */
+export type EntitiesSearchFilter = {
+  key: string;
+  values?: string[];
+};
+
+/**
+ * @alpha
+ */
+export type CatalogPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
+
+/**
+ * @alpha
+ */
+export interface CatalogPermissionExtensionPoint {
+  addPermissionRules(
+    ...rules: Array<
+      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
+    >
+  ): void;
+}
+
+/**
+ * @alpha
+ */
+export const catalogPermissionExtensionPoint =
+  createExtensionPoint<CatalogPermissionExtensionPoint>({
+    id: 'catalog.permission',
   });

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
-import { CatalogPermissionRuleInput } from '@backstage/plugin-catalog-backend';
+import { Entity } from '@backstage/catalog-model';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
+import { PermissionRule } from '@backstage/plugin-permission-node';
 import {
   EntityProvider,
   CatalogProcessor,
   PlaceholderResolver,
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
+
+type EntitiesSearchFilter = {
+  key: string;
+  values?: string[];
+};
+type CatalogPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 /**
  * @alpha

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
+import { CatalogPermissionRuleInput } from '@backstage/plugin-catalog-backend';
 import {
   EntityProvider,
   CatalogProcessor,
@@ -32,6 +33,11 @@ export interface CatalogProcessingExtensionPoint {
     ...providers: Array<EntityProvider | Array<EntityProvider>>
   ): void;
   addPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;
+  addPermissionRules(
+    ...rules: Array<
+      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
+    >
+  ): void;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5940,6 +5940,8 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
+    "@backstage/plugin-permission-common": "workspace:^"
+    "@backstage/plugin-permission-node": "workspace:^"
     "@backstage/types": "workspace:^"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,6 +5939,7 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
+    "@backstage/plugin-catalog-backend": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/types": "workspace:^"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,7 +5939,6 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
-    "@backstage/plugin-catalog-backend": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/types": "workspace:^"
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This allows additional permission rules to be added for the Catalog plugin through a new `CatalogPermissionExtensionPoint` interface.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Closes #21271 