### PR TITLE
core-components: show arrow heads in dependency graph

### DIFF
--- a/.changeset/forty-beers-sniff.md
+++ b/.changeset/forty-beers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added arrow heads for graph edges in `DependencyGraph` for better understandability.

--- a/.changeset/forty-beers-sniff.md
+++ b/.changeset/forty-beers-sniff.md
@@ -3,4 +3,36 @@
 '@backstage/plugin-catalog-graph': patch
 ---
 
-Added possibility to show arrow heads for graph edges in `DependencyGraph` for better understandability.
+Added possibility to show arrow heads for graph edges for better understandability.
+
+In order to show arrow heads in the catalog graph page, add `showArrowHeads` attribute to `CatalogGraphPage` component
+(typically in `packages/app/src/App.tsx`):
+
+```diff
+  <CatalogGraphPage
+    initialState={{
+      selectedKinds: ['component', 'domain', 'system', 'api', 'group'],
+      selectedRelations: [
+        RELATION_OWNER_OF,
+        RELATION_OWNED_BY,
+        RELATION_CONSUMES_API,
+        RELATION_API_CONSUMED_BY,
+        RELATION_PROVIDES_API,
+        RELATION_API_PROVIDED_BY,
+        RELATION_HAS_PART,
+        RELATION_PART_OF,
+        RELATION_DEPENDS_ON,
+        RELATION_DEPENDENCY_OF,
+      ],
+    }}
++   showArrowHeads
+  />
+```
+
+In order to show arrow heads in entity graphs, add `showArrowHeads` attribute to `EntityCatalogGraphCard` components
+(typically multiple occurrences in `packages/app/src/components/catalog/EntityPage.tsx`):
+
+```diff
+- <EntityCatalogGraphCard variant="gridItem" height={400} />
++ <EntityCatalogGraphCard variant="gridItem" height={400} showArrowHeads />
+```

--- a/.changeset/forty-beers-sniff.md
+++ b/.changeset/forty-beers-sniff.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/core-components': patch
+'@backstage/plugin-catalog-graph': patch
 ---
 
-Added arrow heads for graph edges in `DependencyGraph` for better understandability.
+Added possibility to show arrow heads for graph edges in `DependencyGraph` for better understandability.

--- a/.changeset/forty-beers-sniff.md
+++ b/.changeset/forty-beers-sniff.md
@@ -9,24 +9,8 @@ In order to show arrow heads in the catalog graph page, add `showArrowHeads` att
 (typically in `packages/app/src/App.tsx`):
 
 ```diff
-  <CatalogGraphPage
-    initialState={{
-      selectedKinds: ['component', 'domain', 'system', 'api', 'group'],
-      selectedRelations: [
-        RELATION_OWNER_OF,
-        RELATION_OWNED_BY,
-        RELATION_CONSUMES_API,
-        RELATION_API_CONSUMED_BY,
-        RELATION_PROVIDES_API,
-        RELATION_API_PROVIDED_BY,
-        RELATION_HAS_PART,
-        RELATION_PART_OF,
-        RELATION_DEPENDS_ON,
-        RELATION_DEPENDENCY_OF,
-      ],
-    }}
-+   showArrowHeads
-  />
+- <CatalogGraphPage />
++ <CatalogGraphPage showArrowHeads />
 ```
 
 In order to show arrow heads in entity graphs, add `showArrowHeads` attribute to `EntityCatalogGraphCard` components

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -265,6 +265,7 @@ export interface DependencyGraphProps<NodeData, EdgeData>
   rankMargin?: number;
   renderLabel?: DependencyGraphTypes.RenderLabelFunction<EdgeData>;
   renderNode?: DependencyGraphTypes.RenderNodeFunction<NodeData>;
