### PR TITLE
[MUI] Migration Guide for Unified Theme & Material UI v5

### DIFF
--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -487,29 +487,4 @@ homepage of your app. Read the full guide on the [next page](homepage.md).
 
 ## Migrating to Material UI v5
 
-To support Material UI v5 in addition to v4, we have introduced a `UnifiedThemeProvider`. This allows a step-by-step migration. To use it, you need to update your app's `ThemeProvider` in `app/src/App.tsx` as follows
-
-```diff
-     provider: ({ children }) => (
-- <ThemeProvider theme={lightTheme}>.
-- <CssBaseline>{children}</CssBaseline>.
-- </ThemeProvider
-+ <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
-     ),
-```
-
-In addition, the [Migration Guide provided by MUI](https://mui.com/material-ui/migration/migration-v4/) is a helpful resource that breaks down the differences between v4 & v5. It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion` yet.
-
-To comply with MUI recommendations, we are enforcing a new linting rules that favours standard imports over named imports and also restricting 3rd level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
-
-For current knonw issues with the MUI v5 migration follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
-
-### Plugins
-
-To migrate your plugin to MUI v5, you can build on the resources available.
-
-1. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe <path>`.
-2. Manually fix the imports to match the new [linting rules](https://mui.com/material-ui/guides/minimizing-bundle-size). Take a look at possible `TODO:` items the `codemod` could not fix.
-3. Removal of types & methods from `@backstage/theme` which are marked as `@deprecated`.
-
-You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.
+We now support Material UI v5 in Backstage. Check out our [migration guide](../tutorials/migrate-to-mui5.md) to get started.

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -484,3 +484,28 @@ You can see more ways to use this in the [Storybook Sidebar examples](https://ba
 
 In addition to a custom theme, a custom logo, you can also customize the
 homepage of your app. Read the full guide on the [next page](homepage.md).
+
+## Migrating to Material UI v5
+
+For supporting Material UI v5 in addition to v4 we introduced a `UnifiedThemeProvider` allowing a step-by-step migration. To use it you have to update your App's `ThemeProvider` in `app/src/App.tsx` like the following:
+
+```diff
+     Provider: ({ children }) => (
+-    <ThemeProvider theme={lightTheme}>
+-      <CssBaseline>{children}</CssBaseline>
+-    </ThemeProvider>
++    <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
+     ),
+```
+
+When you are looking for migrating code from v4 to v5 the [Migration Guide provided by MUI](https://mui.com/material-ui/migration/migration-v4/) might be a helpful resource. It is worth mentioning that we are still using `@mui/styles` & thereby `jss`. You might stumble accross the migration to `emotion` for `makeStyles` or `withStyles`. It is not required to move to `emotion` yet.
+
+### Plugins
+
+To migrate your plugin to MUI v5 you can build up on the resources available.
+
+1. Run the migration `codemod` for the path of the specific plug: `npx @mui/codemod v5.0.0/preset-safe <path>`
+2. Manual fix imports to align with linting rules & take a look at potential `TODO:` items the `codemod` could not fix.
+3. Remove types & methods from `@backstage/theme`, which are marked as `@deprecated`
+
+You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -487,25 +487,29 @@ homepage of your app. Read the full guide on the [next page](homepage.md).
 
 ## Migrating to Material UI v5
 
-For supporting Material UI v5 in addition to v4 we introduced a `UnifiedThemeProvider` allowing a step-by-step migration. To use it you have to update your App's `ThemeProvider` in `app/src/App.tsx` like the following:
+To support Material UI v5 in addition to v4, we have introduced a `UnifiedThemeProvider`. This allows a step-by-step migration. To use it, you need to update your app's `ThemeProvider` in `app/src/App.tsx` as follows
 
 ```diff
-     Provider: ({ children }) => (
--    <ThemeProvider theme={lightTheme}>
--      <CssBaseline>{children}</CssBaseline>
--    </ThemeProvider>
-+    <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
+     provider: ({ children }) => (
+- <ThemeProvider theme={lightTheme}>.
+- <CssBaseline>{children}</CssBaseline>.
+- </ThemeProvider
++ <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
      ),
 ```
 
-When you are looking for migrating code from v4 to v5 the [Migration Guide provided by MUI](https://mui.com/material-ui/migration/migration-v4/) might be a helpful resource. It is worth mentioning that we are still using `@mui/styles` & thereby `jss`. You might stumble accross the migration to `emotion` for `makeStyles` or `withStyles`. It is not required to move to `emotion` yet.
+In addition, the [Migration Guide provided by MUI](https://mui.com/material-ui/migration/migration-v4/) is a helpful resource that breaks down the differences between v4 & v5. It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion` yet.
+
+To comply with MUI recommendations, we are enforcing a new linting rules that favours standard imports over named imports and also restricting 3rd level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
+
+For current knonw issues with the MUI v5 migration follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
 
 ### Plugins
 
-To migrate your plugin to MUI v5 you can build up on the resources available.
+To migrate your plugin to MUI v5, you can build on the resources available.
 
-1. Run the migration `codemod` for the path of the specific plug: `npx @mui/codemod v5.0.0/preset-safe <path>`
-2. Manual fix imports to align with linting rules & take a look at potential `TODO:` items the `codemod` could not fix.
-3. Remove types & methods from `@backstage/theme`, which are marked as `@deprecated`
+1. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe <path>`.
+2. Manually fix the imports to match the new [linting rules](https://mui.com/material-ui/guides/minimizing-bundle-size). Take a look at possible `TODO:` items the `codemod` could not fix.
+3. Removal of types & methods from `@backstage/theme` which are marked as `@deprecated`.
 
 You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.

--- a/docs/tutorials/migrate-to-mui5.md
+++ b/docs/tutorials/migrate-to-mui5.md
@@ -1,0 +1,34 @@
+---
+id: migrate-to-mui5
+title: Migrating from Material UI v4 to v5
+description: Additionally resources to the Material UI migration guide specifically for Backstage
+---
+
+Before diving into the specific changes in Backstage, it may be helpful to take a look at the [Migration Guide provided by MUI](https://mui.com/material-ui/migration/migration-v4/). It breaks down the differences between v4, v5 and will make it easier to understand the impact on your Backstage instance & plugins.
+
+To support Material UI v5 in addition to v4, we have introduced a `UnifiedThemeProvider`. This allows a gradual migration by running both versions in parallel. To use it, you need to update your app's `ThemeProvider` in `app/src/App.tsx` as follows:
+
+```diff
+     provider: ({ children }) => (
+- <ThemeProvider theme={lightTheme}>.
+- <CssBaseline>{children}</CssBaseline>.
+- </ThemeProvider
++ <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
+     ),
+```
+
+It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion` yet.
+
+To comply with MUI recommendations, we are enforcing a new linting rules that favours standard imports over named imports and also restricting 3rd level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
+
+For current knonw issues with the MUI v5 migration follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
+
+### Plugins
+
+To migrate your plugin to MUI v5, you can build on the resources available.
+
+1. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe <path>`.
+2. Manually fix the imports to match the new [linting rules](https://mui.com/material-ui/guides/minimizing-bundle-size). Take a look at possible `TODO:` items the `codemod` could not fix.
+3. Removal of types & methods from `@backstage/theme` which are marked as `@deprecated`.
+
+You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.

--- a/docs/tutorials/migrate-to-mui5.md
+++ b/docs/tutorials/migrate-to-mui5.md
@@ -21,7 +21,7 @@ It is worth noting that we are still using `@mui/styles` & `jss`. You may stumbl
 
 To comply with MUI recommendations, we are enforcing a new linting rules that favours standard imports over named imports and also restricting 3rd level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
 
-For current knonw issues with the MUI v5 migration follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
+For current known issues with the MUI v5 migration, follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
 
 ### Plugins
 

--- a/docs/tutorials/migrate-to-mui5.md
+++ b/docs/tutorials/migrate-to-mui5.md
@@ -27,8 +27,9 @@ For current knonw issues with the MUI v5 migration follow our [Milestone on GitH
 
 To migrate your plugin to MUI v5, you can build on the resources available.
 
-1. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe <path>`.
-2. Manually fix the imports to match the new [linting rules](https://mui.com/material-ui/guides/minimizing-bundle-size). Take a look at possible `TODO:` items the `codemod` could not fix.
-3. Removal of types & methods from `@backstage/theme` which are marked as `@deprecated`.
+1. Manually fix the imports from named to default imports to match the new [linting rules for minimizing bundle size](https://mui.com/material-ui/guides/minimizing-bundle-size).
+2. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe plugins/<path>`.
+3. Take a look at possible `TODO:` items the `codemod` could not fix.
+4. Remove types & methods from `@backstage/theme` which are marked as `@deprecated`.
 
 You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.

--- a/docs/tutorials/migrate-to-mui5.md
+++ b/docs/tutorials/migrate-to-mui5.md
@@ -17,9 +17,11 @@ To support Material UI v5 in addition to v4, we have introduced a `UnifiedThemeP
      ),
 ```
 
-It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion` yet.
+It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion`.
 
 To comply with MUI recommendations, we are enforcing a new linting rules that favours standard imports over named imports and also restricting 3rd level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
+
+Important to keep in mind is, that Material UI v5 is meant to be used with React Version 17 or higher. This means if you intend to use the Material UI v5 components in your plugins you have to enforce React Version to be at least 17.
 
 For current known issues with the MUI v5 migration, follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
 
@@ -31,5 +33,6 @@ To migrate your plugin to MUI v5, you can build on the resources available.
 2. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe plugins/<path>`.
 3. Take a look at possible `TODO:` items the `codemod` could not fix.
 4. Remove types & methods from `@backstage/theme` which are marked as `@deprecated`.
+5. Ensure you are using `"react": "^17.0.0"` (or newer) as a peer dependency
 
 You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.

--- a/docs/tutorials/migrate-to-mui5.md
+++ b/docs/tutorials/migrate-to-mui5.md
@@ -1,33 +1,45 @@
 ---
 id: migrate-to-mui5
 title: Migrating from Material UI v4 to v5
-description: Additionally resources to the Material UI migration guide specifically for Backstage
+description: Additional resources for the Material UI v5 migration guide specifically for Backstage
 ---
 
-Before diving into the specific changes in Backstage, it may be helpful to take a look at the [Migration Guide provided by MUI](https://mui.com/material-ui/migration/migration-v4/). It breaks down the differences between v4, v5 and will make it easier to understand the impact on your Backstage instance & plugins.
+Backstage supports developing new plugins or components using Material UI v5. At the same time, large parts of the application as well as existing plugins will still be using Material UI v4. To support Material UI v4 and v5 at the same time, we have introduced a new concept called the `UnifiedTheme`. The goal of the `UnifiedTheme` is to allow gradual migration by running both versions in parallel, applying theme options similarly & supporting potential future versions of Material UI.
 
-To support Material UI v5 in addition to v4, we have introduced a `UnifiedThemeProvider`. This allows a gradual migration by running both versions in parallel. To use it, you need to update your app's `ThemeProvider` in `app/src/App.tsx` as follows:
+By default, the `UnifiedThemeProvider` is already used. If you add a custom theme in your `createApp` function, you would need to replace the Material UI `ThemeProvider` with the `UnifiedThemeProvider`:
 
-```diff
-     provider: ({ children }) => (
-- <ThemeProvider theme={lightTheme}>.
-- <CssBaseline>{children}</CssBaseline>.
-- </ThemeProvider
-+ <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
-     ),
+```diff ts
+const app = createApp({
+  // ...
+  themes: [
+    {
+      // ...
+      provider: ({ children }) => (
+-       <ThemeProvider theme={lightTheme}>.
+-         <CssBaseline>{children}</CssBaseline>.
+-       </ThemeProvider
++       <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
+      ),
+    }
+  ]
+});
 ```
+
+Before making specific changes to your Backstage instance, it might be helpful to take a look at the [Migration Guide provided by Material UI](https://mui.com/material-ui/migration/migration-v4/) first. It breaks down the differences between v4 and v5, and will make it easier to understand the impact on your Backstage instance & plugins.
 
 It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion`.
 
-To comply with MUI recommendations, we are enforcing a new linting rules that favours standard imports over named imports and also restricting 3rd level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
+To comply with Material UI recommendations, we are enforcing a new linting rule that favors standard imports over named imports and also restricts 3rd-level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
 
-Important to keep in mind is, that Material UI v5 is meant to be used with React Version 17 or higher. This means if you intend to use the Material UI v5 components in your plugins you have to enforce React Version to be at least 17.
+Important to keep in mind is that Material UI v5 is meant to be used with React Version 17 or higher. This means if you intend to use the Material UI v5 components in your plugins, you have to enforce React Version to be at least 17 for these plugins as well.
 
-For current known issues with the MUI v5 migration, follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
+There are `core-components` as well as components exported from `*-react` plugins written in Material UI v4, which expect Material UI components as props. In these cases you will still be forced to import Material UI v4 components.
+
+For current known issues with the Material UI v5 migration, follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
 
 ### Plugins
 
-To migrate your plugin to MUI v5, you can build on the resources available.
+To migrate your plugin to Material UI v5, you can build on the resources available.
 
 1. Manually fix the imports from named to default imports to match the new [linting rules for minimizing bundle size](https://mui.com/material-ui/guides/minimizing-bundle-size).
 2. Run the migration `codemod` for the path of the specific plugin: `npx @mui/codemod v5.0.0/preset-safe plugins/<path>`.
@@ -35,4 +47,4 @@ To migrate your plugin to MUI v5, you can build on the resources available.
 4. Remove types & methods from `@backstage/theme` which are marked as `@deprecated`.
 5. Ensure you are using `"react": "^17.0.0"` (or newer) as a peer dependency
 
-You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example plugin migration.
+You can follow the [migration of the GraphiQL plugin](https://github.com/backstage/backstage/pull/17696) as an example of a plugin migration.

--- a/docs/tutorials/migrate-to-mui5.md
+++ b/docs/tutorials/migrate-to-mui5.md
@@ -9,31 +9,46 @@ Backstage supports developing new plugins or components using Material UI v5. At
 By default, the `UnifiedThemeProvider` is already used. If you add a custom theme in your `createApp` function, you would need to replace the Material UI `ThemeProvider` with the `UnifiedThemeProvider`:
 
 ```diff ts
-const app = createApp({
-  // ...
-  themes: [
-    {
-      // ...
-      provider: ({ children }) => (
--       <ThemeProvider theme={lightTheme}>.
--         <CssBaseline>{children}</CssBaseline>.
--       </ThemeProvider
-+       <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
-      ),
-    }
-  ]
-});
++ import import {
++   UnifiedThemeProvider,
++   themes as builtinThemes,
++ } from '@backstage/theme';
+
+  const app = createApp({
+    // ...
+    themes: [
+      {
+        // ...
+        provider: ({ children }) => (
+-         <ThemeProvider theme={lightTheme}>.
+-           <CssBaseline>{children}</CssBaseline>.
+-         </ThemeProvider
++         <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
+        ),
+      }
+    ]
+  });
 ```
 
 Before making specific changes to your Backstage instance, it might be helpful to take a look at the [Migration Guide provided by Material UI](https://mui.com/material-ui/migration/migration-v4/) first. It breaks down the differences between v4 and v5, and will make it easier to understand the impact on your Backstage instance & plugins.
 
 It is worth noting that we are still using `@mui/styles` & `jss`. You may stumble upon documentation for migrating to `emotion` when using `makeStyles` or `withStyles`. It is not necessary to switch to `emotion`.
 
+Important to keep in mind is that Material UI v5 is meant to be used with React Version 17 or higher. This means if you intend to use the Material UI v5 components in your plugins, you have to enforce React Version to be at least 17 for these plugins:
+
+```json
+...
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
+  },
+...
+```
+
 To comply with Material UI recommendations, we are enforcing a new linting rule that favors standard imports over named imports and also restricts 3rd-level imports as they are considered private ([Guide: Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size)).
 
-Important to keep in mind is that Material UI v5 is meant to be used with React Version 17 or higher. This means if you intend to use the Material UI v5 components in your plugins, you have to enforce React Version to be at least 17 for these plugins as well.
-
-There are `core-components` as well as components exported from `*-react` plugins written in Material UI v4, which expect Material UI components as props. In these cases you will still be forced to import Material UI v4 components.
+There are `core-components` as well as components exported from Backstage `*-react` plugins written in Material UI v4, which expect Material UI components as props. In these cases you will still be forced to use Material UI v4.
 
 For current known issues with the Material UI v5 migration, follow our [Milestone on GitHub](https://github.com/backstage/backstage/milestone/40). Please open a new issue if you run into different problems.
 

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -408,7 +408,8 @@
       "tutorials/configuring-plugin-databases",
       "tutorials/switching-sqlite-postgres",
       "tutorials/using-backstage-proxy-within-plugin",
-      "tutorials/yarn-migration"
+      "tutorials/yarn-migration",
+      "tutorials/migrate-to-mui5.md"
     ],
     "Architecture Decision Records (ADRs)": [
       "architecture-decisions/adrs-overview",

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -409,7 +409,7 @@
       "tutorials/switching-sqlite-postgres",
       "tutorials/using-backstage-proxy-within-plugin",
       "tutorials/yarn-migration",
-      "tutorials/migrate-to-mui5.md"
+      "tutorials/migrate-to-mui5"
     ],
     "Architecture Decision Records (ADRs)": [
       "architecture-decisions/adrs-overview",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
       - Switching Backstage from SQLite to PostgreSQL: 'tutorials/switching-sqlite-postgres.md'
       - Using the Backstage Proxy from Within a Plugin: 'tutorials/using-backstage-proxy-within-plugin.md'
       - Migration to Yarn 3: 'tutorials/yarn-migration.md'
+      - Migration to Material UI v5: 'tutorials/migrate-to-mui5.md'
   - Architecture Decision Records (ADRs):
       - Overview: 'architecture-decisions/index.md'
       - ADR001 - Architecture Decision Record (ADR) log: 'architecture-decisions/adr001-add-adr-log.md'


### PR DESCRIPTION
New version of https://github.com/backstage/backstage/pull/18098 due to `force` push.

**What**: Creating a seperate, short documentation for migrating to MUI v5 (https://github.com/backstage/backstage/pull/17696#discussion_r1212114911)

**Why**: Moving this to a seperate PR to ship it faster, align with potential issues raised on the migration & additionally gather feedback if this is the right approacht for documentation or if something else is needed.


Follow up: 
- Update GraphiQL plugin PR
- Update https://backstage.io/docs/getting-started/app-custom-theme to use `createUnifiedTheme`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
