### PR TITLE
switch all backend module IDs to use kebab-case

### DIFF
--- a/.changeset/wicked-pants-end.md
+++ b/.changeset/wicked-pants-end.md
@@ -1,0 +1,35 @@
+---
+'@backstage/plugin-catalog-backend-module-scaffolder-entity-model': patch
+'@backstage/plugin-search-backend-module-stack-overflow-collator': patch
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+'@backstage/plugin-permission-backend-module-allow-all-policy': patch
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-server': patch
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-events-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+'@backstage/plugin-auth-backend-module-google-provider': patch
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+'@backstage/plugin-catalog-backend-module-unprocessed': patch
+'@backstage/plugin-catalog-backend-module-github-org': patch
+'@backstage/plugin-catalog-backend-module-puppetdb': patch
+'@backstage/plugin-search-backend-module-techdocs': patch
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+'@backstage/plugin-catalog-backend-module-github': patch
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/plugin-events-backend-module-aws-sqs': patch
+'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-search-backend-module-explore': patch
+'@backstage/plugin-catalog-backend-module-azure': patch
+'@backstage/plugin-events-backend-module-gerrit': patch
+'@backstage/plugin-events-backend-module-github': patch
+'@backstage/plugin-events-backend-module-gitlab': patch
+'@backstage/plugin-events-backend-module-azure': patch
+'@backstage/plugin-catalog-backend-module-aws': patch
+'@backstage/plugin-catalog-backend-module-gcp': patch
+'@backstage/plugin-search-backend-module-pg': patch
+'@backstage/backend-test-utils': patch
+'@backstage/plugin-events-backend': patch
+---
+
+Switched module ID to use kebab-case.

