### PR TITLE
Fix push expression in deploy_docker-image.yml

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           context: './example-app'
           file: ./example-app/packages/backend/Dockerfile
-          push: ${{ github.event_name == "repository_dispatch" && github.event.action == "release-published" }}
+          push: ${{ (github.event_name == "repository_dispatch") && (github.event.action == "release-published") }}
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/backstage:latest


### PR DESCRIPTION
Fix push expression in deploy_docker-image.yml

https://github.com/backstage/backstage/actions/runs/6877816904

```
Invalid workflow file: .github/workflows/deploy_docker-image.yml#L64
The workflow is not valid. .github/workflows/deploy_docker-image.yml (Line: 64, Col: 17): Unexpected symbol: '"repository_dispatch"'. Located at position 22 within expression: github.event_name == "repository_dispatch" && github.event.action == "release-published"
```
