### PR TITLE
ensure that things stringify nicely overall

### DIFF
--- a/.changeset/calm-grapes-remember.md
+++ b/.changeset/calm-grapes-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Exposed `createComponentRef`, and ensured that produced refs and feature bits have a `toString` for easier debugging

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
@@ -33,6 +33,7 @@ function makeExt(
     id,
     attachTo: { id: attachId, input: 'default' },
     disabled: status === 'disabled',
+    toString: expect.any(Function),
   } as Extension<unknown>;
 }
 

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -280,6 +280,8 @@ export interface BackstagePlugin<
   readonly id: string;
   // (undocumented)
   readonly routes: Routes;
+  // (undocumented)
+  toString(): string;
 }
 
 export { BackstageUserIdentity };
@@ -427,6 +429,11 @@ export namespace createComponentExtension {
       {}
     >;
 }
+
+// @public (undocumented)
+export function createComponentRef<T extends {} = {}>(options: {
+  id: string;
+}): ComponentRef<T>;
 
 // @public (undocumented)
 export function createExtension<
@@ -735,6 +742,8 @@ export interface Extension<TConfig> {
   readonly disabled: boolean;
   // (undocumented)
   readonly id: string;
+  // (undocumented)
+  toString(): string;
 }
 
 // @public (undocumented)
@@ -763,6 +772,7 @@ export type ExtensionDataRef<
   T: TData;
   config: TConfig;
   $$type: '@backstage/ExtensionDataRef';
+  toString(): string;
 };
 
 // @public
@@ -799,6 +809,8 @@ export interface ExtensionDefinition<TConfig> {
   readonly name?: string;
   // (undocumented)
   readonly namespace?: string;
+  // (undocumented)
+  toString(): string;
 }
 
 // @public (undocumented)
@@ -821,6 +833,8 @@ export interface ExtensionInput<
 export interface ExtensionOverrides {
   // (undocumented)
   readonly $$type: '@backstage/ExtensionOverrides';
+  // (undocumented)
+  toString(): string;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -280,8 +280,6 @@ export interface BackstagePlugin<
   readonly id: string;
   // (undocumented)
   readonly routes: Routes;
-  // (undocumented)
-  toString(): string;
 }
 
 export { BackstageUserIdentity };
@@ -742,8 +740,6 @@ export interface Extension<TConfig> {
   readonly disabled: boolean;
   // (undocumented)
   readonly id: string;
-  // (undocumented)
-  toString(): string;
 }
 
 // @public (undocumented)
@@ -772,7 +768,6 @@ export type ExtensionDataRef<
   T: TData;
   config: TConfig;
   $$type: '@backstage/ExtensionDataRef';
-  toString(): string;
 };
 
 // @public
@@ -809,8 +804,6 @@ export interface ExtensionDefinition<TConfig> {
   readonly name?: string;
   // (undocumented)
   readonly namespace?: string;
-  // (undocumented)
-  toString(): string;
 }
 
 // @public (undocumented)
