### PR TITLE
microsite: enable frontend system docs

### DIFF
--- a/docs/frontend-system/architecture/01-index.md
+++ b/docs/frontend-system/architecture/01-index.md
@@ -6,7 +6,7 @@ sidebar_label: Overview
 description: The structure and architecture of the new Frontend System
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 ## Building Blocks
 

--- a/docs/frontend-system/architecture/02-app.md
+++ b/docs/frontend-system/architecture/02-app.md
@@ -1,12 +1,12 @@
 ---
-id: apps
+id: app
 title: App Instances
 sidebar_label: App
 # prettier-ignore
 description: App instances
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 ## The App Instance
 

--- a/docs/frontend-system/architecture/03-extensions.md
+++ b/docs/frontend-system/architecture/03-extensions.md
@@ -6,7 +6,7 @@ sidebar_label: Extensions
 description: Frontend extensions
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 As mentioned in the [previous section](./02-app.md), Backstage apps are built up from a tree of extensions. This section will go into more detail about what extensions are, how to create and use them, and how to create your own extensibility patterns.
 

--- a/docs/frontend-system/architecture/04-plugins.md
+++ b/docs/frontend-system/architecture/04-plugins.md
@@ -6,7 +6,7 @@ sidebar_label: Plugins
 description: Frontend plugins
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 ## Introduction
 

--- a/docs/frontend-system/architecture/05-extension-overrides.md
+++ b/docs/frontend-system/architecture/05-extension-overrides.md
@@ -1,12 +1,12 @@
 ---
-id: extension overrides
+id: extension-overrides
 title: Frontend Extension Overrides
 sidebar_label: Extension Overrides
 # prettier-ignore
 description: Frontend extension overrides
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 ## Introduction
 

--- a/docs/frontend-system/architecture/06-utility-apis.md
+++ b/docs/frontend-system/architecture/06-utility-apis.md
@@ -6,7 +6,7 @@ sidebar_label: Utility APIs
 description: Utility APIs
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 ## Overview
 

