### PR TITLE
Disabled `send_page_view` to get rid of events duplication in ga4 plugin

### DIFF
--- a/.changeset/five-bears-share.md
+++ b/.changeset/five-bears-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-analytics-module-ga4': patch
+---
+
+Disabled `send_page_view` to get rid of events duplication

--- a/plugins/analytics-module-ga4/README.md
+++ b/plugins/analytics-module-ga4/README.md
@@ -87,6 +87,7 @@ Additional dimensional data can be captured using custom dimensions, like this:
    attribute names will be prefixed by `a_`.
 5. `allowedContexts` and `allowedAttributes` are optional, if not provided, no additional context and attributes will be sent.
 6. if `allowedContexts` or `allowedAttributes` is set to '\*', all context and attributes will be sent.
+7. `enableSendPageView` is used to send default events and is disabled by default.
 
 ```yaml
 app:

--- a/plugins/analytics-module-ga4/config.d.ts
+++ b/plugins/analytics-module-ga4/config.d.ts
@@ -55,6 +55,14 @@ export interface Config {
         debug?: boolean;
 
         /**
+         * Whether to send default send_page_view event.
+         * Defaults to false.
+         *
+         * @visibility frontend
+         */
+        enableSendPageView?: boolean;
+
+        /**
          * Prevents events from actually being sent when set to true. Defaults
          * to false.
          *

--- a/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
+++ b/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
@@ -47,6 +47,7 @@ export class GoogleAnalytics4 implements AnalyticsApi {
     measurementId: string;
     testMode: boolean;
     debug: boolean;
+    enableSendPageView: boolean;
     contentGroupBy?: string;
     allowedContexts?: string[];
     allowedAttributes?: string[];
@@ -58,6 +59,7 @@ export class GoogleAnalytics4 implements AnalyticsApi {
       userIdTransform = 'sha-256',
       testMode,
       debug,
+      enableSendPageView,
       contentGroupBy,
       allowedContexts,
       allowedAttributes,
@@ -70,7 +72,7 @@ export class GoogleAnalytics4 implements AnalyticsApi {
       },
       gtagOptions: {
         debug_mode: debug,
-        send_page_view: false,
+        send_page_view: enableSendPageView,
       },
     });
 
@@ -113,6 +115,9 @@ export class GoogleAnalytics4 implements AnalyticsApi {
     const identity =
       config.getOptionalString('app.analytics.ga4.identity') || 'disabled';
     const debug = config.getOptionalBoolean('app.analytics.ga4.debug') ?? false;
+    const enableSendPageView =
+      config.getOptionalBoolean('app.analytics.ga4.enableSendPageView') ??
+      false;
     const testMode =
       config.getOptionalBoolean('app.analytics.ga4.testMode') ?? false;
 
@@ -139,6 +144,7 @@ export class GoogleAnalytics4 implements AnalyticsApi {
       measurementId: measurementId,
       testMode,
       debug,
+      enableSendPageView,
       contentGroupBy,
       allowedContexts,
       allowedAttributes,

--- a/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
+++ b/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
@@ -70,6 +70,7 @@ export class GoogleAnalytics4 implements AnalyticsApi {
       },
       gtagOptions: {
         debug_mode: debug,
+        send_page_view: false,
       },
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Due to the fact that the default invents with send_page_view are sent, it turns out that the sending happens by default and from the plugin itself. And due to the fact that the default events cannot collect uid, there is a duplication (event with and without uid).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
