### PR TITLE
feat(plugin-api-docs) : adding supportedSubmitMethods prop to SwaggerUI component

### DIFF
--- a/.changeset/large-frogs-grab.md
+++ b/.changeset/large-frogs-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Adding `supportedSubmitMethods` prop to `api-docs` to pass to the Swagger UI. This allows users to specify which HTTP methods they wish to allow end-users to make requests through the `Try It Out` button on the Swagger UI.

--- a/plugins/api-docs/README.md
+++ b/plugins/api-docs/README.md
@@ -263,3 +263,56 @@ createApiFactory({
 ```
 
 In the same way as the `requestInterceptor` you can override any property of Swagger UI
+
+### Provide Specific Supported Methods to Swagger UI
+
+This can be done through utilising the
+[supportedSubmitMethods prop](https://github.com/swagger-api/swagger-ui/tree/master/flavors/swagger-ui-react#supportedsubmitmethods-proptypesarrayofproptypesoneofget-put-post-delete-options-head-patch-trace).
+If you wish to limit the HTTP methods available for the `Try It Out` feature of an OpenAPI API
+component, you will need to add the following to your `api.tsx`, listing the permitted methods for
+your API in the `supportedSubmitMethods` parameter:
+
+```tsx
+...
+import {
+  OpenApiDefinitionWidget,
+  apiDocsConfigRef,
+  defaultDefinitionWidgets,
+} from '@backstage/plugin-api-docs';
+import { ApiEntity } from '@backstage/catalog-model';
+
+export const apis: AnyApiFactory[] = [
+...
+  createApiFactory({
+    api: apiDocsConfigRef,
+    deps: {},
+    factory: () => {
+      const supportedSubmitMethods = ['get', 'post', 'put', 'delete'];
+      const definitionWidgets = defaultDefinitionWidgets().map(obj => {
+        if (obj.type === 'openapi') {
+          return {
+            ...obj,
+            component: definition => (
+              <OpenApiDefinitionWidget
+                definition={definition}
+                supportedSubmitMethods={supportedSubmitMethods}
+              />
+            ),
+          };
+        }
+        return obj;
+      });
+
+      return {
+        getApiDefinitionWidget: (apiEntity: ApiEntity) => {
+          return definitionWidgets.find(d => d.type === apiEntity.spec.type);
+        }
+      };
+    }
+  })
+]
+
+```
+
+N.B. if you wish to disable the `Try It Out` feature for your API, you can provide an empty list to
+the `supportedSubmitMethods` parameter.

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -166,6 +166,7 @@ export const OpenApiDefinitionWidget: (
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
   requestInterceptor?: (req: any) => any | Promise<any>;
+  supportedSubmitMethods?: string[];
 };
 
 // @public (undocumented)

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
@@ -97,11 +97,13 @@ paths:
     `;
 
     const requestInterceptor = (req: any) => req;
+    const supportedSubmitMethods = ['get', 'post', 'put', 'delete'];
 
     const { findByRole, getByRole, getByLabelText } = await renderInTestApp(
       <OpenApiDefinition
         definition={definition}
         requestInterceptor={requestInterceptor}
+        supportedSubmitMethods={supportedSubmitMethods}
       />,
     );
 

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -25,10 +25,21 @@ const LazyOpenApiDefinition = React.lazy(() =>
   })),
 );
 
+type HttpMethods =
+  | 'get'
+  | 'put'
+  | 'post'
+  | 'delete'
+  | 'options'
+  | 'head'
+  | 'patch'
+  | 'trace';
+
 /** @public */
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
   requestInterceptor?: (req: any) => any | Promise<any>;
+  supportedSubmitMethods?: HttpMethods[];
 };
 
 /** @public */

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -25,30 +25,26 @@ const LazyOpenApiDefinition = React.lazy(() =>
   })),
 );
 
-type HttpMethods =
-  | 'get'
-  | 'put'
-  | 'post'
-  | 'delete'
-  | 'options'
-  | 'head'
-  | 'patch'
-  | 'trace';
-
 /** @public */
 export type OpenApiDefinitionWidgetProps = {
   definition: string;
   requestInterceptor?: (req: any) => any | Promise<any>;
-  supportedSubmitMethods?: HttpMethods[];
+  supportedSubmitMethods?: string[];
 };
 
 /** @public */
 export const OpenApiDefinitionWidget = (
   props: OpenApiDefinitionWidgetProps,
 ) => {
+  const validSubmitMethods = props.supportedSubmitMethods?.map(method =>
+    method.toLocaleLowerCase(),
+  );
   return (
     <Suspense fallback={<Progress />}>
-      <LazyOpenApiDefinition {...props} />
+      <LazyOpenApiDefinition
+        {...props}
+        supportedSubmitMethods={validSubmitMethods}
+      />
     </Suspense>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I saw a while ago someone mentioned [looking to add in this functionality](https://github.com/backstage/backstage/issues/15323) but I don't think it was ever added? 

More recently the `reuestInterceptor` functionality was [added](https://github.com/backstage/backstage/pull/19260/files) which made me think adding the `supportedSubmitMethods` prop as an option may be helpful to prevent users carrying out unwanted actions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
