### PR TITLE
techdocs: Move `tlr` to `peerDependencies`

### DIFF
--- a/.changeset/brave-socks-raise.md
+++ b/.changeset/brave-socks-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Move `@testing-library/react` to be a `peerDependency`

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -46,12 +46,12 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@testing-library/react": "^14.0.0",
     "@types/react": "^16.13.1 || ^17.0.0",
     "react-use": "^17.2.4",
     "testing-library__dom": "^7.29.4-beta.1"
   },
   "peerDependencies": {
+    "@testing-library/react": "^12.1.3 || ^13.0.0 || ^14.0.0",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9621,13 +9621,13 @@ __metadata:
     "@material-ui/lab": 4.0.0-alpha.61
     "@testing-library/dom": ^9.0.0
     "@testing-library/jest-dom": ^6.0.0
-    "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
     "@types/react": ^16.13.1 || ^17.0.0
     msw: ^1.0.0
     react-use: ^17.2.4
     testing-library__dom: ^7.29.4-beta.1
   peerDependencies:
+    "@testing-library/react": ^12.1.3 || ^13.0.0 || ^14.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0


### PR DESCRIPTION
This can cause unexpected issues when on React <18.