### PR TITLE
add forcefork input to github pull request action

### DIFF
--- a/.changeset/calm-items-double.md
+++ b/.changeset/calm-items-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Allow to force the creation of a pull request from a forked repository

--- a/.changeset/calm-items-double.md
+++ b/.changeset/calm-items-double.md
@@ -1,4 +1,5 @@
 ---
+'@backstage/plugin-scaffolder-backend-module-github': minor
 '@backstage/plugin-scaffolder-backend': minor
 ---
 

--- a/.changeset/calm-items-double.md
+++ b/.changeset/calm-items-double.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-scaffolder-backend-module-github': minor
-'@backstage/plugin-scaffolder-backend': minor
 ---
 
 Allow to force the creation of a pull request from a forked repository

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -374,6 +374,7 @@ export const createPublishGithubPullRequestAction: (
     teamReviewers?: string[] | undefined;
     commitMessage?: string | undefined;
     update?: boolean | undefined;
+    forceFork?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -135,6 +135,7 @@ export const createPublishGithubPullRequestAction = (
     teamReviewers?: string[];
     commitMessage?: string;
     update?: boolean;
+    forceFork?: boolean;
   }>({
     id: 'publish:github:pull-request',
     examples,
@@ -217,6 +218,11 @@ export const createPublishGithubPullRequestAction = (
             title: 'Update',
             description: 'Update pull request if already exists',
           },
+          forceFork: {
+            type: 'boolean',
+            title: 'Force Fork',
+            description: 'Create pull request from a fork',
+          },
         },
       },
       output: {
@@ -255,6 +261,7 @@ export const createPublishGithubPullRequestAction = (
         teamReviewers,
         commitMessage,
         update,
+        forceFork,
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -327,6 +334,7 @@ export const createPublishGithubPullRequestAction = (
           head: branchName,
           draft,
           update,
+          forceFork,
         };
         if (targetBranchName) {
           createOptions.base = targetBranchName;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -266,6 +266,7 @@ export const createPublishGithubPullRequestAction: (
     teamReviewers?: string[] | undefined;
     commitMessage?: string | undefined;
     update?: boolean | undefined;
+    forceFork?: boolean | undefined;
   },
   JsonObject
 >;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implements 'forcefork' input for GitHub Pull Request action, enabling users to initiate the creation of a new pull request from a forked repository rather than the upstream repository, irrespective of their write permissions. This [option](https://github.com/gr2m/octokit-plugin-create-pull-request/blob/main/src/types.ts#L18) is already supported by Octokit, so it only requires passing it from the action to the client.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
