### PR TITLE
[Azure DevOps] Added support for using config for all frontend props

### DIFF
--- a/plugins/azure-devops/config.d.ts
+++ b/plugins/azure-devops/config.d.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PullRequestColumnConfig } from './src/components/PullRequestsPage/lib/types';
+
+export interface Config {
+  /**
+   * Configuration options for the azure-devops plugin
+   */
+  azureDevOps?: {
+    /**
+     * Section for Azure Repos settings
+     */
+    repos?: {
+      /**
+       * Default limit for the number of pull requests to load (optional), default is 10
+       * @visibility frontend
+       */
+      defaultLimit?: number;
+      /**
+       * Sets the maximum screen size of the README card, if not set it will default to 100%
+       * @visibility frontend
+       */
+      maxHeight?: number;
+      /**
+       * Project Name to use for the Pull Request Dashboard
+       * @visibility frontend
+       */
+      projectName?: string;
+      /**
+       * Polling interval milliseconds to use when checking for new Pull Requests
+       * on the Pull Request Dashboard, default is 10000
+       * @visibility frontend
+       */
+      pollingInterval?: number;
+      /**
+       * Column configuration for the Pull Request Dashboard
+       * @visibility frontend
+       */
+      defaultColumnConfigs?: PullRequestColumnConfig[];
+    };
+    /**
+     * Section for Azure Pipelines settings
+     */
+    pipelines?: {
+      /**
+       * Default limit for the number of builds to load (optional), default is 10
+       * @visibility frontend
+       */
+      defaultLimit?: number;
+    };
+  };
+}

--- a/plugins/azure-devops/package.json
+++ b/plugins/azure-devops/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "workspace:^",
+    "@backstage/config": "workspace:^",
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
@@ -56,6 +57,8 @@
     "@testing-library/react": "^14.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/azure-devops/src/components/PullRequestsPage/PullRequestsPage.tsx
