### PR TITLE
collectLegacyRoutes throws error in case invalid element is found

### DIFF
--- a/.changeset/wet-emus-work.md
+++ b/.changeset/wet-emus-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+collectLegacyRoutes throws in case invalid <Route /> element is found

--- a/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
@@ -289,8 +289,7 @@ describe('collectLegacyRoutes', () => {
       createRoutableExtension({
         name: 'Test',
         mountPoint: routeRef,
-        component: () =>
-          Promise.resolve(() => {
+        component: async () => () => {
             const app = useApp();
             return <div>plugins: {app.getPlugins().map(p => p.getId())}</div>;
           }),

--- a/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
@@ -279,4 +279,58 @@ describe('collectLegacyRoutes', () => {
       screen.findByText('plugins: test'),
     ).resolves.toBeInTheDocument();
   });
+
+  it('should throw if invalid Route has been detected', async () => {
+    const plugin = createPlugin({
+      id: 'test',
+    });
+    const routeRef = createRouteRef({ id: 'test' });
+    const Page = plugin.provide(
+      createRoutableExtension({
+        name: 'Test',
+        mountPoint: routeRef,
+        component: () =>
+          Promise.resolve(() => {
+            const app = useApp();
+            return <div>plugins: {app.getPlugins().map(p => p.getId())}</div>;
+          }),
+      }),
+    );
+
+    expect(() =>
+      collectLegacyRoutes(
+        <FlatRoutes>
+          <Route path="/" element={<Page />} />
+          <Route path="/" element={<Page />} />
+          <div />
+        </FlatRoutes>,
+      ),
+    ).toThrow(/Invalid <Route/);
+  });
+
+  it('should throw if <Route /> has no path', async () => {
+    const plugin = createPlugin({
+      id: 'test',
+    });
+    const routeRef = createRouteRef({ id: 'test' });
+    const Page = plugin.provide(
+      createRoutableExtension({
+        name: 'Test',
+        mountPoint: routeRef,
+        component: () =>
+          Promise.resolve(() => {
+            const app = useApp();
+            return <div>plugins: {app.getPlugins().map(p => p.getId())}</div>;
+          }),
+      }),
+    );
+
+    expect(() =>
+      collectLegacyRoutes(
+        <FlatRoutes>
+          <Route element={<Page />} />
+        </FlatRoutes>,
+      ),
+    ).toThrow(/<Route \/> element with invalid path/);
+  });
 });

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -194,7 +194,8 @@ export function collectLegacyRoutes(
       );
       if (!plugin) {
         throw new Error(
-          `Route with path ${path} has en element that can not be converted as it does not belong to a plugin. Make sure that the top-level React element of the element prop is an extension from a Backstage plugin, or remove the Route completely. See <link-to-app-migration-docs> for more info`,
+          // TODO(vinzscam): add See <link-to-app-migration-docs> for more info
+          `Route with path ${path} has en element that can not be converted as it does not belong to a plugin. Make sure that the top-level React element of the element prop is an extension from a Backstage plugin, or remove the Route completely.`,
         );
       }
       if (path === undefined) {

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -173,9 +173,8 @@ export function collectLegacyRoutes(
     (route: ReactNode) => {
       // TODO(freben): Handle feature flag and permissions framework wrapper elements
       if (!React.isValidElement(route) || route.type !== Route) {
-        return;
+        throw new Error('Invalid <Route /> element has been detected.');
       }
-
       const routeElement = route.props.element;
       const path: string | undefined = route.props.path;
       const plugin = getComponentData<LegacyBackstagePlugin>(
@@ -186,7 +185,12 @@ export function collectLegacyRoutes(
         routeElement,
         'core.mountPoint',
       );
-      if (!plugin || !path) {
+      if (path === undefined) {
+        throw new Error(
+          `<Route /> element with invalid path has been detected. Please make sure to pass the path's props`,
+        );
+      }
+      if (!plugin) {
         return;
       }
 

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -172,8 +172,15 @@ export function collectLegacyRoutes(
     flatRoutesElement.props.children,
     (route: ReactNode) => {
       // TODO(freben): Handle feature flag and permissions framework wrapper elements
-      if (!React.isValidElement(route) || route.type !== Route) {
-        throw new Error(`Invalid element inside FlatRoutes, expected Route but found ${route.type}.`);
+      if (!React.isValidElement(route)) {
+        throw new Error(
+          `Invalid element inside FlatRoutes, expected Route but found element of type ${typeof route}.`,
+        );
+      }
+      if (route.type !== Route) {
+        throw new Error(
+          `Invalid element inside FlatRoutes, expected Route but found ${route.type}.`,
+        );
       }
       const routeElement = route.props.element;
       const path: string | undefined = route.props.path;
@@ -185,13 +192,15 @@ export function collectLegacyRoutes(
         routeElement,
         'core.mountPoint',
       );
+      if (!plugin) {
+        throw new Error(
+          `Route with path ${path} has en element that can not be converted as it does not belong to a plugin. Make sure that the top-level React element of the element prop is an extension from a Backstage plugin, or remove the Route completely. See <link-to-app-migration-docs> for more info`,
+        );
+      }
       if (path === undefined) {
         throw new Error(
           `Route element inside FlatRoutes had no path prop value given`,
         );
-      }
-      if (!plugin) {
-        return;
       }
 
       const extensions = getPluginExtensions(plugin);

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -173,7 +173,7 @@ export function collectLegacyRoutes(
     (route: ReactNode) => {
       // TODO(freben): Handle feature flag and permissions framework wrapper elements
       if (!React.isValidElement(route) || route.type !== Route) {
-        throw new Error('Invalid <Route /> element has been detected.');
+        throw new Error(`Invalid element inside FlatRoutes, expected Route but found ${route.type}.`);
       }
       const routeElement = route.props.element;
       const path: string | undefined = route.props.path;
@@ -187,7 +187,7 @@ export function collectLegacyRoutes(
       );
       if (path === undefined) {
         throw new Error(
-          `<Route /> element with invalid path has been detected. Please make sure to pass the path's props`,
+          `Route element inside FlatRoutes had no path prop value given`,
         );
       }
       if (!plugin) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`collectLegacyRoutes` throws error in case an invalid `<Route />` element is found or `<Route />` doesn't contain `path`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
