### PR TITLE
Move the AWS account e-mail from labels to annotations

### DIFF
--- a/.changeset/spotty-phones-attend.md
+++ b/.changeset/spotty-phones-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Move the AWS account e-mail from labels to annotations to fix the creation of `cloud-account` resources.

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
@@ -59,11 +59,11 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
               'amazonaws.com/arn':
                 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
               'amazonaws.com/account-id': '957140518395',
+              'amazonaws.com/account-email': 'aws-test-account@backstage.io',
               'amazonaws.com/organization-id': 'o-1vl18kc5a3',
             },
             labels: {
               'amazonaws.com/account-status': 'active',
-              'amazonaws.com/account-email': 'aws-test-account@backstage.io',
             },
             name: 'test-account',
             title: 'Test Account',
@@ -108,11 +108,11 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
               'amazonaws.com/arn':
                 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
               'amazonaws.com/account-id': '957140518395',
+              'amazonaws.com/account-email': '',
               'amazonaws.com/organization-id': 'o-1vl18kc5a3',
             },
             labels: {
               'amazonaws.com/account-status': '',
-              'amazonaws.com/account-email': '',
             },
             name: 'test-account',
             title: 'Test Account',

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.ts
@@ -38,11 +38,11 @@ const AWS_ORGANIZATION_REGION = 'us-east-1';
 const LOCATION_TYPE = 'aws-cloud-accounts';
 
 const ACCOUNTID_ANNOTATION = 'amazonaws.com/account-id';
+const ACCOUNT_EMAIL_ANNOTATION = 'amazonaws.com/account-email';
 const ARN_ANNOTATION = 'amazonaws.com/arn';
 const ORGANIZATION_ANNOTATION = 'amazonaws.com/organization-id';
 
 const ACCOUNT_STATUS_LABEL = 'amazonaws.com/account-status';
-const ACCOUNT_EMAIL_LABEL = 'amazonaws.com/account-email';
 
 /**
  * A processor for ingesting AWS Accounts from AWS Organizations.
@@ -171,9 +171,9 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
           [ACCOUNTID_ANNOTATION]: accountId,
           [ARN_ANNOTATION]: account.Arn || '',
           [ORGANIZATION_ANNOTATION]: organizationId,
+          [ACCOUNT_EMAIL_ANNOTATION]: account.Email || '',
         },
         labels: {
-          [ACCOUNT_EMAIL_LABEL]: account.Email || '',
           [ACCOUNT_STATUS_LABEL]: this.normalizeAccountStatus(
             account.Status || '',
           ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By moving the e-mail info from the labels to the annotations of a resource, AWS `cloud-account` resources will be imported (again).
The import currently fails because the "@" character of the e-mail addresses violates the naming restrictions for labels.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Closes #22481

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
