### PR TITLE
frontend-*-api: add initial support for feature flags

### DIFF
--- a/.changeset/gold-humans-tease.md
+++ b/.changeset/gold-humans-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Add feature flags to plugins and extension overrides.

--- a/.changeset/green-seals-play.md
+++ b/.changeset/green-seals-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Collect and register feature flags from plugins and extension overrides.

--- a/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
@@ -22,6 +22,8 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 
 import { collectLegacyRoutes } from './collectLegacyRoutes';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { toInternalBackstagePlugin } from '../../frontend-plugin-api/src/wiring/createPlugin';
 
 describe('collectLegacyRoutes', () => {
   it('should collect legacy routes', () => {
@@ -37,7 +39,7 @@ describe('collectLegacyRoutes', () => {
     expect(
       collected.map(p => ({
         id: p.id,
-        extensions: p.extensions.map(e => ({
+        extensions: toInternalBackstagePlugin(p).extensions.map(e => ({
           id: e.id,
           attachTo: e.attachTo,
           disabled: e.disabled,

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
@@ -23,6 +23,8 @@ import {
 import { toInternalExtensionOverrides } from '../../../frontend-plugin-api/src/wiring/createExtensionOverrides';
 import { ExtensionParameters } from './readAppExtensionsConfig';
 import { AppNodeSpec } from '@backstage/frontend-plugin-api';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { toInternalBackstagePlugin } from '../../../frontend-plugin-api/src/wiring/createPlugin';
 
 /** @internal */
 export function resolveAppNodeSpecs(options: {
@@ -42,7 +44,10 @@ export function resolveAppNodeSpecs(options: {
   );
 
   const pluginExtensions = plugins.flatMap(source => {
-    return source.extensions.map(extension => ({ ...extension, source }));
+    return toInternalBackstagePlugin(source).extensions.map(extension => ({
+      ...extension,
+      source,
+    }));
   });
   const overrideExtensions = overrides.flatMap(
     override => toInternalExtensionOverrides(override).extensions,

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -218,15 +218,13 @@ export interface BackstagePlugin<
   ExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
 > {
   // (undocumented)
-  $$type: '@backstage/BackstagePlugin';
+  readonly $$type: '@backstage/BackstagePlugin';
   // (undocumented)
-  extensions: Extension<unknown>[];
+  readonly externalRoutes: ExternalRoutes;
   // (undocumented)
-  externalRoutes: ExternalRoutes;
+  readonly id: string;
   // (undocumented)
-  id: string;
-  // (undocumented)
-  routes: Routes;
+  readonly routes: Routes;
 }
 
 export { BackstageUserIdentity };
@@ -607,13 +605,15 @@ export type ExtensionInputValues<
 // @public (undocumented)
 export interface ExtensionOverrides {
   // (undocumented)
-  $$type: '@backstage/ExtensionOverrides';
+  readonly $$type: '@backstage/ExtensionOverrides';
 }
 
 // @public (undocumented)
 export interface ExtensionOverridesOptions {
   // (undocumented)
   extensions: Extension<unknown>[];
+  // (undocumented)
+  featureFlags?: FeatureFlagConfig[];
 }
 
 // @public
@@ -630,6 +630,11 @@ export interface ExternalRouteRef<
 }
 
 export { FeatureFlag };
+
+// @public
+export type FeatureFlagConfig = {
+  name: string;
+};
 
 export { FeatureFlagsApi };
 
@@ -701,6 +706,8 @@ export interface PluginOptions<
   extensions?: Extension<unknown>[];
   // (undocumented)
   externalRoutes?: ExternalRoutes;
+  // (undocumented)
+  featureFlags?: FeatureFlagConfig[];
   // (undocumented)
   id: string;
   // (undocumented)

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.test.ts
@@ -26,6 +26,7 @@ describe('createExtensionOverrides', () => {
       {
         "$$type": "@backstage/ExtensionOverrides",
         "extensions": [],
+        "featureFlags": [],
         "version": "v1",
       }
     `);
@@ -60,6 +61,7 @@ describe('createExtensionOverrides', () => {
             "output": {},
           },
         ],
+        "featureFlags": [],
         "version": "v1",
       }
     `);

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
@@ -15,21 +15,24 @@
  */
 
 import { Extension } from './createExtension';
+import { FeatureFlagConfig } from './types';
 
 /** @public */
 export interface ExtensionOverridesOptions {
   extensions: Extension<unknown>[];
+  featureFlags?: FeatureFlagConfig[];
 }
 
 /** @public */
 export interface ExtensionOverrides {
-  $$type: '@backstage/ExtensionOverrides';
+  readonly $$type: '@backstage/ExtensionOverrides';
 }
 
 /** @internal */
 export interface InternalExtensionOverrides extends ExtensionOverrides {
-  version: string;
-  extensions: Extension<unknown>[];
+  readonly version: 'v1';
+  readonly extensions: Extension<unknown>[];
+  readonly featureFlags: FeatureFlagConfig[];
 }
 
 /** @public */
@@ -40,6 +43,7 @@ export function createExtensionOverrides(
     $$type: '@backstage/ExtensionOverrides',
     version: 'v1',
     extensions: options.extensions,
+    featureFlags: options.featureFlags ?? [],
   } as InternalExtensionOverrides;
 }
 
@@ -50,12 +54,12 @@ export function toInternalExtensionOverrides(
   const internal = overrides as InternalExtensionOverrides;
   if (internal.$$type !== '@backstage/ExtensionOverrides') {
     throw new Error(
-      `Invalid translation resource, bad type '${internal.$$type}'`,
+      `Invalid extension overrides instance, bad type '${internal.$$type}'`,
     );
   }
   if (internal.version !== 'v1') {
     throw new Error(
-      `Invalid translation resource, bad version '${internal.version}'`,
+      `Invalid extension overrides instance, bad version '${internal.version}'`,
     );
   }
   return internal;

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -45,3 +45,4 @@ export {
   type ExtensionOverrides,
   type ExtensionOverridesOptions,
 } from './createExtensionOverrides';
+export type { FeatureFlagConfig } from './types';

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Feature flag configuration.
+ *
+ * @public
+ */
+export type FeatureFlagConfig = {
+  /** Feature flag name */
+  name: string;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #19545. We did consider adding feature flags to extensions also/instead, but figured this is probably what makes sense in the end.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
