### PR TITLE
fix(Github): use `x-ratelimit-remaining` and 429 status code for rate limit detection

### DIFF
--- a/.changeset/sweet-ravens-glow.md
+++ b/.changeset/sweet-ravens-glow.md
@@ -1,0 +1,6 @@
+---
+'@backstage/integration': minor
+'@backstage/backend-common': patch
+---
+
+Fix rate limit detection by looking for HTTP status code 429 and updating the header `x-ratelimit-remaining` to look for in case of a 403 code is returned

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -333,7 +333,7 @@ export class GithubUrlReader implements UrlReader {
       // GitHub returns a 403 response with a couple of headers indicating rate
       // limit status. See more in the GitHub docs:
       // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
-      if (this.integration.isRateLimited(response)) {
+      if (this.integration.parseRateLimitInfo(response).isRateLimited) {
         message += ' (rate limit exceeded)';
       }
 

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -568,7 +568,7 @@ export class GithubIntegration implements ScmIntegration {
   // (undocumented)
   static factory: ScmIntegrationsFactory<GithubIntegration>;
   // (undocumented)
-  isRateLimited(response: ConsumedResponse): boolean;
+  parseRateLimitInfo(response: ConsumedResponse): RateLimitInfo;
   // (undocumented)
   resolveEditUrl(url: string): string;
   // (undocumented)
@@ -696,6 +696,12 @@ export type PersonalAccessTokenCredential = AzureCredentialBase & {
   kind: 'PersonalAccessToken';
   personalAccessToken: string;
 };
+
+// @public
+export interface RateLimitInfo {
+  // (undocumented)
+  isRateLimited: boolean;
+}
 
 // @public
 export function readAwsS3IntegrationConfig(

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { Config } from '@backstage/config';
+import { ConsumedResponse } from '@backstage/errors';
 import { RestEndpointMethodTypes } from '@octokit/rest';
 
 // @public
@@ -566,6 +567,8 @@ export class GithubIntegration implements ScmIntegration {
   get config(): GithubIntegrationConfig;
   // (undocumented)
   static factory: ScmIntegrationsFactory<GithubIntegration>;
+  // (undocumented)
+  isRateLimited(response: ConsumedResponse): boolean;
   // (undocumented)
   resolveEditUrl(url: string): string;
   // (undocumented)

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@azure/identity": "^4.0.0",
     "@backstage/config": "workspace:^",
+    "@backstage/errors": "workspace:^",
     "@octokit/auth-app": "^4.0.0",
     "@octokit/rest": "^19.0.3",
     "cross-fetch": "^4.0.0",

--- a/packages/integration/src/github/GithubIntegration.test.ts
+++ b/packages/integration/src/github/GithubIntegration.test.ts
@@ -95,11 +95,13 @@ describe('GithubIntegration', () => {
         const headers = new Headers({
           'x-ratelimit-remaining': ratelimitRemaining,
         });
-        const result = integration.isRateLimited({
+        const result = integration.parseRateLimitInfo({
           status,
           headers,
         } as Response);
-        expect(expected).toBe(result);
+        expect(result).toMatchObject({
+          isRateLimited: expected,
+        });
       },
     );
   });

--- a/packages/integration/src/github/GithubIntegration.ts
+++ b/packages/integration/src/github/GithubIntegration.ts
@@ -20,6 +20,7 @@ import {
   GithubIntegrationConfig,
   readGithubIntegrationConfigs,
 } from './config';
+import { ConsumedResponse } from '@backstage/errors';
 
 /**
  * A GitHub based integration.
@@ -66,7 +67,7 @@ export class GithubIntegration implements ScmIntegration {
     return replaceGithubUrlType(url, 'edit');
   }
 
-  isRateLimited(response: Response): boolean {
+  isRateLimited(response: ConsumedResponse): boolean {
     return (
       response.status === 429 ||
       (response.status === 403 &&

--- a/packages/integration/src/github/GithubIntegration.ts
+++ b/packages/integration/src/github/GithubIntegration.ts
@@ -65,6 +65,14 @@ export class GithubIntegration implements ScmIntegration {
   resolveEditUrl(url: string): string {
     return replaceGithubUrlType(url, 'edit');
   }
+
+  isRateLimited(response: Response): boolean {
+    return (
+      response.status === 429 ||
+      (response.status === 403 &&
+        response.headers.get('x-ratelimit-remaining') === '0')
+    );
+  }
 }
 
 /**

--- a/packages/integration/src/github/GithubIntegration.ts
+++ b/packages/integration/src/github/GithubIntegration.ts
@@ -15,7 +15,11 @@
  */
 
 import { basicIntegrations, defaultScmResolveUrl } from '../helpers';
-import { ScmIntegration, ScmIntegrationsFactory } from '../types';
+import {
+  RateLimitInfo,
+  ScmIntegration,
+  ScmIntegrationsFactory,
+} from '../types';
 import {
   GithubIntegrationConfig,
   readGithubIntegrationConfigs,
@@ -67,12 +71,13 @@ export class GithubIntegration implements ScmIntegration {
     return replaceGithubUrlType(url, 'edit');
   }
 
-  isRateLimited(response: ConsumedResponse): boolean {
-    return (
-      response.status === 429 ||
-      (response.status === 403 &&
-        response.headers.get('x-ratelimit-remaining') === '0')
-    );
+  parseRateLimitInfo(response: ConsumedResponse): RateLimitInfo {
+    return {
+      isRateLimited:
+        response.status === 429 ||
+        (response.status === 403 &&
+          response.headers.get('x-ratelimit-remaining') === '0'),
+    };
   }
 }
 

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -37,5 +37,6 @@ export type {
   ScmIntegration,
   ScmIntegrationsFactory,
   ScmIntegrationsGroup,
+  RateLimitInfo,
 } from './types';
 export type { ScmIntegrationRegistry } from './registry';

--- a/packages/integration/src/types.ts
+++ b/packages/integration/src/types.ts
@@ -108,3 +108,12 @@ export interface ScmIntegrationsGroup<T extends ScmIntegration> {
 export type ScmIntegrationsFactory<T extends ScmIntegration> = (options: {
   config: Config;
 }) => ScmIntegrationsGroup<T>;
+
+/**
+ * Encapsulates information about the RateLimit state
+ *
+ * @public
+ */
+export interface RateLimitInfo {
+  isRateLimited: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4285,6 +4285,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"
+    "@backstage/errors": "workspace:^"
     "@octokit/auth-app": ^4.0.0
     "@octokit/rest": ^19.0.3
     "@types/luxon": ^3.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR contains following changes:
- adds an `isRateLimited` method to GithubIntegration and makes use of it the GithubUrlReader class.
- add rate limiting messages on 429 errors
- update the header key on which the rate limit is expected as this is no longer working https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