+  showArrowHeads?: boolean;
   zoom?: 'enabled' | 'disabled' | 'enable-on-click';
 }
 

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -161,6 +161,12 @@ export interface DependencyGraphProps<NodeData, EdgeData>
    */
   curve?: 'curveStepBefore' | 'curveMonotoneX';
   /**
+   * Controls if the arrow heads should be rendered or not.
+   *
+   * Default: true
+   */
+  showArrowHeads?: boolean;
+  /**
    * Controls if the graph should be contained or grow
    *
    * @remarks
@@ -201,6 +207,7 @@ export function DependencyGraph<NodeData, EdgeData>(
     defs,
     zoom = 'enabled',
     curve = 'curveMonotoneX',
+    showArrowHeads = true,
     fit = 'grow',
     ...svgProps
   } = props;
@@ -436,6 +443,7 @@ export function DependencyGraph<NodeData, EdgeData>(
                 render={renderLabel}
                 edge={edge}
                 curve={curve}
+                showArrowHeads={showArrowHeads}
               />
             );
           })}

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -163,7 +163,7 @@ export interface DependencyGraphProps<NodeData, EdgeData>
   /**
    * Controls if the arrow heads should be rendered or not.
    *
-   * Default: true
+   * Default: false
    */
   showArrowHeads?: boolean;
   /**
@@ -207,7 +207,7 @@ export function DependencyGraph<NodeData, EdgeData>(
     defs,
     zoom = 'enabled',
     curve = 'curveMonotoneX',
-    showArrowHeads = true,
+    showArrowHeads = false,
     fit = 'grow',
     ...svgProps
   } = props;

--- a/packages/core-components/src/components/DependencyGraph/Edge.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Edge.tsx
@@ -19,7 +19,7 @@ import * as d3Shape from 'd3-shape';
 import isFinite from 'lodash/isFinite';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { DependencyGraphTypes as Types } from './types';
-import { EDGE_TEST_ID, LABEL_TEST_ID } from './constants';
+import { ARROW_MARKER_ID, EDGE_TEST_ID, LABEL_TEST_ID } from './constants';
 import { DefaultLabel } from './DefaultLabel';
 import dagre from 'dagre';
 
@@ -43,7 +43,7 @@ export type DependencyGraphEdgeClassKey = 'path' | 'label';
 const useStyles = makeStyles(
   theme => ({
     path: {
-      strokeWidth: 1,
+      strokeWidth: 1.3,
       stroke: theme.palette.textSubtle,
       fill: 'none',
       transition: `${theme.transitions.duration.shortest}ms`,
@@ -126,7 +126,12 @@ export function Edge<EdgeData>({
   return (
     <>
       {path && (
-        <path data-testid={EDGE_TEST_ID} className={classes.path} d={path} />
+        <path
+          data-testid={EDGE_TEST_ID}
+          className={classes.path}
+          markerEnd={`url(#${ARROW_MARKER_ID})`}
+          d={path}
+        />
       )}
       {labelProps.label ? (
         <g

--- a/packages/core-components/src/components/DependencyGraph/Edge.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Edge.tsx
@@ -67,6 +67,7 @@ export type EdgeComponentProps<T = unknown> = {
     edge: Types.DependencyEdge<T>,
   ) => dagre.graphlib.Graph<{}>;
   curve: 'curveStepBefore' | 'curveMonotoneX';
+  showArrowHeads?: boolean;
 };
 
 const renderDefault = (props: Types.RenderLabelProps<unknown>) => (
@@ -79,6 +80,7 @@ export function Edge<EdgeData>({
   id,
   edge,
   curve,
+  showArrowHeads,
 }: EdgeComponentProps<EdgeData>) {
   const { x = 0, y = 0, width, height, points } = edge;
   const labelProps: Types.DependencyEdge<EdgeData> = edge;
@@ -129,7 +131,7 @@ export function Edge<EdgeData>({
         <path
           data-testid={EDGE_TEST_ID}
           className={classes.path}
-          markerEnd={`url(#${ARROW_MARKER_ID})`}
+          markerEnd={showArrowHeads ? `url(#${ARROW_MARKER_ID})` : undefined}
           d={path}
         />
       )}

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -123,6 +123,7 @@ export type EntityRelationsGraphProps = {
   renderNode?: DependencyGraphTypes.RenderNodeFunction<EntityNode>;
   renderLabel?: DependencyGraphTypes.RenderLabelFunction<EntityEdge>;
   curve?: 'curveStepBefore' | 'curveMonotoneX';
+  showArrowHeads?: boolean;
 };
 
 // @public

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -84,6 +84,7 @@ export type EntityRelationsGraphProps = {
   renderNode?: DependencyGraphTypes.RenderNodeFunction<EntityNode>;
   renderLabel?: DependencyGraphTypes.RenderLabelFunction<EntityEdge>;
   curve?: 'curveStepBefore' | 'curveMonotoneX';
+  showArrowHeads?: boolean;
 };
 
 /**
@@ -107,6 +108,7 @@ export const EntityRelationsGraph = (props: EntityRelationsGraphProps) => {
     renderNode,
     renderLabel,
     curve,
+    showArrowHeads,
   } = props;
 
   const theme = useTheme();
@@ -154,6 +156,7 @@ export const EntityRelationsGraph = (props: EntityRelationsGraphProps) => {
           labelOffset={theme.spacing(1)}
           zoom={zoom}
           curve={curve}
+          showArrowHeads={showArrowHeads}
         />
       )}
     </div>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Show arrow heads in the dependency graph. Fixes #21587.

The dependency graph component used to show arrow heads before, this reverts part of https://github.com/backstage/backstage/pull/13673/, reusing `ARROW_MARKER_ID` that has been unused since then. I slightly increased the stroke width as well since that has influence on the size of the arrow heads.

#### Before and after: A depends on B, B depends on C, C depends on A (not simplified, with merged relations)
![before](https://github.com/backstage/backstage/assets/92733935/c3369c03-e16c-4734-add0-4ecc8705e1f8)
![after](https://github.com/backstage/backstage/assets/92733935/bc747fe9-c905-4ed1-890d-93e41a805470)

#### Before and after: artist engagement portal from Backstage examples (not simplified, without merged relations)
![before](https://github.com/backstage/backstage/assets/92733935/49c0e08e-4dda-48c8-834a-c86910fa2195)
![after](https://github.com/backstage/backstage/assets/92733935/172ea5ad-a597-4796-a2d4-f76245646a1b)


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
