### PR TITLE
Adding in type chip to search results

### DIFF
--- a/.changeset/real-bees-thank.md
+++ b/.changeset/real-bees-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Adding in component type chip to search results for clarity

--- a/.changeset/real-bees-thank.md
+++ b/.changeset/real-bees-thank.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Adding in component type chip to search results for clarity
+Adding in spec.type chip to search results for clarity

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -107,6 +107,7 @@ export function CatalogSearchResultListItem(
         />
         <Box>
           {result.kind && <Chip label={`Kind: ${result.kind}`} size="small" />}
+          {result.type && <Chip label={`Type: ${result.type}`} size="small" />}
           {result.lifecycle && (
             <Chip label={`Lifecycle: ${result.lifecycle}`} size="small" />
           )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As we did more customer research for our plugin work, we realized determining the type of entity you were looking at in search results was unclear

This PR adds a chip to show the type if it exists on the catalog component

<img width="701" alt="Screenshot 2023-11-21 at 4 19 29 PM" src="https://github.com/backstage/backstage/assets/7171310/67e581dc-cd37-4513-8af3-6a1679600d41">
list

<img width="747" alt="Screenshot 2023-11-21 at 4 21 44 PM" src="https://github.com/backstage/backstage/assets/7171310/2856449b-e9d5-4520-9dc3-9ccf14f1b287">

#### :heavy_check_mark: Check

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
