### PR TITLE
Added tooltip to advanced setting switch button

### DIFF
--- a/.changeset/smart-waves-smoke.md
+++ b/.changeset/smart-waves-smoke.md
@@ -1,0 +1,5 @@
+---
+'example-app': patch
+---
+
+Added tooltip to advanced setting switch button

--- a/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
+++ b/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
@@ -23,6 +23,7 @@ import {
   ListItemText,
   ListItemSecondaryAction,
   Switch,
+  Tooltip,
 } from '@material-ui/core';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
@@ -47,12 +48,18 @@ export function AdvancedSettings() {
                 secondary="An extra settings tab to further customize the experience"
               />
               <ListItemSecondaryAction>
-                <Switch
-                  color="primary"
-                  value={value}
-                  onChange={toggleValue}
-                  name="advanced"
-                />
+                <Tooltip
+                  placement="top"
+                  arrow
+                  title={value === 'on' ? 'Disable' : 'Enable'}
+                >
+                  <Switch
+                    color="primary"
+                    value={value}
+                    onChange={toggleValue}
+                    name="advanced"
+                  />
+                </Tooltip>
               </ListItemSecondaryAction>
             </ListItem>
           </List>


### PR DESCRIPTION
Adding tooltip to advanced setting toggle button

Like other pages featured flags & pin sidebar ****

![image](https://github.com/backstage/backstage/assets/133481507/11cfc225-60bc-4f00-b525-dabc401330d8)

Adding tooltip to advanced setting toggle

![image](https://github.com/backstage/backstage/assets/133481507/6012cf7e-76ab-4258-b94a-a24ae6476652)

![image](https://github.com/backstage/backstage/assets/133481507/9bc22f35-657a-4277-8c9b-8538de1403d7)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [yes ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ yes] Screenshots attached (for UI changes)
- [ yes] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
