### PR TITLE
fix: don't use commas for jest test files

### DIFF
--- a/.changeset/late-hats-beam.md
+++ b/.changeset/late-hats-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fixed a bug where `schema openapi init` created an invalid test command.

--- a/packages/repo-tools/src/commands/openapi/test/init.ts
+++ b/packages/repo-tools/src/commands/openapi/test/init.ts
@@ -35,7 +35,7 @@ async function init(directoryPath: string) {
     );
   }
   const opticConfigFilePath = join(directoryPath, 'optic.yml');
-  if (!(await fs.pathExists(opticConfigFilePath))) {
+  if (await fs.pathExists(opticConfigFilePath)) {
     throw new Error(`This directory already has an optic.yml file. Exiting.`);
   }
   await fs.writeFile(
@@ -56,7 +56,7 @@ capture:
                 # 🔧 Specify a command that will generate traffic
                 command: yarn backstage-cli package test --no-watch ${ROUTER_TEST_PATHS.map(
                   e => `"${e}"`,
-                ).join(',')} 
+                ).join(' ')} 
   `,
   );
   if (await cliPaths.resolveTargetRoot('node_modules/.bin/prettier')) {

--- a/plugins/catalog-backend/optic.yml
+++ b/plugins/catalog-backend/optic.yml
@@ -12,4 +12,4 @@ capture:
       # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
       run:
         # 🔧 Specify a command that will generate traffic
-        command: yarn backstage-cli package test --no-watch src/service/router.test.ts src/service/createRouter.test.ts
+        command: yarn backstage-cli package test --no-watch "src/service/router.test.ts" "src/service/createRouter.test.ts"

--- a/plugins/search-backend/optic.yml
+++ b/plugins/search-backend/optic.yml
@@ -12,4 +12,4 @@ capture:
       # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
       run:
         # 🔧 Specify a command that will generate traffic
-        command: yarn backstage-cli package test --no-watch src/service/router.test.ts src/service/createRouter.test.ts
+        command: yarn backstage-cli package test --no-watch "src/service/router.test.ts" "src/service/createRouter.test.ts"


### PR DESCRIPTION
Signed-off-by: Aramis Sennyey <aramiss@spotify.com>

## Hey, I just made a Pull Request!

Fixes a bug where `schema openapi init` would create a config file with a test command that used comma separate file names instead of space separated. This caused Jest to register no tests to run instead of running the router tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
