### PR TITLE
Fix plugin-id that does not match with frontend

### DIFF
--- a/.changeset/empty-beers-wash.md
+++ b/.changeset/empty-beers-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings-backend': patch
+---
+
+The plugin-id used for this plugin does not match what is used in frontend or the documentation. Current id results in 404 response when used.

--- a/plugins/user-settings-backend/src/alpha.ts
+++ b/plugins/user-settings-backend/src/alpha.ts
@@ -26,7 +26,7 @@ import { createRouter } from './service/router';
  * @alpha
  */
 export default createBackendPlugin({
-  pluginId: 'userSettings',
+  pluginId: 'user-settings',
   register(env) {
     env.registerInit({
       deps: {


### PR DESCRIPTION
This plugin-id does not match what is used in frontend: https://github.com/backstage/backstage/blob/df4a219c5266ac1759a411ce7681399f2c21213e/plugins/user-settings/src/apis/StorageApi/UserSettingsStorage.ts#L206

Is is also not the same as is used in documentation: https://github.com/backstage/backstage/blob/df4a219c5266ac1759a411ce7681399f2c21213e/plugins/user-settings-backend/README.md#L40

This results in 404 responses when using this with new backend system.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
