### PR TITLE
Feature: Add latest_report_status to puppetdb backend provider #22167

### DIFF
--- a/.changeset/wet-lions-crash.md
+++ b/.changeset/wet-lions-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-puppetdb': patch
+---
+
+Added latest_report_status parameter from the puppetdb node api and added it as a tag to the nodes. The status is valuable information as it displays which nodes are compliant to your configuration and which ones are failing are making changes.

--- a/plugins/catalog-backend-module-puppetdb/api-report.md
+++ b/plugins/catalog-backend-module-puppetdb/api-report.md
@@ -65,6 +65,7 @@ export type PuppetNode = {
   timestamp: string;
   certname: string;
   hash: string;
+  latest_report_status: string;
   producer_timestamp: string;
   producer: string;
   environment: string;

--- a/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProvider.test.ts
@@ -108,7 +108,7 @@ describe('PuppetEntityProvider', () => {
             annotations: {
               [ANNOTATION_PUPPET_CERTNAME]: 'node1',
             },
-            tags: ['windows'],
+            tags: ['windows', 'unchanged'],
             description: 'Description 1',
           },
           spec: {
@@ -127,7 +127,7 @@ describe('PuppetEntityProvider', () => {
             annotations: {
               [ANNOTATION_PUPPET_CERTNAME]: 'node2',
             },
-            tags: ['linux'],
+            tags: ['linux', 'unchanged'],
             description: 'Description 2',
           },
           spec: {
@@ -173,7 +173,7 @@ describe('PuppetEntityProvider', () => {
                     'catalog.providers.puppetdb.baseUrl',
                   )}/${ENDPOINT_NODES}/node1`,
                 },
-                tags: ['windows'],
+                tags: ['windows', 'unchanged'],
                 description: 'Description 1',
               },
               spec: {
@@ -201,7 +201,7 @@ describe('PuppetEntityProvider', () => {
                     'catalog.providers.puppetdb.baseUrl',
                   )}/${ENDPOINT_NODES}/node2`,
                 },
-                tags: ['linux'],
+                tags: ['linux', 'unchanged'],
                 description: 'Description 2',
               },
               spec: {

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/read.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/read.test.ts
@@ -53,6 +53,7 @@ describe('readPuppetNodes', () => {
                 producer_timestamp: 'producer_time1',
                 producer: 'producer1',
                 environment: 'environment1',
+                latest_report_status: 'unchanged',
                 facts: {
                   data: [
                     {
@@ -84,6 +85,7 @@ describe('readPuppetNodes', () => {
                 hash: 'hash2',
                 producer_timestamp: 'producer_time2',
                 producer: 'producer2',
+                latest_report_status: 'unchanged',
                 environment: 'environment2',
                 facts: {
                   data: [

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.test.ts
@@ -33,6 +33,7 @@ describe('defaultResourceTransformer', () => {
       producer_timestamp: 'producer_time1',
       producer: 'producer1',
       environment: 'environment1',
+      latest_report_status: 'unchanged',
       facts: {
         href: 'facts1',
         data: [

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.test.ts
@@ -72,7 +72,7 @@ describe('defaultResourceTransformer', () => {
           [ANNOTATION_PUPPET_CERTNAME]: 'node1',
         },
         description: 'ipaddress1',
-        tags: ['linux'],
+        tags: ['linux', 'unchanged'],
       },
       spec: {
         type: 'virtual-machine',

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.ts
@@ -37,6 +37,7 @@ export const defaultResourceTransformer: ResourceTransformer = async (
     ? 'virtual-machine'
     : 'physical-server';
   const kernel = node.facts?.data?.find(e => e.name === 'kernel')?.value;
+  const latest_report_status = node.latest_report_status;
 
   return {
     apiVersion: 'backstage.io/v1beta1',
@@ -50,7 +51,7 @@ export const defaultResourceTransformer: ResourceTransformer = async (
       description: node.facts?.data
         ?.find(e => e.name === 'ipaddress')
         ?.value?.toString(),
-      tags: kernel ? [kernel.toString().toLocaleLowerCase('en-US')] : [],
+      tags: kernel ? [kernel.toString().toLocaleLowerCase('en-US'), latest_report_status.toString().toLocaleLowerCase('en-US')] : [],
     },
     spec: {
       type: type,

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/transformers.ts
@@ -51,7 +51,12 @@ export const defaultResourceTransformer: ResourceTransformer = async (
       description: node.facts?.data
         ?.find(e => e.name === 'ipaddress')
         ?.value?.toString(),
-      tags: kernel ? [kernel.toString().toLocaleLowerCase('en-US'), latest_report_status.toString().toLocaleLowerCase('en-US')] : [],
+      tags: kernel
+        ? [
+            kernel.toString().toLocaleLowerCase('en-US'),
+            latest_report_status.toString().toLocaleLowerCase('en-US'),
+          ]
+        : [],
     },
     spec: {
       type: type,

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/types.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/types.ts
@@ -52,7 +52,11 @@ export type PuppetNode = {
    */
   hash: string;
   /**
-   *  The most recent time of fact submission for the relevant certname from the Puppet Server.
+   * A hash of the factset's certname, environment, timestamp, facts, and producer_timestamp.
+   */
+  latest_report_status: string;
+  /**
+   *  The status of the latest report. Possible values come from Puppet's report status failed, changed, or unchanged.
    */
   producer_timestamp: string;
   /**


### PR DESCRIPTION
This pull request is made for feature #22167
I just added the latest report status to the tags. because it is usefull info about the nodes