### PR TITLE
Feature: Add custom Kinds to default columns for CatalogTable

### DIFF
--- a/.changeset/seven-dots-serve.md
+++ b/.changeset/seven-dots-serve.md
@@ -1,0 +1,35 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Exported `defaultCatalogTableColumnsFunc` to create a seam for defining the columns in [CatalogTable](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx) of some Kinds while using the default columns for the others.
+This is useful for defining the columns of a custom Kind or to redefine the columns for a built-in Kind.
+
+```diff
+// packages/app/src/App.tsx
+
+import {
+  CatalogEntityPage,
+  CatalogIndexPage,
+  catalogPlugin,
++  CatalogTable,
++  CatalogTableColumnsFunc,
++  defaultCatalogTableColumnsFunc,
+} from '@backstage/plugin-catalog';
+
++ const myColumnsFunc: CatalogTableColumnsFunc = (entityListContext) => {
++   if (entityListContext.filters.kind?.value === 'MyKind') {
++     return [
++       CatalogTable.columns.createNameColumn(),
++       CatalogTable.columns.createOwnerColumn()
++     ];
++   }
++
++   return defaultCatalogTableColumnsFunc(entityListContext);
++ };
+
+...
+
+- <Route path="/catalog" element={<CatalogIndexPage />} />
++ <Route path="/catalog" element={<CatalogIndexPage columns={myColumnsFunc} />} />
+```

--- a/.changeset/seven-dots-serve.md
+++ b/.changeset/seven-dots-serve.md
@@ -2,33 +2,4 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Exported `CatalogTable.defaultColumnsFunc` to create a seam for defining the columns in `<CatalogTable />` of some Kinds while using the default columns for the others.
-This is useful for defining the columns of a custom Kind or to redefine the columns for a built-in Kind.
-
-```diff
-// packages/app/src/App.tsx
-
-import {
-  CatalogEntityPage,
-  CatalogIndexPage,
-  catalogPlugin,
-+  CatalogTable,
-+  CatalogTableColumnsFunc,
-} from '@backstage/plugin-catalog';
-
-+ const myColumnsFunc: CatalogTableColumnsFunc = (entityListContext) => {
-+   if (entityListContext.filters.kind?.value === 'MyKind') {
-+     return [
-+       CatalogTable.columns.createNameColumn(),
-+       CatalogTable.columns.createOwnerColumn()
-+     ];
-+   }
-+
-+   return CatalogTable.defaultColumnsFunc(entityListContext);
-+ };
-
-...
-
-- <Route path="/catalog" element={<CatalogIndexPage />} />
-+ <Route path="/catalog" element={<CatalogIndexPage columns={myColumnsFunc} />} />
-```
+Exported `CatalogTable.defaultColumnsFunc` for defining the columns in `<CatalogTable />` of some Kinds while using the default columns for the others.

--- a/.changeset/seven-dots-serve.md
+++ b/.changeset/seven-dots-serve.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Exported `defaultCatalogTableColumnsFunc` to create a seam for defining the columns in [CatalogTable](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx) of some Kinds while using the default columns for the others.
+Exported `defaultCatalogTableColumnsFunc` to create a seam for defining the columns in `<CatalogTable />` of some Kinds while using the default columns for the others.
 This is useful for defining the columns of a custom Kind or to redefine the columns for a built-in Kind.
 
 ```diff

--- a/.changeset/seven-dots-serve.md
+++ b/.changeset/seven-dots-serve.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Exported `defaultCatalogTableColumnsFunc` to create a seam for defining the columns in `<CatalogTable />` of some Kinds while using the default columns for the others.
+Exported `CatalogTable.defaultColumnsFunc` to create a seam for defining the columns in `<CatalogTable />` of some Kinds while using the default columns for the others.
 This is useful for defining the columns of a custom Kind or to redefine the columns for a built-in Kind.
 
 ```diff
@@ -14,7 +14,6 @@ import {
   catalogPlugin,
 +  CatalogTable,
 +  CatalogTableColumnsFunc,
-+  defaultCatalogTableColumnsFunc,
 } from '@backstage/plugin-catalog';
 
 + const myColumnsFunc: CatalogTableColumnsFunc = (entityListContext) => {
@@ -25,7 +24,7 @@ import {
 +     ];
 +   }
 +
-+   return defaultCatalogTableColumnsFunc(entityListContext);
++   return CatalogTable.defaultColumnsFunc(entityListContext);
 + };
 
 ...

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -245,6 +245,9 @@ export interface DefaultCatalogPageProps {
   tableOptions?: TableProps<CatalogTableRow>['options'];
 }
 
