### PR TITLE
fix: fix custom http resolvers for AsyncAPI widget

### DIFF
--- a/.changeset/blue-hats-admire.md
+++ b/.changeset/blue-hats-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Fix custom http resolvers for AsyncAPI widget.

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
@@ -143,18 +143,33 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const fetchResolver = {
-  order: 199, // Use 199 as the built-in http resolver is 200
-  canRead: /^https?:\/\//,
-  async read(file: any) {
-    const response = await fetch(file.url);
+const httpsFetchResolver = {
+  schema: 'https',
+  order: 1,
+  canRead: true,
+  async read(uri: any) {
+    const response = await fetch(uri.toString());
+    return response.text();
+  },
+};
+
+const httpFetchResolver = {
+  schema: 'http',
+  order: 1,
+  canRead: true,
+  async read(uri: any) {
+    const response = await fetch(uri.toString());
     return response.text();
   },
 };
 
 const config = {
   parserOptions: {
-    resolve: { fetch: fetchResolver },
+    __unstable: {
+      resolver: {
+        resolvers: [httpsFetchResolver, httpFetchResolver],
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will fix the custom http resolvers for the AsyncAPI widget as the underlying components have updated heavily.
With this I could fix `$ref: https://example.com....`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
