### PR TITLE
Scaffolder-backend-gerrit: Add dry run support for 'publish:gerrit'

### DIFF
--- a/.changeset/early-pumpkins-hope.md
+++ b/.changeset/early-pumpkins-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+---
+
+Add dry run support for the `publish:gerrit` action.

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
@@ -241,7 +241,22 @@ describe('publish:gerrit', () => {
       'https://gerrithost.org/repo/+/refs/heads/master',
     );
   });
+  it('should not create new projects on dryRun', async () => {
+    await action.handler({
+      ...mockContext,
+      isDryRun: true,
+      input: {
+        ...mockContext.input,
+        repoUrl: 'gerrithost.org?workspace=workspace&repo=repo',
+        sourcePath: 'repository/',
+      },
+    });
 
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'commitHash',
+      'abcd-dry-run-1234',
+    );
+  });
   afterEach(() => {
     jest.resetAllMocks();
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for running the "publish:gerrit" scaffolder action in "dry run" mode. In dry run mode the input arguments will be logged.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
