### PR TITLE
[Search] update ids of config options for search DI

### DIFF
--- a/docs/features/search/declarative-integration.md
+++ b/docs/features/search/declarative-integration.md
@@ -51,18 +51,19 @@ _Example disabling the search page extension_
 # app-config.yaml
 app:
   extensions:
-    - plugin.search.page: false # ✨
+    - page:search: false # ✨
+    - nav-item:search: false # ✨
 ```
 
-_Example setting the search sidebar item label_
+_Example setting the search sidebar item title_
 
 ```yaml
 # app-config.yaml
 app:
   extensions:
-    - plugin.search.nav.index: # ✨
+    - nav-item:search: # ✨
         config:
-          label: 'Search Page'
+          title: 'Search Page'
 ```
 
 > **Known limitations:**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

ids used for config was outdated so this PR updates those. It also seems required to disable `nav-item:search:` if you disable the page, so added that into the example

I noticed the diagrams used in the docs were referring to the same ids, let me know if you want me to update those too. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
