### PR TITLE
Updated Template.v1beta3.schema.json, added a missing "presentation" field 

### DIFF
--- a/.changeset/fresh-mirrors-shake.md
+++ b/.changeset/fresh-mirrors-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-common': patch
+---
+
+Updated Template.v1beta3.schema.json, added a missing "presentation" field

--- a/plugins/scaffolder-common/src/Template.v1beta3.schema.json
+++ b/plugins/scaffolder-common/src/Template.v1beta3.schema.json
@@ -139,24 +139,6 @@
                 }
               ]
             },
-            "presentation": {
-              "type": "object",
-              "description": "A way to redefine the labels for actionable buttons.",
-              "properties": {
-                "backButtonText": {
-                  "type": "string",
-                  "description": "A button which return the user to one step back."
-                },
-                "createButtonText": {
-                  "type": "string",
-                  "description": "A button which start the execution of the template."
-                },
-                "reviewButtonText": {
-                  "type": "string",
-                  "description": "A button which open the review step to verify the input prior to start the execution."
-                }
-              }
-            },
             "steps": {
               "type": "array",
               "description": "A list of steps to execute.",

--- a/plugins/scaffolder-common/src/Template.v1beta3.schema.json
+++ b/plugins/scaffolder-common/src/Template.v1beta3.schema.json
@@ -139,6 +139,24 @@
                 }
               ]
             },
+            "presentation": {
+              "type": "object",
+              "description": "A way to redefine the labels for actionable buttons.",
+              "properties": {
+                "backButtonText": {
+                  "type": "string",
+                  "description": "A button which return the user to one step back."
+                },
+                "createButtonText": {
+                  "type": "string",
+                  "description": "A button which start the execution of the template."
+                },
+                "reviewButtonText": {
+                  "type": "string",
+                  "description": "A button which open the review step to verify the input prior to start the execution."
+                }
+              }
+            },
             "steps": {
               "type": "array",
               "description": "A list of steps to execute.",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated Template.v1beta3.schema.json which was lacking in  https://github.com/backstage/backstage/pull/20615 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
