### PR TITLE
[scaffolder] Fix issue where parameters is set to empty object

### DIFF
--- a/.changeset/empty-poets-camp.md
+++ b/.changeset/empty-poets-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix bug where `properties` is set to empty object when it should be empty for schema dependencies

--- a/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.test.tsx
+++ b/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.test.tsx
@@ -263,7 +263,6 @@ describe('useTemplateSchema', () => {
 
       expect(first.schema).toEqual({
         type: 'object',
-        properties: {},
       });
     });
   });

--- a/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.ts
+++ b/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.ts
@@ -59,13 +59,18 @@ export const useTemplateSchema = (
       return stepFeatureFlag ? featureFlags.isActive(stepFeatureFlag) : true;
     })
     // Then filter out the properties that are not enabled with feature flag
-    .map(step => ({
-      ...step,
-      schema: {
-        ...step.schema,
-        // Title is rendered at the top of the page, so let's ignore this from jsonschemaform
-        title: undefined,
-        properties: Object.fromEntries(
+    .map(step => {
+      const strippedSchema = {
+        ...step,
+        schema: {
+          ...step.schema,
+          // Title is rendered at the top of the page, so let's ignore this from jsonschemaform
+          title: undefined,
+        },
+      } as ParsedTemplateSchema;
+
+      if (step.schema?.properties) {
+        strippedSchema.schema.properties = Object.fromEntries(
           Object.entries((step.schema?.properties ?? []) as JsonObject).filter(
             ([key]) => {
               const stepFeatureFlag =
@@ -75,9 +80,11 @@ export const useTemplateSchema = (
                 : true;
             },
           ),
-        ),
-      },
-    }));
+        );
+      }
+
+      return strippedSchema;
+    });
 
   return {
     presentation: manifest.presentation,


### PR DESCRIPTION
There's an issue that we make `properties` an empty object if there isn't one present in when parsing the template schema.

This causes no items to be rendered by `rjsf` rather than using the `dependencies` or any other rendering method that's not defined from properties in the schema.

