### PR TITLE
Added status and e-mail as labels to the AWS Account Resource

### DIFF
--- a/.changeset/stale-hairs-sparkle.md
+++ b/.changeset/stale-hairs-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Added status and e-mail as labels to the AWS Account Resource

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
@@ -40,7 +40,9 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
         Accounts: [
           {
             Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
-            Name: 'testaccount',
+            Name: 'Test Account',
+            Email: 'aws-test-account@backstage.io',
+            Status: 'ACTIVE',
           },
         ],
         NextToken: undefined,
@@ -59,7 +61,12 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
               'amazonaws.com/account-id': '957140518395',
               'amazonaws.com/organization-id': 'o-1vl18kc5a3',
             },
-            name: 'testaccount',
+            labels: {
+              'amazonaws.com/account-status': 'active',
+              'amazonaws.com/account-email': 'aws-test-account@backstage.io',
+            },
+            name: 'test-account',
+            title: 'Test Account',
             namespace: 'default',
           },
           spec: {
@@ -79,11 +86,11 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
         Accounts: [
           {
             Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
-            Name: 'testaccount',
+            Name: 'Test Account',
           },
           {
             Arn: 'arn:aws:organizations::192594491037:account/o-zzzzzzzzz/957140518395',
-            Name: 'testaccount2',
+            Name: 'Test Account 2',
           },
         ],
         NextToken: undefined,
@@ -103,7 +110,12 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
               'amazonaws.com/account-id': '957140518395',
               'amazonaws.com/organization-id': 'o-1vl18kc5a3',
             },
-            name: 'testaccount',
+            labels: {
+              'amazonaws.com/account-status': '',
+              'amazonaws.com/account-email': '',
+            },
+            name: 'test-account',
+            title: 'Test Account',
             namespace: 'default',
           },
           spec: {

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.ts
@@ -41,6 +41,9 @@ const ACCOUNTID_ANNOTATION = 'amazonaws.com/account-id';
 const ARN_ANNOTATION = 'amazonaws.com/arn';
 const ORGANIZATION_ANNOTATION = 'amazonaws.com/organization-id';
 
+const ACCOUNT_STATUS_LABEL = 'amazonaws.com/account-status';
+const ACCOUNT_EMAIL_LABEL = 'amazonaws.com/account-email';
+
 /**
  * A processor for ingesting AWS Accounts from AWS Organizations.
  *
@@ -123,6 +126,10 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
       .replace(/[^a-zA-Z0-9\-]/g, '-');
   }
 
+  private normalizeAccountStatus(name: string): string {
+    return name.toLocaleLowerCase('en-US');
+  }
+
   private extractInformationFromArn(arn: string): {
     accountId: string;
     organizationId: string;
@@ -165,7 +172,14 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
           [ARN_ANNOTATION]: account.Arn || '',
           [ORGANIZATION_ANNOTATION]: organizationId,
         },
+        labels: {
+          [ACCOUNT_EMAIL_LABEL]: account.Email || '',
+          [ACCOUNT_STATUS_LABEL]: this.normalizeAccountStatus(
+            account.Status || '',
+          ),
+        },
         name: this.normalizeName(account.Name || ''),
+        title: account.Name || '',
         namespace: 'default',
       },
       spec: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the status (`amazonaws.com/account-status`) and e-mail (`amazonaws.com/account-email`) of an AWS Account as labels to Resources created by the `AwsOrganizationCloudAccountProcessor`.
The `title` of the Resource is being set to the Account Name.

Closes #19975

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))