### PR TITLE
Corrects dynatrace plugin README.md

### DIFF
--- a/plugins/dynatrace/README.md
+++ b/plugins/dynatrace/README.md
@@ -62,10 +62,11 @@ This plugin requires a proxy endpoint for Dynatrace configured in `app-config.ya
 
 ```yaml
 proxy:
+  endpoints:
   '/dynatrace':
-    target: 'https://example.dynatrace.com/api/v2'
-    headers:
-      Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
+      target: 'https://example.dynatrace.com/api/v2'
+      headers:
+        Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
 ```
 
 It also requires a `baseUrl` for rendering links to problems in the table like so:

--- a/plugins/dynatrace/README.md
+++ b/plugins/dynatrace/README.md
@@ -64,9 +64,9 @@ This plugin requires a proxy endpoint for Dynatrace configured in `app-config.ya
 proxy:
   endpoints:
   '/dynatrace':
-      target: 'https://example.dynatrace.com/api/v2'
-      headers:
-        Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
+    target: 'https://example.dynatrace.com/api/v2'
+    headers:
+      Authorization: 'Api-Token ${DYNATRACE_ACCESS_TOKEN}'
 ```
 
 It also requires a `baseUrl` for rendering links to problems in the table like so:


### PR DESCRIPTION
## Dynatrace pluguin proxy configuration fix

Provides correction to dynatrace plugin proxy configuration instructions. When attempting setup, the backstage proxy service for dynatrace will return a 404 error due to trying to retrieve a missing parameter in the configuration. 

### Current documentation
<img width="1058" alt="Screenshot 2024-01-24 at 1 26 22 PM" src="https://github.com/ionSurf/backstage/assets/1911873/7d8a8751-7b53-4453-b015-dece7ac20e68">


While the readme instructions advise to setup proxy configurations like this: 

```js
proxy:
  '/dynatrace':
    target: 'https://example.dynatrace.com/api/v2'
    ...
```

The parent key "endpoints" is missing and should be added like the following: 

```js
proxy:
  endpoints:
    '/dynatrace':
      target: 'https://example.dynatrace.com/api/v2'
      ...
```

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
