### PR TITLE
CI: Include cluster name in initial "deploying" comment.

### DIFF
--- a/.github/workflows/uffizzi-preview.yaml
+++ b/.github/workflows/uffizzi-preview.yaml
@@ -124,7 +124,7 @@ jobs:
           body: |
             ## Uffizzi Ephemeral Environment - Virtual Cluster
 
-            :cloud: deploying ...
+            :cloud: deploying cluster `pr-${{ needs.cache-manifests-file.outputs.pr-number }}`
 
             :gear: Updating now by workflow run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 


### PR DESCRIPTION
This ensures the initial comment is discovered by the `find-comment` step. See line `114`. 

This should prevent duplicate comments if the deployment fails, as seen in this PR https://github.com/backstage/backstage/pull/22260#issuecomment-1896258320