### PR TITLE
[gcp-projects] fix query params for links pointing to "GCP" & "Logs" in Project Details Page

### DIFF
--- a/.changeset/sweet-buckets-hunt.md
+++ b/.changeset/sweet-buckets-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gcp-projects': patch
+---
+
+Fix query parameter for project details page which should point to projectId rather than project name

--- a/plugins/gcp-projects/src/components/ProjectDetailsPage/ProjectDetailsPage.tsx
+++ b/plugins/gcp-projects/src/components/ProjectDetailsPage/ProjectDetailsPage.tsx
@@ -127,7 +127,7 @@ const DetailsPage = () => {
                 {details?.name && (
                   <Button>
                     <a
-                      href={`${cloud_home_url}/home/dashboard?project=${details.name}&supportedpurview=project`}
+                      href={`${cloud_home_url}/home/dashboard?project=${details.projectId}&supportedpurview=project`}
                       target="_blank"
                       rel="noreferrer noopener"
                     >
@@ -138,7 +138,7 @@ const DetailsPage = () => {
                 {details?.name && (
                   <Button>
                     <a
-                      href={`${cloud_home_url}/logs/query?project=${details.name}&supportedpurview=project`}
+                      href={`${cloud_home_url}/logs/query?project=${details.projectId}&supportedpurview=project`}
                       target="_blank"
                       rel="noreferrer noopener"
                     >


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://github.com/backstage/backstage/issues/21150

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
