### PR TITLE
Fixing frontend system docs

### DIFF
--- a/docs/frontend-system/index.md
+++ b/docs/frontend-system/index.md
@@ -12,4 +12,4 @@ description: The Frontend System
 
 The new frontend system is in alpha, and only a few plugins support the system so far. We do not yet recommend migrating any apps to the new system. If you add support for the new system to your plugin, please do so under a `/alpha` sub-path export.
 
-You can find an example app setup in [the `app-next` package](https://github.com/backstage/backstage/tree/master/packages/app-next).
+You can find an example app setup in the [`app-next` package](https://github.com/backstage/backstage/tree/master/packages/app-next).


### PR DESCRIPTION
The word **the** should not be included in the links .

**current screen :**
![image](https://github.com/backstage/backstage/assets/133481507/684bdbf4-5c93-4ae0-ba43-364ce8da35b4)

**similar page screen for example:**
![image](https://github.com/backstage/backstage/assets/133481507/53242350-768f-4b58-bd0f-c216cd3df869)
