### PR TITLE
Patch release of #21285

### DIFF
--- a/.changeset/plenty-numbers-enjoy.md
+++ b/.changeset/plenty-numbers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Removed `@backstage/frontend-app-api` dependency.

--- a/.changeset/plenty-numbers-enjoy.md
+++ b/.changeset/plenty-numbers-enjoy.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-search-react': patch
----
-
-Removed `@backstage/frontend-app-api` dependency.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch"
   },
-  "version": "1.20.0",
+  "version": "1.20.1",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",

--- a/plugins/search-react/CHANGELOG.md
+++ b/plugins/search-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-search-react
 
+## 1.7.3
+
+### Patch Changes
+
+- 43a3ce18947c: Removed `@backstage/frontend-app-api` dependency.
+
 ## 1.7.2
 
 ### Patch Changes

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-react",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
-    "@backstage/frontend-app-api": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/theme": "workspace:^",
@@ -69,6 +68,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
+    "@backstage/frontend-app-api": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^6.0.0",


### PR DESCRIPTION
This release fixes an issue where the `@backstage/plugin-search-react` package had an unnecessary dependency on `@backstage/frontend-app-api`.