### PR TITLE
[Azure DevOps] Added `azureDevOpsAnnotatorProcessorModule`

### DIFF
--- a/.changeset/thin-coats-cry.md
+++ b/.changeset/thin-coats-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Added `azureDevOpsAnnotatorProcessorModule` to make using the `AzureDevOpsAnnotatorProcessor` with the new backend system easier

--- a/plugins/azure-devops-backend/README.md
+++ b/plugins/azure-devops-backend/README.md
@@ -118,35 +118,17 @@ The Azure DevOps backend plugin includes the `AzureDevOpsAnnotatorProcessor` whi
   }
 ```
 
-To use this with the New Backend System you'll want to create a [backend module extension for the Catalog](https://backstage.io/docs/backend-system/building-backends/migrating#other-catalog-extensions) if you haven't already. Here's a basic example of this assuming you are only adding the `AzureDevOpsAnnotatorProcessor`, this would go in your `packages/backend/index.ts`:
+To use this with the [new backend system](https://backstage.io/docs/backend-system/) you'll make the following changes, this would go in your `packages/backend/index.ts`:
 
 ```diff
    import { createBackend } from '@backstage/backend-defaults';
-+  import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-+  import { coreServices, createBackendModule } from '@backstage/backend-plugin-api';
-+  import { AzureDevOpsAnnotatorProcessor } from '@backstage/plugin-azure-devops-backend';
-
-+  const catalogModuleCustomExtensions = createBackendModule({
-+    pluginId: 'catalog', // name of the plugin that the module is targeting
-+    moduleId: 'custom-extensions',
-+    register(env) {
-+      env.registerInit({
-+        deps: {
-+          catalog: catalogProcessingExtensionPoint,
-+          config: coreServices.rootConfig,
-+        },
-+        async init({ catalog, config }) {
-+          catalog.addProcessor(AzureDevOpsAnnotatorProcessor.fromConfig(config));
-+        },
-+      });
-+    },
-+  });
++  import { azureDevOpsAnnotatorProcessorModule } from '@backstage/plugin-azure-devops-backend';
 
    const backend = createBackend();
 
    // ... other feature additions
 
-+  backend.add(catalogModuleCustomExtensions());
++  backend.add(azureDevOpsAnnotatorProcessorModule());
 
    backend.start();
 ```

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -44,6 +44,9 @@ export class AzureDevOpsAnnotatorProcessor implements CatalogProcessor {
   preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
 }
 
+// @public
+export const azureDevOpsAnnotatorProcessorModule: () => BackendFeature;
+
 // @public (undocumented)
 export class AzureDevOpsApi {
   // (undocumented)

--- a/plugins/azure-devops-backend/src/index.ts
+++ b/plugins/azure-devops-backend/src/index.ts
@@ -24,3 +24,4 @@ export { AzureDevOpsApi } from './api';
 export * from './service/router';
 export { azureDevOpsPlugin as default } from './plugin';
 export { AzureDevOpsAnnotatorProcessor } from './processor';
+export { azureDevOpsAnnotatorProcessorModule } from './module';

--- a/plugins/azure-devops-backend/src/module.ts
+++ b/plugins/azure-devops-backend/src/module.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { AzureDevOpsAnnotatorProcessor } from '@backstage/plugin-azure-devops-backend';
+
+/**
+ * Azure DevOps Annotator Processor Module
+ *
+ * @public
+ */
+export const azureDevOpsAnnotatorProcessorModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'azure-devops-annotator-processor-module',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogProcessingExtensionPoint,
+        config: coreServices.rootConfig,
+      },
+      async init({ catalog, config }) {
+        catalog.addProcessor(AzureDevOpsAnnotatorProcessor.fromConfig(config));
+      },
+    });
+  },
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `azureDevOpsAnnotatorProcessorModule` to make using the `AzureDevOpsAnnotatorProcessor` with the new backend system easier. This is based on feedback from here: https://github.com/backstage/backstage/pull/21595#discussion_r1416955093

🎩 tip to @afscrome, this is much nicer!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
