### PR TITLE
[Azure DevOps] Added support for annotations that use a subpath for the host

### DIFF
--- a/.changeset/odd-bats-kick.md
+++ b/.changeset/odd-bats-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops': patch
+---
+
+Added support for annotations that use a subpath for the host

--- a/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -67,7 +67,7 @@ describe('getAnnotationValuesFromEntity', () => {
   });
 
   describe('with project-repo annotation missing project', () => {
-    it('should throw missing project error', () => {
+    it('should throw incorrect format error', () => {
       const entity: Entity = {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Component',
@@ -91,7 +91,7 @@ describe('getAnnotationValuesFromEntity', () => {
   });
 
   describe('with project-repo annotation missing repo', () => {
-    it('should throw missing repo error', () => {
+    it('should throw incorrect format error', () => {
       const entity: Entity = {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Component',
@@ -261,7 +261,7 @@ describe('getAnnotationValuesFromEntity', () => {
   });
 
   describe('with host-org annotation missing host', () => {
-    it('should throw missing project error', () => {
+    it('should throw incorrect format error', () => {
       const entity: Entity = {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Component',
@@ -285,7 +285,7 @@ describe('getAnnotationValuesFromEntity', () => {
   });
 
   describe('with host-org annotation missing org', () => {
-    it('should throw missing repo error', () => {
+    it('should throw incorrect format error', () => {
       const entity: Entity = {
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Component',
@@ -304,6 +304,56 @@ describe('getAnnotationValuesFromEntity', () => {
 
       expect(test).toThrow(
         'Invalid value for annotation "dev.azure.com/host-org"; expected format is: <host-name>/<organization-name>, found: "host/"',
+      );
+    });
+  });
+
+  describe('with tfs subpath for org', () => {
+    it('should return host and org', () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          namespace: 'default',
+          name: 'tfs-subpath',
+          annotations: {
+            'dev.azure.com/project-repo': 'projectName/repoName',
+            'dev.azure.com/host-org': 'company.com/tfs/organizationName',
+          },
+        },
+      };
+
+      const values = getAnnotationValuesFromEntity(entity);
+      expect(values).toEqual({
+        project: 'projectName',
+        repo: 'repoName',
+        definition: undefined,
+        host: 'company.com/tfs',
+        org: 'organizationName',
+      });
+    });
+  });
+
+  describe('with more then expected slashes', () => {
+    it('should throw incorrect format error', () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          namespace: 'default',
+          name: 'host-org',
+          annotations: {
+            'dev.azure.com/host-org': 'host/subpath/another-path/org/project',
+          },
+        },
+      };
+
+      const test = () => {
+        return getAnnotationValuesFromEntity(entity);
+      };
+
+      expect(test).toThrow(
+        'Invalid value for annotation "dev.azure.com/host-org"; expected format is: <host-name>/<organization-name>, found: "host/subpath/another-path/org/project"',
       );
     });
   });

--- a/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.ts
+++ b/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.ts
@@ -89,11 +89,15 @@ function getHostOrg(annotations?: Record<string, string>): {
     return { host: undefined, org: undefined };
   }
 
-  if (annotation.includes('/')) {
-    const [host, org] = annotation.split('/');
+  const segments = annotation.split('/');
+  if (segments.length === 2) {
+    const [host, org] = segments;
     if (host && org) {
       return { host, org };
     }
+  } else if (segments.length === 3) {
+    const [host, subpath, org] = segments;
+    return { host: `${host}/${subpath}`, org };
   }
 
   throw new Error(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for annotations that use a subpath for the host. For those who started on TFS and upgraded from there it's pretty common that the URL would be something like this: `https://company.com/tfs/project-collection/team-project`. This PR adds support for this case

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
