### PR TITLE
[GitHub Issue Templates] Removed placeholder and moved text to description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -13,33 +13,29 @@ body:
       required: true
     attributes:
       label: '📜 Description'
-      description: 'A clear and concise description of what the bug is.'
-      placeholder: 'It bugs out when ...'
+      description: 'A clear and concise description of what the bug is. It bugs out when ...'
   - type: textarea
     id: expected-behavior
     validations:
       required: true
     attributes:
       label: '👍 Expected behavior'
-      description: 'What did you think should happen?'
-      placeholder: 'It should ...'
+      description: 'What did you think should happen? It should ...'
   - type: textarea
     id: actual-behavior
     validations:
       required: true
     attributes:
       label: '👎 Actual Behavior with Screenshots'
-      description: 'What did actually happen? Add screenshots, if applicable.'
-      placeholder: 'It actually ...'
+      description: 'What did actually happen? Add screenshots, if applicable. It actually ...'
   - type: textarea
     id: steps-to-reproduce
     validations:
       required: true
     attributes:
       label: '👟 Reproduction steps'
-      description: 'How do you trigger this bug? Please walk us through it step by step.'
-      placeholder:
-        "Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code or configuration to reproduce, if relevant.\n
+      description: 'How do you trigger this bug? Please walk us through it step by step. Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code or configuration to reproduce, if relevant.'
+      placeholder: "\n
         1. Go to '...'\n
         2. Click on '....'\n
         3. Scroll down to '....'"
@@ -49,17 +45,14 @@ body:
       required: false
     attributes:
       label: '📃 Provide the context for the Bug.'
-      description: 'How has this issue affected you? What are you trying to accomplish?'
-      placeholder: 'Providing context (e.g. links to configuration settings, stack trace or log data) helps us come up with a solution that is most useful in the real world.'
+      description: 'How has this issue affected you? What are you trying to accomplish? Providing context (e.g. links to configuration settings, stack trace or log data) helps us come up with a solution that is most useful in the real world.'
   - type: textarea
     id: environment
     validations:
       required: false
     attributes:
       label: '🖥️ Your Environment'
-      description: 'Provide Browser Information
-        Provide Output of `yarn backstage-cli info`'
-      placeholder: 'Include as many relevant details about the environment you experienced the bug in.'
+      description: 'Always provide output of `yarn backstage-cli info`; provide browser information when applicable. Include as many relevant details about the environment you experienced the bug in.'
   - type: checkboxes
     id: no-duplicate-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -14,7 +14,6 @@ body:
     attributes:
       label: '🔖 Feature description'
       description: 'A clear and concise description of what the feature is.'
-      placeholder: 'You should add ...'
   - type: textarea
     id: context
     validations:
@@ -22,13 +21,11 @@ body:
     attributes:
       label: '🎤 Context'
       description: 'Please explain why this feature should be implemented and how it would be used. Add examples, if applicable.'
-      placeholder: 'In my use-case, ...'
   - type: textarea
     id: implementation
     attributes:
       label: '✌️ Possible Implementation'
-      description: 'A clear and concise description of what you want to happen.'
-      placeholder: 'Not obligatory, but ideas as to the implementation of the addition or change'
+      description: 'A clear and concise description of what you want to happen. Not obligatory, but ideas as to the implementation of the addition or change.'
   - type: checkboxes
     id: no-duplicate-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin.yaml
@@ -14,19 +14,16 @@ body:
     attributes:
       label: '🔖 Summary'
       description: 'Provide a general summary of the plugin and how it should work'
-      placeholder: 'You should add ...'
   - type: textarea
     id: website
     attributes:
       label: '🌐 Project website (if applicable)'
       description: 'Add a link to the open source project or product this plugin will integrate with, if existing'
-      placeholder: 'Website Link is ...'
   - type: textarea
     id: context
     attributes:
       label: '✌️ Context'
-      description: 'A clear and concise description about the Plugin.'
-      placeholder: 'Providing additional context'
+      description: 'A clear and concise description about the Plugin and any additional context.'
   - type: checkboxes
     id: no-duplicate-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/rfc.yaml
