### PR TITLE
Update frontend-plugin-api package.json with repo information

### DIFF
--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -12,6 +12,11 @@
   "backstage": {
     "role": "web-library"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/frontend-plugin-api"
+  },
   "sideEffects": false,
   "scripts": {
     "start": "backstage-cli package start",


### PR DESCRIPTION
To fix https://www.npmjs.com/package/@backstage/frontend-plugin-api having a source code URL location (and thus fixing security scanners triggering on that information missing).
