### PR TITLE
feat(catalog): Support defining metadata on relations.

### DIFF
--- a/.changeset/olive-pillows-add.md
+++ b/.changeset/olive-pillows-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-node': minor
+---
+
+Updates the relation types to support metadata on relations.

--- a/.changeset/stupid-grapes-exist.md
+++ b/.changeset/stupid-grapes-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Adds support for metadata on relations to stitching.

--- a/.changeset/tender-hornets-suffer.md
+++ b/.changeset/tender-hornets-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Adds a new `RelationReference` type that supports complex entity references. This can be used on `Component.providesApis` and `Component.consumesApis`. The primary purpose of this new type is to support defining metadata on relations.

--- a/packages/catalog-model/examples/components/wayback-search-component.yaml
+++ b/packages/catalog-model/examples/components/wayback-search-component.yaml
@@ -8,7 +8,7 @@ spec:
   lifecycle: production
   owner: team-a
   providesApis:
-    - entityRef: wayback-search
+    - targetRef: wayback-search
       metadata:
         version: '1'
         apis: '/test,/123'

--- a/packages/catalog-model/examples/components/wayback-search-component.yaml
+++ b/packages/catalog-model/examples/components/wayback-search-component.yaml
@@ -8,6 +8,9 @@ spec:
   lifecycle: production
   owner: team-a
   providesApis:
-    - wayback-search
+    - entityRef: wayback-search
+      metadata:
+        version: '1'
+        apis: '/test,/123'
   consumesApis:
     - wayback-archive

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JsonObject } from '@backstage/types';
+import { JsonObject, JsonPrimitive } from '@backstage/types';
 
 /**
  * The parts of the format that's common to all versions/kinds of entity.
@@ -168,6 +168,8 @@ export type EntityRelation = {
    * The entity ref of the target of this relation.
    */
   targetRef: string;
+
+  metadata?: Record<string, JsonPrimitive>;
 };
 
 /**

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
@@ -141,9 +141,99 @@ describe('ComponentV1alpha1Validator', () => {
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
+  it('accepts complex providesApis', async () => {
+    (entity as ComponentEntityV1alpha1).spec.providesApis = [
+      {
+        entityRef: '123',
+      },
+    ];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts complex providesApis with metadata', async () => {
+    (entity as ComponentEntityV1alpha1).spec.providesApis = [
+      {
+        entityRef: '123',
+        metadata: {
+          test: '123',
+        },
+      },
+    ];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects complex providesApis without entityRef', async () => {
+    (entity as any).spec.providesApis = [
+      {
+        metadata: {
+          test: '123',
+        },
+      },
+    ];
+    await expect(validator.check(entity)).rejects.toThrow(/providesApis/);
+  });
+
+  it('rejects complex providesApis with invalid metadata', async () => {
+    (entity as any).spec.providesApis = [
+      {
+        metadata: {
+          test: {
+            myNestedValue: true,
+          },
+        },
+      },
+    ];
+    await expect(validator.check(entity)).rejects.toThrow(/providesApis/);
+  });
+
   it('accepts missing consumesApis', async () => {
     delete (entity as any).spec.consumesApis;
     await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts complex consumesApis', async () => {
+    (entity as ComponentEntityV1alpha1).spec.consumesApis = [
+      {
+        entityRef: '123',
+      },
+    ];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts complex consumesApis with metadata', async () => {
+    (entity as ComponentEntityV1alpha1).spec.consumesApis = [
+      {
+        entityRef: '123',
+        metadata: {
+          test: '123',
+        },
+      },
+    ];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects complex consumesApis without entityRef', async () => {
+    (entity as any).spec.consumesApis = [
+      {
+        metadata: {
+          test: '123',
+        },
+      },
+    ];
+    await expect(validator.check(entity)).rejects.toThrow(/consumesApis/);
+  });
+
+  it('rejects complex consumesApis with invalid metadata', async () => {
+    (entity as any).spec.consumesApis = [
+      {
+        metadata: {
+          test: {
+            myNestedValue: true,
+          },
+        },
+      },
+    ];
+    await expect(validator.check(entity)).rejects.toThrow(/consumesApis/);
   });
 
   it('rejects empty consumesApis', async () => {

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
@@ -144,7 +144,7 @@ describe('ComponentV1alpha1Validator', () => {
   it('accepts complex providesApis', async () => {
     (entity as ComponentEntityV1alpha1).spec.providesApis = [
       {
-        entityRef: '123',
+        targetRef: '123',
       },
     ];
     await expect(validator.check(entity)).resolves.toBe(true);
@@ -153,7 +153,7 @@ describe('ComponentV1alpha1Validator', () => {
   it('accepts complex providesApis with metadata', async () => {
     (entity as ComponentEntityV1alpha1).spec.providesApis = [
       {
-        entityRef: '123',
+        targetRef: '123',
         metadata: {
           test: '123',
         },
@@ -162,7 +162,7 @@ describe('ComponentV1alpha1Validator', () => {
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
-  it('rejects complex providesApis without entityRef', async () => {
+  it('rejects complex providesApis without targetRef', async () => {
     (entity as any).spec.providesApis = [
       {
         metadata: {
@@ -194,7 +194,7 @@ describe('ComponentV1alpha1Validator', () => {
   it('accepts complex consumesApis', async () => {
     (entity as ComponentEntityV1alpha1).spec.consumesApis = [
       {
-        entityRef: '123',
+        targetRef: '123',
       },
     ];
     await expect(validator.check(entity)).resolves.toBe(true);
@@ -203,7 +203,7 @@ describe('ComponentV1alpha1Validator', () => {
   it('accepts complex consumesApis with metadata', async () => {
     (entity as ComponentEntityV1alpha1).spec.consumesApis = [
       {
-        entityRef: '123',
+        targetRef: '123',
         metadata: {
           test: '123',
         },
@@ -212,7 +212,7 @@ describe('ComponentV1alpha1Validator', () => {
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
-  it('rejects complex consumesApis without entityRef', async () => {
+  it('rejects complex consumesApis without targetRef', async () => {
     (entity as any).spec.consumesApis = [
       {
         metadata: {

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -16,6 +16,7 @@
 
 import type { Entity } from '../entity/Entity';
 import schema from '../schema/kinds/Component.v1alpha1.schema.json';
+import { RelationReference } from './relations';
 import { ajvCompiledJsonSchemaValidator } from './util';
 
 /**
@@ -35,8 +36,8 @@ export interface ComponentEntityV1alpha1 extends Entity {
     lifecycle: string;
     owner: string;
     subcomponentOf?: string;
-    providesApis?: string[];
-    consumesApis?: string[];
+    providesApis?: RelationReference[];
+    consumesApis?: RelationReference[];
     dependsOn?: string[];
     system?: string;
   };

--- a/packages/catalog-model/src/kinds/relations.ts
+++ b/packages/catalog-model/src/kinds/relations.ts
@@ -136,3 +136,10 @@ export const RELATION_PART_OF = 'partOf';
  * @public
  */
 export const RELATION_HAS_PART = 'hasPart';
