### PR TITLE
feat(cli): support dynamic imports from cjs

### DIFF
--- a/.changeset/orange-dragons-grab.md
+++ b/.changeset/orange-dragons-grab.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/cli': patch
+'@backstage/cli': minor
 ---
 
 Support dynamic imports when compiling to CommonJS.

--- a/.changeset/orange-dragons-grab.md
+++ b/.changeset/orange-dragons-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Support dynamic imports when compiling to CommonJS.

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -2,23 +2,25 @@
   "name": "@backstage/backend-dynamic-feature-service",
   "description": "Backstage dynamic feature service",
   "version": "0.2.10-next.2",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/backend-dynamic-feature-service"
   },
-  "backstage": {
-    "role": "node-library"
-  },
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json"
   },
+  "main": "dist/index.cjs.js",
+  "types": "src/index.ts",
   "typesVersions": {
     "*": {
       "package.json": [
@@ -26,19 +28,18 @@
       ]
     }
   },
-  "homepage": "https://backstage.io",
-  "keywords": [
-    "backstage"
+  "files": [
+    "dist",
+    "config.d.ts"
   ],
-  "license": "Apache-2.0",
   "scripts": {
     "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "clean": "backstage-cli package clean",
-    "start": "backstage-cli package start"
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
   },
   "dependencies": {
     "@backstage/backend-app-api": "workspace:^",
@@ -73,9 +74,5 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "wait-for-expect": "^3.0.2"
-  },
-  "files": [
-    "dist",
-    "config.d.ts"
-  ]
+  }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -18,8 +18,11 @@ import { createBackend } from '@backstage/backend-defaults';
 
 const backend = createBackend();
 
+console.log(import('./test.mjs'));
+
 backend.add(import('@backstage/plugin-auth-backend'));
-backend.add(import('./authModuleGithubProvider'));
+backend.add(Promise.resolve(require('./authModuleGithubProvider')));
+
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
 
 backend.add(import('@backstage/plugin-app-backend/alpha'));

--- a/packages/backend/src/test.mjs
+++ b/packages/backend/src/test.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
-
-export * from './modules';
-export * from './processing';
-export * from './search';
-export * from './service';
-export * from './deprecated';
-export * from './constants';
-import('./test.mjs').then(console.log);
+export default function test() {
+  console.log('test');
+}

