### PR TITLE
fixed circular structure json in json stringify

### DIFF
--- a/.changeset/clever-wolves-listen.md
+++ b/.changeset/clever-wolves-listen.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+---
+
+Fixed circular json during stringify JSON object in software-template.
+This will fix #21992 - circular structure json for `oneOf` operator in template.

--- a/plugins/scaffolder-react/src/next/lib/schema.ts
+++ b/plugins/scaffolder-react/src/next/lib/schema.ts
@@ -116,6 +116,24 @@ function extractUiSchema(schema: JsonObject, uiSchema: JsonObject) {
 }
 
 /**
+ * Remove the circular json reference value
+ * @alpha
+ */
+const getCircularReplacer = (): ((key: string, value: any) => any) => {
+  const seen = new WeakSet();
+  return (_: String, value: any): any => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return;
+      }
+      seen.add(value);
+    }
+    // eslint-disable-next-line consistent-return
+    return value;
+  };
+};
+
+/**
  * Takes a step from a Backstage Template Manifest and converts it to a JSON Schema and UI Schema for rjsf
  * @alpha
  */
@@ -123,7 +141,9 @@ export const extractSchemaFromStep = (
   inputStep: JsonObject,
 ): { uiSchema: UiSchema; schema: JsonObject } => {
   const uiSchema: UiSchema = {};
-  const returnSchema: JsonObject = JSON.parse(JSON.stringify(inputStep));
+  const returnSchema: JsonObject = JSON.parse(
+    JSON.stringify(inputStep, getCircularReplacer()),
+  );
   extractUiSchema(returnSchema, uiSchema);
   return { uiSchema, schema: returnSchema };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will fix Bug #21992 - Circular structure to JSON while using `oneOf` operator in software-template.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
