### PR TITLE
Bumped the default TechDocs docker image version

### DIFF
--- a/.changeset/stale-bats-end.md
+++ b/.changeset/stale-bats-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Bumped the default TechDocs docker image version to the latest which was released several month ago

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -264,7 +264,7 @@ export class TechdocsGenerator implements GeneratorBase {
     config: Config;
     scmIntegrations: ScmIntegrationRegistry;
   });
-  static readonly defaultDockerImage = 'spotify/techdocs:v1.2.1';
+  static readonly defaultDockerImage = 'spotify/techdocs:v1.2.3';
   static fromConfig(
     config: Config,
     options: GeneratorOptions,

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -53,7 +53,7 @@ export class TechdocsGenerator implements GeneratorBase {
    * The default docker image (and version) used to generate content. Public
    * and static so that techdocs-node consumers can use the same version.
    */
-  public static readonly defaultDockerImage = 'spotify/techdocs:v1.2.1';
+  public static readonly defaultDockerImage = 'spotify/techdocs:v1.2.3';
   private readonly logger: Logger;
   private readonly containerRunner?: ContainerRunner;
   private readonly options: GeneratorConfig;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumped the default TechDocs docker image version

https://github.com/backstage/techdocs-container/releases/tag/v1.2.3

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
