### PR TITLE
backend-{common,tasks}: stop depending on full DatabaseManager type

### DIFF
--- a/.changeset/brave-jobs-invite.md
+++ b/.changeset/brave-jobs-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added a new `LegacyRootDatabaseService` interface that can be used to avoid direct dependencies on the `DatabaseManager`.

--- a/.changeset/lazy-dolls-roll.md
+++ b/.changeset/lazy-dolls-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+The `TaskScheduler.fromConfig` method now accepts the `LegacyRootDatabaseService` interface rather than the full `DatabaseManager` implementation.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -249,7 +249,7 @@ export function createStatusCheckRouter(options: {
 }): Promise<express.Router>;
 
 // @public
-export class DatabaseManager {
+export class DatabaseManager implements LegacyRootDatabaseService {
   forPlugin(
     pluginId: string,
     deps?: {
@@ -554,6 +554,11 @@ export const legacyPlugin: (
     >;
   }>,
 ) => BackendFeature;
+
+// @public
+export type LegacyRootDatabaseService = {
+  forPlugin(pluginId: string): PluginDatabaseManager;
+};
 
 // @public
 export function loadBackendConfig(options: {

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -30,6 +30,7 @@ import {
 import { PluginDatabaseManager } from './types';
 import path from 'path';
 import {
+  DatabaseService,
   LifecycleService,
   LoggerService,
   PluginMetadataService,
@@ -54,6 +55,14 @@ export type DatabaseManagerOptions = {
 };
 
 /**
+ * An interface that represents the legacy global DatabaseManager implementation.
+ * @public
+ */
+export type LegacyRootDatabaseService = {
+  forPlugin(pluginId: string): DatabaseService;
+};
+
+/**
  * Manages database connections for Backstage backend plugins.
  *
  * @public
@@ -65,7 +74,7 @@ export type DatabaseManagerOptions = {
  * set `prefix` which is used to prefix generated database names if config is
  * not provided.
  */
-export class DatabaseManager {
+export class DatabaseManager implements LegacyRootDatabaseService {
   /**
    * Creates a {@link DatabaseManager} from `backend.database` config.
    *

--- a/packages/backend-tasks/api-report.md
+++ b/packages/backend-tasks/api-report.md
@@ -4,10 +4,10 @@
 
 ```ts
 import { Config } from '@backstage/config';
-import { DatabaseManager } from '@backstage/backend-common';
 import { Duration } from 'luxon';
 import { HumanDuration as HumanDuration_2 } from '@backstage/types';
 import { JsonObject } from '@backstage/types';
+import { LegacyRootDatabaseService } from '@backstage/backend-common';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 
@@ -83,7 +83,7 @@ export interface TaskScheduleDefinitionConfig {
 
 // @public
 export class TaskScheduler {
-  constructor(databaseManager: DatabaseManager, logger: Logger);
+  constructor(databaseManager: LegacyRootDatabaseService, logger: Logger);
   forPlugin(pluginId: string): PluginTaskScheduler;
   // (undocumented)
   static forPlugin(opts: {
@@ -95,7 +95,7 @@ export class TaskScheduler {
   static fromConfig(
     config: Config,
     options?: {
-      databaseManager?: DatabaseManager;
+      databaseManager?: LegacyRootDatabaseService;
       logger?: Logger;
     },
   ): TaskScheduler;

--- a/packages/backend-tasks/src/tasks/TaskScheduler.ts
+++ b/packages/backend-tasks/src/tasks/TaskScheduler.ts
@@ -17,6 +17,7 @@
 import {
   DatabaseManager,
   getRootLogger,
+  LegacyRootDatabaseService,
   PluginDatabaseManager,
 } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
@@ -37,7 +38,7 @@ export class TaskScheduler {
   static fromConfig(
     config: Config,
     options?: {
-      databaseManager?: DatabaseManager;
+      databaseManager?: LegacyRootDatabaseService;
       logger?: Logger;
     },
   ): TaskScheduler {
@@ -50,7 +51,7 @@ export class TaskScheduler {
   }
 
   constructor(
-    private readonly databaseManager: DatabaseManager,
+    private readonly databaseManager: LegacyRootDatabaseService,
     private readonly logger: Logger,
   ) {}
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This introduces a new `LegacyDatabaseService` type in `backend-common`, which we can use instead of the full `DatabaseManager` until that has all been deprecated.

Fixes #22108

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
