### PR TITLE
Updated backend plugin start docs

### DIFF
--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -41,8 +41,10 @@ standalone mode. You can do a first-light test of your service:
 
 ```sh
 cd plugins/carmen-backend
-yarn start
+LEGACY_BACKEND_START=true yarn start
 ```
+
+> Note: `LEGACY_BACKEND_START=true` is needed while we transition fully to the [New Backend System](../backend-system/index.md). The templates have not been migrated yet; you can track this in [issue 21288](https://github.com/backstage/backstage/issues/21288)
 
 This will think for a bit, and then say `Listening on :7007`. In a different
 terminal window, now run


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated backend plugin start docs to use `LEGACY_BACKEND_START=true yarn start` as we haven't migrated the templates. If you don't then you get this error: https://github.com/backstage/backstage/issues/21996

Closed #21996

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