+// @public (undocumented)
+export const defaultColumnsFunc: CatalogTableColumnsFunc;
+
 // @public
 export class DefaultEntityPresentationApi implements EntityPresentationApi {
   static create(

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -182,6 +182,7 @@ export const CatalogTable: {
     ): TableColumn<CatalogTableRow>;
     createNamespaceColumn(): TableColumn<CatalogTableRow>;
   }>;
+  defaultColumnsFunc: CatalogTableColumnsFunc;
 };
 
 // @public
@@ -244,9 +245,6 @@ export interface DefaultCatalogPageProps {
   // (undocumented)
   tableOptions?: TableProps<CatalogTableRow>['options'];
 }
-
-// @public (undocumented)
-export const defaultCatalogTableColumnsFunc: CatalogTableColumnsFunc;
 
 // @public
 export class DefaultEntityPresentationApi implements EntityPresentationApi {

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -246,7 +246,7 @@ export interface DefaultCatalogPageProps {
 }
 
 // @public (undocumented)
-export const defaultColumnsFunc: CatalogTableColumnsFunc;
+export const defaultCatalogTableColumnsFunc: CatalogTableColumnsFunc;
 
 // @public
 export class DefaultEntityPresentationApi implements EntityPresentationApi {

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -226,6 +226,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
 };
 
 CatalogTable.columns = columnFactories;
+CatalogTable.defaultColumnsFunc = defaultCatalogTableColumnsFunc;
 
 function toEntityRow(entity: Entity) {
   const partOfSystemRelations = getEntityRelations(entity, RELATION_PART_OF, {

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -78,7 +78,7 @@ const refCompare = (a: Entity, b: Entity) => {
 };
 
 /** @public */
-export const defaultColumnsFunc: CatalogTableColumnsFunc = ({
+export const defaultCatalogTableColumnsFunc: CatalogTableColumnsFunc = ({
   filters,
   entities,
 }) => {
@@ -126,7 +126,7 @@ export const defaultColumnsFunc: CatalogTableColumnsFunc = ({
 /** @public */
 export const CatalogTable = (props: CatalogTableProps) => {
   const {
-    columns = defaultColumnsFunc,
+    columns = defaultCatalogTableColumnsFunc,
     tableOptions,
     subtitle,
     emptyContent,

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -47,6 +47,7 @@ import React, { ReactNode, useMemo } from 'react';
 import { columnFactories } from './columns';
 import { CatalogTableColumnsFunc, CatalogTableRow } from './types';
 import { PaginatedCatalogTable } from './PaginatedCatalogTable';
+import { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc';
 
 /**
  * Props for {@link CatalogTable}.
@@ -75,52 +76,6 @@ const refCompare = (a: Entity, b: Entity) => {
     });
 
   return toRef(a).localeCompare(toRef(b));
-};
-
-/** @public */
-export const defaultCatalogTableColumnsFunc: CatalogTableColumnsFunc = ({
-  filters,
-  entities,
-}) => {
-  const showTypeColumn = filters.type === undefined;
-
-  return [
-    columnFactories.createTitleColumn({ hidden: true }),
-    columnFactories.createNameColumn({ defaultKind: filters.kind?.value }),
-    ...createEntitySpecificColumns(),
-    columnFactories.createMetadataDescriptionColumn(),
-    columnFactories.createTagsColumn(),
-  ];
-
-  function createEntitySpecificColumns(): TableColumn<CatalogTableRow>[] {
-    const baseColumns = [
-      columnFactories.createSystemColumn(),
-      columnFactories.createOwnerColumn(),
-      columnFactories.createSpecTypeColumn({ hidden: !showTypeColumn }),
-      columnFactories.createSpecLifecycleColumn(),
-    ];
-    switch (filters.kind?.value) {
-      case 'user':
-        return [];
-      case 'domain':
-      case 'system':
-        return [columnFactories.createOwnerColumn()];
-      case 'group':
-      case 'template':
-        return [
-          columnFactories.createSpecTypeColumn({ hidden: !showTypeColumn }),
-        ];
-      case 'location':
-        return [
-          columnFactories.createSpecTypeColumn({ hidden: !showTypeColumn }),
-          columnFactories.createSpecTargetsColumn(),
-        ];
-      default:
-        return entities.every(entity => entity.metadata.namespace === 'default')
-          ? baseColumns
-          : [...baseColumns, columnFactories.createNamespaceColumn()];
-    }
-  }
 };
 
 /** @public */

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -77,7 +77,11 @@ const refCompare = (a: Entity, b: Entity) => {
   return toRef(a).localeCompare(toRef(b));
 };
 
-const defaultColumnsFunc: CatalogTableColumnsFunc = ({ filters, entities }) => {
+/** @public */
+export const defaultColumnsFunc: CatalogTableColumnsFunc = ({
+  filters,
+  entities,
+}) => {
   const showTypeColumn = filters.type === undefined;
 
   return [

--- a/plugins/catalog/src/components/CatalogTable/defaultCatalogTableColumnsFunc.tsx
+++ b/plugins/catalog/src/components/CatalogTable/defaultCatalogTableColumnsFunc.tsx
@@ -18,6 +18,8 @@ import { TableColumn } from '@backstage/core-components';
 import { columnFactories } from './columns';
 import { CatalogTableColumnsFunc, CatalogTableRow } from './types';
 
+// The defaultCatalogTableColumnsFunc symbol is not directly exported, but through the
+// CatalogTable.defaultColumnsFunc field.
 /** @public */
 export const defaultCatalogTableColumnsFunc: CatalogTableColumnsFunc = ({
   filters,

--- a/plugins/catalog/src/components/CatalogTable/defaultCatalogTableColumnsFunc.tsx
+++ b/plugins/catalog/src/components/CatalogTable/defaultCatalogTableColumnsFunc.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TableColumn } from '@backstage/core-components';
+import { columnFactories } from './columns';
+import { CatalogTableColumnsFunc, CatalogTableRow } from './types';
+
+/** @public */
+export const defaultCatalogTableColumnsFunc: CatalogTableColumnsFunc = ({
+  filters,
+  entities,
+}) => {
+  const showTypeColumn = filters.type === undefined;
+
+  return [
+    columnFactories.createTitleColumn({ hidden: true }),
+    columnFactories.createNameColumn({ defaultKind: filters.kind?.value }),
+    ...createEntitySpecificColumns(),
+    columnFactories.createMetadataDescriptionColumn(),
+    columnFactories.createTagsColumn(),
+  ];
+
+  function createEntitySpecificColumns(): TableColumn<CatalogTableRow>[] {
+    const baseColumns = [
+      columnFactories.createSystemColumn(),
+      columnFactories.createOwnerColumn(),
+      columnFactories.createSpecTypeColumn({ hidden: !showTypeColumn }),
+      columnFactories.createSpecLifecycleColumn(),
+    ];
+    switch (filters.kind?.value) {
+      case 'user':
+        return [];
+      case 'domain':
+      case 'system':
+        return [columnFactories.createOwnerColumn()];
+      case 'group':
+      case 'template':
+        return [
+          columnFactories.createSpecTypeColumn({ hidden: !showTypeColumn }),
+        ];
+      case 'location':
+        return [
+          columnFactories.createSpecTypeColumn({ hidden: !showTypeColumn }),
+          columnFactories.createSpecTargetsColumn(),
+        ];
+      default:
+        return entities.every(entity => entity.metadata.namespace === 'default')
+          ? baseColumns
+          : [...baseColumns, columnFactories.createNamespaceColumn()];
+    }
+  }
+};

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { CatalogTable } from './CatalogTable';
+export { CatalogTable, defaultColumnsFunc } from './CatalogTable';
 export type { CatalogTableProps } from './CatalogTable';
 export type { CatalogTableRow, CatalogTableColumnsFunc } from './types';

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-export { CatalogTable, defaultCatalogTableColumnsFunc } from './CatalogTable';
+export { CatalogTable } from './CatalogTable';
+export { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc';
 export type { CatalogTableProps } from './CatalogTable';
 export type { CatalogTableRow, CatalogTableColumnsFunc } from './types';

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -15,6 +15,5 @@
  */
 
 export { CatalogTable } from './CatalogTable';
-export { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc';
 export type { CatalogTableProps } from './CatalogTable';
 export type { CatalogTableRow, CatalogTableColumnsFunc } from './types';

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { CatalogTable, defaultColumnsFunc } from './CatalogTable';
+export { CatalogTable, defaultCatalogTableColumnsFunc } from './CatalogTable';
 export type { CatalogTableProps } from './CatalogTable';
 export type { CatalogTableRow, CatalogTableColumnsFunc } from './types';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #21873 

Exported `defaultCatalogTableColumnsFunc` to create a seam for defining the columns in [CatalogTable](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx) of some Kinds while using the default columns for the others.
This is useful for defining the columns of a custom Kind or to redefine the columns for a built-in Kind.

## Example

Redefine the columns of the `component` Kind while using the default of the others such as `system`:
```ts
const myColumnsFunc: CatalogTableColumnsFunc = (entityListContext) => {
  if (entityListContext.filters.kind?.value === 'component') {
    return [
      CatalogTable.columns.createNameColumn(),
      CatalogTable.columns.createOwnerColumn()
    ];
  }

  return defaultCatalogTableColumnsFunc(entityListContext);
};
```
<img width="1045" alt="image" src="https://github.com/backstage/backstage/assets/6308176/d937475c-7ef6-4f71-81c6-ada05739195e">
<img width="1052" alt="image" src="https://github.com/backstage/backstage/assets/6308176/d867dddb-2173-4ef6-9917-a17b7f4f0537">



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~ Exporting the symbol did not change functionality, and the default columns are already tested through the `CatalogTable` tests
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
