### PR TITLE
Use openapitools.json from @backstage/repo-tools package

### DIFF
--- a/.changeset/spotty-terms-occur.md
+++ b/.changeset/spotty-terms-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+No longer using yarn to execute openapi-generator-cli and prettier in `repo-tools openapi generate-client`

--- a/.changeset/spotty-terms-occur.md
+++ b/.changeset/spotty-terms-occur.md
@@ -2,4 +2,4 @@
 '@backstage/repo-tools': patch
 ---
 
-No longer using yarn to execute openapi-generator-cli and prettier in `repo-tools openapi generate-client`
+Execute `openapi-generator-cli` from `@backstage/repo-tools` directory to force it to use our openapitools.json config file.

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -87,7 +87,8 @@
   "files": [
     "bin",
     "dist/**/*.js",
-    "templates"
+    "templates",
+    "openapitools.json"
   ],
   "nodemonConfig": {
     "watch": "./src",

--- a/packages/repo-tools/src/commands/openapi/client/generate.ts
+++ b/packages/repo-tools/src/commands/openapi/client/generate.ts
@@ -36,10 +36,9 @@ async function generate(spec: string, outputDirectory: string) {
   );
 
   await exec(
-    // The actual main.js file for the binary isn't executable but yarn does _something_ to make it executable.
-    // TODO (sennyeya@): Make this use the actual binary
-    `yarn openapi-generator-cli`,
+    'node',
     [
+      resolvePackagePath('@openapitools/openapi-generator-cli', 'main.js'),
       'generate',
       '-i',
       resolvedOpenapiPath,
@@ -62,10 +61,8 @@ async function generate(spec: string, outputDirectory: string) {
     ],
     {
       maxBuffer: Number.MAX_VALUE,
-      cwd: cliPaths.ownDir,
       env: {
         ...process.env,
-        // PWD: outputDirectory,
       },
     },
   );
@@ -74,8 +71,9 @@ async function generate(spec: string, outputDirectory: string) {
     `yarn backstage-cli package lint --fix ${resolvedOutputDirectory}`,
   );
 
-  if (cliPaths.resolveTargetRoot('node_modules/.bin/prettier')) {
-    await exec(`yarn prettier --write ${resolvedOutputDirectory}`);
+  const prettier = cliPaths.resolveTargetRoot('node_modules/.bin/prettier');
+  if (prettier) {
+    await exec(`${prettier} --write ${resolvedOutputDirectory}`);
   }
 
   fs.removeSync(resolve(resolvedOutputDirectory, '.openapi-generator-ignore'));

--- a/packages/repo-tools/src/commands/openapi/client/generate.ts
+++ b/packages/repo-tools/src/commands/openapi/client/generate.ts
@@ -51,16 +51,12 @@ async function generate(spec: string, outputDirectory: string) {
         '@backstage/repo-tools',
         'templates/typescript-backstage.yaml',
       ),
-      '-t',
-      resolvePackagePath(
-        '@backstage/repo-tools',
-        'templates/typescript-backstage',
-      ),
       '--generator-key',
       'v3.0',
     ],
     {
       maxBuffer: Number.MAX_VALUE,
+      cwd: resolvePackagePath('@backstage/repo-tools'),
       env: {
         ...process.env,
       },

--- a/packages/repo-tools/templates/typescript-backstage.yaml
+++ b/packages/repo-tools/templates/typescript-backstage.yaml
@@ -1,3 +1,5 @@
+templateDir: templates/typescript-backstage
+
 files:
   api.mustache:
     templateType: API

--- a/packages/repo-tools/templates/typescript-backstage.yaml
+++ b/packages/repo-tools/templates/typescript-backstage.yaml
@@ -1,5 +1,3 @@
-templateDir: templates/typescript-backstage
-
 files:
   api.mustache:
     templateType: API


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow-up to https://github.com/backstage/backstage/pull/21696. I tested the nightly release and found that a few problems were not visible previously. 

1. ~`openapi-generator-cli` attempts to read `templateDir` even when overwritten via CLI arguments. When running in the `backstage/backstage` monorepo, `openapi-generator-cli` can resolve the file. The same doesn't work when running `@backstage/repo-tools` inside a project. I removed `templateDir` from `typescript-backstage.yaml` file so `openapi-generator-cli` doesn't try to resolve it and rely on the one passed via CLI arguments.~
2. @sennyeya left a TODO in the code to make the generate command using `main.js` from `openapi-generator-cli` instead of relying on `yarn openapi-generator-cli`. I removed the todo by executing `main.js` with the `node` executable.
3. ~executing `openapi-generator-cli` with yarn necessitated specifying CWD for child_process otherwise, yarn couldn't resolve the binary correctly when executing inside of `backstage/backstage` monorepo. Changing CWD caused the child process to not find openapitools.json file correctly when running inside of a project. I removed CWD because it was no longer necessary since we're not using yarn to execute openapi-generator-cli (see item 2)~
4. Added `openapitools.json` to `@backstage/repo-tools` package to allow us to use that config in backstage projects. 
5. Changed the working directory where `openapi-generator-cli` is executed to `@backstage/repo-tools` in node_modules determined using `resolvePackagePath` to force `openapi-generator-cli` to use `openapitools.json` file provided by our package. 
6.  Using yarn to execute prettier required that prettier was installed inside of the workspace - otherwise yarn wouldn't find the binary. I changed to use the same path as specified to check if prettier is available.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
