### PR TITLE
theme: add type for component overrides

### DIFF
--- a/.changeset/perfect-apes-sing.md
+++ b/.changeset/perfect-apes-sing.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog': patch
+---
+
+Register component overrides in the global `OverrideComponentNameToClassKeys` provided by `@backstage/theme`. This will in turn will provide component style override types for `createUnifiedTheme`.

--- a/.changeset/violet-zebras-thank.md
+++ b/.changeset/violet-zebras-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': minor
+---
+
+Added a global `OverrideComponentNameToClassKeys` for other plugins and packages to populate using module augmentation. This will in turn will provide component style override types for `createUnifiedTheme`.

--- a/packages/core-components/src/overridableComponents.ts
+++ b/packages/core-components/src/overridableComponents.ts
@@ -173,3 +173,8 @@ export type BackstageOverrides = Overrides & {
     StyleRules<BackstageComponentsNameToClassKey[Name]>
   >;
 };
+
+declare module '@backstage/theme' {
+  interface OverrideComponentNameToClassKeys
+    extends BackstageComponentsNameToClassKey {}
+}

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -15,6 +15,7 @@ import { Theme as Theme_3 } from '@material-ui/core';
 import { ThemeOptions } from '@mui/material/styles';
 import { ThemeOptions as ThemeOptions_2 } from '@material-ui/core/styles';
 import type { ThemeOptions as ThemeOptions_3 } from '@material-ui/core';
+import { UnifiedTheme as UnifiedTheme_2 } from '@backstage/theme';
 
 // @public @deprecated
 export type BackstagePalette = Palette & BackstagePaletteAdditions;
@@ -217,6 +218,9 @@ export function genPageTheme(props: {
 export const lightTheme: Theme_3;
 
 // @public
+export interface OverrideComponentNameToClassKeys {}
+
+// @public
 export type PageTheme = {
   colors: string[];
   shape: string;
@@ -401,8 +405,8 @@ export type SupportedVersions = 'v4' | 'v5';
 
 // @public
 export const themes: {
-  light: UnifiedTheme;
-  dark: UnifiedTheme;
+  light: UnifiedTheme_2;
+  dark: UnifiedTheme_2;
 };
 
 // @public

--- a/packages/theme/src/v5/types.test.ts
+++ b/packages/theme/src/v5/types.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { palettes } from '../base';
+import { createUnifiedTheme } from '../unified';
+
+declare module '@backstage/theme' {
+  interface OverrideComponentNameToClassKeys {
+    MyTestComponent: 'root' | 'header';
+  }
+}
+
+describe('OverrideComponentNameToClassKeys', () => {
+  it('should provide type safe component style overrides', () => {
+    const theme = createUnifiedTheme({
+      palette: palettes.light,
+      components: {
+        MyTestComponent: {
+          styleOverrides: {
+            root: {
+              color: '#f00',
+            },
+            // @ts-expect-error
+            invalid: {
+              color: '#b45',
+            },
+          },
+        },
+      },
+    });
+
+    expect(theme).toBeDefined();
+  });
+});

--- a/packages/theme/src/v5/types.ts
+++ b/packages/theme/src/v5/types.ts
@@ -19,6 +19,8 @@ import {
   BackstagePaletteAdditions,
   BackstageThemeAdditions,
 } from '../base/types';
+// eslint-disable-next-line no-restricted-imports
+import { OverridesStyleRules } from '@mui/material/styles/overrides';
 
 declare module '@mui/material/styles' {
   interface Palette extends BackstagePaletteAdditions {}
@@ -34,4 +36,31 @@ declare module '@mui/material/styles' {
 
 declare module '@mui/private-theming/defaultTheme' {
   interface DefaultTheme extends Theme {}
+}
+
+/**
+ * Merge interface declarations into this type to register overrides for your components.
+ *
+ * @public
+ * @example
+ * ```ts
+ * declare module '@backstage/theme' {
+ *   interface OverrideComponentNameToClassKeys {
+ *     MyComponent: 'root' | 'header';
+ *   }
+ * }
+ * ```
+ */
+export interface OverrideComponentNameToClassKeys {}
+
+type BackstageComponentOverrides = {
+  [TName in keyof OverrideComponentNameToClassKeys]?: {
+    styleOverrides?: Partial<
+      OverridesStyleRules<OverrideComponentNameToClassKeys[TName], TName, Theme>
+    >;
+  };
+};
+
+declare module '@mui/material/styles' {
+  interface Components extends BackstageComponentOverrides {}
 }

--- a/plugins/catalog-react/src/overridableComponents.ts
+++ b/plugins/catalog-react/src/overridableComponents.ts
@@ -44,3 +44,8 @@ export type BackstageOverrides = Overrides & {
     StyleRules<CatalogReactComponentsNameToClassKey[Name]>
   >;
 };
+
+declare module '@backstage/theme' {
+  interface OverrideComponentNameToClassKeys
+    extends CatalogReactComponentsNameToClassKey {}
+}

--- a/plugins/catalog/src/overridableComponents.ts
+++ b/plugins/catalog/src/overridableComponents.ts
@@ -33,3 +33,8 @@ export type BackstageOverrides = Overrides & {
     StyleRules<PluginCatalogComponentsNameToClassKey[Name]>
   >;
 };
+
+declare module '@backstage/theme' {
+  interface OverrideComponentNameToClassKeys
+    extends PluginCatalogComponentsNameToClassKey {}
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #18422. This introduces a way to globally register component override keys through module augmentation. Since we've only done style overrides I figured we'd stick to that for now. If we at some point want to allow for prop and variant overrides I figured we could add a separate type that allows that to be augmented. Was striving to keep it simple for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
