### PR TITLE
fix: signing/verification key encoding

### DIFF
--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -115,6 +115,17 @@ value of the configured key as the secret. It must also have the following paylo
 > NOTE: The JWT must encode the `alg` header as a protected header, such as with
 > [setProtectedHeader](https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md#setprotectedheader).
 
+For example:
+```ts
+const secret = new TextEncoder().encode('my-token-secret');
+
+const jwt = await new jose.SignJWT({})
+  .setProtectedHeader({ 'HS256' })
+  .setSubject('backstage-server')
+  .setExpirationTime('1h')
+  .sign(secret);
+```
+
 ## Granular Access Control
 
 We plan to build out the service-to-service auth to be much more powerful in the

--- a/packages/backend-common/src/tokens/ServerTokenManager.test.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.test.ts
@@ -204,7 +204,7 @@ describe('ServerTokenManager', () => {
         .setProtectedHeader({ alg: 'HS256' })
         .setSubject('backstage-server')
         .setExpirationTime(Date.now() + 1000 * 60 * 60)
-        .sign(jose.base64url.decode(secret));
+        .sign(new TextEncoder().encode(secret));
 
       const tokenManager = ServerTokenManager.fromConfig(
         new ConfigReader({
@@ -220,7 +220,7 @@ describe('ServerTokenManager', () => {
       const token = await new jose.SignJWT({})
         .setProtectedHeader({ alg: 'HS256' })
         .setSubject('backstage-server')
-        .sign(jose.base64url.decode(secret));
+        .sign(new TextEncoder().encode(secret));
 
       const tokenManager = ServerTokenManager.fromConfig(
         new ConfigReader({

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -77,7 +77,7 @@ export class ServerTokenManager implements TokenManager {
     const keys = config.getOptionalConfigArray('backend.auth.keys');
     if (keys?.length) {
       return new ServerTokenManager(
-        keys.map(key => key.getString('secret')),
+        keys.map(key => encodeURIComponent(key.getString('secret'))),
         options,
       );
     }
@@ -155,7 +155,7 @@ export class ServerTokenManager implements TokenManager {
         .setExpirationTime(
           DateTime.now().plus(TOKEN_EXPIRY_AFTER).toUnixInteger(),
         )
-        .sign(new TextEncoder().encode(this.signingKey.toString()));
+        .sign(this.signingKey.toString());
       return { token: jwt };
     });
 

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -16,7 +16,7 @@
 
 import { Config } from '@backstage/config';
 import { AuthenticationError } from '@backstage/errors';
-import { base64url, exportJWK, generateSecret, jwtVerify, SignJWT } from 'jose';
+import { exportJWK, generateSecret, jwtVerify, SignJWT } from 'jose';
 import { DateTime, Duration } from 'luxon';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { TokenManager } from './types';

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -25,6 +25,7 @@ const TOKEN_ALG = 'HS256';
 const TOKEN_SUB = 'backstage-server';
 const TOKEN_EXPIRY_AFTER = Duration.fromObject({ hours: 1 });
 const TOKEN_REISSUE_AFTER = Duration.fromObject({ minutes: 10 });
+const TEXT_ENCODER = new TextEncoder();
 
 /**
  * A token manager that issues static fake tokens and never fails
@@ -77,7 +78,7 @@ export class ServerTokenManager implements TokenManager {
     const keys = config.getOptionalConfigArray('backend.auth.keys');
     if (keys?.length) {
       return new ServerTokenManager(
-        keys.map(key => encodeURIComponent(key.getString('secret'))),
+        keys.map(key => key.getString('secret')),
         options,
       );
     }
@@ -103,7 +104,7 @@ export class ServerTokenManager implements TokenManager {
     }
     this.options = options;
     this.verificationKeys = secrets.map(s => base64url.decode(s));
-    this.signingKey = this.verificationKeys[0];
+    this.signingKey = new TextEncoder().encode(secrets[0]);
   }
 
   // Called when no keys have been generated yet in the dev environment

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -155,7 +155,7 @@ export class ServerTokenManager implements TokenManager {
         .setExpirationTime(
           DateTime.now().plus(TOKEN_EXPIRY_AFTER).toUnixInteger(),
         )
-        .sign(this.signingKey.toString());
+        .sign(this.signingKey);
       return { token: jwt };
     });
 

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -155,7 +155,7 @@ export class ServerTokenManager implements TokenManager {
         .setExpirationTime(
           DateTime.now().plus(TOKEN_EXPIRY_AFTER).toUnixInteger(),
         )
-        .sign(this.signingKey);
+        .sign(new TextEncoder().encode(this.signingKey.toString()));
       return { token: jwt };
     });
 

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -103,8 +103,8 @@ export class ServerTokenManager implements TokenManager {
       );
     }
     this.options = options;
-    this.verificationKeys = secrets.map(s => base64url.decode(s));
-    this.signingKey = TEXT_ENCODER.encode(secrets[0]);
+    this.verificationKeys = secrets.map(s => TEXT_ENCODER.encode(s));
+    this.signingKey = this.verificationKeys[0];
   }
 
   // Called when no keys have been generated yet in the dev environment
@@ -122,7 +122,7 @@ export class ServerTokenManager implements TokenManager {
     const promise = (async () => {
       const secret = await generateSecret(TOKEN_ALG);
       const jwk = await exportJWK(secret);
-      this.verificationKeys.push(base64url.decode(jwk.k ?? ''));
+      this.verificationKeys.push(TEXT_ENCODER.encode(jwk.k ?? ''));
       this.signingKey = this.verificationKeys[0];
       return;
     })();

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -104,7 +104,7 @@ export class ServerTokenManager implements TokenManager {
     }
     this.options = options;
     this.verificationKeys = secrets.map(s => base64url.decode(s));
-    this.signingKey = new TextEncoder().encode(secrets[0]);
+    this.signingKey = TEXT_ENCODER.encode(secrets[0]);
   }
 
   // Called when no keys have been generated yet in the dev environment


### PR DESCRIPTION
## Fix token signing/verification encoding
Fixes this [issue](https://github.com/backstage/backstage/issues/18622). 

Here is the official documentation for [signing](https://github.com/panva/jose/blob/main/docs/classes/jwt_sign.SignJWT.md?plain=1#L16) and [verification](https://github.com/panva/jose/blob/main/docs/functions/jwt_verify.jwtVerify.md) (see Usage with a symmetric secret) of HS256 tokens. Instead of encoding the secret  for the signing and verification keys, the current implementation is decoding it. We are still able to generate a token using the wrong encoding(decoding), but the problem arises during the token authentication in which the `invalid alg` exception is thrown.

I fixed the issue by following the official documentation to get the right encoding for the keys.
Also added example in the documentation for token generation
 
#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
