### PR TITLE
conditionally rendering the user name and email in user settings page

### DIFF
--- a/.changeset/shiny-clocks-greet.md
+++ b/.changeset/shiny-clocks-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+conditionally rendering the user name and email in user settings page

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -101,16 +101,20 @@ export const ProviderSettingsItem = (props: {
               <Grid item xs={12} sm container>
                 <Grid item xs container direction="column" spacing={2}>
                   <Grid item xs>
-                    <Typography
-                      variant="subtitle1"
-                      color="textPrimary"
-                      gutterBottom
-                    >
-                      {profile.displayName}
-                    </Typography>
-                    <Typography variant="body2" color="textSecondary">
-                      {profile.email}
-                    </Typography>
+                    {profile.displayName && (
+                      <Typography
+                        variant="subtitle1"
+                        color="textPrimary"
+                        gutterBottom
+                      >
+                        {profile.displayName}
+                      </Typography>
+                    )}
+                    {profile.email && (
+                      <Typography variant="body2" color="textSecondary">
+                        {profile.email}
+                      </Typography>
+                    )}
                     <Typography variant="body2" color="textSecondary">
                       {description}
                     </Typography>


### PR DESCRIPTION
The issues is similar to 

https://github.com/backstage/backstage/pull/19596/files

avoid empty div and paragraph :  attached screen below

![image](https://github.com/backstage/backstage/assets/133481507/82fcef46-864f-457e-85e2-1d584f511efc)
