### PR TITLE
New root-scoped `RootFeatureRegistryService`.

### DIFF
--- a/.changeset/brave-timers-wonder.md
+++ b/.changeset/brave-timers-wonder.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-plugin-api': minor
+'@backstage/backend-defaults': minor
+'@backstage/backend-app-api': minor
+---
+
+New root-scoped `FeatureRegistryService` that allows getting the list of all the registered features in the backend application.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -30,6 +30,7 @@ import { RemoteConfigSourceOptions } from '@backstage/config-loader';
 import { RequestHandler } from 'express';
 import { RequestListener } from 'http';
 import { RootConfigService } from '@backstage/backend-plugin-api';
+import { RootFeatureRegistryService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { RootLoggerService } from '@backstage/backend-plugin-api';
@@ -265,6 +266,12 @@ export interface RootConfigFactoryOptions {
 export const rootConfigServiceFactory: (
   options?: RootConfigFactoryOptions | undefined,
 ) => ServiceFactory<RootConfigService, 'root'>;
+
+// @public (undocumented)
+export const rootFeatureRegistryServiceFactory: () => ServiceFactory<
+  RootFeatureRegistryService,
+  'root'
+>;
 
 // @public (undocumented)
 export interface RootHttpRouterConfigureContext {

--- a/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/DefaultRootFeatureRegistry.ts
+++ b/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/DefaultRootFeatureRegistry.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackendFeatureRegistration,
+  RootFeatureRegistryService,
+  RootFeatureRegistryServiceImplementation,
+} from '@backstage/backend-plugin-api';
+
+/**
+ * The default implementation of the {@link @backstage/backend-plugin-api#RootFeatureRegistryService} interface for
+ * {@link @backstage/backend-plugin-api#coreServices.rootFeatureRegistry}.
+ *
+ */
+export class DefaultRootFeatureRegistryService
+  extends RootFeatureRegistryServiceImplementation
+  implements RootFeatureRegistryService
+{
+  #features: BackendFeatureRegistration[] = [];
+
+  setFeatures(features: BackendFeatureRegistration[]): void {
+    this.#features = features;
+  }
+
+  getFeatures(): BackendFeatureRegistration[] {
+    return this.#features;
+  }
+}

--- a/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/DefaultRootFeatureRegistry.ts
+++ b/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/DefaultRootFeatureRegistry.ts
@@ -35,7 +35,7 @@ export class DefaultRootFeatureRegistryService
     this.#features = features;
   }
 
-  getFeatures(): BackendFeatureRegistration[] {
+  async getFeatures(): Promise<BackendFeatureRegistration[]> {
     return this.#features;
   }
 }

--- a/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/index.ts
+++ b/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,4 @@
  * limitations under the License.
  */
 
-export * from './cache';
-export * from './config';
-export * from './database';
-export * from './discovery';
-export * from './httpRouter';
-export * from './identity';
-export * from './lifecycle';
-export * from './logger';
-export * from './permissions';
-export * from './rootHttpRouter';
-export * from './rootLifecycle';
-export * from './rootLogger';
-export * from './scheduler';
-export * from './tokenManager';
-export * from './urlReader';
-export * from './rootFeatureRegistry';
+export { rootFeatureRegistryServiceFactory } from './rootFeatureRegistryServiceFactory';

--- a/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/rootFeatureRegistryServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/rootFeatureRegistry/rootFeatureRegistryServiceFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-export * from './cache';
-export * from './config';
-export * from './database';
-export * from './discovery';
-export * from './httpRouter';
-export * from './identity';
-export * from './lifecycle';
-export * from './logger';
-export * from './permissions';
-export * from './rootHttpRouter';
-export * from './rootLifecycle';
-export * from './rootLogger';
-export * from './scheduler';
-export * from './tokenManager';
-export * from './urlReader';
-export * from './rootFeatureRegistry';
+import {
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { DefaultRootFeatureRegistryService } from './DefaultRootFeatureRegistry';
+
+/** @public */
+export const rootFeatureRegistryServiceFactory = createServiceFactory({
+  service: coreServices.rootFeatureRegistry,
+  deps: {},
+  async factory() {
+    return new DefaultRootFeatureRegistryService();
+  },
+});

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -32,6 +32,7 @@ import {
   tokenManagerServiceFactory,
   urlReaderServiceFactory,
   identityServiceFactory,
+  rootFeatureRegistryServiceFactory,
 } from '@backstage/backend-app-api';
 
 export const defaultServiceFactories = [
@@ -50,6 +51,7 @@ export const defaultServiceFactories = [
   schedulerServiceFactory(),
   tokenManagerServiceFactory(),
   urlReaderServiceFactory(),
+  rootFeatureRegistryServiceFactory(),
 ];
 
 /**

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -383,7 +383,7 @@ export interface RootConfigService extends Config {}
 // @public
 export interface RootFeatureRegistryService {
   // (undocumented)
-  getFeatures(): BackendFeatureRegistration[];
+  getFeatures(): Promise<BackendFeatureRegistration[]>;
 }
 
 // @public

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -21,12 +21,27 @@ export interface BackendFeature {
   $$type: '@backstage/BackendFeature';
 }
 
+// @public (undocumented)
+export type BackendFeatureRegistration =
+  | BackendPluginRegistration
+  | BackendModuleRegistration;
+
 // @public
 export interface BackendModuleConfig {
   moduleId: string;
   pluginId: string;
   // (undocumented)
   register(reg: BackendModuleRegistrationPoints): void;
+}
+
+// @public (undocumented)
+export interface BackendModuleRegistration {
+  // (undocumented)
+  moduleId: string;
+  // (undocumented)
+  pluginId: string;
+  // (undocumented)
+  type: 'module';
 }
 
 // @public
@@ -54,6 +69,14 @@ export interface BackendPluginConfig {
   pluginId: string;
   // (undocumented)
   register(reg: BackendPluginRegistrationPoints): void;
+}
+
+// @public (undocumented)
+export interface BackendPluginRegistration {
+  // (undocumented)
+  pluginId: string;
+  // (undocumented)
+  type: 'plugin';
 }
 
 // @public
@@ -116,6 +139,7 @@ export namespace coreServices {
   const tokenManager: ServiceRef<TokenManagerService, 'plugin'>;
   const urlReader: ServiceRef<UrlReaderService, 'plugin'>;
   const identity: ServiceRef<IdentityService, 'plugin'>;
+  const rootFeatureRegistry: ServiceRef<RootFeatureRegistryService, 'root'>;
 }
 
 // @public
@@ -355,6 +379,18 @@ export type ReadUrlResponse = {
 
 // @public (undocumented)
 export interface RootConfigService extends Config {}
+
+// @public
+export interface RootFeatureRegistryService {
+  // (undocumented)
+  getFeatures(): BackendFeatureRegistration[];
+}
+
+// @public
+export abstract class RootFeatureRegistryServiceImplementation {
+  // (undocumented)
+  abstract setFeatures(features: BackendFeatureRegistration[]): void;
+}
 
 // @public (undocumented)
 export interface RootHttpRouterService {

--- a/packages/backend-plugin-api/src/index.ts
+++ b/packages/backend-plugin-api/src/index.ts
@@ -21,5 +21,10 @@
  */
 
 export * from './services';
-export type { BackendFeature } from './types';
+export type {
+  BackendFeature,
+  BackendFeatureRegistration,
+  BackendPluginRegistration,
+  BackendModuleRegistration,
+} from './types';
 export * from './wiring';

--- a/packages/backend-plugin-api/src/services/definitions/RootFeatureRegistryService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootFeatureRegistryService.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackendFeatureRegistration } from '../../types';
+
+/**
+ * The RootFeatureRegistryService is a root-scoped service used to provide a mechanism for backend
+ * plugins to discover the list of backend features registered in the application.
+ *
+ * Implementations of the registry API can be as simple as gathering the list of registered features
+ * at application initialization, but could also query a separate service.
+ *
+ * @public
+ */
+export interface RootFeatureRegistryService {
+  getFeatures(): BackendFeatureRegistration[];
+}
+
+/**
+ * The RootFeatureRegistryServiceImplementation is an abstract class that a RootFeatureRegistryService
+ * would extend, so that it can be fed with the list of registered features during
+ * application initialization.
+ *
+ * @public
+ */
+export abstract class RootFeatureRegistryServiceImplementation {
+  abstract setFeatures(features: BackendFeatureRegistration[]): void;
+}

--- a/packages/backend-plugin-api/src/services/definitions/RootFeatureRegistryService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootFeatureRegistryService.ts
@@ -26,7 +26,7 @@ import { BackendFeatureRegistration } from '../../types';
  * @public
  */
 export interface RootFeatureRegistryService {
-  getFeatures(): BackendFeatureRegistration[];
+  getFeatures(): Promise<BackendFeatureRegistration[]>;
 }
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -165,4 +165,13 @@ export namespace coreServices {
   export const identity = createServiceRef<
     import('./IdentityService').IdentityService
   >({ id: 'core.identity' });
+
+  /**
+   * The service reference for the root scoped {@link RootFeatureRegistryService}.
+   *
+   * @public
+   */
+  export const rootFeatureRegistry = createServiceRef<
+    import('./RootFeatureRegistryService').RootFeatureRegistryService
+  >({ id: 'core.featureRegistry', scope: 'root' });
 }

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -52,3 +52,5 @@ export type {
   UrlReaderService,
 } from './UrlReaderService';
 export type { IdentityService } from './IdentityService';
+export type { RootFeatureRegistryService } from './RootFeatureRegistryService';
+export { RootFeatureRegistryServiceImplementation } from './RootFeatureRegistryService';

--- a/packages/backend-plugin-api/src/types.ts
+++ b/packages/backend-plugin-api/src/types.ts
@@ -27,3 +27,21 @@ export interface BackendFeature {
   // NOTE: This type is opaque in order to simplify future API evolution.
   $$type: '@backstage/BackendFeature';
 }
+
+/** @public */
+export type BackendFeatureRegistration =
+  | BackendPluginRegistration
+  | BackendModuleRegistration;
+
+/** @public */
+export interface BackendPluginRegistration {
+  pluginId: string;
+  type: 'plugin';
+}
+
+/** @public */
+export interface BackendModuleRegistration {
+  pluginId: string;
+  moduleId: string;
+  type: 'module';
+}

--- a/packages/backend-plugin-api/src/wiring/types.ts
+++ b/packages/backend-plugin-api/src/wiring/types.ts
@@ -15,7 +15,11 @@
  */
 
 import { ServiceRef } from '../services/system/types';
-import { BackendFeature } from '../types';
+import {
+  BackendFeature,
+  BackendModuleRegistration,
+  BackendPluginRegistration,
+} from '../types';
 
 /**
  * TODO
@@ -81,7 +85,8 @@ export interface InternalBackendFeature extends BackendFeature {
 }
 
 /** @internal */
-export interface InternalBackendPluginRegistration {
+export interface InternalBackendPluginRegistration
+  extends BackendPluginRegistration {
   pluginId: string;
   type: 'plugin';
   extensionPoints: Array<readonly [ExtensionPoint<unknown>, unknown]>;
@@ -92,7 +97,8 @@ export interface InternalBackendPluginRegistration {
 }
 
 /** @internal */
-export interface InternalBackendModuleRegistration {
+export interface InternalBackendModuleRegistration
+  extends BackendModuleRegistration {
   pluginId: string;
   moduleId: string;
   type: 'module';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR introduces a new root-scoped `RootFeatureRegistryService` that allows getting the list of all the registered features (plugin or module) in the backend application.

A default service implementation is provided  (which simply gathers the list of all features added in the local backstage application). But it can be overridden by another implementation that would use some other mechanism to support distributed backends (as the discovery service already needs to be overridden in such cases).

This PR tries to implement task 1 of RFC [17538](https://github.com/backstage/backstage/issues/17538

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
