### PR TITLE
frontend-plugin-api: re-export translation API and add createTranslationExtension

### DIFF
--- a/.changeset/breezy-houses-eat.md
+++ b/.changeset/breezy-houses-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Add support for translation extensions.

--- a/.changeset/six-cooks-attack.md
+++ b/.changeset/six-cooks-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added translation APIs as well as `createTranslationExtension`.

--- a/packages/frontend-app-api/src/extensions/Core.tsx
+++ b/packages/frontend-app-api/src/extensions/Core.tsx
@@ -18,6 +18,7 @@ import {
   coreExtensionData,
   createExtension,
   createExtensionInput,
+  createTranslationExtension,
 } from '@backstage/frontend-plugin-api';
 
 export const Core = createExtension({
@@ -32,6 +33,9 @@ export const Core = createExtension({
     }),
     components: createExtensionInput({
       component: coreExtensionData.component,
+    }),
+    translations: createExtensionInput({
+      translation: createTranslationExtension.translationDataRef,
     }),
     root: createExtensionInput(
       {

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -23,6 +23,7 @@ import {
   ComponentRef,
   componentsApiRef,
   coreExtensionData,
+  createTranslationExtension,
   ExtensionDataRef,
   ExtensionOverrides,
   RouteRef,
@@ -415,6 +416,16 @@ function createApiHolder(
       ?.map(e => e.instance?.getData(coreExtensionData.theme))
       .filter((x): x is AppTheme => !!x) ?? [];
 
+  const translationResources =
+    tree.root.edges.attachments
+      .get('translations')
+      ?.map(e =>
+        e.instance?.getData(createTranslationExtension.translationDataRef),
+      )
+      .filter(
+        (x): x is typeof createTranslationExtension.translationDataRef.T => !!x,
+      ) ?? [];
+
   for (const factory of [...defaultApis, ...pluginApis]) {
     factoryRegistry.register('default', factory);
   }
@@ -471,15 +482,6 @@ function createApiHolder(
     factory: () => AppLanguageSelector.createWithStorage(),
   });
 
-  factoryRegistry.register('default', {
-    api: translationApiRef,
-    deps: { languageApi: appLanguageApiRef },
-    factory: ({ languageApi }) =>
-      I18nextTranslationApi.create({
-        languageApi,
-      }),
-  });
-
   factoryRegistry.register('static', {
     api: configApiRef,
     deps: {},
@@ -492,12 +494,13 @@ function createApiHolder(
     factory: () => AppLanguageSelector.createWithStorage(),
   });
 
-  factoryRegistry.register('default', {
+  factoryRegistry.register('static', {
     api: translationApiRef,
     deps: { languageApi: appLanguageApiRef },
     factory: ({ languageApi }) =>
       I18nextTranslationApi.create({
         languageApi,
+        resources: translationResources,
       }),
   });
 

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -74,6 +74,8 @@ import { SignInPageProps } from '@backstage/core-plugin-api';
 import { StorageApi } from '@backstage/core-plugin-api';
 import { storageApiRef } from '@backstage/core-plugin-api';
 import { StorageValueSnapshot } from '@backstage/core-plugin-api';
+import { TranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { TranslationResource } from '@backstage/core-plugin-api/alpha';
 import { TypesToApiRefs } from '@backstage/core-plugin-api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useApiHolder } from '@backstage/core-plugin-api';
@@ -627,6 +629,28 @@ export function createSubRouteRef<
 export function createThemeExtension(
   theme: AppTheme,
 ): ExtensionDefinition<never>;
+
+// @public (undocumented)
+export function createTranslationExtension(options: {
+  name?: string;
+  resource: TranslationResource | TranslationMessages;
+}): ExtensionDefinition<never>;
+
+// @public (undocumented)
+export namespace createTranslationExtension {
+  const // (undocumented)
+    translationDataRef: ConfigurableExtensionDataRef<
+      | TranslationResource<string>
+      | TranslationMessages<
+          string,
+          {
+            [x: string]: string;
+          },
+          boolean
+        >,
+      {}
+    >;
+}
 
 export { DiscoveryApi };
 

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -31,6 +31,9 @@ import { ConfigApi } from '@backstage/core-plugin-api';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { createApiFactory } from '@backstage/core-plugin-api';
 import { createApiRef } from '@backstage/core-plugin-api';
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { discoveryApiRef } from '@backstage/core-plugin-api';
 import { ErrorApi } from '@backstage/core-plugin-api';
@@ -75,10 +78,15 @@ import { StorageApi } from '@backstage/core-plugin-api';
 import { storageApiRef } from '@backstage/core-plugin-api';
 import { StorageValueSnapshot } from '@backstage/core-plugin-api';
 import { TranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { TranslationMessagesOptions } from '@backstage/core-plugin-api/alpha';
+import { TranslationRef } from '@backstage/core-plugin-api/alpha';
+import { TranslationRefOptions } from '@backstage/core-plugin-api/alpha';
 import { TranslationResource } from '@backstage/core-plugin-api/alpha';
+import { TranslationResourceOptions } from '@backstage/core-plugin-api/alpha';
 import { TypesToApiRefs } from '@backstage/core-plugin-api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useApiHolder } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { withApis } from '@backstage/core-plugin-api';
 import { z } from 'zod';
 import { ZodSchema } from 'zod';
@@ -652,6 +660,12 @@ export namespace createTranslationExtension {
     >;
 }
 
+export { createTranslationMessages };
+
+export { createTranslationRef };
+
+export { createTranslationResource };
+
 export { DiscoveryApi };
 
 export { discoveryApiRef };
@@ -969,6 +983,18 @@ export interface SubRouteRef<
   readonly T: TParams;
 }
 
+export { TranslationMessages };
+
+export { TranslationMessagesOptions };
+
+export { TranslationRef };
+
+export { TranslationRefOptions };
+
+export { TranslationResource };
+
+export { TranslationResourceOptions };
+
 export { TypesToApiRefs };
 
 // @public
@@ -995,6 +1021,8 @@ export function useRouteRef<TParams extends AnyRouteRefParams>(
 export function useRouteRefParams<Params extends AnyRouteRefParams>(
   _routeRef: RouteRef<Params> | SubRouteRef<Params>,
 ): Params;
+
+export { useTranslationRef };
 
 export { withApis };
 ```

--- a/packages/frontend-plugin-api/src/extensions/createTranslationExtension.test.ts
+++ b/packages/frontend-plugin-api/src/extensions/createTranslationExtension.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createTranslationRef,
+  createTranslationMessages,
+  createTranslationResource,
+} from '@backstage/core-plugin-api/alpha';
+import { createTranslationExtension } from './createTranslationExtension';
+
+const translationRef = createTranslationRef({
+  id: 'test',
+  messages: {
+    a: 'a',
+    b: 'b',
+  },
+});
+
+describe('createTranslationExtension', () => {
+  it('creates a translation message extension', () => {
+    const messages = createTranslationMessages({
+      ref: translationRef,
+      messages: {
+        a: 'A',
+      },
+    });
+    const extension = createTranslationExtension({ resource: messages });
+
+    expect(extension).toEqual({
+      $$type: '@backstage/ExtensionDefinition',
+      kind: 'translation',
+      namespace: 'test',
+      attachTo: { id: 'core', input: 'translations' },
+      disabled: false,
+      inputs: {},
+      output: {
+        resource: createTranslationExtension.translationDataRef,
+      },
+      factory: expect.any(Function),
+    });
+
+    expect(extension.factory({} as any)).toEqual({
+      resource: messages,
+    });
+  });
+
+  it('creates a translation resource extension', () => {
+    const resource = createTranslationResource({
+      ref: translationRef,
+      translations: {
+        sv: () =>
+          Promise.resolve({
+            default: createTranslationMessages({
+              ref: translationRef,
+              messages: {
+                a: 'Ä',
+                b: 'Ö',
+              },
+            }),
+          }),
+      },
+    });
+    const extension = createTranslationExtension({ resource });
+
+    expect(extension).toEqual({
+      $$type: '@backstage/ExtensionDefinition',
+      kind: 'translation',
+      namespace: 'test',
+      attachTo: { id: 'core', input: 'translations' },
+      disabled: false,
+      inputs: {},
+      output: {
+        resource: createTranslationExtension.translationDataRef,
+      },
+      factory: expect.any(Function),
+    });
+
+    expect(extension.factory({} as any)).toEqual({ resource });
+  });
+
+  it('creates a translation resource extension with a name', () => {
+    expect(
+      createTranslationExtension({
+        name: 'sv',
+        resource: createTranslationResource({
+          ref: translationRef,
+          translations: {
+            sv: () =>
+              Promise.resolve({
+                default: createTranslationMessages({
+                  ref: translationRef,
+                  messages: {
+                    a: 'Ä',
+                    b: 'Ö',
+                  },
+                }),
+              }),
+          },
+        }),
+      }),
+    ).toEqual({
+      $$type: '@backstage/ExtensionDefinition',
+      kind: 'translation',
+      namespace: 'test',
+      name: 'sv',
+      attachTo: { id: 'core', input: 'translations' },
+      disabled: false,
+      inputs: {},
+      output: {
+        resource: createTranslationExtension.translationDataRef,
+      },
+      factory: expect.any(Function),
+    });
+  });
+});

--- a/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createExtension, createExtensionDataRef } from '../wiring';
+import {
+  TranslationResource,
+  TranslationMessages,
+} from '@backstage/core-plugin-api/alpha';
+
+/** @public */
+export function createTranslationExtension(options: {
+  name?: string;
+  resource: TranslationResource | TranslationMessages;
+}) {
+  return createExtension({
+    kind: 'translation',
+    namespace: options.resource.id,
+    name: options.name,
+    attachTo: { id: 'core', input: 'translations' },
+    output: {
+      resource: createTranslationExtension.translationDataRef,
+    },
+    factory: () => ({ resource: options.resource }),
+  });
+}
+
+/** @public */
+export namespace createTranslationExtension {
+  export const translationDataRef = createExtensionDataRef<
+    TranslationResource | TranslationMessages
+  >('core.translationResource');
+}

--- a/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
+import { TranslationMessages, TranslationResource } from '../translation';
 import { createExtension, createExtensionDataRef } from '../wiring';
-import {
-  TranslationResource,
-  TranslationMessages,
-} from '@backstage/core-plugin-api/alpha';
 
 /** @public */
 export function createTranslationExtension(options: {

--- a/packages/frontend-plugin-api/src/extensions/index.ts
+++ b/packages/frontend-plugin-api/src/extensions/index.ts
@@ -20,3 +20,4 @@ export { createNavItemExtension } from './createNavItemExtension';
 export { createSignInPageExtension } from './createSignInPageExtension';
 export { createThemeExtension } from './createThemeExtension';
 export { createComponentExtension } from './createComponentExtension';
+export { createTranslationExtension } from './createTranslationExtension';

--- a/packages/frontend-plugin-api/src/translation/index.ts
+++ b/packages/frontend-plugin-api/src/translation/index.ts
@@ -14,26 +14,15 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage frontend plugins.
- *
- * @packageDocumentation
- */
-
-export * from './analytics';
-export * from './apis';
-export * from './components';
-export * from './extensions';
-export * from './icons';
-export * from './routing';
-export * from './schema';
-export * from './apis/system';
-export * from './translation';
-export * from './wiring';
-
-export type {
-  CoreProgressComponent,
-  CoreBootErrorPageComponent,
-  CoreNotFoundErrorPageComponent,
-  CoreErrorBoundaryFallbackComponent,
-} from './types';
+export {
+  type TranslationMessages,
+  type TranslationMessagesOptions,
+  type TranslationResource,
+  type TranslationResourceOptions,
+  type TranslationRef,
+  type TranslationRefOptions,
+  createTranslationMessages,
+  createTranslationResource,
+  createTranslationRef,
+  useTranslationRef,
+} from '@backstage/core-plugin-api/alpha';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #19545. There's a question whether we should skip the `TranslationResource` abstraction and just make that part of the extension creator instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
