### PR TITLE
add a config declaration for `backend.workingDirectory`

### DIFF
--- a/.changeset/wise-papayas-cough.md
+++ b/.changeset/wise-papayas-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add a config declaration for `workingDirectory`

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -67,6 +67,22 @@ export interface Config {
           };
         };
 
+    /**
+     * An absolute path to a directory that can be used as a working dir, for
+     * example as scratch space for large operations.
+     *
+     * @remarks
+     *
+     * Note that this must be an absolute path.
+     *
+     * If not set, the operating system's designated temporary directory is
+     * commonly used, but that is implementation defined per plugin.
+     *
+     * Plugins are encouraged to heed this config setting if present, to allow
+     * deployment in severely locked-down or limited environments.
+     */
+    workingDirectory?: string;
+
     /** Database connection configuration, select base database type using the `client` field */
     database: {
       /** Default database client to use */


### PR DESCRIPTION
Accidentally discovered that this one has just been implicit the whole time, although it's used in a couple of places (notably, the scaffolder).