### PR TITLE
ensure that luxon based tests are not os locale dependent

### DIFF
--- a/plugins/home/src/setupTests.ts
+++ b/plugins/home/src/setupTests.ts
@@ -13,4 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';
+import { Settings } from 'luxon';
+
+Settings.defaultLocale = 'en';

--- a/plugins/kubernetes-react/src/setupTests.ts
+++ b/plugins/kubernetes-react/src/setupTests.ts
@@ -13,4 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import '@testing-library/jest-dom';
+import { Settings } from 'luxon';
+
+Settings.defaultLocale = 'en';

--- a/plugins/scaffolder-backend/src/setupTests.ts
+++ b/plugins/scaffolder-backend/src/setupTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom';
 import { Settings } from 'luxon';
 
 Settings.defaultLocale = 'en';


### PR DESCRIPTION
These packages had tests which will render OS locale dependent text if this setup code is not in place.

No changeset since it only affects tests