### PR TITLE
core-plugin-api: update createTranslationRef to support nested messages and use camelCase keys

### DIFF
--- a/.changeset/famous-flies-kick.md
+++ b/.changeset/famous-flies-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+The `createTranslationRef` function from the `/alpha` subpath can now also accept a nested object structure of default translation messages, which will be flatted using `.` separators.

--- a/.changeset/silver-rocks-deliver.md
+++ b/.changeset/silver-rocks-deliver.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-user-settings': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-adr': patch
+---
+
+Updated alpha translation message keys to use nested format and camel case.

--- a/docs/plugins/internationalization.md
+++ b/docs/plugins/internationalization.md
@@ -10,7 +10,7 @@ The Backstage core function provides internationalization for plugins
 
 ## For a plugin developer
 
-When you are creating your plugin, you have the possibility to use `createTranslationRef` to define all messages for your plugin. For example
+When you are creating your plugin, you have the possibility to use `createTranslationRef` to define all messages for your plugin. For example:
 
 ```ts
 import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
@@ -19,8 +19,13 @@ import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
 export const myPluginTranslationRef = createTranslationRef({
   id: 'plugin.my-plugin',
   messages: {
-    index_page_title: 'All your components',
-    create_component_button_label: 'Create new component',
+    indexPage: {
+      title: 'All your components',
+      createButtonTitle: 'Create new component',
+    },
+    entityPage: {
+      notFound: 'Entity not found',
+    },
   },
 });
 ```
@@ -33,9 +38,9 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 const { t } = useTranslationRef(myPluginTranslationRef);
 
 return (
-  <PageHeader title={t('index_page_title')}>
+  <PageHeader title={t('indexPage.title')}>
     <Button onClick={handleCreateComponent}>
-      {t('create_component_button_label')}
+      {t('indexPage.createButtonTitle')}
     </Button>
   </PageHeader>
 );
@@ -53,7 +58,7 @@ In an app you can both override the default messages, as well as register transl
 +      createTranslationMessages({
 +        ref: myPluginTranslationRef,
 +        messages: {
-+          create_component_button_label: 'Create new entity',
++          'indexPage.createButtonTitle': 'Create new entity',
 +        },
 +      }),
 +      createTranslationResource({

--- a/packages/core-plugin-api/alpha-api-report.md
+++ b/packages/core-plugin-api/alpha-api-report.md
@@ -39,19 +39,17 @@ export function createTranslationMessages<
 // @alpha (undocumented)
 export function createTranslationRef<
   TId extends string,
-  const TMessages extends {
-    [key in string]: string;
-  },
+  const TNestedMessages extends AnyNestedMessages,
   TTranslations extends {
     [language in string]: () => Promise<{
       default: {
-        [key in keyof TMessages]: string | null;
+        [key in keyof FlattenedMessages<TNestedMessages>]: string | null;
       };
     }>;
   },
 >(
-  config: TranslationRefOptions<TId, TMessages, TTranslations>,
-): TranslationRef<TId, TMessages>;
+  config: TranslationRefOptions<TId, TNestedMessages, TTranslations>,
+): TranslationRef<TId, FlattenedMessages<TNestedMessages>>;
 
 // @alpha (undocumented)
 export function createTranslationResource<
@@ -169,13 +167,11 @@ export interface TranslationRef<
 // @alpha (undocumented)
 export interface TranslationRefOptions<
   TId extends string,
-  TMessages extends {
-    [key in string]: string;
-  },
+  TNestedMessages extends AnyNestedMessages,
   TTranslations extends {
     [language in string]: () => Promise<{
       default: {
-        [key in keyof TMessages]: string | null;
+        [key in keyof FlattenedMessages<TNestedMessages>]: string | null;
       };
     }>;
   },
@@ -183,7 +179,7 @@ export interface TranslationRefOptions<
   // (undocumented)
   id: TId;
   // (undocumented)
-  messages: TMessages;
+  messages: TNestedMessages;
   // (undocumented)
   translations?: TTranslations;
 }

--- a/packages/core-plugin-api/src/translation/TranslationRef.test.ts
+++ b/packages/core-plugin-api/src/translation/TranslationRef.test.ts
@@ -34,6 +34,40 @@ describe('TranslationRefImpl', () => {
     expect(internalRef.getDefaultMessages()).toEqual({ key: 'value' });
   });
 
