### PR TITLE
Wrap adaptV4Theme with createV5Theme to support extra vars

### DIFF
--- a/.changeset/hungry-days-remain.md
+++ b/.changeset/hungry-days-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Fixed missing extra variables like `applyDarkStyles` in Mui V5 theme after calling `createUnifiedThemeFromV4` function

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -93,5 +93,5 @@ export function createUnifiedThemeFromV4(
 ): UnifiedTheme {
   const v5Theme = adaptV4Theme(options as DeprecatedThemeOptions);
   const v4Theme = createTheme(options);
-  return new UnifiedThemeHolder(v4Theme, v5Theme);
+  return new UnifiedThemeHolder(v4Theme, createV5Theme(v5Theme));
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi, found the problem that after calling `createUnifiedThemeFromV4` there is missing `applyDarkStyles` variable in Mui V5 theme. I guess creating new Mui V5 theme out of adopted should fix the problem.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
