### PR TITLE
cli: tweak check for when to use module register API

### DIFF
--- a/.changeset/poor-pandas-dream.md
+++ b/.changeset/poor-pandas-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Tweaked Node.js version check for when to use the new module register API with the new backend `package start` command.

--- a/packages/cli/src/lib/experimental/startBackendExperimental.ts
+++ b/packages/cli/src/lib/experimental/startBackendExperimental.ts
@@ -28,7 +28,8 @@ import { paths } from '../paths';
 import spawn from 'cross-spawn';
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(Number);
-const supportsModuleLoaderRegister = nodeMajor >= 20 && nodeMinor >= 6;
+const supportsModuleLoaderRegister =
+  nodeMajor > 20 || (nodeMajor === 20 && nodeMinor >= 6);
 
 const loaderArgs = [
   '--require',


### PR DESCRIPTION
🧹, it's >= v20.6.0, v21+ supports the new API too. This isn't really needed since we don't support Node.js v21 anyway, but figured we might as well use the correct API when trying to run v21