+  it('should create a TranslationRef instance with nested messages', () => {
+    const ref = createTranslationRef({
+      id: 'test',
+      messages: {
+        key: 'value',
+        'nested.conflict1': 'outer conflict1',
+        nested: {
+          key: 'nested value',
+          key2: 'nested value2',
+          conflict1: 'inner conflict1',
+          conflict2: 'inner conflict2',
+          inner: {
+            key: 'inner value',
+          },
+        },
+        'nested.conflict2': 'outer conflict2',
+      },
+    });
+
+    const internalRef = toInternalTranslationRef(ref);
+
+    expect(internalRef.$$type).toBe('@backstage/TranslationRef');
+    expect(internalRef.version).toBe('v1');
+    expect(internalRef.id).toBe('test');
+    expect(internalRef.getDefaultMessages()).toEqual({
+      key: 'value',
+      'nested.key': 'nested value',
+      'nested.key2': 'nested value2',
+      'nested.conflict1': 'inner conflict1',
+      'nested.inner.key': 'inner value',
+      'nested.conflict2': 'outer conflict2',
+    });
+  });
+
   it('should be created with lazy translations', async () => {
     const ref = createTranslationRef({
       id: 'test',

--- a/plugins/adr/alpha-api-report.md
+++ b/plugins/adr/alpha-api-report.md
@@ -17,9 +17,9 @@ export const AdrSearchResultListItemExtension: Extension<{
 export const adrTranslationRef: TranslationRef<
   'adr',
   {
-    readonly content_header_title: 'Architecture Decision Records';
-    readonly failed_to_fetch: 'Failed to fetch ADRs';
-    readonly no_adrs: 'No ADRs found';
+    readonly contentHeaderTitle: 'Architecture Decision Records';
+    readonly failedToFetch: 'Failed to fetch ADRs';
+    readonly notFound: 'No ADRs found';
   }
 >;
 

--- a/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
+++ b/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
@@ -219,7 +219,7 @@ export const EntityAdrContent = (props: {
 
   return (
     <Content>
-      <ContentHeader title={t('content_header_title')}>
+      <ContentHeader title={t('contentHeaderTitle')}>
         {appSupportConfigured && <SupportButton />}
       </ContentHeader>
 
@@ -230,7 +230,7 @@ export const EntityAdrContent = (props: {
       {loading && <Progress />}
 
       {entityHasAdrs && !loading && error && (
-        <WarningPanel title={t('failed_to_fetch')} message={error?.message} />
+        <WarningPanel title={t('failedToFetch')} message={error?.message} />
       )}
 
       {entityHasAdrs &&
@@ -257,7 +257,7 @@ export const EntityAdrContent = (props: {
             </Grid>
           </Grid>
         ) : (
-          <Typography>{t('no_adrs')}</Typography>
+          <Typography>{t('notFound')}</Typography>
         ))}
     </Content>
   );

--- a/plugins/adr/src/translations.ts
+++ b/plugins/adr/src/translations.ts
@@ -19,8 +19,8 @@ import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
 export const adrTranslationRef = createTranslationRef({
   id: 'adr',
   messages: {
-    content_header_title: 'Architecture Decision Records',
-    failed_to_fetch: 'Failed to fetch ADRs',
-    no_adrs: 'No ADRs found',
+    contentHeaderTitle: 'Architecture Decision Records',
+    failedToFetch: 'Failed to fetch ADRs',
+    notFound: 'No ADRs found',
   },
 });

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -62,11 +62,11 @@ export function BaseCatalogPage(props: BaseCatalogPageProps) {
   const { t } = useTranslationRef(catalogTranslationRef);
 
   return (
-    <PageWithHeader title={t('catalog_page_title', { orgName })} themeId="home">
+    <PageWithHeader title={t('indexPage.title', { orgName })} themeId="home">
       <Content>
         <ContentHeader title="">
           <CreateButton
-            title={t('catalog_page_create_button_title')}
+            title={t('indexPage.createButtonTitle')}
             to={createComponentLink && createComponentLink()}
           />
           <SupportButton>All your software catalog entities</SupportButton>

--- a/plugins/catalog/src/translation.ts
+++ b/plugins/catalog/src/translation.ts
@@ -20,7 +20,9 @@ import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
 export const catalogTranslationRef = createTranslationRef({
   id: 'catalog',
   messages: {
-    catalog_page_title: `{{orgName}} Catalog`,
-    catalog_page_create_button_title: 'Create',
+    indexPage: {
+      title: `{{orgName}} Catalog`,
+      createButtonTitle: 'Create',
+    },
   },
 });

--- a/plugins/user-settings/alpha-api-report.md
+++ b/plugins/user-settings/alpha-api-report.md
@@ -20,16 +20,16 @@ export default _default;
 export const userSettingsTranslationRef: TranslationRef<
   'user-settings',
   {
-    readonly language: 'Language';
-    readonly change_the_language: 'Change the language';
-    readonly theme: 'Theme';
-    readonly theme_light: 'Light';
-    readonly theme_dark: 'Dark';
-    readonly theme_auto: 'Auto';
-    readonly change_the_theme_mode: 'Change the theme mode';
-    readonly select_theme: 'Select {{theme}}';
-    readonly select_theme_auto: 'Select Auto Theme';
-    readonly select_lng: 'Select language {{language}}';
+    readonly 'languageToggle.select': 'Select language {{language}}';
+    readonly 'languageToggle.title': 'Language';
+    readonly 'languageToggle.description': 'Change the language';
+    readonly 'themeToggle.select': 'Select theme {{theme}}';
+    readonly 'themeToggle.title': 'Theme';
+    readonly 'themeToggle.description': 'Change the theme mode';
+    readonly 'themeToggle.names.auto': 'Auto';
+    readonly 'themeToggle.names.dark': 'Dark';
+    readonly 'themeToggle.names.light': 'Light';
+    readonly 'themeToggle.selectAuto': 'Select Auto Theme';
   }
 >;
 

--- a/plugins/user-settings/src/components/General/UserSettingsLanguageToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsLanguageToggle.tsx
@@ -118,8 +118,8 @@ export const UserSettingsLanguageToggle = () => {
     >
       <ListItemText
         className={classes.listItemText}
-        primary={t('language')}
-        secondary={t('change_the_language')}
+        primary={t('languageToggle.title')}
+        secondary={t('languageToggle.description')}
       />
       <ListItemSecondaryAction className={classes.listItemSecondaryAction}>
         <ToggleButtonGroup
@@ -132,7 +132,7 @@ export const UserSettingsLanguageToggle = () => {
             return (
               <TooltipToggleButton
                 key={language}
-                title={t('select_lng', { language })}
+                title={t('languageToggle.select', { language })}
                 value={language}
               >
                 <>{language}</>

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
@@ -130,8 +130,8 @@ export const UserSettingsThemeToggle = () => {
     >
       <ListItemText
         className={classes.listItemText}
-        primary={t('theme')}
-        secondary={t('change_the_theme_mode')}
+        primary={t('themeToggle.title')}
+        secondary={t('themeToggle.description')}
       />
       <ListItemSecondaryAction className={classes.listItemSecondaryAction}>
         <ToggleButtonGroup
@@ -146,12 +146,12 @@ export const UserSettingsThemeToggle = () => {
             const themeTitle =
               theme.title ||
               (themeId === 'light' || themeId === 'dark'
-                ? t(`theme_${themeId}`)
+                ? t(`themeToggle.names.${themeId}`)
                 : themeId);
             return (
               <TooltipToggleButton
                 key={themeId}
-                title={t('select_theme', { theme: themeTitle })}
+                title={t('themeToggle.select', { theme: themeTitle })}
                 value={themeId}
               >
                 <>
@@ -165,9 +165,9 @@ export const UserSettingsThemeToggle = () => {
               </TooltipToggleButton>
             );
           })}
-          <Tooltip placement="top" arrow title={t('select_theme_auto')}>
+          <Tooltip placement="top" arrow title={t('themeToggle.selectAuto')}>
             <ToggleButton value="auto" selected={activeThemeId === undefined}>
-              {t('theme_auto')}&nbsp;
+              {t('themeToggle.names.auto')}&nbsp;
               <AutoIcon
                 color={activeThemeId === undefined ? 'primary' : undefined}
               />

--- a/plugins/user-settings/src/translation.ts
+++ b/plugins/user-settings/src/translation.ts
@@ -20,15 +20,21 @@ import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
 export const userSettingsTranslationRef = createTranslationRef({
   id: 'user-settings',
   messages: {
-    language: 'Language',
-    change_the_language: 'Change the language',
-    theme: 'Theme',
-    theme_light: 'Light',
-    theme_dark: 'Dark',
-    theme_auto: 'Auto',
-    change_the_theme_mode: 'Change the theme mode',
-    select_theme: 'Select {{theme}}',
-    select_theme_auto: 'Select Auto Theme',
-    select_lng: 'Select language {{language}}',
+    languageToggle: {
+      title: 'Language',
+      description: 'Change the language',
+      select: 'Select language {{language}}',
+    },
+    themeToggle: {
+      title: 'Theme',
+      description: 'Change the theme mode',
+      select: 'Select theme {{theme}}',
+      selectAuto: 'Select Auto Theme',
+      names: {
+        light: 'Light',
+        dark: 'Dark',
+        auto: 'Auto',
+      },
+    },
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is work towards #21267, it switches the translation key format to `camelCaseKeys.withDotSeparators`. The camel case keys is in line with i18next, see for example https://www.i18next.com/translation-function/formatting. This switch is also necessary to avoid confusion with [plural keys](https://www.i18next.com/translation-function/plurals), which rely on `_`-separated suffixes. I'm not sure about the dot separators though, but it seems sensible and haven't found any issues so far. It also works well with the other feature introduced in this PR, which is that messages can now be declared using a nested structure that will be immediately flattened out. This nested structure is only supported for `createTranslationRef` itself, and not when defining translation messages or resources.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
