### PR TITLE
[Google Cloud Storage Catalog Backend] Add User-Agent as Header to identify Backstage use case for GCP telemetry

### DIFF
--- a/.changeset/neat-kiwis-joke.md
+++ b/.changeset/neat-kiwis-joke.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': minor
 ---
 
-adds a User-Agent header to existing API requests in this package to clearly identify API requests from this Google Cloud Storage. headers are formatted as follows where `libVersion` represents the current dotted version number of the Backstage GCs package and `libName` represent the current Google API used at backstage.
+adds a User-Agent header to existing API requests in this package to clearly identify API requests from this Google Cloud Storage. headers are formatted as follows where `userAgent` is the property and the value is `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`

--- a/.changeset/neat-kiwis-joke.md
+++ b/.changeset/neat-kiwis-joke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-common': minor
+'@backstage/backend-common': patch
 ---
 
-adds a User-Agent header to existing API requests in this package to clearly identify API requests from this Google Cloud Storage. headers are formatted as follows where `userAgent` is the property and the value is `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`
+Add a User-Agent header for calls towards Google Cloud Storage.

--- a/.changeset/neat-kiwis-joke.md
+++ b/.changeset/neat-kiwis-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+adds a User-Agent header to existing API requests in this package to clearly identify API requests from this Google Cloud Storage. headers are formatted as follows where `libVersion` represents the current dotted version number of the Backstage GCs package and `libName` represent the current Google API used at backstage.

--- a/packages/backend-common/src/reading/GoogleGcsUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GoogleGcsUrlReader.test.ts
@@ -80,7 +80,7 @@ describe('GcsUrlReader', () => {
   });
   it('check if userAgent has been called with this key value', async () => {
     const getStorage: any = {
-      userAgent: `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
+      userAgent: `backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
     };
     jest.mock('@google-cloud/storage', () => {
       return {
@@ -89,7 +89,7 @@ describe('GcsUrlReader', () => {
     });
     const getUserAgent = getStorage.userAgent.toString();
     expect(getUserAgent).toBe(
-      `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
+      `backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
     );
   });
 

--- a/packages/backend-common/src/reading/GoogleGcsUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GoogleGcsUrlReader.test.ts
@@ -20,6 +20,7 @@ import { getVoidLogger } from '../logging';
 import { DefaultReadTreeResponseFactory } from './tree';
 import { GoogleGcsUrlReader } from './GoogleGcsUrlReader';
 import { UrlReaderPredicateTuple } from './types';
+import packageinfo from '../../package.json';
 
 const bucketGetFilesMock = jest.fn();
 jest.mock('@google-cloud/storage', () => {
@@ -76,6 +77,20 @@ describe('GcsUrlReader', () => {
       },
     });
     expect(entries).toHaveLength(1);
+  });
+  it('check if userAgent has been called with this key value', async () => {
+    const getStorage: any = {
+      userAgent: `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+    };
+    jest.mock('@google-cloud/storage', () => {
+      return {
+        Storage: jest.fn(() => getStorage),
+      };
+    });
+    const getUserAgent = getStorage.userAgent.toString();
+    expect(getUserAgent).toBe(
+      `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+    );
   });
 
   describe('predicates', () => {

--- a/packages/backend-common/src/reading/GoogleGcsUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GoogleGcsUrlReader.test.ts
@@ -80,7 +80,7 @@ describe('GcsUrlReader', () => {
   });
   it('check if userAgent has been called with this key value', async () => {
     const getStorage: any = {
-      userAgent: `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+      userAgent: `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
     };
     jest.mock('@google-cloud/storage', () => {
       return {
@@ -89,7 +89,7 @@ describe('GcsUrlReader', () => {
     });
     const getUserAgent = getStorage.userAgent.toString();
     expect(getUserAgent).toBe(
-      `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+      `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
     );
   });
 

--- a/packages/backend-common/src/reading/GoogleGcsUrlReader.ts
+++ b/packages/backend-common/src/reading/GoogleGcsUrlReader.ts
@@ -30,6 +30,7 @@ import {
 } from '@backstage/integration';
 import { Readable } from 'stream';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
+import packageinfo from '../../package.json';
 
 const GOOGLE_GCS_HOST = 'storage.cloud.google.com';
 
@@ -68,13 +69,16 @@ export class GoogleGcsUrlReader implements UrlReader {
       logger.info(
         'googleGcs credentials not found in config. Using default credentials provider.',
       );
-      storage = new Storage();
+      storage = new Storage({
+        userAgent: `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+      });
     } else {
       storage = new Storage({
         credentials: {
           client_email: gcsConfig.clientEmail || undefined,
           private_key: gcsConfig.privateKey || undefined,
         },
+        userAgent: `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
       });
     }
     const reader = new GoogleGcsUrlReader(gcsConfig, storage);

--- a/packages/backend-common/src/reading/GoogleGcsUrlReader.ts
+++ b/packages/backend-common/src/reading/GoogleGcsUrlReader.ts
@@ -70,7 +70,7 @@ export class GoogleGcsUrlReader implements UrlReader {
         'googleGcs credentials not found in config. Using default credentials provider.',
       );
       storage = new Storage({
-        userAgent: `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+        userAgent: `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
       });
     } else {
       storage = new Storage({
@@ -78,7 +78,7 @@ export class GoogleGcsUrlReader implements UrlReader {
           client_email: gcsConfig.clientEmail || undefined,
           private_key: gcsConfig.privateKey || undefined,
         },
-        userAgent: `backstage/kubernetes-backend.GkeClusterLocator/${packageinfo.version}`,
+        userAgent: `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
       });
     }
     const reader = new GoogleGcsUrlReader(gcsConfig, storage);

--- a/packages/backend-common/src/reading/GoogleGcsUrlReader.ts
+++ b/packages/backend-common/src/reading/GoogleGcsUrlReader.ts
@@ -70,7 +70,7 @@ export class GoogleGcsUrlReader implements UrlReader {
         'googleGcs credentials not found in config. Using default credentials provider.',
       );
       storage = new Storage({
-        userAgent: `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
+        userAgent: `backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
       });
     } else {
       storage = new Storage({
@@ -78,7 +78,7 @@ export class GoogleGcsUrlReader implements UrlReader {
           client_email: gcsConfig.clientEmail || undefined,
           private_key: gcsConfig.privateKey || undefined,
         },
-        userAgent: `backstage/backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
+        userAgent: `backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`,
       });
     }
     const reader = new GoogleGcsUrlReader(gcsConfig, storage);


### PR DESCRIPTION
> ## Hey, I just made a Pull Request!
> This PR adds a User-Agent header to existing API requests in this package to clearly identify API requests from this Google Cloud Storage. headers are formatted as follows where `userAgent` is the property and the value is `backstage/backend-common.GoogleGcsUrlReader/${packageinfo.version}`
> 
> Please before continue reading the following adds remember that we could not pass the headers with specific key value to the `x-goog-api-client` we rasised a question to googleapis nodejs module to find a way to pass those parameters to the script src/nodejs-common/service.ts and the answer was that is not feasible.
https://github.com/googleapis/nodejs-storage/issues/2399

>
> #### ✔️ Checklist
> * [x]  A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
> * [ ]  Added or updated documentation
> * [x]  Tests for new functionality and regression tests for bug fixes
> * [ ]  Screenshots attached (for UI changes)
> * [x]  All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Thank you for taking your time to review this PR guys.

