### PR TITLE
Allow injecting the list of backend features in a root service.

### DIFF
--- a/.changeset/brave-timers-wonder.md
+++ b/.changeset/brave-timers-wonder.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-plugin-api': minor
+'@backstage/backend-defaults': minor
+'@backstage/backend-app-api': minor
+---
+
+New root-scoped `FeatureRegistryService` that allows getting the list of all the registered features in the backend application.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -21,12 +21,33 @@ export interface BackendFeature {
   $$type: '@backstage/BackendFeature';
 }
 
+// @public (undocumented)
+export type BackendFeatureRegistration =
+  | BackendPluginRegistration
+  | BackendModuleRegistration;
+
+// @public
+export abstract class BackendFeatureRegistrationObserver {
+  // (undocumented)
+  abstract setFeatures(features: BackendFeatureRegistration[]): void;
+}
+
 // @public
 export interface BackendModuleConfig {
   moduleId: string;
   pluginId: string;
   // (undocumented)
   register(reg: BackendModuleRegistrationPoints): void;
+}
+
+// @public (undocumented)
+export interface BackendModuleRegistration {
+  // (undocumented)
+  moduleId: string;
+  // (undocumented)
+  pluginId: string;
+  // (undocumented)
+  type: 'module';
 }
 
 // @public
@@ -54,6 +75,14 @@ export interface BackendPluginConfig {
   pluginId: string;
   // (undocumented)
   register(reg: BackendPluginRegistrationPoints): void;
+}
+
+// @public (undocumented)
+export interface BackendPluginRegistration {
+  // (undocumented)
+  pluginId: string;
+  // (undocumented)
+  type: 'plugin';
 }
 
 // @public

--- a/packages/backend-plugin-api/src/index.ts
+++ b/packages/backend-plugin-api/src/index.ts
@@ -21,5 +21,11 @@
  */
 
 export * from './services';
-export type { BackendFeature } from './types';
+export type {
+  BackendFeature,
+  BackendFeatureRegistration,
+  BackendPluginRegistration,
+  BackendModuleRegistration,
+} from './types';
+export { BackendFeatureRegistrationObserver } from './types';
 export * from './wiring';

--- a/packages/backend-plugin-api/src/types.ts
+++ b/packages/backend-plugin-api/src/types.ts
@@ -27,3 +27,32 @@ export interface BackendFeature {
   // NOTE: This type is opaque in order to simplify future API evolution.
   $$type: '@backstage/BackendFeature';
 }
+
+/** @public */
+export type BackendFeatureRegistration =
+  | BackendPluginRegistration
+  | BackendModuleRegistration;
+
+/** @public */
+export interface BackendPluginRegistration {
+  pluginId: string;
+  type: 'plugin';
+}
+
+/** @public */
+export interface BackendModuleRegistration {
+  pluginId: string;
+  moduleId: string;
+  type: 'module';
+}
+
+/**
+ * The BackendFeatureListener is an abstract class that a service
+ * would extend, so that it can be fed with the list of registered features during
+ * application initialization.
+ *
+ * @public
+ */
+export abstract class BackendFeatureRegistrationObserver {
+  abstract setFeatures(features: BackendFeatureRegistration[]): void;
+}

--- a/packages/backend-plugin-api/src/wiring/types.ts
+++ b/packages/backend-plugin-api/src/wiring/types.ts
@@ -15,7 +15,11 @@
  */
 
 import { ServiceRef } from '../services/system/types';
-import { BackendFeature } from '../types';
+import {
+  BackendFeature,
+  BackendModuleRegistration,
+  BackendPluginRegistration,
+} from '../types';
 
 /**
  * TODO
@@ -81,7 +85,8 @@ export interface InternalBackendFeature extends BackendFeature {
 }
 
 /** @internal */
-export interface InternalBackendPluginRegistration {
+export interface InternalBackendPluginRegistration
+  extends BackendPluginRegistration {
   pluginId: string;
   type: 'plugin';
   extensionPoints: Array<readonly [ExtensionPoint<unknown>, unknown]>;
@@ -92,7 +97,8 @@ export interface InternalBackendPluginRegistration {
 }
 
 /** @internal */
-export interface InternalBackendModuleRegistration {
+export interface InternalBackendModuleRegistration
+  extends BackendModuleRegistration {
   pluginId: string;
   moduleId: string;
   type: 'module';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow injecting the list of `BackendFeatureRegstration`s in a root service by simply have the service implement a given interface.

This PR is the minimal change required to be able to further implement the requirement behind RFC https://github.com/backstage/backstage/issues/17538, possibly in different ways.

It is provided as a non-invasive, and non-opinionated alternative to PR https://github.com/backstage/backstage/pull/22332, which would let users have way to retrieve the list of local pluginIDs (and possibly moduleIDs) without imposing a given implementation choice for the whole RFC.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
