### PR TITLE
beps/0003: add TODOs for issuing service tokens

### DIFF
--- a/beps/0003-auth-architecture-evolution/README.md
+++ b/beps/0003-auth-architecture-evolution/README.md
@@ -111,6 +111,8 @@ type BackstageCredentials =
 export interface AuthService {
   authenticate(token: string): Promise<BackstageCredentials>;
 
+  // TODO: should the caller provide the target plugin ID?
+  // TODO: how can we make it very difficult to forget to forward credentials
   issueToken(credentials: BackstageCredentials): Promise<{ token: string }>;
 }
 ```


### PR DESCRIPTION
Couple of concerns around how service tokens are issued that came up. First one is whether we should require callers to specify which plugin they want to talk to - as this information can be quite valuable to the implementation. Second is how we make it hard to forget to forward credentials, since the existing interface doesn't really do that.
