### PR TITLE
core-compat-api: wrap discovered elements with compatWrapper

### DIFF
--- a/.changeset/brave-queens-crash.md
+++ b/.changeset/brave-queens-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Make `convertLegacyApp` wrap discovered routes with `compatWrapper`.

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -33,6 +33,7 @@ import {
 import React, { Children, ReactNode, isValidElement } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { convertLegacyRouteRef } from './convertLegacyRouteRef';
+import { compatWrapper } from './compatWrapper';
 
 /*
 
@@ -207,14 +208,16 @@ export function collectLegacyRoutes(
             }),
           },
           loader: async () =>
-            route.props.children ? (
-              <Routes>
-                <Route path="*" element={routeElement}>
-                  <Route path="*" element={route.props.children} />
-                </Route>
-              </Routes>
-            ) : (
-              routeElement
+            compatWrapper(
+              route.props.children ? (
+                <Routes>
+                  <Route path="*" element={routeElement}>
+                    <Route path="*" element={route.props.children} />
+                  </Route>
+                </Routes>
+              ) : (
+                routeElement
+              ),
             ),
         }),
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Without this most plugins won't function due to the missing legacy `AppContext`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
