### PR TITLE
Show Azure site tags in EntityAzureSitesOverviewWidget

### DIFF
--- a/.changeset/curvy-dingos-jump.md
+++ b/.changeset/curvy-dingos-jump.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-azure-sites': minor
+'@backstage/plugin-azure-sites': patch
 ---
 
-Show Azure site tags in EntityAzureSitesOverviewWidget
+Show Azure site tags in `EntityAzureSitesOverviewWidget`.

--- a/.changeset/curvy-dingos-jump.md
+++ b/.changeset/curvy-dingos-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-sites': minor
+---
+
+Show Azure site tags in EntityAzureSitesOverviewWidget

--- a/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.tsx
+++ b/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.tsx
@@ -18,6 +18,7 @@ import React, { Dispatch, useEffect, useState } from 'react';
 import {
   Box,
   Card,
+  Chip,
   IconButton,
   LinearProgress,
   Menu,
@@ -89,6 +90,18 @@ const Kind = ({ value }: { value: Kinds }) => {
       <Tooltip title={iconValue}>{iconMap[iconValue]}</Tooltip>
     </Box>
   );
+};
+
+const Tags = ({ tags }: { tags: any }) => {
+  return Object.keys(tags).map((key: any) => (
+    <Chip
+      key={key}
+      label={`${key}: ${tags[key]}`}
+      size="small"
+      variant="default"
+      style={{ marginBottom: '1px' }}
+    />
+  ));
 };
 
 type TableProps = {
@@ -222,6 +235,11 @@ export const AzureSitesOverviewTable = ({ data, loading }: TableProps) => {
       title: 'status',
       field: 'status',
       render: (func: AzureSite) => <State value={func.state as States} />,
+    },
+    {
+      title: 'Tags',
+      field: 'tags',
+      render: (func: AzureSite) => (func.tags ? <Tags tags={func.tags} /> : ''),
     },
     {
       title: 'last modified',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR  fixes #21919 

Now the Azure site tags show in EntityAzureSitesOverviewWidget

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
