### PR TITLE
Fix position of the ReportIssue component

### DIFF
--- a/.changeset/tame-rockets-sin.md
+++ b/.changeset/tame-rockets-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+---
+
+Fix position of the ReportIssue component when is displaying at the top of the container.

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
@@ -111,8 +111,25 @@ export const ReportIssueAddon = ({
     const mainContentPosition = mainContent!.getBoundingClientRect();
     const selectionPosition = selection.getRangeAt(0).getBoundingClientRect();
 
+    // Calculating the distance between the selection's top and the main content's top
+    const distanceFromTop = selectionPosition.top - mainContentPosition.top;
+    const minDistanceFromTop = 50;
+
+    // Defining a base value for 'top'
+    let top = distanceFromTop < minDistanceFromTop ? 101 : distanceFromTop - 16;
+
+    // Checking if the main content is off-screen towards the top
+    if (mainContentPosition.top < 0) {
+      const absMainContentTop = Math.abs(mainContentPosition.top);
+
+      // Adjusting 'top' if the selection is close to the top edge and the main content is off-screen
+      if (distanceFromTop - absMainContentTop < minDistanceFromTop) {
+        top += 89;
+      }
+    }
+
     setStyle({
-      top: `${selectionPosition.top - mainContentPosition.top - 16}px`,
+      top: `${top}px`,
       left: `${selectionPosition.left + selectionPosition.width / 2}px`,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix position of the ReportIssue component at the top of teh container. For reference, I created https://github.com/backstage/backstage/issues/21871.

**before changes:**

![image](https://github.com/backstage/backstage/assets/44613627/c75256a9-2d06-4beb-88bb-83591eca232d)

**After changes:**

![image](https://github.com/backstage/backstage/assets/44613627/b96c95f7-b321-4161-812f-98e706c42b71)


#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
