### PR TITLE
fix: theme id and headerOptions in TemplateListPage

### DIFF
--- a/.changeset/dry-readers-raise.md
+++ b/.changeset/dry-readers-raise.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added `headerOptions` to `TemplateListPage` to optionally override default values.
+Changed themeId of TemplateListPage from `website` to `home`.

--- a/.changeset/dry-readers-raise.md
+++ b/.changeset/dry-readers-raise.md
@@ -3,4 +3,4 @@
 ---
 
 Added `headerOptions` to `TemplateListPage` to optionally override default values.
-Changed themeId of TemplateListPage from `website` to `home`.
+Changed `themeId` of TemplateListPage from `website` to `home`.

--- a/plugins/scaffolder/alpha-api-report.md
+++ b/plugins/scaffolder/alpha-api-report.md
@@ -70,6 +70,11 @@ export type TemplateListPageProps = {
     actions?: boolean;
     tasks?: boolean;
   };
+  headerOptions?: {
+    pageTitleOverride?: string;
+    title?: string;
+    subtitle?: string;
+  };
 };
 
 // @alpha (undocumented)

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -133,6 +133,7 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
             contextMenu={props.contextMenu}
             groups={props.groups}
             templateFilter={props.templateFilter}
+            headerOptions={props.headerOptions}
           />
         }
       />

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -67,6 +67,11 @@ export type TemplateListPageProps = {
     actions?: boolean;
     tasks?: boolean;
   };
+  headerOptions?: {
+    pageTitleOverride?: string;
+    title?: string;
+    subtitle?: string;
+  };
 };
 
 const defaultGroup: TemplateGroupFilter = {
@@ -93,6 +98,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
     TemplateCardComponent,
     groups: givenGroups = [],
     templateFilter,
+    headerOptions,
   } = props;
   const navigate = useNavigate();
   const editorLink = useRouteRef(editRouteRef);
@@ -151,11 +157,12 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
 
   return (
     <EntityListProvider>
-      <Page themeId="website">
+      <Page themeId="home">
         <Header
           pageTitleOverride="Create a new component"
           title="Create a new component"
           subtitle="Create new software components using standard templates in your organization"
+          {...headerOptions}
         >
           <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
         </Header>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Added `headerOptions` to `TemplateListPage` to optionally override default values.
- Changed themeId of TemplateListPage from `website` to `home`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Related Issue

Closes #21313