### PR TITLE
Added permissionIntegrationRouter for azure-sites-backend routes

### DIFF
--- a/.changeset/tall-frogs-clap.md
+++ b/.changeset/tall-frogs-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-sites-backend': patch
+---
+
+Added `permissionIntegrationRouter` for azure-sites-backend routes

--- a/plugins/azure-sites-backend/src/service/router.ts
+++ b/plugins/azure-sites-backend/src/service/router.ts
@@ -27,8 +27,10 @@ import {
 } from '@backstage/plugin-permission-common';
 import {
   azureSitesActionPermission,
+  azureSitesPermissions,
   AZURE_WEB_SITE_NAME_ANNOTATION,
 } from '@backstage/plugin-azure-sites-common';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import { CatalogApi } from '@backstage/catalog-client';
 
 import { AzureSitesApi } from '../api';
@@ -47,8 +49,13 @@ export async function createRouter(
 ): Promise<express.Router> {
   const { logger, azureSitesApi, permissions, catalogApi } = options;
 
+  const permissionIntegrationRouter = createPermissionIntegrationRouter({
+    permissions: azureSitesPermissions,
+  });
+
   const router = Router();
   router.use(express.json());
+  router.use(permissionIntegrationRouter);
 
   router.get('/health', (_, response) => {
     logger.info('PONG!');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `permissionIntegrationRouter` for `azure-sites-backend` routes.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