@@ -833,8 +826,6 @@ export interface ExtensionInput<
 export interface ExtensionOverrides {
   // (undocumented)
   readonly $$type: '@backstage/ExtensionOverrides';
-  // (undocumented)
-  toString(): string;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -25,7 +25,7 @@ import { ErrorBoundary } from './ErrorBoundary';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { routableExtensionRenderedEvent } from '../../../core-plugin-api/src/analytics/Tracker';
 import { AppNode, useComponentRef } from '../apis';
-import { coreComponentRefs } from './ComponentRef';
+import { coreComponentRefs } from './coreComponentRefs';
 
 type RouteTrackerProps = PropsWithChildren<{
   disableTracking?: boolean;

--- a/packages/frontend-plugin-api/src/components/coreComponentRefs.ts
+++ b/packages/frontend-plugin-api/src/components/coreComponentRefs.ts
@@ -19,22 +19,7 @@ import {
   CoreNotFoundErrorPageProps,
   CoreProgressProps,
 } from '../types';
-
-/** @public */
-export type ComponentRef<T extends {} = {}> = {
-  id: string;
-  T: T;
-};
-
-/** @public */
-export function createComponentRef<T extends {} = {}>(options: {
-  id: string;
-}): ComponentRef<T> {
-  const { id } = options;
-  return {
-    id,
-  } as ComponentRef<T>;
-}
+import { createComponentRef } from './createComponentRef';
 
 const coreProgressComponentRef = createComponentRef<CoreProgressProps>({
   id: 'core.components.progress',

--- a/packages/frontend-plugin-api/src/components/createComponentRef.test.tsx
+++ b/packages/frontend-plugin-api/src/components/createComponentRef.test.tsx
@@ -20,6 +20,6 @@ describe('createComponentRef', () => {
   it('can be created and read', () => {
     const ref = createComponentRef({ id: 'foo' });
     expect(ref.id).toBe('foo');
-    expect(String(ref)).toBe('componentRef{id=foo}');
+    expect(String(ref)).toBe('ComponentRef{id=foo}');
   });
 });

--- a/packages/frontend-plugin-api/src/components/createComponentRef.test.tsx
+++ b/packages/frontend-plugin-api/src/components/createComponentRef.test.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-export {
-  ExtensionBoundary,
-  type ExtensionBoundaryProps,
-} from './ExtensionBoundary';
-export { coreComponentRefs } from './coreComponentRefs';
-export { createComponentRef, type ComponentRef } from './createComponentRef';
+import { createComponentRef } from './createComponentRef';
+
+describe('createComponentRef', () => {
+  it('can be created and read', () => {
+    const ref = createComponentRef({ id: 'foo' });
+    expect(ref.id).toBe('foo');
+    expect(String(ref)).toBe('componentRef{id=foo}');
+  });
+});

--- a/packages/frontend-plugin-api/src/components/createComponentRef.tsx
+++ b/packages/frontend-plugin-api/src/components/createComponentRef.tsx
@@ -27,6 +27,8 @@ export function createComponentRef<T extends {} = {}>(options: {
   const { id } = options;
   return {
     id,
-    toString: () => `componentRef{id=${id}}`,
+    toString() {
+      return `ComponentRef{id=${id}}`;
+    },
   } as ComponentRef<T>;
 }

--- a/packages/frontend-plugin-api/src/components/createComponentRef.tsx
+++ b/packages/frontend-plugin-api/src/components/createComponentRef.tsx
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
-export {
-  ExtensionBoundary,
-  type ExtensionBoundaryProps,
-} from './ExtensionBoundary';
-export { coreComponentRefs } from './coreComponentRefs';
-export { createComponentRef, type ComponentRef } from './createComponentRef';
+/** @public */
+export type ComponentRef<T extends {} = {}> = {
+  id: string;
+  T: T;
+};
+
+/** @public */
+export function createComponentRef<T extends {} = {}>(options: {
+  id: string;
+}): ComponentRef<T> {
+  const { id } = options;
+  return {
+    id,
+    toString: () => `componentRef{id=${id}}`,
+  } as ComponentRef<T>;
+}

--- a/packages/frontend-plugin-api/src/extensions/createApiExtension.test.ts
+++ b/packages/frontend-plugin-api/src/extensions/createApiExtension.test.ts
@@ -47,6 +47,7 @@ describe('createApiExtension', () => {
         }),
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
   });
 
@@ -83,6 +84,7 @@ describe('createApiExtension', () => {
         }),
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
   });
 });

