### PR TITLE
avoid build warning

### DIFF
--- a/.changeset/smooth-pumas-fold.md
+++ b/.changeset/smooth-pumas-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Minor internal refactor

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
@@ -72,7 +72,7 @@ export const RepoUrlPickerHost = (props: {
       >
         <Select
           native
-          disabled={hosts?.length === 1 ?? false}
+          disabled={hosts?.length === 1}
           label="Host"
           onChange={s => onChange(String(Array.isArray(s) ? s[0] : s))}
           selected={host}


### PR DESCRIPTION
Gets rid of [this](/Users/freben/dev/github/backstage/.changeset/smooth-pumas-fold.md)

```
plugins/scaffolder: ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]

    /home/runner/work/backstage/backstage/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx:75:40:
      75 │           disabled={hosts?.length === 1 ?? false}
         ╵                                         ~~

  The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:

    /home/runner/work/backstage/backstage/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx:75:20:
      75 │           disabled={hosts?.length === 1 ?? false}
         ╵                     ~~~~~~~~~~~~~~~~~~~
```