### PR TITLE
Update README.md for DevTools plugin

### DIFF
--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -418,6 +418,8 @@ By default, only packages with names starting with `@backstage` and `@internal` 
 devTools:
   info:
     packagePrefixes:
+      # Note that you MUST have quotes around these. The YAML won't be valid
+      # if you don't, because of the leading at-symbols.
       - '@roadiehq/backstage-'
       - '@spotify/backstage-'
 ```

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -418,8 +418,8 @@ By default, only packages with names starting with `@backstage` and `@internal` 
 devTools:
   info:
     packagePrefixes:
-      - @roadiehq/backstage-
-      - @spotify/backstage-
+      - '@roadiehq/backstage-'
+      - '@spotify/backstage-'
 ```
 
 ### External Dependencies Configuration


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I did a little correction in the README.md for DevTools plugin. To configure the package dependencies, you have to add in app-config.yaml the list of packages prefixes you want to be listed (by default only `@backstage` and `@internal` are listed).

If you follow the doc, you will have a problem when you start Backstage with yarn dev:
```
[0] 
[0] YAMLParseError: Plain value cannot start with reserved character @ at line 89, column 9:
[0] 
[0]       - @immobiliarelabs/backstage-
[0]         ^
[0] 
[0] 
error Command failed with exit code 1.
```
You have to add single quotes around packages prefixes.

I updated the doc for that.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
