### PR TITLE
fix: export oauth2Proxy as default so featureDiscoveryServiceFactory discovers it

### DIFF
--- a/.changeset/chilly-lies-collect.md
+++ b/.changeset/chilly-lies-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+---
+
+Exported the plugin as default so it gets discovered by using `featureDiscoveryServiceFactory()`

--- a/.changeset/chilly-lies-collect.md
+++ b/.changeset/chilly-lies-collect.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
 ---
 
-Exported the plugin as default so it gets discovered by using `featureDiscoveryServiceFactory()`
+Exported the provider as default so it gets discovered when using `featureDiscoveryServiceFactory()`

--- a/plugins/auth-backend-module-oauth2-proxy-provider/api-report.md
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/api-report.md
@@ -10,7 +10,8 @@ import { IncomingHttpHeaders } from 'http';
 import { ProxyAuthenticator } from '@backstage/plugin-auth-node';
 
 // @public (undocumented)
-export const authModuleOauth2ProxyProvider: () => BackendFeature;
+const authModuleOauth2ProxyProvider: () => BackendFeature;
+export default authModuleOauth2ProxyProvider;
 
 // @public
 export const OAUTH2_PROXY_JWT_HEADER = 'X-OAUTH2-PROXY-ID-TOKEN';

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/index.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/index.ts
@@ -19,7 +19,7 @@
  *
  * @packageDocumentation
  */
-export { authModuleOauth2ProxyProvider } from './module';
+export { authModuleOauth2ProxyProvider as default } from './module';
 export {
   oauth2ProxyAuthenticator,
   OAUTH2_PROXY_JWT_HEADER,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
