### PR TITLE
[Lighthouse] Fixed crashes when customizing the schedule

### DIFF
--- a/.changeset/long-cycles-grow.md
+++ b/.changeset/long-cycles-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-lighthouse': patch
+---
+
+Updated README

--- a/.changeset/ninety-otters-report.md
+++ b/.changeset/ninety-otters-report.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-lighthouse-backend': major
+'@backstage/plugin-lighthouse-backend': minor
 ---
 
 Updated Lighthouse schedule configuration to fix crashes when using custom configuration

--- a/.changeset/ninety-otters-report.md
+++ b/.changeset/ninety-otters-report.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-lighthouse-backend': minor
 ---
 
-Updated Lighthouse schedule configuration to fix crashes when using custom configuration
+Fixed crashes faced with custom schedule configuration. The configuration schema has been update to leverage the TaskScheduleDefinition interface. It is highly recommended to move the `lighthouse.shedule` and `lighthouse.timeout` respectively to `lighthouse.schedule.frequency` and `lighthouse.schedule.timeout`.

--- a/.changeset/ninety-otters-report.md
+++ b/.changeset/ninety-otters-report.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-lighthouse-backend': major
 ---
 
-Updated Ligthouse schedule configuration to fix crashes when using custom confinguration
+Updated Lighthouse schedule configuration to fix crashes when using custom confinguration

--- a/.changeset/ninety-otters-report.md
+++ b/.changeset/ninety-otters-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-lighthouse-backend': major
+---
+
+Updated Ligthouse schedule configuration to fix crashes when using custom confinguration

--- a/.changeset/ninety-otters-report.md
+++ b/.changeset/ninety-otters-report.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-lighthouse-backend': major
 ---
 
-Updated Lighthouse schedule configuration to fix crashes when using custom confinguration
+Updated Lighthouse schedule configuration to fix crashes when using custom configuration

--- a/plugins/lighthouse-backend/README.md
+++ b/plugins/lighthouse-backend/README.md
@@ -25,7 +25,13 @@ export default async function createPlugin(env: PluginEnvironment) {
     discoveryApi: env.discovery,
   });
 
-  await createScheduler({ logger, scheduler, config, catalogClient, tokenManager });
+  await createScheduler({
+    logger,
+    scheduler,
+    config,
+    catalogClient,
+    tokenManager,
+  });
 }
 ```
 

--- a/plugins/lighthouse-backend/README.md
+++ b/plugins/lighthouse-backend/README.md
@@ -19,13 +19,13 @@ import { PluginEnvironment } from '../types';
 import { CatalogClient } from '@backstage/catalog-client';
 
 export default async function createPlugin(env: PluginEnvironment) {
-  const { logger, scheduler, config } = env;
+  const { logger, scheduler, config, tokenManager } = env;
 
   const catalogClient = new CatalogClient({
     discoveryApi: env.discovery,
   });
 
-  await createScheduler({ logger, scheduler, config, catalogClient });
+  await createScheduler({ logger, scheduler, config, catalogClient tokenManager });
 }
 ```
 
@@ -80,5 +80,8 @@ You can define how often and when the scheduler should run the audits:
 ```yaml
 lighthouse:
   schedule:
-    days: 1
+    frequency:
+      hours: 12 # Default: days 1
+    timeout:
+      minutes: 30 # Default: null
 ```

--- a/plugins/lighthouse-backend/README.md
+++ b/plugins/lighthouse-backend/README.md
@@ -25,7 +25,7 @@ export default async function createPlugin(env: PluginEnvironment) {
     discoveryApi: env.discovery,
   });
 
