### PR TITLE
Gerrit: Make the gitilesBaseUrl mandatory

### DIFF
--- a/.changeset/cyan-ducks-sin.md
+++ b/.changeset/cyan-ducks-sin.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-common': minor
+---
+
+**BREAKING**: `A gitilesBaseUrl` must be provided for the Gerrit integration to work.
+You can disable this check by setting `DISABLE_GERRIT_GITILES_REQUIREMENT=1` but
+this will be removed in a future release. If you are not able to use the Gitiles
+Gerrit plugin, please open an issue towards `https://github.com/backstage/backstage`

--- a/packages/backend-common/src/reading/GerritUrlReader.ts
+++ b/packages/backend-common/src/reading/GerritUrlReader.ts
@@ -49,6 +49,12 @@ import {
 
 const pipeline = promisify(pipelineCb);
 
+export const GITILES_BASE_URL_DEPRECATION_MESSSAGE = `A gitilesBaseUrl must be provided \
+for the gerrit integration to work. You can disable this check by setting \
+DISABLE_GERRIT_GITILES_REQUIREMENT=1 but this will be removed in a future release. If you \
+are not able to use the gitiles gerrit plugin, please open an issue towards \
+https://github.com/backstage/backstage`;
+
 const createTemporaryDirectory = async (workDir: string): Promise<string> =>
   await fs.mkdtemp(joinPath(workDir, '/gerrit-clone-'));
 
@@ -81,6 +87,12 @@ export class GerritUrlReader implements UrlReader {
     const workDir =
       config.getOptionalString('backend.workingDirectory') ?? os.tmpdir();
     return integrations.gerrit.list().map(integration => {
+      if (
+        integration.config.gitilesBaseUrl === integration.config.baseUrl &&
+        process.env.DISABLE_GERRIT_GITILES_REQUIREMENT === undefined
+      ) {
+        throw new Error(GITILES_BASE_URL_DEPRECATION_MESSSAGE);
+      }
       const reader = new GerritUrlReader(
         integration,
         { treeResponseFactory },


### PR DESCRIPTION
This patch makes the Gerrit UrlReader throw an exception if the gitilesBaseUrl is not set. To opt out of this set the env variable DISABLE_GERRIT_GITILES_REQUIREMENT.

## Hey, I just made a Pull Request!

This is as discussed in #22500.  

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
