### PR TITLE
Update custom permission rule documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ yarn build:api-reports # Build API Reports used for documentation
 
 yarn lint # lint packages that have changed since later commit on origin/master
 yarn lint:all # lint all packages
-yarn lind:docs # lint all the Markdown files
+yarn lint:docs # lint all the Markdown files
 yarn lint:type-deps # verify that @types/* dependencies are placed correctly in packages
 
 yarn test # test packages that have changed since later commit on origin/master

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -8,9 +8,9 @@ For some use cases, you may want to define custom [rules](./concepts.md#resource
 
 ## Define a custom rule
 
-Plugins should export a rule factory that provides type-safety that ensures compatibility with the plugin's backend. The catalog plugin exports `createCatalogPermissionRule` from `@backstage/plugin-catalog-backend/alpha` for this purpose. Note: the `/alpha` path segment is temporary until this API is marked as stable. For this example, we'll define the rule in `packages/backend/src/plugins/permission.ts`, but you can put it anywhere that's accessible by your `backend` package.
+Plugins should export a rule factory that provides type-safety that ensures compatibility with the plugin's backend. The catalog plugin exports `createCatalogPermissionRule` from `@backstage/plugin-catalog-backend/alpha` for this purpose. Note: the `/alpha` path segment is temporary until this API is marked as stable. For this example, we'll define the rule in `packages/backend/src/customPermissionRules/isInSystem`, but you can put it anywhere that's accessible by your `backend` package.
 
-```typescript title="packages/backend/src/plugins/permission.ts"
+```typescript title="packages/backend/src/customPermissionRules/isInSystem.ts"
 import type { Entity } from '@backstage/catalog-model';
 import { createCatalogPermissionRule } from '@backstage/plugin-catalog-backend/alpha';
 import { createConditionFactory } from '@backstage/plugin-permission-node';
@@ -40,7 +40,7 @@ export const isInSystemRule = createCatalogPermissionRule({
   }),
 });
 
-const isInSystem = createConditionFactory(isInSystemRule);
+export const isInSystemRuleFactory = createConditionFactory(isInSystemRule);
 ```
 
 For a more detailed explanation on defining rules, refer to the [documentation for plugin authors](./plugin-authors/03-adding-a-resource-permission-check.md#adding-support-for-conditional-decisions).
@@ -52,9 +52,8 @@ Now that we have a custom rule defined, we need provide it to the catalog plugin
 The api for providing custom rules may differ between plugins, but there should typically be some integration point during the creation of the backend router. For the catalog, this integration point is exposed via `CatalogBuilder.addPermissionRules`.
 
 ```typescript title="packages/backend/src/plugins/catalog.ts"
-import { isInSystemRule } from './permission';
-// The CatalogBuilder with the addPermissionRules function is in the alpha path
-import { CatalogBuilder } from '@backstage/plugin-catalog-backend/alpha';
+import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import { isInSystemRule } from '../customPermissionRules/isInSystem';
 
 ...
 
@@ -76,7 +75,8 @@ Let's bring this all together by extending the example policy from the previous 
 
 ```ts title="packages/backend/src/plugins/permission.ts"
 /* highlight-add-next-line */
-import { isInSystem } from './catalog';
+...
+import { isInSystemRuleFactory } from '../customPermissionRules/isInSystem';
 
 class TestPermissionPolicy implements PermissionPolicy {
   async handle(
@@ -97,7 +97,7 @@ class TestPermissionPolicy implements PermissionPolicy {
             catalogConditions.isEntityOwner({
               claims: user?.identity.ownershipEntityRefs ?? []
             }),
-            isInSystem('interviewing')
+            isInSystemRuleFactory({ systemRef: 'interviewing' }),
           ]
         }
         /* highlight-add-end */
@@ -106,6 +106,9 @@ class TestPermissionPolicy implements PermissionPolicy {
 
     return { result: AuthorizeResult.ALLOW };
   }
+}
+
+...
 ```
 
 The updated policy will allow catalog entity resource permissions if any of the following are true:

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -74,8 +74,8 @@ The new rule is now ready for use in a permission policy!
 Let's bring this all together by extending the example policy from the previous section.
 
 ```ts title="packages/backend/src/plugins/permission.ts"
-/* highlight-add-next-line */
 ...
+/* highlight-add-next-line */
 import { isInSystemRuleFactory } from '../customPermissionRules/isInSystem';
 
 class TestPermissionPolicy implements PermissionPolicy {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the custom permission rule documentation to fix several inaccuracies and improve the readability of the document.

### Updated sections

We now use a new folder and file to make a distinction between the permissions plugin and the customer rule.
<img width="987" alt="Screenshot 2023-11-24 at 12 40 33" src="https://github.com/backstage/backstage/assets/25782443/606c8979-0f4b-48fe-8ff5-5da139236337">

Updated naming make it clear when we are using the rule (used in catalog plugin) versus the factory (used in permissions plugin).
<img width="1022" alt="Screenshot 2023-11-24 at 12 40 47" src="https://github.com/ba
<img width="1008" alt="Screenshot 2023-11-24 at 12 42 15" src="https://github.com/backstage/backstage/assets/25782443/d1a0e054-3572-4129-819b-551077ecc212">
ckstage/backstage/assets/25782443/69924436-149e-4b23-b48e-bf4c95f0daa8">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