--- a/packages/frontend-plugin-api/src/extensions/createNavLogoExtension.test.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createNavLogoExtension.test.tsx
@@ -41,6 +41,7 @@ describe('createNavLogoExtension', () => {
         logos: expect.anything(),
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
   });
 });

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.test.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.test.tsx
@@ -55,6 +55,7 @@ describe('createPageExtension', () => {
         routeRef: expect.anything(),
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
 
     expect(
@@ -89,6 +90,7 @@ describe('createPageExtension', () => {
         routeRef: expect.anything(),
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
 
     expect(
@@ -112,6 +114,7 @@ describe('createPageExtension', () => {
         routeRef: expect.anything(),
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
   });
 

--- a/packages/frontend-plugin-api/src/extensions/createTranslationExtension.test.ts
+++ b/packages/frontend-plugin-api/src/extensions/createTranslationExtension.test.ts
@@ -51,6 +51,7 @@ describe('createTranslationExtension', () => {
         resource: createTranslationExtension.translationDataRef,
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
 
     expect((extension as any).factory({} as any)).toEqual({
@@ -88,6 +89,7 @@ describe('createTranslationExtension', () => {
         resource: createTranslationExtension.translationDataRef,
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
 
     expect((extension as any).factory({} as any)).toEqual({ resource });
@@ -126,6 +128,7 @@ describe('createTranslationExtension', () => {
         resource: createTranslationExtension.translationDataRef,
       },
       factory: expect.any(Function),
+      toString: expect.any(Function),
     });
   });
 });

--- a/packages/frontend-plugin-api/src/setupTests.ts
+++ b/packages/frontend-plugin-api/src/setupTests.ts
@@ -15,5 +15,3 @@
  */
 
 import '@testing-library/jest-dom';
-
-(global as unknown as { CSSOM: any }).CSSOM = { parse() {} };

--- a/packages/frontend-plugin-api/src/setupTests.ts
+++ b/packages/frontend-plugin-api/src/setupTests.ts
@@ -15,3 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
+(global as unknown as { CSSOM: any }).CSSOM = { parse() {} };

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -288,7 +288,7 @@ describe('createExtension', () => {
     });
     expect(extension.namespace).toBe('test');
     expect(String(extension)).toBe(
-      'extensionDefinition{namespace=test,attachTo=root@default}',
+      'ExtensionDefinition{namespace=test,attachTo=root@default}',
     );
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -287,5 +287,8 @@ describe('createExtension', () => {
       },
     });
     expect(extension.namespace).toBe('test');
+    expect(String(extension)).toBe(
+      'extensionDefinition{namespace=test,attachTo=root@default}',
+    );
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -107,6 +107,7 @@ export interface ExtensionDefinition<TConfig> {
   readonly attachTo: { id: string; input: string };
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig>;
+  toString(): string;
 }
 
 /** @internal */
@@ -120,6 +121,7 @@ export interface InternalExtensionDefinition<TConfig>
     config: TConfig;
     inputs: ResolvedExtensionInputs<any>;
   }): ExtensionDataValues<any>;
+  toString(): string;
 }
 
 /** @internal */
@@ -165,6 +167,20 @@ export function createExtension<
         inputs: inputs as Expand<ResolvedExtensionInputs<TInputs>>,
         ...rest,
       });
+    },
+    toString() {
+      const parts: string[] = [];
+      if (options.kind) {
+        parts.push(`kind=${options.kind}`);
+      }
+      if (options.namespace) {
+        parts.push(`namespace=${options.namespace}`);
+      }
+      if (options.name) {
+        parts.push(`name=${options.name}`);
+      }
+      parts.push(`attachTo=${options.attachTo.id}@${options.attachTo.input}`);
+      return `extensionDefinition{${parts.join(',')}}`;
     },
   } as InternalExtensionDefinition<TConfig>;
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -107,7 +107,6 @@ export interface ExtensionDefinition<TConfig> {
   readonly attachTo: { id: string; input: string };
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig>;
-  toString(): string;
 }
 
 /** @internal */
@@ -121,7 +120,6 @@ export interface InternalExtensionDefinition<TConfig>
     config: TConfig;
     inputs: ResolvedExtensionInputs<any>;
   }): ExtensionDataValues<any>;
-  toString(): string;
 }
 
 /** @internal */
@@ -180,7 +178,7 @@ export function createExtension<
         parts.push(`name=${options.name}`);
       }
       parts.push(`attachTo=${options.attachTo.id}@${options.attachTo.input}`);
