### PR TITLE
[CatalogBackend] Add API to get location by entity

### DIFF
--- a/.changeset/large-moons-speak.md
+++ b/.changeset/large-moons-speak.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-client': minor
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add API to get location by entity

--- a/docs/features/software-catalog/api.md
+++ b/docs/features/software-catalog/api.md
@@ -474,6 +474,34 @@ Response type is JSON, on the form
 ]
 ```
 
+### `GET /locations/{id}`
+
+Gets a location by it's location ID.
+
+Response type is JSON, on the form
+
+```json
+{
+  "id": "b9784c38-7118-472f-9e22-5638fc73bab0",
+  "target": "https://git.example.com/example-project/example-repository/blob/main/catalog-info.yaml",
+  "type": "url"
+}
+```
+
+### `GET /locations/by-entity/{kind}/{namespace}/{name}`
+
+Gets a location referring to a given entity.
+
+Response type is JSON, on the form
+
+```json
+{
+  "id": "b9784c38-7118-472f-9e22-5638fc73bab0",
+  "target": "https://git.example.com/example-project/example-repository/blob/main/catalog-info.yaml",
+  "type": "url"
+}
+```
+
 ### `POST /locations`
 
 Adds a location to be ingested by the catalog.

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -51,7 +51,7 @@ export interface CatalogApi {
     options?: CatalogRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
   getLocationByEntity(
-    entityRef: CompoundEntityRef,
+    entityRef: string | CompoundEntityRef,
     options?: CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
   getLocationById(
@@ -125,7 +125,7 @@ export class CatalogClient implements CatalogApi {
     options?: CatalogRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
   getLocationByEntity(
-    entityRef: CompoundEntityRef,
+    entityRef: CompoundEntityRef | string,
     options?: CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
   getLocationById(

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -50,6 +50,10 @@ export interface CatalogApi {
     request: GetEntityFacetsRequest,
     options?: CatalogRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
+  getLocationByEntity(
+    entityRef: CompoundEntityRef,
+    options?: CatalogRequestOptions,
+  ): Promise<Location_2 | undefined>;
   getLocationById(
     id: string,
     options?: CatalogRequestOptions,
@@ -120,6 +124,10 @@ export class CatalogClient implements CatalogApi {
     request: GetEntityFacetsRequest,
     options?: CatalogRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
+  getLocationByEntity(
+    entityRef: CompoundEntityRef,
+    options?: CatalogRequestOptions,
+  ): Promise<Location_2 | undefined>;
   getLocationById(
     id: string,
     options?: CatalogRequestOptions,

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -617,6 +617,71 @@ describe('CatalogClient', () => {
     });
   });
 
+  describe('getLocationByEntity', () => {
+    const defaultResponse = {
+      data: {
+        kind: 'c',
+        namespace: 'ns',
+        name: 'n',
+      },
+    };
+
+    beforeEach(() => {
+      server.use(
+        rest.get(`${mockBaseUrl}/locations/by-entity/c/ns/n`, (_, res, ctx) => {
+          return res(ctx.json(defaultResponse));
+        }),
+      );
+    });
+
+    it('should locations from correct endpoint', async () => {
+      const response = await client.getLocationByEntity(
+        { kind: 'c', namespace: 'ns', name: 'n' },
+        { token },
+      );
+      expect(response).toEqual(defaultResponse);
+    });
+
+    it('forwards authorization token', async () => {
+      expect.assertions(1);
+
+      server.use(
+        rest.get(
+          `${mockBaseUrl}/locations/by-entity/c/ns/n`,
+          (req, res, ctx) => {
+            expect(req.headers.get('authorization')).toBe(`Bearer ${token}`);
+            return res(ctx.json(defaultResponse));
+          },
+        ),
+      );
+
+      await client.getLocationByEntity(
+        { kind: 'c', namespace: 'ns', name: 'n' },
+        { token },
+      );
+    });
+
+    it('skips authorization header if token is omitted', async () => {
+      expect.assertions(1);
+
+      server.use(
+        rest.get(
+          `${mockBaseUrl}/locations/by-entity/c/ns/n`,
+          (req, res, ctx) => {
+            expect(req.headers.get('authorization')).toBeNull();
+            return res(ctx.json(defaultResponse));
+          },
+        ),
+      );
+
+      await client.getLocationByEntity({
+        kind: 'c',
+        namespace: 'ns',
+        name: 'n',
+      });
+    });
+  });
+
   describe('validateEntity', () => {
     it('returns valid false when validation fails', async () => {
       server.use(

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -89,6 +89,18 @@ export class CatalogClient implements CatalogApi {
   }
 
   /**
+   * {@inheritdoc CatalogApi.getLocationByEntity}
+   */
+  async getLocationByEntity(
+    entityRef: CompoundEntityRef,
+    options?: CatalogRequestOptions,
+  ): Promise<Location | undefined> {
+    return await this.requestOptional(
+      await this.apiClient.getLocationByEntity({ path: entityRef }, options),
+    );
+  }
+
+  /**
    * {@inheritdoc CatalogApi.getEntities}
    */
   async getEntities(

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -92,11 +92,14 @@ export class CatalogClient implements CatalogApi {
    * {@inheritdoc CatalogApi.getLocationByEntity}
    */
   async getLocationByEntity(
-    entityRef: CompoundEntityRef,
+    entityRef: CompoundEntityRef | string,
     options?: CatalogRequestOptions,
   ): Promise<Location | undefined> {
     return await this.requestOptional(
-      await this.apiClient.getLocationByEntity({ path: entityRef }, options),
+      await this.apiClient.getLocationByEntity(
+        { path: parseEntityRef(entityRef) },
+        options,
+      ),
     );
   }
 

--- a/packages/catalog-client/src/generated/apis/DefaultApi.client.ts
+++ b/packages/catalog-client/src/generated/apis/DefaultApi.client.ts
@@ -462,6 +462,42 @@ export class DefaultApiClient {
   }
 
   /**
+   * Get a location for entity.
+   * @param kind
+   * @param namespace
+   * @param name
+   */
+  public async getLocationByEntity(
+    // @ts-ignore
+    request: {
+      path: {
+        kind: string;
+        namespace: string;
+        name: string;
+      };
+    },
+    options?: RequestOptions,
+  ): Promise<TypedResponse<Location>> {
+    const baseUrl = await this.discoveryApi.getBaseUrl(pluginId);
+
+    const uriTemplate = `/locations/by-entity/{kind}/{namespace}/{name}`;
+
+    const uri = parser.parse(uriTemplate).expand({
+      kind: request.path.kind,
+      namespace: request.path.namespace,
+      name: request.path.name,
+    });
+
+    return await this.fetchApi.fetch(`${baseUrl}${uri}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options?.token && { Authorization: `Bearer ${options?.token}` }),
+      },
+      method: 'GET',
+    });
+  }
+
+  /**
    * Get all locations
    */
   public async getLocations(

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -630,6 +630,17 @@ export interface CatalogApi {
   ): Promise<void>;
 
   /**
+   * Gets a location associated with an entity.
+   *
+   * @param entityRef - A reference to an entity
+   * @param options - Additional options
+   */
+  getLocationByEntity(
+    entityRef: CompoundEntityRef,
+    options?: CatalogRequestOptions,
+  ): Promise<Location | undefined>;
+
+  /**
    * Validate entity and its location.
    *
    * @param entity - Entity to validate

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -632,11 +632,11 @@ export interface CatalogApi {
   /**
    * Gets a location associated with an entity.
    *
-   * @param entityRef - A reference to an entity
+   * @param entityRef - A complete entity ref, either on string or compound form
    * @param options - Additional options
    */
   getLocationByEntity(
-    entityRef: CompoundEntityRef,
+    entityRef: string | CompoundEntityRef,
     options?: CatalogRequestOptions,
   ): Promise<Location | undefined>;
 

--- a/plugins/catalog-backend/src/modules/core/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/modules/core/DefaultLocationStore.ts
@@ -33,6 +33,7 @@ import { LocationInput, LocationStore } from '../../service/types';
 import {
   ANNOTATION_ORIGIN_LOCATION,
   CompoundEntityRef,
+  parseLocationRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 
@@ -143,9 +144,8 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
         `found no origin annotation for ref ${entityRefString}`,
       );
     }
