### PR TITLE
Fixes #21798 StarredEntities home page component calls getEntitiesByRefs instead of getEntities

### DIFF
--- a/.changeset/shy-boxes-sleep.md
+++ b/.changeset/shy-boxes-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+StarredEntities component calls `getEntitiesByRefs` instead of `getEntities` to improve performance since we have the `entityRefs`

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
@@ -49,7 +49,7 @@ describe('StarredEntitiesContent', () => {
     mockedApi.toggleStarred('component:default/mock-starred-entity-3');
 
     const mockCatalogApi = {
-      getEntities: jest
+      getEntitiesByRefs: jest
         .fn()
         .mockImplementation(async () => ({ items: entities })),
     };
@@ -87,7 +87,7 @@ describe('StarredEntitiesContent', () => {
     const mockedApi = new MockStarredEntitiesApi();
 
     const mockCatalogApi = {
-      getEntities: jest
+      getEntitiesByRefs: jest
         .fn()
         .mockImplementation(async () => ({ items: entities })),
     };
@@ -117,7 +117,7 @@ describe('StarredEntitiesContent', () => {
     const mockedApi = new MockStarredEntitiesApi();
 
     const mockCatalogApi = {
-      getEntities: jest
+      getEntitiesByRefs: jest
         .fn()
         .mockImplementation(async () => ({ items: entities })),
     };

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -18,11 +18,7 @@ import {
   catalogApiRef,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
-import {
-  Entity,
-  parseEntityRef,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { List, Typography, Tabs, Tab } from '@material-ui/core';
@@ -55,17 +51,9 @@ export const Content = ({
       return [];
     }
 
-    const filter = [...starredEntities]
-      .map(ent => parseEntityRef(ent))
-      .map(ref => ({
-        kind: ref.kind,
-        'metadata.namespace': ref.namespace,
-        'metadata.name': ref.name,
-      }));
-
     return (
-      await catalogApi.getEntities({
-        filter,
+      await catalogApi.getEntitiesByRefs({
+        entityRefs: [...starredEntities],
         fields: [
           'kind',
           'metadata.namespace',
@@ -73,7 +61,7 @@ export const Content = ({
           'metadata.title',
         ],
       })
-    ).items;
+    ).items.filter((e): e is Entity => !!e);
   }, [catalogApi, starredEntities]);
 
   if (starredEntities.size === 0)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

StarredEntities home page component calls getEntitiesByRefs instead of getEntities.

In addition to the automated tests, I tested manually with 10 starred entities (component, user, group) and also tested the groupByKind option. Additionally test when no entities starred too.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
