### PR TITLE
feat: Add 'gitlab:repo:push' scaffolder action

### DIFF
--- a/.changeset/rich-poets-stare.md
+++ b/.changeset/rich-poets-stare.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add 'gitlab:repo:push' scaffolder action to push files to arbitrary branch without creating a Merge Request

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -77,6 +77,22 @@ export const createGitlabProjectVariableAction: (options: {
 >;
 
 // @public
+export const createGitlabRepoPushAction: (options: {
+  integrations: ScmIntegrationRegistry;
+}) => TemplateAction<
+  {
+    repoUrl: string;
+    branchName: string;
+    commitMessage: string;
+    sourcePath?: string | undefined;
+    targetPath?: string | undefined;
+    token?: string | undefined;
+    commitAction?: 'update' | 'delete' | 'create' | undefined;
+  },
+  JsonObject
+>;
+
+// @public
 export function createPublishGitlabAction(options: {
   integrations: ScmIntegrationRegistry;
   config: Config;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createRootLogger, getRootLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
+import { TemplateAction } from '@backstage/plugin-scaffolder-node';
+import { Writable } from 'stream';
+import { createMockDirectory } from '@backstage/backend-test-utils';
+import { createGitlabRepoPushAction } from './gitlabRepoPush';
+
+// Make sure root logger is initialized ahead of FS mock
+createRootLogger();
+
+const mockGitlabClient = {
+  Projects: {
+    create: jest.fn(),
+    show: jest.fn(async (_: any) => {
+      return {
+        default_branch: 'main',
+      };
+    }),
+  },
+  Branches: {
+    create: jest.fn(),
+    show: jest.fn(),
+  },
+  Commits: {
+    create: jest.fn(async (_: any) => ({
+      id: 'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+    })),
+  },
+};
+
+jest.mock('@gitbeaker/node', () => ({
+  Gitlab: class {
+    constructor() {
+      return mockGitlabClient;
+    }
+  },
+}));
+
+describe('createGitLabCommit', () => {
+  let instance: TemplateAction<any>;
+
+  const mockDir = createMockDirectory();
+  const workspacePath = mockDir.resolve('workspace');
+
+  beforeEach(() => {
+    mockDir.clear();
+
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            token: 'token',
+            apiBaseUrl: 'https://api.gitlab.com',
+          },
+          {
+            host: 'hosted.gitlab.com',
+            apiBaseUrl: 'https://api.hosted.gitlab.com',
+          },
+        ],
+      },
+    });
+
+    const integrations = ScmIntegrations.fromConfig(config);
+    instance = createGitlabRepoPushAction({ integrations });
+  });
+
+  describe('createGitLabCommitWithoutCommitAction', () => {
+    it('default commitAction is create', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledTimes(0);
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'create',
+            filePath: 'foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+  });
+
+  describe('createGitLabCommitWithCommitAction', () => {
+    it('commitAction is create when create is passed in options', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        commitAction: 'create',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledTimes(0);
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'create',
+            filePath: 'foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+
+    it('commitAction is update when update is passed in options', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        commitAction: 'update',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledTimes(0);
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'update',
+            filePath: 'foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+
+    it('commitAction is delete when delete is passed in options', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        commitAction: 'delete',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledTimes(0);
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'delete',
+            filePath: 'foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+  });
+
+  describe('with sourcePath', () => {
+    it('creates a commit with only relevant files', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        sourcePath: 'source',
+        commitAction: 'create',
+      };
+
+      mockDir.setContent({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledTimes(0);
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'create',
+            filePath: 'foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+
+    it('creates a commit with only relevant files placed under different targetPath', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        sourcePath: 'source',
+        targetPath: 'target',
+        commitAction: 'create',
+      };
+
+      mockDir.setContent({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledTimes(0);
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'create',
+            filePath: 'target/foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+
+    it('should not allow to use files outside of the workspace', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        sourcePath: '../../test',
+        commitAction: 'create',
+      };
+
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+
+      await expect(instance.handler(ctx)).rejects.toThrow(
+        'Relative path is not allowed to refer to a directory outside its parent',
+      );
+    });
+  });
+
+  describe('createCommitToBranchThatDoesNotExist', () => {
+    it('should create a new branch', async () => {
+      mockGitlabClient.Branches.show.mockRejectedValue({
+        response: {
+          statusCode: 404,
+        },
+      });
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+      const ctx = {
+        createTemporaryDirectory: jest.fn(),
+        output: jest.fn(),
+        logger: getRootLogger(),
+        logStream: new Writable(),
+        input,
+        workspacePath,
+      };
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'main',
+      );
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Create my new commit',
+        [
+          {
+            action: 'create',
+            filePath: 'foo.txt',
+            content: 'SGVsbG8gdGhlcmUh',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+      );
+    });
+  });
+});

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { parseRepoUrl } from '@backstage/plugin-scaffolder-node';
+import { InputError } from '@backstage/errors';
+import { Gitlab } from '@gitbeaker/node';
+import { ScmIntegrationRegistry } from '@backstage/integration';
+import { Resources } from '@gitbeaker/core';
+
+export function createGitlabApi(options: {
+  integrations: ScmIntegrationRegistry;
+  token?: string;
+  repoUrl: string;
+}): Resources.Gitlab {
+  const { integrations, token: providedToken, repoUrl } = options;
+
+  const { host } = parseRepoUrl(repoUrl, integrations);
+
+  const integrationConfig = integrations.gitlab.byHost(host);
+
+  if (!integrationConfig) {
+    throw new InputError(
+      `No matching integration configuration for host ${host}, please check your integrations config`,
+    );
+  }
+
+  if (!integrationConfig.config.token && !providedToken) {
+    throw new InputError(`No token available for host ${host}`);
+  }
+
+  const token = providedToken ?? integrationConfig.config.token!;
+  const tokenType = providedToken ? 'oauthToken' : 'token';
+
+  return new Gitlab({
+    host: integrationConfig.config.baseUrl,
+    [tokenType]: token,
+  });
+}

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/index.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/index.ts
@@ -19,3 +19,4 @@ export * from './createGitlabProjectAccessTokenAction';
 export * from './createGitlabProjectVariableAction';
 export * from './gitlab';
 export * from './gitlabMergeRequest';
+export * from './gitlabRepoPush';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -69,6 +69,7 @@ import {
 
 import {
   createPublishGitlabAction,
+  createGitlabRepoPushAction,
   createPublishGitlabMergeRequestAction,
 } from '@backstage/plugin-scaffolder-backend-module-gitlab';
 
@@ -163,6 +164,9 @@ export const createBuiltinActions = (
       config,
     }),
     createPublishGitlabMergeRequestAction({
+      integrations,
+    }),
+    createGitlabRepoPushAction({
       integrations,
     }),
     createPublishBitbucketAction({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR adds new action to make a push to a branch in gitlab repository. The action requires `branchName` as an input. If that branch exists, the commit will be made into it, if branch doesn't exist - the action will create new branch using default branch as a base ref.
> [!NOTE]
> I could've used the default repository branch, but I thought it's better to be explicit here. Let me know if you prefer that

In addition to unit tests I've tried it on my playground repository
1. [Commit to an existing branch `main`](https://gitlab.com/agavlyukovskiy/backstage-playground/-/commit/0fcb00dc697482dbbb3970645470214c00932e39)
2. [Commit into a new branch](https://gitlab.com/agavlyukovskiy/backstage-playground/-/tree/my-new-branch?ref_type=heads)
3. [Commit into a branch for which PR has been already opened](https://gitlab.com/agavlyukovskiy/backstage-playground/-/merge_requests/1)

This partially solves problems described in https://github.com/backstage/backstage/issues/16662 as it's possible to make additional commits to an already openned Merge Request, so that one could mix `commitAction: create` with `commitAction: update` or `commitAction: delete` using different commits. 
Using this new action is different from the other solutions proposed in that issue (using isomorphic git) or the one I suggested with using multiple actions per path, but I thought that this action might be useful not only when you need to mix different actions, but for simply committing to a custom branch without opening an MR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
