### PR TITLE
Fields limitation for EntityPicker

### DIFF
--- a/.changeset/four-walls-perform.md
+++ b/.changeset/four-walls-perform.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-Scaffolding - EntityPicker component - now it does not load full entity data, only a specified set - defaults to `['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']`. It can significantly reduce loaded time bigger data set. It's possible to set fields to ignore configure via `fields` in UI options of the EntityPicker component.
+Updating the `EntityPicker` to only select by default `kind` `metadata.name` `metadata.namespace` and `metadata.title` by default to improve performance on larger datasets.
+

--- a/.changeset/four-walls-perform.md
+++ b/.changeset/four-walls-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Scaffolding - EntityPicker component - now it does not load full entity data, only a specified set - defaults to `['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']`. It can significantly reduce loaded time bigger data set. It's possible to set fields to ignore configure via `fieldsToIgnore` in UI options of the EntityPicker component.

--- a/.changeset/four-walls-perform.md
+++ b/.changeset/four-walls-perform.md
@@ -2,5 +2,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-Updating the `EntityPicker` to only select by default `kind` `metadata.name` `metadata.namespace` and `metadata.title` by default to improve performance on larger datasets.
-
+Updating the `EntityPicker` to only select `kind` `metadata.name` and `metadata.namespace` by default to improve performance on larger datasets.

--- a/.changeset/four-walls-perform.md
+++ b/.changeset/four-walls-perform.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-Scaffolding - EntityPicker component - now it does not load full entity data, only a specified set - defaults to `['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']`. It can significantly reduce loaded time bigger data set. It's possible to set fields to ignore configure via `fieldsToIgnore` in UI options of the EntityPicker component.
+Scaffolding - EntityPicker component - now it does not load full entity data, only a specified set - defaults to `['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']`. It can significantly reduce loaded time bigger data set. It's possible to set fields to ignore configure via `fields` in UI options of the EntityPicker component.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -89,7 +89,10 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(undefined);
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        fields: ['metadata.name', 'metadata.namespace', 'kind'],
+        filter: undefined,
+      });
     });
 
     it('updates even if there is not an exact match', async () => {
@@ -130,11 +133,13 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: {
-          kind: ['User'],
-        },
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: {
+            kind: ['User'],
+          },
+        }),
+      );
     });
   });
 
@@ -173,18 +178,20 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: [
-          {
-            kind: ['Group'],
-            'metadata.name': 'test-entity',
-          },
-          {
-            kind: ['User'],
-            'metadata.name': 'test-entity',
-          },
-        ],
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['Group'],
+              'metadata.name': 'test-entity',
+            },
+            {
+              kind: ['User'],
+              'metadata.name': 'test-entity',
+            },
+          ],
+        }),
+      );
     });
     it('allow single top level filter', async () => {
       uiSchema = {
@@ -204,12 +211,14 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: {
-          kind: ['Group'],
-          'metadata.name': 'test-entity',
-        },
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: {
+            kind: ['Group'],
+            'metadata.name': 'test-entity',
+          },
+        }),
+      );
     });
 
     it('search for entitities containing an specific key', async () => {
@@ -230,14 +239,16 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: [
-          {
-            kind: ['User'],
-            'metadata.annotation.some/anotation': CATALOG_FILTER_EXISTS,
-          },
-        ],
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['User'],
+              'metadata.annotation.some/anotation': CATALOG_FILTER_EXISTS,
+            },
+          ],
+        }),
+      );
     });
   });
 
@@ -273,14 +284,16 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: [
-          {
-            kind: ['Group'],
-            'metadata.name': 'test-group',
-          },
-        ],
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['Group'],
+              'metadata.name': 'test-group',
+            },
+          ],
+        }),
+      );
     });
   });
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -61,14 +61,24 @@ export const EntityPicker = (props: EntityPickerProps) => {
   } = props;
   const catalogFilter = buildCatalogFilter(uiSchema);
   const defaultKind = uiSchema['ui:options']?.defaultKind;
+  const fieldsToIgnore = uiSchema['ui:options']?.fieldsToIgnore;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
 
   const catalogApi = useApi(catalogApiRef);
 
   const { value: entities, loading } = useAsync(async () => {
+    const defaultFieldsToIgnore = [
+      'metadata.name',
+      'metadata.namespace',
+      'metadata.title',
+      'kind',
+    ];
+    const fields = fieldsToIgnore || defaultFieldsToIgnore;
     const { items } = await catalogApi.getEntities(
-      catalogFilter ? { filter: catalogFilter } : undefined,
+      catalogFilter
+        ? { filter: catalogFilter, fields: fields }
+        : { filter: undefined, fields: fields },
     );
     return items;
   });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -61,20 +61,13 @@ export const EntityPicker = (props: EntityPickerProps) => {
   } = props;
   const catalogFilter = buildCatalogFilter(uiSchema);
   const defaultKind = uiSchema['ui:options']?.defaultKind;