+
+export type ComplexEntityRelationReference = {
+  entityRef: string;
+  metadata?: Record<string, number | boolean | string>;
+};
+
+export type RelationReference = string | ComplexEntityRelationReference;

--- a/packages/catalog-model/src/kinds/relations.ts
+++ b/packages/catalog-model/src/kinds/relations.ts
@@ -138,7 +138,7 @@ export const RELATION_PART_OF = 'partOf';
 export const RELATION_HAS_PART = 'hasPart';
 
 export type ComplexEntityRelationReference = {
-  entityRef: string;
+  targetRef: string;
   metadata?: Record<string, number | boolean | string>;
 };
 

--- a/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
@@ -73,16 +73,14 @@
               "type": "array",
               "description": "An array of entity references to the APIs that are provided by the component.",
               "items": {
-                "type": "string",
-                "minLength": 1
+                "$ref": "common#complexEntityRelation"
               }
             },
             "consumesApis": {
               "type": "array",
               "description": "An array of entity references to the APIs that are consumed by the component.",
               "items": {
-                "type": "string",
-                "minLength": 1
+                "$ref": "common#complexEntityRelation"
               }
             },
             "dependsOn": {

--- a/packages/catalog-model/src/schema/shared/common.schema.json
+++ b/packages/catalog-model/src/schema/shared/common.schema.json
@@ -134,9 +134,9 @@
         },
         {
           "type": "object",
-          "required": ["entityRef"],
+          "required": ["targetRef"],
           "properties": {
-            "entityRef": {
+            "targetRef": {
               "type": "string"
             },
             "metadata": {

--- a/packages/catalog-model/src/schema/shared/common.schema.json
+++ b/packages/catalog-model/src/schema/shared/common.schema.json
@@ -124,6 +124,43 @@
           "description": "An error stack trace"
         }
       }
+    },
+    "complexEntityRelation": {
+      "$id": "#complexEntityRelation",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "required": ["entityRef"],
+          "properties": {
+            "entityRef": {
+              "type": "string"
+            },
+            "metadata": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/plugins/catalog-backend/migrations/20240108010601_relation_metadata.js
+++ b/plugins/catalog-backend/migrations/20240108010601_relation_metadata.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async function (knex) {
+  await knex.schema.createTable('relations_search', table => {
+    table.comment(
+      'Flattened key-values from the relations, used for quick filtering',
+    );
+    table.comment('All relations between entities');
+    table
+      .string('originating_entity_id')
+      .references('entity_id')
+      .inTable('refresh_state')
+      .onDelete('CASCADE')
+      .notNullable()
+      .comment('The entity that provided the relation');
+    table
+      .string('source_entity_ref')
+      .notNullable()
+      .comment('Entity reference of the source entity of the relation');
+    table
+      .string('type')
+      .notNullable()
+      .comment('The type of the relation between the entities');
+    table
+      .string('target_entity_ref')
+      .notNullable()
+      .comment('Entity reference of the target entity of the relation');
+    table
+      .string('key')
+      .notNullable()
+      .comment('A key that occurs in the entity');
+    table
+      .string('value')
+      .nullable()
+      .comment('The corresponding value to match on');
+    table.index('source_entity_ref', 'relations_search_source_entity_ref_idx');
+    table.index('target_entity_ref', 'relations_search_target_entity_ref_idx');
+
+    // table.index(['entity_id'], 'search_entity_id_idx');
+    table.index(['key'], 'relations_search_key_idx');
+    table.index(['value'], 'relations_search_value_idx');
+  });
+
+  await knex.schema.alterTable('relations', table => {
+    table.text('metadata').nullable().comment('Relation metadata blob.');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable('relations_search', table => {
+    table.dropIndex([], 'relations_search_source_entity_ref_idx');
+    table.dropIndex([], 'relations_search_target_entity_ref_idx');
+    table.dropIndex([], 'relations_search_key_idx');
+    table.dropIndex([], 'relations_search_value_idx');
+  });
+  await knex.schema.dropTable('relations_search');
+
+  await knex.schema.alterTable('relations', table => {
+    table.dropColumn('metadata');
+  });
+};

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -130,11 +130,12 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
     // Batch insert new relations
     const relationRows: DbRelationsRow[] = relations.map(
-      ({ source, target, type }) => ({
+      ({ source, target, type, metadata }) => ({
         originating_entity_id: id,
         source_entity_ref: stringifyEntityRef(source),
         target_entity_ref: stringifyEntityRef(target),
         type,
+        metadata: metadata ? JSON.stringify(metadata) : undefined,
       }),
     );
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.test.ts
@@ -81,6 +81,14 @@ describe('performStitching', () => {
           type: 'looksAt',
           target_entity_ref: 'k:ns/other',
         },
+        // handles metadata on relations.
+        {
+          originating_entity_id: 'my-id',
+          source_entity_ref: 'k:ns/n',
+          type: 'looksAt',
+          target_entity_ref: 'k:ns/other2',
+          metadata: JSON.stringify({ version: '1' }),
+        },
       ]);
 
       await performStitching({
@@ -103,6 +111,13 @@ describe('performStitching', () => {
           {
             type: 'looksAt',
             targetRef: 'k:ns/other',
+          },
+          {
+            type: 'looksAt',
+            targetRef: 'k:ns/other2',
+            metadata: {
+              version: '1',
+            },
           },
         ],
         apiVersion: 'a',

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
@@ -104,6 +104,7 @@ export async function performStitching(options: {
         relationType: 'type',
         relationTarget: 'target_entity_ref',
       })
+      .select('metadata')
       .from('relations')
       .where({ source_entity_ref: entityRef })
       .orderBy('relationType', 'asc')
@@ -180,6 +181,7 @@ export async function performStitching(options: {
     .map<EntityRelation>(row => ({
       type: row.relationType!,
       targetRef: row.relationTarget!,
+      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
     }));
   if (statusItems.length) {
     entity.status = {

--- a/plugins/catalog-backend/src/database/tables.ts
+++ b/plugins/catalog-backend/src/database/tables.ts
@@ -171,6 +171,7 @@ export type DbRelationsRow = {
   source_entity_ref: string;
   target_entity_ref: string;
   type: string;
+  metadata?: string;
 };
 
 export type DbFinalEntitiesRow = {

--- a/plugins/catalog-node/src/api/common.ts
+++ b/plugins/catalog-node/src/api/common.ts
@@ -16,6 +16,7 @@
 
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { LocationSpec as NonDeprecatedLocationSpec } from '@backstage/plugin-catalog-common';
+import { JsonPrimitive } from '@backstage/types';
 
 /**
  * Holds the entity location information.
@@ -46,6 +47,11 @@ export type EntityRelationSpec = {
    * The type of the relation.
    */
   type: string;
+
+  /**
+   * Metadata to attach to this relation.
+   */
+  metadata?: Record<string, JsonPrimitive>;
 
   /**
    * The target entity of this relation.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for metadata on relations. It adds the new `metadata` field to the stitched entity's relation data and to the relation database. I've also added a way to define this for `consumesApi` and `providesApi`,
```yaml
spec:
    providesApi/consumesApi:
        - targetRef: 'my-api'
           metadata:
               version: '1'
```
I was interested in overlap between this and #11027, this may or may not be a sane approach for that.


Context: I initially implemented an `environmentOverrides` key on `Component` in https://github.com/backstage/backstage/pull/21560. From feedback (https://github.com/backstage/backstage/pull/21560#issuecomment-1826773724, https://github.com/backstage/backstage/issues/16389#issuecomment-1819928947 and Catalog SIG), metadata on relations came up. The idea would be to support overrides on the annotation per environment. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
