### PR TITLE
deprecate support for react-router beta

### DIFF
--- a/.changeset/kind-cycles-happen.md
+++ b/.changeset/kind-cycles-happen.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/cli': patch
+---
+
+Added deprecation warning for React Router v6 beta, please make sure you have migrated your apps to use React Router v6 stable as support for the beta version will be removed. See the [migration tutorial](https://backstage.io/docs/tutorials/react-router-stable-migration) for more information.

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -72,6 +72,20 @@ export async function serveBundle(options: ServeOptions) {
         ),
       );
     }
+
+    if (
+      targetPkg.dependencies?.['react-router']?.includes('beta') ||
+      targetPkg.dependencies?.['react-router-dom']?.includes('beta')
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        chalk.yellow(`
+DEPRECATION WARNING: React Router Beta is deprecated and support for it will be removed in a future release.
+                     Please migrate to use React Router v6 stable.
+                     See https://backstage.io/docs/tutorials/react-router-stable-migration
+`),
+      );
+    }
   }
 
   checkReactVersion();

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -240,11 +240,21 @@ export class AppManager implements BackstageApp {
       );
 
       const { routing, featureFlags, routeBindings } = useMemo(() => {
+        const usesReactRouterBeta = isReactRouterBeta();
+        if (usesReactRouterBeta) {
+          // eslint-disable-next-line no-console
+          console.warn(`
+DEPRECATION WARNING: React Router Beta is deprecated and support for it will be removed in a future release.
+                     Please migrate to use React Router v6 stable.
+                     See https://backstage.io/docs/tutorials/react-router-stable-migration
+`);
+        }
+
         const result = traverseElementTree({
           root: children,
           discoverers: [childDiscoverer, routeElementDiscoverer],
           collectors: {
-            routing: isReactRouterBeta()
+            routing: usesReactRouterBeta
               ? routingV1Collector
               : routingV2Collector,
             collectedPlugins: pluginCollector,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Figured it's time to make sure everyone is moved over to React Router v6 stable 😁. Dropping support for it will allow us to move ugly workarounds in a few places, in particular `core-components` has some stuff that could be tidied up.

Running `yarn start`:

<img width="767" alt="image" src="https://github.com/backstage/backstage/assets/4984472/a1d5d0ef-5564-474b-bbc1-24913eaabdbf">



In the browser:

<img width="937" alt="image" src="https://github.com/backstage/backstage/assets/4984472/749c7d4a-9a49-41e1-b4ba-04e6a6113d0d">

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
