### PR TITLE
Fix wrong `alpha` support in dynamic plugins support

### DIFF
--- a/.changeset/calm-cups-rule.md
+++ b/.changeset/calm-cups-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Fix wrong `alpha` support in dynamic plugins support: the `alpha` sub-package should not be required for the dynamic plugins to be loaded under the new backend system.

--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
@@ -485,6 +485,37 @@ Please add '${mockDir.resolve(
         },
       },
       {
+        name: "alpha manifest preferred but skipped because the `alpha` sub-directory doesn't exist",
+        preferAlpha: true,
+        fileSystem: {
+          backstageRoot: {
+            'dist-dynamic': {
+              'test-backend-plugin': {
+                'package.json': JSON.stringify({
+                  name: 'test-backend-plugin-dynamic',
+                  version: '0.0.0',
+                  main: 'dist/index.cjs.js',
+                  backstage: { role: 'backend-plugin' },
+                }),
+              },
+            },
+          },
+        },
+        expectedPluginPackages: [
+          {
+            location: url.pathToFileURL(
+              mockDir.resolve('backstageRoot/dist-dynamic/test-backend-plugin'),
+            ),
+            manifest: {
+              name: 'test-backend-plugin-dynamic',
+              version: '0.0.0',
+              main: 'dist/index.cjs.js',
+              backstage: { role: 'backend-plugin' },
+            },
+          },
+        ],
+      },
+      {
         name: 'invalid alpha package.json',
         preferAlpha: true,
         fileSystem: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix wrong `alpha` support in dynamic plugins support

The `alpha` sub-package should not be required for the dynamic plugins to be loaded under the new backend system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
