### PR TITLE
[CatalogClient] extra headers in Catalog request

### DIFF
--- a/.changeset/tasty-dodos-perform.md
+++ b/.changeset/tasty-dodos-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': minor
+---
+
+Introduce option to add custom headers to Catalog API requests

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -154,6 +154,8 @@ export class CatalogClient implements CatalogApi {
 // @public
 export interface CatalogRequestOptions {
   // (undocumented)
+  headers?: Record<string, string>;
+  // (undocumented)
   token?: string;
 }
 

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -519,6 +519,23 @@ describe('CatalogClient', () => {
       await client.getLocationById('42', { token });
     });
 
+    it('forwards extra headers', async () => {
+      expect.assertions(1);
+
+      server.use(
+        rest.get(`${mockBaseUrl}/locations/42`, (req, res, ctx) => {
+          expect(req.headers.get('x-backstage-custom')).toBe(
+            'a custom header value',
+          );
+          return res(ctx.json(defaultResponse));
+        }),
+      );
+
+      await client.getLocationById('42', {
+        headers: { 'x-backstage-custom': 'a custom header value' },
+      });
+    });
+
     it('skips authorization header if token is omitted', async () => {
       expect.assertions(1);
 

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -474,9 +474,10 @@ export class CatalogClient implements CatalogApi {
     options?: CatalogRequestOptions,
   ): Promise<void> {
     const url = `${await this.discoveryApi.getBaseUrl('catalog')}${path}`;
-    const headers: Record<string, string> = options?.token
-      ? { Authorization: `Bearer ${options.token}` }
-      : {};
+    const headers: Record<string, string> = { ...options?.headers };
+    if (options?.token) {
+      headers.Authorization = `Bearer ${options.token}`;
+    }
     const response = await this.fetchApi.fetch(url, { method, headers });
 
     if (!response.ok) {
@@ -490,9 +491,10 @@ export class CatalogClient implements CatalogApi {
     options?: CatalogRequestOptions,
   ): Promise<T> {
     const url = `${await this.discoveryApi.getBaseUrl('catalog')}${path}`;
-    const headers: Record<string, string> = options?.token
-      ? { Authorization: `Bearer ${options.token}` }
-      : {};
+    const headers: Record<string, string> = { ...options?.headers };
+    if (options?.token) {
+      headers.Authorization = `Bearer ${options.token}`;
+    }
     const response = await this.fetchApi.fetch(url, { method, headers });
 
     if (!response.ok) {
@@ -508,9 +510,10 @@ export class CatalogClient implements CatalogApi {
     options?: CatalogRequestOptions,
   ): Promise<any | undefined> {
     const url = `${await this.discoveryApi.getBaseUrl('catalog')}${path}`;
-    const headers: Record<string, string> = options?.token
-      ? { Authorization: `Bearer ${options.token}` }
-      : {};
+    const headers: Record<string, string> = { ...options?.headers };
+    if (options?.token) {
+      headers.Authorization = `Bearer ${options.token}`;
+    }
     const response = await this.fetchApi.fetch(url, { method, headers });
 
     if (!response.ok) {

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -332,6 +332,7 @@ export interface GetEntityFacetsResponse {
  */
 export interface CatalogRequestOptions {
   token?: string;
+  headers?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
Allow the setting of custom extra headers in CatalogRequestOptions.

Use-case: Passing in information from the front-end or another backend service for example for logging request information (like identity, correlation-id, etc.).

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
