### PR TITLE
chore(docs): Improve API reference wording

### DIFF
--- a/.changeset/hot-paws-tap.md
+++ b/.changeset/hot-paws-tap.md
@@ -1,0 +1,7 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/test-utils': patch
+'@backstage/plugin-explore': patch
+---
+
+Fix wording in API reference

--- a/packages/catalog-model/src/kinds/relations.ts
+++ b/packages/catalog-model/src/kinds/relations.ts
@@ -114,7 +114,7 @@ export const RELATION_CHILD_OF = 'childOf';
 export const RELATION_MEMBER_OF = 'memberOf';
 
 /**
- * A relation from a group to its member, typcally a user in a group. Reversed direction of
+ * A relation from a group to its member, typically a user in a group. Reversed direction of
  * {@link RELATION_MEMBER_OF}.
  *
  * @public

--- a/packages/test-utils/src/testUtils/TestApiProvider.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.tsx
@@ -93,8 +93,8 @@ export class TestApiRegistry implements ApiHolder {
  *
  * @remarks
  * todo: remove this remark tag and ship in the api-reference. There's some odd formatting going on when this is made into a markdown doc, that there's no line break between
- * the emmited <p> for To the following </p> so what happens is that when parsing in docusaurus, it thinks that the code block is mdx rather than a code
- * snippet. Just ommiting this from the report for now until we can work out how to fix laterr.
+ * the emitted <p> for To the following </p> so what happens is that when parsing in docusaurus, it thinks that the code block is mdx rather than a code
+ * snippet. Just omitting this from the report for now until we can work out how to fix later.
  * A migration from `ApiRegistry` and `ApiProvider` might look like this, from:
  *
  * ```tsx

--- a/plugins/explore/src/api/ExploreApi.ts
+++ b/plugins/explore/src/api/ExploreApi.ts
@@ -29,7 +29,7 @@ export interface ExploreApi {
   /**
    * Returns a list of explore tools.
    *
-   * @param request - The The request query options
+   * @param request - The request query options
    */
   getTools(request?: GetExploreToolsRequest): Promise<GetExploreToolsResponse>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Minor edits to some parts of the API reference I happened upon on the published docs. These JSDocs get elevated up to the published Docusaurus site on backstage.io.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
