### PR TITLE
feat(catalog): support `onProcessingError` handler at the catalog plugin

### DIFF
--- a/.changeset/twelve-shirts-buy.md
+++ b/.changeset/twelve-shirts-buy.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-node': patch
+---
+
+Add support for `onProcessingError` handler at the catalog plugin (new backend system).
+
+You can use `setOnProcessingErrorHandler` at the `catalogProcessingExtensionPoint`
+as replacement for
+
+```ts
+catalogBuilder.subscribe({
+  onProcessingError: hander,
+});
+```

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -54,6 +54,13 @@ export interface CatalogProcessingExtensionPoint {
   addProcessor(
     ...processors: Array<CatalogProcessor | Array<CatalogProcessor>>
   ): void;
+  // (undocumented)
+  setOnProcessingErrorHandler(
+    handler: (event: {
+      unprocessedEntity: Entity;
+      errors: Error[];
+    }) => Promise<void> | void,
+  ): void;
 }
 
 // @alpha (undocumented)

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -37,6 +37,12 @@ export interface CatalogProcessingExtensionPoint {
     ...providers: Array<EntityProvider | Array<EntityProvider>>
   ): void;
   addPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;
+  setOnProcessingErrorHandler(
+    handler: (event: {
+      unprocessedEntity: Entity;
+      errors: Error[];
+    }) => Promise<void> | void,
+  ): void;
 }
 
 /**


### PR DESCRIPTION
Add the missing support for the `onProcessingError` handler at the catalog plugin of the new backend system
using the `CatalogProcessingExtensionPoint`.

Related-to: #18301

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
