### PR TITLE
Events backend module AWS SQS - Fix errors when deleting SQS messages

### DIFF
--- a/.changeset/shaggy-coins-happen.md
+++ b/.changeset/shaggy-coins-happen.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-events-backend-module-aws-sqs': patch
+---
+
+Fix errors when deleting SQS messages:
+
+- If zero messages were received, skip deletion to avoid `EmptyBatchRequest` error from the SQS client.
+- If zero failures were returned from the SQS client during deletion, skip error logging.

--- a/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.ts
@@ -111,7 +111,7 @@ export class AwsSqsConsumingEventPublisher implements EventPublisher {
   }
 
   private async deleteMessages(messages?: Message[]): Promise<void> {
-    if (!messages) {
+    if (!messages || messages.length === 0) {
       return;
     }
 
@@ -129,7 +129,7 @@ export class AwsSqsConsumingEventPublisher implements EventPublisher {
       const result = await this.sqs.send(
         new DeleteMessageBatchCommand(deleteParams),
       );
-      if (result.Failed) {
+      if (result.Failed && result.Failed.length > 0) {
         this.logger.error(
           `Failed to delete ${result.Failed!.length} of ${
             messages.length


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix errors when deleting SQS messages:
- If zero messages were received, skip deletion to avoid `EmptyBatchRequest` error from the SQS client.
- If zero failures were returned from the SQS client during deletion, skip error logging.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Closes #22026 