### PR TITLE
improve `resolveInputData` error messaging

### DIFF
--- a/.changeset/silent-poets-grab.md
+++ b/.changeset/silent-poets-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Improved the error message when data input/output shapes do not match

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -615,8 +615,8 @@ describe('createAppNodeInstance', () => {
           ),
         ),
       }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test', input 'singleton' did not receive required extension data 'other' from extension 'app/test'",
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Failed to instantiate extension 'app/test', extension 'app/test' could not be attached because its output data ('test', 'other') does not match what the input 'singleton' requires ('other')"`,
     );
   });
 });

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -37,8 +37,17 @@ function resolveInputData(
   return mapValues(dataMap, ref => {
     const value = attachment.instance?.getData(ref);
     if (value === undefined && !ref.config.optional) {
+      const expected = Object.values(dataMap)
+        .filter(r => !r.config.optional)
+        .map(r => `'${r.id}'`)
+        .join(', ');
+
+      const provided = [...(attachment.instance?.getDataRefs() ?? [])]
+        .map(r => `'${r.id}'`)
+        .join(', ');
+
       throw new Error(
-        `input '${inputName}' did not receive required extension data '${ref.id}' from extension '${attachment.spec.id}'`,
+        `extension '${attachment.spec.id}' could not be attached because its output data (${provided}) does not match what the input '${inputName}' requires (${expected})`,
       );
     }
     return value;

--- a/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
@@ -63,8 +63,8 @@ describe('createExtensionTester', () => {
       factory: () => ({ path: '/foo' }),
     });
     const tester = createExtensionTester(extension);
-    expect(() => tester.render()).toThrow(
-      "Failed to instantiate extension 'app/routes', input 'routes' did not receive required extension data 'core.reactElement' from extension 'test'",
+    expect(() => tester.render()).toThrowErrorMatchingInlineSnapshot(
+      `"Failed to instantiate extension 'app/routes', extension 'test' could not be attached because its output data ('core.routing.path') does not match what the input 'routes' requires ('core.routing.path', 'core.reactElement')"`,
     );
   });
 


### PR DESCRIPTION
Example:

<img width="802" alt="Screenshot 2024-01-20 at 10 51 06" src="https://github.com/backstage/backstage/assets/3097461/f96ae594-aa1e-4b4e-8662-afd69aa15f9c">

Arguably, this should really not be a hard error. But improving this message, whether it's thrown or logged, still felt worthwhile. We can clean up how errors are reported in a separate PR.