### PR TITLE
start on a gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+**/api-report*.md linguist-generated=true
+**/cli-report.md linguist-generated=true
+**/knip-report.md linguist-generated=true


### PR DESCRIPTION
https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

This should exclude them from our github language breakdown reports.