### PR TITLE
Organizes imports for kubernetes-backend/plugin.ts

### DIFF
--- a/.changeset/perfect-colts-hammer.md
+++ b/.changeset/perfect-colts-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Organized imports in plugin.ts

--- a/plugins/kubernetes-backend/src/plugin.ts
+++ b/plugins/kubernetes-backend/src/plugin.ts
@@ -16,30 +16,29 @@
 
 import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
-  createBackendPlugin,
   coreServices,
+  createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 
 import { KubernetesBuilder } from '@backstage/plugin-kubernetes-backend';
+
 import {
-  KubernetesObjectsProviderExtensionPoint,
-  kubernetesObjectsProviderExtensionPoint,
-  KubernetesObjectsProvider,
-  KubernetesClusterSupplierExtensionPoint,
-  kubernetesClusterSupplierExtensionPoint,
-  KubernetesClustersSupplier,
-  KubernetesAuthStrategyExtensionPoint,
-  AuthenticationStrategy,
   kubernetesAuthStrategyExtensionPoint,
-  KubernetesFetcher,
-  KubernetesServiceLocatorExtensionPoint,
-  KubernetesServiceLocator,
-  kubernetesServiceLocatorExtensionPoint,
-} from '@backstage/plugin-kubernetes-node';
-import {
-  KubernetesFetcherExtensionPoint,
+  kubernetesClusterSupplierExtensionPoint,
   kubernetesFetcherExtensionPoint,
+  kubernetesObjectsProviderExtensionPoint,
+  kubernetesServiceLocatorExtensionPoint,
+  type AuthenticationStrategy,
+  type KubernetesAuthStrategyExtensionPoint,
+  type KubernetesClusterSupplierExtensionPoint,
+  type KubernetesClustersSupplier,
+  type KubernetesFetcher,
+  type KubernetesFetcherExtensionPoint,
+  type KubernetesObjectsProvider,
+  type KubernetesObjectsProviderExtensionPoint,
+  type KubernetesServiceLocator,
+  type KubernetesServiceLocatorExtensionPoint,
 } from '@backstage/plugin-kubernetes-node';
 
 class ObjectsProvider implements KubernetesObjectsProviderExtensionPoint {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Organizes imports for kubernetes-backend/plugin.ts

I found it really difficult to read the imports particularly for plugin-kubernetes-node so I organized them
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
