### PR TITLE
fix presentation icon passing

### DIFF
--- a/.changeset/fifty-cameras-share.md
+++ b/.changeset/fifty-cameras-share.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog': patch
+---
+
+Ensure that passed-in icons are taken advantage of in the presentation API

--- a/plugins/catalog-react/src/apis/EntityPresentationApi/defaultEntityPresentation.test.ts
+++ b/plugins/catalog-react/src/apis/EntityPresentationApi/defaultEntityPresentation.test.ts
@@ -37,7 +37,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'test',
         secondaryTitle: 'component:default/test | type | desc',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(
@@ -58,7 +58,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'title',
         secondaryTitle: 'component:default/test | type | desc',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(
@@ -82,7 +82,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'displayName',
         secondaryTitle: 'component:default/test | type | desc',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
 
@@ -96,7 +96,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
 
@@ -107,7 +107,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'unknown:default/unknown',
         primaryTitle: 'unknown',
         secondaryTitle: 'unknown:default/unknown',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
   });
@@ -118,7 +118,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(
@@ -129,7 +129,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'component:test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(
@@ -140,7 +140,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'default/test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
 
@@ -149,14 +149,14 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'unknown:default/unknown',
         primaryTitle: 'unknown',
         secondaryTitle: 'unknown:default/unknown',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(defaultEntityPresentation('name')).toEqual({
         entityRef: 'unknown:default/name',
         primaryTitle: 'name',
         secondaryTitle: 'unknown:default/name',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
   });
@@ -173,7 +173,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(
@@ -187,7 +187,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'component:test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(
@@ -201,7 +201,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'default/test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
 
@@ -217,14 +217,14 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'component:default/test',
         primaryTitle: 'default/test',
         secondaryTitle: 'component:default/test',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(defaultEntityPresentation('')).toEqual({
         entityRef: 'unknown:default/unknown',
         primaryTitle: 'unknown',
         secondaryTitle: 'unknown:default/unknown',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
   });
@@ -235,7 +235,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'unknown:default/unknown',
         primaryTitle: 'unknown',
         secondaryTitle: 'unknown:default/unknown',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
 
       expect(defaultEntityPresentation(undefined as unknown as Entity)).toEqual(
@@ -243,7 +243,7 @@ describe('defaultEntityPresentation', () => {
           entityRef: 'unknown:default/unknown',
           primaryTitle: 'unknown',
           secondaryTitle: 'unknown:default/unknown',
-          Icon: expect.anything(),
+          Icon: undefined,
         },
       );
 
@@ -253,7 +253,7 @@ describe('defaultEntityPresentation', () => {
         entityRef: 'unknown:default/unknown',
         primaryTitle: 'unknown',
         secondaryTitle: 'unknown:default/unknown',
-        Icon: expect.anything(),
+        Icon: undefined,
       });
     });
   });

