### PR TITLE
Fix for issue 20256: Bug Report: converting circular structure to JSON error

### DIFF
--- a/.changeset/chilled-ways-wave.md
+++ b/.changeset/chilled-ways-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+fix for: converting circular structure to JSON error

--- a/plugins/scaffolder-react/package.json
+++ b/plugins/scaffolder-react/package.json
@@ -66,6 +66,7 @@
     "@types/json-schema": "^7.0.9",
     "@types/react": "^16.13.1 || ^17.0.0",
     "classnames": "^2.2.6",
+    "flatted": "3.2.9",
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.1",
     "json-schema": "^0.4.0",

--- a/plugins/scaffolder-react/src/next/lib/schema.ts
+++ b/plugins/scaffolder-react/src/next/lib/schema.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { JsonObject } from '@backstage/types';
+import { stringify, parse } from 'flatted';
 import { FieldValidation, UiSchema } from '@rjsf/utils';
 
 function isObject(value: unknown): value is JsonObject {
@@ -123,7 +124,7 @@ export const extractSchemaFromStep = (
   inputStep: JsonObject,
 ): { uiSchema: UiSchema; schema: JsonObject } => {
   const uiSchema: UiSchema = {};
-  const returnSchema: JsonObject = JSON.parse(JSON.stringify(inputStep));
+  const returnSchema: JsonObject = parse(stringify(inputStep));
   extractUiSchema(returnSchema, uiSchema);
   return { uiSchema, schema: returnSchema };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,6 +8420,7 @@ __metadata:
     "@types/luxon": ^3.0.0
     "@types/react": ^16.13.1 || ^17.0.0
     classnames: ^2.2.6
+    flatted: 3.2.9
     humanize-duration: ^3.25.1
     immer: ^9.0.1
     json-schema: ^0.4.0
@@ -27530,10 +27531,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "flatted@npm:3.1.1"
-  checksum: 508935e3366d95444131f0aaa801a4301f24ea5bcb900d12764e7335b46b910730cc1b5bcfcfb8eccb7c8db261ba0671c6a7ca30d10870ff7a7756dc7e731a7a
+"flatted@npm:3.2.9, flatted@npm:^3.1.0":
+  version: 3.2.9
+  resolution: "flatted@npm:3.2.9"
+  checksum: f14167fbe26a9d20f6fca8d998e8f1f41df72c8e81f9f2c9d61ed2bea058248f5e1cbd05e7f88c0e5087a6a0b822a1e5e2b446e879f3cfbe0b07ba2d7f80b026
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

![Screenshot 2024-01-27 at 23 03 46](https://github.com/backstage/backstage/assets/2265094/7a70364c-7487-4f24-b0e6-f0732f9cc687)


## Hey, I just made a Pull Request!

Problem is indeed here: https://github.com/backstage/backstage/blob/53b7c7668d0f783e50359e091d63ddc429aee05b/plugins/scaffolder-react/src/next/components/Stepper/createAsyncValidators.ts#L77 

But it's not an error, this call made by "json-schema-library" changes the object, and inserts there extra fields, one of them is circular. 

[This library](https://www.npmjs.com/package/flatted) can handle it well and removes this trash.
Idk any better solution to it, if to the same logic of using json-schema-library and getting schema this way.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
