### PR TITLE
chore: added install path and fixed import on plugin-octopus-deploy

### DIFF
--- a/.changeset/fuzzy-ants-rule.md
+++ b/.changeset/fuzzy-ants-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-octopus-deploy': patch
+---
+
+chore: added install path and fixed import on plugin-octopus-deploy

--- a/.changeset/fuzzy-ants-rule.md
+++ b/.changeset/fuzzy-ants-rule.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-octopus-deploy': patch
 ---
 
-chore: added install path and fixed import on plugin-octopus-deploy
+chore: added install path and fixed import on plugin-octopus-deploy readme

--- a/plugins/octopus-deploy/README.md
+++ b/plugins/octopus-deploy/README.md
@@ -8,6 +8,17 @@ Welcome to the octopus-deploy plugin!
 
 ## Getting started
 
+### Installing
+
+To get started, first install the plugin with the following command:
+
+```bash
+# From your Backstage root directory
+yarn add --cwd packages/app @backstage/plugin-octopus-deploy
+```
+
+### Setup
+
 This plugin (currently) uses the Backstage proxy to securely communicate with the Octopus Deploy API.
 
 To use it, you will need to generate an [API Key](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) within Octopus Deploy.
@@ -35,7 +46,7 @@ octopusdeploy:
 ```
 // In packages/app/src/components/catalog/EntityPage.tsx
 import {
-  isOctopusDeployAvailable
+  isOctopusDeployAvailable,
   EntityOctopusDeployContent
 } from '@backstage/plugin-octopus-deploy';
 


### PR DESCRIPTION
chore: added install path and fixed import on plugin-octopus-deploy

## Hey, I just made a Pull Request!

The readme for plugin-octopus-deploy does not have the plugin install command & was missing a comma on the import

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
