### PR TITLE
TextSize - fix value label text color

### DIFF
--- a/.changeset/fresh-gifts-smile.md
+++ b/.changeset/fresh-gifts-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': major
+---
+
+textsize-fix value label text color

--- a/.changeset/fresh-gifts-smile.md
+++ b/.changeset/fresh-gifts-smile.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs-module-addons-contrib': major
+'@backstage/plugin-techdocs-module-addons-contrib': patch
 ---
 
 textsize-fix value label text color

--- a/.changeset/fresh-gifts-smile.md
+++ b/.changeset/fresh-gifts-smile.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-module-addons-contrib': patch
 ---
 
-textsize-fix value label text color
+Fixed the value label text color in dark mode for the TextSize addon.

--- a/plugins/techdocs-module-addons-contrib/src/TextSize/TextSize.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/TextSize/TextSize.tsx
@@ -70,7 +70,7 @@ const StyledSlider = withStyles(theme => ({
     left: '50%',
     transform: 'scale(1) translate(-50%, -5px) !important',
     '& *': {
-      color: theme.palette.common.black,
+      color: theme.palette.textSubtle,
       fontSize: theme.typography.caption.fontSize,
       background: 'transparent',
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!


This PR corrects the color of the value text, to improve its visualization when we are using dark mode

before
![Captura de Tela 2024-01-18 às 15 11 06](https://github.com/backstage/backstage/assets/90638175/06e687dd-9472-4ad6-8aff-f5b6d24df5f6)


after
![Captura de Tela 2024-01-18 às 15 18 30](https://github.com/backstage/backstage/assets/90638175/29dc77bd-7beb-461d-9044-7ff49accf100)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
