### PR TITLE
feat(apollo explorer): export browser

### DIFF
--- a/.changeset/few-hairs-attend.md
+++ b/.changeset/few-hairs-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-apollo-explorer': minor
+---
+
+feat(apollo-explorer): export browser for users needing to pass tokens

--- a/plugins/apollo-explorer/README.md
+++ b/plugins/apollo-explorer/README.md
@@ -69,3 +69,74 @@ That's it! You should now see an `Apollo Explorer` item in your sidebar, and if 
 Once you authenticate, your graph is ready to use 🚀
 
 ![Logged In](./docs/img/logged-in.png)
+
+#### Alternative Use to pass in token
+
+In order to use a token from an async method, some changes to the above are needed.
+
+Create a function in `packages/app/src/App.tsx` such as the below to obtain a token.
+
+```typescript
+function ApolloPlugin() {
+  const ssoApi = useApi(authApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    const authToken = await ssoApi.getAccessToken();
+    return authToken;
+  }, [ssoApi]);
+
+  return (
+    <>
+      {loading ? (
+        <Progress />
+      ) : (
+        <Box>
+          {error ? (
+            <Alert severity="error" aria-label="error">
+              Error loading token.
+            </Alert>
+          ) : (
+            <Page themeId="tool">
+              <Header title={'Apollo Explorer 👩‍🚀'} />
+              <Content noPadding>
+                <ApolloExplorerBrowser
+                  endpoints={[
+                    {
+                      title: 'Github',
+                      graphRef: 'my-github-graph-ref@current',
+                      initialState: {
+                        headers: {
+                          authorization: `Bearer ${value}`,
+                        },
+                        displayOptions: {
+                          docsPanelState: 'open',
+                          showHeadersAndEnvVars: true,
+                        },
+                      },
+                    },
+                    {
+                      title: 'Linear',
+                      graphRef: 'my-linear-graph-ref@current',
+                    },
+                  ]}
+                />
+              </Content>
+            </Page>
+          )}
+        </Box>
+      )}
+    </>
+  );
+}
+```
+
+Then use the route code below.
+
+```typescript
+import { ApolloExplorerPage } from '@backstage/plugin-apollo-explorer';
+
+const routes = (
+  <FlatRoutes>
+    {/* other routes... */}
+    <Route path="/apollo-explorer" element={<ApolloPlugin />} />
+```

--- a/plugins/apollo-explorer/api-report.md
+++ b/plugins/apollo-explorer/api-report.md
@@ -8,7 +8,16 @@
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { JSONObject } from '@apollo/explorer/src/helpers/types';
 import { JSX as JSX_2 } from 'react';
+import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
+
+// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "ApolloExplorerBrowser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const ApolloExplorerBrowser: ({
+  endpoints,
+}: Props) => React_2.JSX.Element;
 
 // @public
 export const ApolloExplorerPage: (props: {

--- a/plugins/apollo-explorer/src/index.ts
+++ b/plugins/apollo-explorer/src/index.ts
@@ -20,3 +20,4 @@
  * @packageDocumentation
  */
 export { apolloExplorerPlugin, ApolloExplorerPage } from './plugin';
+export { ApolloExplorerBrowser } from './components/ApolloExplorerBrowser';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

feat(apollo-explorer): export browser

Currently async methods cannot be used to fetch necessary tokens which has the errors below

> Routable extension component with mount point routeRef{type=absolute,id=apollo-explorer} was not discovered in the app element tree. Routable extension components may not be rendered by other components and must be directly available as an element within the App provider component.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
