### PR TITLE
Autocomplete picker: add argument for which filters should be applied

### DIFF
--- a/.changeset/lazy-pumas-sniff.md
+++ b/.changeset/lazy-pumas-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Adds an argument for which filters should be applied when fetching/counting available values

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -204,6 +204,7 @@ export type EntityAutocompletePickerProps<
   };
   InputProps?: TextFieldProps;
   initialSelectedOptions?: string[];
+  filtersForAvailableValues?: Array<keyof T>;
 };
 
 // @public

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -28,6 +28,7 @@ import {
   useEntityList,
 } from '../../hooks/useEntityListProvider';
 import { EntityFilter } from '../../types';
+import { reduceBackendCatalogFilters } from '../../utils';
 
 /** @public */
 export type AllowedEntityFilters<T extends DefaultEntityFilters> = {
@@ -96,13 +97,9 @@ export function EntityAutocompletePicker<
     const facet = path;
     const { facets } = await catalogApi.getEntityFacets({
       facets: [facet],
-      filter: availableValuesFilters
-        .map(f =>
-          f && typeof f.getCatalogFilters === 'function'
-            ? f.getCatalogFilters()
-            : {},
-        )
-        .reduce((a, b) => ({ ...a, ...b }), {}),
+      filter: reduceBackendCatalogFilters(
+        availableValuesFilters.filter(Boolean) as EntityFilter[],
+      ),
     });
 
     return Object.fromEntries(


### PR DESCRIPTION
Autocomplete picker: add argument for which filters should be applied.

The intention of this change is to be able to filter the values pulled in for the `EntityAutoCompletePicker`.
I can do this by copying this whole class, but I would prefer to use the default component if possible.

My problem with the default component is that it only filters on "kind" and we have pages that are pre-filtered on other values, such as "type". This makes the component show filter values and counts for items that are not relevant to the current view.

I'm not really a strong react dev, but I have tested this on our instance and it seems to work as expected.

The default value should leave it unchanged when the parameter is unused.

```
  <CustomEntityAutoCompletePicker<DefaultEntityFilters>
    label="Tags"
    name="tags"
    path="metadata.tags"
    Filter={EntityTagFilter}
    showCounts
    filtersForAvailableValues={['kind', 'type']}
  />
);
```

## Hey, I just made a Pull Request!


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
