### PR TITLE
Fix closing of k8s pod drawer when data reloads

### DIFF
--- a/.changeset/large-weeks-accept.md
+++ b/.changeset/large-weeks-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Add ID property to the table displaying kubernetes pods to avoid closing the info sidebar when the data reloads and needs to rerender.

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -183,7 +183,12 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
         options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
         // It was observed that in some instances the pod "sideboard" closes when new data (like CPU usage) is available and the table reloads.
         // Mapping the metadata UID to the tables ID fixes this problem.
-        data={(pods as Pod[]).map((pod: Pod) => ({ ...pod, id: pod?.metadata?.uid })) as any as Pod[]}
+        data={
+          (pods as Pod[]).map((pod: Pod) => ({
+            ...pod,
+            id: pod?.metadata?.uid,
+          })) as any as Pod[]
+        }
         columns={columns}
       />
     </div>

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -181,7 +181,7 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
     <div style={tableStyle}>
       <Table
         options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
-        // It was observed that in some instances the pod "sideboard" closes when new data (like CPU usage) is available and the table reloads.
+        // It was observed that in some instances the pod drawer closes when new data (like CPU usage) is available and the table reloads.
         // Mapping the metadata UID to the tables ID fixes this problem.
         data={
           (pods as Pod[]).map((pod: Pod) => ({

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -126,6 +126,11 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
   const cluster = useContext(ClusterContext);
   const defaultColumns: TableColumn<Pod>[] = [
     {
+      title: 'ID',
+      field: 'metadata.uid',
+      hidden: true,
+    },
+    {
       title: 'name',
       highlight: true,
       render: (pod: Pod) => {
@@ -176,7 +181,9 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
     <div style={tableStyle}>
       <Table
         options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
-        data={pods as Pod[]}
+        // It was observed that in some instances the pod "sideboard" closes when new data (like CPU usage) is available and the table reloads.
+        // Mapping the metadata UID to the tables ID fixes this problem.
+        data={(pods as Pod[]).map((pod: Pod) => ({ ...pod, id: pod?.metadata?.uid })) as any as Pod[]}
         columns={columns}
       />
     </div>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add ID property to the table displaying kubernetes pods to avoid closing the drawer when the data reloads and needs to rerender.

Fixes #18471.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
