### PR TITLE
Scaffolder-backend-gerrit: Set branches to defaultBranch

### DIFF
--- a/.changeset/short-cherries-mix.md
+++ b/.changeset/short-cherries-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+---
+
+Provide default branch when creating repositories.

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
@@ -38,15 +38,17 @@ const createGerritProject = async (
     parent: string;
     owner?: string;
     description: string;
+    defaultBranch: string;
   },
 ): Promise<void> => {
-  const { projectName, parent, owner, description } = options;
+  const { projectName, parent, owner, description, defaultBranch } = options;
 
   const fetchOptions: RequestInit = {
     method: 'PUT',
     body: JSON.stringify({
       parent,
       description,
+      branches: [defaultBranch],
       owners: owner ? [owner] : [],
       create_empty_commit: false,
     }),
@@ -221,6 +223,7 @@ export function createPublishGerritAction(options: {
         owner: owner,
         projectName: repo,
         parent: workspace,
+        defaultBranch,
       });
       const auth = {
         username: integrationConfig.config.username!,


### PR DESCRIPTION
## Scaffolder-backend-gerrit needs to set the default branch when creating the project

When a project is created in `publish:gerrit` the default branch needs to be provided to the Gerrit API that creates the project. If the branches attribute is not provided, the default branch for the project will be set to whatever is configured as default on the Gerrit host.

Reference: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#project-input

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
