### PR TITLE
cli: switch ts-eslint plugin back to ^ range

### DIFF
--- a/.changeset/strange-suits-glow.md
+++ b/.changeset/strange-suits-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched the `@typescript-eslint/eslint-plugin` dependency back to using a `^` version range.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "@swc/jest": "^0.2.22",
     "@types/jest": "^29.0.0",
     "@types/webpack-env": "^1.15.2",
-    "@typescript-eslint/eslint-plugin": "6.12.0",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.7.2",
     "@yarnpkg/lockfile": "^1.1.0",
     "@yarnpkg/parsers": "^3.0.0-rc.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,7 +3637,7 @@ __metadata:
     "@types/terser-webpack-plugin": ^5.0.4
     "@types/webpack-env": ^1.15.2
     "@types/yarnpkg__lockfile": ^1.1.4
-    "@typescript-eslint/eslint-plugin": 6.12.0
+    "@typescript-eslint/eslint-plugin": ^6.12.0
     "@typescript-eslint/parser": ^6.7.2
     "@yarnpkg/lockfile": ^1.1.0
     "@yarnpkg/parsers": ^3.0.0-rc.4
@@ -19454,7 +19454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:6.12.0":
+"@typescript-eslint/eslint-plugin@npm:^6.12.0":
   version: 6.12.0
   resolution: "@typescript-eslint/eslint-plugin@npm:6.12.0"
   dependencies:


### PR DESCRIPTION
🧹, looks like this was switched by mistake in #20054 and it *should* be fine to switch it back