### PR TITLE
Update extractPartsFromAsset function in azure-devops-backend to handle paths beginning with ".".

### DIFF
--- a/.changeset/giant-suits-switch.md
+++ b/.changeset/giant-suits-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Fixed bug with extractPartsFromAsset that resulted in a leading "." being removed from the path in an otherwise valid path (ex. ".assets/image.png"). The leading "." will now only be moved for paths beginning with "./".

--- a/.changeset/giant-suits-switch.md
+++ b/.changeset/giant-suits-switch.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-azure-devops-backend': patch
 ---
 
-Fixed bug with `extractPartsFromAsset` (used by the README card feature) that resulted in a leading "." being removed from the path in an otherwise valid path (ex. ".assets/image.png"). The leading "." will now only be moved for paths beginning with "./".
+Fixed bug with `extractPartsFromAsset` that resulted in a leading `.` being removed from the path in an otherwise valid path (ex. `.assets/image.png`). The leading `.` will now only be moved for paths beginning with `./`.

--- a/.changeset/giant-suits-switch.md
+++ b/.changeset/giant-suits-switch.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-azure-devops-backend': patch
 ---
 
-Fixed bug with extractPartsFromAsset that resulted in a leading "." being removed from the path in an otherwise valid path (ex. ".assets/image.png"). The leading "." will now only be moved for paths beginning with "./".
+Fixed bug with `extractPartsFromAsset` (used by the README card feature) that resulted in a leading "." being removed from the path in an otherwise valid path (ex. ".assets/image.png"). The leading "." will now only be moved for paths beginning with "./".

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.test.ts
@@ -235,6 +235,15 @@ describe('extractPartsFromAsset', () => {
       ext: '.gif',
     });
   });
+
+  it('should return parts from asset with leading . without /', () => {
+    const result = extractPartsFromAsset('[Image 1](.images/sample-1.PNG)');
+    expect(result).toEqual({
+      label: 'Image 1',
+      path: '.images/sample-1',
+      ext: '.PNG',
+    });
+  });
 });
 
 describe('replaceReadme', () => {

--- a/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
+++ b/plugins/azure-devops-backend/src/utils/azure-devops-utils.ts
@@ -325,7 +325,7 @@ export function extractPartsFromAsset(content: string): {
   return {
     ext,
     label,
-    path: path.startsWith('.') ? path.substring(1, path.length) : path,
+    path: path.startsWith('./') ? path.substring(1, path.length) : path,
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The "extractPartsFromAsset" function in the "azure-devops-backend" plugin extracts information (label, path, extension) from a string (a file path). As a part of this parsing/extraction, the path resulting from a regex is checked to determine if the path beings with a "." or not. If the path began with a ".", the "." was dropped from the path. This would handle scenarios with a path such as "./images/image-1.png". The unintended consequence of this logic was that a valid path such as ".assets/image-1.png" would have the "." dropped resulting in an incorrect path ("assets/image-1.png"). This PR resolves this issue by only dropping the "." if the path begins with "./".

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