+++ b/plugins/azure-devops/src/components/PullRequestsPage/PullRequestsPage.tsx
@@ -28,6 +28,7 @@ import { FilterType } from './lib/filters';
 import { PullRequestGrid } from './lib/PullRequestGrid';
 import { useDashboardPullRequests } from '../../hooks';
 import { useFilterProcessor } from './lib/hooks';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 type PullRequestsPageContentProps = {
   pullRequestGroups: PullRequestGroup[] | undefined;
@@ -72,15 +73,23 @@ type PullRequestsPageProps = {
 
 export const PullRequestsPage = (props: PullRequestsPageProps) => {
   const { projectName, pollingInterval, defaultColumnConfigs } = props;
+  const config = useApi(configApiRef);
+  const configProjectName = config.getOptionalString(
+    'azureDevOps.repos.projectName',
+  );
+  const configPollingInterval = config.getOptionalNumber(
+    'azureDevOps.repos.pollingInterval',
+  );
+  const configDefaultColumnConfig = config.getOptional<
+    PullRequestColumnConfig[]
+  >('azureDevOps.repos.defaultColumnConfigs');
 
   const { pullRequests, loading, error } = useDashboardPullRequests(
-    projectName,
-    pollingInterval,
+    projectName ?? configProjectName,
+    pollingInterval ?? configPollingInterval,
   );
-
-  const [columnConfigs] = useState(
-    defaultColumnConfigs ?? DEFAULT_COLUMN_CONFIGS,
-  );
+  const colConfigs = defaultColumnConfigs ?? configDefaultColumnConfig;
+  const [columnConfigs] = useState(colConfigs ?? DEFAULT_COLUMN_CONFIGS);
 
   const filterProcessor = useFilterProcessor();
 

--- a/plugins/azure-devops/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/azure-devops/src/components/ReadmeCard/ReadmeCard.tsx
@@ -24,7 +24,7 @@ import {
 } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import React from 'react';
-
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { useReadme } from '../../hooks';
 
 const useStyles = makeStyles(theme => ({
@@ -82,6 +82,11 @@ const ReadmeCardError = ({ error }: ErrorProps) => {
 };
 
 export const ReadmeCard = (props: Props) => {
+  const config = useApi(configApiRef);
+  const configMaxHeight = config.getOptionalNumber(
+    'azureDevOps.repos.maxHeight',
+  );
+  const maxHeight = props.maxHeight ?? configMaxHeight;
   const classes = useStyles();
   const { entity } = useEntity();
 
@@ -101,7 +106,7 @@ export const ReadmeCard = (props: Props) => {
         title: 'Readme',
       }}
     >
-      <Box className={classes.readMe} sx={{ maxHeight: props.maxHeight }}>
+      <Box className={classes.readMe} sx={{ maxHeight: maxHeight }}>
         <MarkdownContent content={value?.content ?? ''} />
       </Box>
     </InfoCard>

--- a/plugins/azure-devops/src/hooks/useBuildRuns.test.tsx
+++ b/plugins/azure-devops/src/hooks/useBuildRuns.test.tsx
@@ -21,6 +21,8 @@ import { BuildRun } from '@backstage/plugin-azure-devops-common';
 import { TestApiProvider } from '@backstage/test-utils';
 import { AzureDevOpsApi, azureDevOpsApiRef } from '../api';
 import { useBuildRuns } from './useBuildRuns';
+import { configApiRef } from '@backstage/core-plugin-api';
+import { ConfigReader } from '@backstage/config';
 
 describe('useBuildRuns', () => {
   const azureDevOpsApiMock = {
@@ -30,7 +32,15 @@ describe('useBuildRuns', () => {
     azureDevOpsApiMock as Partial<AzureDevOpsApi> as AzureDevOpsApi;
 
   const Wrapper = (props: { children?: React.ReactNode }) => (
-    <TestApiProvider apis={[[azureDevOpsApiRef, azureDevOpsApi]]}>
+    <TestApiProvider
+      apis={[
+        [azureDevOpsApiRef, azureDevOpsApi],
+        [
+          configApiRef,
+          new ConfigReader({ azureDevOps: { pipelines: { defaultLimit: 5 } } }),
+        ],
+      ]}
+    >
       {props.children}
     </TestApiProvider>
   );

--- a/plugins/azure-devops/src/hooks/useBuildRuns.ts
+++ b/plugins/azure-devops/src/hooks/useBuildRuns.ts
@@ -21,7 +21,7 @@ import {
 } from '@backstage/plugin-azure-devops-common';
 
 import { azureDevOpsApiRef } from '../api';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/lib/useAsync';
 import { getAnnotationValuesFromEntity } from '../utils';
 import { Entity } from '@backstage/catalog-model';
@@ -34,12 +34,15 @@ export function useBuildRuns(
   loading: boolean;
   error?: Error;
 } {
-  const top = defaultLimit ?? AZURE_DEVOPS_DEFAULT_TOP;
-  const options: BuildRunOptions = {
-    top: top,
-  };
-
   const api = useApi(azureDevOpsApiRef);
+  const config = useApi(configApiRef);
+  const configDefaultLimit = config.getOptionalNumber(
+    'azureDevOps.pipelines.defaultLimit',
+  );
+  const top = defaultLimit ?? configDefaultLimit;
+  const options: BuildRunOptions = {
+    top: top ?? AZURE_DEVOPS_DEFAULT_TOP,
+  };
 
   const { value, loading, error } = useAsync(() => {
     const { project, repo, definition, host, org } =

--- a/plugins/azure-devops/src/hooks/useDashboardPullRequests.ts
+++ b/plugins/azure-devops/src/hooks/useDashboardPullRequests.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { errorApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, errorApiRef, useApi } from '@backstage/core-plugin-api';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
 import useInterval from 'react-use/lib/useInterval';
 
@@ -26,7 +26,7 @@ const POLLING_INTERVAL = 10000;
 
 export function useDashboardPullRequests(
   project?: string,
-  pollingInterval: number = POLLING_INTERVAL,
+  pollingInterval?: number,
 ): {
   pullRequests?: DashboardPullRequest[];
   loading: boolean;
@@ -34,6 +34,11 @@ export function useDashboardPullRequests(
 } {
   const api = useApi(azureDevOpsApiRef);
   const errorApi = useApi(errorApiRef);
+  const config = useApi(configApiRef);
+  const configPollingInterval = config.getOptionalNumber(
+    'azureDevOps.repos.pollingInterval',
+  );
+  const polling = pollingInterval ?? configPollingInterval;
 
   const getDashboardPullRequests = useCallback(async (): Promise<
     DashboardPullRequest[]
@@ -63,7 +68,7 @@ export function useDashboardPullRequests(
     [getDashboardPullRequests],
   );
 
-  useInterval(() => retry(), pollingInterval);
+  useInterval(() => retry(), polling ?? POLLING_INTERVAL);
 
   return {
     pullRequests,

--- a/plugins/azure-devops/src/hooks/usePullRequests.test.tsx
+++ b/plugins/azure-devops/src/hooks/usePullRequests.test.tsx
@@ -21,6 +21,8 @@ import { PullRequest } from '@backstage/plugin-azure-devops-common';
 import { TestApiProvider } from '@backstage/test-utils';
 import { AzureDevOpsApi, azureDevOpsApiRef } from '../api';
 import { usePullRequests } from './usePullRequests';
+import { configApiRef } from '@backstage/core-plugin-api';
+import { ConfigReader } from '@backstage/config';
 
 describe('usePullRequests', () => {
   const azureDevOpsApiMock = {
@@ -30,7 +32,15 @@ describe('usePullRequests', () => {
     azureDevOpsApiMock as Partial<AzureDevOpsApi> as AzureDevOpsApi;
 
   const Wrapper = (props: { children?: React.ReactNode }) => (
-    <TestApiProvider apis={[[azureDevOpsApiRef, azureDevOpsApi]]}>
+    <TestApiProvider
+      apis={[
+        [azureDevOpsApiRef, azureDevOpsApi],
+        [
+          configApiRef,
+          new ConfigReader({ azureDevOps: { pipelines: { defaultLimit: 5 } } }),
+        ],
+      ]}
+    >
       {props.children}
     </TestApiProvider>
   );

--- a/plugins/azure-devops/src/hooks/usePullRequests.ts
+++ b/plugins/azure-devops/src/hooks/usePullRequests.ts
@@ -23,7 +23,7 @@ import {
 
 import { Entity } from '@backstage/catalog-model';
 import { azureDevOpsApiRef } from '../api';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/lib/useAsync';
 import { getAnnotationValuesFromEntity } from '../utils';
 
@@ -36,14 +36,17 @@ export function usePullRequests(
   loading: boolean;
   error?: Error;
 } {
-  const top = defaultLimit ?? AZURE_DEVOPS_DEFAULT_TOP;
+  const api = useApi(azureDevOpsApiRef);
+  const config = useApi(configApiRef);
+  const configDefaultLimit = config.getOptionalNumber(
+    'azureDevOps.repos.defaultLimit',
+  );
+  const top = defaultLimit ?? configDefaultLimit;
   const status = requestedStatus ?? PullRequestStatus.Active;
   const options: PullRequestOptions = {
-    top,
+    top: top ?? AZURE_DEVOPS_DEFAULT_TOP,
     status,
   };
-
-  const api = useApi(azureDevOpsApiRef);
 
   const { value, loading, error } = useAsync(() => {
     const { project, repo, host, org } = getAnnotationValuesFromEntity(entity);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4947,6 +4947,7 @@ __metadata:
   dependencies:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
+    "@backstage/config": "workspace:^"
     "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/dev-utils": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for using config for all frontend props, this is how adopters will be able to control these values when we eventually move to the New Frontend System (Declarative Integration)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
