### PR TITLE
Drop databases after unit tests if the database instance is not running in docker

### DIFF
--- a/.changeset/fifty-files-argue.md
+++ b/.changeset/fifty-files-argue.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-test-utils': minor
+'@backstage/backend-common': minor
+---
+
+drop databases after unit tests if the database instance is not running in docker

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -277,6 +277,12 @@ export class DockerContainerRunner implements ContainerRunner {
 }
 
 // @public
+export function dropDatabase(
+  dbConfig: Config,
+  ...databases: Array<string>
+): Promise<void>;
+
+// @public
 export function ensureDatabaseExists(
   dbConfig: Config,
   ...databases: Array<string>

--- a/packages/backend-common/src/database/connection.ts
+++ b/packages/backend-common/src/database/connection.ts
@@ -96,6 +96,22 @@ export async function ensureDatabaseExists(
 }
 
 /**
+ * Drops the given databases.
+ *
+ * @public
+ */
+export async function dropDatabase(
+  dbConfig: Config,
+  ...databases: Array<string>
+): Promise<void> {
+  const client: DatabaseClient = dbConfig.getString('client');
+
+  return await ddlLimiter(() =>
+    ConnectorMapping[client]?.dropDatabase?.(dbConfig, ...databases),
+  );
+}
+
+/**
  * Ensures that the given schemas all exist, creating them if they do not.
  *
  * @public

--- a/packages/backend-common/src/database/connectors/postgres.ts
+++ b/packages/backend-common/src/database/connectors/postgres.ts
@@ -200,6 +200,24 @@ export async function ensurePgSchemaExists(
 }
 
 /**
+ * Drops the Postgres databases.
+ *
+ * @param dbConfig - The database config
+ * @param databases - The name of the databases to drop
+ */
+export async function dropPgDatabase(
+  dbConfig: Config,
+  ...databases: Array<string>
+) {
+  const admin = createPgDatabaseClient(dbConfig);
+  await Promise.all(
+    databases.map(async database => {
+      await admin.raw(`DROP DATABASE ??`, [database]);
+    }),
+  );
+}
+
+/**
  * PostgreSQL database connector.
  *
  * Exposes database connector functionality via an immutable object.
@@ -211,4 +229,5 @@ export const pgConnector: DatabaseConnector = Object.freeze({
   createNameOverride: defaultNameOverride,
   createSchemaOverride: defaultSchemaOverride,
   parseConnectionString: parsePgConnectionString,
+  dropDatabase: dropPgDatabase,
 });

--- a/packages/backend-common/src/database/index.ts
+++ b/packages/backend-common/src/database/index.ts
@@ -20,7 +20,11 @@ export * from './DatabaseManager';
  * Undocumented API surface from connection is being reduced for future deprecation.
  * Avoid exporting additional symbols.
  */
-export { createDatabaseClient, ensureDatabaseExists } from './connection';
+export {
+  createDatabaseClient,
+  ensureDatabaseExists,
+  dropDatabase,
+} from './connection';
 
 export type { PluginDatabaseManager } from './types';
 export { isDatabaseConflictError } from './util';

--- a/packages/backend-common/src/database/types.ts
+++ b/packages/backend-common/src/database/types.ts
@@ -79,4 +79,6 @@ export interface DatabaseConnector {
     dbConfig: Config,
     ...schemas: Array<string>
   ): Promise<void>;
+
+  dropDatabase?(dbConfig: Config, ...databases: Array<string>): Promise<void>;
 }

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -43,8 +43,10 @@ export type TestDatabaseProperties = {
 
 export type Instance = {
   stopContainer?: () => Promise<void>;
+  dropDatabases?: () => Promise<void>;
   databaseManager: DatabaseManager;
   connections: Array<Knex>;
+  databaseNames: Array<string>;
 };
 
 export const allDatabases: Record<TestDatabaseId, TestDatabaseProperties> =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR extends backend-test-utils to drop databases after tests has run if the database instance is not running in docker. This is to make sure that we don't inadvertently fill the database instance with bunch of test databases. It is assumed that if you give a connection string to external database then the database is more "permanent" that the one that has been launched in a container just for the tests.

Relates to the discussion here: #21619

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
