### PR TITLE
Plugins page dropdown filter alignment fix

### DIFF
--- a/microsite/src/pages/plugins/plugins.module.scss
+++ b/microsite/src/pages/plugins/plugins.module.scss
@@ -100,7 +100,7 @@
   }
 
   :global(.dropdown__label) {
-    font-size: 15px;
+    font-size: 14px;
     cursor: pointer;
   }
 

--- a/microsite/src/pages/plugins/plugins.module.scss
+++ b/microsite/src/pages/plugins/plugins.module.scss
@@ -78,6 +78,8 @@
   :global(.dropdown) {
     float: right;
     margin-bottom: 1rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   :global(.button--info) {
@@ -100,7 +102,7 @@
   }
 
   :global(.dropdown__label) {
-    font-size: 14px;
+    font-size: 15px;
     cursor: pointer;
   }
 


### PR DESCRIPTION
In the [Plugin market place](https://backstage.io/plugins/) the category filter have misalignment for the some of the options .

**current screen :**
![image](https://github.com/backstage/backstage/assets/133481507/5b358979-d86a-45d6-9ab5-2c3d557c59e4)

**After fix in font size:**
![image](https://github.com/backstage/backstage/assets/133481507/bcadb476-19c7-4a21-a2b0-c2cf64d831d8)



- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
