### PR TITLE
Update how-to-guides.md

### DIFF
--- a/.github/vale/Vocab/Backstage/accept.txt
+++ b/.github/vale/Vocab/Backstage/accept.txt
@@ -323,6 +323,7 @@ reusability
 Reusability
 roadmaps
 rollbar
+Roboto
 Rollbar
 Rollup
 routable

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -508,7 +508,7 @@ Done! You now have support for TechDocs in your own software template!
 
 If your Backstage instance does not have internet access, the generation will fail. TechDocs tries to download the Roboto font from Google. You can disable it by adding the following lines to mkdocs.yaml:
 
-```markdown
+```yaml
 theme:
   name: material
   font: false

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -483,6 +483,8 @@ plugins:
   - techdocs-core
 ```
 
+note: 
+
 3. Create a `/docs` folder in the skeleton folder with at least an `index.md`
    file in it.
 
@@ -503,6 +505,18 @@ folder (/docs) or replace the content in this file.
 > on how you have configured your `template.yaml`
 
 Done! You now have support for TechDocs in your own software template!
+
+### Prevent download of Google fonts
+
+If your Backstage instance does not have internet access, the generation will fail. TechDocs tries to download the Roboto font from Google. You can disable it by adding the following lines to mkdocs.yaml:
+
+```markdown
+theme:
+  name: material
+  font: false
+```
+
+note: The addition "name material" is necessary. Otherwise it will not work
 
 ## How to enable iframes in TechDocs
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -516,7 +516,7 @@ theme:
   font: false
 ```
 
-note: The addition "name material" is necessary. Otherwise it will not work
+> Note: The addition `name: material` is necessary. Otherwise it will not work
 
 ## How to enable iframes in TechDocs
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -483,8 +483,6 @@ plugins:
   - techdocs-core
 ```
 
-note: 
-
 3. Create a `/docs` folder in the skeleton folder with at least an `index.md`
    file in it.
 


### PR DESCRIPTION
# Added new section in doc, to prevent download of Google fonts

I added a new section in file docs/features/techdocs/how-to-guide.md. I described how the user can disable the download of Google font and i added another important note.

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

@awanlin FYI