### PR TITLE
Correct docs to react-refresh instead of react-hot-loader

### DIFF
--- a/docs/local-dev/cli-build-system.md
+++ b/docs/local-dev/cli-build-system.md
@@ -295,7 +295,8 @@ Webpack configuration itself varies very little between the frontend development
 and production bundling, so we'll dive more into the configuration in the
 production section below. The main differences are that `process.env.NODE_ENV`
 is set to `'development'`, minification is disabled, cheap source maps are used,
-and [React Hot Loader](https://github.com/gaearon/react-hot-loader) is enabled.
+and [React Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin#readme)
+is enabled.
 
 If you prefer to run type checking and linting as part of the Webpack process,
 you can enable usage of the


### PR DESCRIPTION
## Hey, I just made a Pull Request!

[We no longer are using react-hot-loader](https://github.com/backstage/backstage/blob/115298e74f9a17fde09519f660b1edbfa7df3b3b/packages/dev-utils/CHANGELOG.md?plain=1#L918), but it's still mentioned in the docs. Let's correct this to avoid confusion.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