-  const customFields = uiSchema['ui:options']?.fields;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
 
   const catalogApi = useApi(catalogApiRef);
 
   const { value: entities, loading } = useAsync(async () => {
-    const defaultFields = [
-      'metadata.name',
-      'metadata.namespace',
-      'metadata.title',
-      'kind',
-    ];
-    const fields = customFields || defaultFields;
+    const fields = ['metadata.name', 'metadata.namespace', 'kind'];
     const { items } = await catalogApi.getEntities(
       catalogFilter
         ? { filter: catalogFilter, fields: fields }

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -61,20 +61,20 @@ export const EntityPicker = (props: EntityPickerProps) => {
   } = props;
   const catalogFilter = buildCatalogFilter(uiSchema);
   const defaultKind = uiSchema['ui:options']?.defaultKind;
-  const fieldsToIgnore = uiSchema['ui:options']?.fields;
+  const customFields = uiSchema['ui:options']?.fields;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
 
   const catalogApi = useApi(catalogApiRef);
 
   const { value: entities, loading } = useAsync(async () => {
-    const defaultFieldsToIgnore = [
+    const defaultFields = [
       'metadata.name',
       'metadata.namespace',
       'metadata.title',
       'kind',
     ];
-    const fields = fieldsToIgnore || defaultFieldsToIgnore;
+    const fields = customFields || defaultFields;
     const { items } = await catalogApi.getEntities(
       catalogFilter
         ? { filter: catalogFilter, fields: fields }

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -70,8 +70,8 @@ export const EntityPicker = (props: EntityPickerProps) => {
     const fields = ['metadata.name', 'metadata.namespace', 'kind'];
     const { items } = await catalogApi.getEntities(
       catalogFilter
-        ? { filter: catalogFilter, fields: fields }
-        : { filter: undefined, fields: fields },
+        ? { filter: catalogFilter, fields }
+        : { filter: undefined, fields },
     );
     return items;
   });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -61,7 +61,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
   } = props;
   const catalogFilter = buildCatalogFilter(uiSchema);
   const defaultKind = uiSchema['ui:options']?.defaultKind;
-  const fieldsToIgnore = uiSchema['ui:options']?.fieldsToIgnore;
+  const fieldsToIgnore = uiSchema['ui:options']?.fields;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -45,7 +45,7 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .array(z.string())
       .optional()
       .describe(
-        'Fields to ignore from loading - download only the parts of each entity that match the field declarations.' +
+        'Download only the parts of each entity that match the field declarations.' +
           " Defaults to: fields: ['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']",
       ),
     defaultKind: z

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -41,13 +41,6 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from',
       ),
-    fields: z
-      .array(z.string())
-      .optional()
-      .describe(
-        'Download only the parts of each entity that match the field declarations.' +
-          " Defaults to: fields: ['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']",
-      ),
     defaultKind: z
       .string()
       .optional()

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -41,6 +41,13 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from',
       ),
+    fieldsToIgnore: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Fields to ignore from loading - download only the parts of each entity that match the field declarations.' +
+          " Defaults to: fields: ['metadata.name', 'metadata.namespace', 'metadata.title', 'kind']",
+      ),
     defaultKind: z
       .string()
       .optional()

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -41,7 +41,7 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from',
       ),
-    fieldsToIgnore: z
+    fields: z
       .array(z.string())
       .optional()
       .describe(

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -94,11 +94,14 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: {
-          kind: ['Group', 'User'],
-        },
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: {
+            kind: ['Group', 'User'],
+          },
+          fields: ['metadata.name', 'metadata.namespace', 'kind'],
+        }),
+      );
     });
   });
 
@@ -124,11 +127,14 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: {
-          kind: ['User'],
-        },
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: {
+            kind: ['User'],
+          },
+          fields: ['metadata.name', 'metadata.namespace', 'kind'],
+        }),
+      );
     });
   });
 
@@ -163,14 +169,16 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: [
-          {
-            kind: ['Group'],
-            'spec.type': 'team',
-          },
-        ],
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['Group'],
+              'spec.type': 'team',
+            },
+          ],
+        }),
+      );
     });
   });
 
@@ -208,16 +216,18 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        filter: [
-          {
-            kind: ['Group', 'User'],
-          },
-          {
-            'spec.type': ['team', 'business-unit'],
-          },
-        ],
-      });
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['Group', 'User'],
+            },
+            {
+              'spec.type': ['team', 'business-unit'],
+            },
+          ],
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

"In the current scenario, EntityPicker loads complete entity data without any field limitations. This results in the loading of a substantial amount of entity data, causing the browser to freeze when dealing with larger datasets, such as all users and groups for the Owner field.

To address this issue, I have implemented a default limitation on specific fields, including `metadata.name`, `metadata.namespace` and `kind`. 
![image](https://github.com/backstage/backstage/assets/2512959/aeced412-6fe7-4490-bc61-179ad6e27b9b)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
