### PR TITLE
fix the tsx loader bug on node 18.19

### DIFF
--- a/.changeset/clean-clouds-fry.md
+++ b/.changeset/clean-clouds-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Enable the `tsx` loader to work on Node 18.19 and up

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -130,7 +130,7 @@
     "swc-loader": "^0.2.3",
     "tar": "^6.1.12",
     "terser-webpack-plugin": "^5.1.3",
-    "tsx": "^3.14.0",
+    "tsx": "^4.0.0",
     "util": "^0.12.3",
     "webpack": "^5.70.0",
     "webpack-dev-server": "^4.7.3",

--- a/packages/cli/src/lib/experimental/startBackendExperimental.ts
+++ b/packages/cli/src/lib/experimental/startBackendExperimental.ts
@@ -29,7 +29,9 @@ import spawn from 'cross-spawn';
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(Number);
 const supportsModuleLoaderRegister =
-  nodeMajor > 20 || (nodeMajor === 20 && nodeMinor >= 6);
+  nodeMajor > 20 ||
+  (nodeMajor === 20 && nodeMinor >= 6) ||
+  (nodeMajor === 18 && nodeMinor >= 19);
 
 const loaderArgs = [
   '--require',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3723,7 +3723,7 @@ __metadata:
     tar: ^6.1.12
     terser-webpack-plugin: ^5.1.3
     ts-node: ^10.0.0
-    tsx: ^3.14.0
+    tsx: ^4.0.0
     util: ^0.12.3
     webpack: ^5.70.0
     webpack-dev-server: ^4.7.3
@@ -41129,7 +41129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.21, source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -42982,20 +42982,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^3.14.0":
-  version: 3.14.0
-  resolution: "tsx@npm:3.14.0"
+"tsx@npm:^4.0.0":
+  version: 4.6.2
+  resolution: "tsx@npm:4.6.2"
   dependencies:
     esbuild: ~0.18.20
     fsevents: ~2.3.3
     get-tsconfig: ^4.7.2
-    source-map-support: ^0.5.21
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     tsx: dist/cli.mjs
-  checksum: afcef5d9b90b5800cf1ffb749e943f63042d78a4c0d9eef6e13e43f4ecab465d45e2c9812a2c515cbdc2ee913ff1cd01bf5c606a48013dd3ce2214a631b45557
+  checksum: a9f13bdb67bfb316bbfc92303d8464323ab1b673aa93ea97271c211a8ba7c59274d4b32eeec5ad8fbd0b04260a092a3ad2116abeb6913254ba456010ff685743
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #21738

Tested this by running `yarn start` in `packages/backend-next`, on Node versions v20.8.0, v18.19.0, and v18.14.2