### PR TITLE
chore(backend-app-api): added redacting of secrets for stack traces that appear in logs

### DIFF
--- a/.changeset/khaki-clocks-happen.md
+++ b/.changeset/khaki-clocks-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Add redacting for secrets in stack traces of logs

--- a/packages/backend-app-api/src/logging/WinstonLogger.test.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.test.ts
@@ -14,25 +14,37 @@
  * limitations under the License.
  */
 
+import { TransformableInfo } from 'logform';
 import { WinstonLogger } from './WinstonLogger';
 
-function msg(message: string) {
-  return { message, level: 'info' };
+function msg(info: TransformableInfo): TransformableInfo {
+  return { message: info.message, level: info.level, stack: info.stack };
 }
 
 describe('WinstonLogger', () => {
   it('redacter should redact and escape regex', () => {
     const redacter = WinstonLogger.redacter();
-    expect(redacter.format.transform(msg('hello (world)'))).toEqual(
-      msg('hello (world)'),
-    );
+    const log = {
+      level: 'error',
+      message: 'hello (world)',
+      stack: 'hello (world) from this file',
+    };
+    expect(redacter.format.transform(msg(log))).toEqual(msg(log));
     redacter.add(['hello']);
-    expect(redacter.format.transform(msg('hello (world)'))).toEqual(
-      msg('[REDACTED] (world)'),
+    expect(redacter.format.transform(msg(log))).toEqual(
+      msg({
+        ...log,
+        message: '[REDACTED] (world)',
+        stack: '[REDACTED] (world) from this file',
+      }),
     );
-    redacter.add(['(world)']);
-    expect(redacter.format.transform(msg('hello (world)'))).toEqual(
-      msg('[REDACTED] [REDACTED]'),
+    redacter.add(['(world']);
+    expect(redacter.format.transform(msg(log))).toEqual(
+      msg({
+        ...log,
+        message: '[REDACTED] [REDACTED])',
+        stack: '[REDACTED] [REDACTED]) from this file',
+      }),
     );
   });
 });

--- a/packages/backend-app-api/src/logging/WinstonLogger.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.ts
@@ -82,6 +82,9 @@ export class WinstonLogger implements RootLoggerService {
         if (redactionPattern && typeof info.message === 'string') {
           info.message = info.message.replace(redactionPattern, '[REDACTED]');
         }
+        if (redactionPattern && typeof info.stack === 'string') {
+          info.stack = info.stack.replace(redactionPattern, '[REDACTED]');
+        }
         return info;
       })(),
       add(newRedactions) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Added secret redacting in stack traces of logs.

Using example issue from #21503, the new behavior would be:
```bash
2023-11-24T02:45:31.619Z catalog error GitlabDiscoveryEntityProvider:my-test-provider refresh failed, TypeError: [REDACTED] is not a legal HTTP header value [REDACTED] is not a legal HTTP header value type=plugin target=GitlabDiscoveryEntityProvider:my-test-provider class=GitlabDiscoveryEntityProvider taskId=GitlabDiscoveryEntityProvider:my-test-provider:refresh taskInstanceId=29d4ad5b-9ed9-4b17-8df5-81885c2db08d stack=TypeError: [REDACTED] is not a legal HTTP header value
    at validateValue (/home/frkong/coding/janus-idp/backstage/node_modules/node-fetch/lib/index.js:684:9)
    at Headers.append (/home/frkong/coding/janus-idp/backstage/node_modules/node-fetch/lib/index.js:836:3)
    at Headers (/home/frkong/coding/janus-idp/backstage/node_modules/node-fetch/lib/index.js:761:11)
    at Request (/home/frkong/coding/janus-idp/backstage/node_modules/node-fetch/lib/index.js:1231:19)
    at <anonymous> (/home/frkong/coding/janus-idp/backstage/node_modules/node-fetch/lib/index.js:1449:19)
    at new Promise (<anonymous>)
    at fetch (/home/frkong/coding/janus-idp/backstage/node_modules/node-fetch/lib/index.js:1447:9)
    at GitLabClient.pagedRequest (/home/frkong/coding/janus-idp/backstage/plugins/catalog-backend-module-gitlab/src/lib/client.ts:330:28)
    at GitLabClient.listProjects (/home/frkong/coding/janus-idp/backstage/plugins/catalog-backend-module-gitlab/src/lib/client.ts:68:19)
    at projects.archived (/home/frkong/coding/janus-idp/backstage/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts:159:25)
    at paginated (/home/frkong/coding/janus-idp/backstage/plugins/catalog-backend-module-gitlab/src/lib/client.ts:370:17)
    at paginated.next (<anonymous>)
    at GitlabDiscoveryEntityProvider.refresh (/home/frkong/coding/janus-idp/backstage/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts:173:22)
    at fn (/home/frkong/coding/janus-idp/backstage/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts:134:24)
    at TaskWorker.fn (/home/frkong/coding/janus-idp/backstage/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.ts:134:15)
    at TaskWorker.runOnce (/home/frkong/coding/janus-idp/backstage/packages/backend-tasks/src/tasks/TaskWorker.ts:155:18)
```
Fixes #21503 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
