### PR TITLE
chore(Renovate): improve security posture of setup and other general improvements

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,8 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
 
   labels: ['dependencies'],
-  extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
+  extends: ['config:recommended', ':gitSignOff'],
+
   postUpdateOptions: ['yarnDedupeHighest'],
   rangeStrategy: 'update-lockfile',
   // @elastic/elasticsearch is ignored due to licensing issues. See #10992

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,10 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
 
   labels: ['dependencies'],
-  extends: ['config:recommended', ':gitSignOff'],
+
+  extends: ['config:best-practices', ':gitSignOff'],
+  // do not pin dev dependencies, which are part of the best-practices preset
+  ignorePresets: [':pinDevDependencies'],
 
   // the default limit are 10 PRs
   prConcurrentLimit: 20,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,9 @@
   labels: ['dependencies'],
   extends: ['config:recommended', ':gitSignOff'],
 
+  // the default limit are 10 PRs
+  prConcurrentLimit: 20,
+
   postUpdateOptions: ['yarnDedupeHighest'],
   rangeStrategy: 'update-lockfile',
   // @elastic/elasticsearch is ignored due to licensing issues. See #10992

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,6 @@
 {
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
   postUpdateOptions: ['yarnDedupeHighest'],


### PR DESCRIPTION
## Hey, I just made a Pull Request!
These are some basic changes to your Renovate configuration, which I would recommend. 
If you have questions or are not agreeing, to these changes, I can provide some input here. 
It may be of interest that Renovate has currently 107 updates pending on this repository, so there is quite a backlog. 

Changes:
- add schema tag to give intellisense to all IDEs which support jsonschema
- use [`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) instead of `config:base` which includes in turn [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended)
  - enables DependencyDashboard
  - enables configMigration, which enables auto migration for not backwards compatible changes
  - pin Docker images and Github actions to digests for security purposes
  - tough the recommended pinning of dev dependencies is for now ignored
  - add community provided monorepo, grouping and replacement rules
- increase PR limit to allow processing of more PRs by Collaborators/Maintainers in parallel.
 Consider the input in this [guide](https://docs.renovatebot.com/noise-reduction/). I'm happy to help you to improve your workflow here. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
