### PR TITLE
Update @backstage/plugin-auth-backend-module-oauth2-proxy-provider, @backstage/plugin-auth-backend-module-vmware-cloud-provider, @backstage/plugin-auth-backend-module-atlassian-provider, @backstage/plugin-auth-backend-module-microsoft-provider, @backstage/plugin-auth-backend-module-pinniped-provider, @backstage/plugin-auth-backend-module-github-provider, @backstage/plugin-auth-backend-module-gitlab-provider, @backstage/plugin-auth-backend-module-oauth2-provider, @backstage/plugin-auth-backend-module-oidc-provider, @backstage/plugin-auth-backend-module-okta-provider package.jsons with repo information

### DIFF
--- a/.changeset/sharp-ways-kiss.md
+++ b/.changeset/sharp-ways-kiss.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+'@backstage/plugin-auth-backend-module-vmware-cloud-provider': patch
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-pinniped-provider': patch
+'@backstage/plugin-auth-backend-module-github-provider': patch
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+'@backstage/plugin-auth-backend-module-oauth2-provider': patch
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+'@backstage/plugin-auth-backend-module-okta-provider': patch
+---
+
+Added repo information to package.json

--- a/plugins/auth-backend-module-atlassian-provider/package.json
+++ b/plugins/auth-backend-module-atlassian-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-atlassian-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-github-provider/package.json
+++ b/plugins/auth-backend-module-github-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-github-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-gitlab-provider/package.json
+++ b/plugins/auth-backend-module-gitlab-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-gitlab-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-microsoft-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-oauth2-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oauth2-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-oauth2-proxy-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oauth2-proxy-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oidc-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-okta-provider/package.json
+++ b/plugins/auth-backend-module-okta-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-okta-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-pinniped-provider/package.json
+++ b/plugins/auth-backend-module-pinniped-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-pinniped-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-vmware-cloud-provider/package.json
+++ b/plugins/auth-backend-module-vmware-cloud-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-vmware-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",


### PR DESCRIPTION
To fix these NPM packages having a source code URL location (and thus fixing security scanners triggering on that information missing).