### PR TITLE
Scaffolder: Fix for a step with no properties

### DIFF
--- a/.changeset/giant-fans-type.md
+++ b/.changeset/giant-fans-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix for a step with no properties

--- a/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.ts
+++ b/plugins/scaffolder-react/src/next/hooks/useTemplateSchema.ts
@@ -69,9 +69,9 @@ export const useTemplateSchema = (
         },
       } as ParsedTemplateSchema;
 
-      if (step.schema?.properties) {
+      if (step.schema?.properties || !step.schema?.dependencies) {
         strippedSchema.schema.properties = Object.fromEntries(
-          Object.entries((step.schema?.properties ?? []) as JsonObject).filter(
+          Object.entries((step.schema?.properties ?? {}) as JsonObject).filter(
             ([key]) => {
               const stepFeatureFlag =
                 step.uiSchema[key]?.['ui:backstage']?.featureFlag;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For a template which has a step without any properties it will fail:

![Screenshot_2024-01-04_at_09 23 20](https://github.com/backstage/backstage/assets/2265094/fde9e470-53d0-4bc6-8cf0-7a4528608622)

The way to reproduce it, is to include to a template:

    - title: About this template
      ui:ObjectFieldTemplate: AboutStep

And create `AboutStep` Layout, something like this:

```

const AboutStep: LayoutTemplate = () => {
  const classes = useStyles();
  return (
    <Box>
      <Box className={classes.section}>
        {
          'This wizard will assist you in the creation and running of a new application.'
        }
      </Box>
      ....
    </Box>
  );
};

```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
