### PR TITLE
Update authorizing-parameters-steps-and-actions.md

### DIFF
--- a/docs/features/software-templates/authorizing-parameters-steps-and-actions.md
+++ b/docs/features/software-templates/authorizing-parameters-steps-and-actions.md
@@ -128,10 +128,10 @@ class ExamplePermissionPolicy implements PermissionPolicy {
 }
 ```
 
-With this permission policy, the user `spiderman` won't be able to execute the debug:log action.
+With this permission policy, the user `spiderman` won't be able to execute the `debug:log` action.
 
 You can also restrict the input provided to the action by combining multiple rules.
-In the example below, `spiderman` won't be able to execute debug:log when passing `{ "message": "not-this!" }` as action input:
+In the example below, `spiderman` won't be able to execute `debug:log` when passing `{ "message": "not-this!" }` as action input:
 
 ```ts title="packages/backend/src/plugins/permission.ts"
 /* highlight-add-start */


### PR DESCRIPTION
debug:log is causing markdown rendering issues - it should be enclosed in back-ticks.

## Hey, I just made a Pull Request!

If you navigate to:
* [Authorizing parameters, steps and actions | Backstage Software Catalog and Developer Platform](https://backstage.io/docs/features/software-templates/authorizing-parameters-steps-and-actions)

you will see this poor rendering (highlighted with red arrows) in the latest Chrome:

> ![Authorizing_Parameters](https://github.com/backstage/backstage/assets/143034967/411e5fe9-85ad-4dda-80b3-e8b172969b93)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
