### PR TITLE
implements edit link for workflow template

### DIFF
--- a/.changeset/funny-cameras-speak.md
+++ b/.changeset/funny-cameras-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added 'editUrl' to the '/v2/templates/:namespace/:kind/:name/parameter-schema' API response. This 'editUrl' references 'backstage.io/edit-url' in the template metadata annotations

--- a/.changeset/honest-poems-visit.md
+++ b/.changeset/honest-poems-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+---
+
+Added an edit link to the template page for direct access to editing the template

--- a/plugins/scaffolder-backend/sample-templates/all-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/all-templates.yaml
@@ -3,8 +3,6 @@ kind: Location
 metadata:
   name: example-templates
   description: A collection of all Backstage example templates
-#  annotations:
-#    backstage.io/edit-url: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/all-templates.yaml
 spec:
   targets:
     - ./remote-templates.yaml

--- a/plugins/scaffolder-backend/sample-templates/all-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/all-templates.yaml
@@ -3,6 +3,8 @@ kind: Location
 metadata:
   name: example-templates
   description: A collection of all Backstage example templates
+#  annotations:
+#    backstage.io/edit-url: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/all-templates.yaml
 spec:
   targets:
     - ./remote-templates.yaml

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -105,6 +105,7 @@ describe('createRouter', () => {
       title: 'Create React App Template',
       annotations: {
         'backstage.io/managed-by-location': 'url:https://dev.azure.com',
+        'backstage.io/edit-url': 'url:EDIT_URL',
       },
     },
     spec: {
@@ -876,6 +877,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
         expect(response.body).toEqual({
           title: 'Create React App Template',
           description: 'Create a new CRA website project',
+          editUrl: 'url:EDIT_URL',
           steps: [
             {
               title: 'Please enter the following information',
@@ -930,6 +932,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
         expect(response.body).toEqual({
           title: 'Create React App Template',
           description: 'Create a new CRA website project',
+          editUrl: 'url:EDIT_URL',
           steps: [],
         });
       });
@@ -961,7 +964,58 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
         expect(response.body).toEqual({
           title: 'Create React App Template',
           description: 'Create a new CRA website project',
+          editUrl: 'url:EDIT_URL',
           steps: [
+            {
+              title: 'Please enter the following information',
+              schema: {
+                type: 'object',
+                required: ['requiredParameter2'],
+                'backstage:permissions': {
+                  tags: ['parameters-tag'],
+                },
+                properties: {
+                  requiredParameter2: {
+                    type: 'string',
+                    description: 'Required parameter 2',
+                  },
+                },
+              },
+            },
+          ],
+        });
+      });
+      it('should not return editUrl', async () => {
+        jest
+          .spyOn(catalogClient, 'getEntityByRef')
+          .mockImplementationOnce(async () => {
+            const template = getMockTemplate();
+            delete template.metadata.annotations?.['backstage.io/edit-url'];
+            return template;
+          });
+        const response = await request(app)
+          .get(
+            '/v2/templates/default/Template/create-react-app-template/parameter-schema',
+          )
+          .send();
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual({
+          title: 'Create React App Template',
+          description: 'Create a new CRA website project',
+          steps: [
+            {
+              title: 'Please enter the following information',
+              schema: {
+                required: ['requiredParameter1'],
+                type: 'object',
+                properties: {
+                  requiredParameter1: {
+                    description: 'Required parameter 1',
+                    type: 'string',
+                  },
+                },
+              },
+            },
             {
               title: 'Please enter the following information',
               schema: {

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -394,6 +394,7 @@ export async function createRouter(
         res.json({
           title: template.metadata.title ?? template.metadata.name,
           ...(presentation ? { presentation } : {}),
+          editUrl: template.metadata.annotations?.['backstage.io/edit-url'],
           description: template.metadata.description,
           'ui:options': template.metadata['ui:options'],
           steps: parameters.map(schema => ({

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -483,6 +483,7 @@ export type TemplateGroupFilter = {
 export type TemplateParameterSchema = {
   title: string;
   description?: string;
+  editUrl?: string;
   presentation?: TemplatePresentationV1beta3;
   steps: Array<{
     title: string;

--- a/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
+++ b/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
@@ -20,6 +20,7 @@ import {
   InfoCard,
   MarkdownContent,
   Progress,
+  Link,
 } from '@backstage/core-components';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { makeStyles } from '@material-ui/core';
@@ -29,6 +30,8 @@ import { Stepper, type StepperProps } from '../Stepper/Stepper';
 import { SecretsContextProvider } from '../../../secrets/SecretsContext';
 import { useFilteredSchemaProperties } from '../../hooks/useFilteredSchemaProperties';
 import { ReviewStepProps } from '@backstage/plugin-scaffolder-react';
+import IconButton from '@material-ui/core/IconButton';
+import EditIcon from '@material-ui/icons/Edit';
 
 const useStyles = makeStyles({
   markdown: {
@@ -93,13 +96,23 @@ export const Workflow = (workflowProps: WorkflowProps): JSX.Element | null => {
   if (error) {
     return props.onError(error);
   }
-
   return (
     <Content>
       {loading && <Progress />}
       {sortedManifest && (
         <InfoCard
           title={title ?? sortedManifest.title}
+          action={
+            <IconButton
+              component={Link}
+              aria-label="Edit"
+              title="Edit Template"
+              to={sortedManifest.editUrl ?? '#'}
+              disabled={!sortedManifest.editUrl}
+            >
+              <EditIcon />
+            </IconButton>
+          }
           subheader={
             <MarkdownContent
               className={styles.markdown}

--- a/plugins/scaffolder-react/src/types.ts
+++ b/plugins/scaffolder-react/src/types.ts
@@ -27,6 +27,7 @@ import { TemplatePresentationV1beta3 } from '@backstage/plugin-scaffolder-common
 export type TemplateParameterSchema = {
   title: string;
   description?: string;
+  editUrl?: string;
   presentation?: TemplatePresentationV1beta3;
   steps: Array<{
     title: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have implemented the edit link on the template page.

I did this to resolve this issue.
https://github.com/backstage/backstage/issues/17986

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

before
<img width="2547" alt="スクリーンショット 2023-12-30 22 00 56" src="https://github.com/backstage/backstage/assets/21999231/5b6bde75-0ea2-4390-bc4f-39ae3fed82b8">
after
<img width="2561" alt="スクリーンショット 2023-12-30 21 53 32" src="https://github.com/backstage/backstage/assets/21999231/d3213f72-8ffd-47f2-a2b1-043f6adc56a6">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
