### PR TITLE
Patch release of #21388, #21356, #21351

### DIFF
--- a/.changeset/brave-socks-raise.md
+++ b/.changeset/brave-socks-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Move `@testing-library/react` to be a `peerDependency`

--- a/.changeset/brave-socks-raise.md
+++ b/.changeset/brave-socks-raise.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-techdocs-addons-test-utils': patch
----
-
-Move `@testing-library/react` to be a `peerDependency`

--- a/.changeset/dry-readers-raise.md
+++ b/.changeset/dry-readers-raise.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added `headerOptions` to `TemplateListPage` to optionally override default values.
+Changed `themeId` of TemplateListPage from `website` to `home`.

--- a/.changeset/dry-readers-raise.md
+++ b/.changeset/dry-readers-raise.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-scaffolder': patch
----
-
-Added `headerOptions` to `TemplateListPage` to optionally override default values.
-Changed `themeId` of TemplateListPage from `website` to `home`.

--- a/.changeset/twenty-beans-laugh.md
+++ b/.changeset/twenty-beans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed a issue where `CatalogPage` wasn't using the chosen `initiallySelectedFilter` as intended.

--- a/.changeset/twenty-beans-laugh.md
+++ b/.changeset/twenty-beans-laugh.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-react': patch
----
-
-Fixed a issue where `CatalogPage` wasn't using the chosen `initiallySelectedFilter` as intended.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch"
   },
-  "version": "1.20.2",
+  "version": "1.20.3",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,66 @@
 # example-app-next
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder@1.16.1
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.2
+  - @backstage/plugin-adr@0.6.10
+  - @backstage/plugin-airbrake@0.3.27
+  - @backstage/plugin-api-docs@0.10.1
+  - @backstage/plugin-azure-devops@0.3.9
+  - @backstage/plugin-azure-sites@0.1.16
+  - @backstage/plugin-badges@0.2.51
+  - @backstage/plugin-catalog@1.15.1
+  - @backstage/plugin-catalog-graph@0.3.1
+  - @backstage/plugin-catalog-import@0.10.3
+  - @backstage/plugin-circleci@0.3.27
+  - @backstage/plugin-cloudbuild@0.3.27
+  - @backstage/plugin-code-coverage@0.2.20
+  - @backstage/plugin-cost-insights@0.12.16
+  - @backstage/plugin-dynatrace@8.0.1
+  - @backstage/plugin-entity-feedback@0.2.10
+  - @backstage/plugin-explore@0.4.13
+  - @backstage/plugin-github-actions@0.6.8
+  - @backstage/plugin-gocd@0.1.33
+  - @backstage/plugin-home@0.5.11
+  - @backstage/plugin-jenkins@0.9.2
+  - @backstage/plugin-kafka@0.3.27
+  - @backstage/plugin-kubernetes@0.11.2
+  - @backstage/plugin-lighthouse@0.4.12
+  - @backstage/plugin-linguist@0.1.12
+  - @backstage/plugin-newrelic-dashboard@0.3.2
+  - @backstage/plugin-octopus-deploy@0.2.9
+  - @backstage/plugin-org@0.6.17
+  - @backstage/plugin-pagerduty@0.6.8
+  - @backstage/plugin-playlist@0.2.1
+  - @backstage/plugin-puppetdb@0.1.10
+  - @backstage/plugin-rollbar@0.4.27
+  - @backstage/plugin-scaffolder-react@1.6.1
+  - @backstage/plugin-search@1.4.3
+  - @backstage/plugin-sentry@0.5.12
+  - @backstage/plugin-tech-insights@0.3.19
+  - @backstage/plugin-techdocs@1.9.1
+  - @backstage/plugin-todo@0.2.31
+  - @backstage/plugin-user-settings@0.7.13
+  - @backstage/cli@0.24.0
+  - @backstage/integration-react@1.1.21
+  - @backstage/plugin-apache-airflow@0.2.17
+  - @backstage/plugin-catalog-unprocessed-entities@0.1.5
+  - @backstage/plugin-devtools@0.1.6
+  - @backstage/plugin-gcalendar@0.3.20
+  - @backstage/plugin-gcp-projects@0.3.43
+  - @backstage/plugin-graphiql@0.3.0
+  - @backstage/plugin-microsoft-calendar@0.1.9
+  - @backstage/plugin-newrelic@0.3.42
+  - @backstage/plugin-shortcuts@0.3.16
+  - @backstage/plugin-stackstorm@0.1.8
+  - @backstage/plugin-tech-radar@0.6.10
+  - @backstage/core-compat-api@0.0.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,68 @@
 # example-app
 
