### PR TITLE
Enable persisted scopes for OIDC authenticator

### DIFF
--- a/.changeset/eleven-walls-relate.md
+++ b/.changeset/eleven-walls-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+---
+
+Fixed a bug where the OIDC authenticator did not properly persist granted OAuth scopes.

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -42,6 +42,7 @@ export type OidcAuthResult = {
 
 /** @public */
 export const oidcAuthenticator = createOAuthAuthenticator({
+  shouldPersistScopes: true,
   defaultProfileTransform: async (
     input: OAuthAuthenticatorResult<OidcAuthResult>,
   ) => ({
@@ -161,9 +162,6 @@ export const oidcAuthenticator = createOAuthAuthenticator({
     const tokenset = await client.refresh(input.refreshToken);
     if (!tokenset.access_token) {
       throw new Error('Refresh failed');
-    }
-    if (!tokenset.scope) {
-      tokenset.scope = input.scope;
     }
     const userinfo = await client.userinfo(tokenset.access_token);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/22847.

This PR fixes the issue for OIDC authenticator when requested scopes are not properly persisted during session creation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
