### PR TITLE
workflows: remove package publish parallelism

### DIFF
--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -171,7 +171,7 @@ jobs:
           if [ -f ".changeset/pre.json" ]; then
               yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag next
           else
-              yarn workspaces foreach -p -j 10 -v --no-private npm publish --access public --tolerate-republish
+              yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We've had some trouble publishing main line releases in the past, so let's switch back to the slower but (maybe?) more stable option.