### PR TITLE
Includes templates in @backstage/repo-tools package and use them in CLI

### DIFF
--- a/.changeset/four-foxes-juggle.md
+++ b/.changeset/four-foxes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Includes templates in @backstage/repo-tools package and use them in the CLI

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@apisyouwonthate/style-guide": "^1.4.0",
+    "@backstage/backend-common": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/cli-common": "workspace:^",
     "@backstage/cli-node": "workspace:^",
@@ -85,7 +86,8 @@
   },
   "files": [
     "bin",
-    "dist/**/*.js"
+    "dist/**/*.js",
+    "templates"
   ],
   "nodemonConfig": {
     "watch": "./src",

--- a/packages/repo-tools/src/commands/openapi/client/generate.ts
+++ b/packages/repo-tools/src/commands/openapi/client/generate.ts
@@ -21,6 +21,7 @@ import { paths as cliPaths } from '../../../lib/paths';
 import { mkdirpSync } from 'fs-extra';
 import fs from 'fs-extra';
 import { exec } from '../../../lib/exec';
+import { resolvePackagePath } from '@backstage/backend-common';
 
 async function generate(spec: string, outputDirectory: string) {
   const resolvedOpenapiPath = resolve(spec);
@@ -47,7 +48,15 @@ async function generate(spec: string, outputDirectory: string) {
       '-g',
       'typescript',
       '-c',
-      'templates/typescript-backstage.yaml',
+      resolvePackagePath(
+        '@backstage/repo-tools',
+        'templates/typescript-backstage.yaml',
+      ),
+      '-t',
+      resolvePackagePath(
+        '@backstage/repo-tools',
+        'templates/typescript-backstage',
+      ),
       '--generator-key',
       'v3.0',
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -10083,6 +10083,7 @@ __metadata:
   dependencies:
     "@apidevtools/swagger-parser": ^10.1.0
     "@apisyouwonthate/style-guide": ^1.4.0
+    "@backstage/backend-common": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"


### PR DESCRIPTION
I encountered `ERROR o.o.c.config.CodegenConfigurator - templates/typescript-backstage.yaml (No such file or directory)` error while running openapi client generator from repo tools.

<img width="1689" alt="image" src="https://github.com/backstage/backstage/assets/74687/d8acb857-6ee7-41b9-bacc-f5b782090d70">

The error is happening because `openapi-generator-cli` needs access to the `typescript-backstage` template but it's not able to find it. The template is not actually included in the 

## Hey, I just made a Pull Request!

1. Added `templates` to `files` property in package.json of `@backstage/repo-tools`
2. Added `resolvePackagePath` to resolve `'templates/typescript-backstage'` and 'templates/typescript-backstage.yaml'
3. Added `@backstage/backend-common` to dependencies

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
