### PR TITLE
LocalKubectlProxyClusterLocator when resolving "localhost" prioritizes IPv4 results

### DIFF
--- a/.changeset/wicked-dolphins-wash.md
+++ b/.changeset/wicked-dolphins-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+On LocalKubectlProxyClusterLocator, when resolving localhost, IPv4 address is placed before IPv6 address, ignoring the order from the DNS resolver. This change is necessary since by default kubectl proxy listen on IPv4

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -646,7 +646,7 @@ describe('KubernetesProxy', () => {
     });
 
     worker.use(
-      rest.get('http://localhost:8001/api/v1/namespaces', (req, res, ctx) => {
+      rest.get('http://127.0.0.1:8001/api/v1/namespaces', (req, res, ctx) => {
         return req.headers.get('Authorization')
           ? res(ctx.status(401))
           : res(


### PR DESCRIPTION
Fixes #19931 

By default kubectl proxy listens on 127.0.0.1 instead of [::1], so LocalKubectlProxyClusterLocator when resolving "localhost" domain should prioritize IPv4 results

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
