### PR TITLE
Change project link button name in bazaar plugin ui

### DIFF
--- a/.changeset/fuzzy-hotels-remember.md
+++ b/.changeset/fuzzy-hotels-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Updated project link name

--- a/plugins/bazaar/src/components/LinkProjectDialog/LinkProjectDialog.tsx
+++ b/plugins/bazaar/src/components/LinkProjectDialog/LinkProjectDialog.tsx
@@ -99,7 +99,7 @@ export const LinkProjectDialog = ({
 
       <DialogActions>
         <Button onClick={handleSubmit} color="primary" type="submit">
-          OK
+          LINK
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
When we unlink a project we show the "UNLINK" 

![image](https://github.com/backstage/backstage/assets/133481507/1d710e99-017d-4f5b-b5dd-b9ca239209ee)



When we link a project we show just "ok" instead "LINK"

![image](https://github.com/backstage/backstage/assets/133481507/3b7c8208-9c0d-4ab7-8c4b-b91362563110)

