### PR TITLE
chore: automatically label Kubernetes + auth PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,9 @@ area:discoverability: # search + home
   - plugins/search-*/**/*
   - packages/search-*/**/*
   - plugins/home/**/*
+area:kubernetes:
+  - plugins/kubernetes/**/*
+  - plugins/kubernetes-*/**/*
 area:permission:
   - plugins/permission-*/**/*
 area:scaffolder:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,34 +2,34 @@ area:catalog:
   - plugins/catalog/**/*
   - plugins/catalog-*/**/*
   - packages/catalog-*/**/*
-area:scaffolder:
-  - plugins/scaffolder/**/*
-  - plugins/scaffolder-*/**/*
-search:
-  - plugins/search/**/*
-  - plugins/search-*/**/*
-  - packages/search-*/**/*
-homepage:
-  - plugins/home/**/*
 area:discoverability: # search + home
   - plugins/search/**/*
   - plugins/search-*/**/*
   - packages/search-*/**/*
   - plugins/home/**/*
+area:permission:
+  - plugins/permission-*/**/*
+area:scaffolder:
+  - plugins/scaffolder/**/*
+  - plugins/scaffolder-*/**/*
 area:techdocs:
   - plugins/techdocs/**/*
   - plugins/techdocs-*/**/*
   - packages/techdocs-*/**/*
-documentation:
-  - docs/**/*
-microsite:
-  - microsite/**/*
-storybook:
-  - storybook/**/*
 auth:
   - plugins/auth-backend/**/*
   - packages/core-app-api/src/apis/implementations/auth/**/*
   - packages/core-app-api/src/lib/Auth*/**/*
   - packages/core-plugin-api/src/apis/definitions/auth.ts
-area:permission:
-  - plugins/permission-*/**/*
+documentation:
+  - docs/**/*
+homepage:
+  - plugins/home/**/*
+microsite:
+  - microsite/**/*
+search:
+  - plugins/search/**/*
+  - plugins/search-*/**/*
+  - packages/search-*/**/*
+storybook:
+  - storybook/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,7 +20,7 @@ area:techdocs:
   - plugins/techdocs-*/**/*
   - packages/techdocs-*/**/*
 auth:
-  - plugins/auth-backend/**/*
+  - plugins/auth-*/**/*
   - packages/core-app-api/src/apis/implementations/auth/**/*
   - packages/core-app-api/src/lib/Auth*/**/*
   - packages/core-plugin-api/src/apis/definitions/auth.ts


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a bit more clear when reviewed commit-by-commit, but summarized here: I also sorted the labeler config file and updated the config to accommodate the new auth packages introduced pursuant to #19476.

#### :heavy_check_mark: Checklist

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~ project automation only
- [ ] ~Added or updated documentation~ project automation only
- [ ] ~Tests for new functionality and regression tests for bug fixes~ project automation only
- [ ] ~Screenshots attached (for UI changes)~ project automation only
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