-    const [type, ...rest] = locationKeyValue.value?.split(':') ?? [];
-    const target = rest.join(':');
 
+    const { type, target } = parseLocationRef(entityRefString);
     // const kind, target = split[0], split[1];
     const [location] = await this.db<DbLocationsRow>('locations')
       .where({ type, target })

--- a/plugins/catalog-backend/src/modules/core/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/modules/core/DefaultLocationStore.ts
@@ -18,7 +18,11 @@ import { Location } from '@backstage/catalog-client';
 import { ConflictError, NotFoundError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { v4 as uuid } from 'uuid';
-import { DbLocationsRow } from '../../database/tables';
+import {
+  DbLocationsRow,
+  DbRefreshStateRow,
+  DbSearchRow,
+} from '../../database/tables';
 import { getEntityLocationRef } from '../../processing/util';
 import {
   EntityProvider,
@@ -26,6 +30,11 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { locationSpecToLocationEntity } from '../../util/conversion';
 import { LocationInput, LocationStore } from '../../service/types';
+import {
+  ANNOTATION_ORIGIN_LOCATION,
+  CompoundEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 
 export class DefaultLocationStore implements LocationStore, EntityProvider {
   private _connection: EntityProviderConnection | undefined;
@@ -109,6 +118,47 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
       added: [],
       removed: [{ entity, locationKey: getEntityLocationRef(entity) }],
     });
+  }
+
+  async getLocationByEntity(entityRef: CompoundEntityRef): Promise<Location> {
+    const entityRefString = stringifyEntityRef(entityRef);
+
+    const [entity] = await this.db<DbRefreshStateRow>('refresh_state')
+      .where({ entity_ref: entityRefString })
+      .select('entity_id')
+      .limit(1);
+    if (!entity) {
+      throw new NotFoundError(`found no entity for ref ${entityRefString}`);
+    }
+
+    const [locationKeyValue] = await this.db<DbSearchRow>('search')
+      .where({
+        entity_id: entity.entity_id,
+        key: `metadata.annotations.${ANNOTATION_ORIGIN_LOCATION}`,
+      })
+      .select('value')
+      .limit(1);
+    if (!locationKeyValue) {
+      throw new NotFoundError(
+        `found no origin annotation for ref ${entityRefString}`,
+      );
+    }
+    const [type, ...rest] = locationKeyValue.value?.split(':') ?? [];
+    const target = rest.join(':');
+
+    // const kind, target = split[0], split[1];
+    const [location] = await this.db<DbLocationsRow>('locations')
+      .where({ type, target })
+      .select()
+      .limit(1);
+
+    // select * from locations where type = 'split(prev)[0]'
+    if (!location) {
+      throw new NotFoundError(
+        `Found no location with type ${type} and target ${target}`,
+      );
+    }
+    return location;
   }
 
   private get connection(): EntityProviderConnection {

--- a/plugins/catalog-backend/src/schema/openapi.generated.ts
+++ b/plugins/catalog-backend/src/schema/openapi.generated.ts
@@ -1420,6 +1420,62 @@ export const spec = {
         ],
       },
     },
