### PR TITLE
docs(CoC): fix CNCF Code of Conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Community Code of Conduct
 
-Backstage follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Backstage follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Since [CNCF renamed](https://github.com/cncf/foundation/issues/149) `master` to `main`, the link is not correct. Although there seem to be a redirect in place, because it works from the browser, that is not always the case. 

Following the CODE_OF_CONDUCT.md link inside GitHub iOS app does not redirect to the renamed branch, and results in "Something went wrong" error.

This PR simply updates the link to use the correct branch name.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