--- a/packages/cli/config/nodeTransform.cjs
+++ b/packages/cli/config/nodeTransform.cjs
@@ -22,7 +22,7 @@ addHook(
     const transformed = transformSync(code, {
       filename,
       // sourceMaps: 'inline',
-      module: { type: 'commonjs' },
+      module: { type: 'commonjs', ignoreDynamic: true },
       jsc: {
         target: 'es2022',
         parser: {

--- a/packages/cli/config/nodeTransform.cjs
+++ b/packages/cli/config/nodeTransform.cjs
@@ -31,7 +31,7 @@ addHook(
         },
       },
     });
-    if (filename.includes('backend-next')) {
+    if (filename.includes('backend')) {
       console.log(transformed.code);
     }
     process.send?.({ type: 'watch', path: filename });

--- a/packages/cli/config/nodeTransform.cjs
+++ b/packages/cli/config/nodeTransform.cjs
@@ -27,6 +27,7 @@ addHook(
         target: 'es2022',
         parser: {
           syntax: 'typescript',
+          dynamicImport: true,
         },
       },
     });

--- a/packages/cli/config/nodeTransform.cjs
+++ b/packages/cli/config/nodeTransform.cjs
@@ -21,7 +21,7 @@ addHook(
   (code, filename) => {
     const transformed = transformSync(code, {
       filename,
-      sourceMaps: 'inline',
+      // sourceMaps: 'inline',
       module: { type: 'commonjs' },
       jsc: {
         target: 'es2022',
@@ -31,6 +31,9 @@ addHook(
         },
       },
     });
+    if (filename.includes('backend-next')) {
+      console.log(transformed.code);
+    }
     process.send?.({ type: 'watch', path: filename });
     return transformed.code;
   },

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -29,7 +29,9 @@ export function registerOnboardCommand(program: Command) {
   program
     .command('onboard', { hidden: true })
     .description('Get help setting up your Backstage App.')
-    .action(lazy(() => import('./onboard').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./onboard')).then(m => m.command)),
+    );
 }
 
 export function registerRepoCommand(program: Command) {
@@ -50,7 +52,9 @@ export function registerRepoCommand(program: Command) {
       '--since <ref>',
       'Only build packages and their dev dependents that changed since the specified ref',
     )
-    .action(lazy(() => import('./repo/build').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./repo/build')).then(m => m.command)),
+    );
 
   command
     .command('lint')
@@ -65,7 +69,9 @@ export function registerRepoCommand(program: Command) {
       'Only lint packages that changed since the specified ref',
     )
     .option('--fix', 'Attempt to automatically fix violations')
-    .action(lazy(() => import('./repo/lint').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./repo/lint')).then(m => m.command)),
+    );
 
   command
     .command('fix')
@@ -74,19 +80,27 @@ export function registerRepoCommand(program: Command) {
       '--check',
       'Fail if any packages would have been changed by the command',
     )
-    .action(lazy(() => import('./repo/fix').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./repo/fix')).then(m => m.command)),
+    );
 
   command
     .command('clean')
     .description('Delete cache and output directories')
-    .action(lazy(() => import('./repo/clean').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./repo/clean')).then(m => m.command)),
+    );
 
   command
     .command('list-deprecations')
     .description('List deprecations')
     .option('--json', 'Output as JSON')
     .action(
-      lazy(() => import('./repo/list-deprecations').then(m => m.command)),
+      lazy(() =>
+        Promise.resolve(require('./repo/list-deprecations')).then(
+          m => m.command,
+        ),
+      ),
     );
 
   command
@@ -101,7 +115,9 @@ export function registerRepoCommand(program: Command) {
       'Show help for Jest CLI options, which are passed through',
     )
     .description('Run tests, forwarding args to Jest, defaulting to watch mode')
-    .action(lazy(() => import('./repo/test').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./repo/test')).then(m => m.command)),
+    );
 }
 
 export function registerScriptCommand(program: Command) {
@@ -121,7 +137,9 @@ export function registerScriptCommand(program: Command) {
       'Enable debugger in Node.js environments, breaking before code starts',
     )
     .option('--require <path>', 'Add a --require argument to the node process')
-    .action(lazy(() => import('./start').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./start')).then(m => m.command)),
+    );
 
   command
     .command('build')
@@ -145,7 +163,9 @@ export function registerScriptCommand(program: Command) {
       (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
       Array<string>(),
     )
-    .action(lazy(() => import('./build').then(m => m.command)));
+    .action(
+      lazy(() => Promise.resolve(require('./build')).then(m => m.command)),
+    );
 
   command
     .command('lint [directories...]')
@@ -156,29 +176,37 @@ export function registerScriptCommand(program: Command) {
     )
     .option('--fix', 'Attempt to automatically fix violations')
     .description('Lint a package')
-    .action(lazy(() => import('./lint').then(m => m.default)));
+    .action(
+      lazy(() => Promise.resolve(require('./lint')).then(m => m.default)),
+    );
 
   command
     .command('test')
     .allowUnknownOption(true) // Allows the command to run, but we still need to parse raw args
     .helpOption(', --backstage-cli-help') // Let Jest handle help
     .description('Run tests, forwarding args to Jest, defaulting to watch mode')
-    .action(lazy(() => import('./test').then(m => m.default)));
+    .action(
+      lazy(() => Promise.resolve(require('./test')).then(m => m.default)),
+    );
 
   command
     .command('clean')
     .description('Delete cache directories')
-    .action(lazy(() => import('./clean/clean').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./clean/clean')).then(m => m.default),
+      ),
+    );
 
   command
     .command('prepack')
     .description('Prepares a package for packaging before publishing')
-    .action(lazy(() => import('./pack').then(m => m.pre)));
+    .action(lazy(() => Promise.resolve(require('./pack')).then(m => m.pre)));
 
   command
     .command('postpack')
     .description('Restores the changes made by the prepack command')
-    .action(lazy(() => import('./pack').then(m => m.post)));
+    .action(lazy(() => Promise.resolve(require('./pack')).then(m => m.post)));
 }
 
 export function registerMigrateCommand(program: Command) {
@@ -189,20 +217,32 @@ export function registerMigrateCommand(program: Command) {
   command
     .command('package-roles')
     .description(`Add package role field to packages that don't have it`)
-    .action(lazy(() => import('./migrate/packageRole').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./migrate/packageRole')).then(m => m.default),
+      ),
+    );
 
   command
     .command('package-scripts')
     .description('Set package scripts according to each package role')
     .action(
-      lazy(() => import('./migrate/packageScripts').then(m => m.command)),
+      lazy(() =>
+        Promise.resolve(require('./migrate/packageScripts')).then(
+          m => m.command,
+        ),
+      ),
     );
 
   command
     .command('package-exports')
     .description('Synchronize package subpath export definitions')
     .action(
-      lazy(() => import('./migrate/packageExports').then(m => m.command)),
+      lazy(() =>
+        Promise.resolve(require('./migrate/packageExports')).then(
+          m => m.command,
+        ),
+      ),
     );
 
   command
@@ -211,7 +251,11 @@ export function registerMigrateCommand(program: Command) {
       'Migrates all packages to use @backstage/cli/config/eslint-factory',
     )
     .action(
-      lazy(() => import('./migrate/packageLintConfigs').then(m => m.command)),
+      lazy(() =>
+        Promise.resolve(require('./migrate/packageLintConfigs')).then(
+          m => m.command,
+        ),
+      ),
     );
 
   command
@@ -220,7 +264,11 @@ export function registerMigrateCommand(program: Command) {
       'Migrates the react-router dependencies for all packages to be peer dependencies',
     )
     .action(
-      lazy(() => import('./migrate/reactRouterDeps').then(m => m.command)),
+      lazy(() =>
+        Promise.resolve(require('./migrate/reactRouterDeps')).then(
+          m => m.command,
+        ),
+      ),
     );
 }
 
@@ -251,7 +299,9 @@ export function registerCommands(program: Command) {
       'The version to use for any new packages (default: 0.1.0)',
     )
     .option('--no-private', 'Do not mark new packages as private')
-    .action(lazy(() => import('./new/new').then(m => m.default)));
+    .action(
+      lazy(() => Promise.resolve(require('./new/new')).then(m => m.default)),
+    );
 
   program
     .command('create', { hidden: true })
@@ -275,7 +325,9 @@ export function registerCommands(program: Command) {
       'The package registry to use for new packages',
     )
     .option('--no-private', 'Do not mark new packages as private')
-    .action(lazy(() => import('./new/new').then(m => m.default)));
+    .action(
+      lazy(() => Promise.resolve(require('./new/new')).then(m => m.default)),
+    );
 
   program
     .command('create-plugin', { hidden: true })
@@ -288,7 +340,11 @@ export function registerCommands(program: Command) {
     .option('--npm-registry <URL>', 'npm registry URL')
     .option('--no-private', 'Public npm package')
     .action(
-      lazy(() => import('./create-plugin/createPlugin').then(m => m.default)),
+      lazy(() =>
+        Promise.resolve(require('./create-plugin/createPlugin')).then(
+          m => m.default,
+        ),
+      ),
     );
 
   program
@@ -298,7 +354,11 @@ export function registerCommands(program: Command) {
     .description(
       'Diff an existing plugin with the creation template [DEPRECATED]',
     )
-    .action(lazy(() => import('./plugin/diff').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./plugin/diff')).then(m => m.default),
+      ),
+    );
 
   // TODO(Rugvip): Deprecate in favor of package variant
   program
@@ -308,7 +368,9 @@ export function registerCommands(program: Command) {
     .description(
       'Run tests, forwarding args to Jest, defaulting to watch mode [DEPRECATED]',
     )
-    .action(lazy(() => import('./test').then(m => m.default)));
+    .action(
+      lazy(() => Promise.resolve(require('./test')).then(m => m.default)),
+    );
 
   program
     .command('config:docs')
@@ -317,7 +379,11 @@ export function registerCommands(program: Command) {
       'Only include the schema that applies to the given package',
     )
     .description('Browse the configuration reference documentation')
-    .action(lazy(() => import('./config/docs').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./config/docs')).then(m => m.default),
+      ),
+    );
 
   program
     .command('config:print')
@@ -334,7 +400,11 @@ export function registerCommands(program: Command) {
     )
     .option(...configOption)
     .description('Print the app configuration for the current package')
-    .action(lazy(() => import('./config/print').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./config/print')).then(m => m.default),
+      ),
+    );
 
   program
     .command('config:check')
@@ -353,7 +423,11 @@ export function registerCommands(program: Command) {
     .description(
       'Validate that the given configuration loads and matches schema',
     )
-    .action(lazy(() => import('./config/validate').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./config/validate')).then(m => m.default),
+      ),
+    );
 
   program
     .command('config:schema')
@@ -368,7 +442,11 @@ export function registerCommands(program: Command) {
     .option('--merge', 'Print the config schemas merged', true)
     .option('--no-merge', 'Print the config schemas not merged')
     .description('Print configuration schema')
-    .action(lazy(() => import('./config/schema').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./config/schema')).then(m => m.default),
+      ),
+    );
 
   registerRepoCommand(program);
   registerScriptCommand(program);
@@ -389,13 +467,21 @@ export function registerCommands(program: Command) {
     .option('--skip-install', 'Skips yarn install step')
     .option('--skip-migrate', 'Skips migration of any moved packages')
     .description('Bump Backstage packages to the latest versions')
-    .action(lazy(() => import('./versions/bump').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./versions/bump')).then(m => m.default),
+      ),
+    );
 
   program
     .command('versions:check')
     .option('--fix', 'Fix any auto-fixable versioning problems')
     .description('Check Backstage package versioning')
-    .action(lazy(() => import('./versions/lint').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./versions/lint')).then(m => m.default),
+      ),
+    );
 
   program
     .command('versions:migrate')
@@ -416,7 +502,11 @@ export function registerCommands(program: Command) {
   program
     .command('clean')
     .description('Delete cache directories [DEPRECATED]')
-    .action(lazy(() => import('./clean/clean').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./clean/clean')).then(m => m.default),
+      ),
+    );
 
   program
     .command('build-workspace <workspace-dir> [packages...]')
@@ -425,17 +515,27 @@ export function registerCommands(program: Command) {
       'Force workspace output to be a result of running `yarn pack` on each package (warning: very slow)',
     )
     .description('Builds a temporary dist workspace from the provided packages')
-    .action(lazy(() => import('./buildWorkspace').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./buildWorkspace')).then(m => m.default),
+      ),
+    );
 
   program
     .command('create-github-app <github-org>')
     .description('Create new GitHub App in your organization.')
-    .action(lazy(() => import('./create-github-app').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./create-github-app')).then(m => m.default),
+      ),
+    );
 
   program
     .command('info')
     .description('Show helpful information for debugging and reporting bugs')
-    .action(lazy(() => import('./info').then(m => m.default)));
+    .action(
+      lazy(() => Promise.resolve(require('./info')).then(m => m.default)),
+    );
 
   program
     .command('install [plugin-id]', { hidden: true })
@@ -444,7 +544,11 @@ export function registerCommands(program: Command) {
       'Install from a local package.json containing the installation recipe',
     )
     .description('Install a Backstage plugin [EXPERIMENTAL]')
-    .action(lazy(() => import('./install/install').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./install/install')).then(m => m.default),
+      ),
+    );
 }
 
 // Wraps an action function so that it always exits and handles errors

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -96,6 +96,7 @@ export async function makeRollupConfigs(
         interop: 'compat',
         sourcemap: true,
         exports: 'named',
+        dynamicImportInCjs: true,
       });
     }
     if (options.outputs.has(Output.esm)) {

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -40,7 +40,9 @@ function registerPackageCommand(program: Command) {
     )
     .action(
       lazy(() =>
-        import('./package/schema/openapi/init').then(m => m.singleCommand),
+        Promise.resolve(require('./package/schema/openapi/init')).then(
+          m => m.singleCommand,
+        ),
       ),
     );
 
@@ -56,7 +58,9 @@ function registerPackageCommand(program: Command) {
     )
     .action(
       lazy(() =>
-        import('./package/schema/openapi/generate').then(m => m.command),
+        Promise.resolve(require('./package/schema/openapi/generate')).then(
+          m => m.command,
+        ),
       ),
     );
 
@@ -109,7 +113,9 @@ function registerRepoCommand(program: Command) {
     )
     .action(
       lazy(() =>
-        import('./repo/schema/openapi/verify').then(m => m.bulkCommand),
+        Promise.resolve(require('./repo/schema/openapi/verify')).then(
+          m => m.bulkCommand,
+        ),
       ),
     );
 
@@ -121,7 +127,11 @@ function registerRepoCommand(program: Command) {
       'Fail on any linting severity messages, not just errors.',
     )
     .action(
-      lazy(() => import('./repo/schema/openapi/lint').then(m => m.bulkCommand)),
+      lazy(() =>
+        Promise.resolve(require('./repo/schema/openapi/lint')).then(
+          m => m.bulkCommand,
+        ),
+      ),
     );
 
   openApiCommand
@@ -129,7 +139,11 @@ function registerRepoCommand(program: Command) {
     .description('Test OpenAPI schemas against written tests')
     .option('--update', 'Update the spec on failure.')
     .action(
-      lazy(() => import('./repo/schema/openapi/test').then(m => m.bulkCommand)),
+      lazy(() =>
+        Promise.resolve(require('./repo/schema/openapi/test')).then(
+          m => m.bulkCommand,
+        ),
+      ),
     );
 
   openApiCommand
@@ -194,14 +208,20 @@ export function registerCommands(program: Command) {
     .description('Generate an API report for selected packages')
     .action(
       lazy(() =>
-        import('./api-reports/api-reports').then(m => m.buildApiReports),
+        Promise.resolve(require('./api-reports/api-reports')).then(
+          m => m.buildApiReports,
+        ),
       ),
     );
 
   program
     .command('type-deps')
     .description('Find inconsistencies in types of all packages and plugins')
-    .action(lazy(() => import('./type-deps/type-deps').then(m => m.default)));
+    .action(
+      lazy(() =>
+        Promise.resolve(require('./type-deps/type-deps')).then(m => m.default),
+      ),
+    );
 
   program
     .command('generate-catalog-info')
@@ -216,9 +236,9 @@ export function registerCommands(program: Command) {
     .description('Create or fix info yaml files for all backstage packages')
     .action(
       lazy(() =>
-        import('./generate-catalog-info/generate-catalog-info').then(
-          m => m.default,
-        ),
+        Promise.resolve(
+          require('./generate-catalog-info/generate-catalog-info'),
+        ).then(m => m.default),
       ),
     );
 
@@ -228,7 +248,9 @@ export function registerCommands(program: Command) {
     .description('Generate a knip report for selected packages')
     .action(
       lazy(() =>
-        import('./knip-reports/knip-reports').then(m => m.buildKnipReports),
+        Promise.resolve(require('./knip-reports/knip-reports')).then(
+          m => m.buildKnipReports,
+        ),
       ),
     );
 

--- a/plugins/app-backend/package.json
+++ b/plugins/app-backend/package.json
@@ -2,17 +2,34 @@
   "name": "@backstage/plugin-app-backend",
   "description": "A Backstage backend plugin that serves the Backstage frontend app",
   "version": "0.3.66-next.1",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/app-backend"
+  },
   "exports": {
-    ".": "./src/index.ts",
-    "./alpha": "./src/alpha.ts",
+    ".": {
+      "import": "./dist/index.cjs.js",
+      "require": "./dist/index.cjs.js",
+      "types": "./src/index.ts"
+    },
+    "./alpha": {
+      "import": "./dist/alpha.cjs.js",
+      "require": "./dist/alpha.cjs.js",
+      "types": "./src/alpha.ts"
+    },
     "./package.json": "./package.json"
   },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "typesVersions": {
     "*": {
       "alpha": [
@@ -23,26 +40,20 @@
       ]
     }
   },
-  "backstage": {
-    "role": "backend-plugin"
-  },
-  "homepage": "https://backstage.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/backstage/backstage",
-    "directory": "plugins/app-backend"
-  },
-  "keywords": [
-    "backstage"
+  "files": [
+    "dist",
+    "config.d.ts",
+    "migrations/**/*.{js,d.ts}",
+    "static"
   ],
   "scripts": {
-    "start": "backstage-cli package start",
     "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "clean": "backstage-cli package clean"
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
   },
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
@@ -73,11 +84,5 @@
     "node-fetch": "^2.6.7",
     "supertest": "^6.1.3"
   },
-  "configSchema": "config.d.ts",
-  "files": [
-    "dist",
-    "config.d.ts",
-    "migrations/**/*.{js,d.ts}",
-    "static"
-  ]
+  "configSchema": "config.d.ts"
 }

--- a/plugins/auth-backend-module-guest-provider/package.json
+++ b/plugins/auth-backend-module-guest-provider/package.json
@@ -16,7 +16,13 @@
     "directory": "plugins/auth-backend-module-guest-provider"
   },
   "license": "Apache-2.0",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.cjs.js",
+      "require": "./dist/index.cjs.js",
+      "types": "./src/index.ts"
+    }
+  },
   "types": "src/index.ts",
   "files": [
     "dist",

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -17,7 +17,7 @@
     "directory": "plugins/catalog-backend-module-unprocessed"
   },
   "license": "Apache-2.0",
-  "main": "src/index.ts",
+  "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "files": [
     "dist"

--- a/plugins/catalog-backend/src/test.mjs
+++ b/plugins/catalog-backend/src/test.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
-
-export * from './modules';
-export * from './processing';
-export * from './search';
-export * from './service';
-export * from './deprecated';
-export * from './constants';
-import('./test.mjs').then(console.log);
+export default function test() {
+  console.log('test');
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

might fix #8242? 

Context: I ran into the ESM module support issue while testing out `ink` + a new Backstage CLI.  It would be great to start the ball rolling on adding support and this seems like the first blocker.

This PR adds a new plugin that handles rollup's `resolveDynamicPlugin` and `renderDynamicPlugin` methods. Currently, I enabled it just for non-relative files as the bundler doesn't pick up relative `.mjs` files directly. Given the context of where this would be used, I doubt that that is a necessary usecase as well. I did see that the commonjs plugin is set up to run against just node_modules, 
```
       commonjs({
          include: /node_modules/,
          exclude: [/\/[^/]+\.(?:stories|test)\.[^/]+$/],
        }),
```
Not sure if that impacts this work. From what I can tell, the resolutions for the dynamic imports work despite this, but it may require further investigation. Interestingly, I only needed to change the build config, and was able to leave the webpack config untouched.

Testing plan: I'm not quite sure what else should be tested here. I ran both the `build` and `start` commands with dynamic imports and they worked as expected (like the snapshot in the rollup test). Would love ideas here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
