### PR TITLE
CI/CD: Correct `postgres` mount point on Uffizzi Virtual Clusters

### DIFF
--- a/.github/uffizzi/k8s/manifests/backstage-deploy.yaml
+++ b/.github/uffizzi/k8s/manifests/backstage-deploy.yaml
@@ -35,3 +35,10 @@ spec:
               value: 'postgres.default.svc.cluster.local'
             - name: NODE_ENV
               value: production
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 384Mi
+            requests:
+              cpu: 20m
+              memory: 160Mi

--- a/.github/uffizzi/k8s/manifests/pg-deploy.yaml
+++ b/.github/uffizzi/k8s/manifests/pg-deploy.yaml
@@ -25,6 +25,13 @@ spec:
           envFrom:
             - secretRef:
                 name: postgres-secrets
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 96Mi
           volumeMounts:
             - mountPath: /data
               name: postgresdb

--- a/.github/uffizzi/k8s/manifests/pg-deploy.yaml
+++ b/.github/uffizzi/k8s/manifests/pg-deploy.yaml
@@ -19,11 +19,14 @@ spec:
           imagePullPolicy: 'IfNotPresent'
           ports:
             - containerPort: 5432
+          env:
+            - name: PGDATA
+              value: "/data/pgdata"
           envFrom:
             - secretRef:
                 name: postgres-secrets
           volumeMounts:
-            - mountPath: /var/lib/postgresql
+            - mountPath: /data
               name: postgresdb
       volumes:
         - name: postgresdb

--- a/.github/uffizzi/k8s/manifests/pg-deploy.yaml
+++ b/.github/uffizzi/k8s/manifests/pg-deploy.yaml
@@ -21,7 +21,7 @@ spec:
             - containerPort: 5432
           env:
             - name: PGDATA
-              value: "/data/pgdata"
+              value: '/data/pgdata'
           envFrom:
             - secretRef:
                 name: postgres-secrets

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Generate UUID image name
         id: uuid
-        run: echo "UUID_TAG_APP=$(uuidgen)" >> $GITHUB_ENV
+        run: echo "UUID_TAG_APP=backstage-$(uuidgen)" >> $GITHUB_ENV
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Generate UUID image name
         id: uuid
-        run: echo "UUID_TAG_APP=backstage-$(uuidgen)" >> $GITHUB_ENV
+        run: echo "UUID_TAG_APP=backstage-$(uuidgen --time)" >> $GITHUB_ENV
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
We noticed that databases were not persisting when `postgres` containers restarted on Uffizzi Virtual Clusters. I regret this was because we were mounting the persistent disk at `/var/lib/postgresql` while the `postgres` image was also mounting a temporary volume at `/var/lib/postgresql/data`, so the persistent volume was never used.

This PR corrects this by instead mounting the persistent volume at `/data` and setting the `PGDATA` environment variable so data is written to the `/data/pgdata` directory within. I've tested this change successfully on my own fork.

Additionally I've changed the temporary image name generator to use a string prefix and time-base (version 1) UUID strings. This will help us identify and garbage-collect images within our registry.

Thank you for your consideration and please reach out if you've any questions or concerns,
Adam Vollrath
Uffizzi