### PR TITLE
Add missing export for IconLinkVertical

### DIFF
--- a/.changeset/curly-walls-relate.md
+++ b/.changeset/curly-walls-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add missing export for IconLinkVertical

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -542,6 +542,17 @@ export type HorizontalScrollGridClassKey =
   | 'buttonRight';
 
 // @public (undocumented)
+export function IconLinkVertical({
+  color,
+  disabled,
+  href,
+  icon,
+  label,
+  onClick,
+  title,
+}: IconLinkVerticalProps): React_2.JSX.Element;
+
+// @public (undocumented)
 export type IconLinkVerticalClassKey =
   | 'link'
   | 'disabled'

--- a/packages/core-components/src/components/HeaderIconLinkRow/index.ts
+++ b/packages/core-components/src/components/HeaderIconLinkRow/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { HeaderIconLinkRow } from './HeaderIconLinkRow';
+export { IconLinkVertical } from './IconLinkVertical';
 export type { HeaderIconLinkRowClassKey } from './HeaderIconLinkRow';
 export type {
   IconLinkVerticalProps,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The component marked as `public`, however it wasn't exported on the directory level.

This should make it possible to import it in the userland.

Do we want to add some eslint rules to avoid that in the future?

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
