### PR TITLE
workflows: remove tsc step from preview build

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -42,10 +42,6 @@ jobs:
         run: |
           cp -f ./.github/uffizzi/uffizzi.production.app-config.yaml ./app-config.yaml
 
-      - name: typescript build
-        run: |
-          yarn tsc
-
       - name: backstage build
         run: |
           yarn workspace example-backend build


### PR DESCRIPTION
🧹, no need to generate types when only building the backend