### PR TITLE
fix: search-backend router tests should use standard URL query parameter format

### DIFF
--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -104,8 +104,8 @@ describe('createRouter', () => {
       '',
       'term=foo',
       'term=foo&extra=param',
-      'types[0]=first-type',
-      'types[0]=first-type&types[1]=second-type',
+      'types=first-type',
+      'types=first-type&types=second-type',
       'filters[prop]=value',
       'pageCursor=foo',
     ])('accepts valid query string "%s"', async queryString => {
@@ -118,13 +118,13 @@ describe('createRouter', () => {
     });
 
     it.each([
-      'term[0]=foo',
+      'term[prop]=foo',
       'term[prop]=value',
       'types=foo',
-      'types[0]=unknown-type',
-      'types[length]=10000&types[0]=first-type',
+      'types[props]=unknown-type',
+      'types[length]=10000&types[zero]=first-type',
       'filters=stringValue',
-      'pageCursor[0]=1',
+      'pageCursor[props]=1',
     ])('rejects invalid query string "%s"', async queryString => {
       const response = await request(app).get(`/query?${queryString}`);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While working to fix #21543, I noticed that we use `a[0]=a&a[1]=b` notation in the tests (and possibly from the `qs.stringify` call in the `apis.ts`). This is not standard. The OpenAPI specification doesn't recognize [it](https://github.com/OAI/OpenAPI-Specification/issues/1501) and IEEE standard [either](https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.8). There are some asks for this as it seems like a language feature for _some_ languages (PHP and C# were noted), but currently not supported.

Ideally, we could use OpenAPI [compatible formats](https://swagger.io/docs/specification/serialization/). The weirdness here is that at the express-level this is a non-issue as there is already `qs` middleware, but for my work using Optic for test traffic it becomes an issue. Basically, `express` transforms the query params to the correct type and passes them through the validation layer [here](https://github.com/sennyeya/backstage/blob/2fcdaa5f1d7dfe4dbec404f19b5d240be92951d0/packages/backend-openapi-utils/src/stub.ts#L102), but with the [use of Optic for validating test traffic](https://github.com/backstage/backstage/pull/19955), the transformation isn't done before hitting the reverse proxy and we capture non-OpenAPI traffic. 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
