### PR TITLE
update announcements plugin ownership

### DIFF
--- a/microsite/data/plugins/announcements.yaml
+++ b/microsite/data/plugins/announcements.yaml
@@ -1,10 +1,10 @@
 ---
 title: Announcements
-author: K-Phoen
-authorUrl: https://github.com/K-Phoen
+author: procore-oss
+authorUrl: https://github.com/procore-oss
 category: Discovery
 description: Write and share announcements within Backstage.
-documentation: https://github.com/K-Phoen/backstage-plugin-announcements/
+documentation: https://github.com/procore-oss/backstage-plugin-announcements/
 iconUrl: /img/plugin-announcements-logo.png
-npmPackageName: '@k-phoen/backstage-plugin-announcements'
+npmPackageName: '@procore-oss/backstage-plugin-announcements'
 addedDate: '2022-11-09'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For several months, I have attempted to communicate with the owner of the announcement plugins. I have tried emailing, [opening an issue](https://github.com/K-Phoen/backstage-plugin-announcements/issues/181), messaging them on Discord, and posting in the Backstage Discord.

I don't know what else to do, but I see a backlog of issues and feature requests not receiving adequate attention. We started [our own version](https://github.com/procore-oss/backstage-plugin-announcements) based on the [recommendation of the maintainer](https://github.com/K-Phoen/backstage-plugin-grafana/issues/78#issuecomment-1743959439) and are now at a point where we would receive more traction if the marketplace pointed to our maintained version. A lof the open issues have been resolved in our version, and we are excited about the opportunity for community contributions. 

I elected not to open a PR to include these plugins here based on the recent [RFC](https://github.com/backstage/backstage/issues/20266).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
