### PR TITLE
feat(plugin-catalog-graph): Added kind name to final display title of the node

### DIFF
--- a/.changeset/happy-rockets-drive.md
+++ b/.changeset/happy-rockets-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Added kind name to displayTitle when title property ecists in the entity

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderNode.tsx
@@ -91,11 +91,17 @@ export function DefaultRenderNode({
   const paddedWidth = paddedIconWidth + width + padding * 2;
   const paddedHeight = height + padding * 2;
 
-  const displayTitle =
-    title ??
-    (kind && name && namespace
-      ? humanizeEntityRef({ kind, name, namespace })
-      : id);
+  let displayTitle;
+
+  if (title && kind) {
+    displayTitle = `${kind.toLocaleLowerCase('en-US')}:${title}`;
+  } else if (title) {
+    displayTitle = title;
+  } else if (kind && name && namespace) {
+    displayTitle = humanizeEntityRef({ kind, name, namespace });
+  } else {
+    displayTitle = id;
+  }
 
   return (
     <g onClick={onClick} className={classNames(onClick && classes.clickable)}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When an Entity has a title field, it's being used in the Node as the whole name without the kind name. This PR adds the kind name to the final rendered Node.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
