### PR TITLE
[feat] add stack trace option in error page

### DIFF
--- a/.changeset/real-grapes-sing.md
+++ b/.changeset/real-grapes-sing.md
@@ -1,5 +1,8 @@
 ---
 '@backstage/core-components': patch
+'@backstage/app-defaults': minor
+'@backstage/playlist': patch
+'@backstage/scaffolder': minor
 ---
 
-Included stack trace display option in ErrorPage component
+Added stack trace display to `ErrorPage` and updated existing refs

--- a/.changeset/real-grapes-sing.md
+++ b/.changeset/real-grapes-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Included stack trace display option in ErrorPage component

--- a/.changeset/real-grapes-sing.md
+++ b/.changeset/real-grapes-sing.md
@@ -1,8 +1,8 @@
 ---
 '@backstage/core-components': patch
 '@backstage/app-defaults': minor
-'@backstage/playlist': patch
-'@backstage/scaffolder': minor
+'@backstage/plugin-playlist': patch
+'@backstage/plugin-scaffolder': minor
 ---
 
 Added stack trace display to `ErrorPage` and updated existing refs

--- a/packages/app-defaults/src/defaults/components.tsx
+++ b/packages/app-defaults/src/defaults/components.tsx
@@ -49,7 +49,7 @@ const DefaultBootErrorPage = ({ step, error }: BootErrorPageProps) => {
   // TODO: figure out a nicer way to handle routing on the error page, when it can be done.
   return (
     <OptionallyWrapInRouter>
-      <ErrorPage statusMessage={message} />
+      <ErrorPage statusMessage={message} stack={error.stack} />
     </OptionallyWrapInRouter>
   );
 };

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -99,4 +99,15 @@ describe('<ErrorPage/>', () => {
       'https://error-page-test-support-url.com',
     );
   });
+
+  it('should render with stack trace if stack is provided', async () => {
+    const { getByText } = await renderInTestApp(
+      <ErrorPage
+        status="500"
+        statusMessage="INTERNAL ERROR"
+        stack="this is my stack trace!"
+      />,
+    );
+    expect(getByText(/this is my stack trace!/i)).toBeInTheDocument();
+  });
 });

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -100,7 +100,7 @@ describe('<ErrorPage/>', () => {
     );
   });
 
-  it('should render with stack trace if stack is provided', async () => {
+  it('should render show details if stack is provided', async () => {
     const { getByText } = await renderInTestApp(
       <ErrorPage
         status="500"
@@ -108,6 +108,6 @@ describe('<ErrorPage/>', () => {
         stack="this is my stack trace!"
       />,
     );
-    expect(getByText(/this is my stack trace!/i)).toBeInTheDocument();
+    expect(getByText(/Show more details/i)).toBeInTheDocument();
   });
 });

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -20,9 +20,9 @@ import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Link } from '../../components/Link';
-import { CopyTextButton, WarningPanel } from '../../components';
 import { useSupportConfig } from '../../hooks';
 import { MicDrop } from './MicDrop';
+import { StackDetails } from './StackDetails';
 
 interface IErrorPageProps {
   status?: string;
@@ -53,26 +53,6 @@ const useStyles = makeStyles(
     subtitle: {
       color: theme.palette.textSubtle,
     },
-    goBackTitle: {
-      color: theme.palette.textSubtle,
-      marginBottom: theme.spacing(5),
-      [theme.breakpoints.down('xs')]: {
-        marginBottom: theme.spacing(4),
-      },
-    },
-    stackTraceText: {
-      maxHeight: '30vh',
-      overflow: 'scroll',
-      fontFamily: 'monospace',
-      whiteSpace: 'pre',
-      overflowX: 'auto',
-      marginRight: theme.spacing(2),
-    },
-    copyTextContainer: {
-      display: 'flex',
-      justifyContent: 'flex-end',
-      alignItems: 'flex-start',
-    },
   }),
   { name: 'BackstageErrorPage' },
 );