--- a/docs/backend-system/architecture/06-modules.md
+++ b/docs/backend-system/architecture/06-modules.md
@@ -25,8 +25,8 @@ import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node'
 import { MyCustomProcessor } from './MyCustomProcessor';
 
 export const catalogModuleExampleCustomProcessor = createBackendModule({
-  moduleId: 'exampleCustomProcessor',
   pluginId: 'catalog',
+  moduleId: 'example-custom-processor',
   register(env) {
     env.registerInit({
       deps: {

--- a/docs/backend-system/architecture/07-naming-patterns.md
+++ b/docs/backend-system/architecture/07-naming-patterns.md
@@ -10,18 +10,20 @@ description: Naming patterns in the backend system
 
 These are the naming patterns to adhere to within the backend system. They help us keep exports consistent across packages and make it easier to understand the usage and intent of exports.
 
+As a rule, all names should be camel case, with the exceptions of plugin and module IDs, which should be kebab case.
+
 ### Plugins
 
-| Description | Pattern      | Examples                            |
-| ----------- | ------------ | ----------------------------------- |
-| export      | `<id>Plugin` | `catalogPlugin`, `scaffolderPlugin` |
-| ID          | `'<id>'`     | `'catalog'`, `'scaffolder'`         |
+| Description | Pattern           | Examples                              |
+| ----------- | ----------------- | ------------------------------------- |
+| export      | `<camelId>Plugin` | `catalogPlugin`, `userSettingsPlugin` |
+| ID          | `'<kebab-id>'`    | `'catalog'`, `'user-settings'`        |
 
 Example:
 
 ```ts
-export const catalogPlugin = createBackendPlugin({
-  pluginId: 'catalog',
+export const userSettingsPlugin = createBackendPlugin({
+  pluginId: 'user-settings',
   ...
 })
 ```
@@ -31,14 +33,14 @@ export const catalogPlugin = createBackendPlugin({
 | Description | Pattern                      | Examples                            |
 | ----------- | ---------------------------- | ----------------------------------- |
 | export      | `<pluginId>Module<ModuleId>` | `catalogModuleGithubEntityProvider` |
-| ID          | `'<moduleId>'`               | `'githubEntityProvider'`            |
+| ID          | `'<module-id>'`              | `'github-entity-provider'`          |
 
 Example:
 
 ```ts
 export const catalogModuleGithubEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'githubEntityProvider',
+  moduleId: 'github-entity-provider',
   ...
 })
 ```

--- a/docs/backend-system/building-backends/08-migrating.md
+++ b/docs/backend-system/building-backends/08-migrating.md
@@ -297,7 +297,7 @@ import { microsoftGraphOrgEntityProviderTransformExtensionPoint } from '@backsta
 backend.add(
   createBackendModule({
     pluginId: 'catalog',
-    moduleId: 'microsoftGraphExtensions',
+    moduleId: 'microsoft-graph-extensions',
     register(env) {
       env.registerInit({
         deps: {
@@ -337,7 +337,7 @@ import { createBackendModule } from '@backstage/backend-plugin-api';
 /* highlight-add-start */
 const catalogModuleCustomExtensions = createBackendModule({
   pluginId: 'catalog', // name of the plugin that the module is targeting
-  moduleId: 'customExtensions',
+  moduleId: 'custom-extensions',
   register(env) {
     env.registerInit({
       deps: {
@@ -406,7 +406,7 @@ import { createBackendModule } from '@backstage/backend-plugin-api';
 /* highlight-add-start */
 const eventsModuleCustomExtensions = createBackendModule({
   pluginId: 'events', // name of the plugin that the module is targeting
-  moduleId: 'customExtensions',
+  moduleId: 'custom-extensions',
   register(env) {
     env.registerInit({
       deps: {
@@ -471,7 +471,7 @@ import { createBackendModule } from '@backstage/backend-plugin-api';
 /* highlight-add-start */
 const scaffolderModuleCustomExtensions = createBackendModule({
   pluginId: 'scaffolder', // name of the plugin that the module is targeting
-  moduleId: 'customExtensions',
+  moduleId: 'custom-extensions',
   register(env) {
     env.registerInit({
       deps: {

--- a/docs/backend-system/building-plugins-and-modules/01-index.md
+++ b/docs/backend-system/building-plugins-and-modules/01-index.md
@@ -104,8 +104,8 @@ import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node'
 import { MyCustomProcessor } from './MyCustomProcessor';
 
 export const catalogModuleExampleCustomProcessor = createBackendModule({
-  moduleId: 'exampleCustomProcessor',
   pluginId: 'catalog',
+  moduleId: 'example-custom-processor',
   register(env) {
     env.registerInit({
       deps: {

--- a/docs/backend-system/building-plugins-and-modules/08-migrating.md
+++ b/docs/backend-system/building-plugins-and-modules/08-migrating.md
@@ -196,7 +196,7 @@ import { GoogleContainerEngineSupplier } from './GoogleContainerEngineSupplier';
 
 export default createBackendModule({
   pluginId: 'kubernetes',
-  moduleId: 'gke.supplier',
+  moduleId: 'gke-supplier',
   register(env) {
     env.registerInit({
       deps: {

--- a/docs/plugins/new-backend-system.md
+++ b/docs/plugins/new-backend-system.md
@@ -147,8 +147,8 @@ import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node'
 import { MyCustomProcessor } from './processor';
 
 export const exampleCustomProcessorCatalogModule = createBackendModule({
-  moduleId: 'exampleCustomProcessor',
   pluginId: 'catalog',
+  moduleId: 'example-custom-processor',
   register(env) {
     env.registerInit({
       deps: {

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -102,7 +102,7 @@ describe('BackendInitializer', () => {
     init.add(
       createBackendModule({
         pluginId: 'test',
-        moduleId: 'modA',
+        moduleId: 'mod-a',
         register(reg) {
           reg.registerInit({
             deps: { extension: extensionPoint },
@@ -118,7 +118,7 @@ describe('BackendInitializer', () => {
     init.add(
       createBackendModule({
         pluginId: 'test',
-        moduleId: 'modB',
+        moduleId: 'mod-b',
         register(reg) {
           const values = ['b'];
           reg.registerExtensionPoint(extensionPoint, { values });
@@ -135,7 +135,7 @@ describe('BackendInitializer', () => {
     init.add(
       createBackendModule({
         pluginId: 'test',
-        moduleId: 'modC',
+        moduleId: 'mod-c',
         register(reg) {
           reg.registerInit({
             deps: { extension: extensionPoint },
@@ -265,7 +265,7 @@ describe('BackendInitializer', () => {
     init.add(
       createBackendModule({
         pluginId: 'test',
-        moduleId: 'modA',
+        moduleId: 'mod-a',
         register(reg) {
           reg.registerExtensionPoint(extA, 'a');
           reg.registerInit({
@@ -278,7 +278,7 @@ describe('BackendInitializer', () => {
     init.add(
       createBackendModule({
         pluginId: 'test',
-        moduleId: 'modB',
+        moduleId: 'mod-b',
         register(reg) {
           reg.registerExtensionPoint(extB, 'b');
           reg.registerInit({
@@ -289,7 +289,7 @@ describe('BackendInitializer', () => {
       })(),
     );
     await expect(init.start()).rejects.toThrow(
-      "Circular dependency detected for modules of plugin 'test', 'modA' -> 'modB' -> 'modA'",
+      "Circular dependency detected for modules of plugin 'test', 'mod-a' -> 'mod-b' -> 'mod-a'",
     );
   });
 
@@ -298,7 +298,7 @@ describe('BackendInitializer', () => {
     const extA = createExtensionPoint<string>({ id: 'a' });
     init.add(
       createBackendPlugin({
-        pluginId: 'testA',
+        pluginId: 'test-a',
         register(reg) {
           reg.registerExtensionPoint(extA, 'a');
           reg.registerInit({
@@ -310,7 +310,7 @@ describe('BackendInitializer', () => {
     );
     init.add(
       createBackendModule({
-        pluginId: 'testB',
+        pluginId: 'test-b',
         moduleId: 'mod',
         register(reg) {
           reg.registerInit({
@@ -321,7 +321,7 @@ describe('BackendInitializer', () => {
       })(),
     );
     await expect(init.start()).rejects.toThrow(
-      "Extension point registered for plugin 'testA' may not be used by module for plugin 'testB'",
+      "Extension point registered for plugin 'test-a' may not be used by module for plugin 'test-b'",
     );
   });
 });

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
@@ -33,8 +33,8 @@ beforeAll(async () => {
   await startTestBackend({
     features: [
       createBackendModule({
-        moduleId: 'test.module',
         pluginId: 'test',
+        moduleId: 'test-module',
         register(env) {
           env.registerInit({
             deps: { lifecycle: coreServices.lifecycle },
@@ -128,8 +128,8 @@ describe('TestBackend', () => {
     });
 
     const testModule = createBackendModule({
-      moduleId: 'test.module',
       pluginId: 'test',
+      moduleId: 'test-module',
       register(env) {
         env.registerInit({
           deps: {
@@ -153,8 +153,8 @@ describe('TestBackend', () => {
     const shutdownSpy = jest.fn();
 
     const testModule = createBackendModule({
-      moduleId: 'test.module',
       pluginId: 'test',
+      moduleId: 'test-module',
       register(env) {
         env.registerInit({
           deps: {

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -156,7 +156,7 @@ function createExtensionPointTestModules(
     modules.push(
       createBackendModule({
         pluginId,
-        moduleId: 'testExtensionPointRegistration',
+        moduleId: 'test-extension-point-registration',
         register(reg) {
           for (const id of pluginExtensionPointIds) {
             const tuple = extensionPointMap.get(id)!;

--- a/plugins/auth-backend-module-gcp-iap-provider/src/module.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/module.ts
@@ -26,7 +26,7 @@ import { gcpIapSignInResolvers } from './resolvers';
 /** @public */
 export const authModuleGcpIapProvider = createBackendModule({
   pluginId: 'auth',
-  moduleId: 'gcpIapProvider',
+  moduleId: 'gcp-iap-provider',
   register(reg) {
     reg.registerInit({
       deps: {

--- a/plugins/auth-backend-module-google-provider/src/module.ts
+++ b/plugins/auth-backend-module-google-provider/src/module.ts
@@ -26,7 +26,7 @@ import { googleSignInResolvers } from './resolvers';
 /** @public */
 export const authModuleGoogleProvider = createBackendModule({
   pluginId: 'auth',
-  moduleId: 'googleProvider',
+  moduleId: 'google-provider',
   register(reg) {
     reg.registerInit({
       deps: {

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/module.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/module.ts
@@ -26,7 +26,7 @@ import { oauth2ProxySignInResolvers } from './resolvers';
 /** @public */
 export const authModuleOauth2ProxyProvider = createBackendModule({
   pluginId: 'auth',
-  moduleId: 'oauth2ProxyProvider',
+  moduleId: 'oauth2-proxy-provider',
   register(reg) {
     reg.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.ts
@@ -29,7 +29,7 @@ import { AwsS3EntityProvider } from '../providers';
  */
 export const catalogModuleAwsS3EntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'awsS3EntityProvider',
+  moduleId: 'aws-s3-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.ts
+++ b/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.ts
@@ -29,7 +29,7 @@ import { AzureDevOpsEntityProvider } from '../providers';
  */
 export const catalogModuleAzureDevOpsEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'azureDevOpsEntityProvider',
+  moduleId: 'azure-dev-ops-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.ts
@@ -31,7 +31,7 @@ import { BitbucketCloudEntityProvider } from '../providers/BitbucketCloudEntityP
  */
 export const catalogModuleBitbucketCloudEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'bitbucketCloudEntityProvider',
+  moduleId: 'bitbucket-cloud-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.ts
@@ -27,7 +27,7 @@ import { BitbucketServerEntityProvider } from '../providers';
  */
 export const catalogModuleBitbucketServerEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'bitbucketServerEntityProvider',
+  moduleId: 'bitbucket-server-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-gcp/src/module/catalogModuleGcpGkeEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/module/catalogModuleGcpGkeEntityProvider.ts
@@ -29,7 +29,7 @@ import { GkeEntityProvider } from '../providers/GkeEntityProvider';
  */
 export const catalogModuleGcpGkeEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'gcpGkeEntityProvider',
+  moduleId: 'gcp-gke-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.ts
@@ -27,7 +27,7 @@ import { GerritEntityProvider } from '../providers/GerritEntityProvider';
  */
 export const catalogModuleGerritEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'gerritEntityProvider',
+  moduleId: 'gerrit-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-github-org/src/module.ts
+++ b/plugins/catalog-backend-module-github-org/src/module.ts
@@ -68,7 +68,7 @@ export const githubOrgEntityProviderTransformsExtensionPoint =
  */
 export const catalogModuleGithubOrgEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'githubOrgEntityProvider',
+  moduleId: 'github-org-entity-provider',
   register(env) {
     let userTransformer: UserTransformer | undefined;
     let teamTransformer: TeamTransformer | undefined;

--- a/plugins/catalog-backend-module-github/src/module/catalogModuleGithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/module/catalogModuleGithubEntityProvider.ts
@@ -29,7 +29,7 @@ import { GithubEntityProvider } from '../providers/GithubEntityProvider';
  */
 export const catalogModuleGithubEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'githubEntityProvider',
+  moduleId: 'github-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.ts
@@ -29,7 +29,7 @@ import { GitlabDiscoveryEntityProvider } from '../providers';
  */
 export const catalogModuleGitlabDiscoveryEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'gitlabDiscoveryEntityProvider',
+  moduleId: 'gitlab-discovery-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.test.ts
@@ -48,7 +48,7 @@ describe('catalogModuleIncrementalIngestionEntityProvider', () => {
         catalogModuleIncrementalIngestionEntityProvider(),
         createBackendModule({
           pluginId: 'catalog',
-          moduleId: 'incrementalTest',
+          moduleId: 'incremental-test',
           register(env) {
             env.registerInit({
               deps: { extension: incrementalIngestionProvidersExtensionPoint },

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.ts
@@ -49,7 +49,7 @@ export interface IncrementalIngestionProviderExtensionPoint {
  * ```ts
  * backend.add(createBackendModule({
  *   pluginId: 'catalog',
- *   moduleId: 'myIncrementalProvider',
+ *   moduleId: 'my-incremental-provider',
  *   register(env) {
  *     env.registerInit({
  *       deps: {
@@ -85,7 +85,7 @@ export const incrementalIngestionProvidersExtensionPoint =
 export const catalogModuleIncrementalIngestionEntityProvider =
   createBackendModule({
     pluginId: 'catalog',
-    moduleId: 'incrementalIngestionEntityProvider',
+    moduleId: 'incremental-ingestion-entity-provider',
     register(env) {
       const addedProviders = new Array<{
         provider: IncrementalEntityProvider<unknown, unknown>;

--- a/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/run.ts
@@ -67,7 +67,7 @@ async function main() {
   backend.add(
     createBackendModule({
       pluginId: 'catalog',
-      moduleId: 'incrementalTestProvider',
+      moduleId: 'incremental-test-provider',
       register(reg) {
         reg.registerInit({
           deps: { extension: incrementalIngestionProvidersExtensionPoint },

--- a/plugins/catalog-backend-module-puppetdb/src/module/catalogModulePuppetDbEntityProvider.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/module/catalogModulePuppetDbEntityProvider.ts
@@ -29,7 +29,7 @@ import { PuppetDbEntityProvider } from '../providers/PuppetDbEntityProvider';
  */
 export const catalogModulePuppetDbEntityProvider = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'puppetDbEntityProvider',
+  moduleId: 'puppetdb-entity-provider',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-scaffolder-entity-model/src/module.ts
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/src/module.ts
@@ -26,7 +26,7 @@ import { ScaffolderEntitiesProcessor } from '@backstage/plugin-catalog-backend-m
  */
 export const catalogModuleScaffolderEntityModel = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'scaffolderEntityModel',
+  moduleId: 'scaffolder-entity-model',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend-module-unprocessed/src/module.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/module.ts
@@ -27,7 +27,7 @@ import { UnprocessedEntitiesModule } from './UnprocessedEntitiesModule';
  */
 export const catalogModuleUnprocessedEntities = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'catalogModuleUnprocessedEntities',
+  moduleId: 'catalog-module-unprocessed-entities',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/catalog-backend/src/tests/performance/stitchingPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/stitchingPerformance.test.ts
@@ -188,8 +188,8 @@ describePerformanceTest('stitchingPerformance', () => {
             factory: () => ({ getClient: async () => knex }),
           }),
           createBackendModule({
-            moduleId: 'syntheticLoadEntities',
             pluginId: 'catalog',
+            moduleId: 'synthetic-load-entities',
             register(reg) {
               reg.registerInit({
                 deps: {
@@ -245,8 +245,8 @@ describePerformanceTest('stitchingPerformance', () => {
             factory: () => ({ getClient: async () => knex }),
           }),
           createBackendModule({
-            moduleId: 'syntheticLoadEntities',
             pluginId: 'catalog',
+            moduleId: 'synthetic-load-entities',
             register(reg) {
               reg.registerInit({
                 deps: {

--- a/plugins/events-backend-module-aws-sqs/src/service/eventsModuleAwsSqsConsumingEventPublisher.ts
+++ b/plugins/events-backend-module-aws-sqs/src/service/eventsModuleAwsSqsConsumingEventPublisher.ts
@@ -29,7 +29,7 @@ import { AwsSqsConsumingEventPublisher } from '../publisher/AwsSqsConsumingEvent
  */
 export const eventsModuleAwsSqsConsumingEventPublisher = createBackendModule({
   pluginId: 'events',
-  moduleId: 'awsSqsConsumingEventPublisher',
+  moduleId: 'aws-sqs-consuming-event-publisher',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
@@ -27,7 +27,7 @@ import { AzureDevOpsEventRouter } from '../router/AzureDevOpsEventRouter';
  */
 export const eventsModuleAzureDevOpsEventRouter = createBackendModule({
   pluginId: 'events',
-  moduleId: 'azureDevOpsEventRouter',
+  moduleId: 'azure-dev-ops-event-router',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-bitbucket-cloud/src/service/eventsModuleBitbucketCloudEventRouter.ts
+++ b/plugins/events-backend-module-bitbucket-cloud/src/service/eventsModuleBitbucketCloudEventRouter.ts
@@ -27,7 +27,7 @@ import { BitbucketCloudEventRouter } from '../router/BitbucketCloudEventRouter';
  */
 export const eventsModuleBitbucketCloudEventRouter = createBackendModule({
   pluginId: 'events',
-  moduleId: 'bitbucketCloudEventRouter',
+  moduleId: 'bitbucket-cloud-event-router',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-gerrit/src/service/eventsModuleGerritEventRouter.ts
+++ b/plugins/events-backend-module-gerrit/src/service/eventsModuleGerritEventRouter.ts
@@ -27,7 +27,7 @@ import { GerritEventRouter } from '../router/GerritEventRouter';
  */
 export const eventsModuleGerritEventRouter = createBackendModule({
   pluginId: 'events',
-  moduleId: 'gerritEventRouter',
+  moduleId: 'gerrit-event-router',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-github/src/service/eventsModuleGithubEventRouter.ts
+++ b/plugins/events-backend-module-github/src/service/eventsModuleGithubEventRouter.ts
@@ -27,7 +27,7 @@ import { GithubEventRouter } from '../router/GithubEventRouter';
  */
 export const eventsModuleGithubEventRouter = createBackendModule({
   pluginId: 'events',
-  moduleId: 'githubEventRouter',
+  moduleId: 'github-event-router',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-github/src/service/eventsModuleGithubWebhook.ts
+++ b/plugins/events-backend-module-github/src/service/eventsModuleGithubWebhook.ts
@@ -30,7 +30,7 @@ import { createGithubSignatureValidator } from '../http/createGithubSignatureVal
  */
 export const eventsModuleGithubWebhook = createBackendModule({
   pluginId: 'events',
-  moduleId: 'githubWebhook',
+  moduleId: 'github-webhook',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabEventRouter.ts
+++ b/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabEventRouter.ts
@@ -27,7 +27,7 @@ import { GitlabEventRouter } from '../router/GitlabEventRouter';
  */
 export const eventsModuleGitlabEventRouter = createBackendModule({
   pluginId: 'events',
-  moduleId: 'gitlabEventRouter',
+  moduleId: 'gitlab-event-router',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabWebhook.ts
+++ b/plugins/events-backend-module-gitlab/src/service/eventsModuleGitlabWebhook.ts
@@ -32,7 +32,7 @@ import { createGitlabTokenValidator } from '../http/createGitlabTokenValidator';
  */
 export const eventsModuleGitlabWebhook = createBackendModule({
   pluginId: 'events',
-  moduleId: 'gitlabWebhook',
+  moduleId: 'gitlab-webhook',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/events-backend/README.md
+++ b/plugins/events-backend/README.md
@@ -201,7 +201,7 @@ import { eventsExtensionPoint } from '@backstage/plugin-events-node';
 
 export const yourModuleEventsModule = createBackendModule({
   pluginId: 'events',
-  moduleId: 'yourModule',
+  moduleId: 'your-module',
   register(env) {
     // [...]
     env.registerInit({
@@ -252,7 +252,7 @@ import { eventsExtensionPoint } from '@backstage/plugin-events-node';
 
 export const eventsModuleYourFeature = createBackendModule({
   pluginId: 'events',
-  moduleId: 'yourFeature',
+  moduleId: 'your-feature',
   register(env) {
     // [...]
     env.registerInit({

--- a/plugins/kubernetes-backend/src/routes/resourceRoutes.test.ts
+++ b/plugins/kubernetes-backend/src/routes/resourceRoutes.test.ts
@@ -107,7 +107,7 @@ describe('resourcesRoutes', () => {
         import('@backstage/plugin-kubernetes-backend/alpha'),
         createBackendModule({
           pluginId: 'kubernetes',
-          moduleId: 'testObjectsProvider',
+          moduleId: 'test-objects-provider',
           register(env) {
             env.registerInit({
               deps: { extension: kubernetesObjectsProviderExtensionPoint },

--- a/plugins/permission-backend-module-policy-allow-all/src/module.ts
+++ b/plugins/permission-backend-module-policy-allow-all/src/module.ts
@@ -23,8 +23,8 @@ import { AllowAllPermissionPolicy } from './policy';
  * @public
  */
 export const permissionModuleAllowAllPolicy = createBackendModule({
-  moduleId: 'allowAllPolicy',
   pluginId: 'permission',
+  moduleId: 'allow-all-policy',
   register(reg) {
     reg.registerInit({
       deps: { policy: policyExtensionPoint },

--- a/plugins/search-backend-module-catalog/README.md
+++ b/plugins/search-backend-module-catalog/README.md
@@ -61,7 +61,7 @@ backend.add(searchModuleCatalogCollator());
 backend.add(
   createBackendModule({
     pluginId: 'search',
-    moduleId: 'myCatalogCollatorOptions',
+    moduleId: 'my-catalog-collator-options',
     register(reg) {
       reg.registerInit({
         deps: { collator: catalogCollatorExtensionPoint },

--- a/plugins/search-backend-module-catalog/src/alpha.ts
+++ b/plugins/search-backend-module-catalog/src/alpha.ts
@@ -61,8 +61,8 @@ export const catalogCollatorExtensionPoint =
  * @alpha
  */
 export default createBackendModule({
-  moduleId: 'catalogCollator',
   pluginId: 'search',
+  moduleId: 'catalog-collator',
   register(env) {
     let entityTransformer: CatalogCollatorEntityTransformer | undefined;
 

--- a/plugins/search-backend-module-elasticsearch/src/alpha.ts
+++ b/plugins/search-backend-module-elasticsearch/src/alpha.ts
@@ -45,8 +45,8 @@ export const elasticsearchTranslatorExtensionPoint =
  * @alpha
  */
 export default createBackendModule({
-  moduleId: 'elasticsearchEngine',
   pluginId: 'search',
+  moduleId: 'elasticsearch-engine',
   register(env) {
     let translator: ElasticSearchQueryTranslator | undefined;
 

--- a/plugins/search-backend-module-explore/src/alpha.ts
+++ b/plugins/search-backend-module-explore/src/alpha.ts
@@ -35,8 +35,8 @@ import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
  * @alpha
  */
 export default createBackendModule({
-  moduleId: 'exploreCollator',
   pluginId: 'search',
+  moduleId: 'explore-collator',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/search-backend-module-pg/src/alpha.ts
+++ b/plugins/search-backend-module-pg/src/alpha.ts
@@ -25,8 +25,8 @@ import { PgSearchEngine } from './PgSearchEngine';
  * Search backend module for the Postgres engine.
  */
 export default createBackendModule({
-  moduleId: 'postgresEngine',
   pluginId: 'search',
+  moduleId: 'postgres-engine',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/search-backend-module-stack-overflow-collator/src/module/SearchStackOverflowCollatorModule.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/module/SearchStackOverflowCollatorModule.ts
@@ -28,8 +28,8 @@ import { StackOverflowQuestionsCollatorFactory } from '../collators';
  * Search backend module for the Stack Overflow index.
  */
 export const searchStackOverflowCollatorModule = createBackendModule({
-  moduleId: 'stackOverflowCollator',
   pluginId: 'search',
+  moduleId: 'stack-overflow-collator',
   register(env) {
     env.registerInit({
       deps: {

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -51,8 +51,8 @@ export const techdocsCollatorEntityTransformerExtensionPoint =
  * Search backend module for the TechDocs index.
  */
 export default createBackendModule({
-  moduleId: 'techDocsCollator',
   pluginId: 'search',
+  moduleId: 'techdocs-collator',
   register(env) {
     let transformer: TechDocsCollatorEntityTransformer | undefined;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some more changes related to #21596

We generally stick to camelCase in most places, but have been using kebab-case for plugin IDs. That is somewhat of a historical thing and it would have very high impact to change that right now, but it does have a couple of benefits too. Most notably it means we can match the package name more precisely, and it's slightly easier to read, especially for people not familiar with camelCase. Plugin IDs do show up in some places, such as route paths, logs, dev-tools, etc. We have now also moved to have plugins be installed using dynamic imports rather than importing the plugin symbol itself, which means that there is a lot less interaction with camelCase versions of the plugin ID outside of the plugin itself. There is however still config where we use camelCase, which is unfortunate but hard to do anything about.

The fact that plugin IDs are kebab-case was not obvious in the naming pattern docs, since there was no multi-word example. That has now been fixed by this PR.

In addition I suggest that we move module IDs to use kebab-case as well. Main reason is consistency, since having plugin IDs and module IDs use different patterns is a bit strange, but also for the reasons mentioned above. We'd stop there though, and keep things like extension point and service IDs as camelCase, since those are more hidden IDs and more tightly coupled to the symbol in code.

This should be a low impact change, since module IDs are currently only used to detect conflicts and for error messages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
