### PR TITLE
fix(deps): update dependency passport-saml  @backstage/plugin-auth-backend  

### DIFF
--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -80,7 +80,7 @@
     "passport-microsoft": "^1.0.0",
     "passport-oauth2": "^1.6.1",
     "passport-onelogin-oauth": "^0.0.1",
-    "passport-saml": "^3.1.2",
+    "passport-saml": "^3.2.4",
     "uuid": "^8.0.0",
     "winston": "^3.2.1",
     "yn": "^4.0.0"


### PR DESCRIPTION
I update _passport-saml_ dependency because it use _xml2js_ in version 0.4.23 this allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the __proto__ property to be edited.

You can get more detail here [CVE-2023-0842](https://nvd.nist.gov/vuln/detail/CVE-2023-0842)

The solution is update _xml2js_ to ^0.5.0 version and  _passport-saml_ solved in 3.2.4 version

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
