### PR TITLE
Fixes #21961 Header component uses h3 variant to avoid mixing styling between h1 and h3

### DIFF
--- a/.changeset/shiny-balloons-sip.md
+++ b/.changeset/shiny-balloons-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Header uses h3 Typography variant so that `fontSize` and `fontWeight` come from same h3 theme settings

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -164,7 +164,7 @@ const TitleFragment = ({ pageTitle, classes, tooltip }: TitleFragmentProps) => {
       ref={contentRef}
       tabIndex={-1}
       className={classes.title}
-      variant="h1"
+      variant="h3"
     >
       {pageTitle}
     </Typography>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Change Header <Typography> to use h3 variant. The style applied to Header selects the fontSize from h3, however the fontWeight uses the h1 theme setting. There were two options to fix this:

1. Change the style applied to Header to select the fontSize from h1. However, this would mean the headers on pages would now have a font size of 54 rather than 32 by default.
2. Change the variant of the Typography component used by Header from h1 to h3. Since the fontWeight for both are 700 in the default theme, there would be no visible change by selecting this option.

This PR selected #2 above as the best fix. Confirmed the headers appear the same in the test application with this change and that by changing the theme setting for h3 typography, one could change both the fontSize and fontWeight.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
