### PR TITLE
[Google Cloud Build] Added User-Agent headers

### DIFF
--- a/.changeset/soft-beans-tease.md
+++ b/.changeset/soft-beans-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cloudbuild': minor
+---
+
+Add telemetry HTTP header Google Cloud Platform


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a User-Agent header to existing API requests in this plugin to clearly identify API requests from this Cloud Build plugin. User-Agent headers are formatted as follows where VERSION represents the current dotted version number of the Backstage Cloud Build plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
