### PR TITLE
chore: rollback issue with wildcard paths

### DIFF
--- a/.changeset/olive-experts-fold.md
+++ b/.changeset/olive-experts-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Rollback the change for wildcard discovery, this fixes a bug with the `AzureUrlReader` not working with wildcard paths

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
@@ -213,34 +213,4 @@ describe('UrlReaderProcessor', () => {
 
     expect(reader.search).toHaveBeenCalledTimes(1);
   });
-
-  it('parser return valid URL with wildcard *', async () => {
-    const logger = getVoidLogger();
-
-    const reader: jest.Mocked<UrlReader> = {
-      readUrl: jest.fn(),
-      readTree: jest.fn(),
-      search: jest.fn().mockImplementation(async () => []),
-    };
-
-    const processor = new UrlReaderProcessor({ reader, logger });
-
-    const emit = jest.fn();
-
-    await processor.readLocation(
-      {
-        type: 'url',
-        target: 'https://storage.cloud.google.com/ah-backstage-poc-catalog/*',
-      },
-      false,
-      emit,
-      defaultEntityDataParser,
-      mockCache,
-    );
-
-    expect(reader.search).toHaveBeenCalledWith(
-      'https://storage.cloud.google.com/ah-backstage-poc-catalog/*',
-      { etag: undefined },
-    );
-  });
 });

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
@@ -20,6 +20,7 @@ import { assertError } from '@backstage/errors';
 import limiterFactory from 'p-limit';
 import { Logger } from 'winston';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
+import parseGitUrl from 'git-url-parse';
 import {
   CatalogProcessor,
   CatalogProcessorCache,
@@ -124,7 +125,7 @@ export class UrlReaderProcessor implements CatalogProcessor {
     // Does it contain globs? I.e. does it contain asterisks or question marks
     // (no curly braces for now)
 
-    const { pathname: filepath } = new URL(location);
+    const { filepath } = parseGitUrl(location);
     if (filepath?.match(/[*?]/)) {
       const limiter = limiterFactory(5);
       const response = await this.options.reader.search(location, { etag });


### PR DESCRIPTION
Fixes #22465 

Rollback of #22141 

We need to work out a better way to do this, will open a followup issue. This is caused because the wildcard for Azure is specified in the `querystring` which is not evaluated with this change. We need to work out a better way to check the URL's which doesn't leak implementation into the Catalog processor.
