### PR TITLE
Add "path" to `TransformFunc` context

### DIFF
--- a/.changeset/eighty-phones-peel.md
+++ b/.changeset/eighty-phones-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': minor
+---
+
+Add "path" to `TransformFunc` context

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -274,6 +274,7 @@ export type TransformFunc<T extends number | string | boolean> = (
   value: T,
   context: {
     visibility: ConfigVisibility;
+    path: string;
   },
 ) => T | undefined;
 ```

--- a/packages/config-loader/src/schema/filtering.ts
+++ b/packages/config-loader/src/schema/filtering.ts
@@ -68,7 +68,7 @@ export function filterByVisibility(
     if (typeof jsonVal !== 'object') {
       if (isVisible) {
         if (transformFunc) {
-          return transformFunc(jsonVal, { visibility });
+          return transformFunc(jsonVal, { visibility, path: filterPath });
         }
         return jsonVal;
       }

--- a/packages/config-loader/src/schema/types.ts
+++ b/packages/config-loader/src/schema/types.ts
@@ -105,11 +105,22 @@ export type ValidationFunc = (configs: AppConfig[]) => ValidationResult;
 /**
  * A function used to transform primitive configuration values.
  *
+ * The "path" in the context is a JQ-style path to the current value from
+ * within the original object passed to filterByVisibility().
+ * For example, "field.list[2]" would refer to:
+ * \{
+ *   field: [
+ *     "foo",
+ *     "bar",
+ *     "baz" -- this one
+ *   ]
+ * \}
+ *
  * @public
  */
 export type TransformFunc<T extends number | string | boolean> = (
   value: T,
-  context: { visibility: ConfigVisibility },
+  context: { visibility: ConfigVisibility; path: string },
 ) => T | undefined;
 
 /**


### PR DESCRIPTION
We have a use case where the transform we're applying to a value _depends_ on where that value sits in the object tree.

`filterPath` seemed better to expose that `visibilityPath` because:
* JQ-style paths with `.` as separate are more common, and are supported by `lodash`'s `get()` function.
* For array items, `visibilityPath` doesn't include the array index


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
