### PR TITLE
Cli: add warning when starting standalone backend plugin

### DIFF
--- a/.changeset/honest-houses-hide.md
+++ b/.changeset/honest-houses-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added a warning when starting a standalone backend plugin that hasn't been updated to the new backend system.

--- a/packages/cli/src/commands/start/command.ts
+++ b/packages/cli/src/commands/start/command.ts
@@ -16,7 +16,7 @@
 
 import { OptionValues } from 'commander';
 import { findRoleFromCommand } from '../../lib/role';
-import { startBackend } from './startBackend';
+import { startBackend, startBackendPlugin } from './startBackend';
 import { startFrontend } from './startFrontend';
 
 export async function command(opts: OptionValues): Promise<void> {
@@ -31,10 +31,11 @@ export async function command(opts: OptionValues): Promise<void> {
 
   switch (role) {
     case 'backend':
+      return startBackend(options);
     case 'backend-plugin':
     case 'backend-plugin-module':
     case 'node-library':
-      return startBackend(options);
+      return startBackendPlugin(options);
     case 'frontend':
       return startFrontend({
         ...options,

--- a/packages/cli/src/commands/start/startBackend.ts
+++ b/packages/cli/src/commands/start/startBackend.ts
@@ -36,12 +36,7 @@ export async function startBackend(options: StartBackendOptions) {
 
     await waitForExit();
   } else {
-    // Cleaning dist/ before we start the dev process helps work around an issue
-    // where we end up with the entrypoint executing multiple times, causing
-    // a port bind conflict among other things.
-    await fs.remove(paths.resolveTarget('dist'));
-
-    const waitForExit = await serveBackend({
+    const waitForExit = await cleanDistAndServeBackend({
       entry: 'src/index',
       checksEnabled: options.checksEnabled,
       inspectEnabled: options.inspectEnabled,
@@ -78,12 +73,8 @@ Please run "LEGACY_BACKEND_START=1 yarn start" instead.`,
       console.log(`src/run.ts is missing.`);
       return;
     }
-    // Cleaning dist/ before we start the dev process helps work around an issue
-    // where we end up with the entrypoint executing multiple times, causing
-    // a port bind conflict among other things.
-    await fs.remove(paths.resolveTarget('dist'));
 
-    const waitForExit = await serveBackend({
+    const waitForExit = await cleanDistAndServeBackend({
       entry: 'src/run',
       checksEnabled: options.checksEnabled,
       inspectEnabled: options.inspectEnabled,
@@ -92,4 +83,18 @@ Please run "LEGACY_BACKEND_START=1 yarn start" instead.`,
 
     await waitForExit();
   }
+}
+
+async function cleanDistAndServeBackend(options: {
+  entry: string;
+  checksEnabled: boolean;
+  inspectEnabled: boolean;
+  inspectBrkEnabled: boolean;
+}) {
+  // Cleaning dist/ before we start the dev process helps work around an issue
+  // where we end up with the entrypoint executing multiple times, causing
+  // a port bind conflict among other things.
+  await fs.remove(paths.resolveTarget('dist'));
+
+  return serveBackend(options);
 }

--- a/packages/cli/src/commands/start/startBackend.ts
+++ b/packages/cli/src/commands/start/startBackend.ts
@@ -49,10 +49,16 @@ export async function startBackend(options: StartBackendOptions) {
 
 export async function startBackendPlugin(options: StartBackendOptions) {
   if (!process.env.LEGACY_BACKEND_START) {
-    const hasEntry = await fs.pathExists(paths.resolveTarget('dev'));
-    if (!hasEntry) {
+    const hasDevEntry = await fs.pathExists(paths.resolveTarget('dev'));
+    const hasSrcIndexEntry = await fs.pathExists(
+      paths.resolveTarget('src', 'run.ts'),
+    );
+
+    if (!hasDevEntry && !hasSrcIndexEntry) {
       console.warn(
-        `The 'dev' directory is missing. This plugin might not be updated for the new backend system. To run, use "LEGACY_BACKEND_START=1 yarn start".`,
+        hasSrcIndexEntry
+          ? `The 'dev' directory is missing. The plugin might not be updated for the new backend system. To run, use "LEGACY_BACKEND_START=1 yarn start".`
+          : `The 'dev' directory is missing. Please create a proper dev/index.ts in order to start the plugin.`,
       );
       return;
     }
@@ -68,7 +74,9 @@ export async function startBackendPlugin(options: StartBackendOptions) {
   } else {
     const hasEntry = await fs.pathExists(paths.resolveTarget('src', 'run.ts'));
     if (!hasEntry) {
-      console.log(`src/run.ts is missing.`);
+      console.warn(
+        `src/run.ts is missing. Please create the file or run the command without LEGACY_BACKEND_START`,
+      );
       return;
     }
 

--- a/packages/cli/src/commands/start/startBackend.ts
+++ b/packages/cli/src/commands/start/startBackend.ts
@@ -49,12 +49,14 @@ export async function startBackend(options: StartBackendOptions) {
 
 export async function startBackendPlugin(options: StartBackendOptions) {
   if (!process.env.LEGACY_BACKEND_START) {
-    const hasDevEntry = await fs.pathExists(paths.resolveTarget('dev'));
+    const hasDevIndexEntry = await fs.pathExists(
+      paths.resolveTarget('dev', 'index.ts'),
+    );
     const hasSrcIndexEntry = await fs.pathExists(
       paths.resolveTarget('src', 'run.ts'),
     );
 
-    if (!hasDevEntry && !hasSrcIndexEntry) {
+    if (!hasDevIndexEntry && !hasSrcIndexEntry) {
       console.warn(
         hasSrcIndexEntry
           ? `The 'dev' directory is missing. The plugin might not be updated for the new backend system. To run, use "LEGACY_BACKEND_START=1 yarn start".`

--- a/packages/cli/src/commands/start/startBackend.ts
+++ b/packages/cli/src/commands/start/startBackend.ts
@@ -52,9 +52,7 @@ export async function startBackendPlugin(options: StartBackendOptions) {
     const hasEntry = await fs.pathExists(paths.resolveTarget('dev'));
     if (!hasEntry) {
       console.warn(
-        `dev directory doesn't exist. \
-It looks like this plugin hasn't been migrated to the new backend system. \
-Please run "LEGACY_BACKEND_START=1 yarn start" instead.`,
+        `The 'dev' directory is missing. This plugin might not be updated for the new backend system. To run, use "LEGACY_BACKEND_START=1 yarn start".`,
       );
       return;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a warning when executing the `yarn start` on a backend plugin which hasn't been migrated to the new backend system.
Related to #21454

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
