### PR TITLE
docs(microsite): Update microsite info on PagerDuty plugin

### DIFF
--- a/microsite/data/plugins/pager-duty.yaml
+++ b/microsite/data/plugins/pager-duty.yaml
@@ -1,12 +1,12 @@
 ---
 title: PagerDuty
-author: Spotify
-authorUrl: https://github.com/spotify
+author: PagerDuty
+authorUrl: https://github.com/pagerduty
 category: Monitoring
-description: PagerDuty offers a simple way to identify any active incidents for an entity and the escalation policy.
-documentation: https://github.com/backstage/backstage/tree/master/plugins/pagerduty
+description: Bring the power of PagerDuty to Backstage, reduce cognitive load, improve service visibility and enforce incident management best practices.
+documentation: https://pagerduty.github.io/backstage-plugin-docs/index.html
 iconUrl: https://avatars2.githubusercontent.com/u/766800?s=200&v=4
-npmPackageName: '@backstage/plugin-pagerduty'
+npmPackageName: '@pagerduty/backstage-plugin'
 tags:
   - monitoring
   - errors


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have updated the information on the microsite related to the PagerDuty plugin as it still points to the old version of the plugin created by the Backstage team instead of the new one maintained by PagerDuty.

![image](https://github.com/backstage/backstage/assets/2689939/6b200933-717a-429b-bcac-1168da785423)

PS: For this PR I haven't created a changeset as it is only necessary for changes in *packages* and *plugins*. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
