### PR TITLE
Wrap task pipeline loop in a span

### DIFF
--- a/.changeset/late-eyes-serve.md
+++ b/.changeset/late-eyes-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Wrap single `pipelineLoop` of TaskPipeline in a span for better traces

--- a/plugins/catalog-backend/src/processing/TaskPipeline.ts
+++ b/plugins/catalog-backend/src/processing/TaskPipeline.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+import { TRACER_ID, withActiveSpan } from '../util/opentelemetry';
+import { trace } from '@opentelemetry/api';
+
 const DEFAULT_POLLING_INTERVAL_MS = 1000;
+const tracer = trace.getTracer(TRACER_ID);
 
 type Options<T> = {
   /**
@@ -85,34 +89,36 @@ export function startTaskPipeline<T>(options: Options<T>) {
 
   async function pipelineLoop() {
     while (!abortSignal.aborted) {
-      if (state.inFlightCount <= lowWatermark) {
-        const loadCount = highWatermark - state.inFlightCount;
-        const loadedItems = await Promise.resolve()
-          .then(() => loadTasks(loadCount))
-          .catch(() => {
-            // Silently swallow errors and go back to sleep to try again; we
-            // delegate to the loadTasks function itself to catch errors and log
-            // if it so desires
-            return [];
-          });
-        if (loadedItems.length && !abortSignal.aborted) {
-          state.inFlightCount += loadedItems.length;
-          for (const item of loadedItems) {
-            Promise.resolve()
-              .then(() => processTask(item))
-              .catch(() => {
-                // Silently swallow errors and go back to sleep to try again; we
-                // delegate to the processTask function itself to catch errors
-                // and log if it so desires
-              })
-              .finally(() => {
-                state.inFlightCount -= 1;
-                barrier.release();
-              });
+      await withActiveSpan(tracer, 'TaskPipelineLoop', async span => {
+        if (state.inFlightCount <= lowWatermark) {
+          const loadCount = highWatermark - state.inFlightCount;
+          const loadedItems = await Promise.resolve(loadCount)
+            .then(loadTasks)
+            .catch(() => {
+              // Silently swallow errors and go back to sleep to try again; we
+              // delegate to the loadTasks function itself to catch errors and log
+              // if it so desires
+              return [];
+            });
+          span.setAttribute('itemCount', loadedItems.length);
+          if (loadedItems.length && !abortSignal.aborted) {
+            state.inFlightCount += loadedItems.length;
+            for (const item of loadedItems) {
+              Promise.resolve(item)
+                .then(processTask)
+                .catch(() => {
+                  // Silently swallow errors and go back to sleep to try again; we
+                  // delegate to the processTask function itself to catch errors
+                  // and log if it so desires
+                })
+                .finally(() => {
+                  state.inFlightCount -= 1;
+                  barrier.release();
+                });
+            }
           }
         }
-      }
-
+      });
       await barrier.wait();
     }
   }


### PR DESCRIPTION
This makes traces from `DefaultCatalogProcessingEngine` nicer

before (signalfx on production with postgres. You can see related, but separate traces):
<img width="857" alt="Screenshot 2023-11-24 at 19 05 39" src="https://github.com/backstage/backstage/assets/603853/c4a9edb3-b654-4cf9-86ae-5ecf75bf6707">
After (local dev with sqlite. Single trace emitted):
<img width="990" alt="Screenshot 2023-11-24 at 18 58 23" src="https://github.com/backstage/backstage/assets/603853/6dc1ede2-4323-48f6-9750-7cdb61ae23d0">

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
