### PR TITLE
fix: Updates the imports in frontend docs

### DIFF
--- a/docs/features/software-templates/writing-custom-step-layouts.md
+++ b/docs/features/software-templates/writing-custom-step-layouts.md
@@ -20,11 +20,11 @@ The [createScaffolderLayout](https://backstage.io/docs/reference/plugin-scaffold
 
 ```ts
 import React from 'react';
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import {
   createScaffolderLayout,
   LayoutTemplate,
-  scaffolderPlugin,
-} from '@backstage/plugin-scaffolder';
+} from '@backstage/plugin-scaffolder-react';
 import { Grid } from '@material-ui/core';
 
 const TwoColumn: LayoutTemplate = ({ properties, description, title }) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

createScaffolderLayout and LayoutTemplate are deprecated in the '@backstage/plugin-scaffolder' they need to be moved to the '@backstage/plugin-scaffolder-react'. This PR updates that in the docs. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
