### PR TITLE
feat(catalog-backend-module-gitlab): add userTransformer and groupTransformer

### DIFF
--- a/.changeset/neat-hotels-wink.md
+++ b/.changeset/neat-hotels-wink.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-add `groupTransformer`, `userTransformer` and `groupNameTransformer` to allow custom transformations when groups and users are created
+Added the option to provide custom `groupTransformer`, `userTransformer` and `groupNameTransformer` to allow custom transformations of groups and users

--- a/.changeset/neat-hotels-wink.md
+++ b/.changeset/neat-hotels-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+add `groupTransformer`, `userTransformer` and `groupNameTransformer` to allow custom transformations when groups and users are created

--- a/plugins/catalog-backend-module-gitlab/api-report.md
+++ b/plugins/catalog-backend-module-gitlab/api-report.md
@@ -58,6 +58,20 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
 }
 
 // @public
+export type GitLabGroup = {
+  id: number;
+  name: string;
+  full_path: string;
+  description?: string;
+  parent_id?: number;
+};
+
+// @public (undocumented)
+export type GitLabGroupSamlIdentity = {
+  extern_uid: string;
+};
+
+// @public
 export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
   // (undocumented)
   connect(connection: EntityProviderConnection): Promise<void>;
@@ -77,9 +91,75 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
   getProviderName(): string;
 }
 
