### PR TITLE
Feature: add getGitBranches() to @backstage/plugin-azure-devops-backend

### DIFF
--- a/.changeset/smooth-jeans-type.md
+++ b/.changeset/smooth-jeans-type.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-azure-devops-backend': minor
+'@backstage/plugin-azure-devops-common': minor
+---
+
+Add getBranches()

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -12,6 +12,7 @@ import { Config } from '@backstage/config';
 import { DashboardPullRequest } from '@backstage/plugin-azure-devops-common';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
+import { GitBranch } from '@backstage/plugin-azure-devops-common';
 import { GitRepository } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { GitTag } from '@backstage/plugin-azure-devops-common';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
@@ -94,6 +95,13 @@ export class AzureDevOpsApi {
     projectName: string,
     options: PullRequestOptions,
   ): Promise<DashboardPullRequest[]>;
+  // (undocumented)
+  getGitBranches(
+    repo: string,
+    project: string,
+    host?: string,
+    org?: string,
+  ): Promise<GitBranch[]>;
   // (undocumented)
   getGitRepository(
     projectName: string,

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
@@ -31,6 +31,7 @@ import {
   BuildStatus,
 } from 'azure-devops-node-api/interfaces/BuildInterfaces';
 import {
+  GitBranchStats,
   GitPullRequest,
   GitRef,
   PullRequestStatus,
@@ -758,6 +759,55 @@ describe('AzureDevOpsApi', () => {
         finishTime: '2020-09-12T06:20:23.932Z',
         source: 'main (abcd)',
         uniqueName: 'N/A',
+      },
+    ]);
+  });
+
+  it('should get branches', async () => {
+    const mockGitBranchStats: GitBranchStats[] = [
+      {
+        aheadCount: 0,
+        behindCount: 0,
+        isBaseVersion: true,
+        name: 'main',
+      },
+      {
+        aheadCount: 1,
+        behindCount: 0,
+        isBaseVersion: false,
+        name: 'feature/add-something-new',
+      },
+    ];
+
+    const mockGitClient = {
+      getBranches: jest.fn().mockResolvedValue(mockGitBranchStats),
+    };
+
+    const mockGitApi = {
+      getGitApi: jest.fn().mockReturnValue(mockGitClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockGitApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getGitBranches('a-repo', 'a-project');
+
+    expect(result).toEqual([
+      {
+        aheadCount: 0,
+        behindCount: 0,
+        isBaseVersion: true,
+        name: 'main',
+      },
+      {
+        aheadCount: 1,
+        behindCount: 0,
+        isBaseVersion: false,
+        name: 'feature/add-something-new',
       },
     ]);
   });

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -21,6 +21,7 @@ import {
 import {
   BuildRun,
   DashboardPullRequest,
+  GitBranch,
   GitTag,
   Policy,
   PullRequest,
@@ -31,6 +32,7 @@ import {
   Project,
 } from '@backstage/plugin-azure-devops-common';
 import {
+  GitBranchStats,
   GitPullRequest,
   GitPullRequestSearchCriteria,
   GitRef,
@@ -543,5 +545,33 @@ export class AzureDevOpsApi {
       buffer.toString(),
     );
     return { url, content };
+  }
+
+  public async getGitBranches(
+    repo: string,
+    project: string,
+    host?: string,
+    org?: string,
+  ): Promise<GitBranch[]> {
+    this.logger?.debug(
+      `Calling Azure DevOps REST API, getting branches for Repository Id ${repo} for Project ${project}`,
+    );
+
+    const webApi = await this.getWebApi(host, org);
+    const client = await webApi.getGitApi();
+
+    const branchList: GitBranchStats[] = await client.getBranches(
+      repo,
+      project,
+    );
+
+    const branches: GitBranch[] = branchList.map(branch => ({
+      aheadCount: branch.aheadCount,
+      behindCount: branch.behindCount,
+      isBaseVersion: branch.isBaseVersion,
+      name: branch.name,
+    }));
+
+    return branches;
   }
 }

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -22,6 +22,7 @@ import {
   BuildResult,
   BuildRun,
   BuildStatus,
+  GitBranch,
   GitTag,
   PullRequest,
   PullRequestStatus,
@@ -47,6 +48,7 @@ describe('createRouter', () => {
       getBuildDefinitions: jest.fn(),
       getRepoBuilds: jest.fn(),
       getDefinitionBuilds: jest.fn(),
+      getGitBranches: jest.fn(),
       getGitTags: jest.fn(),
       getPullRequests: jest.fn(),
       getBuilds: jest.fn(),
@@ -505,6 +507,32 @@ describe('createRouter', () => {
         content,
         url,
       });
+    });
+  });
+
+  describe('GET /repository/:projectName/:repoName/branches', () => {
+    it('fetches all the branches in a repository', async () => {
+      const branches: GitBranch[] = [
+        {
+          aheadCount: 0,
+          behindCount: 0,
+          isBaseVersion: true,
+          name: 'main',
+        },
+      ];
+
+      azureDevOpsApi.getGitBranches.mockResolvedValueOnce(branches);
+
+      const response = await request(app).get(
+        '/repository/myProject/myRepo/branches',
+      );
+
+      expect(azureDevOpsApi.getGitBranches).toHaveBeenCalledWith(
+        'myRepo',
+        'myProject',
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(branches);
     });
   });
 });

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -226,6 +226,18 @@ export async function createRouter(
     res.status(200).json(readme);
   });
 
+  router.get(
+    '/repository/:projectName/:repoName/branches',
+    async (req, res) => {
+      const { projectName, repoName } = req.params;
+      const branches = await azureDevOpsApi.getGitBranches(
+        repoName,
+        projectName,
+      );
+      res.status(200).json(branches);
+    },
+  );
+
   router.use(errorHandler());
   return router;
 }

--- a/plugins/azure-devops-common/api-report.md
+++ b/plugins/azure-devops-common/api-report.md
@@ -103,6 +103,14 @@ export interface DashboardPullRequest {
 }
 
 // @public (undocumented)
+export type GitBranch = {
+  aheadCount?: number;
+  behindCount?: number;
+  isBaseVersion?: boolean;
+  name?: string;
+};
+
+// @public (undocumented)
 export type GitTag = {
   objectId?: string;
   peeledObjectId?: string;

--- a/plugins/azure-devops-common/src/types.ts
+++ b/plugins/azure-devops-common/src/types.ts
@@ -331,3 +331,26 @@ export type Project = {
   name?: string;
   description?: string;
 };
+
+/** @public */
+export type GitBranch = {
+  /**
+   * Number of commits ahead.
+   */
+  aheadCount?: number;
+
+  /**
+   * Number of commits behind.
+   */
+  behindCount?: number;
+
+  /**
+   * True if this is the result for the base version.
+   */
+  isBaseVersion?: boolean;
+
+  /**
+   * Name of the ref.
+   */
+  name?: string;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added getGitBranches() to @backstage/plugin-azure-devops-backend so that it is possible to get all of the branches within a repository.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
