### PR TITLE
Add a section in the migration docs on how to use legacy auth providers with the new backend system

### DIFF
--- a/docs/backend-system/building-backends/08-migrating.md
+++ b/docs/backend-system/building-backends/08-migrating.md
@@ -1042,3 +1042,24 @@ backend.add(import('@backstage/plugin-auth-backend'));
 backend.add(authModuleGoogleProvider);
 /* highlight-add-end */
 ```
+
+#### Using Legacy Providers
+
+Not all authentication providers have been refactored to support the new backend system. If your authentication provider module is not available yet, you will need to import your backend auth plugin using the legacy helper:
+
+```ts title="packages/backend/src/index.ts"
+import { createBackend } from '@backstage/backend-defaults';
+/* highlight-add-next-line */
+import { legacyPlugin } from '@backstage/backend-common';
+import { coreServices } from '@backstage/backend-plugin-api';
+
+const backend = createBackend();
+/* highlight-remove-next-line */
+backend.add(import('@backstage/plugin-auth-backend'));
+/* highlight-add-next-line */
+backend.add(legacyPlugin('auth'), import('./plugins/auth'));
+
+backend.start();
+```
+
+> You can track the progress of the module migration efforts [here](https://github.com/backstage/backstage/issues/19476).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Related to #21288.

- ~~`backstage-cli new` template for backend-plugin exports plugin using `createBackendPlugin` while still exporting `createRouter` to be compatible with both the new and old backend systems~~
- Added tidbit in migrating-to-backend doc in the auth section for using legacy resolvers

---

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))