### PR TITLE
fix: add resource icon

### DIFF
--- a/.changeset/healthy-poets-search.md
+++ b/.changeset/healthy-poets-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Add default icon for kind resource.

--- a/plugins/catalog-react/src/apis/EntityPresentationApi/defaultEntityPresentation.ts
+++ b/plugins/catalog-react/src/apis/EntityPresentationApi/defaultEntityPresentation.ts
@@ -30,6 +30,7 @@ import LocationOnIcon from '@material-ui/icons/LocationOn';
 import MemoryIcon from '@material-ui/icons/Memory';
 import PeopleIcon from '@material-ui/icons/People';
 import PersonIcon from '@material-ui/icons/Person';
+import WorkIcon from '@material-ui/icons/Work';
 import get from 'lodash/get';
 import { EntityRefPresentationSnapshot } from './EntityPresentationApi';
 
@@ -39,6 +40,7 @@ const DEFAULT_ICONS: Record<string, IconComponent> = {
   api: ExtensionIcon,
   component: MemoryIcon,
   system: BusinessIcon,
+  resource: WorkIcon,
   domain: ApartmentIcon,
   location: LocationOnIcon,
   user: PersonIcon,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add resource default icon, looking like
![Screen Shot 2023-11-20 at 22 09 14 PM](https://github.com/backstage/backstage/assets/1021324/b4e8901b-9cb0-41e7-9290-de30a7fd63f7)

Reused the work icon as this is the default one in all Backstage demos, as seen here
![Screen Shot 2023-11-20 at 22 04 06 PM](https://github.com/backstage/backstage/assets/1021324/488423af-1ae7-4f38-9ae1-ce8094ddef5b)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
