### PR TITLE
.github/workflows: switch to 4 Jest workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         run: yarn backstage-cli repo lint --since origin/master
 
       - name: test changed packages
-        run: yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=1300M --since origin/master
+        run: yarn backstage-cli repo test --maxWorkers=4 --workerIdleMemoryLimit=1300M --since origin/master
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES16_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres16.ports[5432] }}

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: test (and upload coverage)
         run: |
-          yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=1300M --coverage
+          yarn backstage-cli repo test --maxWorkers=4 --workerIdleMemoryLimit=1300M --coverage
           bash <(curl -s https://codecov.io/bash)
           # Upload code coverage for some specific flags. Also see .codecov.yml
           bash <(curl -s https://codecov.io/bash) -f packages/core-app-api/coverage/* -F core-app-api

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn lint:type-deps
 
       - name: test
-        run: yarn backstage-cli repo test --maxWorkers=2 --workerIdleMemoryLimit=1300M
+        run: yarn backstage-cli repo test --maxWorkers=4 --workerIdleMemoryLimit=1300M
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
 


### PR DESCRIPTION
https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/ 🎉 

<img width="491" alt="image" src="https://github.com/backstage/backstage/assets/4984472/010d9350-fd56-4224-acf5-e71d0d24e7d9">
