### PR TITLE
skip unnecessary `--build-dependencies` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:docs": "node ./scripts/check-docs-quality",
     "lint:all": "backstage-cli repo lint",
     "lint:type-deps": "backstage-repo-tools type-deps",
-    "docker-build": "yarn tsc && yarn workspace example-backend build --build-dependencies && yarn workspace example-backend build-image",
+    "docker-build": "yarn tsc && yarn workspace example-backend build && yarn workspace example-backend build-image",
     "new": "backstage-cli new --scope backstage --baseVersion 0.0.0 --no-private",
     "create-plugin": "echo \"use 'yarn new' instead\"",
     "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",


### PR DESCRIPTION
This flag no longer exists, and instead there's the inverse `--no-build-dependencies`