### PR TITLE
frontend-plugin-api: refactor createThemeExtension to accept both theme and name

### DIFF
--- a/.changeset/good-weeks-eat.md
+++ b/.changeset/good-weeks-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+The `theme` passed to `createThemeExtension` is now wrapped into an options object, with the option to pass a extension `name` as well.

--- a/.changeset/heavy-terms-agree.md
+++ b/.changeset/heavy-terms-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Updated usage of `createThemeExtension`.

--- a/packages/frontend-app-api/src/extensions/themes.tsx
+++ b/packages/frontend-app-api/src/extensions/themes.tsx
@@ -24,21 +24,25 @@ import LightIcon from '@material-ui/icons/WbSunny';
 import { createThemeExtension } from '@backstage/frontend-plugin-api';
 
 export const LightTheme = createThemeExtension({
-  id: 'light',
-  title: 'Light Theme',
-  variant: 'light',
-  icon: <LightIcon />,
-  Provider: ({ children }) => (
-    <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
-  ),
+  theme: {
+    id: 'light',
+    title: 'Light Theme',
+    variant: 'light',
+    icon: <LightIcon />,
+    Provider: ({ children }) => (
+      <UnifiedThemeProvider theme={builtinThemes.light} children={children} />
+    ),
+  },
 });
 
 export const DarkTheme = createThemeExtension({
-  id: 'dark',
-  title: 'Dark Theme',
-  variant: 'dark',
-  icon: <DarkIcon />,
-  Provider: ({ children }) => (
-    <UnifiedThemeProvider theme={builtinThemes.dark} children={children} />
-  ),
+  theme: {
+    id: 'dark',
+    title: 'Dark Theme',
+    variant: 'dark',
+    icon: <DarkIcon />,
+    Provider: ({ children }) => (
+      <UnifiedThemeProvider theme={builtinThemes.dark} children={children} />
+    ),
+  },
 });

--- a/packages/frontend-app-api/src/wiring/createApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.test.tsx
@@ -36,10 +36,7 @@ describe('createApp', () => {
       configLoader: async () =>
         new MockConfigApi({
           app: {
-            extensions: [
-              { 'theme:app/light': false },
-              { 'theme:app/dark': false },
-            ],
+            extensions: [{ 'theme:light': false }, { 'theme:dark': false }],
           },
         }),
       features: [
@@ -47,10 +44,12 @@ describe('createApp', () => {
           id: 'test',
           extensions: [
             createThemeExtension({
-              id: 'derp',
-              title: 'Derp',
-              variant: 'dark',
-              Provider: () => <div>Derp</div>,
+              theme: {
+                id: 'derp',
+                title: 'Derp',
+                variant: 'dark',
+                Provider: () => <div>Derp</div>,
+              },
             }),
           ],
         }),
@@ -207,8 +206,8 @@ describe('createApp', () => {
           <component:core.components.notFoundErrorPage out=[component.ref] />
         ]
         themes [
-          <theme:app/light out=[core.theme] />
-          <theme:app/dark out=[core.theme] />
+          <theme:light out=[core.theme] />
+          <theme:dark out=[core.theme] />
         ]
       </core>"
     `);

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -624,9 +624,10 @@ export function createSubRouteRef<
 }): MakeSubRouteRef<PathParams<Path>, ParentParams>;
 
 // @public (undocumented)
-export function createThemeExtension(
-  theme: AppTheme,
-): ExtensionDefinition<never>;
+export function createThemeExtension(options: {
+  name?: string;
+  theme: AppTheme;
+}): ExtensionDefinition<never>;
 
 export { DiscoveryApi };
 

--- a/packages/frontend-plugin-api/src/extensions/createThemeExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createThemeExtension.ts
@@ -18,11 +18,15 @@ import { createExtension, coreExtensionData } from '../wiring';
 import { AppTheme } from '@backstage/core-plugin-api';
 
 /** @public */
-export function createThemeExtension(theme: AppTheme) {
+export function createThemeExtension(options: {
+  name?: string;
+  theme: AppTheme;
+}) {
+  const { theme } = options;
   return createExtension({
     kind: 'theme',
-    namespace: 'app',
-    name: theme.id,
+    namespace: theme.id,
+    name: options?.name,
     attachTo: { id: 'core', input: 'themes' },
     output: {
       theme: coreExtensionData.theme,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work towards #19545, related to https://github.com/backstage/backstage/pull/21481#discussion_r1406088848. This is the same change as was applied to API extensions in #21545.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
