### PR TITLE
Changed TestApiProvider imports in shortcut plugin

### DIFF
--- a/.changeset/mean-ads-prove.md
+++ b/.changeset/mean-ads-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+Changed TestApiProvider imports

--- a/.changeset/mean-ads-prove.md
+++ b/.changeset/mean-ads-prove.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-shortcuts': patch
----
-
-Changed TestApiProvider imports

--- a/plugins/shortcuts/src/AddShortcut.test.tsx
+++ b/plugins/shortcuts/src/AddShortcut.test.tsx
@@ -21,10 +21,10 @@ import { DefaultShortcutsApi, shortcutsApiRef } from './api';
 import {
   MockAnalyticsApi,
   MockStorageApi,
+  TestApiProvider,
   renderInTestApp,
 } from '@backstage/test-utils';
 import { AlertDisplay } from '@backstage/core-components';
-import { TestApiProvider } from '@backstage/test-utils';
 import { analyticsApiRef } from '@backstage/core-plugin-api';
 
 describe('AddShortcut', () => {


### PR DESCRIPTION
Added TestApiProvider in the previous imports instead adding it separately

![image](https://github.com/backstage/backstage/assets/133481507/2b6b1519-ea90-4f74-993c-70d9bcd406b5)
