### PR TITLE
plugins: add missing repository info to package.json

### DIFF
--- a/.changeset/two-goats-type.md
+++ b/.changeset/two-goats-type.md
@@ -1,0 +1,21 @@
+---
+'@backstage/plugin-catalog-backend-module-scaffolder-entity-model': patch
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+'@backstage/plugin-auth-backend-module-vmware-cloud-provider': patch
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-pinniped-provider': patch
+'@backstage/plugin-auth-backend-module-github-provider': patch
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+'@backstage/plugin-auth-backend-module-oauth2-provider': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket': patch
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+'@backstage/plugin-auth-backend-module-okta-provider': patch
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+'@backstage/plugin-scaffolder-backend-module-github': patch
+'@backstage/plugin-scaffolder-backend-module-azure': patch
+'@backstage/plugin-kubernetes-react': patch
+'@backstage/plugin-kubernetes-node': patch
+---
+
+chore: add missing repo information to package.jsons

--- a/plugins/auth-backend-module-atlassian-provider/package.json
+++ b/plugins/auth-backend-module-atlassian-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-atlassian-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-github-provider/package.json
+++ b/plugins/auth-backend-module-github-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-github-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-gitlab-provider/package.json
+++ b/plugins/auth-backend-module-gitlab-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-gitlab-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-microsoft-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-oauth2-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oauth2-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-oauth2-proxy-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oauth2-proxy-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oidc-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-okta-provider/package.json
+++ b/plugins/auth-backend-module-okta-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-okta-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-pinniped-provider/package.json
+++ b/plugins/auth-backend-module-pinniped-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-pinniped-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/auth-backend-module-vmware-cloud-provider/package.json
+++ b/plugins/auth-backend-module-vmware-cloud-provider/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-vmware-provider"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/catalog-backend-module-scaffolder-entity-model/package.json
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/package.json
@@ -22,6 +22,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/catalog-backend-module-scaffolder-entity-model"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/kubernetes-node/package.json
+++ b/plugins/kubernetes-node/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "node-library"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/kubernetes-node"
+  },
   "scripts": {
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",

--- a/plugins/kubernetes-react/package.json
+++ b/plugins/kubernetes-react/package.json
@@ -13,6 +13,11 @@
   "backstage": {
     "role": "web-library"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/kubernetes-react"
+  },
   "sideEffects": false,
   "configSchema": "config.d.ts",
   "scripts": {

--- a/plugins/scaffolder-backend-module-azure/package.json
+++ b/plugins/scaffolder-backend-module-azure/package.json
@@ -11,6 +11,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/scaffolder-backend-module-azure"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json"

--- a/plugins/scaffolder-backend-module-bitbucket/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket/package.json
@@ -11,6 +11,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/scaffolder-backend-module-bitbucket"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json"

--- a/plugins/scaffolder-backend-module-gerrit/package.json
+++ b/plugins/scaffolder-backend-module-gerrit/package.json
@@ -11,6 +11,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/scaffolder-backend-module-gerrit"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json"

--- a/plugins/scaffolder-backend-module-github/package.json
+++ b/plugins/scaffolder-backend-module-github/package.json
@@ -11,6 +11,11 @@
   "backstage": {
     "role": "backend-plugin-module"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/scaffolder-backend-module-github"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json"


### PR DESCRIPTION
To fix these NPM packages having a source code URL location (and thus fixing security scanners triggering on that information missing).