### PR TITLE
feat(scaffolder): Use more distinguishable icons for link and text output

### DIFF
--- a/.changeset/twelve-hounds-know.md
+++ b/.changeset/twelve-hounds-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+---
+
+Use more distinguishable icons for link (`Link`) and text output (`Description`).

--- a/plugins/scaffolder-react/src/next/components/TemplateOutputs/LinkOutputs.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateOutputs/LinkOutputs.tsx
@@ -17,7 +17,7 @@ import { IconComponent, useApp, useRouteRef } from '@backstage/core-plugin-api';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { Button, makeStyles } from '@material-ui/core';
 import React from 'react';
-import WebIcon from '@material-ui/icons/Web';
+import LinkIcon from '@material-ui/icons/Link';
 import { parseEntityRef } from '@backstage/catalog-model';
 import { Link } from '@backstage/core-components';
 import { ScaffolderTaskOutput } from '../../../api';
@@ -37,7 +37,7 @@ export const LinkOutputs = (props: { output: ScaffolderTaskOutput }) => {
   const entityRoute = useRouteRef(entityRouteRef);
 
   const iconResolver = (key?: string): IconComponent =>
-    app.getSystemIcon(key!) ?? WebIcon;
+    app.getSystemIcon(key!) ?? LinkIcon;
 
   return (
     <>

--- a/plugins/scaffolder-react/src/next/components/TemplateOutputs/TextOutputs.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateOutputs/TextOutputs.tsx
@@ -15,7 +15,7 @@
  */
 import { IconComponent, useApp } from '@backstage/core-plugin-api';
 import { Button } from '@material-ui/core';
-import WebIcon from '@material-ui/icons/Web';
+import DescriptionIcon from '@material-ui/icons/Description';
 import React from 'react';
 import { ScaffolderTaskOutput } from '../../../api';
 
@@ -33,7 +33,7 @@ export const TextOutputs = (props: {
   const app = useApp();
 
   const iconResolver = (key?: string): IconComponent =>
-    app.getSystemIcon(key!) ?? WebIcon;
+    app.getSystemIcon(key!) ?? DescriptionIcon;
 
   return (
     <>


### PR DESCRIPTION
Use more distinguishable icons for link (`Link`) and text output (`Description`).

Currently, both use the same icon `Web` (until specified explicitly at the template). For a user, it is not really clear which of these will open more output below it vs open a URL/a new tab.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
