### PR TITLE
Add a user-settings core nav item

### DIFF
--- a/.changeset/chilled-zebras-wash.md
+++ b/.changeset/chilled-zebras-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+add user-settings declarative integration core nav item

--- a/plugins/user-settings/api-report-alpha.md
+++ b/plugins/user-settings/api-report-alpha.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { BackstagePlugin } from '@backstage/frontend-plugin-api';
+import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
@@ -15,6 +16,11 @@ const _default: BackstagePlugin<
   {}
 >;
 export default _default;
+
+// @alpha (undocumented)
+export const settingsNavItem: ExtensionDefinition<{
+  title: string;
+}>;
 
 // @alpha (undocumented)
 export const userSettingsTranslationRef: TranslationRef<

--- a/plugins/user-settings/src/alpha.tsx
+++ b/plugins/user-settings/src/alpha.tsx
@@ -16,6 +16,7 @@
 import {
   coreExtensionData,
   createExtensionInput,
+  createNavItemExtension,
   createPageExtension,
   createPlugin,
 } from '@backstage/frontend-plugin-api';
@@ -23,6 +24,7 @@ import {
   convertLegacyRouteRef,
   compatWrapper,
 } from '@backstage/core-compat-api';
+import SettingsIcon from '@material-ui/icons/Settings';
 import { settingsRouteRef } from './plugin';
 
 import React from 'react';
@@ -50,12 +52,19 @@ const userSettingsPage = createPageExtension({
     ),
 });
 
+/** @alpha */
+export const settingsNavItem = createNavItemExtension({
+  routeRef: convertLegacyRouteRef(settingsRouteRef),
+  title: 'Settings',
+  icon: SettingsIcon,
+});
+
 /**
  * @alpha
  */
 export default createPlugin({
   id: 'user-settings',
-  extensions: [userSettingsPage],
+  extensions: [userSettingsPage, settingsNavItem],
   routes: {
     root: convertLegacyRouteRef(settingsRouteRef),
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As user-settings should show up in the core nav, add a user-settings nav
item to the declarative integration plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
