### PR TITLE
Fix typo in VisitsStorageApi.ts

### DIFF
--- a/.changeset/ten-planets-guess.md
+++ b/.changeset/ten-planets-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fix typo in VisitsStorageApi

--- a/plugins/home/src/api/VisitsStorageApi.ts
+++ b/plugins/home/src/api/VisitsStorageApi.ts
@@ -130,16 +130,16 @@ export class VisitsStorageApi implements VisitsApi {
     }
 
     return new Promise((resolve, reject) => {
-      const subsription = this.storageApi
+      const subscription = this.storageApi
         .observe$<Visit[]>(storageKey)
         .subscribe({
           next: next => {
             const visits = next.value ?? [];
-            subsription.unsubscribe();
+            subscription.unsubscribe();
             resolve(visits);
           },
           error: err => {
-            subsription.unsubscribe();
+            subscription.unsubscribe();
             reject(err);
           },
         });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changed `subsription` to `subscription`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