+## 0.2.90
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder@1.16.1
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.2
+  - @backstage/plugin-adr@0.6.10
+  - @backstage/plugin-airbrake@0.3.27
+  - @backstage/plugin-api-docs@0.10.1
+  - @backstage/plugin-azure-devops@0.3.9
+  - @backstage/plugin-azure-sites@0.1.16
+  - @backstage/plugin-badges@0.2.51
+  - @backstage/plugin-catalog@1.15.1
+  - @backstage/plugin-catalog-graph@0.3.1
+  - @backstage/plugin-catalog-import@0.10.3
+  - @backstage/plugin-circleci@0.3.27
+  - @backstage/plugin-cloudbuild@0.3.27
+  - @backstage/plugin-code-coverage@0.2.20
+  - @backstage/plugin-cost-insights@0.12.16
+  - @backstage/plugin-dynatrace@8.0.1
+  - @backstage/plugin-entity-feedback@0.2.10
+  - @backstage/plugin-explore@0.4.13
+  - @backstage/plugin-github-actions@0.6.8
+  - @backstage/plugin-gocd@0.1.33
+  - @backstage/plugin-home@0.5.11
+  - @backstage/plugin-jenkins@0.9.2
+  - @backstage/plugin-kafka@0.3.27
+  - @backstage/plugin-kubernetes@0.11.2
+  - @backstage/plugin-kubernetes-cluster@0.0.3
+  - @backstage/plugin-lighthouse@0.4.12
+  - @backstage/plugin-linguist@0.1.12
+  - @backstage/plugin-newrelic-dashboard@0.3.2
+  - @backstage/plugin-nomad@0.1.8
+  - @backstage/plugin-octopus-deploy@0.2.9
+  - @backstage/plugin-org@0.6.17
+  - @backstage/plugin-pagerduty@0.6.8
+  - @backstage/plugin-playlist@0.2.1
+  - @backstage/plugin-puppetdb@0.1.10
+  - @backstage/plugin-rollbar@0.4.27
+  - @backstage/plugin-scaffolder-react@1.6.1
+  - @backstage/plugin-search@1.4.3
+  - @backstage/plugin-sentry@0.5.12
+  - @backstage/plugin-tech-insights@0.3.19
+  - @backstage/plugin-techdocs@1.9.1
+  - @backstage/plugin-todo@0.2.31
+  - @backstage/plugin-user-settings@0.7.13
+  - @backstage/cli@0.24.0
+  - @backstage/integration-react@1.1.21
+  - @backstage/plugin-apache-airflow@0.2.17
+  - @backstage/plugin-catalog-unprocessed-entities@0.1.5
+  - @backstage/plugin-devtools@0.1.6
+  - @backstage/plugin-gcalendar@0.3.20
+  - @backstage/plugin-gcp-projects@0.3.43
+  - @backstage/plugin-graphiql@0.3.0
+  - @backstage/plugin-microsoft-calendar@0.1.9
+  - @backstage/plugin-newrelic@0.3.42
+  - @backstage/plugin-shortcuts@0.3.16
+  - @backstage/plugin-stack-overflow@0.1.22
+  - @backstage/plugin-stackstorm@0.1.8
+  - @backstage/plugin-tech-radar@0.6.10
+
 ## 0.2.89
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.89",
+  "version": "0.2.90",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/dev-utils/CHANGELOG.md
+++ b/packages/dev-utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/dev-utils
 
+## 1.0.24
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 1.0.23
 
 ### Patch Changes

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/dev-utils",
   "description": "Utilities for developing Backstage plugins.",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,15 @@
 # techdocs-cli-embedded-app
 
+## 0.2.89
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.15.1
+  - @backstage/plugin-techdocs@1.9.1
+  - @backstage/cli@0.24.0
+  - @backstage/integration-react@1.1.21
+
 ## 0.2.88
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/plugins/adr/CHANGELOG.md
+++ b/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-adr
 
+## 0.6.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 0.6.9
 
 ### Patch Changes

--- a/plugins/adr/package.json
+++ b/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-adr",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/airbrake/CHANGELOG.md
+++ b/plugins/airbrake/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-airbrake
 
+## 0.3.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/dev-utils@1.0.24
+
 ## 0.3.26
 
 ### Patch Changes

