### PR TITLE
Multistage docker build with baseUrl as build arg

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -96,6 +96,14 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
+# If you want to configure the baseUrl using an environment variable in your app-config.yaml
+# # app-config.yaml
+# app:
+#   baseUrl: ${BASE_URL}
+
+# You may set the BASE_URL argument to provide the value, and pass it as -build-arg on docker build
+# ARG BASE_URL
+
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]
 ```
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -203,7 +203,7 @@ COPY --chown=node:node . .
 
 # Passing the baseUrl in your app-config.yaml app.baseUrl: ${BASE_URL}
 # Uncomment to activate the argument and then execute:
-# docker build --build-arg="BASE_URL=https://<your-url>"
+# docker build --build-arg="BASE_URL=https://<your-url>" .
 # ARG BASE_URL
 
 RUN yarn tsc

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -201,7 +201,6 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
 
 COPY --chown=node:node . .
 
-
 # Passing the baseUrl in your app-config.yaml app.baseUrl: ${BASE_URL}
 # Uncomment to activate the argument and then execute:
 # docker build --build-arg="BASE_URL=https://backstage.example.com"

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -96,14 +96,6 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
 COPY --chown=node:node packages/backend/dist/bundle.tar.gz app-config*.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
-# If you want to configure the baseUrl using an environment variable in your app-config.yaml
-# # app-config.yaml
-# app:
-#   baseUrl: ${BASE_URL}
-
-# You may set the BASE_URL argument to provide the value, and pass it as -build-arg on docker build
-# ARG BASE_URL
-
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]
 ```
 
@@ -208,6 +200,13 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
     yarn install --frozen-lockfile --network-timeout 600000
 
 COPY --chown=node:node . .
+
+# If you want to configure the baseUrl using an environment variable in your app-config.yaml
+# # app-config.yaml
+# app:
+#   baseUrl: ${BASE_URL}
+# You may set the BASE_URL argument to provide the value, and pass it as -build-arg on docker build
+# ARG BASE_URL
 
 RUN yarn tsc
 RUN yarn --cwd packages/backend build

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -201,11 +201,10 @@ RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid
 
 COPY --chown=node:node . .
 
-# If you want to configure the baseUrl using an environment variable in your app-config.yaml
-# # app-config.yaml
-# app:
-#   baseUrl: ${BASE_URL}
-# You may set the BASE_URL argument to provide the value, and pass it as -build-arg on docker build
+
+# Passing the baseUrl in your app-config.yaml app.baseUrl: ${BASE_URL}
+# Uncomment to activate the argument and then execute:
+# docker build --build-arg="BASE_URL=https://backstage.example.com"
 # ARG BASE_URL
 
 RUN yarn tsc

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -203,7 +203,7 @@ COPY --chown=node:node . .
 
 # Passing the baseUrl in your app-config.yaml app.baseUrl: ${BASE_URL}
 # Uncomment to activate the argument and then execute:
-# docker build --build-arg="BASE_URL=https://backstage.example.com"
+# docker build --build-arg="BASE_URL=https://<your-url>"
 # ARG BASE_URL
 
 RUN yarn tsc


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When aiming to construct a multistage Dockerfile capable of accommodating various base URLs—for instance, deploying to dev.example.io, pre.example.io, and pro.example.io—I prefer to avoid the creation of multiple app-config.yaml files. Instead, I envision using a single app-config.yaml file while parameterizing the baseUrl. This way, by introducing an ARG in the Dockerfile, we can achieve the desired flexibility.

In the updated Dockerfile, I've thoughtfully included comments to guide the user on how to leverage this approach when building the image. This enhancement ensures a streamlined process for deploying the application across different environments without the need for duplicating configuration files.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
