### PR TITLE
frontend-app-api: switch undeclared inputs to be a warning instead of error

### DIFF
--- a/.changeset/silver-countries-notice.md
+++ b/.changeset/silver-countries-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+Attaching extensions to an input that does not exist is now a warning rather than an error.

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -475,7 +475,7 @@ describe('createAppNodeInstance', () => {
     );
 
     expect(warn).toEqual([
-      "The extension 'app/test' is attached to the input 'undeclared' of 'app/parent', but the extension 'app/parent' noes not declare a 'undeclared' input",
+      "The extension 'app/test' is attached to the input 'undeclared' of the extension 'app/parent', but it has no such input (candidates are 'declared')",
     ]);
   });
 
@@ -510,8 +510,8 @@ describe('createAppNodeInstance', () => {
     );
 
     expect(warn).toEqual([
-      "The extension 'app/test' is attached to the input 'undeclared1' of 'app/parent', but the extension 'app/parent' noes not declare a 'undeclared1' input",
-      "The extensions 'app/test', 'app/test' are attached to the input 'undeclared2' of 'app/parent', but the extension 'app/parent' noes not declare a 'undeclared2' input",
+      "The extension 'app/test' is attached to the input 'undeclared1' of the extension 'app/parent', but it has no inputs",
+      "The extensions 'app/test', 'app/test' are attached to the input 'undeclared2' of the extension 'app/parent', but it has no inputs",
     ]);
   });
 

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -55,15 +55,21 @@ function resolveInputs(
   );
 
   if (process.env.NODE_ENV !== 'production') {
+    const inputNames = Object.keys(inputMap);
+
     for (const [name, nodes] of undeclaredAttachments) {
       const pl = nodes.length > 1;
       // eslint-disable-next-line no-console
       console.warn(
-        `The extension${pl ? 's' : ''} '${nodes
-          .map(n => n.spec.id)
-          .join("', '")}' ${
-          pl ? 'are' : 'is'
-        } attached to the input '${name}' of '${id}', but the extension '${id}' noes not declare a '${name}' input`,
+        [
+          `The extension${pl ? 's' : ''} '${nodes
+            .map(n => n.spec.id)
+            .join("', '")}' ${pl ? 'are' : 'is'}`,
+          `attached to the input '${name}' of the extension '${id}', but it`,
+          inputNames.length === 0
+            ? 'has no inputs'
+            : `has no such input (candidates are '${inputNames.join("', '")}')`,
+        ].join(' '),
       );
     }
   }

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -46,26 +46,26 @@ function resolveInputData(
 }
 
 function resolveInputs(
+  id: string,
   inputMap: AnyExtensionInputMap,
   attachments: ReadonlyMap<string, AppNode[]>,
 ): ResolvedExtensionInputs<AnyExtensionInputMap> {
   const undeclaredAttachments = Array.from(attachments.entries()).filter(
     ([inputName]) => inputMap[inputName] === undefined,
   );
-  // TODO: Make this a warning rather than an error
-  if (undeclaredAttachments.length > 0) {
-    throw new Error(
-      `received undeclared input${
-        undeclaredAttachments.length > 1 ? 's' : ''
-      } ${undeclaredAttachments
-        .map(
-          ([k, exts]) =>
-            `'${k}' from extension${exts.length > 1 ? 's' : ''} '${exts
-              .map(e => e.spec.id)
-              .join("', '")}'`,
-        )
-        .join(' and ')}`,
-    );
+
+  if (process.env.NODE_ENV !== 'production') {
+    for (const [name, nodes] of undeclaredAttachments) {
+      const pl = nodes.length > 1;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `The extension${pl ? 's' : ''} '${nodes
+          .map(n => n.spec.id)
+          .join("', '")}' ${
+          pl ? 'are' : 'is'
+        } attached to the input '${name}' of '${id}', but the extension '${id}' noes not declare a '${name}' input`,
+      );
+    }
   }
 
   return mapValues(inputMap, (input, inputName) => {
@@ -129,7 +129,7 @@ export function createAppNodeInstance(options: {
     const namedOutputs = internalExtension.factory({
       node,
       config: parsedConfig,
-      inputs: resolveInputs(internalExtension.inputs, attachments),
+      inputs: resolveInputs(id, internalExtension.inputs, attachments),
     });
 
     for (const [name, output] of Object.entries(namedOutputs)) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Having this be an error is a bit too strict, since it might be intentional to switch out components for ones that don't declare the same input and leave detached extensions. Prime example of this is overriding the nav (sidebar) extension, right now you have to go disable all nav item extensions to avoid this error, or declare and ignore the items input on your custom sidebar.

We'll see exactly how useful this warning will be in the long run, but for now I think it can be good to have still in order to identify setup issues more easily.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