--- a/plugins/airbrake/package.json
+++ b/plugins/airbrake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-airbrake",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/allure/CHANGELOG.md
+++ b/plugins/allure/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-allure
 
+## 0.1.43
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.42
 
 ### Patch Changes

--- a/plugins/allure/package.json
+++ b/plugins/allure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-allure",
   "description": "A Backstage plugin that integrates with Allure",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/api-docs/CHANGELOG.md
+++ b/plugins/api-docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-api-docs
 
+## 0.10.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-catalog@1.15.1
+
 ## 0.10.0
 
 ### Minor Changes

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-api-docs",
   "description": "A Backstage plugin that helps represent API entities in the frontend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-devops/CHANGELOG.md
+++ b/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-azure-devops
 
+## 0.3.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.8
 
 ### Patch Changes

--- a/plugins/azure-devops/package.json
+++ b/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-devops",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-sites/CHANGELOG.md
+++ b/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-azure-sites
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.15
 
 ### Patch Changes

--- a/plugins/azure-sites/package.json
+++ b/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-sites",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/badges/CHANGELOG.md
+++ b/plugins/badges/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-badges
 
+## 0.2.51
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.50
 
 ### Patch Changes

--- a/plugins/badges/package.json
+++ b/plugins/badges/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-badges",
   "description": "A Backstage plugin that generates README badges for your entities",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bazaar/CHANGELOG.md
+++ b/plugins/bazaar/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-bazaar
 
+## 0.2.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-catalog@1.15.1
+
 ## 0.2.18
 
 ### Patch Changes

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-bazaar",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/bitrise/CHANGELOG.md
+++ b/plugins/bitrise/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-bitrise
 
+## 0.1.54
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.53
 
 ### Patch Changes

--- a/plugins/bitrise/package.json
+++ b/plugins/bitrise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-bitrise",
   "description": "A Backstage plugin that integrates towards Bitrise",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-graph/CHANGELOG.md
+++ b/plugins/catalog-graph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-graph
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-graph",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-import/CHANGELOG.md
+++ b/plugins/catalog-import/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-import
 
+## 0.10.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 0.10.2
 
 ### Patch Changes

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-import",
   "description": "A Backstage plugin the helps you import entities into your catalog",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-react/CHANGELOG.md
+++ b/plugins/catalog-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-react
 