@@ -91,7 +71,7 @@ export function ErrorPage(props: IErrorPageProps) {
 
   return (
     <Grid container className={classes.container}>
-      <Grid item xs={12} md={5}>
+      <Grid item xs={12} sm={8} md={4}>
         <Typography
           data-testid="error"
           variant="body1"
@@ -105,7 +85,7 @@ export function ErrorPage(props: IErrorPageProps) {
         <Typography variant="h2" className={classes.title}>
           Looks like someone dropped the mic!
         </Typography>
-        <Typography variant="h6" className={classes.goBackTitle}>
+        <Typography variant="h6" className={classes.title}>
           <Link to="#" data-testid="go-back-link" onClick={() => navigate(-1)}>
             Go back
           </Link>
@@ -113,29 +93,9 @@ export function ErrorPage(props: IErrorPageProps) {
           <Link to={supportUrl || support.url}>contact support</Link> if you
           think this is a bug.
         </Typography>
-        {stack && (
-          <WarningPanel severity="error" title={statusMessage}>
-            <Grid container>
-              <Grid item xs={11}>
-                <Typography variant="subtitle1">Stack Trace</Typography>
-                <Typography
-                  className={classes.stackTraceText}
-                  color="textSecondary"
-                  variant="body2"
-                >
-                  {stack}
-                </Typography>
-              </Grid>
-              <Grid item xs={1} className={classes.copyTextContainer}>
-                <CopyTextButton text={stack} />
-              </Grid>
-            </Grid>
-          </WarningPanel>
-        )}
+        {stack && <StackDetails stack={stack} />}
       </Grid>
-      <Grid item xs={12} md={7}>
-        <MicDrop />
-      </Grid>
+      <MicDrop />
     </Grid>
   );
 }

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -15,7 +15,6 @@
  */
 
 import Grid from '@material-ui/core/Grid';
-import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
@@ -38,16 +37,10 @@ export type ErrorPageClassKey = 'container' | 'title' | 'subtitle';
 
 const useStyles = makeStyles(
   theme => ({
-    parent: {
+    container: {
       padding: theme.spacing(8),
       [theme.breakpoints.down('xs')]: {
         padding: theme.spacing(2),
-      },
-    },
-    container: {
-      marginBottom: theme.spacing(5),
-      [theme.breakpoints.down('xs')]: {
-        marginBottom: theme.spacing(4),
       },
     },
     title: {
@@ -59,6 +52,13 @@ const useStyles = makeStyles(
     },
     subtitle: {
       color: theme.palette.textSubtle,
+    },
+    goBackTitle: {
+      color: theme.palette.textSubtle,
+      marginBottom: theme.spacing(5),
+      [theme.breakpoints.down('xs')]: {
+        marginBottom: theme.spacing(4),
+      },
     },
     text: {
       fontFamily: 'monospace',
@@ -88,56 +88,52 @@ export function ErrorPage(props: IErrorPageProps) {
   const support = useSupportConfig();
 
   return (
-    <Box className={classes.parent}>
-      <Grid container className={classes.container}>
-        <Grid item xs={12} sm={8} md={4}>
-          <Typography
-            data-testid="error"
-            variant="body1"
-            className={classes.subtitle}
-          >
-            ERROR {status}: {statusMessage}
-          </Typography>
-          <Typography variant="body1" className={classes.subtitle}>
-            {additionalInfo}
-          </Typography>
-          <Typography variant="h2" className={classes.title}>
-            Looks like someone dropped the mic!
-          </Typography>
-          <Typography variant="h6">
-            <Link
-              to="#"
-              data-testid="go-back-link"
-              onClick={() => navigate(-1)}
-            >
-              Go back
-            </Link>
-            ... or please{' '}
-            <Link to={supportUrl || support.url}>contact support</Link> if you
-            think this is a bug.
-          </Typography>
-        </Grid>
+    <Grid container className={classes.container}>
+      <Grid item xs={12} md={5}>
+        <Typography
+          data-testid="error"
+          variant="body1"
+          className={classes.subtitle}
+        >
+          ERROR {status}: {statusMessage}
+        </Typography>
+        <Typography variant="body1" className={classes.subtitle}>
+          {additionalInfo}
+        </Typography>
+        <Typography variant="h2" className={classes.title}>
+          Looks like someone dropped the mic!
+        </Typography>
+        <Typography variant="h6" className={classes.goBackTitle}>
+          <Link to="#" data-testid="go-back-link" onClick={() => navigate(-1)}>
+            Go back
+          </Link>
+          ... or please{' '}
+          <Link to={supportUrl || support.url}>contact support</Link> if you
+          think this is a bug.
+        </Typography>
+        {stack && (
+          <WarningPanel severity="error" title={statusMessage}>
+            <Grid container>
+              <Grid item xs={11}>
+                <Typography variant="subtitle1">Stack Trace</Typography>
+                <Typography
+                  className={classes.text}
+                  color="textSecondary"
+                  variant="body2"
+                >
+                  {stack}
+                </Typography>
+              </Grid>
+              <Grid item xs={1} className={classes.copyTextContainer}>
+                <CopyTextButton text={stack} />
+              </Grid>
+            </Grid>
+          </WarningPanel>
+        )}
+      </Grid>
+      <Grid item xs={12} md={7}>
         <MicDrop />
       </Grid>
-      {stack && (
-        <WarningPanel severity="error" title={statusMessage}>
-          <Grid container className={classes.container}>
-            <Grid item xs={10} sm={8}>
-              <Typography variant="subtitle1">Stack Trace</Typography>
-              <Typography
-                className={classes.text}
-                color="error"
-                variant="body1"
-              >
-                {stack}
-              </Typography>
-            </Grid>
-            <Grid item xs={2} sm={4} className={classes.copyTextContainer}>
-              <CopyTextButton text={stack} />
-            </Grid>
-          </Grid>
-        </WarningPanel>
-      )}
-    </Box>
+    </Grid>
   );
 }

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -60,7 +60,9 @@ const useStyles = makeStyles(
         marginBottom: theme.spacing(4),
       },
     },
-    text: {
+    stackTraceText: {
+      maxHeight: '30vh',
+      overflow: 'scroll',
       fontFamily: 'monospace',
       whiteSpace: 'pre',
       overflowX: 'auto',
@@ -117,7 +119,7 @@ export function ErrorPage(props: IErrorPageProps) {
               <Grid item xs={11}>
                 <Typography variant="subtitle1">Stack Trace</Typography>
                 <Typography
-                  className={classes.text}
+                  className={classes.stackTraceText}
                   color="textSecondary"
                   variant="body2"
                 >

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -21,7 +21,7 @@ import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Link } from '../../components/Link';
-import { LogViewer } from '../../components';
+import { CopyTextButton, WarningPanel } from '../../components';
 import { useSupportConfig } from '../../hooks';
 import { MicDrop } from './MicDrop';
 
@@ -59,6 +59,17 @@ const useStyles = makeStyles(
     },
     subtitle: {
       color: theme.palette.textSubtle,
+    },
+    text: {
+      fontFamily: 'monospace',
+      whiteSpace: 'pre',
+      overflowX: 'auto',
+      marginRight: theme.spacing(2),
+    },
+    copyTextContainer: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      alignItems: 'flex-start',
     },
   }),
   { name: 'BackstageErrorPage' },
@@ -108,7 +119,25 @@ export function ErrorPage(props: IErrorPageProps) {
         </Grid>
         <MicDrop />
       </Grid>
-      {stack && <LogViewer text={stack} />}
+      {stack && (
+        <WarningPanel severity="error" title={statusMessage}>
+          <Grid container className={classes.container}>
+            <Grid item xs={10} sm={8}>
+              <Typography variant="subtitle1">Stack Trace</Typography>
+              <Typography
+                className={classes.text}
+                color="error"
+                variant="body1"
+              >
+                {stack}
+              </Typography>
+            </Grid>
+            <Grid item xs={2} sm={4} className={classes.copyTextContainer}>
+              <CopyTextButton text={stack} />
+            </Grid>
+          </Grid>
+        </WarningPanel>
+      )}
     </Box>
   );
 }

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -15,11 +15,13 @@
  */
 
 import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Link } from '../../components/Link';
+import { LogViewer } from '../../components';
 import { useSupportConfig } from '../../hooks';
 import { MicDrop } from './MicDrop';
 
@@ -28,6 +30,7 @@ interface IErrorPageProps {
   statusMessage: string;
   additionalInfo?: React.ReactNode;
   supportUrl?: string;
+  stack?: string;
 }
 
 /** @public */
@@ -35,10 +38,16 @@ export type ErrorPageClassKey = 'container' | 'title' | 'subtitle';
 
 const useStyles = makeStyles(
   theme => ({
-    container: {
+    parent: {
       padding: theme.spacing(8),
       [theme.breakpoints.down('xs')]: {
         padding: theme.spacing(2),
+      },
+    },
+    container: {
+      marginBottom: theme.spacing(5),
+      [theme.breakpoints.down('xs')]: {
+        marginBottom: theme.spacing(4),
       },
     },
     title: {
@@ -62,37 +71,44 @@ const useStyles = makeStyles(
  *
  */
 export function ErrorPage(props: IErrorPageProps) {
-  const { status, statusMessage, additionalInfo, supportUrl } = props;
+  const { status, statusMessage, additionalInfo, supportUrl, stack } = props;
   const classes = useStyles();
   const navigate = useNavigate();
   const support = useSupportConfig();
 
   return (
-    <Grid container spacing={0} className={classes.container}>
-      <Grid item xs={12} sm={8} md={4}>
-        <Typography
-          data-testid="error"
-          variant="body1"
-          className={classes.subtitle}
-        >
-          ERROR {status}: {statusMessage}
-        </Typography>
-        <Typography variant="body1" className={classes.subtitle}>
-          {additionalInfo}
-        </Typography>
-        <Typography variant="h2" className={classes.title}>
-          Looks like someone dropped the mic!
-        </Typography>
-        <Typography variant="h6">
-          <Link to="#" data-testid="go-back-link" onClick={() => navigate(-1)}>
-            Go back
-          </Link>
-          ... or please{' '}
-          <Link to={supportUrl || support.url}>contact support</Link> if you
-          think this is a bug.
-        </Typography>
+    <Box className={classes.parent}>
+      <Grid container className={classes.container}>
+        <Grid item xs={12} sm={8} md={4}>
+          <Typography
+            data-testid="error"
+            variant="body1"
+            className={classes.subtitle}
+          >
+            ERROR {status}: {statusMessage}
+          </Typography>
+          <Typography variant="body1" className={classes.subtitle}>
+            {additionalInfo}
+          </Typography>
+          <Typography variant="h2" className={classes.title}>
+            Looks like someone dropped the mic!
+          </Typography>
+          <Typography variant="h6">
+            <Link
+              to="#"
+              data-testid="go-back-link"
+              onClick={() => navigate(-1)}
+            >
+              Go back
+            </Link>
+            ... or please{' '}
+            <Link to={supportUrl || support.url}>contact support</Link> if you
+            think this is a bug.
+          </Typography>
+        </Grid>
+        <MicDrop />
       </Grid>
-      <MicDrop />
-    </Grid>
+      {stack && <LogViewer text={stack} />}
+    </Box>
   );
 }

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
@@ -21,7 +21,7 @@ import MicDropSvgUrl from './mic-drop.svg';
 const useStyles = makeStyles(
   theme => ({
     micDrop: {
-      maxWidth: '80%',
+      maxWidth: '60%',
       bottom: theme.spacing(2),
       right: theme.spacing(2),
       [theme.breakpoints.down('xs')]: {

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
@@ -21,7 +21,7 @@ import MicDropSvgUrl from './mic-drop.svg';
 const useStyles = makeStyles(
   theme => ({
     micDrop: {
-      maxWidth: '60%',
+      maxWidth: '80%',
       bottom: theme.spacing(2),
       right: theme.spacing(2),
       [theme.breakpoints.down('xs')]: {

--- a/packages/core-components/src/layout/ErrorPage/StackDetails.tsx
+++ b/packages/core-components/src/layout/ErrorPage/StackDetails.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Typography from '@material-ui/core/Typography';
+import React from 'react';
+import { useState } from 'react';
+import { Link } from '../../components/Link';
+import { CodeSnippet } from '../../components';
+import { makeStyles } from '@material-ui/core/styles';
+
+interface IStackDetailsProps {
+  stack: string;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    title: {
+      paddingBottom: theme.spacing(5),
+      [theme.breakpoints.down('xs')]: {
+        paddingBottom: theme.spacing(4),
+        fontSize: theme.typography.h3.fontSize,
+      },
+    },
+  }),
+  { name: 'BackstageErrorPageStackDetails' },
+);
+
+/**
+ * Error page details with stack trace
+ *
+ * @public
+ *
+ */
+export function StackDetails(props: IStackDetailsProps) {
+  const { stack } = props;
+  const classes = useStyles();
+
+  const [detailsOpen, setDetailsOpen] = useState<boolean>(false);
+
+  if (!detailsOpen) {
+    return (
+      <Typography variant="h6" className={classes.title}>
+        <Link to="#" onClick={() => setDetailsOpen(true)}>
+          Show more details
+        </Link>
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      <Typography variant="h6" className={classes.title}>
+        <Link to="#" onClick={() => setDetailsOpen(false)}>
+          Show less details
+        </Link>
+      </Typography>
+      <CodeSnippet
+        text={stack}
+        language="text"
+        showCopyCodeButton
+        showLineNumbers
+      />
+    </>
+  );
+}

--- a/plugins/playlist/src/components/PlaylistPage/PlaylistPage.tsx
+++ b/plugins/playlist/src/components/PlaylistPage/PlaylistPage.tsx
@@ -84,6 +84,7 @@ export const PlaylistPage = () => {
       <ErrorPage
         status={(error as ResponseError).response?.status.toString()}
         statusMessage={error.toString()}
+        stack={error.stack}
       />
     );
   }

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -142,6 +142,7 @@ export const ActionsPage = () => {
       <ErrorPage
         statusMessage="Failed to load installed actions"
         status="500"
+        stack={error.stack}
       />
     );
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add option to include stack trace in the ErrorPage for debugging purposes

<img width="1792" alt="Screenshot 2024-01-12 at 3 21 45 PM" src="https://github.com/backstage/backstage/assets/67240543/2f91d456-8326-46e6-b47a-0a09c3724801">

Closes #22156

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
