### PR TITLE
Support `token` in `URLReaders` for `fetch:*` actions in Scaffolder

### DIFF
--- a/.changeset/quick-ties-stare.md
+++ b/.changeset/quick-ties-stare.md
@@ -3,4 +3,4 @@
 '@backstage/backend-common': patch
 ---
 
-Support `token` in `readTree` and `readUrl`
+Support `token` in `readTree`, `readUrl` and `search`

--- a/.changeset/quick-ties-stare.md
+++ b/.changeset/quick-ties-stare.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-common': patch
+---
+
+Support `token` in `readTree` and `readUrl`

--- a/.changeset/ten-trainers-cough.md
+++ b/.changeset/ten-trainers-cough.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-node': minor
+---
+
+Support providing an overriding token for `fetch:template`, `fetch:plain` and `fetch:file` when interacting with upstream integrations

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -185,9 +185,7 @@ export class GithubUrlReader implements UrlReader {
     }
 
     const { filepath } = parseGitUrl(url);
-    const { headers } = await this.deps.credentialsProvider.getCredentials({
-      url,
-    });
+    const { headers } = await this.getCredentials(url, options);
 
     const files = await this.doSearch(
       url,

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -316,6 +316,7 @@ export type ReadTreeOptions = {
   ): boolean;
   etag?: string;
   signal?: AbortSignal;
+  token?: string;
 };
 
 // @public
@@ -343,6 +344,7 @@ export type ReadUrlOptions = {
   etag?: string;
   lastModifiedAfter?: Date;
   signal?: AbortSignal;
+  token?: string;
 };
 
 // @public

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -392,6 +392,7 @@ export interface SchedulerService extends PluginTaskScheduler {}
 export type SearchOptions = {
   etag?: string;
   signal?: AbortSignal;
+  token?: string;
 };
 
 // @public

--- a/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
@@ -92,6 +92,18 @@ export type ReadUrlOptions = {
    * Not all reader implementations may take this field into account.
    */
   signal?: AbortSignal;
+
+  /**
+   * An optional token to use for authentication when reading the resources.
+   *
+   * @remarks
+   *
+   * By default all URL Readers will use the integrations config which is supplied
+   * when creating the Readers. Sometimes it might be desireable to use the already
+   * created URLReaders but with a different token, maybe that's supplied by the user
+   * at runtime.
+   */
+  token?: string;
 };
 
 /**
@@ -179,6 +191,18 @@ export type ReadTreeOptions = {
    * Not all reader implementations may take this field into account.
    */
   signal?: AbortSignal;
