### PR TITLE
azure-devops plugin: Ability to fetch the README file from a different AZD path

### DIFF
--- a/.changeset/itchy-news-drive.md
+++ b/.changeset/itchy-news-drive.md
@@ -11,5 +11,5 @@ Defaults to the current, AZD default behaviour (`README.md` in the root of the g
 Example:
 
 ```yaml
-dev.azure.com/readme-path: /my-path/CHANGELOG.md
+dev.azure.com/readme-path: /my-path/README.md
 ```

--- a/.changeset/itchy-news-drive.md
+++ b/.changeset/itchy-news-drive.md
@@ -4,7 +4,7 @@
 '@backstage/plugin-azure-devops': minor
 ---
 
-Ability to fetch the README file from a different AZD path.
+Ability to fetch the README file from a different Azure DevOps path.
 
 Defaults to the current, Azure DevOps default behaviour (`README.md` in the root of the git repo); to use a different path, add the annotation `dev.azure.com/readme-path`
 

--- a/.changeset/itchy-news-drive.md
+++ b/.changeset/itchy-news-drive.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-azure-devops-backend': minor
+'@backstage/plugin-azure-devops-common': minor
+'@backstage/plugin-azure-devops': minor
+---
+
+Ability to fetch the README file from a different AZD path.
+
+Defaults to the current, AZD default behaviour (`README.md` in the root of the git repo); to use a different path, add the annotation `dev.azure.com/readme-path`
+
+Example:
+
+```yaml
+dev.azure.com/readme-path: /my-path/CHANGELOG.md
+```

--- a/.changeset/itchy-news-drive.md
+++ b/.changeset/itchy-news-drive.md
@@ -6,7 +6,7 @@
 
 Ability to fetch the README file from a different AZD path.
 
-Defaults to the current, AZD default behaviour (`README.md` in the root of the git repo); to use a different path, add the annotation `dev.azure.com/readme-path`
+Defaults to the current, Azure DevOps default behaviour (`README.md` in the root of the git repo); to use a different path, add the annotation `dev.azure.com/readme-path`
 
 Example:
 

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -124,6 +124,7 @@ export class AzureDevOpsApi {
     org: string,
     project: string,
     repo: string,
+    path: string,
   ): Promise<{
     url: string;
     content: string;

--- a/plugins/azure-devops-backend/package.json
+++ b/plugins/azure-devops-backend/package.json
@@ -32,6 +32,7 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-azure-devops-common": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -527,11 +527,12 @@ export class AzureDevOpsApi {
     org: string,
     project: string,
     repo: string,
+    path: string,
   ): Promise<{
     url: string;
     content: string;
   }> {
-    const url = buildEncodedUrl(host, org, project, repo, 'README.md');
+    const url = buildEncodedUrl(host, org, project, repo, path);
     const response = await this.urlReader.readUrl(url);
     const buffer = await response.buffer();
     const content = await replaceReadme(

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -482,7 +482,7 @@ describe('createRouter', () => {
   });
 
   describe('GET /readme/:projectName/:repoName', () => {
-    it('fetches readme file', async () => {
+    it('fetches default readme file', async () => {
       const content = getReadmeMock();
       const url = `https://host.com/myOrg/myProject/_git/myRepo?path=README.md`;
 
@@ -491,14 +491,41 @@ describe('createRouter', () => {
         url,
       });
 
+      const response = await request(app).get('/readme/myProject/myRepo');
+      expect(azureDevOpsApi.getReadme).toHaveBeenCalledWith(
+        'host.com',
+        'myOrg',
+        'myProject',
+        'myRepo',
+        'README.md',
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        content,
+        url,
+      });
+    });
+  });
+
+  describe('GET /readme/:projectName/:repoName with readme path', () => {
+    it('fetches specified readme file', async () => {
+      const content = getReadmeMock();
+      const url = `https://host.com/myOrg/myProject/_git/myRepo?path=README_NOT_DEFAULT.md`;
+
+      azureDevOpsApi.getReadme.mockResolvedValueOnce({
+        content,
+        url,
+      });
+
       const response = await request(app).get(
-        '/readme/myProject/myRepo?path=README.md',
+        '/readme/myProject/myRepo?path=README_NOT_DEFAULT.md',
       );
       expect(azureDevOpsApi.getReadme).toHaveBeenCalledWith(
         'host.com',
         'myOrg',
         'myProject',
         'myRepo',
+        'README_NOT_DEFAULT.md',
       );
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -482,7 +482,7 @@ describe('createRouter', () => {
   });
 
   describe('GET /readme/:projectName/:repoName', () => {
-    it('fetches default readme file', async () => {
+    it('fetches default default readme file', async () => {
       const content = getReadmeMock();
       const url = `https://host.com/myOrg/myProject/_git/myRepo?path=README.md`;
 
@@ -507,7 +507,7 @@ describe('createRouter', () => {
     });
   });
 
-  describe('GET /readme/:projectName/:repoName with readme path', () => {
+  describe('GET /readme/:projectName/:repoName with readme filename', () => {
     it('fetches specified readme file', async () => {
       const content = getReadmeMock();
       const url = `https://host.com/myOrg/myProject/_git/myRepo?path=README_NOT_DEFAULT.md`;
@@ -526,6 +526,34 @@ describe('createRouter', () => {
         'myProject',
         'myRepo',
         'README_NOT_DEFAULT.md',
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        content,
+        url,
+      });
+    });
+  });
+
+  describe('GET /readme/:projectName/:repoName with readme path', () => {
+    it('fetches specified readme file from subfolder', async () => {
+      const content = getReadmeMock();
+      const url = `https://host.com/myOrg/myProject/_git/myRepo?path=/my-path/README.md`;
+
+      azureDevOpsApi.getReadme.mockResolvedValueOnce({
+        content,
+        url,
+      });
+
+      const response = await request(app).get(
+        '/readme/myProject/myRepo?path=/my-path/README.md',
+      );
+      expect(azureDevOpsApi.getReadme).toHaveBeenCalledWith(
+        'host.com',
+        'myOrg',
+        'myProject',
+        'myRepo',
+        '/my-path/README.md',
       );
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -572,6 +572,14 @@ describe('createRouter', () => {
       expect(response.status).toEqual(400);
     });
   });
+
+  describe('GET /readme/:projectName/:repoName with a bad readme path (empty string)', () => {
+    it('throws InputError', async () => {
+      const response = await request(app).get('/readme/myProject/myRepo?path=');
+      expect(azureDevOpsApi.getReadme).not.toHaveBeenCalled();
+      expect(response.status).toEqual(400);
+    });
+  });
 });
 
 function getReadmeMock() {

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -562,6 +562,16 @@ describe('createRouter', () => {
       });
     });
   });
+
+  describe('GET /readme/:projectName/:repoName with a bad readme path (multiple values)', () => {
+    it('throws InputError', async () => {
+      const response = await request(app).get(
+        '/readme/myProject/myRepo?path=1&path=2',
+      );
+      expect(azureDevOpsApi.getReadme).not.toHaveBeenCalled();
+      expect(response.status).toEqual(400);
+    });
+  });
 });
 
 function getReadmeMock() {

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -216,12 +216,14 @@ export async function createRouter(
       req.query.host?.toString() ?? config.getString('azureDevOps.host');
     const org =
       req.query.org?.toString() ?? config.getString('azureDevOps.organization');
+    const path = req.query.path?.toString() ?? 'README.md';
     const { projectName, repoName } = req.params;
     const readme = await azureDevOpsApi.getReadme(
       host,
       org,
       projectName,
       repoName,
+      path,
     );
     res.status(200).json(readme);
   });

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -228,6 +228,10 @@ export async function createRouter(
       throw new InputError('Invalid path param');
     }
 
+    if (path === '') {
+      throw new InputError('If present, the path param should not be empty');
+    }
+
     const { projectName, repoName } = req.params;
     const readme = await azureDevOpsApi.getReadme(
       host,

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -26,6 +26,7 @@ import { Logger } from 'winston';
 import { PullRequestsDashboardProvider } from '../api/PullRequestsDashboardProvider';
 import Router from 'express-promise-router';
 import { errorHandler, UrlReader } from '@backstage/backend-common';
+import { InputError } from '@backstage/errors';
 import express from 'express';
 
 const DEFAULT_TOP = 10;
@@ -216,7 +217,17 @@ export async function createRouter(
       req.query.host?.toString() ?? config.getString('azureDevOps.host');
     const org =
       req.query.org?.toString() ?? config.getString('azureDevOps.organization');
-    const path = req.query.path?.toString() ?? 'README.md';
+    let path = req.query.path;
+
+    if (path === undefined) {
+      // if the annotation is missing, default to the previous behaviour (look for README.md in the root of the repo)
+      path = 'README.md';
+    }
+
+    if (typeof path !== 'string') {
+      throw new InputError('Invalid path param');
+    }
+
     const { projectName, repoName } = req.params;
     const readme = await azureDevOpsApi.getReadme(
       host,

--- a/plugins/azure-devops-common/api-report.md
+++ b/plugins/azure-devops-common/api-report.md
@@ -17,6 +17,9 @@ export const AZURE_DEVOPS_HOST_ORG_ANNOTATION = 'dev.azure.com/host-org';
 export const AZURE_DEVOPS_PROJECT_ANNOTATION = 'dev.azure.com/project';
 
 // @public (undocumented)
+export const AZURE_DEVOPS_README_ANNOTATION = 'dev.azure.com/readme-path';
+
+// @public (undocumented)
 export const AZURE_DEVOPS_REPO_ANNOTATION = 'dev.azure.com/project-repo';
 
 // @public (undocumented)
@@ -227,6 +230,8 @@ export interface ReadmeConfig {
   host?: string;
   // (undocumented)
   org?: string;
+  // (undocumented)
+  path?: string;
   // (undocumented)
   project: string;
   // (undocumented)

--- a/plugins/azure-devops-common/src/constants.ts
+++ b/plugins/azure-devops-common/src/constants.ts
@@ -22,6 +22,8 @@ export const AZURE_DEVOPS_HOST_ORG_ANNOTATION = 'dev.azure.com/host-org';
 /** @public */
 export const AZURE_DEVOPS_PROJECT_ANNOTATION = 'dev.azure.com/project';
 /** @public */
+export const AZURE_DEVOPS_README_ANNOTATION = 'dev.azure.com/readme-path';
+/** @public */
 export const AZURE_DEVOPS_REPO_ANNOTATION = 'dev.azure.com/project-repo';
 /** @public */
 export const AZURE_DEVOPS_DEFAULT_TOP: number = 10;

--- a/plugins/azure-devops-common/src/types.ts
+++ b/plugins/azure-devops-common/src/types.ts
@@ -212,6 +212,7 @@ export interface ReadmeConfig {
   repo: string;
   host?: string;
   org?: string;
+  path?: string;
 }
 
 /** @public */

--- a/plugins/azure-devops/README.md
+++ b/plugins/azure-devops/README.md
@@ -63,11 +63,19 @@ spec:
 
 #### Mono repos
 
-If you have multiple entities within a single repo, you will need to specify which pipelines belong to each entity.
+If you have multiple entities within a single repo, you will need to specify which pipelines belong to each entity:
 
 ```yaml
 dev.azure.com/project-repo: <my-project>/<my-repo>
 dev.azure.com/build-definition: <build-definition-name>
+```
+
+...and which README file belongs to each entity.
+
+Example:
+
+```yaml
+dev.azure.com/readme-path: /<path-to>/<my-readme-file>.md
 ```
 
 #### Pipeline in different project to repo

--- a/plugins/azure-devops/README.md
+++ b/plugins/azure-devops/README.md
@@ -63,7 +63,7 @@ spec:
 
 #### Mono repos
 
-If you have multiple entities within a single repo, you will need to specify which pipelines belong to each entity:
+If you have multiple entities within a single repo, you will need to specify which pipelines belong to each entity, like this:
 
 ```yaml
 dev.azure.com/project-repo: <my-project>/<my-repo>

--- a/plugins/azure-devops/README.md
+++ b/plugins/azure-devops/README.md
@@ -70,9 +70,7 @@ dev.azure.com/project-repo: <my-project>/<my-repo>
 dev.azure.com/build-definition: <build-definition-name>
 ```
 
-...and which README file belongs to each entity.
-
-Example:
+Then to display the `README` file that belongs to each entity you would do this:
 
 ```yaml
 dev.azure.com/readme-path: /<path-to>/<my-readme-file>.md

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -189,6 +189,9 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     if (opts.org) {
       queryString.append('org', opts.org);
     }
+    if (opts.path) {
+      queryString.append('path', opts.path);
+    }
     return await this.get(
       `readme/${encodeURIComponent(opts.project)}/${encodeURIComponent(
         opts.repo,

--- a/plugins/azure-devops/src/hooks/useReadme.ts
+++ b/plugins/azure-devops/src/hooks/useReadme.ts
@@ -30,8 +30,15 @@ export function useReadme(entity: Entity): {
   const api = useApi(azureDevOpsApiRef);
 
   const { value, loading, error } = useAsync(() => {
-    const { project, repo, host, org } = getAnnotationValuesFromEntity(entity);
-    return api.getReadme({ project, repo: repo as string, host, org });
+    const { project, repo, host, org, readmePath } =
+      getAnnotationValuesFromEntity(entity);
+    return api.getReadme({
+      project,
+      repo: repo as string,
+      host,
+      org,
+      path: readmePath,
+    });
   }, [api]);
 
   return {

--- a/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -52,6 +52,7 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: 'repoName',
         definition: undefined,
+        readmePath: undefined,
         host: undefined,
         org: undefined,
       });
@@ -149,6 +150,7 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: undefined,
         definition: 'buildDefinitionName',
+        readmePath: undefined,
         host: undefined,
         org: undefined,
       });
@@ -220,6 +222,7 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: 'repoName',
         definition: undefined,
+        readmePath: undefined,
         host: 'hostName',
         org: 'organizationName',
       });
@@ -246,6 +249,7 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: undefined,
         definition: 'buildDefinitionName',
+        readmePath: undefined,
         host: 'hostName',
         org: 'organizationName',
       });
@@ -344,6 +348,7 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: 'repoName',
         definition: undefined,
+        readmePath: undefined,
         host: 'company.com/tfs',
         org: 'organizationName',
       });
@@ -417,6 +422,7 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: 'repoName',
         definition: 'buildDefinitionName',
+        readmePath: undefined,
         host: undefined,
         org: undefined,
       });
@@ -443,6 +449,87 @@ describe('getAnnotationValuesFromEntity', () => {
         project: 'projectName',
         repo: undefined,
         definition: 'buildDefinitionName',
+        readmePath: undefined,
+        host: undefined,
+        org: undefined,
+      });
+    });
+  });
+
+  describe('definition, project and readme', () => {
+    it('returns with the readme path', () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          namespace: 'default',
+          name: 'project-repo',
+          annotations: {
+            'dev.azure.com/project': 'projectName',
+            'dev.azure.com/build-definition': 'buildDefinitionName',
+            'dev.azure.com/readme-path': 'readme/path.md',
+          },
+        },
+      };
+      const values = getAnnotationValuesFromEntity(entity);
+      expect(values).toEqual({
+        project: 'projectName',
+        repo: undefined,
+        definition: 'buildDefinitionName',
+        readmePath: 'readme/path.md',
+        host: undefined,
+        org: undefined,
+      });
+    });
+  });
+
+  describe('definition, projectRepo and readme', () => {
+    it('returns with the readme path', () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          namespace: 'default',
+          name: 'project-repo',
+          annotations: {
+            'dev.azure.com/project-repo': 'projectName/repoName',
+            'dev.azure.com/build-definition': 'buildDefinitionName',
+            'dev.azure.com/readme-path': 'readme/path.md',
+          },
+        },
+      };
+      const values = getAnnotationValuesFromEntity(entity);
+      expect(values).toEqual({
+        project: 'projectName',
+        repo: 'repoName',
+        definition: 'buildDefinitionName',
+        readmePath: 'readme/path.md',
+        host: undefined,
+        org: undefined,
+      });
+    });
+  });
+
+  describe('projectRepo and readme', () => {
+    it('returns with the readme path', () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          namespace: 'default',
+          name: 'project-repo',
+          annotations: {
+            'dev.azure.com/project-repo': 'projectName/repoName',
+            'dev.azure.com/readme-path': 'readme/path.md',
+          },
+        },
+      };
+      const values = getAnnotationValuesFromEntity(entity);
+      expect(values).toEqual({
+        project: 'projectName',
+        repo: 'repoName',
+        definition: undefined,
+        readmePath: 'readme/path.md',
         host: undefined,
         org: undefined,
       });

--- a/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.ts
+++ b/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.ts
@@ -18,6 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import {
   AZURE_DEVOPS_PROJECT_ANNOTATION,
   AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION,
+  AZURE_DEVOPS_README_ANNOTATION,
   AZURE_DEVOPS_REPO_ANNOTATION,
   AZURE_DEVOPS_HOST_ORG_ANNOTATION,
 } from '@backstage/plugin-azure-devops-common';
@@ -28,6 +29,7 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
   definition?: string;
   host?: string;
   org?: string;
+  readmePath?: string;
 } {
   const hostOrg = getHostOrg(entity.metadata.annotations);
   const projectRepo = getProjectRepo(entity.metadata.annotations);
@@ -35,12 +37,15 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
     entity.metadata.annotations?.[AZURE_DEVOPS_PROJECT_ANNOTATION];
   const definition =
     entity.metadata.annotations?.[AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION];
+  const readmePath =
+    entity.metadata.annotations?.[AZURE_DEVOPS_README_ANNOTATION];
 
   if (definition) {
     if (project) {
       return {
         project,
         definition,
+        readmePath: readmePath,
         ...hostOrg,
       };
     }
@@ -49,6 +54,7 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
         project: projectRepo.project,
         repo: projectRepo.repo,
         definition,
+        readmePath: readmePath,
         ...hostOrg,
       };
     }
@@ -60,6 +66,7 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
       return {
         project: projectRepo.project,
         repo: projectRepo.repo,
+        readmePath: readmePath,
         ...hostOrg,
       };
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5020,6 +5020,7 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-azure-devops-common": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible. -->
Ability to fetch the README file from a different AZD path.

Defaults to the current, AZD default behaviour (`README.md` in the root of the git repo); to use a different path, add the annotation `dev.azure.com/readme-path`

Example:

```yaml
dev.azure.com/readme-path: /my-path/CHANGELOG.md
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
