### PR TITLE
no more featureLoader

### DIFF
--- a/.changeset/fluffy-bikes-laugh.md
+++ b/.changeset/fluffy-bikes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+Removed `featureLoader` from `createApp`, `features` instead accepts both `FrontendFeature` and `CreateAppFeatureLoader`

--- a/packages/frontend-app-api/api-report.md
+++ b/packages/frontend-app-api/api-report.md
@@ -24,9 +24,12 @@ export function createApp(options?: {
 };
 
 // @public
-export type CreateAppFeatureLoader = (options: {
-  config: ConfigApi;
-}) => Promise<FrontendFeature[]>;
+export interface CreateAppFeatureLoader {
+  getLoaderName(): string;
+  load(options: { config: ConfigApi }): Promise<{
+    features: FrontendFeature[];
+  }>;
+}
 
 // @public
 export type CreateAppRouteBinder = <

--- a/packages/frontend-app-api/api-report.md
+++ b/packages/frontend-app-api/api-report.md
@@ -14,15 +14,19 @@ import { SubRouteRef } from '@backstage/frontend-plugin-api';
 
 // @public (undocumented)
 export function createApp(options?: {
-  features?: FrontendFeature[];
+  features?: (FrontendFeature | CreateAppFeatureLoader)[];
   configLoader?: () => Promise<{
     config: ConfigApi;
   }>;
   bindRoutes?(context: { bind: CreateAppRouteBinder }): void;
-  featureLoader?: (ctx: { config: ConfigApi }) => Promise<FrontendFeature[]>;
 }): {
   createRoot(): JSX_2.Element;
 };
+
+// @public
+export type CreateAppFeatureLoader = (options: {
+  config: ConfigApi;
+}) => Promise<FrontendFeature[]>;
 
 // @public
 export type CreateAppRouteBinder = <

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -38,6 +38,7 @@
     "@backstage/core-app-api": "workspace:^",
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
+    "@backstage/errors": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@backstage/types": "workspace:^",

--- a/packages/frontend-app-api/src/wiring/createApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.test.tsx
@@ -99,6 +99,33 @@ describe('createApp', () => {
     );
   });
 
+  it('should support feature loaders', async () => {
+    const app = createApp({
+      configLoader: async () => ({
+        config: new MockConfigApi({ key: 'config-value' }),
+      }),
+      features: [
+        async ({ config }) => [
+          createPlugin({
+            id: 'test',
+            extensions: [
+              createPageExtension({
+                defaultPath: '/',
+                loader: async () => <div>{config.getString('key')}</div>,
+              }),
+            ],
+          }),
+        ],
+      ],
+    });
+
+    await renderWithEffects(app.createRoot());
+
+    await expect(
+      screen.findByText('config-value'),
+    ).resolves.toBeInTheDocument();
+  });
+
   it('should register feature flags', async () => {
     const app = createApp({
       configLoader: async () => ({ config: new MockConfigApi({}) }),

--- a/packages/frontend-app-api/src/wiring/createApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.test.tsx
@@ -126,6 +126,25 @@ describe('createApp', () => {
     ).resolves.toBeInTheDocument();
   });
 
+  it('should propagate errors thrown by feature loaders', async () => {
+    const app = createApp({
+      configLoader: async () => ({
+        config: new MockConfigApi({}),
+      }),
+      features: [
+        async () => {
+          throw new TypeError('boom');
+        },
+      ],
+    });
+
+    await expect(
+      renderWithEffects(app.createRoot()),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Failed to read frontend features from loader, TypeError: boom"`,
+    );
+  });
+
   it('should register feature flags', async () => {
     const app = createApp({
       configLoader: async () => ({ config: new MockConfigApi({}) }),

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -101,6 +101,7 @@ import { toInternalBackstagePlugin } from '../../../frontend-plugin-api/src/wiri
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { toInternalExtensionOverrides } from '../../../frontend-plugin-api/src/wiring/createExtensionOverrides';
 import { DefaultComponentsApi } from '../apis/implementations/ComponentsApi';
+import { stringifyError } from '@backstage/errors';
 
 export const builtinExtensions = [
   Core,
@@ -238,12 +239,20 @@ function deduplicateFeatures(
     .reverse();
 }
 
+/**
+ * A source of dynamically loaded frontend features.
+ *
+ * @public
+ */
+export type CreateAppFeatureLoader = (options: {
+  config: ConfigApi;
+}) => Promise<FrontendFeature[]>;
+
 /** @public */
 export function createApp(options?: {
-  features?: FrontendFeature[];
+  features?: (FrontendFeature | CreateAppFeatureLoader)[];
   configLoader?: () => Promise<{ config: ConfigApi }>;
   bindRoutes?(context: { bind: CreateAppRouteBinder }): void;
-  featureLoader?: (ctx: { config: ConfigApi }) => Promise<FrontendFeature[]>;
 }): {
   createRoot(): JSX.Element;
 } {
@@ -255,15 +264,28 @@ export function createApp(options?: {
       );
 
     const discoveredFeatures = getAvailableFeatures(config);
-    const loadedFeatures = (await options?.featureLoader?.({ config })) ?? [];
+
+    const providedFeatures: FrontendFeature[] = [];
+    for (const feature of options?.features ?? []) {
+      if (typeof feature === 'function') {
+        try {
+          const loadedFeatures = await feature({ config });
+          providedFeatures.push(...loadedFeatures);
+        } catch (e) {
+          throw new Error(
+            `Failed to read frontend features from loader, ${stringifyError(
+              e,
+            )}`,
+          );
+        }
+      } else {
+        providedFeatures.push(feature);
+      }
+    }
 
     const app = createSpecializedApp({
       config,
-      features: [
-        ...discoveredFeatures,
-        ...loadedFeatures,
-        ...(options?.features ?? []),
-      ],
+      features: [...discoveredFeatures, ...providedFeatures],
       bindRoutes: options?.bindRoutes,
     }).createRoot();
 
@@ -285,6 +307,7 @@ export function createApp(options?: {
 /**
  * Synchronous version of {@link createApp}, expecting all features and
  * config to have been loaded already.
+ *
  * @public
  */
 export function createSpecializedApp(options?: {

--- a/packages/frontend-app-api/src/wiring/index.ts
+++ b/packages/frontend-app-api/src/wiring/index.ts
@@ -18,6 +18,7 @@ export {
   createApp,
   createSpecializedApp,
   createExtensionTree,
+  type CreateAppFeatureLoader,
   type ExtensionTreeNode,
   type ExtensionTree,
 } from './createApp';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4158,6 +4158,7 @@ __metadata:
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
+    "@backstage/errors": "workspace:^"
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"


### PR DESCRIPTION
Open questions here:

- Should `CreateAppFeatureLoader` actually be a proper interface with some name or so, like for example entity providers? Feels like we would want some traceability for the loader. Better error messages, more metadata in the app tree, etc. EDIT: This was addressed in 51754bca1971cf8d5a3d68baaa1b2d5fda618389
- Is it ok to just throw like it does? This is the same as before, but I'm wondering if we should change to rendering an error instead of throwing.
- I made a type for the loader. With the prefix in place, it looks kinda nice. Could do the same for a `CreateAppConfigLoader`?