### PR TITLE
feat(catalog): Add a title to the PaginatedCatalogTable.

### DIFF
--- a/.changeset/perfect-chefs-act.md
+++ b/.changeset/perfect-chefs-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Number of results is now directly added as the field `count` on `useEntityList`.

--- a/.changeset/perfect-chefs-act.md
+++ b/.changeset/perfect-chefs-act.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': minor
 ---
 
-Number of results is now directly added as the field `count` on `useEntityList`.
+Number of results is now directly added as the field `totalItems` on `useEntityList`.

--- a/.changeset/rare-worms-sort.md
+++ b/.changeset/rare-worms-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Adds a title to the `PaginatedCatalogTable` for better visibility on what you're viewing.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -306,7 +306,7 @@ export type EntityListContextProps<
     next?: () => void;
     prev?: () => void;
   };
-  count?: number;
+  totalItems?: number;
 };
 
 // @public

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -306,6 +306,7 @@ export type EntityListContextProps<
     next?: () => void;
     prev?: () => void;
   };
+  count?: number;
 };
 
 // @public

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -235,6 +235,7 @@ describe('<EntityListProvider />', () => {
     await waitFor(() => {
       expect(result.current.entities.length).toBe(1);
     });
+    expect(result.current.count).toBe(1);
 
     await expect(() =>
       waitFor(() => {
@@ -251,6 +252,7 @@ describe('<EntityListProvider />', () => {
     await waitFor(() => {
       expect(result.current.backendEntities.length).toBeGreaterThan(0);
     });
+    expect(result.current.count).toBe(2);
     expect(result.current.backendEntities.length).toBe(2);
     expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
 
@@ -275,6 +277,8 @@ describe('<EntityListProvider />', () => {
       expect(result.current.backendEntities.length).toBeGreaterThan(0);
     });
     expect(result.current.backendEntities.length).toBe(2);
+
+    expect(result.current.count).toBe(2);
 
     mockCatalogApi.getEntities!.mockRejectedValueOnce('error');
     act(() => {
@@ -455,6 +459,8 @@ describe('<EntityListProvider pagination />', () => {
         orderFields,
       });
     });
+
+    expect(result.current.count).toBe(10);
   });
 
   it('returns an error on catalogApi failure', async () => {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -235,7 +235,7 @@ describe('<EntityListProvider />', () => {
     await waitFor(() => {
       expect(result.current.entities.length).toBe(1);
     });
-    expect(result.current.count).toBe(1);
+    expect(result.current.totalItems).toBe(1);
 
     await expect(() =>
       waitFor(() => {
@@ -252,7 +252,7 @@ describe('<EntityListProvider />', () => {
     await waitFor(() => {
       expect(result.current.backendEntities.length).toBeGreaterThan(0);
     });
-    expect(result.current.count).toBe(2);
+    expect(result.current.totalItems).toBe(2);
     expect(result.current.backendEntities.length).toBe(2);
     expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
 
@@ -278,7 +278,7 @@ describe('<EntityListProvider />', () => {
     });
     expect(result.current.backendEntities.length).toBe(2);
 
-    expect(result.current.count).toBe(2);
+    expect(result.current.totalItems).toBe(2);
 
     mockCatalogApi.getEntities!.mockRejectedValueOnce('error');
     act(() => {
@@ -460,7 +460,7 @@ describe('<EntityListProvider pagination />', () => {
       });
     });
 
-    expect(result.current.count).toBe(10);
+    expect(result.current.totalItems).toBe(10);
   });
 
   it('returns an error on catalogApi failure', async () => {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -109,7 +109,7 @@ export type EntityListContextProps<
     prev?: () => void;
   };
 
-  count?: number;
+  totalItems?: number;
 };
 
 /**
@@ -126,7 +126,7 @@ type OutputState<EntityFilters extends DefaultEntityFilters> = {
   entities: Entity[];
   backendEntities: Entity[];
   pageInfo?: QueryEntitiesResponse['pageInfo'];
-  count?: number;
+  totalItems?: number;
 };
 
 /**
@@ -226,7 +226,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
               backendEntities: response.items,
               entities: response.items.filter(entityFilter),
               pageInfo: response.pageInfo,
-              count: response.totalItems,
+              totalItems: response.totalItems,
             });
           }
         } else {
@@ -247,7 +247,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
               backendEntities: response.items,
               entities: response.items.filter(entityFilter),
               pageInfo: response.pageInfo,
-              count: response.totalItems,
+              totalItems: response.totalItems,
             });
           }
         }
@@ -272,7 +272,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
             appliedFilters: requestedFilters,
             backendEntities: response.items,
             entities,
-            count: entities.length,
+            totalItems: entities.length,
           });
         } else {
           const entities = outputState.backendEntities.filter(entityFilter);
@@ -280,7 +280,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
             appliedFilters: requestedFilters,
             backendEntities: outputState.backendEntities,
             entities,
-            count: entities.length,
+            totalItems: entities.length,
           });
         }
       }
@@ -361,7 +361,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       loading,
       error,
       pageInfo,
-      count: outputState.count,
+      totalItems: outputState.totalItems,
     }),
     [outputState, updateFilters, queryParameters, loading, error, pageInfo],
   );

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -108,6 +108,8 @@ export type EntityListContextProps<
     next?: () => void;
     prev?: () => void;
   };
+
+  count?: number;
 };
 
 /**
@@ -124,6 +126,7 @@ type OutputState<EntityFilters extends DefaultEntityFilters> = {
   entities: Entity[];
   backendEntities: Entity[];
   pageInfo?: QueryEntitiesResponse['pageInfo'];
+  count?: number;
 };
 
 /**
@@ -223,6 +226,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
               backendEntities: response.items,
               entities: response.items.filter(entityFilter),
               pageInfo: response.pageInfo,
+              count: response.totalItems,
             });
           }
         } else {
@@ -243,6 +247,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
               backendEntities: response.items,
               entities: response.items.filter(entityFilter),
               pageInfo: response.pageInfo,
+              count: response.totalItems,
             });
           }
         }
@@ -262,16 +267,20 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
           const response = await catalogApi.getEntities({
             filter: backendFilter,
           });
+          const entities = response.items.filter(entityFilter);
           setOutputState({
             appliedFilters: requestedFilters,
             backendEntities: response.items,
-            entities: response.items.filter(entityFilter),
+            entities,
+            count: entities.length,
           });
         } else {
+          const entities = outputState.backendEntities.filter(entityFilter);
           setOutputState({
             appliedFilters: requestedFilters,
             backendEntities: outputState.backendEntities,
-            entities: outputState.backendEntities.filter(entityFilter),
+            entities,
+            count: entities.length,
           });
         }
       }
@@ -352,6 +361,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       loading,
       error,
       pageInfo,
+      count: outputState.count,
     }),
     [outputState, updateFilters, queryParameters, loading, error, pageInfo],
   );

--- a/plugins/catalog-react/src/testUtils/providers.tsx
+++ b/plugins/catalog-react/src/testUtils/providers.tsx
@@ -71,6 +71,7 @@ export function MockEntityListContextProvider<
       loading: value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
       error: value?.error,
+      count: (value?.entities ?? defaultValues.entities).length,
     }),
     [value, defaultValues, filters, updateFilters],
   );

--- a/plugins/catalog-react/src/testUtils/providers.tsx
+++ b/plugins/catalog-react/src/testUtils/providers.tsx
@@ -71,7 +71,8 @@ export function MockEntityListContextProvider<
       loading: value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
       error: value?.error,
-      count: (value?.entities ?? defaultValues.entities).length,
+      totalItems:
+        value?.totalItems ?? (value?.entities ?? defaultValues.entities).length,
     }),
     [value, defaultValues, filters, updateFilters],
   );

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -88,7 +88,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const entityListContext = useEntityList();
-  const { loading, error, entities, filters, pageInfo, count } =
+  const { loading, error, entities, filters, pageInfo, totalItems } =
     entityListContext;
   const enablePagination = !!pageInfo;
 
@@ -176,7 +176,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
     .filter(s => s)
     .join(' ');
 
-  const title = `${titleDisplay} (${count})`;
+  const title = `${titleDisplay} (${totalItems})`;
   const actions = props.actions || defaultActions;
   const options = {
     actionsColumnIndex: -1,

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -88,7 +88,8 @@ export const CatalogTable = (props: CatalogTableProps) => {
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const entityListContext = useEntityList();
-  const { loading, error, entities, filters, pageInfo } = entityListContext;
+  const { loading, error, entities, filters, pageInfo, count } =
+    entityListContext;
   const enablePagination = !!pageInfo;
 
   const tableColumns = useMemo(
@@ -175,7 +176,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
     .filter(s => s)
     .join(' ');
 
-  const title = `${titleDisplay} (${entities.length})`;
+  const title = `${titleDisplay} (${count})`;
   const actions = props.actions || defaultActions;
   const options = {
     actionsColumnIndex: -1,
@@ -216,7 +217,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         pageSizeOptions: [20, 50, 100],
         ...options,
       }}
-      title={`${titleDisplay} (${entities.length})`}
+      title={title}
       data={rows}
       actions={actions}
       subtitle={subtitle}

--- a/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.test.tsx
@@ -142,7 +142,7 @@ describe('PaginatedCatalogTable', () => {
       <MockEntityListContextProvider
         value={{
           entities: data.map(e => e.entity),
-          count: data.length,
+          totalItems: data.length,
           filters: {
             kind: new EntityKindFilter('component'),
           },

--- a/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.tsx
@@ -32,11 +32,12 @@ type PaginatedCatalogTableProps = {
  * @internal
  */
 export function PaginatedCatalogTable(props: PaginatedCatalogTableProps) {
-  const { columns, data, next, prev } = props;
+  const { columns, data, next, prev, title, isLoading } = props;
   const { updateFilters } = useEntityList();
 
   return (
     <Table
+      title={isLoading ? '' : title}
       columns={columns}
       data={data}
       options={{


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Thread in discord [here](https://discord.com/channels/687207715902193673/923144214580191282/1186802058830024865).

This PR copies the title from `CatalogTable` to the `PaginatedCatalogTable`. The count without additional information may be confusing re: current page, but I think it's useful so I can decide whether to filter my search further. 

<img width="998" alt="Screenshot 2024-01-25 at 7 13 29 PM" src="https://github.com/backstage/backstage/assets/34432188/9cff7374-df1f-4ff9-8abb-897a6db564e9">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
