### PR TITLE
Fix Filter Selection

### DIFF
--- a/.changeset/twenty-beans-laugh.md
+++ b/.changeset/twenty-beans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed a issue where `CatalogPage` wasn't using the chosen `initiallySelectedFilter` as intended.

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -93,8 +93,8 @@ describe('useOwnedEntitiesCount', () => {
     ).rejects.toThrow();
 
     expect(result.current).toEqual({
-      count: 0,
-      loading: false,
+      count: undefined,
+      loading: true,
       filter: EntityUserFilter.owned([
         'user:default/spiderman',
         'user:group/a-group',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes #21339. `useOwnedEntitiesCount` wasn't waiting for `request` to be defined before fetching the result.
This was causing its `loading` flag to be flipped to `false` which triggered `UserListPicker` to set the initial `EntityUserFilter` with the wrong value.

Before ("owned" filter is set as initial filter but "all" filter is selected):

https://github.com/backstage/backstage/assets/8433119/e5b9101b-80f6-4d95-a305-fff8702833fa

Now Before ("owned" filter is set as initial filter and is correctly selected):

https://github.com/backstage/backstage/assets/8433119/5da9c13b-214a-4f3a-a921-67aebff6c82e

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
