### PR TITLE
scripts/verify-links: skip api reference link validation locally

### DIFF
--- a/scripts/verify-links.js
+++ b/scripts/verify-links.js
@@ -168,6 +168,9 @@ async function findExternalDocsLinks(dir) {
 async function main() {
   process.chdir(projectRoot);
 
+  const isCI = Boolean(process.env.CI);
+  const hasReference = existsSync(resolvePath(projectRoot, 'docs/reference'));
+
   const files = await listFiles('.');
   const mdFiles = files.filter(f => f.endsWith('.md'));
   const badUrls = [];
@@ -180,10 +183,19 @@ async function main() {
     badUrls.push(...badFileUrls);
   }
 
+  if (!hasReference) {
+    console.log(
+      "Skipping API reference link validation, no docs/reference/ dir. Reference docs can be built with 'yarn build:api-docs'",
+    );
+  }
+
   if (badUrls.length) {
     console.log(`Found ${badUrls.length} bad links within repo`);
     for (const { url, basePath, problem } of badUrls) {
       if (problem === 'missing') {
+        if (url.startsWith('../reference/') && !isCI && !hasReference) {
+          continue;
+        }
         console.error(
           `Unable to reach ${url} from root or microsite/static/, linked from ${basePath}`,
         );


### PR DESCRIPTION
This makes the output of verify-links.js a bit more helpful when running locally without docs/reference built.