### PR TITLE
Add yaml file in the  microsite/data/plugins directory to apply for t…

### DIFF
--- a/microsite/data/plugins/IaC-support.yaml
+++ b/microsite/data/plugins/IaC-support.yaml
@@ -1,0 +1,10 @@
+---
+title: IaC Support
+author: Paul Pogonoski
+authorUrl: https://github.com/pogo61
+category: Catalogue Extension
+description: Add two new Catalogue entities - Environment and ResourceComponent as first-class entities. These are analogous to the software oriented entities System and Component.
+documentation: https://github.com/pogo61/Backstage-IaC-Plugin/blob/main/README.md
+iconUrl: /img/Iac-support.png
+npmPackageName: '@paulpogo/plugin-iac-support-backend'
+addedDate: '2024-02-14'


### PR DESCRIPTION
This is to add IaC support as a first class citizen to BackStage

Added two new Catalogue entities - Environment and ResourceComponent as first-class entities. These are analogous to the software oriented entities System and Component.
Therefore allowing the Environment to link to ResourceComponents (modules/collection of resources) and the ResourceComponents point to the actual IaC Resources or other ResourceComponents.

