### PR TITLE
Feat/unique team reviewers

### DIFF
--- a/.changeset/fair-spies-rescue.md
+++ b/.changeset/fair-spies-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': minor
+---
+
+Ensure `teamReviewers` list is unique before calling API

--- a/.changeset/fair-spies-rescue.md
+++ b/.changeset/fair-spies-rescue.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend-module-github': minor
+'@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
 Ensure `teamReviewers` list is unique before calling API

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.test.ts
@@ -377,7 +377,7 @@ describe('createPublishGithubPullRequestAction', () => {
         branchName: 'new-app',
         description: 'This PR is really good',
         reviewers: ['foobar'],
-        teamReviewers: ['team-foo'],
+        teamReviewers: ['team-foo', 'team-foo', 'team-bar'],
       };
 
       mockDir.setContent({ [workspacePath]: {} });
@@ -401,7 +401,7 @@ describe('createPublishGithubPullRequestAction', () => {
         repo: 'myrepo',
         pull_number: 123,
         reviewers: ['foobar'],
-        team_reviewers: ['team-foo'],
+        team_reviewers: ['team-foo', 'team-bar'],
       });
     });
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -372,7 +372,7 @@ export const createPublishGithubPullRequestAction = (
         repo: pr.repo,
         pull_number: pr.number,
         reviewers,
-        team_reviewers: teamReviewers,
+        team_reviewers: teamReviewers ? [...new Set(teamReviewers)] : undefined,
       });
       const addedUsers = result.data.requested_reviewers?.join(', ') ?? '';
       const addedTeams = result.data.requested_teams?.join(', ') ?? '';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When creating a PR from a software template you may wish to add from Groups within the catalog AND add a default team.  But you may find that the Group you select is the default team and then you have duplicates.  

```yaml
teamReviewers:
  - Team A
  - Team B
  - Team A
```

The API then fails to add any teamReviewers to the PullRequest.  This change makes the array unique before calling API so that this use-case is handled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
