### PR TITLE
fix(techdocs-cli): mkdocs parameter casing

### DIFF
--- a/.changeset/selfish-mails-scream.md
+++ b/.changeset/selfish-mails-scream.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+fix: mkdocs parameter casing

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -117,7 +117,7 @@ export default async function serve(opts: OptionValues) {
     stderrLogFunc: mkdocsLogFunc,
     mkdocsConfigFileName: mkdocsYmlPath,
     mkdocsParameterClean: opts.mkdocsParameterClean,
-    mkdocsParameterDirtyReload: opts.mkdocsParameterDirtyReload,
+    mkdocsParameterDirtyReload: opts.mkdocsParameterDirtyreload,
     mkdocsParameterStrict: opts.mkdocsParameterStrict,
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Resolving a casing issue in `mkdocsParameterDirtyReload`.

![Captura de Tela 2024-01-02 às 15 42 33](https://github.com/backstage/backstage/assets/37726261/8cac4647-dafc-4f8a-a725-4e0420fd59ff)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) 
- [x] Added or updated documentation - not necessary
- [x] Tests for new functionality and regression tests for bug fixes - there are no tests for commands
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
