### PR TITLE
align typescript versions to 5.1 + 5.3

### DIFF
--- a/.changeset/mighty-steaks-shave.md
+++ b/.changeset/mighty-steaks-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Bumped TypeScript to version `5.3`.

--- a/microsite/package.json
+++ b/microsite/package.json
@@ -25,7 +25,7 @@
     "@types/webpack-env": "^1.18.0",
     "js-yaml": "^4.1.0",
     "prettier": "^2.6.2",
-    "typescript": "~5.0.0",
+    "typescript": "~5.1.0",
     "yaml-loader": "^0.8.0"
   },
   "prettier": "@spotify/prettier-config",

--- a/microsite/yarn.lock
+++ b/microsite/yarn.lock
@@ -3907,7 +3907,7 @@ __metadata:
     react-dom: ^18.0.0
     sass: ^1.57.1
     swc-loader: ^0.2.3
-    typescript: ~5.0.0
+    typescript: ~5.1.0
     yaml-loader: ^0.8.0
   languageName: unknown
   linkType: soft
@@ -11692,23 +11692,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.0":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:~5.1.0":
+  version: 5.1.6
+  resolution: "typescript@npm:5.1.6"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.0.0#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=a1c5e5"
+"typescript@patch:typescript@~5.1.0#~builtin<compat/typescript>":
+  version: 5.1.6
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "semver": "^7.5.3",
     "shx": "^0.3.2",
     "ts-node": "^10.4.0",
-    "typescript": "~5.2.0"
+    "typescript": "~5.1.0"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -33,23 +33,23 @@ import { SidebarPinStateProvider } from './SidebarPinStateContext';
 
 export type SidebarPageClassKey = 'root';
 
-const useStyles = makeStyles<
-  Theme,
-  { sidebarConfig: SidebarConfig; isPinned: boolean }
->(
+type StyleProps = { sidebarConfig: SidebarConfig; isPinned: boolean };
+
+const useStyles = makeStyles<Theme, StyleProps>(
   theme => ({
     root: {
       width: '100%',
       transition: 'padding-left 0.1s ease-out',
       isolation: 'isolate',
       [theme.breakpoints.up('sm')]: {
-        paddingLeft: props =>
+        paddingLeft: (props: StyleProps) =>
           props.isPinned
             ? props.sidebarConfig.drawerWidthOpen
             : props.sidebarConfig.drawerWidthClosed,
       },
       [theme.breakpoints.down('xs')]: {
-        paddingBottom: props => props.sidebarConfig.mobileSidebarHeight,
+        paddingBottom: (props: StyleProps) =>
+          props.sidebarConfig.mobileSidebarHeight,
       },
       '@media print': {
         padding: '0px !important',

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -39,7 +39,7 @@
     "lerna": "^7.3.0",
     "node-gyp": "^9.0.0",
     "prettier": "^2.3.2",
-    "typescript": "~5.2.0"
+    "typescript": "~5.3.0"
   },
   "resolutions": {
     "@types/react": "^18",

--- a/plugins/git-release-manager/api-report.md
+++ b/plugins/git-release-manager/api-report.md
@@ -317,42 +317,42 @@ function LinearProgressWithLabel(props: {
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_BRANCH_NAME_CALVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_BRANCH_NAME_CALVER = 'rc/2020.01.01_1';
+const MOCK_RELEASE_BRANCH_NAME_CALVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_BRANCH_NAME_SEMVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_BRANCH_NAME_SEMVER = 'rc/1.2.3';
+const MOCK_RELEASE_BRANCH_NAME_SEMVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER = 'rc-2020.01.01_1';
+const MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER = 'rc-1.2.3';
+const MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_NAME_CALVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_NAME_CALVER = 'Version 2020.01.01_1';
+const MOCK_RELEASE_NAME_CALVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_NAME_SEMVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_NAME_SEMVER = 'Version 1.2.3';
+const MOCK_RELEASE_NAME_SEMVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_VERSION_TAG_NAME_CALVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_VERSION_TAG_NAME_CALVER = 'version-2020.01.01_1';
+const MOCK_RELEASE_VERSION_TAG_NAME_CALVER: string;
 
 // Warning: (ae-missing-release-tag) "MOCK_RELEASE_VERSION_TAG_NAME_SEMVER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-const MOCK_RELEASE_VERSION_TAG_NAME_SEMVER = 'version-1.2.3';
+const MOCK_RELEASE_VERSION_TAG_NAME_SEMVER: string;
 
 // Warning: (ae-missing-release-tag) "mockBumpedTag" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/yarn.lock
+++ b/yarn.lock
@@ -40134,7 +40134,7 @@ __metadata:
     semver: ^7.5.3
     shx: ^0.3.2
     ts-node: ^10.4.0
-    typescript: ~5.2.0
+    typescript: ~5.1.0
   languageName: unknown
   linkType: soft
 
@@ -43196,16 +43196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.2.0":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
   resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=a1c5e5"
@@ -43223,16 +43213,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~5.2.0#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=a1c5e5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, according to our [TypeScript versioning policy](https://backstage.io/docs/overview/versioning-policy#typescript-releases) we should now be on 5.1 in the main repo with 5.3 for new projects

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
