### PR TITLE
fix: add horizontal slider if stepper overflows

### DIFF
--- a/.changeset/perfect-crabs-help.md
+++ b/.changeset/perfect-crabs-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Add horizontal slider if stepper overflows

--- a/packages/theme/src/v5/defaultComponentThemes.ts
+++ b/packages/theme/src/v5/defaultComponentThemes.ts
@@ -239,11 +239,4 @@ export const defaultComponentThemes: ThemeOptions['components'] = {
       underline: 'hover',
     },
   },
-  MuiStepper: {
-    styleOverrides: {
-      root: {
-        overflowX: 'auto',
-      },
-    },
-  },
 };

--- a/packages/theme/src/v5/defaultComponentThemes.ts
+++ b/packages/theme/src/v5/defaultComponentThemes.ts
@@ -239,4 +239,11 @@ export const defaultComponentThemes: ThemeOptions['components'] = {
       underline: 'hover',
     },
   },
+  MuiStepper: {
+    styleOverrides: {
+      root: {
+        overflowX: 'auto',
+      },
+    },
+  },
 };

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -190,7 +190,12 @@ export const Stepper = (stepperProps: StepperProps) => {
   return (
     <>
       {isValidating && <LinearProgress variant="indeterminate" />}
-      <MuiStepper activeStep={activeStep} alternativeLabel variant="elevation">
+      <MuiStepper
+        activeStep={activeStep}
+        alternativeLabel
+        variant="elevation"
+        style={{ overflowX: 'auto' }}
+      >
         {steps.map((step, index) => {
           const isAllowedLabelClick = activeStep > index;
           return (

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -190,12 +190,7 @@ export const Stepper = (stepperProps: StepperProps) => {
   return (
     <>
       {isValidating && <LinearProgress variant="indeterminate" />}
-      <MuiStepper
-        activeStep={activeStep}
-        alternativeLabel
-        variant="elevation"
-        style={{ overflowX: 'auto' }}
-      >
+      <MuiStepper activeStep={activeStep} alternativeLabel variant="elevation">
         {steps.map((step, index) => {
           const isAllowedLabelClick = activeStep > index;
           return (

--- a/plugins/scaffolder-react/src/next/components/TaskSteps/TaskSteps.tsx
+++ b/plugins/scaffolder-react/src/next/components/TaskSteps/TaskSteps.tsx
@@ -58,6 +58,7 @@ export const TaskSteps = (props: TaskStepsProps) => {
           activeStep={props.activeStep}
           alternativeLabel
           variant="elevation"
+          style={{ overflowX: 'auto' }}
         >
           {props.steps.map(step => {
             const isCompleted = step.status === 'completed';

--- a/plugins/scaffolder-react/src/next/components/TaskSteps/TaskSteps.tsx
+++ b/plugins/scaffolder-react/src/next/components/TaskSteps/TaskSteps.tsx
@@ -58,7 +58,6 @@ export const TaskSteps = (props: TaskStepsProps) => {
           activeStep={props.activeStep}
           alternativeLabel
           variant="elevation"
-          style={{ overflowX: 'auto' }}
         >
           {props.steps.map(step => {
             const isCompleted = step.status === 'completed';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Add horizontal slider if stepper overflows

<img width="809" alt="Screenshot 2023-11-27 at 16 17 31" src="https://github.com/backstage/backstage/assets/47827254/ff328fee-cc0a-4a12-bf09-813cd3b302dd">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### Related Issue

Closes #21578