-      return `extensionDefinition{${parts.join(',')}}`;
+      return `ExtensionDefinition{${parts.join(',')}}`;
     },
   } as InternalExtensionDefinition<TConfig>;
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-export {
-  ExtensionBoundary,
-  type ExtensionBoundaryProps,
-} from './ExtensionBoundary';
-export { coreComponentRefs } from './coreComponentRefs';
-export { createComponentRef, type ComponentRef } from './createComponentRef';
+import { createExtensionDataRef } from './createExtensionDataRef';
+
+describe('createExtensionDataRef', () => {
+  it('can be created and read', () => {
+    const ref = createExtensionDataRef('foo');
+    expect(ref.id).toBe('foo');
+    expect(String(ref)).toBe('extensionDataRef{id=foo,optional=false}');
+    const refOptional = ref.optional();
+    expect(refOptional.id).toBe('foo');
+    expect(String(refOptional)).toBe('extensionDataRef{id=foo,optional=true}');
+  });
+});

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
@@ -20,9 +20,9 @@ describe('createExtensionDataRef', () => {
   it('can be created and read', () => {
     const ref = createExtensionDataRef('foo');
     expect(ref.id).toBe('foo');
-    expect(String(ref)).toBe('extensionDataRef{id=foo,optional=false}');
+    expect(String(ref)).toBe('ExtensionDataRef{id=foo,optional=false}');
     const refOptional = ref.optional();
     expect(refOptional.id).toBe('foo');
-    expect(String(refOptional)).toBe('extensionDataRef{id=foo,optional=true}');
+    expect(String(refOptional)).toBe('ExtensionDataRef{id=foo,optional=true}');
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -23,6 +23,7 @@ export type ExtensionDataRef<
   T: TData;
   config: TConfig;
   $$type: '@backstage/ExtensionDataRef';
+  toString(): string;
 };
 
 /** @public */
@@ -43,7 +44,14 @@ export function createExtensionDataRef<TData>(
     $$type: '@backstage/ExtensionDataRef',
     config: {},
     optional() {
-      return { ...this, config: { ...this.config, optional: true } };
+      return {
+        ...this,
+        config: { ...this.config, optional: true },
+      };
     },
-  } as ConfigurableExtensionDataRef<TData>;
+    toString() {
+      const optional = Boolean(this.config.optional);
+      return `extensionDataRef{id=${id},optional=${optional}}`;
+    },
+  } as ConfigurableExtensionDataRef<TData, { optional?: true }>;
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -23,7 +23,6 @@ export type ExtensionDataRef<
   T: TData;
   config: TConfig;
   $$type: '@backstage/ExtensionDataRef';
-  toString(): string;
 };
 
 /** @public */
@@ -51,7 +50,7 @@ export function createExtensionDataRef<TData>(
     },
     toString() {
       const optional = Boolean(this.config.optional);
-      return `extensionDataRef{id=${id},optional=${optional}}`;
+      return `ExtensionDataRef{id=${id},optional=${optional}}`;
     },
   } as ConfigurableExtensionDataRef<TData, { optional?: true }>;
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.test.ts
@@ -27,6 +27,7 @@ describe('createExtensionOverrides', () => {
         "$$type": "@backstage/ExtensionOverrides",
         "extensions": [],
         "featureFlags": [],
+        "toString": [Function],
         "version": "v1",
       }
     `);
@@ -74,6 +75,7 @@ describe('createExtensionOverrides', () => {
             "id": "a",
             "inputs": {},
             "output": {},
+            "toString": [Function],
             "version": "v1",
           },
           {
@@ -88,6 +90,7 @@ describe('createExtensionOverrides', () => {
             "id": "b",
             "inputs": {},
             "output": {},
+            "toString": [Function],
             "version": "v1",
           },
           {
@@ -102,10 +105,12 @@ describe('createExtensionOverrides', () => {
             "id": "k:c/n",
             "inputs": {},
             "output": {},
+            "toString": [Function],
             "version": "v1",
           },
         ],
         "featureFlags": [],
+        "toString": [Function],
         "version": "v1",
       }
     `);

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
@@ -50,7 +50,7 @@ export function createExtensionOverrides(
     toString() {
       const ex = extensions.map(String).join(',');
       const ff = featureFlags.map(f => f.name).join(',');
-      return `extensionOverrides{extensions=[${ex}],featureFlags=[${ff}]}`;
+      return `ExtensionOverrides{extensions=[${ex}],featureFlags=[${ff}]}`;
     },
   } as InternalExtensionOverrides;
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
@@ -38,11 +38,20 @@ export interface InternalExtensionOverrides extends ExtensionOverrides {
 export function createExtensionOverrides(
   options: ExtensionOverridesOptions,
 ): ExtensionOverrides {
+  const extensions = options.extensions.map(def =>
+    resolveExtensionDefinition(def),
+  );
+  const featureFlags = options.featureFlags ?? [];
   return {
     $$type: '@backstage/ExtensionOverrides',
     version: 'v1',
-    extensions: options.extensions.map(def => resolveExtensionDefinition(def)),
-    featureFlags: options.featureFlags ?? [],
+    extensions,
+    featureFlags,
+    toString() {
+      const ex = extensions.map(String).join(',');
+      const ff = featureFlags.map(f => f.name).join(',');
+      return `extensionOverrides{extensions=[${ex}],featureFlags=[${ff}]}`;
+    },
   } as InternalExtensionOverrides;
 }
 

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -138,6 +138,7 @@ describe('createPlugin', () => {
     const plugin = createPlugin({ id: 'test' });
 
     expect(plugin).toBeDefined();
+    expect(String(plugin)).toBe('plugin{id=test}');
   });
 
   it('should create a plugin with extension instances', async () => {

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -138,7 +138,7 @@ describe('createPlugin', () => {
     const plugin = createPlugin({ id: 'test' });
 
     expect(plugin).toBeDefined();
-    expect(String(plugin)).toBe('plugin{id=test}');
+    expect(String(plugin)).toBe('Plugin{id=test}');
   });
 
   it('should create a plugin with extension instances', async () => {

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.ts
@@ -83,7 +83,7 @@ export function createPlugin<
     featureFlags: options.featureFlags ?? [],
     extensions,
     toString() {
-      return `plugin{id=${options.id}}`;
+      return `Plugin{id=${options.id}}`;
     },
   } as InternalBackstagePlugin<Routes, ExternalRoutes>;
 }

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.ts
@@ -82,6 +82,9 @@ export function createPlugin<
     externalRoutes: options.externalRoutes ?? ({} as ExternalRoutes),
     featureFlags: options.featureFlags ?? [],
     extensions,
+    toString() {
+      return `plugin{id=${options.id}}`;
+    },
   } as InternalBackstagePlugin<Routes, ExternalRoutes>;
 }
 

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -37,7 +37,7 @@ describe('resolveExtensionDefinition', () => {
       ...definition,
     } as ExtensionDefinition<unknown>);
     expect(resolved.id).toBe(expected);
-    expect(String(resolved)).toBe(`extension{id=${expected}}`);
+    expect(String(resolved)).toBe(`Extension{id=${expected}}`);
   });
 
   it('should fail to resolve extension ID without namespace', () => {

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -37,6 +37,7 @@ describe('resolveExtensionDefinition', () => {
       ...definition,
     } as ExtensionDefinition<unknown>);
     expect(resolved.id).toBe(expected);
+    expect(String(resolved)).toBe(`extension{id=${expected}}`);
   });
 
   it('should fail to resolve extension ID without namespace', () => {

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -32,6 +32,7 @@ export interface Extension<TConfig> {
   readonly attachTo: { id: string; input: string };
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig>;
+  toString(): string;
 }
 
 /** @internal */
@@ -81,10 +82,15 @@ export function resolveExtensionDefinition<TConfig>(
     );
   }
 
+  const id = kind ? `${kind}:${namePart}` : namePart;
+
   return {
     ...rest,
     $$type: '@backstage/Extension',
     version: 'v1',
-    id: kind ? `${kind}:${namePart}` : namePart,
-  } as InternalExtension<TConfig>;
+    id,
+    toString() {
+      return `extension{id=${id}}`;
+    },
+  } as Extension<TConfig>;
 }

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -32,7 +32,6 @@ export interface Extension<TConfig> {
   readonly attachTo: { id: string; input: string };
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig>;
-  toString(): string;
 }
 
 /** @internal */
@@ -90,7 +89,7 @@ export function resolveExtensionDefinition<TConfig>(
     version: 'v1',
     id,
     toString() {
-      return `extension{id=${id}}`;
+      return `Extension{id=${id}}`;
     },
   } as Extension<TConfig>;
 }

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -41,13 +41,11 @@ export interface BackstagePlugin<
   readonly id: string;
   readonly routes: Routes;
   readonly externalRoutes: ExternalRoutes;
-  toString(): string;
 }
 
 /** @public */
 export interface ExtensionOverrides {
   readonly $$type: '@backstage/ExtensionOverrides';
-  toString(): string;
 }
 
 /** @public */

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -41,11 +41,13 @@ export interface BackstagePlugin<
   readonly id: string;
   readonly routes: Routes;
   readonly externalRoutes: ExternalRoutes;
+  toString(): string;
 }
 
 /** @public */
 export interface ExtensionOverrides {
   readonly $$type: '@backstage/ExtensionOverrides';
+  toString(): string;
 }
 
 /** @public */


### PR DESCRIPTION
There are a couple of places that for example throw errors with a stringified framework thing in the message, so we should ensure that things make sense in that context