### PR TITLE
feat(catalog-backend-module-gitlab): add userTransformer and groupTransformer

### DIFF
--- a/.changeset/neat-hotels-wink.md
+++ b/.changeset/neat-hotels-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+add `groupTransformer` and `userTransformer` to allow custom transformations when groups and users are created

--- a/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import { GitLabGroup, GitLabUser, GitlabProviderConfig } from './types';
+import { GitLabIntegrationConfig } from '@backstage/integration';
+
+export function defaultGroupNameTransformer(
+  full_path: string,
+  config: GitlabProviderConfig,
+): string {
+  if (config.group && full_path.startsWith(`${config.group}/`)) {
+    return full_path.replace(`${config.group}/`, '').replaceAll('/', '-');
+  }
+  return full_path.replaceAll('/', '-');
+}
+
+export function defaultGroupTransformer(
+  group: GitLabGroup,
+  provConfig: GitlabProviderConfig,
+): GroupEntity {
+  const annotations: { [annotationName: string]: string } = {};
+
+  annotations[`${provConfig.host}/team-path`] = group.full_path;
+
+  const entity: GroupEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: defaultGroupNameTransformer(group.full_path, provConfig),
+      annotations: annotations,
+    },
+    spec: {
+      type: 'team',
+      children: [],
+      profile: {
+        displayName: group.name,
+      },
+    },
+  };
+
+  if (group.description) {
+    entity.metadata.description = group.description;
+  }
+
+  return entity;
+}
+
+/**
+ * If you want the groupId instead of the fullGroupPath as group name
+ * @see https://github.com/backstage/backstage/issues/19838
+ */
+export function groupIdGroupTransformer(
+  group: GitLabGroup,
+  provConfig: GitlabProviderConfig,
+): GroupEntity {
+  const entity = defaultGroupTransformer(group, provConfig);
+  entity.metadata.name = `${group.id}`;
+  return entity;
+}
+
+/**
+ * The default implementation of the transformation from a graph user entry to
+ * a User entity.
+ *
+ * @public
+ */
+export function defaultUserTransformer(
+  user: GitLabUser,
+  intConfig: GitLabIntegrationConfig,
+  provConfig: GitlabProviderConfig,
+): UserEntity {
+  const annotations: { [annotationName: string]: string } = {};
+
+  annotations[`${intConfig.host}/user-login`] = user.web_url;
+  if (user?.group_saml_identity?.extern_uid) {
+    annotations[`${intConfig.host}/saml-external-uid`] =
+      user.group_saml_identity.extern_uid;
+  }
+
+  const entity: UserEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'User',
+    metadata: {
+      name: user.username,
+      annotations: annotations,
+    },
+    spec: {
+      profile: {
+        displayName: user.name || undefined,
+        picture: user.avatar_url || undefined,
+      },
+      memberOf: [],
+    },
+  };
+
+  if (user.email) {
+    if (!entity.spec) {
+      entity.spec = {};
+    }
+
+    if (!entity.spec.profile) {
+      entity.spec.profile = {};
+    }
+
+    entity.spec.profile.email = user.email;
+  }
+
+  if (user.groups) {
+    for (const group of user.groups) {
+      if (!entity.spec.memberOf) {
+        entity.spec.memberOf = [];
+      }
+      entity.spec.memberOf.push(
+        defaultGroupNameTransformer(group.full_path, provConfig),
+      );
+    }
+  }
+
+  return entity;
+}

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -144,6 +144,16 @@ export type GitlabProviderConfig = {
 };
 
 /**
+ * Customize how group names are generated
+ *
+ * @public
+ */
+export type GroupNameTransformer = (
+  group: GitLabGroup,
+  config: GitlabProviderConfig,
+) => string;
+
+/**
  * Customize the ingested User entity
  *
  * @public
@@ -152,6 +162,7 @@ export type UserTransformer = (
   user: GitLabUser,
   intConfig: GitLabIntegrationConfig,
   provConfig: GitlabProviderConfig,
+  groupNameTransformer: GroupNameTransformer,
 ) => UserEntity;
 
 /**
@@ -162,4 +173,5 @@ export type UserTransformer = (
 export type GroupTransformer = (
   group: GitLabGroup,
   provConfig: GitlabProviderConfig,
+  groupNameTransformer: GroupNameTransformer,
 ) => GroupEntity;

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import { GitLabIntegrationConfig } from '@backstage/integration';
 
 export type PagedResponse<T> = {
   items: T[];
@@ -116,6 +118,10 @@ export type GitLabDescendantGroupsResponse = {
 
 export type GitlabProviderConfig = {
   host: string;
+  /**
+   * Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned.
+   * If present this if present, the discovered groups won't contain this prefix
+   */
   group: string;
   id: string;
   /**
@@ -136,3 +142,24 @@ export type GitlabProviderConfig = {
   schedule?: TaskScheduleDefinition;
   skipForkedRepos?: boolean;
 };
+
+/**
+ * Customize the ingested User entity
+ *
+ * @public
+ */
+export type UserTransformer = (
+  user: GitLabUser,
+  intConfig: GitLabIntegrationConfig,
+  provConfig: GitlabProviderConfig,
+) => UserEntity;
+
+/**
+ * Customize the ingested Group entity
+ *
+ * @public
+ */
+export type GroupTransformer = (
+  group: GitLabGroup,
+  provConfig: GitlabProviderConfig,
+) => GroupEntity;

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -19,7 +19,6 @@ import {
   ANNOTATION_ORIGIN_LOCATION,
   Entity,
   GroupEntity,
-  UserEntity,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { GitLabIntegration, ScmIntegrations } from '@backstage/integration';
@@ -37,7 +36,18 @@ import {
   paginated,
   readGitlabConfigs,
 } from '../lib';
-import { GitLabGroup, GitLabUser, PagedResponse } from '../lib/types';
+import {
+  GitLabGroup,
+  GitLabUser,
+  PagedResponse,
+  UserTransformer,
+  GroupTransformer,
+} from '../lib/types';
+import {
+  defaultGroupNameTransformer,
+  defaultGroupTransformer,
+  defaultUserTransformer,
+} from '../lib/defaultTransformers';
 
 type Result = {
   scanned: number;
@@ -59,6 +69,8 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
   private readonly logger: Logger;
   private readonly scheduleFn: () => Promise<void>;
   private connection?: EntityProviderConnection;
+  private userTransformer: UserTransformer;
+  private groupTransformer: GroupTransformer;
 
   static fromConfig(
     config: Config,
@@ -122,6 +134,8 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
     integration: GitLabIntegration;
     logger: Logger;
     taskRunner: TaskRunner;
+    userTransformer?: UserTransformer;
+    groupTransformer?: GroupTransformer;
   }) {
     this.config = options.config;
     this.integration = options.integration;
@@ -129,6 +143,8 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       target: this.getProviderName(),
     });
     this.scheduleFn = this.createScheduleFn(options.taskRunner);