-  await createScheduler({ logger, scheduler, config, catalogClient tokenManager });
+  await createScheduler({ logger, scheduler, config, catalogClient, tokenManager });
 }
 ```
 

--- a/plugins/lighthouse-backend/config.d.ts
+++ b/plugins/lighthouse-backend/config.d.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+import { HumanDuration } from '@backstage/types';
+
+export interface Config {
+  /**
+   * Configuration options for the Lighthouse backend plugin.
+   */
+  lighthouse?: {
+    /**
+     * Schedule of the audit
+     */
+    schedule?: HumanDuration | TaskScheduleDefinitionConfig;
+  };
+}

--- a/plugins/lighthouse-backend/package.json
+++ b/plugins/lighthouse-backend/package.json
@@ -27,6 +27,7 @@
     "dist",
     "config.d.ts"
   ],
+  "configSchema": "config.d.ts",
   "scripts": {
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",

--- a/plugins/lighthouse-backend/package.json
+++ b/plugins/lighthouse-backend/package.json
@@ -24,7 +24,8 @@
     "lighthouse"
   ],
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
   "scripts": {
     "build": "backstage-cli package build",

--- a/plugins/lighthouse-backend/src/config.ts
+++ b/plugins/lighthouse-backend/src/config.ts
@@ -49,7 +49,7 @@ export class LighthouseAuditScheduleImpl implements TaskScheduleDefinition {
       );
     } else if (config.has('lighthouse.schedule')) {
       logger.warn(
-        `[Deprecation] Please migrate the schedule configuration to 'lighthouse.schedule.frequency' in ${config.config.context}`,
+        `[Deprecation] Please migrate the schedule configuration to 'lighthouse.schedule.frequency'`,
       );
 
       lighthouse.frequency = readDurationFromConfig(
@@ -59,7 +59,7 @@ export class LighthouseAuditScheduleImpl implements TaskScheduleDefinition {
 
     if (config.has('lighthouse.timeout')) {
       logger.warn(
-        `[Deprecation] Please migrate the timeout configuration to 'lighthouse.schedule.timeout' in ${config.config.context}`,
+        `[Deprecation] Please migrate the timeout configuration to 'lighthouse.schedule.timeout'`,
       );
 
       lighthouse.timeout = readDurationFromConfig(

--- a/plugins/lighthouse-backend/src/config.ts
+++ b/plugins/lighthouse-backend/src/config.ts
@@ -39,7 +39,7 @@ export class LighthouseAuditScheduleImpl implements TaskScheduleDefinition {
 
     let lighthouse: TaskScheduleDefinition = {
       frequency: { days: 1 },
-      timeout: {},
+      timeout: { minutes: 10 },
       initialDelay: { minutes: 15 },
     };
 

--- a/plugins/lighthouse-backend/src/service/createScheduler.ts
+++ b/plugins/lighthouse-backend/src/service/createScheduler.ts
@@ -56,14 +56,14 @@ export async function createScheduler(
 
   logger.info(
     `Running with Scheduler Config ${JSON.stringify(
-      lighthouseAuditConfig.getSchedule(),
+      lighthouseAuditConfig.getFrequency(),
     )} and timeout ${JSON.stringify(lighthouseAuditConfig.getTimeout())}`,
   );
 
   if (scheduler) {
     await scheduler.scheduleTask({
       id: 'lighthouse_audit',
-      frequency: lighthouseAuditConfig.getSchedule(),
+      frequency: lighthouseAuditConfig.getFrequency(),
       timeout: lighthouseAuditConfig.getTimeout(),
       initialDelay: { minutes: 15 },
       fn: async () => {

--- a/plugins/lighthouse-backend/src/service/createScheduler.ts
+++ b/plugins/lighthouse-backend/src/service/createScheduler.ts
@@ -39,7 +39,9 @@ export async function createScheduler(
   const { logger, scheduler, catalogClient, config, tokenManager } = options;
   const lighthouseApi = LighthouseRestApi.fromConfig(config);
 
-  const lighthouseAuditConfig = LighthouseAuditScheduleImpl.fromConfig(config);
+  const lighthouseAuditConfig = LighthouseAuditScheduleImpl.fromConfig(config, {
+    logger,
+  });
   const formFactorToScreenEmulationMap = {
     // the default is mobile, so no need to override
     mobile: undefined,
@@ -56,16 +58,16 @@ export async function createScheduler(
 
   logger.info(
     `Running with Scheduler Config ${JSON.stringify(
-      lighthouseAuditConfig.getFrequency(),
-    )} and timeout ${JSON.stringify(lighthouseAuditConfig.getTimeout())}`,
+      lighthouseAuditConfig.frequency,
+    )} and timeout ${JSON.stringify(lighthouseAuditConfig.timeout)}`,
   );
 
   if (scheduler) {
     await scheduler.scheduleTask({
       id: 'lighthouse_audit',
-      frequency: lighthouseAuditConfig.getFrequency(),
-      timeout: lighthouseAuditConfig.getTimeout(),
-      initialDelay: { minutes: 15 },
+      frequency: lighthouseAuditConfig.frequency,
+      timeout: lighthouseAuditConfig.timeout,
+      initialDelay: lighthouseAuditConfig.initialDelay,
       fn: async () => {
         const filter: Record<string, symbol | string> = {
           kind: 'Component',

--- a/plugins/lighthouse/README.md
+++ b/plugins/lighthouse/README.md
@@ -47,6 +47,10 @@ const routes = (
 Then configure the `lighthouse-audit-service` URL in your [`app-config.yaml`](https://github.com/backstage/backstage/blob/master/app-config.yaml).
 
 ```yaml
+backend:
+  csp:
+    frame-src:
+      - http://your-service-url
 lighthouse:
   baseUrl: http://your-service-url
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Backstage crashes when enabling Lighthouse backend plugin schedule with the following error message.

```shell
Backend failed to start up InvalidUnitError: Invalid unit parent
    at normalizeUnit (/app/node_modules/luxon/build/node/luxon.js:2711:28)
    at normalizeObject (/app/node_modules/luxon/build/node/luxon.js:1539:18)
    at Duration.fromObject (/app/node_modules/luxon/build/node/luxon.js:2590:15)
    at parseDuration (/app/node_modules/@backstage/backend-tasks/dist/index.cjs.js:617:84)
    at PluginTaskSchedulerImpl.scheduleTask (/app/node_modules/@backstage/backend-tasks/dist/index.cjs.js:553:16)
    at Object.createScheduler (/app/node_modules/@backstage/plugin-lighthouse-backend/dist/index.cjs.js:64:21)
    at createPlugin (/app/packages/backend/dist/index.cjs.js:297:33)
    at main (/app/packages/backend/dist/index.cjs.js:371:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

The `lighthouse-plugin-backend` configuration has been updated to leverage recent features provided by the `backend-tasks` plugin. This motivated the Lighthouse configuration schema update to align the structure with other plugins (e.g. search,).

##### Old schema

```yaml
lighthouse:
  schedule:
    days: 1
  timeout:
    minutes: 15
```

##### New schema

```yaml
lighthouse:
  schedule:
    frequency
      days: 1
    timeout:
      minutes: 15
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
