### PR TITLE
cli: fix module discovery race

### DIFF
--- a/.changeset/two-geese-explain.md
+++ b/.changeset/two-geese-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue that would cause an invalid `__backstage-autodetected-plugins__.js` to be written when using experimental module discovery.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,6 +112,7 @@
     "node-libs-browser": "^2.2.1",
     "npm-packlist": "^5.0.0",
     "ora": "^5.3.0",
+    "p-queue": "^6.6.2",
     "postcss": "^8.1.0",
     "process": "^0.11.10",
     "react-dev-utils": "^12.0.0-next.60",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3649,6 +3649,7 @@ __metadata:
     nodemon: ^3.0.1
     npm-packlist: ^5.0.0
     ora: ^5.3.0
+    p-queue: ^6.6.2
     postcss: ^8.1.0
     process: ^0.11.10
     react-dev-utils: ^12.0.0-next.60


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Had reports of trouble with the module file failing to compile. Looking into things I believe this is because we're sending multiple concurrent writes the the same file. Something like this might happen:

1. Start writing big content, e.g. `123456`
2. Start writing small content, e.g. `abc`
3. Finish writing big content
4. Finish writing small content

And then you're left with the file content `abc456`

👀 @iamEAP 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
