### PR TITLE
frontend-plugin-api: change extension factory to receive app node instead of id and source

### DIFF
--- a/.changeset/nervous-penguins-sort.md
+++ b/.changeset/nervous-penguins-sort.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-catalog': patch
+---
+
+Internal refactor of alpha exports due to a change in how extension factories are defined.

--- a/.changeset/stale-walls-cross.md
+++ b/.changeset/stale-walls-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Updates to provide `node` to extension factories instead of `id` and `source`.

--- a/.changeset/wicked-elephants-think.md
+++ b/.changeset/wicked-elephants-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+The extension `factory` function now longer receives `id` or `source`, but instead now provides the extension's `AppNode` as `node`. The `ExtensionBoundary` component has also been updated to receive a `node` prop rather than `id` and `source`.

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -103,7 +103,7 @@ export function createAppNodeInstance(options: {
   attachments: ReadonlyMap<string, { id: string; instance: AppNodeInstance }[]>;
 }): AppNodeInstance {
   const { spec, attachments } = options;
-  const { id, extension, config, source } = spec;
+  const { id, extension, config } = spec;
   const extensionData = new Map<string, unknown>();
   const extensionDataRefs = new Set<ExtensionDataRef<unknown>>();
 
@@ -118,7 +118,7 @@ export function createAppNodeInstance(options: {
 
   try {
     const namedOutputs = extension.factory({
-      source,
+      spec,
       config: parsedConfig,
       inputs: resolveInputs(extension.inputs, attachments),
     });

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -20,11 +20,7 @@ import {
   ExtensionDataRef,
 } from '@backstage/frontend-plugin-api';
 import mapValues from 'lodash/mapValues';
-import {
-  AppNode,
-  AppNodeInstance,
-  AppNodeSpec,
-} from '@backstage/frontend-plugin-api';
+import { AppNode, AppNodeInstance } from '@backstage/frontend-plugin-api';
 
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
@@ -99,11 +95,11 @@ function resolveInputs(
 
 /** @internal */
 export function createAppNodeInstance(options: {
-  spec: AppNodeSpec;
+  node: AppNode;
   attachments: ReadonlyMap<string, { id: string; instance: AppNodeInstance }[]>;
 }): AppNodeInstance {
-  const { spec, attachments } = options;
-  const { id, extension, config } = spec;
+  const { node, attachments } = options;
+  const { id, extension, config } = node.spec;
   const extensionData = new Map<string, unknown>();
   const extensionDataRefs = new Set<ExtensionDataRef<unknown>>();
 
@@ -118,7 +114,7 @@ export function createAppNodeInstance(options: {
 
   try {
     const namedOutputs = extension.factory({
-      spec,
+      node,
       config: parsedConfig,
       inputs: resolveInputs(extension.inputs, attachments),
     });
@@ -186,7 +182,7 @@ export function instantiateAppNodeTree(rootNode: AppNode): void {
     }
 
     (node as Mutable<AppNode>).instance = createAppNodeInstance({
-      spec: node.spec,
+      node,
       attachments: instantiatedAttachments,
     });
 

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -339,7 +339,7 @@ export interface CreateExtensionOptions<
   disabled?: boolean;
   // (undocumented)
   factory(options: {
-    source?: BackstagePlugin;
+    node: AppNode;
     config: TConfig;
     inputs: Expand<ExtensionInputValues<TInputs>>;
   }): Expand<ExtensionDataValues<TOutput>>;
@@ -493,7 +493,7 @@ export interface Extension<TConfig> {
   disabled: boolean;
   // (undocumented)
   factory(options: {
-    source?: BackstagePlugin;
+    node: AppNode;
     config: TConfig;
     inputs: Record<
       string,
@@ -518,11 +518,9 @@ export interface ExtensionBoundaryProps {
   // (undocumented)
   children: ReactNode;
   // (undocumented)
-  id: string;
+  node: AppNode;
   // (undocumented)
   routable?: boolean;
-  // (undocumented)
-  source?: BackstagePlugin;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
@@ -34,15 +34,11 @@ const wrapInBoundaryExtension = (element: JSX.Element) => {
       path: coreExtensionData.routePath,
       routeRef: coreExtensionData.routeRef.optional(),
     },
-    factory({ source }) {
+    factory({ node }) {
       return {
         routeRef,
         path: '/',
-        element: (
-          <ExtensionBoundary id={id} source={source}>
-            {element}
-          </ExtensionBoundary>
-        ),
+        element: <ExtensionBoundary node={node}>{element}</ExtensionBoundary>,
       };
     },
   });

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -16,11 +16,11 @@
 
 import React, { PropsWithChildren, ReactNode, useEffect } from 'react';
 import { AnalyticsContext, useAnalytics } from '@backstage/core-plugin-api';
-import { BackstagePlugin } from '../wiring';
 import { ErrorBoundary } from './ErrorBoundary';
 import { ExtensionSuspense } from './ExtensionSuspense';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { routableExtensionRenderedEvent } from '../../../core-plugin-api/src/analytics/Tracker';
+import { AppNodeSpec } from '../apis';
 
 type RouteTrackerProps = PropsWithChildren<{
   disableTracking?: boolean;
@@ -44,25 +44,24 @@ const RouteTracker = (props: RouteTrackerProps) => {
 
 /** @public */
 export interface ExtensionBoundaryProps {
-  id: string;
-  source?: BackstagePlugin;
+  spec: AppNodeSpec;
   routable?: boolean;
   children: ReactNode;
 }
 
 /** @public */
 export function ExtensionBoundary(props: ExtensionBoundaryProps) {
-  const { id, source, routable, children } = props;
+  const { spec, routable, children } = props;
 
   // Skipping "routeRef" attribute in the new system, the extension "id" should provide more insight
   const attributes = {
-    extension: id,
-    pluginId: source?.id,
+    extension: spec.id,
+    pluginId: spec.source?.id,
   };
 
   return (
     <ExtensionSuspense>
-      <ErrorBoundary plugin={source}>
+      <ErrorBoundary plugin={spec.source}>
         <AnalyticsContext attributes={attributes}>
           <RouteTracker disableTracking={!routable}>{children}</RouteTracker>
         </AnalyticsContext>

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -20,7 +20,7 @@ import { ErrorBoundary } from './ErrorBoundary';
 import { ExtensionSuspense } from './ExtensionSuspense';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { routableExtensionRenderedEvent } from '../../../core-plugin-api/src/analytics/Tracker';
-import { AppNodeSpec } from '../apis';
+import { AppNode } from '../apis';
 
 type RouteTrackerProps = PropsWithChildren<{
   disableTracking?: boolean;
@@ -44,24 +44,24 @@ const RouteTracker = (props: RouteTrackerProps) => {
 
 /** @public */
 export interface ExtensionBoundaryProps {
-  spec: AppNodeSpec;
+  node: AppNode;
   routable?: boolean;
   children: ReactNode;
 }
 
 /** @public */
 export function ExtensionBoundary(props: ExtensionBoundaryProps) {
-  const { spec, routable, children } = props;
+  const { node, routable, children } = props;
 
   // Skipping "routeRef" attribute in the new system, the extension "id" should provide more insight
   const attributes = {
-    extension: spec.id,
-    pluginId: spec.source?.id,
+    extension: node.spec.id,
+    pluginId: node.spec.source?.id,
   };
 
   return (
     <ExtensionSuspense>
-      <ErrorBoundary plugin={spec.source}>
+      <ErrorBoundary plugin={node.spec.source}>
         <AnalyticsContext attributes={attributes}>
           <RouteTracker disableTracking={!routable}>{children}</RouteTracker>
         </AnalyticsContext>

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.test.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.test.tsx
@@ -15,16 +15,12 @@
  */
 
 import React from 'react';
-import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
 import { useAnalytics } from '@backstage/core-plugin-api';
 import { waitFor } from '@testing-library/react';
 import { PortableSchema } from '../schema';
-import {
-  coreExtensionData,
-  createExtensionInput,
-  createPlugin,
-} from '../wiring';
+import { coreExtensionData, createExtensionInput } from '../wiring';
 import { createPageExtension } from './createPageExtension';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),
@@ -120,19 +116,13 @@ describe('createPageExtension', () => {
       captureEvent,
     });
 
-    const extension = createPageExtension({
-      id: 'plugin.page',
-      defaultPath: '/',
-      loader: async () => <div>Component</div>,
-    });
-
-    const output = extension.factory({
-      source: createPlugin({ id: 'plugin ' }),
-      config: { path: '/' },
-      inputs: {},
-    });
-
-    renderWithEffects(wrapInTestApp(output.element as unknown as JSX.Element));
+    createExtensionTester(
+      createPageExtension({
+        id: 'plugin.page',
+        defaultPath: '/',
+        loader: async () => <div>Component</div>,
+      }),
+    ).render();
 
     await waitFor(() =>
       expect(captureEvent).toHaveBeenCalledWith(

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
@@ -75,7 +75,7 @@ export function createPageExtension<
       path: coreExtensionData.routePath,
       routeRef: coreExtensionData.routeRef.optional(),
     },
-    factory({ config, inputs, source }) {
+    factory({ config, inputs, node }) {
       const ExtensionComponent = lazy(() =>
         options
           .loader({ config, inputs })
@@ -86,7 +86,7 @@ export function createPageExtension<
         path: config.path,
         routeRef: options.routeRef,
         element: (
-          <ExtensionBoundary id={id} source={source} routable>
+          <ExtensionBoundary node={node} routable>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { AppNodeSpec } from '../apis';
 import { PortableSchema } from '../schema';
 import { Expand } from '../types';
 import { ExtensionDataRef } from './createExtensionDataRef';
 import { ExtensionInput } from './createExtensionInput';
-import { BackstagePlugin } from './createPlugin';
 
 /** @public */
 export type AnyExtensionDataMap = {
@@ -80,7 +80,7 @@ export interface CreateExtensionOptions<
   output: TOutput;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
-    source?: BackstagePlugin;
+    spec: AppNodeSpec;
     config: TConfig;
     inputs: Expand<ExtensionInputValues<TInputs>>;
   }): Expand<ExtensionDataValues<TOutput>>;
@@ -96,7 +96,7 @@ export interface Extension<TConfig> {
   output: AnyExtensionDataMap;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
-    source?: BackstagePlugin;
+    spec: AppNodeSpec;
     config: TConfig;
     inputs: Record<
       string,

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AppNodeSpec } from '../apis';
+import { AppNode } from '../apis';
 import { PortableSchema } from '../schema';
 import { Expand } from '../types';
 import { ExtensionDataRef } from './createExtensionDataRef';
@@ -80,7 +80,7 @@ export interface CreateExtensionOptions<
   output: TOutput;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
-    spec: AppNodeSpec;
+    node: AppNode;
     config: TConfig;
     inputs: Expand<ExtensionInputValues<TInputs>>;
   }): Expand<ExtensionDataValues<TOutput>>;
@@ -96,7 +96,7 @@ export interface Extension<TConfig> {
   output: AnyExtensionDataMap;
   configSchema?: PortableSchema<TConfig>;
   factory(options: {
-    spec: AppNodeSpec;
+    node: AppNode;
     config: TConfig;
     inputs: Record<
       string,

--- a/plugins/catalog-react/src/alpha.tsx
+++ b/plugins/catalog-react/src/alpha.tsx
@@ -113,7 +113,7 @@ export function createEntityCardExtension<
           .optional(),
       }),
     ),
-    factory({ config, inputs, source }) {
+    factory({ config, inputs, node }) {
       const ExtensionComponent = lazy(() =>
         options
           .loader({ inputs })
@@ -122,7 +122,7 @@ export function createEntityCardExtension<
 
       return {
         element: (
-          <ExtensionBoundary id={id} source={source}>
+          <ExtensionBoundary node={node}>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),
@@ -179,7 +179,7 @@ export function createEntityContentExtension<
           .optional(),
       }),
     ),
-    factory({ config, inputs, source }) {
+    factory({ config, inputs, node }) {
       const ExtensionComponent = lazy(() =>
         options
           .loader({ inputs })
@@ -191,7 +191,7 @@ export function createEntityContentExtension<
         title: config.title,
         routeRef: options.routeRef,
         element: (
-          <ExtensionBoundary id={id} source={source} routable>
+          <ExtensionBoundary node={node} routable>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),

--- a/plugins/catalog/src/alpha/createCatalogFilterExtension.tsx
+++ b/plugins/catalog/src/alpha/createCatalogFilterExtension.tsx
@@ -43,7 +43,7 @@ export function createCatalogFilterExtension<
     output: {
       element: coreExtensionData.reactElement,
     },
-    factory({ config, source }) {
+    factory({ config, node }) {
       const ExtensionComponent = lazy(() =>
         options
           .loader({ config })
@@ -52,7 +52,7 @@ export function createCatalogFilterExtension<
 
       return {
         element: (
-          <ExtensionBoundary id={id} source={source}>
+          <ExtensionBoundary node={node}>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),

--- a/plugins/search-react/src/alpha.tsx
+++ b/plugins/search-react/src/alpha.tsx
@@ -107,7 +107,7 @@ export function createSearchResultListItemExtension<
     output: {
       item: searchResultItemExtensionData,
     },
-    factory({ config, source }) {
+    factory({ config, node }) {
       const ExtensionComponent = lazy(() =>
         options
           .component({ config })
@@ -118,7 +118,7 @@ export function createSearchResultListItemExtension<
         item: {
           predicate: options.predicate,
           component: props => (
-            <ExtensionBoundary id={id} source={source}>
+            <ExtensionBoundary node={node}>
               <SearchResultListItemExtension
                 rank={props.rank}
                 result={props.result}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #19545. Broke this out from the extension ID refactor so that we could keep that one a bit smaller.

We've decided to provide the full `AppNode` to extension factories. This should make it easier to build broader abstractions for use in extensions without needing to forward individual items. In particular this simplifies and avoids mistakes when setting up the `ExtensionBoundary`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
