### PR TITLE
`BackendPluginManager` use default exports

### DIFF
--- a/packages/backend-plugin-manager/src/loader/CommonJSModuleLoader.ts
+++ b/packages/backend-plugin-manager/src/loader/CommonJSModuleLoader.ts
@@ -49,6 +49,6 @@ export class CommonJSModuleLoader implements ModuleLoader {
   }
 
   async load(packagePath: string): Promise<any> {
-    return await import(/* webpackIgnore: true */ packagePath);
+    return await require(/* webpackIgnore: true */ packagePath);
   }
 }


### PR DESCRIPTION
## Description

Allow the `BackendPluginManager` use default exports for dynamic plugins on the new backend system.

This allows making a plugin dynamic without any source code change
(which was previously required to add a dedicated entrypoint).

## Which issue(s) does this PR fix

- Fixes no issue, but is a followup of PR comment: https://github.com/backstage/backstage/pull/18862#discussion_r1292317415

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