+    '/locations/by-entity/{kind}/{namespace}/{name}': {
+      get: {
+        operationId: 'getLocationByEntity',
+        description: 'Get a location for entity.',
+        responses: {
+          '200': {
+            description: 'Ok',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Location',
+                },
+              },
+            },
+          },
+          default: {
+            $ref: '#/components/responses/ErrorResponse',
+          },
+        },
+        security: [
+          {},
+          {
+            JWT: [],
+          },
+        ],
+        parameters: [
+          {
+            in: 'path',
+            name: 'kind',
+            required: true,
+            allowReserved: true,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            in: 'path',
+            name: 'namespace',
+            required: true,
+            allowReserved: true,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            in: 'path',
+            name: 'name',
+            required: true,
+            allowReserved: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+      },
+    },
     '/analyze-location': {
       post: {
         operationId: 'AnalyzeLocation',

--- a/plugins/catalog-backend/src/schema/openapi.yaml
+++ b/plugins/catalog-backend/src/schema/openapi.yaml
@@ -1057,6 +1057,41 @@ paths:
           allowReserved: true
           schema:
             type: string
+  /locations/by-entity/{kind}/{namespace}/{name}:
+    get:
+      operationId: getLocationByEntity
+      description: Get a location for entity.
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Location'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - {}
+        - JWT: []
+      parameters:
+        - in: path
+          name: kind
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+        - in: path
+          name: namespace
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          allowReserved: true
+          schema:
+            type: string
   /analyze-location:
     post:
       operationId: AnalyzeLocation

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.test.ts
@@ -24,6 +24,7 @@ describe('AuthorizedLocationService', () => {
     listLocations: jest.fn(),
     getLocation: jest.fn(),
     deleteLocation: jest.fn(),
+    getLocationByEntity: jest.fn(),
   };
   const fakePermissionApi = {
     authorize: jest.fn(),
@@ -142,6 +143,38 @@ describe('AuthorizedLocationService', () => {
           authorizationToken: 'Bearer authtoken',
         }),
       ).rejects.toThrow(NotAllowedError);
+    });
+  });
+
+  describe('getLocationByEntity', () => {
+    it('calls underlying service to get location on ALLOW', async () => {
+      mockAllow();
+      const service = createService();
+
+      await service.getLocationByEntity(
+        { kind: 'c', namespace: 'ns', name: 'n' },
+        {
+          authorizationToken: 'Bearer authtoken',
+        },
+      );
+
+      expect(fakeLocationService.getLocationByEntity).toHaveBeenCalledWith({
+        kind: 'c',
+        namespace: 'ns',
+        name: 'n',
+      });
+    });
+
+    it('throws error on DENY', async () => {
+      mockDeny();
+      const service = createService();
+
+      await expect(() =>
+        service.getLocationByEntity(
+          { kind: 'c', namespace: 'ns', name: 'n' },
+          { authorizationToken: 'Bearer authtoken' },
+        ),
+      ).rejects.toThrow(NotFoundError);
     });
   });
 });

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
@@ -113,7 +113,7 @@ export class AuthorizedLocationService implements LocationService {
   }
 
   async getLocationByEntity(
-    entityRef: CompoundEntityRef,
+    entityRef: CompoundEntityRef | string,
     options?: { authorizationToken?: string | undefined } | undefined,
   ): Promise<Location> {
     const authorizationResponse = (

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
@@ -15,7 +15,7 @@
  */
 
 import { Location } from '@backstage/catalog-client';
-import { Entity } from '@backstage/catalog-model';
+import { CompoundEntityRef, Entity } from '@backstage/catalog-model';
 import { NotAllowedError, NotFoundError } from '@backstage/errors';
 import {
   catalogLocationCreatePermission,
@@ -110,5 +110,22 @@ export class AuthorizedLocationService implements LocationService {
     }
 
     return this.locationService.deleteLocation(id);
+  }
+
+  async getLocationByEntity(
+    entityRef: CompoundEntityRef,
+    options?: { authorizationToken?: string | undefined } | undefined,
+  ): Promise<Location> {
+    const authorizationResponse = (
+      await this.permissionApi.authorize(
+        [{ permission: catalogLocationReadPermission }],
+        { token: options?.authorizationToken },
+      )
+    )[0];
+
+    if (authorizationResponse.result === AuthorizeResult.DENY) {
+      throw new NotFoundError();
+    }
+    return this.locationService.getLocationByEntity(entityRef);
   }
 }

--- a/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.test.ts
@@ -28,6 +28,7 @@ describe('DefaultLocationServiceTest', () => {
     createLocation: jest.fn(),
     listLocations: jest.fn(),
     getLocation: jest.fn(),
+    getLocationByEntity: jest.fn(),
   };
   const locationService = new DefaultLocationService(store, orchestrator);
 
@@ -345,6 +346,21 @@ describe('DefaultLocationServiceTest', () => {
     it('should call locationStore.getLocation', async () => {
       await locationService.getLocation('123');
       expect(store.getLocation).toHaveBeenCalledWith('123');
+    });
+  });
+
+  describe('getLocationByEntity', () => {
+    it('should call locationStore.getLocationByEntity', async () => {
+      await locationService.getLocationByEntity({
+        kind: 'c',
+        namespace: 'ns',
+        name: 'n',
+      });
+      expect(store.getLocationByEntity).toHaveBeenCalledWith({
+        kind: 'c',
+        namespace: 'ns',
+        name: 'n',
+      });
     });
   });
 });

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -19,6 +19,7 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   stringifyEntityRef,
+  CompoundEntityRef,
 } from '@backstage/catalog-model';
 import { Location } from '@backstage/catalog-client';
 import { CatalogProcessingOrchestrator } from '../processing/types';
