### PR TITLE
feat(core-components): extend `IconLinkVerticalProps` with `LinkProps`

### DIFF
--- a/.changeset/new-snakes-mate.md
+++ b/.changeset/new-snakes-mate.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+---
+
+Extend `IconLinkVerticalProps` with `LinkProps`.
+Additional props are forwarded to the underlying `Link` component.

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -547,8 +547,8 @@ export function IconLinkVertical({
   href,
   icon,
   label,
-  onClick,
   title,
+  ...props
 }: IconLinkVerticalProps): React_2.JSX.Element;
 
 // @public (undocumented)
@@ -562,14 +562,12 @@ export type IconLinkVerticalClassKey =
 // Warning: (ae-missing-release-tag) "IconLinkVerticalProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type IconLinkVerticalProps = {
+export type IconLinkVerticalProps = Omit<LinkProps, 'to' | 'className'> & {
   color?: 'primary' | 'secondary';
   disabled?: boolean;
   href?: string;
   icon?: React_2.ReactNode;
   label: string;
-  onClick?: React_2.MouseEventHandler<HTMLAnchorElement>;
-  title?: string;
 };
 
 // @public (undocumented)

--- a/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
@@ -17,18 +17,16 @@ import React from 'react';
 import classnames from 'classnames';
 import { makeStyles } from '@material-ui/core/styles';
 import LinkIcon from '@material-ui/icons/Link';
-import { Link } from '../Link';
+import { Link, LinkProps } from '../Link';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-export type IconLinkVerticalProps = {
+export type IconLinkVerticalProps = Omit<LinkProps, 'to' | 'className'> & {
   color?: 'primary' | 'secondary';
   disabled?: boolean;
   href?: string;
   icon?: React.ReactNode;
   label: string;
-  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-  title?: string;
 };
 
 /** @public */
@@ -73,8 +71,8 @@ export function IconLinkVertical({
   href = '#',
   icon = <LinkIcon />,
   label,
-  onClick,
   title,
+  ...props
 }: IconLinkVerticalProps) {
   const classes = useIconStyles();
 
@@ -98,7 +96,7 @@ export function IconLinkVertical({
       title={title}
       className={classnames(classes.link, classes[color])}
       to={href}
-      onClick={onClick}
+      {...props}
     >
       {icon}
       <Typography variant="caption" component="span" className={classes.label}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Extend `IconLinkVerticalProps` with `LinkProps`.
Additional props are forwarded to the underlying `Link` component.

This allows to pass a `ref` prop to the underlying `Link` component, to achieve the following (which was proposed in the original PR but changed).

**Original PR:**
Support sub-links in `IconLinkVertical` component.
Sublinks are displayed inside a Popover component when on hover.
This is useful in case you want to have a header link to external systems that have multiple environments (stg, prd ...)

[Demo Video](https://github.com/backstage/backstage/assets/2379631/46203883-4443-46d9-b01d-9c25c08e1a2b)

![image](https://github.com/backstage/backstage/assets/2379631/fb0dbb6c-c660-4cd8-a397-ee7dba715f65)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
