### PR TITLE
feat: Change Cloud Build plugin to filter build results instead of displaying all builds.

### DIFF
--- a/.changeset/tough-drinks-scream.md
+++ b/.changeset/tough-drinks-scream.md
@@ -2,8 +2,11 @@
 '@backstage/plugin-cloudbuild': minor
 ---
 
-Changed build list view to automatically filter repositories based on component-info's metadata.name.
-Added `google.com/cloudbuild-repo-name` annotation which allows you to specify a different repository to filter on.
-Added `google.com/cloudbuild-trigger-name` annotation which allows you to filter based on a trigger name instead of a repo name.
+Changed build list view to automatically filter builds based on repository name matching component-info's metadata.name.
+Added optional `google.com/cloudbuild-repo-name` annotation which allows you to specify a different repository to filter on.
+Added optional `google.com/cloudbuild-trigger-name` annotation which allows you to filter based on a trigger name instead of a repo name.
 Updated the ReadMe with information about the filtering and some other minor verbiage updates.
 Changed `substitutions.BRANCH_NAME` to `substitutions.REF_NAME` so that the Ref field is populated properly.
+Added optional `google.com/cloudbuild-location` annotation which allows you to specify the Cloud Build location of your builds. Default is global scope.
+Changed build list view to show builds in a specific location if the location annotation is used.
+Updated ReadMe with information about the use of the location filtering.

--- a/.changeset/tough-drinks-scream.md
+++ b/.changeset/tough-drinks-scream.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-cloudbuild': minor
+---
+
+Changed build list view to automatically filter repositories based on component-info's metadata.name.
+Added `google.com/cloudbuild-repo-name` annotation which allows you to specify a different repository to filter on.
+Added `google.com/cloudbuild-trigger-name` annotation which allows you to filter based on a trigger name instead of a repo name.
+Updated the ReadMe with information about the filtering and some other minor verbiage updates.
+Changed `substitutions.BRANCH_NAME` to `substitutions.REF_NAME` so that the Ref field is populated properly.

--- a/plugins/cloudbuild/README.md
+++ b/plugins/cloudbuild/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Build
+# Google Cloud Build Plugin
 
 ### Welcome to the Google Cloud Build plugin!
 
