### PR TITLE
Use JSON logging when NODE_ENV=production or LOG_FORMAT=json env is set while developing

### DIFF
--- a/.changeset/popular-eggs-hang.md
+++ b/.changeset/popular-eggs-hang.md
@@ -1,0 +1,12 @@
+---
+'@backstage/backend-app-api': patch
+'@backstage/backend-common': patch
+'@backstage/cli': patch
+---
+
+Allow developers to enable JSON logging, and also enable it automatically when `NODE_ENV=production` environment variable is set and the server is started with Webpack.
+
+- Added a new environment variable `LOG_FORMAT` that can be set to `json` to enforce winston json logging.
+  This happens also automatically in a production environment when the env var `NODE_ENV=production` is set.
+- Automatically set this new environment variable `LOG_FORMAT` with a warning message when someone uses `NODE_ENV=production`
+  and a command that starts a local backstage instance that supports code reloading via webpack like `yarn start` or `backstage-cli package start`

--- a/docs/backend-system/core-services/01-index.md
+++ b/docs/backend-system/core-services/01-index.md
@@ -261,6 +261,7 @@ backend.add(
         },
         level: process.env.LOG_LEVEL || 'info',
         format:
+          process.env.LOG_FORMAT === 'json' ||
           process.env.NODE_ENV === 'production'
             ? format.json()
             : WinstonLogger.colorFormat(),

--- a/docs/local-dev/debugging.md
+++ b/docs/local-dev/debugging.md
@@ -47,3 +47,31 @@ The resulting log should now have more information available for debugging:
 [1] 2023-04-12T00:51:44.118Z search info Collating documents for tools succeeded type=plugin documentType=tools
 [1] 2023-04-12T00:51:44.119Z backstage debug task: search_index_tools will next occur around 2023-04-11T21:01:44.118-04:00 type=taskManager task=search_index_tools
 ```
+
+Starting with Backstage 0.24+ it is possible to enable the JSON log output,
+also while development mode by setting the `LOG_FORMAT` environment variable to `json`.
+
+The JSON output is automatically enabled in production when the environment variable
+`NODE_ENV` is `production`.
+
+But while running a development server (via `yarn dev` or `backstage-cli package start`) this variable was required to be `development` for WebPack.
+
+<!-- See packages/cli/src/lib/bundler/backend.ts for additional informations -->
+
+```
+LOG_FORMAT=json yarn dev
+```
+
+```json
+{"level":"info","message":"Found 3 new secrets in config that will be redacted","service":"backstage"}
+{"level":"info","message":"Created UrlReader predicateMux{readers=azure{host=dev.azure.com,authed=false},bitbucketCloud{host=bitbucket.org,authed=false},github{host=github.com,authed=false},gitlab{host=gitlab.com,authed=false},awsS3{host=amazonaws.com,authed=false},fetch{}","service":"backstage"}
+{"level":"info","message":"Performing database migration","plugin":"catalog","service":"backstage","type":"plugin"}
+{"level":"info","message":"Configuring \"database\" as KeyStore provider","plugin":"auth","service":"backstage","type":"plugin"}
+{"level":"info","message":"Creating Local publisher for TechDocs","plugin":"techdocs","service":"backstage","type":"plugin"}
+{"level":"info","message":"[HPM] Proxy created: /test  -> https://example.com","plugin":"proxy","service":"backstage","type":"plugin"}
+{"level":"info","message":"[HPM] Proxy rewrite rule created: \"^/api/proxy/test/?\" ~> \"/\"","plugin":"proxy","service":"backstage","type":"plugin"}
+{"level":"info","message":"Added DefaultCatalogCollatorFactory collator factory for type software-catalog","plugin":"search","service":"backstage","type":"plugin"}
+{"level":"info","message":"Added DefaultTechDocsCollatorFactory collator factory for type techdocs","plugin":"search","service":"backstage","type":"plugin"}
+{"level":"info","message":"Starting all scheduled search tasks.","plugin":"search","service":"backstage","type":"plugin"}
+{"level":"info","message":"Listening on :7007","service":"backstage"}
+```

--- a/packages/backend-app-api/src/services/implementations/rootLogger/rootLoggerServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootLogger/rootLoggerServiceFactory.ts
@@ -35,6 +35,7 @@ export const rootLoggerServiceFactory = createServiceFactory({
       },
       level: process.env.LOG_LEVEL || 'info',
       format:
+        process.env.LOG_FORMAT === 'json' ||
         process.env.NODE_ENV === 'production'
           ? format.json()
           : WinstonLogger.colorFormat(),

--- a/packages/backend-common/src/logging/createRootLogger.ts
+++ b/packages/backend-common/src/logging/createRootLogger.ts
@@ -108,7 +108,7 @@ export function createRootLogger(
           level: env.LOG_LEVEL || 'info',
           format: winston.format.combine(
             getRedacter().format,
-            env.NODE_ENV === 'production'
+            env.LOG_FORMAT === 'json' || env.NODE_ENV === 'production'
               ? winston.format.json()
               : WinstonLogger.colorFormat(),
           ),

--- a/packages/cli/src/lib/bundler/backend.ts
+++ b/packages/cli/src/lib/bundler/backend.ts
@@ -28,7 +28,19 @@ export async function serveBackend(options: BackendServeOptions) {
 
   // Webpack only replaces occurrences of this in code it touches, which does
   // not include dependencies in node_modules. So we set it here at runtime as well.
-  (process.env as { NODE_ENV: string }).NODE_ENV = 'development';
+  const env = process.env as Record<string, string>;
+  if (env.NODE_ENV === 'production') {
+    console.warn(
+      'Producton mode (your environment variable NODE_ENV=production) is ignored and changed to `development` to support code reloading via Webpack.',
+    );
+    if (!env.LOG_FORMAT) {
+      console.log(
+        'The log format will be JSON similar to the requested production mode. To disable this you can change your NODE_ENV environment variable or set LOG_FORMAT=text|json.',
+      );
+      env.LOG_FORMAT = 'json';
+    }
+  }
+  env.NODE_ENV = 'development';
 
   const compiler = webpack(config, (err: Error | undefined) => {
     if (err) {


### PR DESCRIPTION
Hi, I spent some time to understand how to enable winston JSON logging in my local (dev) environment to reproduce a bug that appears in production. The issue was also discussed here:

* https://github.com/backstage/backstage/discussions/16132

But setting the environment variable `NODE_ENV=production` didn't worked, as I expected after I found the condition in `createRootLogger`:

https://github.com/backstage/backstage/blob/ca4063dd2704eebc630d946bf94cb435e7efd742/packages/backend-common/src/logging/createRootLogger.ts#L107-L114

After some research where me environment variable is dropped I found this code that overrides it:

https://github.com/backstage/backstage/blob/ca4063dd2704eebc630d946bf94cb435e7efd742/packages/cli/src/lib/bundler/backend.ts#L29-L31

So this issue affects all local backstage instance that supports code reloading via webpack. From my understand every time some one uses one of this commands:
- `NODE_ENV=production yarn dev`
- `NODE_ENV=production yarn start:backstage`
- `NODE_ENV=production backstage-cli package start`

This PR:
1. Adds a new environment variable `LOG_FORMAT` that can be set to "json" to **_enforce_** winston json logging. Similar to a production environment when the env var `NODE_ENV=production` is set.
2. It also automatically set this variable with a warning message when someone uses `NODE_ENV=production` on a local dev environment.
3. Added this information to the debugging doc.

What did you think? Does this make sense and is something missing to get this in?

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
