### PR TITLE
TechDocs Collator: Regenerate token on every fetch to the search index

### DIFF
--- a/.changeset/famous-coins-glow.md
+++ b/.changeset/famous-coins-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Regenerates a fresh token for each call to the search index when collating techdocs.

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -136,6 +136,7 @@ export class DefaultTechDocsCollator {
         );
 
         try {
+          const { token: newToken } = await tokenManager.getToken();
           const searchIndexResponse = await fetch(
             DefaultTechDocsCollator.constructDocsIndexUrl(
               techDocsBaseUrl,
@@ -143,7 +144,7 @@ export class DefaultTechDocsCollator {
             ),
             {
               headers: {
-                Authorization: `Bearer ${token}`,
+                Authorization: `Bearer ${newToken}`,
               },
             },
           );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #20731 by providing a fresh token to the call to the search index when collating techdocs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
