### PR TITLE
Error message readability

### DIFF
--- a/.changeset/smart-pumpkins-develop.md
+++ b/.changeset/smart-pumpkins-develop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Changed error message in Catalog Import page to only show the message property.

--- a/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
+++ b/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
@@ -124,7 +124,20 @@ export const StepInitAnalyzeUrl = (props: StepInitAnalyzeUrlProps) => {
           }
         }
       } catch (e: any) {
-        setError(e?.data?.error?.message ?? e.message);
+        let errorMessage;
+
+        if (e?.data?.error?.message) {
+          errorMessage = e.data.error.message;
+        } else {
+          try {
+            const parsedErrorObject = JSON.parse(e.message);
+            errorMessage = parsedErrorObject.error.message;
+          } catch (parseError) {
+            errorMessage = e;
+          }
+        }
+
+        setError(errorMessage);
         setSubmitted(false);
       }
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Makes the error messages easier to read in `StepInitAnalyzeUrl.tsx` by parsing the JSON error string and only rendering the `message` prop.

Before
![image](https://github.com/backstage/backstage/assets/19598619/025d8253-d26b-49b8-a6ad-7eb2e5fea4e9)

After
![image](https://github.com/backstage/backstage/assets/19598619/3b3a321d-5d59-4b19-8e24-fc98bfbe6755)
 

Closes #21970 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
