### PR TITLE
fix some resolutions in create-app template

### DIFF
--- a/.changeset/ninety-starfishes-type.md
+++ b/.changeset/ninety-starfishes-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Newly-scaffolded apps will be built using type definitions from React 18, and `swagger-ui-react` will use v18-compatible dependencies.

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -42,8 +42,8 @@
     "typescript": "~5.2.0"
   },
   "resolutions": {
-    "@types/react": "^17",
-    "@types/react-dom": "^17"
+    "@types/react": "^18",
+    "@types/react-dom": "^18"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -43,7 +43,10 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "swagger-ui-react/react": "^18",
+    "swagger-ui-react/react-dom": "^18",
+    "swagger-ui-react/react-redux": "^8"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The point of this is to resolve those annoying 'E2E Linux' checks that have been blocking everybody's PRs (9 of them from my team at the moment lol)!

I'm not confident about the decisions underlying #12252 or the answer to @Pike's question [here](https://github.com/backstage/backstage/issues/22142#issuecomment-1888991931), but I wanted to see this PR run through the CI checks and hopefully prompt some discussion about what kinds of resolutions are suitable for these templates. Each commit contains a bit of justification, but summarized here:
* I used the react 18 type definitions, which seemed to work around mui/material-ui#40427 and fix `yarn tsc:full` on a fresh app
* I added some `swagger-ui-react`-specific resolutions following the advice in [their wiki](https://github.com/swagger-api/swagger-ui/wiki/Using-older-version-of-React); this is an option to resolve #22142

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~ N/A
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~ no UI
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