+
+  /**
+   * An optional token to use for authentication when reading the resources.
+   *
+   * @remarks
+   *
+   * By default all URL Readers will use the integrations config which is supplied
+   * when creating the Readers. Sometimes it might be desireable to use the already
+   * created URLReaders but with a different token, maybe that's supplied by the user
+   * at runtime.
+   */
+  token?: string;
 };
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
@@ -305,6 +305,18 @@ export type SearchOptions = {
    * Not all reader implementations may take this field into account.
    */
   signal?: AbortSignal;
+
+  /**
+   * An optional token to use for authentication when reading the resources.
+   *
+   * @remarks
+   *
+   * By default all URL Readers will use the integrations config which is supplied
+   * when creating the Readers. Sometimes it might be desireable to use the already
+   * created URLReaders but with a different token, maybe that's supplied by the user
+   * at runtime.
+   */
+  token?: string;
 };
 
 /**

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -145,6 +145,7 @@ export function createFetchPlainAction(options: {
   {
     url: string;
     targetPath?: string | undefined;
+    token?: string | undefined;
   },
   JsonObject
 >;
@@ -157,6 +158,7 @@ export function createFetchPlainFileAction(options: {
   {
     url: string;
     targetPath: string;
+    token?: string | undefined;
   },
   JsonObject
 >;
@@ -179,6 +181,7 @@ export function createFetchTemplateAction(options: {
     replace?: boolean | undefined;
     trimBlocks?: boolean | undefined;
     lstripBlocks?: boolean | undefined;
+    token?: string | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.test.ts
@@ -85,4 +85,23 @@ describe('fetch:plain', () => {
       }),
     );
   });
+
+  it('should fetch plain with token', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        url: 'https://github.com/backstage/community/tree/main/backstage-community-sessions/assets',
+        targetPath: 'lol',
+        token: 'mockToken',
+      },
+    });
+
+    expect(fetchContents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputPath: resolvePath(mockContext.workspacePath, 'lol'),
+        fetchUrl:
+          'https://github.com/backstage/community/tree/main/backstage-community-sessions/assets',
+      }),
+    );
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.test.ts
@@ -77,6 +77,7 @@ describe('fetch:plain', () => {
         targetPath: 'lol',
       },
     });
+
     expect(fetchContents).toHaveBeenCalledWith(
       expect.objectContaining({
         outputPath: resolvePath(mockContext.workspacePath, 'lol'),

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plain.ts
@@ -36,7 +36,11 @@ export function createFetchPlainAction(options: {
 }) {
   const { reader, integrations } = options;
 
-  return createTemplateAction<{ url: string; targetPath?: string }>({
+  return createTemplateAction<{
+    url: string;
+    targetPath?: string;
+    token?: string;
+  }>({
     id: ACTION_ID,
     examples,
     description:
@@ -58,6 +62,12 @@ export function createFetchPlainAction(options: {
               'Target path within the working directory to download the contents to.',
             type: 'string',
           },
+          token: {
+            title: 'Token',
+            description:
+              'An optional token to use for authentication when reading the resources.',
+            type: 'string',
+          },
         },
       },
     },
@@ -75,6 +85,7 @@ export function createFetchPlainAction(options: {
         baseUrl: ctx.templateInfo?.baseUrl,
         fetchUrl: ctx.input.url,
         outputPath,
+        token: ctx.input.token,
       });
     },
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.test.ts
@@ -69,6 +69,21 @@ describe('fetch:plain:file', () => {
     );
   });
 
+  it('passed through the token to fetchFile', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        url: 'https://github.com/backstage/community/tree/main/backstage-community-sessions/assets/Backstage%20Community%20Sessions.png',
+        token: 'mockToken',
+        targetPath: 'lol',
+      },
+    });
+
+    expect(fetchFile).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'mockToken' }),
+    );
+  });
+
   it('should fetch plain', async () => {
     await action.handler({
       ...mockContext,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/plainFile.ts
@@ -33,7 +33,11 @@ export function createFetchPlainFileAction(options: {
 }) {
   const { reader, integrations } = options;
 
-  return createTemplateAction<{ url: string; targetPath: string }>({
+  return createTemplateAction<{
+    url: string;
+    targetPath: string;
+    token?: string;
+  }>({
     id: 'fetch:plain:file',
     description: 'Downloads single file and places it in the workspace.',
     examples,
@@ -52,6 +56,12 @@ export function createFetchPlainFileAction(options: {
             title: 'Target Path',
             description:
               'Target path within the working directory to download the file as.',
+            type: 'string',
+          },
+          token: {
+            title: 'Token',
+            description:
+              'An optional token to use for authentication when reading the resources.',
             type: 'string',
           },
         },
@@ -73,6 +83,7 @@ export function createFetchPlainFileAction(options: {
         baseUrl: ctx.templateInfo?.baseUrl,
         fetchUrl: ctx.input.url,
         outputPath,
+        token: ctx.input.token,
       });
     },
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -371,6 +371,18 @@ describe('fetch:template', () => {
           fs.readlink(`${workspacePath}/target/brokenSymlink`),
         ).resolves.toEqual(`.${pathSep}not-a-real-file.txt`);
       });
+
+      it('passed through the token to the fetchContents call', async () => {
+        await action.handler(
+          mockContext({
+            token: 'mockToken',
+          }),
+        );
+
+        expect(mockFetchContents).toHaveBeenCalledWith(
+          expect.objectContaining({ token: 'mockToken' }),
+        );
+      });
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -71,6 +71,7 @@ export function createFetchTemplateAction(options: {
     replace?: boolean;
     trimBlocks?: boolean;
     lstripBlocks?: boolean;
+    token?: string;
   }>({
     id: 'fetch:template',
     description:
@@ -133,6 +134,12 @@ export function createFetchTemplateAction(options: {
             description:
               'If set, replace files in targetPath instead of skipping existing ones.',
             type: 'boolean',
+          },
+          token: {
+            title: 'Token',
+            description:
+              'An optional token to use for authentication when reading the resources.',
+            type: 'string',
           },
         },
       },
@@ -197,6 +204,7 @@ export function createFetchTemplateAction(options: {
         baseUrl: ctx.templateInfo?.baseUrl,
         fetchUrl: ctx.input.url,
         outputPath: templateDir,
+        token: ctx.input.token,
       });
 
       ctx.logger.info('Listing files and directories in template');

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -195,6 +195,7 @@ export function fetchContents(options: {
   baseUrl?: string;
   fetchUrl?: string;
   outputPath: string;
+  token?: string;
 }): Promise<void>;
 
 // @public
@@ -204,6 +205,7 @@ export function fetchFile(options: {
   baseUrl?: string;
   fetchUrl?: string;
   outputPath: string;
+  token?: string;
 }): Promise<void>;
 
 // @public (undocumented)

--- a/plugins/scaffolder-node/src/actions/fetch.test.ts
+++ b/plugins/scaffolder-node/src/actions/fetch.test.ts
@@ -124,6 +124,20 @@ describe('fetchContents helper', () => {
       expect(fs.ensureDir).toHaveBeenCalledWith('foo');
       expect(dirFunction).toHaveBeenCalledWith({ targetDir: 'foo' });
     });
+
+    it('should pass through the token provided through to the URL reader', async () => {
+      await fetchContents({
+        ...options,
+        outputPath: 'mydir/foo',
+        fetchUrl: 'https://github.com/backstage/foo',
+        token: 'mockToken',
+      });
+
+      expect(readTree).toHaveBeenCalledWith(
+        'https://github.com/backstage/foo',
+        expect.objectContaining({ token: 'mockToken' }),
+      );
+    });
   });
 
   describe('fetch file', () => {
@@ -210,6 +224,20 @@ describe('fetchContents helper', () => {
       });
       expect(fs.ensureDir).toHaveBeenCalledWith('mydir');
       expect(fs.outputFile).toHaveBeenCalledWith('mydir/foo', 'test');
+    });
+
+    it('should pass through the token provided through to the URL reader', async () => {
+      await fetchFile({
+        ...options,
+        outputPath: 'mydir/foo',
+        fetchUrl: 'https://github.com/backstage/foo',
+        token: 'mockToken',
+      });
+
+      expect(readUrl).toHaveBeenCalledWith(
+        'https://github.com/backstage/foo',
+        expect.objectContaining({ token: 'mockToken' }),
+      );
     });
   });
 });

--- a/plugins/scaffolder-node/src/actions/fetch.ts
+++ b/plugins/scaffolder-node/src/actions/fetch.ts
@@ -32,8 +32,16 @@ export async function fetchContents(options: {
   baseUrl?: string;
   fetchUrl?: string;
   outputPath: string;
+  token?: string;
 }) {
-  const { reader, integrations, baseUrl, fetchUrl = '.', outputPath } = options;
+  const {
+    reader,
+    integrations,
+    baseUrl,
+    fetchUrl = '.',
+    outputPath,
+    token,
+  } = options;
 
   const fetchUrlIsAbsolute = isFetchUrlAbsolute(fetchUrl);
 
@@ -45,7 +53,7 @@ export async function fetchContents(options: {
   } else {
     const readUrl = getReadUrl(fetchUrl, baseUrl, integrations);
 
-    const res = await reader.readTree(readUrl);
+    const res = await reader.readTree(readUrl, { token });
     await fs.ensureDir(outputPath);
     await res.dir({ targetDir: outputPath });
   }
@@ -63,8 +71,16 @@ export async function fetchFile(options: {
   baseUrl?: string;
   fetchUrl?: string;
   outputPath: string;
+  token?: string;
 }) {
-  const { reader, integrations, baseUrl, fetchUrl = '.', outputPath } = options;
+  const {
+    reader,
+    integrations,
+    baseUrl,
+    fetchUrl = '.',
+    outputPath,
+    token,
+  } = options;
 
   const fetchUrlIsAbsolute = isFetchUrlAbsolute(fetchUrl);
 
@@ -76,7 +92,7 @@ export async function fetchFile(options: {
   } else {
     const readUrl = getReadUrl(fetchUrl, baseUrl, integrations);
 
-    const res = await reader.readUrl(readUrl);
+    const res = await reader.readUrl(readUrl, { token });
     await fs.ensureDir(path.dirname(outputPath));
     const buffer = await res.buffer();
     await fs.outputFile(outputPath, buffer.toString());


### PR DESCRIPTION
In order to read things from `URLReaders` in the scaffolder, there needs to be a PAT or GitHub app configured.

This alleviates this requirement, by being able to pass `token` to the `fetch:*` actions which can be grabbed from Custom Field Extensions like the `RepoUrlPicker`.

That way, it will use the users oauth token for both reading the template files, and creation of the repository, and being able to be run without any configuration or authentication needed in the scaffolder deployment itself.