### PR TITLE
feat(Stepper): adds custom error list for the top of the form

### DIFF
--- a/.changeset/brown-planes-sort.md
+++ b/.changeset/brown-planes-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Scaffolder form now shows a list of errors at the top of the form.

--- a/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/errorListTemplate.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/errorListTemplate.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { ErrorListTemplate } from './ErrorListTemplate';
+import { ErrorListTemplate } from './errorListTemplate';
 import { renderInTestApp } from '@backstage/test-utils';
 import { ErrorListProps } from '@rjsf/utils';
 

--- a/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/errorListTemplate.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/errorListTemplate.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { ErrorListTemplate } from './ErrorListTemplate';
+import { renderInTestApp } from '@backstage/test-utils';
+import { ErrorListProps } from '@rjsf/utils';
+
+describe('Error List Template', () => {
+  const errorList = {
+    errors: [
+      {
+        stack: 'Test error 1',
+      },
+      {
+        stack: 'Test error 2',
+      },
+    ],
+    errorSchema: {},
+  } as Partial<ErrorListProps> as ErrorListProps;
+
+  it('should render the error messages', async () => {
+    const { getByText } = await renderInTestApp(
+      <ErrorListTemplate {...errorList} />,
+    );
+
+    for (const error of errorList.errors) {
+      expect(getByText(error.stack)).toBeInTheDocument();
+    }
+  });
+});

--- a/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/errorListTemplate.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/errorListTemplate.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { ErrorListProps } from '@rjsf/utils';
+import {
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Theme,
+  createStyles,
+  makeStyles,
+} from '@material-ui/core';
+import ErrorIcon from '@material-ui/icons/Error';
+
+const useStyles = makeStyles((_theme: Theme) =>
+  createStyles({
+    list: {
+      width: '100%',
+    },
+    text: {
+      textWrap: 'wrap',
+    },
+  }),
+);
+
+/**
+ * Shows a list of errors found in the form
+ *
+ * @public
+ */
+export const ErrorListTemplate = ({ errors }: ErrorListProps) => {
+  const classes = useStyles();
+
+  return (
+    <Paper>
+      <List dense className={classes.list}>
+        {errors.map((error, index) => (
+          <ListItem key={index}>
+            <ListItemIcon>
+              <ErrorIcon color="error" />
+            </ListItemIcon>
+            <ListItemText
+              classes={{ primary: classes.text }}
+              primary={error.stack}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Paper>
+  );
+};

--- a/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/index.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/ErrorListTemplate/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { ErrorListTemplate } from './errorListTemplate';

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -51,6 +51,7 @@ import {
   FormProps,
 } from '@backstage/plugin-scaffolder-react';
 import { ReviewStepProps } from '@backstage/plugin-scaffolder-react';
+import { ErrorListTemplate } from './ErrorListTemplate';
 
 const useStyles = makeStyles(theme => ({
   backButton: {
@@ -228,7 +229,8 @@ export const Stepper = (stepperProps: StepperProps) => {
             uiSchema={currentStep.uiSchema}
             onSubmit={handleNext}
             fields={fields}
-            showErrorList={false}
+            showErrorList="top"
+            templates={{ ErrorListTemplate }}
             onChange={handleChange}
             experimental_defaultFormStateBehavior={{
               allOf: 'populateDefaults',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a custom error list component for the stepper form. This shows at the top of the form and captures both internal and input errors in the form.

fixes #21476

![Screenshot 2023-12-15 at 10 11 32](https://github.com/backstage/backstage/assets/57544905/972abdbd-a7b1-44bc-88e9-64adf59e0557)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