+## 1.9.1
+
+### Patch Changes
+
+- ceebf2ca4ba7: Fixed a issue where `CatalogPage` wasn't using the chosen `initiallySelectedFilter` as intended.
+- Updated dependencies
+  - @backstage/integration-react@1.1.21
+
 ## 1.9.0
 
 ### Minor Changes

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-react",
   "description": "A frontend library that helps other Backstage plugins interact with the catalog",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -93,8 +93,8 @@ describe('useOwnedEntitiesCount', () => {
     ).rejects.toThrow();
 
     expect(result.current).toEqual({
-      count: 0,
-      loading: false,
+      count: undefined,
+      loading: true,
       filter: EntityUserFilter.owned([
         'user:default/spiderman',
         'user:group/a-group',

--- a/plugins/catalog/CHANGELOG.md
+++ b/plugins/catalog/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog
 
+## 1.15.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 1.15.0
 
 ### Minor Changes

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog",
   "description": "The Backstage plugin for browsing the Backstage catalog",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-cicd-statistics-module-gitlab
 
+## 0.1.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-cicd-statistics@0.1.29
+
 ## 0.1.22
 
 ### Patch Changes

--- a/plugins/cicd-statistics-module-gitlab/package.json
+++ b/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cicd-statistics-module-gitlab",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cicd-statistics/CHANGELOG.md
+++ b/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-cicd-statistics
 
+## 0.1.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.28
 
 ### Patch Changes

--- a/plugins/cicd-statistics/package.json
+++ b/plugins/cicd-statistics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cicd-statistics",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/circleci/CHANGELOG.md
+++ b/plugins/circleci/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-circleci
 
+## 0.3.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.26
 
 ### Patch Changes

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-circleci",
   "description": "A Backstage plugin that integrates towards Circle CI",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cloudbuild/CHANGELOG.md
+++ b/plugins/cloudbuild/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-cloudbuild
 
+## 0.3.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.26
 
 ### Patch Changes

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cloudbuild",
   "description": "A Backstage plugin that integrates towards Google Cloud Build",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/code-climate/CHANGELOG.md
+++ b/plugins/code-climate/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-code-climate
 
+## 0.1.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.26
 
 ### Patch Changes

--- a/plugins/code-climate/package.json
+++ b/plugins/code-climate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-code-climate",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/code-coverage/CHANGELOG.md
+++ b/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-code-coverage
 
+## 0.2.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.19
 
 ### Patch Changes

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cost-insights/CHANGELOG.md
+++ b/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-cost-insights
 
+## 0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.12.15
 
 ### Patch Changes

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-cost-insights",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/dynatrace/CHANGELOG.md
+++ b/plugins/dynatrace/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-dynatrace
 
+## 8.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 8.0.0
 
 ### Patch Changes

--- a/plugins/dynatrace/package.json
+++ b/plugins/dynatrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-dynatrace",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/entity-feedback/CHANGELOG.md
+++ b/plugins/entity-feedback/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-entity-feedback
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/plugins/entity-feedback/package.json
+++ b/plugins/entity-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-entity-feedback",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/entity-validation/CHANGELOG.md
+++ b/plugins/entity-validation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-entity-validation
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/entity-validation/package.json
+++ b/plugins/entity-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-entity-validation",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/explore/CHANGELOG.md
+++ b/plugins/explore/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-explore
 
+## 0.4.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-explore-react@0.0.33
+
 ## 0.4.12
 
 ### Patch Changes

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-explore",
   "description": "A Backstage plugin for building an exploration page of your software ecosystem",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/firehydrant/CHANGELOG.md
+++ b/plugins/firehydrant/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-firehydrant
 
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.10
 
 ### Patch Changes

--- a/plugins/firehydrant/package.json
+++ b/plugins/firehydrant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-firehydrant",
   "description": "A Backstage plugin that integrates towards FireHydrant",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/fossa/CHANGELOG.md
+++ b/plugins/fossa/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-fossa
 
+## 0.2.59
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.58
 
 ### Patch Changes

--- a/plugins/fossa/package.json
+++ b/plugins/fossa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-fossa",
   "description": "A Backstage plugin that integrates towards FOSSA",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-actions/CHANGELOG.md
+++ b/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-github-actions
 
+## 0.6.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 0.6.7
 
 ### Patch Changes

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-github-actions",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-deployments/CHANGELOG.md
+++ b/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-github-deployments
 
+## 0.1.58
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 0.1.57
 
 ### Patch Changes

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-github-deployments",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-issues/CHANGELOG.md
+++ b/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-github-issues
 
+## 0.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.15
 
 ### Patch Changes

--- a/plugins/github-issues/package.json
+++ b/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-github-issues",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-github-pull-requests-board
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/github-pull-requests-board/package.json
+++ b/plugins/github-pull-requests-board/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-github-pull-requests-board",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/gocd/CHANGELOG.md
+++ b/plugins/gocd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-gocd
 
+## 0.1.33
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.32
 
 ### Patch Changes

--- a/plugins/gocd/package.json
+++ b/plugins/gocd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-gocd",
   "description": "A Backstage plugin that integrates towards GoCD",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/home/CHANGELOG.md
+++ b/plugins/home/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-home
 
+## 0.5.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-home-react@0.1.5
+
 ## 0.5.10
 
 ### Patch Changes

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-home",
   "description": "A Backstage plugin that helps you build a home page",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/ilert/CHANGELOG.md
+++ b/plugins/ilert/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-ilert
 
+## 0.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.15
 
 ### Patch Changes

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-ilert",
   "description": "A Backstage plugin that integrates towards iLert",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/jenkins/CHANGELOG.md
+++ b/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-jenkins
 
+## 0.9.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.9.1
 
 ### Patch Changes

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-jenkins",
   "description": "A Backstage plugin that integrates towards Jenkins",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kafka/CHANGELOG.md
+++ b/plugins/kafka/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-kafka
 
+## 0.3.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.26
 
 ### Patch Changes

--- a/plugins/kafka/package.json
+++ b/plugins/kafka/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kafka",
   "description": "A Backstage plugin that integrates towards Kafka",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-cluster/CHANGELOG.md
+++ b/plugins/kubernetes-cluster/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-kubernetes-cluster
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.0.2
 
 ### Patch Changes

--- a/plugins/kubernetes-cluster/package.json
+++ b/plugins/kubernetes-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kubernetes-cluster",
   "description": "A Backstage plugin that shows details of Kubernetes clusters",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes/CHANGELOG.md
+++ b/plugins/kubernetes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-kubernetes
 
+## 0.11.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.11.1
 
 ### Patch Changes

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kubernetes",
   "description": "A Backstage plugin that integrates towards Kubernetes",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/lighthouse/CHANGELOG.md
+++ b/plugins/lighthouse/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-lighthouse
 
+## 0.4.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.4.11
 
 ### Patch Changes

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-lighthouse",
   "description": "A Backstage plugin that integrates towards Lighthouse",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/linguist/CHANGELOG.md
+++ b/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-linguist
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/linguist/package.json
+++ b/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-linguist",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/newrelic-dashboard/CHANGELOG.md
+++ b/plugins/newrelic-dashboard/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-newrelic-dashboard
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.1
 
 ### Patch Changes

--- a/plugins/newrelic-dashboard/package.json
+++ b/plugins/newrelic-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-newrelic-dashboard",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/nomad/CHANGELOG.md
+++ b/plugins/nomad/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-nomad
 
+## 0.1.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.7
 
 ### Patch Changes

--- a/plugins/nomad/package.json
+++ b/plugins/nomad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-nomad",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/octopus-deploy/CHANGELOG.md
+++ b/plugins/octopus-deploy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-octopus-deploy
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-octopus-deploy",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org-react/CHANGELOG.md
+++ b/plugins/org-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-org-react
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.15
 
 ### Patch Changes

--- a/plugins/org-react/package.json
+++ b/plugins/org-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-org-react",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-org
 
+## 0.6.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.6.16
 
 ### Patch Changes

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-org",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/pagerduty/CHANGELOG.md
+++ b/plugins/pagerduty/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-pagerduty
 
+## 0.6.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-home-react@0.1.5
+
 ## 0.6.7
 
 ### Patch Changes

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-pagerduty",
   "description": "A Backstage plugin that integrates towards PagerDuty",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/periskop/CHANGELOG.md
+++ b/plugins/periskop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-periskop
 
+## 0.1.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.24
 
 ### Patch Changes

--- a/plugins/periskop/package.json
+++ b/plugins/periskop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-periskop",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/playlist/CHANGELOG.md
+++ b/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-playlist
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/playlist/package.json
+++ b/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-playlist",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/puppetdb/CHANGELOG.md
+++ b/plugins/puppetdb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-puppetdb
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.9
 
 ### Patch Changes

--- a/plugins/puppetdb/package.json
+++ b/plugins/puppetdb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-puppetdb",
   "description": "Backstage plugin to visualize resource information and Puppet facts from PuppetDB.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/rollbar/CHANGELOG.md
+++ b/plugins/rollbar/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-rollbar
 
+## 0.4.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.4.26
 
 ### Patch Changes

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-rollbar",
   "description": "A Backstage plugin that integrates towards Rollbar",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-react/CHANGELOG.md
+++ b/plugins/scaffolder-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-scaffolder-react
 
+## 1.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 1.6.0
 
 ### Minor Changes

--- a/plugins/scaffolder-react/package.json
+++ b/plugins/scaffolder-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-react",
   "description": "A frontend library that helps other Backstage plugins interact with the Scaffolder",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder/CHANGELOG.md
+++ b/plugins/scaffolder/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-scaffolder
 
+## 1.16.1
+
+### Patch Changes
+
+- 2c4d57a3ac15: Added `headerOptions` to `TemplateListPage` to optionally override default values.
+  Changed `themeId` of TemplateListPage from `website` to `home`.
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/plugin-scaffolder-react@1.6.1
+  - @backstage/integration-react@1.1.21
+
 ## 1.16.0
 
 ### Minor Changes

--- a/plugins/scaffolder/alpha-api-report.md
+++ b/plugins/scaffolder/alpha-api-report.md
@@ -70,6 +70,11 @@ export type TemplateListPageProps = {
     actions?: boolean;
     tasks?: boolean;
   };
+  headerOptions?: {
+    pageTitleOverride?: string;
+    title?: string;
+    subtitle?: string;
+  };
 };
 
 // @alpha (undocumented)

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder",
   "description": "The Backstage plugin that helps you create new things",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -133,6 +133,7 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
             contextMenu={props.contextMenu}
             groups={props.groups}
             templateFilter={props.templateFilter}
+            headerOptions={props.headerOptions}
           />
         }
       />

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -67,6 +67,11 @@ export type TemplateListPageProps = {
     actions?: boolean;
     tasks?: boolean;
   };
+  headerOptions?: {
+    pageTitleOverride?: string;
+    title?: string;
+    subtitle?: string;
+  };
 };
 
 const defaultGroup: TemplateGroupFilter = {
@@ -93,6 +98,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
     TemplateCardComponent,
     groups: givenGroups = [],
     templateFilter,
+    headerOptions,
   } = props;
   const navigate = useNavigate();
   const editorLink = useRouteRef(editRouteRef);
@@ -151,11 +157,12 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
 
   return (
     <EntityListProvider>
-      <Page themeId="website">
+      <Page themeId="home">
         <Header
           pageTitleOverride="Create a new component"
           title="Create a new component"
           subtitle="Create new software components using standard templates in your organization"
+          {...headerOptions}
         >
           <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
         </Header>

--- a/plugins/search/CHANGELOG.md
+++ b/plugins/search/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-search
 
+## 1.4.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 1.4.2
 
 ### Patch Changes

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search",
   "description": "The Backstage plugin that provides your backstage app with search",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/sentry/CHANGELOG.md
+++ b/plugins/sentry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-sentry
 
+## 0.5.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.5.11
 
 ### Patch Changes

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-sentry",
   "description": "A Backstage plugin that integrates towards Sentry",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/sonarqube/CHANGELOG.md
+++ b/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-sonarqube
 
+## 0.7.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.7.8
 
 ### Patch Changes

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-sonarqube",
   "description": "",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/splunk-on-call/CHANGELOG.md
+++ b/plugins/splunk-on-call/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-splunk-on-call
 
+## 0.4.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.4.15
 
 ### Patch Changes

--- a/plugins/splunk-on-call/package.json
+++ b/plugins/splunk-on-call/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-splunk-on-call",
   "description": "A Backstage plugin that integrates towards Splunk On-Call",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights/CHANGELOG.md
+++ b/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-tech-insights
 
+## 0.3.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.3.18
 
 ### Patch Changes

--- a/plugins/tech-insights/package.json
+++ b/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/techdocs-addons-test-utils/CHANGELOG.md
+++ b/plugins/techdocs-addons-test-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-techdocs-addons-test-utils
 
+## 1.0.24
+
+### Patch Changes
+
+- 06afb51aa1ef: Move `@testing-library/react` to be a `peerDependency`
+- Updated dependencies
+  - @backstage/plugin-catalog@1.15.1
+  - @backstage/plugin-techdocs@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 1.0.23
 
 ### Patch Changes

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -46,12 +46,12 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@testing-library/react": "^14.0.0",
     "@types/react": "^16.13.1 || ^17.0.0",
     "react-use": "^17.2.4",
     "testing-library__dom": "^7.29.4-beta.1"
   },
   "peerDependencies": {
+    "@testing-library/react": "^12.1.3 || ^13.0.0 || ^14.0.0",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-addons-test-utils",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/techdocs/CHANGELOG.md
+++ b/plugins/techdocs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-techdocs
 
+## 1.9.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+  - @backstage/integration-react@1.1.21
+
 ## 1.9.0
 
 ### Minor Changes

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-techdocs",
   "description": "The Backstage plugin that renders technical documentation for your components",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/todo/CHANGELOG.md
+++ b/plugins/todo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-todo
 
+## 0.2.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.2.30
 
 ### Patch Changes

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-todo",
   "description": "A Backstage plugin that lets you browse TODO comments in your source code",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/user-settings/CHANGELOG.md
+++ b/plugins/user-settings/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-user-settings
 
+## 0.7.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.7.12
 
 ### Patch Changes

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-user-settings",
   "description": "A Backstage plugin that provides a settings page",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/vault/CHANGELOG.md
+++ b/plugins/vault/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-vault
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.9.1
+
 ## 0.1.21
 
 ### Patch Changes

--- a/plugins/vault/package.json
+++ b/plugins/vault/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-vault",
   "description": "A Backstage plugin that integrates towards Vault",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9573,13 +9573,13 @@ __metadata:
     "@material-ui/lab": 4.0.0-alpha.61
     "@testing-library/dom": ^9.0.0
     "@testing-library/jest-dom": ^6.0.0
-    "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
     "@types/react": ^16.13.1 || ^17.0.0
     msw: ^1.0.0
     react-use: ^17.2.4
     testing-library__dom: ^7.29.4-beta.1
   peerDependencies:
+    "@testing-library/react": ^12.1.3 || ^13.0.0 || ^14.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0


### PR DESCRIPTION
This release fixes the below issues:

- scaffolder: Include the missing `headerOptions` overrides
- catalog: Fix the `Owned By` filter in the Catalog page
- techdocs: Move `testing-library/react` to `peerDependencies` to fix incompatibility with React 17