### PR TITLE
fix(permission-client): Surface service-to-service auth issues sooner.

### DIFF
--- a/.changeset/spotty-geese-perform.md
+++ b/.changeset/spotty-geese-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': minor
+---
+
+Surface service-to-service issues earlier when using `ServerPermissionClient`.

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -55,6 +55,7 @@
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "jose": "^5.2.0",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.20.4"
   },

--- a/plugins/permission-node/src/ServerPermissionClient.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.ts
@@ -29,6 +29,7 @@ import {
   PolicyDecision,
   QueryPermissionRequest,
 } from '@backstage/plugin-permission-common';
+import { decodeJwt } from 'jose';
 
 /**
  * A thin wrapper around
@@ -103,10 +104,12 @@ export class ServerPermissionClient implements PermissionEvaluator {
     if (!token) {
       return false;
     }
-    return this.tokenManager
-      .authenticate(token)
-      .then(() => true)
-      .catch(() => false);
+    const { sub } = decodeJwt(token);
+    if (sub !== 'backstage-server') {
+      return false;
+    }
+    await this.tokenManager.authenticate(token);
+    return true;
   }
 
   private async isEnabled(token?: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7885,6 +7885,7 @@ __metadata:
     "@types/supertest": ^2.0.8
     express: ^4.17.1
     express-promise-router: ^4.1.0
+    jose: ^5.2.0
     msw: ^1.0.0
     supertest: ^6.1.3
     zod: ^3.22.4
@@ -31401,6 +31402,13 @@ __metadata:
   version: 4.15.4
   resolution: "jose@npm:4.15.4"
   checksum: dccad91cb3357f36423774a0b89ad830dd84b31090de65cd139b85488439f16a00f8c59c0773825e8a1adb0dd9d13ad725ad66e6ea33880ecb3959bb99e1ea5b
+  languageName: node
+  linkType: hard
+
+"jose@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "jose@npm:5.2.0"
+  checksum: 277ef57dcfb2552c3f769e07235ace4d206b8959ca72dff58128be9af480ab591c8cd8724140d0110fd3bc88a020178d552ab29d418a97f98724d5c82593ac93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Helps debugging issues similar to #18622 for non-scaffolder plugins. The goal of this PR is to provide more direct feedback for service-to-service auth integrators about errors that arise in the `ServerTokenManager` about the server token. Ideally, this should reduce frustrations around hitting the `IdentityApi` with no reason to be hitting the `IdentityApi`. 

Depending on security implications of surfacing these jose issues directly, I'm open to adjusting this as needed. Example output:
```
{
	"error": {
		"name": "AuthenticationError",
		"message": "Invalid server token; caused by JWSSignatureVerificationFailed: signature verification failed",
		"cause": {
			"code": "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
			"name": "JWSSignatureVerificationFailed",
			"message": "signature verification failed",
			"stack": "JWSSignatureVerificationFailed: signature verification failed\n    at flattenedVerify (/Users/sennyeya/git/backstage/node_modules/jose/dist/node/cjs/jws/flattened/verify.js:90:15)\n    at async compactVerify (/Users/sennyeya/git/backstage/node_modules/jose/dist/node/cjs/jws/compact/verify.js:18:22)\n    at async jwtVerify (/Users/sennyeya/git/backstage/node_modules/jose/dist/node/cjs/jwt/verify.js:9:22)\n    at ServerTokenManager.authenticate (/Users/sennyeya/git/backstage/packages/backend-common/src/tokens/ServerTokenManager.ts:185:13)\n    at ServerPermissionClient.isValidServerToken (/Users/sennyeya/git/backstage/plugins/permission-node/src/ServerPermissionClient.ts:111:5)\n    at ServerPermissionClient.isEnabled (/Users/sennyeya/git/backstage/plugins/permission-node/src/ServerPermissionClient.ts:120:40)\n    at ServerPermissionClient.authorizeConditional (/Users/sennyeya/git/backstage/plugins/permission-node/src/ServerPermissionClient.ts:87:13)\n    at AuthorizedEntitiesCatalog.entities (/Users/sennyeya/git/backstage/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts:54:7)\n    at <anonymous> (/Users/sennyeya/git/backstage/plugins/catalog-backend/src/service/createRouter.ts:124:40)"
		},
		"stack": "AuthenticationError: Invalid server token; caused by JWSSignatureVerificationFailed: signature verification failed\n    at ServerTokenManager.authenticate (/Users/sennyeya/git/backstage/packages/backend-common/src/tokens/ServerTokenManager.ts:207:11)\n    at ServerPermissionClient.isValidServerToken (/Users/sennyeya/git/backstage/plugins/permission-node/src/ServerPermissionClient.ts:111:5)\n    at ServerPermissionClient.isEnabled (/Users/sennyeya/git/backstage/plugins/permission-node/src/ServerPermissionClient.ts:120:40)\n    at ServerPermissionClient.authorizeConditional (/Users/sennyeya/git/backstage/plugins/permission-node/src/ServerPermissionClient.ts:87:13)\n    at AuthorizedEntitiesCatalog.entities (/Users/sennyeya/git/backstage/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts:54:7)\n    at <anonymous> (/Users/sennyeya/git/backstage/plugins/catalog-backend/src/service/createRouter.ts:124:40)"
	},
	"request": {
		"method": "GET",
		"url": "/entities"
	},
	"response": {
		"statusCode": 401
	}
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
