### PR TITLE
fix Github MultiOrgEntity Provider using Github App Authentication type does not pull emails from Github

### DIFF
--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -159,6 +159,7 @@ export async function getOrganizationUsers(
 
   // There is no user -> teams edge, so we leave the memberships empty for
   // now and let the team iteration handle it instead
+  const fetchEmail = tokenType === 'token' || tokenType === 'app'; 
 
   const users = await queryWithPaging(
     client,
@@ -168,7 +169,7 @@ export async function getOrganizationUsers(
     userTransformer,
     {
       org,
-      email: tokenType === 'token',
+      email: tokenType === fetchEmail,
     },
   );
 


### PR DESCRIPTION
Fix GitHub authentication to retrieve emails for GitHub App Authentication type

The current logic in `GithubMultiOrgProvider` and `GithubOrgProvider` ignores email retrieval when the token type is set to 'app'. This modifies the logic to ensure emails are fetched for users even when the token type is 'app'.

Changes Made:
- Updated logic in `backstage/plugins/catalog-backend-module-github/src/lib/github.ts`
  - Modified the condition to include email retrieval for token type 'app'
#21359 