### PR TITLE
fix(scaffolder-react): prevent erroneous render when empty links are provided

### DIFF
--- a/.changeset/weak-news-jam.md
+++ b/.changeset/weak-news-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix bug that erroneously caused a separator or a 0 to render in the TemplateCard for Templates with empty links

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.test.tsx
@@ -70,7 +70,7 @@ describe('TemplateCard', () => {
       },
     };
 
-    const { getByText } = await renderInTestApp(
+    const { getByText, getByTestId } = await renderInTestApp(
       <TestApiProvider
         apis={[
           [
@@ -87,6 +87,7 @@ describe('TemplateCard', () => {
 
     const description = getByText('hello');
     expect(description.querySelector('strong')).toBeInTheDocument();
+    expect(getByTestId('template-card-separator')).toBeInTheDocument();
   });
 
   it('should render no description if none is provided through the template', async () => {
@@ -118,6 +119,41 @@ describe('TemplateCard', () => {
     expect(getByText('No description')).toBeInTheDocument();
   });
 
+  it('should not render extra separators when tags or links are not present', async () => {
+    const mockTemplate: TemplateEntityV1beta3 = {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: { name: 'bob' },
+      spec: {
+        steps: [],
+        type: 'service',
+      },
+    };
+
+    const { queryByTestId } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+        ]}
+      >
+        <TemplateCard template={mockTemplate} />
+      </TestApiProvider>,
+    );
+
+    expect(queryByTestId('template-card-separator')).toBeInTheDocument();
+    expect(
+      queryByTestId('template-card-separator--tags'),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId('template-card-separator--links'),
+    ).not.toBeInTheDocument();
+  });
+
   it('should render the tags', async () => {
     const mockTemplate: TemplateEntityV1beta3 = {
       apiVersion: 'scaffolder.backstage.io/v1beta3',
@@ -129,7 +165,7 @@ describe('TemplateCard', () => {
       },
     };
 
-    const { getByText } = await renderInTestApp(
+    const { getByText, queryByTestId } = await renderInTestApp(
       <TestApiProvider
         apis={[
           [
@@ -147,6 +183,8 @@ describe('TemplateCard', () => {
     for (const tag of mockTemplate.metadata.tags!) {
       expect(getByText(tag)).toBeInTheDocument();
     }
+    expect(queryByTestId('template-card-separator')).not.toBeInTheDocument();
+    expect(queryByTestId('template-card-separator--tags')).toBeInTheDocument();
   });
 
   it('should not render links section when empty links are defined', async () => {
@@ -166,7 +204,7 @@ describe('TemplateCard', () => {
       ],
     };
 
-    const { queryByRole, queryByText } = await renderInTestApp(
+    const { queryByTestId, queryByText } = await renderInTestApp(
       <TestApiProvider
         apis={[
           [
@@ -186,7 +224,10 @@ describe('TemplateCard', () => {
       },
     );
 
-    expect(queryByRole('separator')).not.toBeInTheDocument();
+    expect(queryByTestId('template-card-separator')).toBeInTheDocument();
+    expect(
+      queryByTestId('template-card-separator--links'),
+    ).not.toBeInTheDocument();
     expect(queryByText('0')).not.toBeInTheDocument();
   });
 
@@ -207,7 +248,7 @@ describe('TemplateCard', () => {
       ],
     };
 
-    const { queryByRole, queryByText } = await renderInTestApp(
+    const { queryByTestId, queryByText } = await renderInTestApp(
       <TestApiProvider
         apis={[
           [
@@ -227,8 +268,57 @@ describe('TemplateCard', () => {
       },
     );
 
-    expect(queryByRole('separator')).not.toBeInTheDocument();
+    expect(queryByTestId('template-card-separator')).toBeInTheDocument();
+    expect(
+      queryByTestId('template-card-separator--links'),
+    ).not.toBeInTheDocument();
     expect(queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('should render links section when links are defined', async () => {
+    const mockTemplate: TemplateEntityV1beta3 = {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: {
+        name: 'bob',
+        tags: [],
+        links: [{ url: '/some/url', title: 'Learn More' }],
+      },
+      spec: {
+        steps: [],
+        type: 'service',
+      },
+      relations: [
+        {
+          targetRef: 'group:default/my-test-user',
+          type: RELATION_OWNED_BY,
+        },
+      ],
+    };
+
+    const { queryByTestId, getByRole } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+        ]}
+      >
+        <TemplateCard template={mockTemplate} additionalLinks={[]} />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:kind/:namespace/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(queryByTestId('template-card-separator')).not.toBeInTheDocument();
+    expect(queryByTestId('template-card-separator--links')).toBeInTheDocument();
+    expect(getByRole('link', { name: 'Learn More' })).toBeInTheDocument();
   });
 
   it('should render a link to the owner', async () => {

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.test.tsx
@@ -149,6 +149,88 @@ describe('TemplateCard', () => {
     }
   });
 
+  it('should not render links section when empty links are defined', async () => {
+    const mockTemplate: TemplateEntityV1beta3 = {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: { name: 'bob', tags: [], links: [] },
+      spec: {
+        steps: [],
+        type: 'service',
+      },
+      relations: [
+        {
+          targetRef: 'group:default/my-test-user',
+          type: RELATION_OWNED_BY,
+        },
+      ],
+    };
+
+    const { queryByRole, queryByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+        ]}
+      >
+        <TemplateCard template={mockTemplate} />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:kind/:namespace/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(queryByRole('separator')).not.toBeInTheDocument();
+    expect(queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('should not render links section when empty additional links are defined', async () => {
+    const mockTemplate: TemplateEntityV1beta3 = {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: { name: 'bob', tags: [], links: [] },
+      spec: {
+        steps: [],
+        type: 'service',
+      },
+      relations: [
+        {
+          targetRef: 'group:default/my-test-user',
+          type: RELATION_OWNED_BY,
+        },
+      ],
+    };
+
+    const { queryByRole, queryByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+        ]}
+      >
+        <TemplateCard template={mockTemplate} additionalLinks={[]} />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:kind/:namespace/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(queryByRole('separator')).not.toBeInTheDocument();
+    expect(queryByText('0')).not.toBeInTheDocument();
+  });
+
   it('should render a link to the owner', async () => {
     const mockTemplate: TemplateEntityV1beta3 = {
       apiVersion: 'scaffolder.backstage.io/v1beta3',

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.tsx
@@ -101,6 +101,10 @@ export const TemplateCard = (props: TemplateCardProps) => {
   const app = useApp();
   const iconResolver = (key?: string): IconComponent =>
     key ? app.getSystemIcon(key) ?? LanguageIcon : LanguageIcon;
+  const hasTags = !!template.metadata.tags?.length;
+  const hasLinks =
+    !!props.additionalLinks?.length || !!template.metadata.links?.length;
+  const displayDefaultDivider = !hasTags && !hasLinks;
 
   return (
     <Card>
@@ -115,15 +119,20 @@ export const TemplateCard = (props: TemplateCardProps) => {
               />
             </Box>
           </Grid>
-          {(template.metadata.tags?.length ?? 0) > 0 && (
+          {displayDefaultDivider && (
+            <Grid item xs={12}>
+              <Divider data-testid="template-card-separator" />
+            </Grid>
+          )}
+          {hasTags && (
             <>
               <Grid item xs={12}>
-                <Divider />
+                <Divider data-testid="template-card-separator--tags" />
               </Grid>
               <Grid item xs={12}>
                 <Grid container spacing={2}>
                   {template.metadata.tags?.map(tag => (
-                    <Grid item>
+                    <Grid key={`grid-${tag}`} item>
                       <Chip
                         style={{ margin: 0 }}
                         size="small"
@@ -136,11 +145,10 @@ export const TemplateCard = (props: TemplateCardProps) => {
               </Grid>
             </>
           )}
-          {(!!props.additionalLinks?.length ||
-            !!template.metadata.links?.length) && (
+          {hasLinks && (
             <>
               <Grid item xs={12}>
-                <Divider />
+                <Divider data-testid="template-card-separator--links" />
               </Grid>
               <Grid item xs={12}>
                 <Grid container spacing={2}>

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.tsx
@@ -136,7 +136,8 @@ export const TemplateCard = (props: TemplateCardProps) => {
               </Grid>
             </>
           )}
-          {(props.additionalLinks || template.metadata.links?.length) && (
+          {(!!props.additionalLinks?.length ||
+            !!template.metadata.links?.length) && (
             <>
               <Grid item xs={12}>
                 <Divider />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a minor UX bug where an extra divider _or_ a 0 could be rendered in the Template Card when the Template being displayed has explicitly a `metadata.links` value of `[]`

The latter issue (where a 0 is rendered) is only a problem if using the `TemplateCard` or rendering templates as a group directly from `@backstage/plugin-scaffolder-react`, say as an embedded Template selector list (and thus, not through the default Template List page)


### Before
![image](https://github.com/backstage/backstage/assets/12898497/bad24c96-ced4-43fc-8858-1229aa21e9bb)

### Before with modified code to show the 0 bug
Commented out https://github.com/backstage/backstage/blob/da462fffc70688766cd70ab51c32d195b7074380/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.tsx#L95 temporarily to show the 0 bug that can happen
![image](https://github.com/backstage/backstage/assets/12898497/ef1a144a-f94c-4333-a7ed-77c5b5ced1a5)

### After
![image](https://github.com/backstage/backstage/assets/12898497/584ed567-af75-4183-8c84-a2b8dfdcd42d)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation **N/A**
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
