### PR TITLE
Added a longTextLength prop to EntityOwnershipCard, OwnershipCard, and ComponentsGrid

### DIFF
--- a/.changeset/honest-humans-juggle.md
+++ b/.changeset/honest-humans-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Updated EntityOwnershipCard to have a longTextLength prop that gets passed to OwnershipCard and ComponentsGrid. Allows users to customize the text length they want the smallFont style to kick in at.

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -32,6 +32,7 @@ export const EntityOwnershipCard: (props: {
   hideRelationsToggle?: boolean | undefined;
   relationsType?: EntityRelationAggregation | undefined;
   entityLimit?: number | undefined;
+  longTextLength?: number | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -113,7 +113,7 @@ export const ComponentsGrid = ({
   relationsType,
   entityFilterKind,
   entityLimit = 6,
-  longTextLength,
+  longTextLength = 10,
 }: {
   entity: Entity;
   relationsType: EntityRelationAggregation;
@@ -144,7 +144,7 @@ export const ComponentsGrid = ({
             kind={c.kind}
             type={c.type}
             url={`${catalogLink()}/?${c.queryParams}`}
-            longTextLength={longTextLength ?? 10}
+            longTextLength={longTextLength}
           />
         </Grid>
       ))}

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -68,16 +68,18 @@ const EntityCountTile = ({
   type,
   kind,
   url,
+  longTextLength,
 }: {
   counter: number;
   type?: string;
   kind: string;
   url: string;
+  longTextLength: number;
 }) => {
   const classes = useStyles({ type: type ?? kind });
 
   const rawTitle = type ?? kind;
-  const isLongText = rawTitle.length > 10;
+  const isLongText = rawTitle.length > longTextLength;
 
   return (
     <Link to={url} variant="body2">
@@ -111,11 +113,13 @@ export const ComponentsGrid = ({
   relationsType,
   entityFilterKind,
   entityLimit = 6,
+  longTextLength,
 }: {
   entity: Entity;
   relationsType: EntityRelationAggregation;
   entityFilterKind?: string[];
   entityLimit?: number;
+  longTextLength?: number;
 }) => {
   const catalogLink = useRouteRef(catalogIndexRouteRef);
   const { componentsWithCounters, loading, error } = useGetEntities(
@@ -140,6 +144,7 @@ export const ComponentsGrid = ({
             kind={c.kind}
             type={c.type}
             url={`${catalogLink()}/?${c.queryParams}`}
+            longTextLength={longTextLength ?? 10}
           />
         </Grid>
       ))}

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -59,6 +59,7 @@ export const OwnershipCard = (props: {
   hideRelationsToggle?: boolean;
   relationsType?: EntityRelationAggregation;
   entityLimit?: number;
+  longTextLength?: number;
 }) => {
   const {
     variant,
@@ -66,6 +67,7 @@ export const OwnershipCard = (props: {
     hideRelationsToggle,
     relationsType,
     entityLimit = 6,
+    longTextLength,
   } = props;
   const relationsToggle =
     hideRelationsToggle === undefined ? false : hideRelationsToggle;
@@ -122,6 +124,7 @@ export const OwnershipCard = (props: {
         entityLimit={entityLimit}
         relationsType={getRelationsType}
         entityFilterKind={entityFilterKind}
+        longTextLength={longTextLength}
       />
     </InfoCard>
   );

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -67,7 +67,7 @@ export const OwnershipCard = (props: {
     hideRelationsToggle,
     relationsType,
     entityLimit = 6,
-    longTextLength,
+    longTextLength = 10,
   } = props;
   const relationsToggle =
     hideRelationsToggle === undefined ? false : hideRelationsToggle;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added a longTextLength prop to EntityOwnershipCard, and passed it down all the way to  EntityCountTile within ComponentsGrid.tsx. My team encountered an issue where one of our ownership cards says "Applications" which was longer than the hardcoded 10 character limit before isLongText and smallFont kicked in, making the font look smaller than all the other cards.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ✔️ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [✔️  ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
