### PR TITLE
Render playlist description based on condition

### DIFF
--- a/.changeset/ninety-hats-kiss.md
+++ b/.changeset/ninety-hats-kiss.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-playlist': patch
 ---
 
-Render playlist description based on condition
+Conditionally render playlist description only when it's non-empty

--- a/.changeset/ninety-hats-kiss.md
+++ b/.changeset/ninety-hats-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-playlist': patch
+---
+
+Render playlist description based on condition

--- a/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
+++ b/plugins/playlist/src/components/PlaylistCard/PlaylistCard.tsx
@@ -106,7 +106,9 @@ export const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
           <Typography variant="body2" className={classes.label}>
             Description
           </Typography>
-          <MarkdownContent content={playlist.description ?? ''} />
+          {playlist.description && (
+            <MarkdownContent content={playlist.description} />
+          )}
         </Box>
         <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>


### PR DESCRIPTION
Render playlist description based on condition instead showing empty DOM

![image](https://github.com/backstage/backstage/assets/133481507/490016ae-6108-4efa-8f90-f9ec388471f3)
