### PR TITLE
lint for illegal role-to-role dependency chains

### DIFF
--- a/.changeset/four-needles-watch.md
+++ b/.changeset/four-needles-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Internalize 'AboutField' to break catalog dependency

--- a/.changeset/giant-files-fry.md
+++ b/.changeset/giant-files-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Remove unnecessary catalog dependency

--- a/.changeset/warm-plums-beg.md
+++ b/.changeset/warm-plums-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-common': patch
+---
+
+Remove unused dependency

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -34,7 +34,6 @@
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/plugin-catalog": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@date-io/luxon": "1.x",

--- a/plugins/bazaar/src/components/CardContentFields/AboutField.tsx
+++ b/plugins/bazaar/src/components/CardContentFields/AboutField.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useElementFilter } from '@backstage/core-plugin-api';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
+import React from 'react';
+
+const useStyles = makeStyles(theme => ({
+  value: {
+    fontWeight: 'bold',
+    overflow: 'hidden',
+    lineHeight: '24px',
+    wordBreak: 'break-word',
+  },
+  label: {
+    color: theme.palette.text.secondary,
+    textTransform: 'uppercase',
+    fontSize: '10px',
+    fontWeight: 'bold',
+    letterSpacing: 0.5,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+  },
+}));
+
+/**
+ * Props for {@link AboutField}.
+ *
+ * @public
+ */
+export interface AboutFieldProps {
+  label: string;
+  value?: string;
+  gridSizes?: Record<string, number>;
+  children?: React.ReactNode;
+}
+
+/** @public */
+export function AboutField(props: AboutFieldProps) {
+  const { label, value, gridSizes, children } = props;
+  const classes = useStyles();
+
+  const childElements = useElementFilter(children, c => c.getElements());
+
+  // Content is either children or a string prop `value`
+  const content =
+    childElements.length > 0 ? (
+      childElements
+    ) : (
+      <Typography variant="body2" className={classes.value}>
+        {value || `unknown`}
+      </Typography>
+    );
+  return (
+    <Grid item {...gridSizes}>
+      <Typography variant="h2" className={classes.label}>
+        {label}
+      </Typography>
+      {content}
+    </Grid>
+  );
+}

--- a/plugins/bazaar/src/components/CardContentFields/AboutField.tsx
+++ b/plugins/bazaar/src/components/CardContentFields/AboutField.tsx
@@ -38,8 +38,6 @@ const useStyles = makeStyles(theme => ({
 
 /**
  * Props for {@link AboutField}.
- *
- * @public
  */
 export interface AboutFieldProps {
   label: string;
@@ -48,7 +46,6 @@ export interface AboutFieldProps {
   children?: React.ReactNode;
 }
 
-/** @public */
 export function AboutField(props: AboutFieldProps) {
   const { label, value, gridSizes, children } = props;
   const classes = useStyles();

--- a/plugins/bazaar/src/components/CardContentFields/CardContentFields.tsx
+++ b/plugins/bazaar/src/components/CardContentFields/CardContentFields.tsx
@@ -25,8 +25,8 @@ import {
 import { parseEntityRef } from '@backstage/catalog-model';
 import { Avatar, Link } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
-import { AboutField } from '@backstage/plugin-catalog';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import { AboutField } from './AboutField';
 import { StatusTag } from '../StatusTag';
 import { Member, BazaarProject } from '../../types';
 

--- a/plugins/kubernetes-common/package.json
+++ b/plugins/kubernetes-common/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "workspace:^",
-    "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/types": "workspace:^",

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -38,6 +38,7 @@
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/integration-react": "workspace:^",
     "@backstage/plugin-catalog": "workspace:^",
+    "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/plugin-search-react": "workspace:^",
     "@backstage/plugin-techdocs": "workspace:^",
     "@backstage/plugin-techdocs-react": "workspace:^",

--- a/plugins/techdocs-addons-test-utils/src/test-utils.tsx
+++ b/plugins/techdocs-addons-test-utils/src/test-utils.tsx
@@ -34,7 +34,7 @@ import {
   techdocsStorageApiRef,
 } from '@backstage/plugin-techdocs-react';
 import { TechDocsReaderPage, techdocsPlugin } from '@backstage/plugin-techdocs';
-import { catalogPlugin } from '@backstage/plugin-catalog';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { searchApiRef } from '@backstage/plugin-search-react';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 
@@ -259,7 +259,7 @@ export class TechDocsAddonTester {
       mountedRoutes: {
         '/docs': techdocsPlugin.routes.root,
         '/docs/:namespace/:kind/:name/*': techdocsPlugin.routes.docRoot,
-        '/catalog/:namespace/:kind/:name': catalogPlugin.routes.catalogEntity,
+        '/catalog/:namespace/:kind/:name': entityRouteRef,
       },
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5033,7 +5033,6 @@ __metadata:
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/dev-utils": "workspace:^"
     "@backstage/errors": "workspace:^"
-    "@backstage/plugin-catalog": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@date-io/luxon": 1.x
@@ -7365,7 +7364,6 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/core-app-api": "workspace:^"
-    "@backstage/core-plugin-api": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/test-utils": "workspace:^"
@@ -9289,6 +9287,7 @@ __metadata:
     "@backstage/dev-utils": "workspace:^"
     "@backstage/integration-react": "workspace:^"
     "@backstage/plugin-catalog": "workspace:^"
+    "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"
     "@backstage/plugin-techdocs": "workspace:^"
     "@backstage/plugin-techdocs-react": "workspace:^"


### PR DESCRIPTION
Just inside the repo for now, rather than packaged directly in the cli `repo lint`. These are probably going to cause trouble out there if introduced wholesale, is my thought. We did have to fix some occurrences internally, after all.