### PR TITLE
.github/workflows: pin Vale CLI version to 2.30.0

### DIFF
--- a/.github/workflows/verify_docs-quality.yml
+++ b/.github/workflows/verify_docs-quality.yml
@@ -30,5 +30,6 @@ jobs:
         with:
           # This also contains --config=.github/vale/config.ini ... :/
           files: '${{ steps.generate.outputs.args }}'
+          version: 2.30.0 # TODO: migrate to v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It's currently defaulting to the latest version of the Vale CLI, which is now 3.0 and contains breaking changes.

Quick fix for now is to pin it to the most recent v2 version, long term we want to migrate to v3: #22171