--- a/plugins/catalog-react/src/apis/EntityPresentationApi/defaultEntityPresentation.ts
+++ b/plugins/catalog-react/src/apis/EntityPresentationApi/defaultEntityPresentation.ts
@@ -20,33 +20,8 @@ import {
   Entity,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { IconComponent } from '@backstage/core-plugin-api';
-import ApartmentIcon from '@material-ui/icons/Apartment';
-import BusinessIcon from '@material-ui/icons/Business';
-import ExtensionIcon from '@material-ui/icons/Extension';
-import HelpIcon from '@material-ui/icons/Help';
-import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
-import LocationOnIcon from '@material-ui/icons/LocationOn';
-import MemoryIcon from '@material-ui/icons/Memory';
-import PeopleIcon from '@material-ui/icons/People';
-import PersonIcon from '@material-ui/icons/Person';
-import WorkIcon from '@material-ui/icons/Work';
 import get from 'lodash/get';
 import { EntityRefPresentationSnapshot } from './EntityPresentationApi';
-
-const UNKNOWN_KIND_ICON: IconComponent = HelpIcon;
-
-const DEFAULT_ICONS: Record<string, IconComponent> = {
-  api: ExtensionIcon,
-  component: MemoryIcon,
-  system: BusinessIcon,
-  resource: WorkIcon,
-  domain: ApartmentIcon,
-  location: LocationOnIcon,
-  user: PersonIcon,
-  group: PeopleIcon,
-  template: LibraryAddIcon,
-};
 
 /**
  * This returns the default representation of an entity.
@@ -67,10 +42,6 @@ export function defaultEntityPresentation(
   // some form of result without crashing.
   const { kind, namespace, name, title, description, displayName, type } =
     getParts(entityOrRef);
-
-  const Icon =
-    (kind && DEFAULT_ICONS[kind.toLocaleLowerCase('en-US')]) ||
-    UNKNOWN_KIND_ICON;
 
   const entityRef: string = stringifyEntityRef({
     kind: kind || 'unknown',
@@ -96,7 +67,7 @@ export function defaultEntityPresentation(
     entityRef,
     primaryTitle: primary,
     secondaryTitle: secondary || undefined,
-    Icon,
+    Icon: undefined, // leave it up to the presentation API to handle
   };
 }
 

--- a/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.ts
+++ b/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_BATCH_DELAY,
   DEFAULT_CACHE_TTL,
   DEFAULT_ICONS,
+  UNKNOWN_KIND_ICON,
   createDefaultRenderer,
 } from './defaults';
 
@@ -134,10 +135,7 @@ export interface DefaultEntityPresentationApiOptions {
    * @remarks
    *
    * The keys are kinds (case insensitive) that map to icon values to represent
-   * kinds by.
-   *
-   * If you do not supply a set of icons here, a set of fallback icons will be
-   * used. If you supply the empty object, no fallback icons will be used.
+   * kinds by. These are merged with the default set of icons.
    */
   kindIcons?: Record<string, IconComponent>;
 
@@ -194,11 +192,12 @@ export class DefaultEntityPresentationApi implements EntityPresentationApi {
     const renderer = options.renderer ?? createDefaultRenderer({ async: true });
 
     const kindIcons: Record<string, IconComponent> = {};
-    Object.entries(options.kindIcons ?? DEFAULT_ICONS).forEach(
-      ([kind, icon]) => {
-        kindIcons[kind.toLocaleLowerCase('en-US')] = icon;
-      },
-    );
+    Object.entries(DEFAULT_ICONS).forEach(([kind, icon]) => {
+      kindIcons[kind.toLocaleLowerCase('en-US')] = icon;
+    });
+    Object.entries(options.kindIcons ?? {}).forEach(([kind, icon]) => {
+      kindIcons[kind.toLocaleLowerCase('en-US')] = icon;
+    });
 
     if (renderer.async) {
       if (!options.catalogApi) {
@@ -396,6 +395,8 @@ export class DefaultEntityPresentationApi implements EntityPresentationApi {
       return false;
     }
 
-    return this.#kindIcons[kind.toLocaleLowerCase('en-US')];
+    return (
+      this.#kindIcons[kind.toLocaleLowerCase('en-US')] ?? UNKNOWN_KIND_ICON
+    );
   }
 }

--- a/plugins/catalog/src/apis/EntityPresentationApi/defaults.tsx
+++ b/plugins/catalog/src/apis/EntityPresentationApi/defaults.tsx
@@ -26,6 +26,7 @@ import LocationOnIcon from '@material-ui/icons/LocationOn';
 import MemoryIcon from '@material-ui/icons/Memory';
 import PeopleIcon from '@material-ui/icons/People';
 import PersonIcon from '@material-ui/icons/Person';
+import WorkIcon from '@material-ui/icons/Work';
 import { DefaultEntityPresentationApiRenderer } from './DefaultEntityPresentationApi';
 
 export const DEFAULT_CACHE_TTL: HumanDuration = { seconds: 10 };
@@ -38,6 +39,7 @@ export const DEFAULT_ICONS: Record<string, IconComponent> = {
   api: ExtensionIcon,
   component: MemoryIcon,
   system: BusinessIcon,
+  resource: WorkIcon,
   domain: ApartmentIcon,
   location: LocationOnIcon,
   user: PersonIcon,


### PR DESCRIPTION
Fixes #21529

I pondered this one for a bit back and forth. The original code had TWO icon picking functions: one in the renderer, and one fallback thing in the API implementation itself. The error was caused by the renderer insisting on always returning a fallback icon on unknown kinds, so the API fallback implementation never kicked in.

But having two seemed odd. So which one to pick?

- Make the default renderer always return no icon at all, and let the API handle fallbacks. This makes it a bit easier to implement custom renderers that don't care about icons, and is also the lightest change in terms of implementation code.
- Make the default renderer handle icons and remove the API fallback handling. Now you instead need to pass the kindIcons argument down through the layers from the API to the renderer, and those who make custom renderers may be tempted to call the default renderer (manually giving it the icons argument again!) and modifying its response. It also cements the API of the default renderer to have specifically kind based icon picking (eg excluding types as a possibility).

I chose to make the smallest possible change for this fix (the first option). But going forward it may be worth thinking about how to iterate on this further.