### PR TITLE
frontend-app-api: switch component refs to be keyed by ID

### DIFF
--- a/.changeset/smart-numbers-call.md
+++ b/.changeset/smart-numbers-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+The default `ComponentsApi` implementation now uses the `ComponentRef` ID as the component key, rather than the reference instance. This fixes a bug where duplicate installations of `@backstage/frontend-plugin-api` would break the app.

--- a/.changeset/strong-lobsters-hide.md
+++ b/.changeset/strong-lobsters-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+App component extensions are no longer wrapped in an `ExtensionBoundary`, allowing them to inherit the outer context instead.

--- a/packages/frontend-app-api/src/apis/implementations/ComponentsApi/DefaultComponentsApi.test.tsx
+++ b/packages/frontend-app-api/src/apis/implementations/ComponentsApi/DefaultComponentsApi.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  coreExtensionData,
+  createComponentExtension,
+  createComponentRef,
+  createExtension,
+  createExtensionOverrides,
+} from '@backstage/frontend-plugin-api';
+import { resolveAppNodeSpecs } from '../../../tree/resolveAppNodeSpecs';
+import { resolveAppTree } from '../../../tree/resolveAppTree';
+import { App } from '../../../extensions/App';
+import { DefaultComponentsApi } from './DefaultComponentsApi';
+import { render, screen } from '@testing-library/react';
+import { instantiateAppNodeTree } from '../../../tree/instantiateAppNodeTree';
+
+const testRefA = createComponentRef({ id: 'test.a' });
+const testRefB1 = createComponentRef({ id: 'test.b' });
+const testRefB2 = createComponentRef({ id: 'test.b' });
+
+const baseOverrides = createExtensionOverrides({
+  extensions: [
+    App,
+    createExtension({
+      namespace: 'app',
+      name: 'root',
+      attachTo: { id: 'app', input: 'root' },
+      output: {
+        element: coreExtensionData.reactElement,
+      },
+      factory() {
+        return {
+          element: <div>root</div>,
+        };
+      },
+    }),
+  ],
+});
+
+describe('DefaultComponentsApi', () => {
+  it('should provide components', () => {
+    const tree = resolveAppTree(
+      'app',
+      resolveAppNodeSpecs({
+        features: [
+          baseOverrides,
+          createExtensionOverrides({
+            extensions: [
+              createComponentExtension({
+                ref: testRefA,
+                loader: { sync: () => () => <div>test.a</div> },
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    instantiateAppNodeTree(tree.root);
+    const api = DefaultComponentsApi.fromTree(tree);
+
+    const ComponentA = api.getComponent(testRefA);
+    render(<ComponentA />);
+
+    expect(screen.getByText('test.a')).toBeInTheDocument();
+  });
+
+  it('should key extension refs by ID', () => {
+    const tree = resolveAppTree(
+      'app',
+      resolveAppNodeSpecs({
+        features: [
+          baseOverrides,
+          createExtensionOverrides({
+            extensions: [
+              createComponentExtension({
+                ref: testRefB1,
+                loader: { sync: () => () => <div>test.b</div> },
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    instantiateAppNodeTree(tree.root);
+    const api = DefaultComponentsApi.fromTree(tree);
+
+    const ComponentB1 = api.getComponent(testRefB1);
+    const ComponentB2 = api.getComponent(testRefB2);
+
+    expect(ComponentB1).toBe(ComponentB2);
+
+    render(<ComponentB2 />);
+
+    expect(screen.getByText('test.b')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend-app-api/src/apis/implementations/ComponentsApi/index.ts
+++ b/packages/frontend-app-api/src/apis/implementations/ComponentsApi/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { DefaultComponentsApi } from './ComponentsApi';
+export { DefaultComponentsApi } from './DefaultComponentsApi';

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
@@ -31,17 +31,22 @@ import { toInternalExtension } from '../../../frontend-plugin-api/src/wiring/res
 
 /** @internal */
 export function resolveAppNodeSpecs(options: {
-  features: FrontendFeature[];
-  builtinExtensions: Extension<unknown>[];
-  parameters: Array<ExtensionParameters>;
+  features?: FrontendFeature[];
+  builtinExtensions?: Extension<unknown>[];
+  parameters?: Array<ExtensionParameters>;
   forbidden?: Set<string>;
 }): AppNodeSpec[] {
-  const { builtinExtensions, parameters, forbidden = new Set() } = options;
+  const {
+    builtinExtensions = [],
+    parameters = [],
+    forbidden = new Set(),
+    features = [],
+  } = options;
 
-  const plugins = options.features.filter(
+  const plugins = features.filter(
     (f): f is BackstagePlugin => f.$$type === '@backstage/BackstagePlugin',
   );
-  const overrides = options.features.filter(
+  const overrides = features.filter(
     (f): f is ExtensionOverrides =>
       f.$$type === '@backstage/ExtensionOverrides',
   );

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -19,11 +19,9 @@ import { ConfigReader } from '@backstage/config';
 import {
   AppTree,
   appTreeApiRef,
-  ComponentRef,
   componentsApiRef,
   coreExtensionData,
   createApiExtension,
-  createComponentExtension,
   createThemeExtension,
   createTranslationExtension,
   FrontendFeature,
@@ -373,22 +371,10 @@ function createApiHolder(
     factory: () => routeResolutionApi,
   });
 
-  const componentsExtensions =
-    tree.root.edges.attachments
-      .get('components')
-      ?.map(e => e.instance?.getData(createComponentExtension.componentDataRef))
-      .filter(x => !!x) ?? [];
-
-  const componentsMap = componentsExtensions.reduce(
-    (components, component) =>
-      component ? components.set(component.ref, component?.impl) : components,
-    new Map<ComponentRef<any>, any>(),
-  );
-
   factoryRegistry.register('static', {
     api: componentsApiRef,
     deps: {},
-    factory: () => new DefaultComponentsApi(componentsMap),
+    factory: () => DefaultComponentsApi.fromTree(tree),
   });
 
   factoryRegistry.register('static', {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This avoids breakage then there are duplicate installations of `@backstage/frontend-plugin-api`.

I also realized that we probably shouldn't be wrapping components with an `ExtensionBoundary`, since that would make analytics and plugin contexts a bit useless since they'd always refer to the component extension rather than the parent one were the component is being rendered.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
