### PR TITLE
Fix Link clipboard copy

### DIFF
--- a/.changeset/chilled-seahorses-clean.md
+++ b/.changeset/chilled-seahorses-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed bug in Link where it was possible to select and copy a hidden element into clipboard

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -42,6 +42,7 @@ const useStyles = makeStyles(
       clipPath: 'inset(50%)',
       overflow: 'hidden',
       position: 'absolute',
+      userSelect: 'none',
       whiteSpace: 'nowrap',
       height: 1,
       width: 1,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A hidden span inside the Link component can accidentally get carried over to a user's clipboard (for example when attempting to select and copy an e-mail address). This PR prevents the user from selecting the hidden span. 

![Screenshot 2023-12-22 at 11 04 47](https://github.com/backstage/backstage/assets/32046496/cd00e526-7d6e-42d3-b767-5e3f75a3e7ce)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
