### PR TITLE
feat: allow defining the default text output in template

### DIFF
--- a/.changeset/forty-cars-scream.md
+++ b/.changeset/forty-cars-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Allow defining default output text to be shown

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -277,6 +277,7 @@ export type ScaffolderOutputText = {
   title?: string;
   icon?: string;
   content?: string;
+  default?: boolean;
 };
 
 // @public

--- a/plugins/scaffolder-react/src/api/types.ts
+++ b/plugins/scaffolder-react/src/api/types.ts
@@ -89,6 +89,7 @@ export type ScaffolderOutputText = {
   title?: string;
   icon?: string;
   content?: string;
+  default?: boolean;
 };
 
 /** @public */

--- a/plugins/scaffolder-react/src/next/components/TemplateOutputs/DefaultTemplateOutputs.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateOutputs/DefaultTemplateOutputs.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 import { InfoCard, MarkdownContent } from '@backstage/core-components';
-import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';
+import {
+  ScaffolderOutputText,
+  ScaffolderTaskOutput,
+} from '@backstage/plugin-scaffolder-react';
 import { Box, Paper } from '@material-ui/core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { LinkOutputs } from './LinkOutputs';
 import { TextOutputs } from './TextOutputs';
 
@@ -30,8 +33,17 @@ export const DefaultTemplateOutputs = (props: {
 }) => {
   const { output } = props;
   const [textOutputIndex, setTextOutputIndex] = useState<number | undefined>(
-    output?.text?.length ? 0 : undefined,
+    undefined,
   );
+
+  useEffect(() => {
+    if (textOutputIndex === undefined && output?.text) {
+      const defaultIndex = output.text.findIndex(
+        (t: ScaffolderOutputText) => t.default,
+      );
+      setTextOutputIndex(defaultIndex >= 0 ? defaultIndex : 0);
+    }
+  }, [textOutputIndex, output]);
 
   const textOutput = useMemo(
     () =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The previous #22243 did not even work as the output.text is not defined when mounting the component. but this fixes that and also allows to define the default output text for scaffolder template.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
