### PR TITLE
Scaffolder-backend: Add dry run support for 'publish:gerrit'

### DIFF
--- a/.changeset/early-pumpkins-hope.md
+++ b/.changeset/early-pumpkins-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gerrit': minor
+---
+
+Add dry run support for the `publish:gerrit` action.

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
@@ -241,7 +241,22 @@ describe('publish:gerrit', () => {
       'https://gerrithost.org/repo/+/refs/heads/master',
     );
   });
+  it('should not create new projects on dryRun', async () => {
+    await action.handler({
+      ...mockContext,
+      isDryRun: true,
+      input: {
+        ...mockContext.input,
+        repoUrl: 'gerrithost.org?workspace=workspace&repo=repo',
+        sourcePath: 'repository/',
+      },
+    });
 
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'commitHash',
+      'abcd-dry-run-1234',
+    );
+  });
   afterEach(() => {
     jest.resetAllMocks();
   });

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
@@ -100,6 +100,7 @@ export function createPublishGerritAction(options: {
     sourcePath?: string;
   }>({
     id: 'publish:gerrit',
+    supportsDryRun: true,
     description:
       'Initializes a git repository of the content in the workspace, and publishes it to Gerrit.',
     examples,
@@ -190,6 +191,29 @@ export function createPublishGerritAction(options: {
         );
       }
 
+      const repoContentsUrl = `${integrationConfig.config.gitilesBaseUrl}/${repo}/+/refs/heads/${defaultBranch}`;
+      const remoteUrl = `${integrationConfig.config.cloneUrl}/a/${repo}`;
+      const gitName = gitAuthorName
+        ? gitAuthorName
+        : config.getOptionalString('scaffolder.defaultAuthor.name');
+      const gitEmail = gitAuthorEmail
+        ? gitAuthorEmail
+        : config.getOptionalString('scaffolder.defaultAuthor.email');
+      const commitMessage = generateCommitMessage(config, gitCommitMessage);
+
+      if (ctx.isDryRun) {
+        ctx.logger.info(`Dry run ctx.input: ${JSON.stringify(ctx.input)}`);
+        ctx.logger.info(`Dry run gitName: ${gitName}`);
+        ctx.logger.info(`Dry run gitEmail: ${gitEmail}`);
+        ctx.logger.info(`Dry run remoteUrl: ${remoteUrl}`);
+        ctx.logger.info(`Dry run repoContentsUrl: ${repoContentsUrl}`);
+        ctx.logger.info(`Dry run commitMessage: ${commitMessage}`);
+        ctx.output('remoteUrl', remoteUrl);
+        ctx.output('commitHash', 'abcd-dry-run-1234');
+        ctx.output('repoContentsUrl', repoContentsUrl);
+        return;
+      }
+
       await createGerritProject(integrationConfig.config, {
         description,
         owner: owner,
@@ -201,15 +225,10 @@ export function createPublishGerritAction(options: {
         password: integrationConfig.config.password!,
       };
       const gitAuthorInfo = {
-        name: gitAuthorName
-          ? gitAuthorName
-          : config.getOptionalString('scaffolder.defaultAuthor.name'),
-        email: gitAuthorEmail
-          ? gitAuthorEmail
-          : config.getOptionalString('scaffolder.defaultAuthor.email'),
+        name: gitName,
+        email: gitEmail,
       };
 
-      const remoteUrl = `${integrationConfig.config.cloneUrl}/a/${repo}`;
       const commitResult = await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, sourcePath),
         remoteUrl,
@@ -220,7 +239,6 @@ export function createPublishGerritAction(options: {
         gitAuthorInfo,
       });
 
-      const repoContentsUrl = `${integrationConfig.config.gitilesBaseUrl}/${repo}/+/refs/heads/${defaultBranch}`;
       ctx.output('remoteUrl', remoteUrl);
       ctx.output('commitHash', commitResult?.commitHash);
       ctx.output('repoContentsUrl', repoContentsUrl);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for running the "publish:gerrit" scaffolder action in "dry run" mode. In dry run mode the input arguments will be logged.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
