### PR TITLE
Added permission Zod schemas to the permisison backend plugin exports

### DIFF
--- a/.changeset/grumpy-rivers-drop.md
+++ b/.changeset/grumpy-rivers-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': patch
+---
+
+Exported the Zod schemas used to validate permissions to allow external plugins that interface with the permission framework to perform some validation on permissions too

--- a/plugins/permission-backend/api-report.md
+++ b/plugins/permission-backend/api-report.md
@@ -7,11 +7,71 @@ import { Config } from '@backstage/config';
 import express from 'express';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { Logger } from 'winston';
+import { PermissionAttributes } from '@backstage/plugin-permission-common';
 import { PermissionPolicy } from '@backstage/plugin-permission-node';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { z } from 'zod';
+
+// @public
+export const attributesSchema: z.ZodSchema<PermissionAttributes>;
 
 // @public
 export function createRouter(options: RouterOptions): Promise<express.Router>;
+
+// @public
+export const permissionSchema: z.ZodUnion<
+  [
+    z.ZodObject<
+      {
+        type: z.ZodLiteral<'basic'>;
+        name: z.ZodString;
+        attributes: z.ZodType<
+          PermissionAttributes,
+          z.ZodTypeDef,
+          PermissionAttributes
+        >;
+      },
+      'strip',
+      z.ZodTypeAny,
+      {
+        type: 'basic';
+        name: string;
+        attributes: PermissionAttributes;
+      },
+      {
+        type: 'basic';
+        name: string;
+        attributes: PermissionAttributes;
+      }
+    >,
+    z.ZodObject<
+      {
+        type: z.ZodLiteral<'resource'>;
+        name: z.ZodString;
+        attributes: z.ZodType<
+          PermissionAttributes,
+          z.ZodTypeDef,
+          PermissionAttributes
+        >;
+        resourceType: z.ZodString;
+      },
+      'strip',
+      z.ZodTypeAny,
+      {
+        type: 'resource';
+        name: string;
+        attributes: PermissionAttributes;
+        resourceType: string;
+      },
+      {
+        type: 'resource';
+        name: string;
+        attributes: PermissionAttributes;
+        resourceType: string;
+      }
+    >,
+  ]
+>;
 
 // @public
 export interface RouterOptions {

--- a/plugins/permission-backend/src/service/index.ts
+++ b/plugins/permission-backend/src/service/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { createRouter } from './router';
+export { createRouter, attributesSchema, permissionSchema } from './router';
 export type { RouterOptions } from './router';

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -47,7 +47,12 @@ import { memoize } from 'lodash';
 import DataLoader from 'dataloader';
 import { Config } from '@backstage/config';
 
-const attributesSchema: z.ZodSchema<PermissionAttributes> = z.object({
+/**
+ * Permission attributes zod schema
+ *
+ * @public
+ */
+export const attributesSchema: z.ZodSchema<PermissionAttributes> = z.object({
   action: z
     .union([
       z.literal('create'),
@@ -58,7 +63,12 @@ const attributesSchema: z.ZodSchema<PermissionAttributes> = z.object({
     .optional(),
 });
 
-const permissionSchema = z.union([
+/**
+ * Permission zod schema
+ *
+ * @public
+ */
+export const permissionSchema = z.union([
   z.object({
     type: z.literal('basic'),
     name: z.string(),


### PR DESCRIPTION
Third party plugins that interact with the permission framework and deal with permissions can have a use case of needing to validate endpoint requests that contain permissions. I've changed the permission backend to expose the zod schemas it currently uses for the permissions and permission attributes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
