### PR TITLE
new backend system: missing default exports auth-backend modules

### DIFF
--- a/.changeset/yellow-lies-fly.md
+++ b/.changeset/yellow-lies-fly.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-pinniped-provider': patch
+---
+
+Add default export for auth-backend module (new backend system).

--- a/plugins/auth-backend-module-microsoft-provider/api-report.md
+++ b/plugins/auth-backend-module-microsoft-provider/api-report.md
@@ -11,7 +11,9 @@ import { PassportProfile } from '@backstage/plugin-auth-node';
 import { SignInResolverFactory } from '@backstage/plugin-auth-node';
 
 // @public (undocumented)
-export const authModuleMicrosoftProvider: () => BackendFeature;
+const authModuleMicrosoftProvider: () => BackendFeature;
+export { authModuleMicrosoftProvider };
+export default authModuleMicrosoftProvider;
 
 // @public (undocumented)
 export const microsoftAuthenticator: OAuthAuthenticator<

--- a/plugins/auth-backend-module-microsoft-provider/src/index.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/index.ts
@@ -21,5 +21,8 @@
  */
 
 export { microsoftAuthenticator } from './authenticator';
-export { authModuleMicrosoftProvider } from './module';
+export {
+  authModuleMicrosoftProvider,
+  authModuleMicrosoftProvider as default,
+} from './module';
 export { microsoftSignInResolvers } from './resolvers';

--- a/plugins/auth-backend-module-pinniped-provider/api-report.md
+++ b/plugins/auth-backend-module-pinniped-provider/api-report.md
@@ -11,7 +11,9 @@ import { Strategy } from 'openid-client';
 import { TokenSet } from 'openid-client';
 
 // @public (undocumented)
-export const authModulePinnipedProvider: () => BackendFeature;
+const authModulePinnipedProvider: () => BackendFeature;
+export { authModulePinnipedProvider };
+export default authModulePinnipedProvider;
 
 // @public (undocumented)
 export const pinnipedAuthenticator: OAuthAuthenticator<

--- a/plugins/auth-backend-module-pinniped-provider/src/index.ts
+++ b/plugins/auth-backend-module-pinniped-provider/src/index.ts
@@ -21,4 +21,7 @@
  */
 
 export { pinnipedAuthenticator, PinnipedStrategyCache } from './authenticator';
-export { authModulePinnipedProvider } from './module';
+export {
+  authModulePinnipedProvider,
+  authModulePinnipedProvider as default,
+} from './module';


### PR DESCRIPTION
Add default export for auth-backend modules

- auth-backend-module-microsoft-provider
- auth-backend-module-pinniped-provider

Related-to: #18301

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
