### PR TITLE
eslint-plugin: prefer existing version ranges when installing deps

### DIFF
--- a/.changeset/chilled-buses-love.md
+++ b/.changeset/chilled-buses-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+The `no-undeclared-imports` rule will now prefer using version queries that already exist en the repo for the same dependency type when installing new packages.


### PR DESCRIPTION
When installing deps using the auto fix it will now prefer version ranges that are already in use in the repo for the same dep type.