@@ -66,6 +67,10 @@ export class DefaultLocationService implements LocationService {
   }
   deleteLocation(id: string): Promise<void> {
     return this.store.deleteLocation(id);
+  }
+
+  getLocationByEntity(entityRef: CompoundEntityRef): Promise<Location> {
+    return this.store.getLocationByEntity(entityRef);
   }
 
   private async processEntities(

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -20,6 +20,7 @@ import {
   ANNOTATION_ORIGIN_LOCATION,
   stringifyEntityRef,
   CompoundEntityRef,
+  parseEntityRef,
 } from '@backstage/catalog-model';
 import { Location } from '@backstage/catalog-client';
 import { CatalogProcessingOrchestrator } from '../processing/types';
@@ -69,8 +70,10 @@ export class DefaultLocationService implements LocationService {
     return this.store.deleteLocation(id);
   }
 
-  getLocationByEntity(entityRef: CompoundEntityRef): Promise<Location> {
-    return this.store.getLocationByEntity(entityRef);
+  getLocationByEntity(
+    entityRef: CompoundEntityRef | string,
+  ): Promise<Location> {
+    return this.store.getLocationByEntity(parseEntityRef(entityRef));
   }
 
   private async processEntities(

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -63,6 +63,7 @@ describe('createRouter readonly disabled', () => {
       createLocation: jest.fn(),
       listLocations: jest.fn(),
       deleteLocation: jest.fn(),
+      getLocationByEntity: jest.fn(),
     };
     refreshService = { refresh: jest.fn() };
     orchestrator = { process: jest.fn() };
@@ -621,6 +622,36 @@ describe('createRouter readonly disabled', () => {
     });
   });
 
+  describe('GET /locations/by-entity/:kind/:namespace/:name', () => {
+    it('happy path: gets location by entity ref', async () => {
+      const location: Location = {
+        id: 'foo',
+        type: 'url',
+        target: 'example.com',
+      };
+      locationService.getLocationByEntity.mockResolvedValueOnce(location);
+
+      const response = await request(app)
+        .get('/locations/by-entity/c/ns/n')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.getLocationByEntity).toHaveBeenCalledTimes(1);
+      expect(locationService.getLocationByEntity).toHaveBeenCalledWith(
+        { kind: 'c', namespace: 'ns', name: 'n' },
+        {
+          authorizationToken: 'someauthtoken',
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        id: 'foo',
+        target: 'example.com',
+        type: 'url',
+      });
+    });
+  });
+
   describe('POST /validate-entity', () => {
     describe('valid entity', () => {
       it('returns 200', async () => {
@@ -753,6 +784,7 @@ describe('createRouter readonly enabled', () => {
       createLocation: jest.fn(),
       listLocations: jest.fn(),
       deleteLocation: jest.fn(),
+      getLocationByEntity: jest.fn(),
     };
     const router = await createRouter({
       entitiesCatalog,
@@ -911,6 +943,36 @@ describe('createRouter readonly enabled', () => {
       expect(response.status).toEqual(403);
     });
   });
+
+  describe('GET /locations/by-entity/:kind/:namespace/:name', () => {
+    it('happy path: gets location by entity ref', async () => {
+      const location: Location = {
+        id: 'foo',
+        type: 'url',
+        target: 'example.com',
+      };
+      locationService.getLocationByEntity.mockResolvedValueOnce(location);
+
+      const response = await request(app)
+        .get('/locations/by-entity/c/ns/n')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.getLocationByEntity).toHaveBeenCalledTimes(1);
+      expect(locationService.getLocationByEntity).toHaveBeenCalledWith(
+        { kind: 'c', namespace: 'ns', name: 'n' },
+        {
+          authorizationToken: 'someauthtoken',
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        id: 'foo',
+        target: 'example.com',
+        type: 'url',
+      });
+    });
+  });
 });
 
 describe('NextRouter permissioning', () => {
@@ -944,6 +1006,7 @@ describe('NextRouter permissioning', () => {
       createLocation: jest.fn(),
       listLocations: jest.fn(),
       deleteLocation: jest.fn(),
+      getLocationByEntity: jest.fn(),
     };
     refreshService = { refresh: jest.fn() };
     const router = await createRouter({

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -290,6 +290,18 @@ export async function createRouter(
           ),
         });
         res.status(204).end();
+      })
+      .get('/locations/by-entity/:kind/:namespace/:name', async (req, res) => {
+        const { kind, namespace, name } = req.params;
+        const output = await locationService.getLocationByEntity(
+          { kind, namespace, name },
+          {
+            authorizationToken: getBearerTokenFromAuthorizationHeader(
+              req.header('authorization'),
+            ),
+          },
+        );
+        res.status(200).json(output);
       });
   }
 

--- a/plugins/catalog-backend/src/service/types.ts
+++ b/plugins/catalog-backend/src/service/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { CompoundEntityRef, Entity } from '@backstage/catalog-model';
 import { Location } from '@backstage/catalog-client';
 
 /**
@@ -48,6 +48,10 @@ export interface LocationService {
     id: string,
     options?: { authorizationToken?: string },
   ): Promise<void>;
+  getLocationByEntity(
+    entityRef: CompoundEntityRef,
+    options?: { authorizationToken?: string },
+  ): Promise<Location>;
 }
 
 /**
@@ -82,4 +86,5 @@ export interface LocationStore {
   listLocations(): Promise<Location[]>;
   getLocation(id: string): Promise<Location>;
   deleteLocation(id: string): Promise<void>;
+  getLocationByEntity(entityRef: CompoundEntityRef): Promise<Location>;
 }

--- a/plugins/catalog-backend/src/service/types.ts
+++ b/plugins/catalog-backend/src/service/types.ts
@@ -49,7 +49,7 @@ export interface LocationService {
     options?: { authorizationToken?: string },
   ): Promise<void>;
   getLocationByEntity(
-    entityRef: CompoundEntityRef,
+    entityRef: CompoundEntityRef | string,
     options?: { authorizationToken?: string },
   ): Promise<Location>;
 }
@@ -86,5 +86,5 @@ export interface LocationStore {
   listLocations(): Promise<Location[]>;
   getLocation(id: string): Promise<Location>;
   deleteLocation(id: string): Promise<void>;
-  getLocationByEntity(entityRef: CompoundEntityRef): Promise<Location>;
+  getLocationByEntity(entityRef: CompoundEntityRef | string): Promise<Location>;
 }


### PR DESCRIPTION
Introduce API route to get location by entity. Solves #21826.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
