### PR TITLE
Update plugin-development.md

### DIFF
--- a/docs/plugins/plugin-development.md
+++ b/docs/plugins/plugin-development.md
@@ -40,7 +40,7 @@ import { createRouteRef } from '@backstage/core-plugin-api';
 
 // Note: This route ref is for internal use only, don't export it from the plugin
 export const rootRouteRef = createRouteRef({
-  title: 'Example Page',
+  id: 'Example Page',
 });
 ```
 


### PR DESCRIPTION
It looks like `createRouteRef` no longer has a "title" key.

<img width="786" alt="Screenshot 2024-01-22 at 10 12 47 AM" src="https://github.com/backstage/backstage/assets/3578908/36a872c4-1026-4bc9-a867-8232dc3b9b81">

