### PR TITLE
Migrate entity page warning components to new frontend system

### DIFF
--- a/.changeset/orange-suns-yell.md
+++ b/.changeset/orange-suns-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Add entity warning components to the default entity overview page.

--- a/packages/app-next/app-config.yaml
+++ b/packages/app-next/app-config.yaml
@@ -29,13 +29,14 @@ app:
     - entity-card:api-docs/providing-components
     - entity-card:api-docs/consuming-components
 
+    # - entity-card:azure-devops/readme
     # Entity page content
     - entity-content:api-docs/definition
     - entity-content:api-docs/apis
     - entity-content:techdocs
-    - entity-content:azure-devops/pipelines
-    - entity-content:azure-devops/pull-requests
-    - entity-content:azure-devops/git-tags
+    # - entity-content:azure-devops/pipelines
+    # - entity-content:azure-devops/pull-requests
+    # - entity-content:azure-devops/git-tags
 
     # Org Plugin
     - entity-card:org/group-profile

--- a/plugins/catalog/src/alpha/EntityOverviewPage.tsx
+++ b/plugins/catalog/src/alpha/EntityOverviewPage.tsx
@@ -19,6 +19,19 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import { FilterWrapper } from './filter/FilterWrapper';
+import { EntitySwitch } from '../components/EntitySwitch';
+import {
+  EntityOrphanWarning,
+  isOrphan,
+} from '../components/EntityOrphanWarning';
+import {
+  EntityRelationWarning,
+  hasRelationWarnings,
+} from '../components/EntityRelationWarning';
+import {
+  EntityProcessingErrorsPanel,
+  hasCatalogProcessingErrors,
+} from '../components/EntityProcessingErrorsPanel';
 
 interface EntityOverviewPageProps {
   cards: Array<{
@@ -28,10 +41,39 @@ interface EntityOverviewPageProps {
   }>;
 }
 
+const entityWarningContent = (
+  <>
+    <EntitySwitch>
+      <EntitySwitch.Case if={isOrphan}>
+        <Grid item xs={12}>
+          <EntityOrphanWarning />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+
+    <EntitySwitch>
+      <EntitySwitch.Case if={hasRelationWarnings}>
+        <Grid item xs={12}>
+          <EntityRelationWarning />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+
+    <EntitySwitch>
+      <EntitySwitch.Case if={hasCatalogProcessingErrors}>
+        <Grid item xs={12}>
+          <EntityProcessingErrorsPanel />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+  </>
+);
+
 export function EntityOverviewPage(props: EntityOverviewPageProps) {
   const { entity } = useEntity();
   return (
     <Grid container spacing={3} alignItems="stretch">
+      {entityWarningContent}
       {props.cards.map((card, index) => (
         <FilterWrapper key={index} entity={entity} {...card} />
       ))}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrate entity page warning components to new frontend system.

![image](https://github.com/backstage/backstage/assets/6290749/560b0057-f803-471d-b034-062e73c0ca3a)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
