### PR TITLE
app-backend: replace all instances when injecting config

### DIFF
--- a/.changeset/red-eggs-serve.md
+++ b/.changeset/red-eggs-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Support injecting config multiple times in a single bundle

--- a/plugins/app-backend/src/lib/config.ts
+++ b/plugins/app-backend/src/lib/config.ts
@@ -49,7 +49,7 @@ export async function injectConfig(
     if (content.includes('__APP_INJECTED_RUNTIME_CONFIG__')) {
       logger.info(`Injecting env config into ${jsFile}`);
 
-      const newContent = content.replace(
+      const newContent = content.replaceAll(
         '"__APP_INJECTED_RUNTIME_CONFIG__"',
         injected,
       );
@@ -58,8 +58,8 @@ export async function injectConfig(
     } else if (content.includes('__APP_INJECTED_CONFIG_MARKER__')) {
       logger.info(`Replacing injected env config in ${jsFile}`);
 
-      const newContent = content.replace(
-        /\/\*__APP_INJECTED_CONFIG_MARKER__\*\/.*\/\*__INJECTED_END__\*\//,
+      const newContent = content.replaceAll(
+        /\/\*__APP_INJECTED_CONFIG_MARKER__\*\/.*?\/\*__INJECTED_END__\*\//g,
         injected,
       );
       await fs.writeFile(path, newContent, 'utf8');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #22621.

Switches the injection and replacement of config in app-backend to replace all instances, rather than just one. This also required making the quantifier lazy in the replacement regex, otherwise we can end up matching the first start marker, the last end marker, and every start and end marker in between them (!).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
