### PR TITLE
Scaffolder action conditions validation fix

### DIFF
--- a/.changeset/gold-pianos-worry.md
+++ b/.changeset/gold-pianos-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed an issue where not passing a `value` to any of the action's permission conditions caused an error.

--- a/plugins/scaffolder-backend/src/service/rules.test.ts
+++ b/plugins/scaffolder-backend/src/service/rules.test.ts
@@ -23,6 +23,9 @@ import {
   hasStringProperty,
   hasTag,
 } from './rules';
+import { createConditionAuthorizer } from '@backstage/plugin-permission-node';
+import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 describe('hasTag', () => {
   describe('apply', () => {
@@ -206,6 +209,84 @@ describe('hasProperty', () => {
         ).toEqual(true);
       },
     );
+
+    it('should throw if params are invalid', () => {
+      const isActionAuthorized = createConditionAuthorizer([hasProperty]);
+
+      expect(() =>
+        isActionAuthorized(
+          {
+            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+            pluginId: 'scaffolder',
+            result: AuthorizeResult.CONDITIONAL,
+            conditions: {
+              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+              rule: 'HAS_PROPERTY',
+              params: {
+                key: 1,
+              },
+            },
+          },
+          { action: 'an-action', input: {} },
+        ),
+      ).toThrow();
+      expect(() =>
+        isActionAuthorized(
+          {
+            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+            pluginId: 'scaffolder',
+            result: AuthorizeResult.CONDITIONAL,
+            conditions: {
+              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+              rule: 'HAS_PROPERTY',
+              params: {},
+            },
+          },
+          { action: 'an-action', input: {} },
+        ),
+      ).toThrow();
+    });
+
+    it('should not throw if params are valid', () => {
+      const isActionAuthorized = createConditionAuthorizer([hasProperty]);
+
+      expect(() =>
+        isActionAuthorized(
+          {
+            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+            pluginId: 'scaffolder',
+            result: AuthorizeResult.CONDITIONAL,
+            conditions: {
+              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+              rule: 'HAS_PROPERTY',
+              params: {
+                key: 'key',
+              },
+            },
+          },
+          { action: 'an-action', input: {} },
+        ),
+      ).not.toThrow();
+
+      expect(() =>
+        isActionAuthorized(
+          {
+            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+            pluginId: 'scaffolder',
+            result: AuthorizeResult.CONDITIONAL,
+            conditions: {
+              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+              rule: 'HAS_PROPERTY',
+              params: {
+                key: 'key',
+                value: 'value',
+              },
+            },
+          },
+          { action: 'an-action', input: {} },
+        ),
+      ).not.toThrow();
+    });
   });
 });
 

--- a/plugins/scaffolder-backend/src/service/rules.ts
+++ b/plugins/scaffolder-backend/src/service/rules.ts
@@ -106,7 +106,9 @@ function buildHasProperty<Schema extends z.ZodType<JsonPrimitive>>({
       key: z
         .string()
         .describe(`Property within the action parameters to match on`),
-      value: valueSchema.describe(`Value of the given property to match on`),
+      value: valueSchema
+        .optional()
+        .describe(`Value of the given property to match on`),
     }) as unknown as z.ZodType<{ key: string; value?: z.infer<Schema> }>,
     apply: (resource, { key, value }) => {
       const foundValue = get(resource.input, key);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue where the permission framework was wrongly throwing a `Parameter to rule are invalid` error when not passing a `value` to any of the scaffolder action conditions, for example:

```ts
scaffolderActionConditions.hasStringProperty({
    key: 'a-key',
})
```

Fixes #21786

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
