### PR TITLE
fix: update azure photo size

### DIFF
--- a/.changeset/stupid-monkeys-smell.md
+++ b/.changeset/stupid-monkeys-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Update azure profile photo size to 96x96.

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -205,7 +205,7 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
   private async getUserPhoto(accessToken: string): Promise<string | undefined> {
     try {
       const res = await fetch(
-        'https://graph.microsoft.com/v1.0/me/photos/48x48/$value',
+        'https://graph.microsoft.com/v1.0/me/photos/96x96/$value',
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update Azure photo to 96x96 else the picture is pixeled.
It would align with https://github.com/backstage/backstage/blob/master/plugins/auth-backend-module-microsoft-provider/src/strategy.ts#L82 too.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
