### PR TITLE
Use the EntityDisplayName component for rendering Group nodes

### DIFF
--- a/.changeset/strong-news-develop.md
+++ b/.changeset/strong-news-develop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Use the EntityDisplayName component for rendering Group nodes

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.test.tsx
@@ -21,6 +21,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import { GroupsDiagram } from './GroupsDiagram';
 
@@ -55,7 +56,7 @@ describe('<GroupsDiagram />', () => {
         }),
     };
 
-    const { getByText } = await renderInTestApp(
+    await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
         <GroupsDiagram />
       </TestApiProvider>,
@@ -65,6 +66,9 @@ describe('<GroupsDiagram />', () => {
         },
       },
     );
-    expect(getByText('Group A', { selector: 'div' })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'group:my-namespace/group-a' }),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -15,7 +15,6 @@
  */
 
 import {
-  GroupEntity,
   parseEntityRef,
   RELATION_CHILD_OF,
   stringifyEntityRef,
@@ -31,8 +30,8 @@ import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
   catalogApiRef,
   entityRouteRef,
-  humanizeEntityRef,
   getEntityRelations,
+  EntityDisplayName,
 } from '@backstage/plugin-catalog-react';
 import { makeStyles, Typography, useTheme } from '@material-ui/core';
 import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
@@ -140,7 +139,9 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
         rx={theme.shape.borderRadius}
         className={classes.groupNode}
       />
-      <title>{props.node.name}</title>
+      <title>
+        <EntityDisplayName entityRef={props.node.id} hideIcon disableTooltip />
+      </title>
 
       <Link
         to={catalogEntityRoute({
@@ -152,7 +153,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
         <foreignObject width={nodeWidth} height={nodeHeight}>
           <div className={classes.centeredContent}>
             <div className={classNames(classes.textWrapper, classes.textGroup)}>
-              {props.node.name}
+              <EntityDisplayName entityRef={props.node.id} hideIcon />
             </div>
           </div>
         </foreignObject>
@@ -210,9 +211,7 @@ export function GroupsDiagram(props: {
     nodes.push({
       id: stringifyEntityRef(catalogItem),
       kind: catalogItem.kind,
-      name:
-        (catalogItem as GroupEntity).spec?.profile?.displayName ||
-        humanizeEntityRef(catalogItem, { defaultKind: 'Group' }),
+      name: '',
     });
 
     // Edge to parent

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
@@ -17,7 +17,7 @@
 import { Entity } from '@backstage/catalog-model';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
-import { waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import { GroupsExplorerContent } from '../GroupsExplorerContent';
 
@@ -73,48 +73,44 @@ describe('<GroupsExplorerContent />', () => {
     ];
     catalogApi.getEntities.mockResolvedValue({ items: entities });
 
-    const { getByText } = await renderInTestApp(
+    await renderInTestApp(
       <Wrapper>
         <GroupsExplorerContent />
       </Wrapper>,
       mountedRoutes,
     );
 
-    await waitFor(() => {
-      expect(
-        getByText('my-namespace/group-a', { selector: 'div' }),
-      ).toBeInTheDocument();
-    });
+    expect(
+      screen.getByRole('link', { name: 'group:my-namespace/group-a' }),
+    ).toBeInTheDocument();
   });
 
   it('renders a custom title', async () => {
     catalogApi.getEntities.mockResolvedValue({ items: [] });
 
-    const { getByText } = await renderInTestApp(
+    await renderInTestApp(
       <Wrapper>
         <GroupsExplorerContent title="Our Teams" />
       </Wrapper>,
       mountedRoutes,
     );
 
-    await waitFor(() =>
-      expect(getByText('Our Teams', { selector: 'h2' })).toBeInTheDocument(),
-    );
+    expect(
+      screen.getByText('Our Teams', { selector: 'h2' }),
+    ).toBeInTheDocument();
   });
 
   it('renders a friendly error if it cannot collect domains', async () => {
     const catalogError = new Error('Network timeout');
     catalogApi.getEntities.mockRejectedValueOnce(catalogError);
 
-    const { getAllByText } = await renderInTestApp(
+    await renderInTestApp(
       <Wrapper>
         <GroupsExplorerContent />
       </Wrapper>,
       mountedRoutes,
     );
 
-    await waitFor(() =>
-      expect(getAllByText(/Error: Network timeout/).length).not.toBe(0),
-    );
+    expect(screen.getAllByText(/Error: Network timeout/).length).not.toBe(0);
   });
 });

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
@@ -17,7 +17,7 @@
 import { Entity } from '@backstage/catalog-model';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
-import { screen } from '@testing-library/react';
+import { waitFor, screen } from '@testing-library/react';
 import React from 'react';
 import { GroupsExplorerContent } from '../GroupsExplorerContent';
 
@@ -80,9 +80,11 @@ describe('<GroupsExplorerContent />', () => {
       mountedRoutes,
     );
 
-    expect(
-      screen.getByRole('link', { name: 'group:my-namespace/group-a' }),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('link', { name: 'group:my-namespace/group-a' }),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('renders a custom title', async () => {
@@ -95,9 +97,11 @@ describe('<GroupsExplorerContent />', () => {
       mountedRoutes,
     );
 
-    expect(
-      screen.getByText('Our Teams', { selector: 'h2' }),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText('Our Teams', { selector: 'h2' }),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('renders a friendly error if it cannot collect domains', async () => {
@@ -111,6 +115,8 @@ describe('<GroupsExplorerContent />', () => {
       mountedRoutes,
     );
 
-    expect(screen.getAllByText(/Error: Network timeout/).length).not.toBe(0);
+    await waitFor(() =>
+      expect(screen.getAllByText(/Error: Network timeout/).length).not.toBe(0),
+    );
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `EntityDisplayName` component is now used when rendering the Groups diagram of the Explore plugin.
Previously the `profile.displayName` or the humanized entity refs were used.

Closes #22192

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