+    this.userTransformer = options.userTransformer ?? defaultUserTransformer;
+    this.groupTransformer = options.groupTransformer ?? defaultGroupTransformer;
   }
 
   getProviderName(): string {
@@ -271,12 +287,9 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
     });
 
     const userEntities = res.matches.map(p =>
-      this.createUserEntity(p, this.integration.config.host),
+      this.userTransformer(p, this.integration.config, this.config),
     );
-    const groupEntities = this.createGroupEntities(
-      groupsWithUsers,
-      this.integration.config.host,
-    );
+    const groupEntities = this.createGroupEntities(groupsWithUsers);
 
     await this.connection.applyMutation({
       type: 'full',
@@ -291,10 +304,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
     });
   }
 
-  private createGroupEntities(
-    groupResult: GitLabGroup[],
-    host: string,
-  ): GroupEntity[] {
+  private createGroupEntities(groupResult: GitLabGroup[]): GroupEntity[] {
     const idMapped: { [groupId: number]: GitLabGroup } = {};
     const entities: GroupEntity[] = [];
 
@@ -303,11 +313,12 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
     }
 
     for (const group of groupResult) {
-      const entity = this.createGroupEntity(group, host);
+      const entity = this.groupTransformer(group, this.config);
 
       if (group.parent_id && idMapped.hasOwnProperty(group.parent_id)) {
-        entity.spec.parent = this.groupName(
+        entity.spec.parent = defaultGroupNameTransformer(
           idMapped[group.parent_id].full_path,
+          this.config,
         );
       }
 
@@ -333,91 +344,5 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       },
       entity,
     ) as Entity;
-  }
-
-  private createUserEntity(user: GitLabUser, host: string): UserEntity {
-    const annotations: { [annotationName: string]: string } = {};
-
-    annotations[`${host}/user-login`] = user.web_url;
-    if (user?.group_saml_identity?.extern_uid) {
-      annotations[`${host}/saml-external-uid`] =
-        user.group_saml_identity.extern_uid;
-    }
-
-    const entity: UserEntity = {
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'User',
-      metadata: {
-        name: user.username,
-        annotations: annotations,
-      },
-      spec: {
-        profile: {
-          displayName: user.name || undefined,
-          picture: user.avatar_url || undefined,
-        },
-        memberOf: [],
-      },
-    };
-
-    if (user.email) {
-      if (!entity.spec) {
-        entity.spec = {};
-      }
-
-      if (!entity.spec.profile) {
-        entity.spec.profile = {};
-      }
-
-      entity.spec.profile.email = user.email;
-    }
-
-    if (user.groups) {
-      for (const group of user.groups) {
-        if (!entity.spec.memberOf) {
-          entity.spec.memberOf = [];
-        }
-        entity.spec.memberOf.push(this.groupName(group.full_path));
-      }
-    }
-
-    return entity;
-  }
-
-  private groupName(full_path: string): string {
-    if (this.config.group && full_path.startsWith(`${this.config.group}/`)) {
-      return full_path
-        .replace(`${this.config.group}/`, '')
-        .replaceAll('/', '-');
-    }
-    return full_path.replaceAll('/', '-');
-  }
-
-  private createGroupEntity(group: GitLabGroup, host: string): GroupEntity {
-    const annotations: { [annotationName: string]: string } = {};
-
-    annotations[`${host}/team-path`] = group.full_path;
-
-    const entity: GroupEntity = {
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'Group',
-      metadata: {
-        name: this.groupName(group.full_path),
-        annotations: annotations,
-      },
-      spec: {
-        type: 'team',
-        children: [],
-        profile: {
-          displayName: group.name,
-        },
-      },
-    };
-
-    if (group.description) {
-      entity.metadata.description = group.description;
-    }
-
-    return entity;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added a userTransfomer and groupTransformer option that allows backstage users to customize how users and groups are created by the gitlab catalog backend module.
This change should not be breaking, as it should fall back to the default behaviour ...

Based on the suggestion from @freben in #19838 - I hope this was what he was thinking of...

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes 
(I was not able to run the existing tests ... have to look into this)
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