@@ -47,7 +47,7 @@ const cicdContent = (
 
 ##### OPTIONAL
 
-If you don't use GitHub Actions, or don't want to show it on your CI/CD page, then you can remove the switch case for it
+If you don't use GitHub Actions, or don't want to show it on your CI/CD page, then you can remove the switch case for it:
 
 ```diff
 // packages/app/src/components/catalog/EntityPage.tsx
@@ -62,9 +62,9 @@ const cicdContent = (
 -    </EntitySwitch.Case>
 ```
 
-### Add annotation to your component-info.yaml file.
+### Add annotation(s) to your component-info.yaml file
 
-Any component, that you would like the Cloud Build Plugin to populate for, should include the following annotation:
+Any component, that you would like the Cloud Build Plugin to populate for, should include the following `cloudbuild-project-slug` annotation. This annotation sets the GCP project name to be used for pulling the cloud build details from.
 
 ```diff
 // component-info.yaml
@@ -79,3 +79,43 @@ spec:
   type: website
   lifecycle: development
 ```
+
+By default, the cloud build results list is filtered by repository name equal to the name you have set in your component-info.yaml file. This is `metadata.name`. So if your metadata.name is `backstage` then it will only show builds matching the backstage repo name.
+
+#### Change Filtering
+
+If you need the page to be filtered on a different repository name, then you can use the following annotation:
+
+```diff
+// component-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: Backstage application.
+  annotations:
+    google.com/cloudbuild-project-slug: your-project-name
++   google.com/cloudbuild-repo-name: my-backstage
+spec:
+  type: website
+  lifecycle: development
+```
+
+You can also automatically filter the results based on trigger name instead of repository name. To so so, use the following annotation:
+
+```diff
+// component-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: Backstage application.
+  annotations:
+    google.com/cloudbuild-project-slug: your-project-name
++   google.com/cloudbuild-trigger-name: my-trigger-name
+spec:
+  type: website
+  lifecycle: development
+```
+
+`Note:` The `cloudbuild-repo-name` annotation takes precedence over the `cloudbuild-trigger-name` annotation. So if you happen to use both annotations, cloudbuild-repo-name will be used. It is recommended to use one or the other if required.

--- a/plugins/cloudbuild/README.md
+++ b/plugins/cloudbuild/README.md
@@ -101,7 +101,7 @@ spec:
   lifecycle: development
 ```
 
-You can also automatically filter the results based on trigger name instead of repository name. To so so, use the following annotation:
+You can also automatically filter the results based on trigger name instead of repository name. To do so, use the following annotation:
 
 ```diff
 // component-info.yaml

--- a/plugins/cloudbuild/README.md
+++ b/plugins/cloudbuild/README.md
@@ -64,7 +64,7 @@ const cicdContent = (
 
 ### Add annotation(s) to your component-info.yaml file
 
-Any component, that you would like the Cloud Build Plugin to populate for, should include the following `cloudbuild-project-slug` annotation. This annotation sets the GCP project name to be used for pulling the cloud build details from.
+Any component, that you would like the Cloud Build Plugin to populate for, should include the following `cloudbuild-project-slug` annotation. This annotation sets the GCP project name to be used for pulling the Cloud Build details from.
 
 ```diff
 // component-info.yaml
@@ -81,6 +81,8 @@ spec:
 ```
 
 By default, the cloud build results list is filtered by repository name equal to the name you have set in your component-info.yaml file. This is `metadata.name`. So if your metadata.name is `backstage` then it will only show builds matching the backstage repo name.
+
+Additionally, build results are pulled from the `global` region by default.
 
 #### Change Filtering
 
@@ -119,3 +121,20 @@ spec:
 ```
 
 `Note:` The `cloudbuild-repo-name` annotation takes precedence over the `cloudbuild-trigger-name` annotation. So if you happen to use both annotations, cloudbuild-repo-name will be used. It is recommended to use one or the other if required.
+
+If you need to pull Cloud Build results from a location or region other than the global scope, then use the following annotation:
+
+```diff
+// component-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: Backstage application.
+  annotations:
+    google.com/cloudbuild-project-slug: your-project-name
++   google.com/cloudbuild-location: us-central1
+spec:
+  type: website
+  lifecycle: development
+```

--- a/plugins/cloudbuild/api-report.md
+++ b/plugins/cloudbuild/api-report.md
@@ -237,7 +237,7 @@ export interface StorageSource {
 // @public (undocumented)
 export interface Substitutions {
   // (undocumented)
-  BRANCH_NAME: string;
+  REF_NAME: string;
   // (undocumented)
   COMMIT_SHA: string;
   // (undocumented)

--- a/plugins/cloudbuild/api-report.md
+++ b/plugins/cloudbuild/api-report.md
@@ -58,6 +58,7 @@ export const CLOUDBUILD_ANNOTATION = 'google.com/cloudbuild-project-slug';
 export type CloudbuildApi = {
   listWorkflowRuns: (options: {
     projectId: string;
+    cloudBuildFilter: string;
   }) => Promise<ActionsListWorkflowRunsForRepoResponseData>;
   getWorkflow: (options: {
     projectId: string;
@@ -94,6 +95,7 @@ export class CloudbuildClient implements CloudbuildApi {
   // (undocumented)
   listWorkflowRuns(options: {
     projectId: string;
+    cloudBuildFilter: string;
   }): Promise<ActionsListWorkflowRunsForRepoResponseData>;
   // (undocumented)
   reRunWorkflow(options: { projectId: string; runId: string }): Promise<void>;

--- a/plugins/cloudbuild/api-report.md
+++ b/plugins/cloudbuild/api-report.md
@@ -58,18 +58,22 @@ export const CLOUDBUILD_ANNOTATION = 'google.com/cloudbuild-project-slug';
 export type CloudbuildApi = {
   listWorkflowRuns: (options: {
     projectId: string;
+    location: string;
     cloudBuildFilter: string;
   }) => Promise<ActionsListWorkflowRunsForRepoResponseData>;
   getWorkflow: (options: {
     projectId: string;
+    location: string;
     id: string;
   }) => Promise<ActionsGetWorkflowResponseData>;
   getWorkflowRun: (options: {
     projectId: string;
+    location: string;
     id: string;
   }) => Promise<ActionsGetWorkflowResponseData>;
   reRunWorkflow: (options: {
     projectId: string;
+    location: string;
     runId: string;
   }) => Promise<any>;
 };
@@ -85,20 +89,27 @@ export class CloudbuildClient implements CloudbuildApi {
   // (undocumented)
   getWorkflow(options: {
     projectId: string;
+    location: string;
     id: string;
   }): Promise<ActionsGetWorkflowResponseData>;
   // (undocumented)
   getWorkflowRun(options: {
     projectId: string;
+    location: string;
     id: string;
   }): Promise<ActionsGetWorkflowResponseData>;
   // (undocumented)
   listWorkflowRuns(options: {
     projectId: string;
+    location: string;
     cloudBuildFilter: string;
   }): Promise<ActionsListWorkflowRunsForRepoResponseData>;
   // (undocumented)
-  reRunWorkflow(options: { projectId: string; runId: string }): Promise<void>;
+  reRunWorkflow(options: {
+    projectId: string;
+    location: string;
+    runId: string;
+  }): Promise<void>;
 }
 
 // @public (undocumented)

--- a/plugins/cloudbuild/api-report.md
+++ b/plugins/cloudbuild/api-report.md
@@ -237,9 +237,9 @@ export interface StorageSource {
 // @public (undocumented)
 export interface Substitutions {
   // (undocumented)
-  REF_NAME: string;
-  // (undocumented)
   COMMIT_SHA: string;
+  // (undocumented)
+  REF_NAME: string;
   // (undocumented)
   REPO_NAME: string;
   // (undocumented)

--- a/plugins/cloudbuild/src/api/CloudbuildApi.ts
+++ b/plugins/cloudbuild/src/api/CloudbuildApi.ts
@@ -29,6 +29,7 @@ export const cloudbuildApiRef = createApiRef<CloudbuildApi>({
 export type CloudbuildApi = {
   listWorkflowRuns: (options: {
     projectId: string;
+    cloudBuildFilter: string;
   }) => Promise<ActionsListWorkflowRunsForRepoResponseData>;
   getWorkflow: (options: {
     projectId: string;

--- a/plugins/cloudbuild/src/api/CloudbuildApi.ts
+++ b/plugins/cloudbuild/src/api/CloudbuildApi.ts
@@ -29,18 +29,22 @@ export const cloudbuildApiRef = createApiRef<CloudbuildApi>({
 export type CloudbuildApi = {
   listWorkflowRuns: (options: {
     projectId: string;
+    location: string;
     cloudBuildFilter: string;
   }) => Promise<ActionsListWorkflowRunsForRepoResponseData>;
   getWorkflow: (options: {
     projectId: string;
+    location: string;
     id: string;
   }) => Promise<ActionsGetWorkflowResponseData>;
   getWorkflowRun: (options: {
     projectId: string;
+    location: string;
     id: string;
   }) => Promise<ActionsGetWorkflowResponseData>;
   reRunWorkflow: (options: {
     projectId: string;
+    location: string;
     runId: string;
   }) => Promise<any>;
 };

--- a/plugins/cloudbuild/src/api/CloudbuildClient.ts
+++ b/plugins/cloudbuild/src/api/CloudbuildClient.ts
@@ -45,11 +45,12 @@ export class CloudbuildClient implements CloudbuildApi {
 
   async listWorkflowRuns(options: {
     projectId: string;
+    cloudBuildFilter: string;
   }): Promise<ActionsListWorkflowRunsForRepoResponseData> {
     const workflowRuns = await fetch(
       `https://cloudbuild.googleapis.com/v1/projects/${encodeURIComponent(
         options.projectId,
-      )}/builds`,
+      )}/builds?filter=${encodeURIComponent(options.cloudBuildFilter)}`,
       {
         headers: new Headers({
           Accept: '*/*',

--- a/plugins/cloudbuild/src/api/CloudbuildClient.ts
+++ b/plugins/cloudbuild/src/api/CloudbuildClient.ts
@@ -27,11 +27,14 @@ export class CloudbuildClient implements CloudbuildApi {
 
   async reRunWorkflow(options: {
     projectId: string;
+    location: string;
     runId: string;
   }): Promise<void> {
     await fetch(
       `https://cloudbuild.googleapis.com/v1/projects/${encodeURIComponent(
         options.projectId,
+      )}/locations/${encodeURIComponent(
+        options.location,
       )}/builds/${encodeURIComponent(options.runId)}:retry`,
       {
         method: 'POST',
@@ -45,11 +48,14 @@ export class CloudbuildClient implements CloudbuildApi {
 
   async listWorkflowRuns(options: {
     projectId: string;
+    location: string;
     cloudBuildFilter: string;
   }): Promise<ActionsListWorkflowRunsForRepoResponseData> {
     const workflowRuns = await fetch(
       `https://cloudbuild.googleapis.com/v1/projects/${encodeURIComponent(
         options.projectId,
+      )}/locations/${encodeURIComponent(
+        options.location,
       )}/builds?filter=${encodeURIComponent(options.cloudBuildFilter)}`,
       {
         headers: new Headers({
@@ -67,11 +73,14 @@ export class CloudbuildClient implements CloudbuildApi {
 
   async getWorkflow(options: {
     projectId: string;
+    location: string;
     id: string;
   }): Promise<ActionsGetWorkflowResponseData> {
     const workflow = await fetch(
       `https://cloudbuild.googleapis.com/v1/projects/${encodeURIComponent(
         options.projectId,
+      )}/locations/${encodeURIComponent(
+        options.location,
       )}/builds/${encodeURIComponent(options.id)}`,
       {
         headers: new Headers({
@@ -88,11 +97,14 @@ export class CloudbuildClient implements CloudbuildApi {
 
   async getWorkflowRun(options: {
     projectId: string;
+    location: string;
     id: string;
   }): Promise<ActionsGetWorkflowResponseData> {
     const workflow = await fetch(
       `https://cloudbuild.googleapis.com/v1/projects/${encodeURIComponent(
         options.projectId,
+      )}/locations/${encodeURIComponent(
+        options.location,
       )}/builds/${encodeURIComponent(options.id)}`,
       {
         headers: new Headers({

--- a/plugins/cloudbuild/src/api/types.ts
+++ b/plugins/cloudbuild/src/api/types.ts
@@ -81,7 +81,7 @@ export interface Options {
 export interface Substitutions {
   COMMIT_SHA: string;
   SHORT_SHA: string;
-  BRANCH_NAME: string;
+  REF_NAME: string;
   REPO_NAME: string;
   REVISION_ID: string;
 }

--- a/plugins/cloudbuild/src/components/Cards/Cards.tsx
+++ b/plugins/cloudbuild/src/components/Cards/Cards.tsx
@@ -22,6 +22,7 @@ import { WorkflowRunStatus } from '../WorkflowRunStatus';
 import { Theme, makeStyles, LinearProgress } from '@material-ui/core';
 import ExternalLinkIcon from '@material-ui/icons/Launch';
 import { CLOUDBUILD_ANNOTATION } from '../useProjectName';
+import { getCloudbuildFilter } from '../useCloudBuildFilter';
 
 import {
   InfoCard,
@@ -79,9 +80,11 @@ export const LatestWorkflowRunCard = (props: { branch: string }) => {
   const { entity } = useEntity();
   const errorApi = useApi(errorApiRef);
   const projectId = entity?.metadata.annotations?.[CLOUDBUILD_ANNOTATION] || '';
+  const cloudBuildFilter = getCloudbuildFilter(entity);
 
   const [{ runs, loading, error }] = useWorkflowRuns({
     projectId,
+    cloudBuildFilter,
   });
   const lastRun = runs?.[0] ?? ({} as WorkflowRun);
   useEffect(() => {

--- a/plugins/cloudbuild/src/components/Cards/Cards.tsx
+++ b/plugins/cloudbuild/src/components/Cards/Cards.tsx
@@ -22,6 +22,7 @@ import { WorkflowRunStatus } from '../WorkflowRunStatus';
 import { Theme, makeStyles, LinearProgress } from '@material-ui/core';
 import ExternalLinkIcon from '@material-ui/icons/Launch';
 import { CLOUDBUILD_ANNOTATION } from '../useProjectName';
+import { getLocation } from '../useLocation';
 import { getCloudbuildFilter } from '../useCloudBuildFilter';
 
 import {
@@ -80,10 +81,12 @@ export const LatestWorkflowRunCard = (props: { branch: string }) => {
   const { entity } = useEntity();
   const errorApi = useApi(errorApiRef);
   const projectId = entity?.metadata.annotations?.[CLOUDBUILD_ANNOTATION] || '';
+  const location = getLocation(entity);
   const cloudBuildFilter = getCloudbuildFilter(entity);
 
   const [{ runs, loading, error }] = useWorkflowRuns({
     projectId,
+    location,
     cloudBuildFilter,
   });
   const lastRun = runs?.[0] ?? ({} as WorkflowRun);

--- a/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -35,6 +35,7 @@ import { useProjectName } from '../useProjectName';
 import { WorkflowRunStatus } from '../WorkflowRunStatus';
 import { useWorkflowRunsDetails } from './useWorkflowRunsDetails';
 import { Breadcrumbs, Link, WarningPanel } from '@backstage/core-components';
+import { getLocation } from '../useLocation';
 
 const useStyles = makeStyles<Theme>(theme => ({
   root: {
@@ -64,8 +65,9 @@ const useStyles = makeStyles<Theme>(theme => ({
 export const WorkflowRunDetails = (props: { entity: Entity }) => {
   const { value: projectName, loading, error } = useProjectName(props.entity);
   const [projectId] = (projectName ?? '/').split('/');
+  const location = getLocation(props.entity);
 
-  const details = useWorkflowRunsDetails(projectId);
+  const details = useWorkflowRunsDetails(projectId, location);
 
   const classes = useStyles();
   if (error) {

--- a/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -97,9 +97,9 @@ export const WorkflowRunDetails = (props: { entity: Entity }) => {
           <TableBody>
             <TableRow>
               <TableCell>
-                <Typography noWrap>Branch</Typography>
+                <Typography noWrap>Ref</Typography>
               </TableCell>
-              <TableCell>{details.value?.substitutions.BRANCH_NAME}</TableCell>
+              <TableCell>{details.value?.substitutions.REF_NAME}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell>

--- a/plugins/cloudbuild/src/components/WorkflowRunDetails/useWorkflowRunsDetails.ts
+++ b/plugins/cloudbuild/src/components/WorkflowRunDetails/useWorkflowRunsDetails.ts
@@ -18,13 +18,14 @@ import { cloudbuildApiRef } from '../../api';
 import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
 import { buildRouteRef } from '../../routes';
 
-export const useWorkflowRunsDetails = (projectId: string) => {
+export const useWorkflowRunsDetails = (projectId: string, location: string) => {
   const api = useApi(cloudbuildApiRef);
   const { id } = useRouteRefParams(buildRouteRef);
   const details = useAsync(async () => {
     return projectId
       ? api.getWorkflowRun({
           projectId,
+          location,
           id: id,
         })
       : Promise.reject('No projectId provided');

--- a/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.test.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.test.tsx
@@ -35,7 +35,7 @@ describe('<WorkflowRunsTableView />', () => {
         substitutions: {
           COMMIT_SHA: 'e3adasd2e3adasd2e3adasd2',
           SHORT_SHA: 'f12j1231',
-          BRANCH_NAME: 'main',
+          REF_NAME: 'main',
           REPO_NAME: 'backstage',
           REVISION_ID: 'g123123',
         },

--- a/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -26,6 +26,7 @@ import { buildRouteRef } from '../../routes';
 import { DateTime } from 'luxon';
 import { Table, TableColumn, Link } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
+import { getLocation } from '../useLocation';
 import { getCloudbuildFilter } from '../useCloudBuildFilter';
 
 const generatedColumns: TableColumn[] = [
@@ -163,10 +164,11 @@ export const WorkflowRunsTableView = ({
 export const WorkflowRunsTable = (props: { entity: Entity }) => {
   const { value: projectName, loading } = useProjectName(props.entity);
   const [projectId] = (projectName ?? '/').split('/');
+  const location = getLocation(props.entity);
   const cloudBuildFilter = getCloudbuildFilter(props.entity);
-
   const [tableProps, { retry, setPage, setPageSize }] = useWorkflowRuns({
     projectId,
+    location,
     cloudBuildFilter,
   });
 

--- a/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -72,7 +72,7 @@ const generatedColumns: TableColumn[] = [
     title: 'Ref',
     render: (row: Partial<WorkflowRun>) => (
       <Typography variant="body2" noWrap>
-        {row.substitutions?.BRANCH_NAME}
+        {row.substitutions?.REF_NAME}
       </Typography>
     ),
   },

--- a/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -26,6 +26,7 @@ import { buildRouteRef } from '../../routes';
 import { DateTime } from 'luxon';
 import { Table, TableColumn, Link } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
+import { getCloudbuildFilter } from '../useCloudBuildFilter';
 
 const generatedColumns: TableColumn[] = [
   {
@@ -162,9 +163,11 @@ export const WorkflowRunsTableView = ({
 export const WorkflowRunsTable = (props: { entity: Entity }) => {
   const { value: projectName, loading } = useProjectName(props.entity);
   const [projectId] = (projectName ?? '/').split('/');
+  const cloudBuildFilter = getCloudbuildFilter(props.entity);
 
   const [tableProps, { retry, setPage, setPageSize }] = useWorkflowRuns({
     projectId,
+    cloudBuildFilter,
   });
 
   return (

--- a/plugins/cloudbuild/src/components/useCloudBuildFilter.ts
+++ b/plugins/cloudbuild/src/components/useCloudBuildFilter.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+
+const CLOUDBUILD_FILTER_REPO_STRING = 'substitutions.REPO_NAME=';
+const CLOUDBUILD_FILTER_REPO_ANNOTATION = 'google.com/cloudbuild-repo-name';
+const CLOUDBUILD_FILTER_TRIGGER_STRING = 'substitutions.TRIGGER_NAME=';
+const CLOUDBUILD_FILTER_TRIGGER_ANNOTATION =
+  'google.com/cloudbuild-trigger-name';
+
+/** @public */
+
+export const getCloudbuildFilter = (entity: Entity) => {
+  const repoAnnotation =
+    entity?.metadata.annotations?.[CLOUDBUILD_FILTER_REPO_ANNOTATION] ?? '';
+  const triggerAnnotation =
+    entity?.metadata.annotations?.[CLOUDBUILD_FILTER_TRIGGER_ANNOTATION] ?? '';
+  if (repoAnnotation) {
+    const cloudbuildFilter = CLOUDBUILD_FILTER_REPO_STRING + repoAnnotation;
+    return cloudbuildFilter;
+  } else if (triggerAnnotation) {
+    const cloudbuildFilter =
+      CLOUDBUILD_FILTER_TRIGGER_STRING + triggerAnnotation;
+    return cloudbuildFilter;
+  }
+  const entityName = entity?.metadata.name ?? '';
+  const cloudbuildFilter = CLOUDBUILD_FILTER_REPO_STRING + entityName;
+  return cloudbuildFilter;
+};

--- a/plugins/cloudbuild/src/components/useLocation.ts
+++ b/plugins/cloudbuild/src/components/useLocation.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+
+const CLOUDBUILD_LOCATION_ANNOTATION = 'google.com/cloudbuild-location';
+
+/** @public */
+
+export const getLocation = (entity: Entity) => {
+  const locationAnnotation =
+    entity?.metadata.annotations?.[CLOUDBUILD_LOCATION_ANNOTATION] ?? '';
+  if (locationAnnotation) {
+    return locationAnnotation;
+  }
+  return 'global';
+};

--- a/plugins/cloudbuild/src/components/useWorkflowRuns.ts
+++ b/plugins/cloudbuild/src/components/useWorkflowRuns.ts
@@ -35,9 +35,10 @@ export type WorkflowRun = {
 
 export function useWorkflowRuns(options: {
   projectId: string;
+  location: string;
   cloudBuildFilter: string;
 }) {
-  const { projectId, cloudBuildFilter } = options;
+  const { projectId, location, cloudBuildFilter } = options;
   const api = useApi(cloudbuildApiRef);
   const errorApi = useApi(errorApiRef);
 
@@ -54,6 +55,7 @@ export function useWorkflowRuns(options: {
     return api
       .listWorkflowRuns({
         projectId,
+        location,
         cloudBuildFilter,
       })
       .then(
@@ -69,6 +71,7 @@ export function useWorkflowRuns(options: {
               try {
                 await api.reRunWorkflow({
                   projectId,
+                  location,
                   runId: run.id,
                 });
               } catch (e) {

--- a/plugins/cloudbuild/src/components/useWorkflowRuns.ts
+++ b/plugins/cloudbuild/src/components/useWorkflowRuns.ts
@@ -33,8 +33,11 @@ export type WorkflowRun = {
   rerun: () => void;
 };
 
-export function useWorkflowRuns(options: { projectId: string }) {
-  const { projectId } = options;
+export function useWorkflowRuns(options: {
+  projectId: string;
+  cloudBuildFilter: string;
+}) {
+  const { projectId, cloudBuildFilter } = options;
   const api = useApi(cloudbuildApiRef);
   const errorApi = useApi(errorApiRef);
 
@@ -51,6 +54,7 @@ export function useWorkflowRuns(options: { projectId: string }) {
     return api
       .listWorkflowRuns({
         projectId,
+        cloudBuildFilter,
       })
       .then(
         (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR closes https://github.com/backstage/backstage/issues/19685 and https://github.com/backstage/backstage/issues/21463

Changed build list view to automatically filter builds based on repository name matching component-info's metadata.name.
Added optional `google.com/cloudbuild-repo-name` annotation which allows you to specify a different repository to filter on.
Added optional `google.com/cloudbuild-trigger-name` annotation which allows you to filter based on a trigger name instead of a repo name.
Updated the ReadMe with information about the filtering and some other minor verbiage updates.
Changed `substitutions.BRANCH_NAME` to `substitutions.REF_NAME` so that the Ref field is populated properly.
Added optional `google.com/cloudbuild-location` annotation which allows you to specify the Cloud Build location of your builds. Default is global scope.
Changed build list view to show builds in a specific location if the location annotation is used.
Updated ReadMe with information about the use of the location filtering.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
