### PR TITLE
fix: Resolve hostname with IPv4 first

### DIFF
--- a/.changeset/blue-pigs-itch.md
+++ b/.changeset/blue-pigs-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Resolve hostname with IPv4 first

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -74,6 +74,10 @@ import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { metrics } from '@opentelemetry/api';
 import { DefaultSignalService } from '@backstage/plugin-signals-node';
+import dns from 'node:dns';
+
+// Fix https://github.com/backstage/backstage/issues/19931
+dns.setDefaultResultOrder('ipv4first');
 
 // Expose opentelemetry metrics using a Prometheus exporter on
 // http://localhost:9464/metrics . See prometheus.yml in packages/backend for

--- a/plugins/kubernetes-backend/src/cluster-locator/LocalKubectlProxyLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/LocalKubectlProxyLocator.ts
@@ -26,7 +26,7 @@ export class LocalKubectlProxyClusterLocator
     this.clusterDetails = [
       {
         name: 'local',
-        url: 'http:/localhost:8001',
+        url: 'http://localhost:8001',
         authMetadata: {
           [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'localKubectlProxy',
         },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The gist of it is, there was a breaking change in NodeJS 17.x that changed the default DNS IP resolving behavior to IPv6, to fix it we need to tell the Node DNS to resolve to IPv4 first.

Fixes #19931

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
