### PR TITLE
Add docs for build-in data refs to plugin docs

### DIFF
--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -305,6 +305,7 @@ Pulumi
 pygments
 pymdownx
 rankdir
+reactElement
 readme
 Readme
 readonly
@@ -330,6 +331,8 @@ Rollbar
 Rollup
 routable
 Routable
+routePath
+routeRef
 Rspack
 rst
 rsync

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -305,7 +305,6 @@ Pulumi
 pygments
 pymdownx
 rankdir
-reactElement
 readme
 Readme
 readonly
@@ -331,8 +330,6 @@ Rollbar
 Rollup
 routable
 Routable
-routePath
-routeRef
 Rspack
 rst
 rsync

--- a/docs/frontend-system/architecture/03-extensions.md
+++ b/docs/frontend-system/architecture/03-extensions.md
@@ -81,8 +81,6 @@ const extension = createExtension({
 
 Note that while the `createExtension` is public API and used in many places, it is not typically what you use when building plugins and features. Instead there are many extension creator functions exported by both the core APIs and plugins that make it easier to create extensions for more specific usages.
 
-... TODO ...
-
 ## Extension Data
 
 Communication between extensions happens in one direction, from one child extension through the attachment point to its parent. The child extension outputs data which is then passed as inputs to the parent extension. This data is called Extension Data, where the shape of each individual piece of data is described by an Extension Data Reference. These references are created separately from the extensions themselves, and can be shared across multiple different kinds of extensions. Each reference consists of an ID and a TypeScript type that the data needs to conform to, and represents one type of data that can be shared between extensions.

--- a/docs/frontend-system/architecture/03-extensions.md
+++ b/docs/frontend-system/architecture/03-extensions.md
@@ -135,7 +135,7 @@ const extension = createExtension({
 
 We provide default `coreExtensionData`, which provides commonly used `ExtensionDataRef`s - e.g. for `React.JSX.Element` and `RouteRef`. They can be used when creating your own extension. For example, the React Element extension data that we defined above is already provided as `coreExtensionData.reactElement`.
 
-For a full list and explanations of all types of core extension data, see the [core extension data reference](../building-plugins/04-built-in-data-refs.md). -->
+For a full list and explanations of all types of core extension data, see the [core extension data reference](../building-plugins/04-built-in-data-refs.md).
 
 ### Optional Extension Data
 

--- a/docs/frontend-system/architecture/03-extensions.md
+++ b/docs/frontend-system/architecture/03-extensions.md
@@ -135,7 +135,7 @@ const extension = createExtension({
 
 We provide default `coreExtensionData`, which provides commonly used `ExtensionDataRef`s - e.g. for `React.JSX.Element` and `RouteRef`. They can be used when creating your own extension. For example, the React Element extension data that we defined above is already provided as `coreExtensionData.reactElement`.
 
-<!-- For a full list and explanations of all types of core extension data, see the [core extension data reference](#TODO). -->
+For a full list and explanations of all types of core extension data, see the [core extension data reference](../building-plugins/04-built-in-data-refs.md). -->
 
 ### Optional Extension Data
 

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -14,90 +14,48 @@ To have a better understanding of extension data references please read [the cor
 
 Data references help to define the inputs and outputs of an extension. A data ref is uniquely identified through its `id`. Through the data ref, strong typing is enforced for the input/output of the extension.
 
-### Core Extension Data
+### reactElement
 
-Commonly used `ExtensionDataRef`s for extensions.
+|         id          |     type      |
+| :-----------------: | :-----------: |
+| `core.reactElement` | `JSX.Element` |
 
-| namespace |     name     |     type      |         id          |
-| :-------: | :----------: | :-----------: | :-----------------: |
-|     -     | reactElement | `JSX.Element` | `core.reactElement` |
-|     -     |  routePath   |   `string`    | `core.routing.path` |
-|     -     |   routeRef   |  `RouteRef`   | `core.routing.ref`  |
+The `reactElement` data reference can be used for defining the extension input/output of React elements. Example usage could be something linke this:
 
-### Core API Data
+```tsx
+import {
+  coreExtensionData,
+  createExtensionInput,
+  createPageExtension,
+} from '@backstage/frontend-plugin-api';
 
-|     namespace      |      name      |      type       |         id         |
-| :----------------: | :------------: | :-------------: | :----------------: |
-| createApiExtension | factoryDataRef | `AnyApiFactory` | `core.api.factory` |
-
-### Core Navigation
-
-#### Item Data
-
-```ts
-type DataType = {
-  title: string;
-  icon: IconComponent;
-  routeRef: RouteRef<undefined>;
-};
+const homePage = createPageExtension({
+  defaultPath: '/home',
+  routeRef: rootRouteRef,
+  inputs: {
+    props: createExtensionInput({
+      children: coreExtensionData.reactElement.optional(),
+    }),
+  },
+});
 ```
 
-|       namespace        |     name      |    type    |           id           |
-| :--------------------: | :-----------: | :--------: | :--------------------: |
-| createNavItemExtension | targetDataRef | `DataType` | `core.nav-item.target` |
+### routePath
 
-#### Logo Data
+|         id          |   type   |
+| :-----------------: | :------: |
+| `core.routing.path` | `string` |
 
-```ts
-type DataType = {
-  logoIcon?: JSX.Element;
-  logoFull?: JSX.Element;
-};
-```
+The `routePath` data reference can be used for defining the extension input/output of string paths.
 
-|       namespace        |        name         |                  type                  |              id               |
-| :--------------------: | :-----------------: | :------------------------------------: | :---------------------------: |
-| createNavLogoExtension | logoElementsDataRef | `ComponentType<PropsWithChildren<{}>>` | `core.nav-logo.logo-elements` |
+### routeRef
 
-### Core App Components Data
+|         id         |    type    |
+| :----------------: | :--------: |
+| `core.routing.ref` | `RouteRef` |
 
-|         namespace         |       name       |               type               |              id               |
-| :-----------------------: | :--------------: | :------------------------------: | :---------------------------: |
-| createSignInPageExtension | componentDataRef | `ComponentType<SignInPageProps>` | `core.sign-in-page.component` |
+The `routeRef` data reference can be used for defining the extension input/output of route references.
 
-### Core Theme Data
+### Other data references
 
-|      namespace       |     name     |    type    |         id         |
-| :------------------: | :----------: | :--------: | :----------------: |
-| createThemeExtension | themeDataRef | `AppTheme` | `core.theme.theme` |
-
-### Core Components
-
-```ts
-type DataType = {
-  ref: ComponentRef;
-  impl: ComponentType;
-};
-```
-
-|        namespace         |       name       |    type    |             id             |
-| :----------------------: | :--------------: | :--------: | :------------------------: |
-| createComponentExtension | componentDataRef | `DataType` | `core.component.component` |
-
-### Core Translation
-
-|         namespace          |        name        |                      type                      |               id               |
-| :------------------------: | :----------------: | :--------------------------------------------: | :----------------------------: |
-| createTranslationExtension | translationDataRef | `TranslationResource` or `TranslationMessages` | `core.translation.translation` |
-
-### App Root
-
-|           namespace           |       name       |                  type                  |         id         |
-| :---------------------------: | :--------------: | :------------------------------------: | :----------------: |
-| createAppRootWrapperExtension | componentDataRef | `ComponentType<PropsWithChildren<{}>>` | `app.root.wrapper` |
-
-### App Router
-
-|       namespace       |       name       |                  type                  |          id          |
-| :-------------------: | :--------------: | :------------------------------------: | :------------------: |
-| createRouterExtension | componentDataRef | `ComponentType<PropsWithChildren<{}>>` | `app.router.wrapper` |
+There are other data refs in the frontend system you might stumble upon while building your plugin. Most of them were created for use cases inside the core of the system, but they can be used also in your plugin.

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -12,7 +12,7 @@ To have a better understanding of extension data references please read [extensi
 
 ## Built-in extension data references
 
-Data references help to define the input & output of an extension. A data ref is uniquely identified through there `id`. Through the data ref strong typing is enforced for the input/output of the extension.
+Data references help to define the inputs and outputs of an extension. A data ref is uniquely identified through its `id`. Through the data ref, strong typing is enforced for the input/output of the extension.
 
 ### Core Extension Data
 

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -3,22 +3,95 @@ id: built-in-data-refs
 title: Built-in data refs
 sidebar_label: Built-in data refs
 # prettier-ignore
-description: Configuring or overriding built-in data refs
+description: Configuring or overriding built-in extension data references
 ---
 
-## Disable built-in data refs
+To have a better understanding of extension data references please read [extension data section the extensions architecture documentation](../architecture/03-extensions.md#extension-data) first.
 
-## Override built-in data refs
+## Built-in extension data references
 
-## Default built-in data refs
+### Frontend Plugin API
 
-### Example
+#### Core Extension Data
 
-#### Example
+| namespace |     name     |    type     |         id          |
+| :-------: | :----------: | :---------: | :-----------------: |
+|     -     | reactElement | JSX.Element | `core.reactElement` |
+|     -     |  routePath   |   string    | `core.routing.path` |
+|     -     |   routeRef   |  RouteRef   | `core.routing.ref`  |
 
-Extensions that provides a default `light` and `dark` app themes.
+####
 
-| kind  | namespace | name  |        id         |
-| :---: | :-------: | :---: | :---------------: |
-| theme |    app    | light | `theme:app/light` |
-| theme |    app    | dark  | `theme:app/dark`  |
+|     namespace      |      name      |     type      |        id        |
+| :----------------: | :------------: | :-----------: | :--------------: |
+| createApiExtension | factoryDataRef | AnyApiFactory | core.api.factory |
+
+####
+
+|           namespace           |       name       |                 type                 |        id        |
+| :---------------------------: | :--------------: | :----------------------------------: | :--------------: |
+| createAppRootWrapperExtension | componentDataRef | ComponentType<PropsWithChildren<{}>> | app.root.wrapper |
+
+####
+
+|       namespace       |       name       |                 type                 |        id        |
+| :-------------------: | :--------------: | :----------------------------------: | :--------------: |
+| createRouterExtension | componentDataRef | ComponentType<PropsWithChildren<{}>> | app.root.wrapper |
+
+####
+
+```ts
+type DataType = {
+  title: string;
+  icon: IconComponent;
+  routeRef: RouteRef<undefined>;
+};
+```
+
+|       namespace        |     name      |   type   |          id          |
+| :--------------------: | :-----------: | :------: | :------------------: |
+| createNavItemExtension | targetDataRef | DataType | core.nav-item.target |
+
+####
+
+```ts
+type DataType = {
+  logoIcon?: JSX.Element;
+  logoFull?: JSX.Element;
+};
+```
+
+|       namespace        |        name         |                 type                 |             id              |
+| :--------------------: | :-----------------: | :----------------------------------: | :-------------------------: |
+| createNavLogoExtension | logoElementsDataRef | ComponentType<PropsWithChildren<{}>> | core.nav-logo.logo-elements |
+
+####
+
+|         namespace         |       name       |              type              |             id              |
+| :-----------------------: | :--------------: | :----------------------------: | :-------------------------: |
+| createSignInPageExtension | componentDataRef | ComponentType<SignInPageProps> | core.sign-in-page.component |
+
+####
+
+|      namespace       |     name     |   type   |        id        |
+| :------------------: | :----------: | :------: | :--------------: |
+| createThemeExtension | themeDataRef | AppTheme | core.theme.theme |
+
+####
+
+```ts
+type DataType = {
+  ref: ComponentRef;
+  impl: ComponentType;
+};
+```
+
+|        namespace         |       name       |   type   |            id            |
+| :----------------------: | :--------------: | :------: | :----------------------: |
+| createComponentExtension | componentDataRef | DataType | core.component.component |
+
+####
+
+|         namespace          |        name        |                    type                    |              id              |
+| :------------------------: | :----------------: | :----------------------------------------: | :--------------------------: |
+| createTranslationExtension | translationDataRef | TranslationResource or TranslationMessages | core.translation.translation |

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -1,0 +1,24 @@
+---
+id: built-in-data-refs
+title: Built-in data refs
+sidebar_label: Built-in data refs
+# prettier-ignore
+description: Configuring or overriding built-in data refs
+---
+
+## Disable built-in data refs
+
+## Override built-in data refs
+
+## Default built-in data refs
+
+### Example
+
+#### Example
+
+Extensions that provides a default `light` and `dark` app themes.
+
+| kind  | namespace | name  |        id         |
+| :---: | :-------: | :---: | :---------------: |
+| theme |    app    | light | `theme:app/light` |
+| theme |    app    | dark  | `theme:app/dark`  |

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -20,7 +20,7 @@ Data references help to define the inputs and outputs of an extension. A data re
 | :-----------------: | :-----------: |
 | `core.reactElement` | `JSX.Element` |
 
-The `reactElement` data reference can be used for defining the extension input/output of React elements. Example usage could be something linke this:
+The `reactElement` data reference can be used for defining the extension input/output of React elements. Example usage could be something like this:
 
 ```tsx
 import {

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -6,39 +6,33 @@ sidebar_label: Built-in data refs
 description: Configuring or overriding built-in extension data references
 ---
 
+> **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
+
 To have a better understanding of extension data references please read [extension data section the extensions architecture documentation](../architecture/03-extensions.md#extension-data) first.
 
 ## Built-in extension data references
 
-### Frontend Plugin API
+Data references help to define the input & output of an extension. A data ref is uniquely identified through there `id`. Through the data ref strong typing is enforced for the input/output of the extension.
 
-#### Core Extension Data
+### Core Extension Data
 
-| namespace |     name     |    type     |         id          |
-| :-------: | :----------: | :---------: | :-----------------: |
-|     -     | reactElement | JSX.Element | `core.reactElement` |
-|     -     |  routePath   |   string    | `core.routing.path` |
-|     -     |   routeRef   |  RouteRef   | `core.routing.ref`  |
+Commonly used `ExtensionDataRef`s for extensions.
 
-####
+| namespace |     name     |     type      |         id          |
+| :-------: | :----------: | :-----------: | :-----------------: |
+|     -     | reactElement | `JSX.Element` | `core.reactElement` |
+|     -     |  routePath   |   `string`    | `core.routing.path` |
+|     -     |   routeRef   |  `RouteRef`   | `core.routing.ref`  |
 
-|     namespace      |      name      |     type      |        id        |
-| :----------------: | :------------: | :-----------: | :--------------: |
-| createApiExtension | factoryDataRef | AnyApiFactory | core.api.factory |
+### Core API Data
 
-####
+|     namespace      |      name      |      type       |         id         |
+| :----------------: | :------------: | :-------------: | :----------------: |
+| createApiExtension | factoryDataRef | `AnyApiFactory` | `core.api.factory` |
 
-|           namespace           |       name       |                 type                 |        id        |
-| :---------------------------: | :--------------: | :----------------------------------: | :--------------: |
-| createAppRootWrapperExtension | componentDataRef | ComponentType<PropsWithChildren<{}>> | app.root.wrapper |
+### Core Navigation
 
-####
-
-|       namespace       |       name       |                 type                 |        id        |
-| :-------------------: | :--------------: | :----------------------------------: | :--------------: |
-| createRouterExtension | componentDataRef | ComponentType<PropsWithChildren<{}>> | app.root.wrapper |
-
-####
+#### Item Data
 
 ```ts
 type DataType = {
@@ -48,11 +42,11 @@ type DataType = {
 };
 ```
 
-|       namespace        |     name      |   type   |          id          |
-| :--------------------: | :-----------: | :------: | :------------------: |
-| createNavItemExtension | targetDataRef | DataType | core.nav-item.target |
+|       namespace        |     name      |    type    |           id           |
+| :--------------------: | :-----------: | :--------: | :--------------------: |
+| createNavItemExtension | targetDataRef | `DataType` | `core.nav-item.target` |
 
-####
+#### Logo Data
 
 ```ts
 type DataType = {
@@ -61,23 +55,23 @@ type DataType = {
 };
 ```
 
-|       namespace        |        name         |                 type                 |             id              |
-| :--------------------: | :-----------------: | :----------------------------------: | :-------------------------: |
-| createNavLogoExtension | logoElementsDataRef | ComponentType<PropsWithChildren<{}>> | core.nav-logo.logo-elements |
+|       namespace        |        name         |                  type                  |              id               |
+| :--------------------: | :-----------------: | :------------------------------------: | :---------------------------: |
+| createNavLogoExtension | logoElementsDataRef | `ComponentType<PropsWithChildren<{}>>` | `core.nav-logo.logo-elements` |
 
-####
+### Core App Components Data
 
-|         namespace         |       name       |              type              |             id              |
-| :-----------------------: | :--------------: | :----------------------------: | :-------------------------: |
-| createSignInPageExtension | componentDataRef | ComponentType<SignInPageProps> | core.sign-in-page.component |
+|         namespace         |       name       |               type               |              id               |
+| :-----------------------: | :--------------: | :------------------------------: | :---------------------------: |
+| createSignInPageExtension | componentDataRef | `ComponentType<SignInPageProps>` | `core.sign-in-page.component` |
 
-####
+### Core Theme Data
 
-|      namespace       |     name     |   type   |        id        |
-| :------------------: | :----------: | :------: | :--------------: |
-| createThemeExtension | themeDataRef | AppTheme | core.theme.theme |
+|      namespace       |     name     |    type    |         id         |
+| :------------------: | :----------: | :--------: | :----------------: |
+| createThemeExtension | themeDataRef | `AppTheme` | `core.theme.theme` |
 
-####
+### Core Components
 
 ```ts
 type DataType = {
@@ -86,12 +80,24 @@ type DataType = {
 };
 ```
 
-|        namespace         |       name       |   type   |            id            |
-| :----------------------: | :--------------: | :------: | :----------------------: |
-| createComponentExtension | componentDataRef | DataType | core.component.component |
+|        namespace         |       name       |    type    |             id             |
+| :----------------------: | :--------------: | :--------: | :------------------------: |
+| createComponentExtension | componentDataRef | `DataType` | `core.component.component` |
 
-####
+### Core Translation
 
-|         namespace          |        name        |                    type                    |              id              |
-| :------------------------: | :----------------: | :----------------------------------------: | :--------------------------: |
-| createTranslationExtension | translationDataRef | TranslationResource or TranslationMessages | core.translation.translation |
+|         namespace          |        name        |                      type                      |               id               |
+| :------------------------: | :----------------: | :--------------------------------------------: | :----------------------------: |
+| createTranslationExtension | translationDataRef | `TranslationResource` or `TranslationMessages` | `core.translation.translation` |
+
+### App Root
+
+|           namespace           |       name       |                  type                  |         id         |
+| :---------------------------: | :--------------: | :------------------------------------: | :----------------: |
+| createAppRootWrapperExtension | componentDataRef | `ComponentType<PropsWithChildren<{}>>` | `app.root.wrapper` |
+
+### App Router
+
+|       namespace       |       name       |                  type                  |          id          |
+| :-------------------: | :--------------: | :------------------------------------: | :------------------: |
+| createRouterExtension | componentDataRef | `ComponentType<PropsWithChildren<{}>>` | `app.router.wrapper` |

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -8,7 +8,7 @@ description: Configuring or overriding built-in extension data references
 
 > **NOTE: The new frontend system is in alpha and is only supported by a small number of plugins.**
 
-To have a better understanding of extension data references please read [extension data section the extensions architecture documentation](../architecture/03-extensions.md#extension-data) first.
+To have a better understanding of extension data references please read [the corresponding architecture section](../architecture/03-extensions.md#extension-data) first.
 
 ## Built-in extension data references
 

--- a/docs/frontend-system/building-plugins/04-built-in-data-refs.md
+++ b/docs/frontend-system/building-plugins/04-built-in-data-refs.md
@@ -14,7 +14,7 @@ To have a better understanding of extension data references please read [the cor
 
 Data references help to define the inputs and outputs of an extension. A data ref is uniquely identified through its `id`. Through the data ref, strong typing is enforced for the input/output of the extension.
 
-### reactElement
+### `reactElement`
 
 |         id          |     type      |
 | :-----------------: | :-----------: |
@@ -40,7 +40,7 @@ const homePage = createPageExtension({
 });
 ```
 
-### routePath
+### `routePath`
 
 |         id          |   type   |
 | :-----------------: | :------: |
@@ -48,7 +48,7 @@ const homePage = createPageExtension({
 
 The `routePath` data reference can be used for defining the extension input/output of string paths.
 
-### routeRef
+### `routeRef`
 
 |         id         |    type    |
 | :----------------: | :--------: |

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -414,7 +414,8 @@
         "items": [
           "frontend-system/building-plugins/index",
           "frontend-system/building-plugins/testing",
-          "frontend-system/building-plugins/extension-types"
+          "frontend-system/building-plugins/extension-types",
+          "frontend-system/building-plugins/built-in-data-refs"
         ]
       },
       {


### PR DESCRIPTION
WIP - I'm a bit lost with what information should be in the documentation in giving addtitional context to those data references.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
