### PR TITLE
cli: stop requiring configuration for the frontend build

### DIFF
--- a/.changeset/long-wasps-wait.md
+++ b/.changeset/long-wasps-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Make schema processing gracefully handle an empty config.

--- a/.changeset/modern-peaches-clean.md
+++ b/.changeset/modern-peaches-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated the default app index template at `packages/app/public/index.html` to have a fallback value for the `app.title` config.

--- a/.changeset/poor-jeans-rescue.md
+++ b/.changeset/poor-jeans-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Make `http://localhost:3000` the default base URL for serving locally, and `/` the default public path for built apps. The app build no longer requires any configuration values to be present.

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -41,7 +41,7 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <title><%= config.getString('app.title') %></title>
+    <title><%= config.getOptionalString('app.title') ?? 'Backstage' %></title>
 
     <% if (config.has('app.datadogRum')) { %>
     <script>

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -23,7 +23,7 @@ import {
   printFileSizesAfterBuild,
 } from 'react-dev-utils/FileSizeReporter';
 import formatWebpackMessages from 'react-dev-utils/formatWebpackMessages';
-import { createConfig, resolveBaseUrl } from './config';
+import { createConfig } from './config';
 import { BuildOptions } from './types';
 import { resolveBundlingPaths, resolveOptionalBundlingPaths } from './paths';
 import chalk from 'chalk';
@@ -51,7 +51,6 @@ export async function buildBundle(options: BuildOptions) {
     ...options,
     checksEnabled: false,
     isDev: false,
-    baseUrl: resolveBaseUrl(options.frontendConfig),
     getFrontendAppConfigs: () => options.frontendAppConfigs,
   };
   const configs = [

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -44,9 +44,9 @@ import { hasReactDomClient } from './hasReactDomClient';
 const BUILD_CACHE_ENV_VAR = 'BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE';
 
 export function resolveBaseUrl(config: Config): URL {
-  const baseUrl = config.getString('app.baseUrl');
+  const baseUrl = config.getOptionalString('app.baseUrl');
   try {
-    return new URL(baseUrl);
+    return new URL(baseUrl ?? '/', 'http://localhost:3000');
   } catch (error) {
     throw new Error(`Invalid app.baseUrl, ${error}`);
   }
@@ -100,8 +100,7 @@ export async function createConfig(
   const { packages } = await getPackages(cliPaths.targetDir);
   const externalPkgs = packages.filter(p => !isChildPath(paths.root, p.dir));
 
-  const baseUrl = frontendConfig.getString('app.baseUrl');
-  const validBaseUrl = new URL(baseUrl);
+  const validBaseUrl = resolveBaseUrl(frontendConfig);
   let publicPath = validBaseUrl.pathname.replace(/\/$/, '');
   if (publicSubPath) {
     publicPath = `${publicPath}${publicSubPath}`.replace('//', '/');

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -110,9 +110,10 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
   });
   latestFrontendAppConfigs = cliConfig.frontendAppConfigs;
 
-  const appBaseUrl = cliConfig.frontendConfig.getString('app.baseUrl');
-  const backendBaseUrl = cliConfig.frontendConfig.getString('backend.baseUrl');
-  if (appBaseUrl === backendBaseUrl) {
+  const appBaseUrl = cliConfig.frontendConfig.getOptionalString('app.baseUrl');
+  const backendBaseUrl =
+    cliConfig.frontendConfig.getOptionalString('backend.baseUrl');
+  if (appBaseUrl && appBaseUrl === backendBaseUrl) {
     console.log(
       chalk.yellow(
         `⚠️   Conflict between app baseUrl and backend baseUrl:

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -23,7 +23,6 @@ export type BundlingOptions = {
   isDev: boolean;
   frontendConfig: Config;
   getFrontendAppConfigs(): AppConfig[];
-  baseUrl: URL;
   parallelism?: number;
   additionalEntryPoints?: string[];
   // Path to append to the detected public path, e.g. '/public'

--- a/packages/config-loader/src/schema/compile.ts
+++ b/packages/config-loader/src/schema/compile.ts
@@ -190,7 +190,7 @@ export function compileConfigSchemas(
   });
 
   return configs => {
-    const config = ConfigReader.fromConfigs(configs).get();
+    const config = ConfigReader.fromConfigs(configs).getOptional();
 
     visibilityByDataPath.clear();
     deepVisibilityByDataPath.clear();

--- a/packages/create-app/templates/default-app/packages/app/public/index.html
+++ b/packages/create-app/templates/default-app/packages/app/public/index.html
@@ -41,7 +41,7 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <title><%= config.getString('app.title') %></title>
+    <title><%= config.getOptionalString('app.title') ?? 'Backstage' %></title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Couple of tweaks to remove the requirement to have a frontend config present when building/serving the app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
