### PR TITLE
Removed alpha symbol from Task List header

### DIFF
--- a/.changeset/lovely-starfishes-remain.md
+++ b/.changeset/lovely-starfishes-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Removed alpha symbol from Task List header

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -18,7 +18,6 @@ import {
   EmptyState,
   ErrorPanel,
   Header,
-  Lifecycle,
   Link,
   Page,
   Progress,
@@ -139,11 +138,7 @@ export const ListTasksPage = (props: MyTaskPageProps) => {
     <Page themeId="home">
       <Header
         pageTitleOverride="Templates Tasks"
-        title={
-          <>
-            List template tasks <Lifecycle shorthand alpha />
-          </>
-        }
+        title={<>List template tasks</>}
         subtitle="All tasks that have been started"
       />
       <Content>

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -138,7 +138,7 @@ export const ListTasksPage = (props: MyTaskPageProps) => {
     <Page themeId="home">
       <Header
         pageTitleOverride="Templates Tasks"
-        title={<>List template tasks</>}
+        title="List template tasks"
         subtitle="All tasks that have been started"
       />
       <Content>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed alpha symbol from Task List header

|  Before | After  |  
|---|---|
|  ![Screenshot 2024-01-20 at 10 28 45 AM](https://github.com/backstage/backstage/assets/67169551/12b87b39-94e9-4fca-9eb7-878e02c5b13d) |  ![Screenshot 2024-01-20 at 10 29 03 AM](https://github.com/backstage/backstage/assets/67169551/dd61c01a-55a2-429e-972b-1786dae6d216) |  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
