### PR TITLE
frontend-plugin-api: use api ref ID as namespace + allow namespace override for plugins

### DIFF
--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -97,12 +97,10 @@ const signInPage = createSignInPageExtension({
 });
 
 const scmAuthExtension = createApiExtension({
-  name: 'scm-auth',
   factory: ScmAuth.createDefaultApiFactory(),
 });
 
 const scmIntegrationApi = createApiExtension({
-  name: 'scm-integration',
   factory: createApiFactory({
     api: scmIntegrationsApiRef,
     deps: { configApi: configApiRef },

--- a/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
@@ -55,7 +55,7 @@ describe('collectLegacyRoutes', () => {
             defaultConfig: { path: 'score-board' },
           },
           {
-            id: 'api:score-card',
+            id: 'api:plugin.scoringdata.service',
             attachTo: { id: 'core', input: 'apis' },
             disabled: false,
           },
@@ -71,7 +71,7 @@ describe('collectLegacyRoutes', () => {
             defaultConfig: { path: 'stackstorm' },
           },
           {
-            id: 'api:stackstorm',
+            id: 'api:plugin.stackstorm.service',
             attachTo: { id: 'core', input: 'apis' },
             disabled: false,
           },
@@ -93,7 +93,7 @@ describe('collectLegacyRoutes', () => {
             defaultConfig: { path: 'puppetdb' },
           },
           {
-            id: 'api:puppetDb',
+            id: 'api:plugin.puppetdb.service',
             attachTo: { id: 'core', input: 'apis' },
             disabled: false,
           },

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -130,11 +130,8 @@ export function collectLegacyRoutes(
       id: plugin.getId(),
       extensions: [
         ...extensions,
-        ...Array.from(plugin.getApis()).map((factory, index) =>
-          createApiExtension({
-            factory,
-            name: index > 0 ? String(index + 1) : undefined,
-          }),
+        ...Array.from(plugin.getApis()).map(factory =>
+          createApiExtension({ factory }),
         ),
       ],
     }),

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -65,7 +65,7 @@ describe('convertLegacyApp', () => {
             defaultConfig: { path: 'score-board' },
           },
           {
-            id: 'api:score-card',
+            id: 'api:plugin.scoringdata.service',
             attachTo: { id: 'core', input: 'apis' },
             disabled: false,
           },
@@ -81,7 +81,7 @@ describe('convertLegacyApp', () => {
             defaultConfig: { path: 'stackstorm' },
           },
           {
-            id: 'api:stackstorm',
+            id: 'api:plugin.stackstorm.service',
             attachTo: { id: 'core', input: 'apis' },
             disabled: false,
           },
@@ -103,7 +103,7 @@ describe('convertLegacyApp', () => {
             defaultConfig: { path: 'puppetdb' },
           },
           {
-            id: 'api:puppetDb',
+            id: 'api:plugin.puppetdb.service',
             attachTo: { id: 'core', input: 'apis' },
             disabled: false,
           },

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -270,18 +270,23 @@ export const coreExtensionData: {
 export function createApiExtension<
   TConfig extends {},
   TInputs extends AnyExtensionInputMap,
->(options: {
-  factory:
-    | AnyApiFactory
-    | ((options: {
-        config: TConfig;
-        inputs: Expand<ExtensionInputValues<TInputs>>;
-      }) => AnyApiFactory);
-  namespace?: string;
-  name?: string;
-  configSchema?: PortableSchema<TConfig>;
-  inputs?: TInputs;
-}): ExtensionDefinition<TConfig>;
+>(
+  options: (
+    | {
+        api: AnyApiRef;
+        factory: (options: {
+          config: TConfig;
+          inputs: Expand<ExtensionInputValues<TInputs>>;
+        }) => AnyApiFactory;
+      }
+    | {
+        factory: AnyApiFactory;
+      }
+  ) & {
+    configSchema?: PortableSchema<TConfig>;
+    inputs?: TInputs;
+  },
+): ExtensionDefinition<TConfig>;
 
 export { createApiFactory };
 

--- a/packages/frontend-plugin-api/src/extensions/createApiExtension.test.ts
+++ b/packages/frontend-plugin-api/src/extensions/createApiExtension.test.ts
@@ -33,31 +33,7 @@ describe('createApiExtension', () => {
     ).toEqual({
       $$type: '@backstage/ExtensionDefinition',
       kind: 'api',
-      attachTo: { id: 'core', input: 'apis' },
-      disabled: false,
-      configSchema: undefined,
-      inputs: {},
-      output: {
-        api: expect.objectContaining({
-          $$type: '@backstage/ExtensionDataRef',
-          id: 'core.api.factory',
-          config: {},
-        }),
-      },
-      factory: expect.any(Function),
-    });
-
-    expect(
-      createApiExtension({
-        factory,
-        namespace: 'ns',
-        name: 'n',
-      }),
-    ).toEqual({
-      $$type: '@backstage/ExtensionDefinition',
-      kind: 'api',
-      namespace: 'ns',
-      name: 'n',
+      namespace: 'test',
       attachTo: { id: 'core', input: 'apis' },
       disabled: false,
       configSchema: undefined,
@@ -78,6 +54,7 @@ describe('createApiExtension', () => {
     const factory = jest.fn(() => ({ foo: 'bar' }));
 
     const extension = createApiExtension({
+      api,
       inputs: {},
       factory({ config: _config, inputs: _inputs }) {
         return createApiFactory({
@@ -91,6 +68,7 @@ describe('createApiExtension', () => {
     expect(extension).toEqual({
       $$type: '@backstage/ExtensionDefinition',
       kind: 'api',
+      namespace: 'test',
       attachTo: { id: 'core', input: 'apis' },
       disabled: false,
       configSchema: undefined,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -22,7 +22,7 @@ export function resolveExtensionDefinition<TConfig>(
   context?: { namespace?: string },
 ): Extension<TConfig> {
   const { name, kind, namespace: _, ...rest } = definition;
-  const namespace = context?.namespace ?? definition.namespace;
+  const namespace = definition.namespace ?? context?.namespace;
 
   const namePart =
     name && namespace ? `${namespace}/${name}` : namespace || name;

--- a/plugins/catalog/src/alpha/apis.tsx
+++ b/plugins/catalog/src/alpha/apis.tsx
@@ -41,7 +41,6 @@ export const CatalogApi = createApiExtension({
 });
 
 export const StarredEntitiesApi = createApiExtension({
-  name: 'starred-entities',
   factory: createApiFactory({
     api: starredEntitiesApiRef,
     deps: { storageApi: storageApiRef },

--- a/plugins/graphiql/src/alpha.tsx
+++ b/plugins/graphiql/src/alpha.tsx
@@ -57,7 +57,7 @@ const endpointDataRef = createExtensionDataRef<GraphQLEndpoint>(
 
 /** @alpha */
 export const graphiqlBrowseApi = createApiExtension({
-  name: 'browse',
+  api: graphQlBrowseApiRef,
   inputs: {
     endpoints: createExtensionInput({
       endpoint: endpointDataRef,

--- a/plugins/tech-radar/src/alpha.tsx
+++ b/plugins/tech-radar/src/alpha.tsx
@@ -49,9 +49,7 @@ export const TechRadarPage = createPageExtension({
 
 /** @alpha */
 export const sampleTechRadarApi = createApiExtension({
-  factory() {
-    return createApiFactory(techRadarApiRef, new SampleTechRadarApi());
-  },
+  factory: createApiFactory(techRadarApiRef, new SampleTechRadarApi()),
 });
 
 /** @alpha */

--- a/plugins/techdocs/src/alpha.tsx
+++ b/plugins/techdocs/src/alpha.tsx
@@ -46,45 +46,40 @@ import { createEntityContentExtension } from '@backstage/plugin-catalog-react/al
 
 /** @alpha */
 const techDocsStorage = createApiExtension({
-  name: 'storage',
-  factory() {
-    return createApiFactory({
-      api: techdocsStorageApiRef,
-      deps: {
-        configApi: configApiRef,
-        discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
-        fetchApi: fetchApiRef,
-      },
-      factory: ({ configApi, discoveryApi, identityApi, fetchApi }) =>
-        new TechDocsStorageClient({
-          configApi,
-          discoveryApi,
-          identityApi,
-          fetchApi,
-        }),
-    });
-  },
+  factory: createApiFactory({
+    api: techdocsStorageApiRef,
+    deps: {
+      configApi: configApiRef,
+      discoveryApi: discoveryApiRef,
+      identityApi: identityApiRef,
+      fetchApi: fetchApiRef,
+    },
+    factory: ({ configApi, discoveryApi, identityApi, fetchApi }) =>
+      new TechDocsStorageClient({
+        configApi,
+        discoveryApi,
+        identityApi,
+        fetchApi,
+      }),
+  }),
 });
 
 /** @alpha */
 const techDocsClient = createApiExtension({
-  factory() {
-    return createApiFactory({
-      api: techdocsApiRef,
-      deps: {
-        configApi: configApiRef,
-        discoveryApi: discoveryApiRef,
-        fetchApi: fetchApiRef,
-      },
-      factory: ({ configApi, discoveryApi, fetchApi }) =>
-        new TechDocsClient({
-          configApi,
-          discoveryApi,
-          fetchApi,
-        }),
-    });
-  },
+  factory: createApiFactory({
+    api: techdocsApiRef,
+    deps: {
+      configApi: configApiRef,
+      discoveryApi: discoveryApiRef,
+      fetchApi: fetchApiRef,
+    },
+    factory: ({ configApi, discoveryApi, fetchApi }) =>
+      new TechDocsClient({
+        configApi,
+        discoveryApi,
+        fetchApi,
+      }),
+  }),
 });
 
 /** @alpha */


### PR DESCRIPTION
On top of #21481, this fixes the awkwardness of API extensions with the new naming system in that PR. The one change needed is to deprioritize the namespace provided by context when converting extension definitions. In practice it means that plugins will be able to defined extensions for a different namespace than their own. My current feeling is that that is likely not a big deal, but if it turns out to be an issue we could revert that particular change and add some slightly uglier workaround such having the resolve function treat `api` extensions differently.

Another solution would be to be able to explicitly mark some extension definitions as not being able to have a namespace, something like passing `namespace: null` to `createExtension`, and then just setting the `name` to the `apiRef.id` instead. LMK what you thinking 😁 