### PR TITLE
Fix creating secrets in github:environment:create action

### DIFF
--- a/.changeset/quick-horses-reply.md
+++ b/.changeset/quick-horses-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix creating env secret in github:environment:create action

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.examples.test.ts
@@ -109,7 +109,9 @@ describe('github:environment:create examples', () => {
     expect(
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.actions.getEnvironmentPublicKey).not.toHaveBeenCalled();
+    expect(
+      mockOctokit.rest.actions.getEnvironmentPublicKey,
+    ).not.toHaveBeenCalled();
     expect(
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).not.toHaveBeenCalled();
@@ -141,7 +143,9 @@ describe('github:environment:create examples', () => {
     expect(
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.actions.getEnvironmentPublicKey).not.toHaveBeenCalled();
+    expect(
+      mockOctokit.rest.actions.getEnvironmentPublicKey,
+    ).not.toHaveBeenCalled();
     expect(
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).not.toHaveBeenCalled();

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.examples.test.ts
@@ -25,7 +25,7 @@ import { examples } from './gitHubEnvironment.examples';
 const mockOctokit = {
   rest: {
     actions: {
-      getRepoPublicKey: jest.fn(),
+      getEnvironmentPublicKey: jest.fn(),
       createEnvironmentVariable: jest.fn(),
       createOrUpdateEnvironmentSecret: jest.fn(),
     },
@@ -68,7 +68,7 @@ describe('github:environment:create examples', () => {
   };
 
   beforeEach(() => {
-    mockOctokit.rest.actions.getRepoPublicKey.mockResolvedValue({
+    mockOctokit.rest.actions.getEnvironmentPublicKey.mockResolvedValue({
       data: {
         key: publicKey,
         key_id: 'keyid',
@@ -109,7 +109,7 @@ describe('github:environment:create examples', () => {
     expect(
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.actions.getRepoPublicKey).not.toHaveBeenCalled();
+    expect(mockOctokit.rest.actions.getEnvironmentPublicKey).not.toHaveBeenCalled();
     expect(
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).not.toHaveBeenCalled();
@@ -141,7 +141,7 @@ describe('github:environment:create examples', () => {
     expect(
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.actions.getRepoPublicKey).not.toHaveBeenCalled();
+    expect(mockOctokit.rest.actions.getEnvironmentPublicKey).not.toHaveBeenCalled();
     expect(
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).not.toHaveBeenCalled();

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.test.ts
@@ -24,7 +24,7 @@ import { ScmIntegrations } from '@backstage/integration';
 const mockOctokit = {
   rest: {
     actions: {
-      getRepoPublicKey: jest.fn(),
+      getEnvironmentPublicKey: jest.fn(),
       createEnvironmentVariable: jest.fn(),
       createOrUpdateEnvironmentSecret: jest.fn(),
     },
@@ -71,7 +71,7 @@ describe('github:environment:create', () => {
   };
 
   beforeEach(() => {
-    mockOctokit.rest.actions.getRepoPublicKey.mockResolvedValue({
+    mockOctokit.rest.actions.getEnvironmentPublicKey.mockResolvedValue({
       data: {
         key: publicKey,
         key_id: 'keyid',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.ts
@@ -167,10 +167,11 @@ export function createGithubEnvironmentAction(options: {
       }
 
       if (secrets) {
-        const publicKeyResponse = await client.rest.actions.getEnvironmentPublicKey({
-          repository_id: repository.data.id,
-          environment_name: name,
-        });
+        const publicKeyResponse =
+          await client.rest.actions.getEnvironmentPublicKey({
+            repository_id: repository.data.id,
+            environment_name: name,
+          });
 
         await Sodium.ready;
         const binaryKey = Sodium.from_base64(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubEnvironment.ts
@@ -167,9 +167,9 @@ export function createGithubEnvironmentAction(options: {
       }
 
       if (secrets) {
-        const publicKeyResponse = await client.rest.actions.getRepoPublicKey({
-          owner: owner,
-          repo: repo,
+        const publicKeyResponse = await client.rest.actions.getEnvironmentPublicKey({
+          repository_id: repository.data.id,
+          environment_name: name,
         });
 
         await Sodium.ready;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The github:environment:create has been using the wrong set of keys for creating secrets. This was causing the secrets to be empty. 

I was able to reproduce the issue with following steps:
1. Created this template 

```apiVersion: scaffolder.backstage.io/v1beta3
kind: Template
metadata:
  name: kamil-template
  title: Kamil Template
  description: Kamil Template
spec:
  owner: web@example.com
  type: website
  parameters:
    - title: Provide some simple information
      required:
        - name
        - clientId
        - clientSecret
      properties:
        name:
            title: Repo name
            description: Repo name
            type: string
        clientId:
            title: Client Id
            description: Client Id
            type: string
        clientSecret:
            title: Client Secret
            description: Client Secret
            type: string
            ui:widget: password
  steps:
    - id: log
      name: "Values"
      action: debug:log
      input:
        name: ${{ parameters.name }}
        clientId: ${{ parameters.clientId }}
        clientSecret: ${{ parameters.clientSecret }}
    - id: create-github-dev-environment
      name: Create GitHub Dev environment
      action: github:environment:create
      input:
        repoUrl: github.com?owner=kmarkow&repo=${{ parameters.name }}
        name: dev
        environmentVariables:
          CLIENT_ID: ${{ parameters.clientId }}
        secrets:
          CLIENT_SECRET: ${{ parameters.clientSecret }}

```
2. Launch the above template from backstage
3. [Print the secret with this github action to see if it was saved correctly](https://github.com/moro-drake/actions_sampler/blob/main/.github/workflows/print_secret.yml)
4. The value would always come empty

After long investigation I found out that the action is fetching repo-level public key and not the env-level public key. After changing the lines included in this PR I was finally able to see my secrets saved correcly.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
