### PR TITLE
auth-backend: refuse to issue excessively large tokens

### DIFF
--- a/.changeset/hip-ears-add.md
+++ b/.changeset/hip-ears-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+The auth backend will now refuse to issue user tokens are excessively large.

--- a/plugins/auth-backend/src/identity/TokenFactory.test.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.test.ts
@@ -154,6 +154,23 @@ describe('TokenFactory', () => {
     }).rejects.toThrow();
   });
 
+  it('should refuse to issue excessively large tokens', async () => {
+    const factory = new TokenFactory({
+      issuer: 'my-issuer',
+      keyStore: new MemoryKeyStore(),
+      keyDurationSeconds: 5,
+      logger,
+    });
+
+    await expect(() => {
+      return factory.issueToken({
+        claims: { sub: 'user:ns/n', ent: Array(10000).fill('group:ns/n') },
+      });
+    }).rejects.toThrow(
+      /^Failed to issue a new user token. The resulting token is excessively large, with either too many ownership claims or too large custom claims./,
+    );
+  });
+
   it('should defaults to ES256 when no algorithm string is supplied', async () => {
     const keyDurationSeconds = 5;
     const factory = new TokenFactory({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #20188

Adding a check to make sure that user tokens aren't ridiculously large. Tokens of this size would never be expected in practice and would basically always be a bug in the sign-in resolver implementation or data model.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