-// Warnings were encountered during analysis:
-//
-// src/providers/GitlabOrgDiscoveryEntityProvider.d.ts:23:9 - (ae-forgotten-export) The symbol "UserTransformer" needs to be exported by the entry point index.d.ts
-// src/providers/GitlabOrgDiscoveryEntityProvider.d.ts:24:9 - (ae-forgotten-export) The symbol "GroupTransformer" needs to be exported by the entry point index.d.ts
-// src/providers/GitlabOrgDiscoveryEntityProvider.d.ts:25:9 - (ae-forgotten-export) The symbol "GroupNameTransformer" needs to be exported by the entry point index.d.ts
+// @public
+export type GitlabProviderConfig = {
+  host: string;
+  group: string;
+  id: string;
+  branch?: string;
+  fallbackBranch: string;
+  catalogFile: string;
+  projectPattern: RegExp;
+  userPattern: RegExp;
+  groupPattern: RegExp;
+  orgEnabled?: boolean;
+  schedule?: TaskScheduleDefinition;
+  skipForkedRepos?: boolean;
+};
+
+// @public
+export type GitLabUser = {
+  id: number;
+  username: string;
+  email?: string;
+  name: string;
+  state: string;
+  web_url: string;
+  avatar_url: string;
+  groups?: GitLabGroup[];
+  group_saml_identity?: GitLabGroupSamlIdentity;
+};
+
+// @public
+export type GroupNameTransformer = (
+  options: GroupNameTransformerOptions,
+) => string;
+
+// @public
+export interface GroupNameTransformerOptions {
+  // (undocumented)
+  group: GitLabGroup;
+  // (undocumented)
+  providerConfig: GitlabProviderConfig;
+}
+
+// @public
+export type GroupTransformer = (
+  options: GroupTransformerOptions,
+) => GroupEntity[];
+
+// @public
+export interface GroupTransformerOptions {
+  // (undocumented)
+  groupNameTransformer: GroupNameTransformer;
+  // (undocumented)
+  groups: GitLabGroup[];
+  // (undocumented)
+  providerConfig: GitlabProviderConfig;
+}
+
+// @public
+export type UserTransformer = (options: UserTransformerOptions) => UserEntity;
+
+// @public
+export interface UserTransformerOptions {
+  // (undocumented)
+  groupNameTransformer: GroupNameTransformer;
+  // (undocumented)
+  integrationConfig: GitLabIntegrationConfig;
+  // (undocumented)
+  providerConfig: GitlabProviderConfig;
+  // (undocumented)
+  user: GitLabUser;
+}
 ```

--- a/plugins/catalog-backend-module-gitlab/api-report.md
+++ b/plugins/catalog-backend-module-gitlab/api-report.md
@@ -8,10 +8,14 @@ import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
 import { Config } from '@backstage/config';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+import { GitLabIntegrationConfig } from '@backstage/integration';
+import { GroupEntity } from '@backstage/catalog-model';
 import { LocationSpec } from '@backstage/plugin-catalog-node';
 import { Logger } from 'winston';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { TaskRunner } from '@backstage/backend-tasks';
+import { TaskScheduleDefinition } from '@backstage/backend-tasks';
+import { UserEntity } from '@backstage/catalog-model';
 
 // @public
 export class GitlabDiscoveryEntityProvider implements EntityProvider {
@@ -64,9 +68,18 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       logger: Logger;
       schedule?: TaskRunner;
       scheduler?: PluginTaskScheduler;
+      userTransformer?: UserTransformer;
+      groupEntitiesTransformer?: GroupTransformer;
+      groupNameTransformer?: GroupNameTransformer;
     },
   ): GitlabOrgDiscoveryEntityProvider[];
   // (undocumented)
   getProviderName(): string;
 }
+
+// Warnings were encountered during analysis:
+//
+// src/providers/GitlabOrgDiscoveryEntityProvider.d.ts:23:9 - (ae-forgotten-export) The symbol "UserTransformer" needs to be exported by the entry point index.d.ts
+// src/providers/GitlabOrgDiscoveryEntityProvider.d.ts:24:9 - (ae-forgotten-export) The symbol "GroupTransformer" needs to be exported by the entry point index.d.ts
+// src/providers/GitlabOrgDiscoveryEntityProvider.d.ts:25:9 - (ae-forgotten-export) The symbol "GroupNameTransformer" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/catalog-backend-module-gitlab/src/index.ts
+++ b/plugins/catalog-backend-module-gitlab/src/index.ts
@@ -25,3 +25,15 @@ export {
   GitlabDiscoveryEntityProvider,
   GitlabOrgDiscoveryEntityProvider,
 } from './providers';
+export type {
+  GitLabUser,
+  GitLabGroup,
+  GitlabProviderConfig,
+  GitLabGroupSamlIdentity,
+  GroupNameTransformer,
+  GroupNameTransformerOptions,
+  GroupTransformer,
+  GroupTransformerOptions,
+  UserTransformer,
+  UserTransformerOptions,
+} from './lib';

--- a/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
@@ -34,18 +34,18 @@ export function defaultGroupNameTransformer(
 
 export function defaultGroupTransformer(
   group: GitLabGroup,
-  provConfig: GitlabProviderConfig,
+  providerConfig: GitlabProviderConfig,
   groupNameTransformer: GroupNameTransformer,
 ): GroupEntity {
   const annotations: { [annotationName: string]: string } = {};
 
-  annotations[`${provConfig.host}/team-path`] = group.full_path;
+  annotations[`${providerConfig.host}/team-path`] = group.full_path;
 
   const entity: GroupEntity = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Group',
     metadata: {
-      name: groupNameTransformer(group, provConfig),
+      name: groupNameTransformer(group, providerConfig),
       annotations: annotations,
     },
     spec: {
@@ -72,15 +72,15 @@ export function defaultGroupTransformer(
  */
 export function defaultUserTransformer(
   user: GitLabUser,
-  intConfig: GitLabIntegrationConfig,
-  provConfig: GitlabProviderConfig,
+  integrationConfig: GitLabIntegrationConfig,
+  providerConfig: GitlabProviderConfig,
   groupNameTransformer: GroupNameTransformer,
 ): UserEntity {
   const annotations: { [annotationName: string]: string } = {};
 
-  annotations[`${intConfig.host}/user-login`] = user.web_url;
+  annotations[`${integrationConfig.host}/user-login`] = user.web_url;
   if (user?.group_saml_identity?.extern_uid) {
-    annotations[`${intConfig.host}/saml-external-uid`] =
+    annotations[`${integrationConfig.host}/saml-external-uid`] =
       user.group_saml_identity.extern_uid;
   }
 
@@ -117,7 +117,7 @@ export function defaultUserTransformer(
       if (!entity.spec.memberOf) {
         entity.spec.memberOf = [];
       }
-      entity.spec.memberOf.push(groupNameTransformer(group, provConfig));
+      entity.spec.memberOf.push(groupNameTransformer(group, providerConfig));
     }
   }
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import {
+  GitLabGroup,
+  GitLabUser,
+  GitlabProviderConfig,
+  GroupNameTransformer,
+} from './types';
+import { GitLabIntegrationConfig } from '@backstage/integration';
+
+export function defaultGroupNameTransformer(
+  group: GitLabGroup,
+  config: GitlabProviderConfig,
+): string {
+  if (config.group && group.full_path.startsWith(`${config.group}/`)) {
+    return group.full_path.replace(`${config.group}/`, '').replaceAll('/', '-');
+  }
+  return group.full_path.replaceAll('/', '-');
+}
+
+export function defaultGroupTransformer(
+  group: GitLabGroup,
+  provConfig: GitlabProviderConfig,
+  groupNameTransformer: GroupNameTransformer,
+): GroupEntity {
+  const annotations: { [annotationName: string]: string } = {};
+
+  annotations[`${provConfig.host}/team-path`] = group.full_path;
+
+  const entity: GroupEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: groupNameTransformer(group, provConfig),
+      annotations: annotations,
+    },
+    spec: {
+      type: 'team',
+      children: [],
+      profile: {
+        displayName: group.name,
+      },
+    },
+  };
+
+  if (group.description) {
+    entity.metadata.description = group.description;
+  }
+
+  return entity;
+}
+
+/**
+ * The default implementation of the transformation from a graph user entry to
+ * a User entity.
+ *
+ * @public
+ */
+export function defaultUserTransformer(
+  user: GitLabUser,
+  intConfig: GitLabIntegrationConfig,
+  provConfig: GitlabProviderConfig,
+  groupNameTransformer: GroupNameTransformer,
+): UserEntity {
+  const annotations: { [annotationName: string]: string } = {};
+
+  annotations[`${intConfig.host}/user-login`] = user.web_url;
+  if (user?.group_saml_identity?.extern_uid) {
+    annotations[`${intConfig.host}/saml-external-uid`] =
+      user.group_saml_identity.extern_uid;
+  }
+
+  const entity: UserEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'User',
+    metadata: {
+      name: user.username,
+      annotations: annotations,
+    },
+    spec: {
+      profile: {
+        displayName: user.name || undefined,
+        picture: user.avatar_url || undefined,
+      },
+      memberOf: [],
+    },
+  };
+
+  if (user.email) {
+    if (!entity.spec) {
+      entity.spec = {};
+    }
+
+    if (!entity.spec.profile) {
+      entity.spec.profile = {};
+    }
+
+    entity.spec.profile.email = user.email;
+  }
+
+  if (user.groups) {
+    for (const group of user.groups) {
+      if (!entity.spec.memberOf) {
+        entity.spec.memberOf = [];
+      }
+      entity.spec.memberOf.push(groupNameTransformer(group, provConfig));
+    }
+  }
+
+  return entity;
+}

--- a/plugins/catalog-backend-module-gitlab/src/lib/index.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/index.ts
@@ -16,8 +16,17 @@
 
 export { GitLabClient, paginated } from './client';
 export type {
+  GitLabUser,
+  GitLabGroup,
+  GitLabGroupSamlIdentity,
   GitLabProject,
   GitlabProviderConfig,
   GitlabGroupDescription,
+  GroupNameTransformer,
+  GroupNameTransformerOptions,
+  GroupTransformer,
+  GroupTransformerOptions,
+  UserTransformer,
+  UserTransformerOptions,
 } from './types';
 export { readGitlabConfigs } from '../providers/config';

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import { GitLabIntegrationConfig } from '@backstage/integration';
 
 export type PagedResponse<T> = {
   items: T[];
@@ -116,6 +118,10 @@ export type GitLabDescendantGroupsResponse = {
 
 export type GitlabProviderConfig = {
   host: string;
+  /**
+   * Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned.
+   * If present this if present, the discovered groups won't contain this prefix
+   */
   group: string;
   id: string;
   /**
@@ -136,3 +142,36 @@ export type GitlabProviderConfig = {
   schedule?: TaskScheduleDefinition;
   skipForkedRepos?: boolean;
 };
+
+/**
+ * Customize how group names are generated
+ *
+ * @public
+ */
+export type GroupNameTransformer = (
+  group: GitLabGroup,
+  config: GitlabProviderConfig,
+) => string;
+
+/**
+ * Customize the ingested User entity
+ *
+ * @public
+ */
+export type UserTransformer = (
+  user: GitLabUser,
+  intConfig: GitLabIntegrationConfig,
+  provConfig: GitlabProviderConfig,
+  groupNameTransformer: GroupNameTransformer,
+) => UserEntity;
+
+/**
+ * Customize the ingested Group entity
+ *
+ * @public
+ */
+export type GroupTransformer = (
+  group: GitLabGroup,
+  provConfig: GitlabProviderConfig,
+  groupNameTransformer: GroupNameTransformer,
+) => GroupEntity;

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -149,21 +149,25 @@ export type GitlabProviderConfig = {
  * @public
  */
 export type GroupNameTransformer = (
-  group: GitLabGroup,
-  config: GitlabProviderConfig,
+  options: GroupNameTransformerOptions,
 ) => string;
 
+export interface GroupNameTransformerOptions {
+  group: GitLabGroup;
+  providerConfig: GitlabProviderConfig;
+}
 /**
  * Customize the ingested User entity
  *
  * @public
  */
-export type UserTransformer = (
-  user: GitLabUser,
-  intConfig: GitLabIntegrationConfig,
-  provConfig: GitlabProviderConfig,
-  groupNameTransformer: GroupNameTransformer,
-) => UserEntity;
+export type UserTransformer = (options: UserTransformerOptions) => UserEntity;
+export interface UserTransformerOptions {
+  user: GitLabUser;
+  integrationConfig: GitLabIntegrationConfig;
+  providerConfig: GitlabProviderConfig;
+  groupNameTransformer: GroupNameTransformer;
+}
 
 /**
  * Customize the ingested Group entity
@@ -171,7 +175,10 @@ export type UserTransformer = (
  * @public
  */
 export type GroupTransformer = (
-  group: GitLabGroup,
-  provConfig: GitlabProviderConfig,
-  groupNameTransformer: GroupNameTransformer,
-) => GroupEntity;
+  options: GroupTransformerOptions,
+) => GroupEntity[];
+export interface GroupTransformerOptions {
+  groups: GitLabGroup[];
+  providerConfig: GitlabProviderConfig;
+  groupNameTransformer: GroupNameTransformer;
+}

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -42,6 +42,11 @@ export type GitLabProject = {
   forked_from_project?: GitlabProjectForkedFrom;
 };
 
+/**
+ * Representation of a GitLab user in the GitLab API
+ *
+ * @public
+ */
 export type GitLabUser = {
   id: number;
   username: string;
@@ -54,10 +59,18 @@ export type GitLabUser = {
   group_saml_identity?: GitLabGroupSamlIdentity;
 };
 
+/**
+ * @public
+ */
 export type GitLabGroupSamlIdentity = {
   extern_uid: string;
 };
 
+/**
+ * Representation of a GitLab group in the GitLab API
+ *
+ * @public
+ */
 export type GitLabGroup = {
   id: number;
   name: string;
@@ -115,14 +128,25 @@ export type GitLabDescendantGroupsResponse = {
     };
   };
 };
-
+/**
+ * The configuration parameters for the GitlabProvider
+ *
+ * @public
+ */
 export type GitlabProviderConfig = {
+  /**
+   * Identifies one of the hosts set up in the integrations
+   */
   host: string;
   /**
-   * Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned.
-   * If present this if present, the discovered groups won't contain this prefix
+   * Required for gitlab.com when `orgEnabled: true`.
+   * Optional for self managed. Must not end with slash.
+   * Accepts only groups under the provided path (which will be stripped)
    */
   group: string;
+  /**
+   * ???
+   */
   id: string;
   /**
    * The name of the branch to be used, to discover catalog files.
@@ -134,12 +158,31 @@ export type GitlabProviderConfig = {
    * Defaults to: `master`
    */
   fallbackBranch: string;
+  /**
+   * Defaults to `catalog-info.yaml`
+   */
   catalogFile: string;
+  /**
+   * Filters found projects based on provided patter.
+   * Defaults to `[\s\S]*`, which means to not filter anything
+   */
   projectPattern: RegExp;
+  /**
+   * Filters found users based on provided patter.
+   * Defaults to `[\s\S]*`, which means to not filter anything
+   */
   userPattern: RegExp;
+  /**
+   * Filters found groups based on provided patter.
+   * Defaults to `[\s\S]*`, which means to not filter anything
+   */
   groupPattern: RegExp;
+
   orgEnabled?: boolean;
   schedule?: TaskScheduleDefinition;
+  /**
+   * If the project is a fork, skip repository
+   */
   skipForkedRepos?: boolean;
 };
 
@@ -152,6 +195,11 @@ export type GroupNameTransformer = (
   options: GroupNameTransformerOptions,
 ) => string;
 
+/**
+ * The GroupTransformerOptions
+ *
+ * @public
+ */
 export interface GroupNameTransformerOptions {
   group: GitLabGroup;
   providerConfig: GitlabProviderConfig;
@@ -162,6 +210,11 @@ export interface GroupNameTransformerOptions {
  * @public
  */
 export type UserTransformer = (options: UserTransformerOptions) => UserEntity;
+/**
+ * The UserTransformerOptions
+ *
+ * @public
+ */
 export interface UserTransformerOptions {
   user: GitLabUser;
   integrationConfig: GitLabIntegrationConfig;
@@ -177,6 +230,11 @@ export interface UserTransformerOptions {
 export type GroupTransformer = (
   options: GroupTransformerOptions,
 ) => GroupEntity[];
+/**
+ * The GroupTransformer options
+ *
+ * @public
+ */
 export interface GroupTransformerOptions {
   groups: GitLabGroup[];
   providerConfig: GitlabProviderConfig;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added a userTransfomer and groupTransformer option that allows backstage users to customize how users and groups are created by the gitlab catalog backend module.
This change should not be breaking, as the default transformers behave like the original implementation. The unit tests still have the same expected result.
I am not sure if I should create and what would be a good unit test for the new functionality. 
Based on the suggestion from @freben in #19838 - I hope this was what he was thinking of...


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
