### PR TITLE
Added redirect for old scaffolder next page

### DIFF
--- a/microsite/docusaurus.config.js
+++ b/microsite/docusaurus.config.js
@@ -140,6 +140,10 @@ module.exports = {
             from: '/docs/getting-started/running-backstage-locally',
             to: '/docs/getting-started/',
           },
+          {
+            from: '/docs/features/software-templates/testing-scaffolder-alpha',
+            to: '/docs/features/software-templates/migrating-to-rjsf-v5',
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just added a redirect for the old scaffolder next page to the new migrating to react-jsonschema-form@v5 page

This came out of this comment on Discord: https://discord.com/channels/687207715902193673/1176516710661103676

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
