### PR TITLE
Fix: Refresh Token on 401 Unauthorized in DefaultTechDocsCollator

### DIFF
--- a/.changeset/angry-dolphins-applaud.md
+++ b/.changeset/angry-dolphins-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Fixed an issue in DefaultTechDocsCollator where indexing of TechDocs would fail due to expired tokens, resulting in 401 Unauthorized errors. Implemented a reactive token refresh mechanism that refreshes the token upon receiving a 401 response and retries the request, ensuring continuous and error-free indexing of TechDocs.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #20731  This PR addresses the issue in the DefaultTechDocsCollator where indexing fails due to expired tokens, leading to 401 Unauthorized errors. I implemented a reactive token refresh mechanism that refreshes the token and retries the request upon receiving a 401 response. This ensures continuous and error-free indexing of TechDocs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