+++ b/.github/ISSUE_TEMPLATE/rfc.yaml
@@ -13,28 +13,24 @@ body:
       required: true
     attributes:
       label: '🔖 Need'
-      description: 'Let us know why are you proposing this change'
-      placeholder: 'The problem we’re trying to address and the benefits/impact we expect to get from this are ...'
+      description: "Let us know why are you proposing this change. The problem we're trying to address and the benefits/impact we expect to get from this are ..."
   - type: textarea
     id: proposal
     validations:
       required: true
     attributes:
       label: '🎉 Proposal'
-      description: 'Describe the proposal in as much detail as needed for reviewers to give concrete feedback.'
-      placeholder: 'Take special care in this section to describe any implications on data privacy or security.'
+      description: 'Describe the proposal in as much detail as needed for reviewers to give concrete feedback. Take special care in this section to describe any implications on data privacy or security.'
   - type: textarea
     id: alternatives
     attributes:
       label: '〽️ Alternatives'
-      description: 'What alternatives to the proposed solution were considered?'
-      placeholder: 'What criteria/data was used to discard these?'
+      description: 'What alternatives to the proposed solution were considered? What criteria/data was used to discard these?'
   - type: textarea
     id: risk
     attributes:
       label: '❌ Risks'
-      description: 'What other things happening could conflict or compete (for example for resources) with the proposal?'
-      placeholder: 'What risk are there and how do we plan to handle them?'
+      description: 'What other things happening could conflict or compete (for example for resources) with the proposal? What risk are there and how do we plan to handle them?'
   - type: checkboxes
     id: no-duplicate-issues
     attributes:

--- a/.github/ISSUE_TEMPLATE/ux_component.yaml
+++ b/.github/ISSUE_TEMPLATE/ux_component.yaml
@@ -6,37 +6,34 @@ body:
   - type: markdown
     attributes:
       value: |
-        We value your time and efforts to submit this RFC form. 🙏
+        We value your time and efforts to submit this UX Component form. 🙏
   - type: textarea
     id: ux-general
     validations:
       required: true
     attributes:
       label: '🔖 General'
-      description: 'Write a nice note to the community requesting the creation of a new component.'
-      placeholder: 'Include an image of your component. Bonus points for a GIF!'
+      description: |
+        'Write a nice note to the community requesting the creation of a new component. Include an image of your component. Bonus points for a GIF!'
   - type: textarea
     id: usage
     validations:
       required: true
     attributes:
       label: '💻 Usage'
-      description: "Tell us what's the point of this component/pattern is."
-      placeholder: 'How does it help? How should it work? Any rules?'
+      description: "Tell us what's the point of this component/pattern is. How does it help? How should it work? Any rules?"
   - type: textarea
     id: specs
     validations:
       required: true
     attributes:
       label: '📐 Specs'
-      description: 'Include images that detail the redlines for your component.'
-      placeholder: "Once we get our Figma workspace set up, we'll be posting the Figma files rather than doing specs by hand."
+      description: "Include images that detail the redlines for your component. Once we get our Figma workspace set up, we'll be posting the Figma files rather than doing specs by hand."
   - type: textarea
     id: future
     attributes:
       label: '🔮 Future'
       description: 'List out any upcoming, exciting functionality for this component.'
-      placeholder: 'The component will have ...'
   - type: checkboxes
     id: no-duplicate-issues
     attributes:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently when you create any issue due to a new feature GitHub rolled out the placeholder text gets mangled with some text being added by the new MarkDown box like this:

![image](https://github.com/backstage/backstage/assets/67169551/4d673366-5738-45eb-ba28-11430d93a1cd)

There aren't any clear directions as to the best way to fix this. I've removed the placeholder text and where it made sense moved it up into the description as a workaround.

One other idea I'd like to try and I left it in place for the `bug.yaml` is to see if we can use the `\n` to put the place holder below the text we don't control. I'm not aware how to test these changes without them being committed though. This will need to be merged and then a follow up for further adjustments may be needed.

Open to other solutions or ideas. 🤔 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
