### PR TITLE
fix(auth-backend): Unknown KeyStore provider: static

### DIFF
--- a/.changeset/nervous-ladybugs-end.md
+++ b/.changeset/nervous-ladybugs-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+fix static token issuer not being able to initialize

--- a/plugins/auth-backend/src/identity/KeyStores.ts
+++ b/plugins/auth-backend/src/identity/KeyStores.ts
@@ -76,7 +76,7 @@ export class KeyStores {
     }
 
     if (provider === 'static') {
-      await StaticKeyStore.fromConfig(config);
+      return await StaticKeyStore.fromConfig(config);
     }
 
     throw new Error(`Unknown KeyStore provider: ${provider}`);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When adding the [static token issuer](https://github.com/backstage/backstage/pull/19649/files#diff-2a4d53d7f7e8560c1111f4ef4231c136968c5dbb35cbc98228d298bdd2784e6e) I overlooked a tiny mistake. A missing return statement. Because of this users cannot use the static key store, and instead are presented with the following error:

```
Unknown KeyStore provider: static
```

I have used the following yarn patch to fix our own instance and tested it in our production environment. As you can see the missing return statement was the only thing I needed to fix:

```
diff --git a/dist/index.cjs.js b/dist/index.cjs.js
index bf01e026771fbc49088ced1fb9620ed10b28849d..71764b4d16d08c81fb1c708f458d199629e47e00 100644
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -3103,7 +3103,7 @@ class KeyStores {
       return keyStore;
     }
     if (provider === "static") {
-      await StaticKeyStore.fromConfig(config);
+      return await StaticKeyStore.fromConfig(config);
     }
     throw new Error(`Unknown KeyStore provider: ${provider}`);
   }
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