--- a/docs/frontend-system/architecture/07-routes.md
+++ b/docs/frontend-system/architecture/07-routes.md
@@ -6,7 +6,7 @@ sidebar_label: Routes
 description: Frontend routes
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 See [routing system docs](../../plugins/composability.md#routing-system)
 
@@ -98,7 +98,7 @@ Explain all of create, use and provide
  -->
 
 ```ts
-/* 
+/*
 
 Some examples
 

--- a/docs/frontend-system/architecture/08-naming-patterns.md
+++ b/docs/frontend-system/architecture/08-naming-patterns.md
@@ -6,7 +6,7 @@ sidebar_label: Naming Patterns
 description: Naming patterns in the frontend system
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 These are the naming patterns to adhere to within the frontend system. They help us keep exports and IDs consistent across packages and make it easier to understand the usage and intent of exports and IDs.
 

--- a/docs/frontend-system/architecture/08-references.md
+++ b/docs/frontend-system/architecture/08-references.md
@@ -6,7 +6,7 @@ sidebar_label: Value References
 description: Value References
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 <!--
 

--- a/docs/frontend-system/building-plugins/testing.md
+++ b/docs/frontend-system/building-plugins/testing.md
@@ -6,7 +6,7 @@ sidebar_label: Testing
 description: Testing plugins in the frontend system
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 # Testing Frontend Plugins
 

--- a/docs/frontend-system/index.md
+++ b/docs/frontend-system/index.md
@@ -6,10 +6,10 @@ sidebar_label: Introduction
 description: The Frontend System
 ---
 
-> **NOTE: The new frontend system is in a highly experimental phase**
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
 ## Status
 
-The new frontend system is in an experimental phase and we do not recommend any plugins or apps to migrate.
+The new frontend system is in alpha, and only a few plugins support the system so far. We do not yet recommend migrating any apps to the new system. If you add support for the new system to your plugin, please do so under a `/alpha` sub-path export.
 
 You can find an example app setup in [the `app-next` package](https://github.com/backstage/backstage/tree/master/packages/app-next).

--- a/docs/frontend-system/utility-apis/01-index.md
+++ b/docs/frontend-system/utility-apis/01-index.md
@@ -6,6 +6,8 @@ sidebar_label: Overview
 description: Working with Utility APIs in the New Frontend System
 ---
 
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
+
 As described [in the architecture section](../architecture/06-utility-apis.md), utility APIs are pieces of shared functionality - interfaces that can be requested by plugins to use. They are defined by a TypeScript interface as well as a reference (an "API ref") used to access its implementation. They can be provided both by plugins and the core framework, and are themselves [extensions](../architecture/03-extensions.md) that can accept inputs, be declaratively configured in your app-config, or transparently be replaced entirely with custom implementations that fulfill the same contract.
 
 ## Creating utility APIs

--- a/docs/frontend-system/utility-apis/02-creating.md
+++ b/docs/frontend-system/utility-apis/02-creating.md
@@ -6,6 +6,8 @@ sidebar_label: Creating APIs
 description: Creating new utility APIs in your plugins and app
 ---
 
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
+
 This section describes how to make a Utility API from scratch, or to add configurability and inputs to an existing one. If you are instead interested in migrating an existing Utility API from the old frontend system, check out [the migrating section](./05-migrating.md).
 
 ## Creating the Utility API contract

--- a/docs/frontend-system/utility-apis/03-consuming.md
+++ b/docs/frontend-system/utility-apis/03-consuming.md
@@ -6,6 +6,8 @@ sidebar_label: Consuming APIs
 description: Consuming utility APIs
 ---
 
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
+
 All of the utility API extensions that were passed into your app through installed plugins, get instantiated and configured in the right order by the framework, and are then made available for consumption. You can interact with these instances in the following ways.
 
 ## Via React hooks

--- a/docs/frontend-system/utility-apis/04-configuring.md
+++ b/docs/frontend-system/utility-apis/04-configuring.md
@@ -6,6 +6,8 @@ sidebar_label: Configuring
 description: Configuring, extending, and overriding utility APIs
 ---
 
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
+
 Utility APIs are extensions and can therefore optionally be amended with configurability, as well as inputs that other extensions attach themselves to. This section describes how to make use of that as a consumer of such utility APIs.
 
 ## Configuring

--- a/docs/frontend-system/utility-apis/05-migrating.md
+++ b/docs/frontend-system/utility-apis/05-migrating.md
@@ -6,6 +6,8 @@ sidebar_label: Migrating
 description: Migrating Utility APIs from the old frontend system
 ---
 
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
+
 If you are migrating your plugins or app over from the old frontend system, there are a few things to keep in mind in regards to utility APIs.
 
 ## Overview

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -380,6 +380,40 @@
         "items": ["backend-system/core-services/index"]
       }
     ],
+    "New Frontend System": [
+      "frontend-system/index",
+      {
+        "type": "category",
+        "label": "Architecture",
+        "items": [
+          "frontend-system/architecture/index",
+          "frontend-system/architecture/app",
+          "frontend-system/architecture/extensions",
+          "frontend-system/architecture/plugins",
+          "frontend-system/architecture/extension-overrides",
+          "frontend-system/architecture/utility-apis",
+          "frontend-system/architecture/routes",
+          "frontend-system/architecture/naming-patterns",
+          "frontend-system/architecture/references"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Building Plugins",
+        "items": ["frontend-system/building-plugins/testing"]
+      },
+      {
+        "type": "category",
+        "label": "Utility APIs",
+        "items": [
+          "frontend-system/utility-apis/index",
+          "frontend-system/utility-apis/creating",
+          "frontend-system/utility-apis/consuming",
+          "frontend-system/utility-apis/configuring",
+          "frontend-system/utility-apis/migrating"
+        ]
+      }
+    ],
     "Designing for Backstage": [
       "dls/design",
       "dls/component-design-guidelines",


### PR DESCRIPTION
🎉 , enabling the frontend system docs section that is currently hidden at https://backstage.io/docs/frontend-system/