### PR TITLE
Expanded and Improved Catalog Customization Docs

### DIFF
--- a/.changeset/stupid-bottles-bow.md
+++ b/.changeset/stupid-bottles-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Added support for passing in custom filters to `CatalogIndexPage`

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -9,7 +9,7 @@ The Backstage software catalog comes with a default `CatalogIndexPage` to filter
 
 ## Pagination
 
-Initial support for pagination of the `CatalogIndexPage` was added in v1.21.0 of Backstage, make sure you are on that version or newer to use this feature. To enable pagination you simply need to pass in the `pagination` prop like this:
+Initial support for pagination of the `CatalogIndexPage` was added in v1.21.0 of Backstage, so make sure you are on that version or newer to use this feature. To enable pagination you simply need to pass in the `pagination` prop like this:
 
 ```tsx title="packages/app/src/App.tsx"
 <Route path="/catalog" element={<CatalogIndexPage pagination />} />
@@ -17,7 +17,7 @@ Initial support for pagination of the `CatalogIndexPage` was added in v1.21.0 of
 
 ## Initially Selected Filter
 
-By default the initially selected filter defaults to Owned, now you might be still building up your catalog and would prefer this to show All as the default. Here's how you can make that change:
+By default the initially selected filter defaults to Owned. If you are still building up your catalog this may show an empty list to start. If you would prefer this to show All as the default, here's how you can make that change:
 
 ```tsx title="packages/app/src/App.tsx"
 <Route
@@ -50,7 +50,7 @@ Possible options are: owners-only or all
 
 ## Table Options
 
-The tables used within Backstage are built on top of [`@material-table/core`](https://material-table-core.github.io/) and the `CatalogIndexPage` has a `tableOptions` prop that allows you to customize the underlying table to a certain extent, there are some hard coded Backstage settings that can't be changed. Here's an example of how to use this prop to disable the search filter field in the table's header:
+The tables used within Backstage are built on top of [`@material-table/core`](https://material-table-core.github.io/) and the `CatalogIndexPage` has a `tableOptions` prop that allows you to customize the underlying table to a certain extent, but there are some hard coded Backstage settings that can't be changed. Here's an example of how to use this prop to disable the search filter field in the table's header:
 
 ```tsx title="packages/app/src/App.tsx"
 <Route
@@ -168,11 +168,11 @@ The above customization will override the existing actions. Currently the only w
 
 ## Customize Filters
 
-There are tree options you have for filters: adjusting the existing filters with props, adding or removing the default filters, or creating a brand new custom filter. The following sections cover these cases
+There are three options you have for filters: adjusting the existing filters with props, adding or removing the default filters, or creating a brand new custom filter. The following sections cover these cases
 
 ### Default Filter Props
 
-There is a set of default filters that you can use, they surface all the props mentioned earlier in this document. Here's how they can be used:
+There are a set of default filters that you can use, which surface all the props mentioned earlier in this document. Here's how they can be used:
 
 ```tsx title="packages/app/src/App.tsx"
 import { DefaultFilters } from '@backstage/plugin-catalog-react';

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -48,6 +48,19 @@ The Owner filter by default will only contain a list of Users and/or Groups that
 
 Possible options are: owners-only or all
 
+## Table Options
+
+The tables used within Backstage are built on top of [`@material-table/core`](https://material-table-core.github.io/) and the `CatalogIndexPage` has a `tableOptions` prop that allows you to customize the underlying table to a certain extent, there are some hard coded Backstage settings that can't be changed. Here's an example of how to use this prop to disable the search filter field in the table's header:
+
+```tsx title="packages/app/src/App.tsx"
+<Route
+  path="/catalog"
+  element={<CatalogIndexPage tableOptions={{ search: false }} />}
+/>
+```
+
+There are many options that can be set using `tableOptions`, the full list of settings can be found in the [`@material-table/core` `Options` interface](https://github.com/material-table-core/core/blob/v3.1.0/types/index.d.ts#L323) (this link goes to `v3.1.0` of `@material-table/core` as that is the version currently used by Backstage).
+
 ## Customize Columns
 
 By default the columns you see in the `CatalogIndexPage` were selected to be a good starting point for most but there may be reasons that you would like to customize these with more or less columns. One primary use case for this customization is if you added a custom Kind. Support for this was added in v1.23.0 of Backstage, make sure you are on that version or newer to use this feature. Here's an example of how to make this customization:

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -30,7 +30,7 @@ Possible options are: owned, starred, or all
 
 ## Initially Selected Kind
 
-By default the initially selected Kind when viewing the Catalog in Component, but you may have reasons that you want this to be different. Let's say at your Organization they would like it to always default to Domain, here's how you would do that:
+By default the initially selected Kind when viewing the Catalog is Component, but you may have reasons that you want this to be different. Let's say at your Organization they would like it to always default to Domain, here's how you would do that:
 
 ```tsx title="packages/app/src/App.tsx"
 <Route path="/catalog" element={<CatalogIndexPage initialKind="domain" />} />
@@ -50,7 +50,7 @@ Possible options are: owners-only or all
 
 ## Customize Columns
 
-By default the columns you see in the `CatalogIndexPage` were selected to be a good starting point for most but there may be reasons that you would like to customize these with more or less columns. On primary use case for this customization is if you added a custom Kind. Support for this was added in v1.23.0 of Backstage, make sure you are on that version or newer to use this feature. Here's an example of how to make this customization:
+By default the columns you see in the `CatalogIndexPage` were selected to be a good starting point for most but there may be reasons that you would like to customize these with more or less columns. One primary use case for this customization is if you added a custom Kind. Support for this was added in v1.23.0 of Backstage, make sure you are on that version or newer to use this feature. Here's an example of how to make this customization:
 
 ```tsx title="packages/app/src/App.tsx"
 import {
@@ -86,9 +86,9 @@ const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
 
 ## Customize Actions
 
-The `CatalogIndexPage` comes with three default actions - view, edit, and star. You might want to add more here's how:
+The `CatalogIndexPage` comes with three default actions - view, edit, and star. You might want to add more.
 
-First you'll need to add `@mui/utils` to your `packages/app/package.json`:
+To do this, first you'll need to add `@mui/utils` to your `packages/app/package.json`:
 
 ```sh
 yarn --cwd packages/app add @mui/utils
@@ -155,7 +155,7 @@ The above customization will override the existing actions. Currently the only w
 
 ## Custom Filters
 
-You can add custom filters. For example, suppose that I want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Here is how we can built a filter to support that need.
+You can add custom filters. For example, suppose that I want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Here is how we can build a filter to support that need.
 
 First we need to create a new filter that implements the `EntityFilter` interface:
 

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -9,7 +9,7 @@ The Backstage software catalog comes with a default `CatalogIndexPage` to filter
 
 ## Pagination
 
-Initial support for pagination of the `CatalogIndexPage` was added in v1.21.0 of Backstage, make sure you are on that version or newer to use this feature. To enable pagination you simply need to pass in the `paganiaiton` prop like this:
+Initial support for pagination of the `CatalogIndexPage` was added in v1.21.0 of Backstage, make sure you are on that version or newer to use this feature. To enable pagination you simply need to pass in the `pagination` prop like this:
 
 ```tsx title="packages/app/src/App.tsx"
 <Route path="/catalog" element={<CatalogIndexPage pagination />} />
@@ -17,7 +17,7 @@ Initial support for pagination of the `CatalogIndexPage` was added in v1.21.0 of
 
 ## Initially Selected Filter
 
-By default the initially selected filter defaults to Owned, now you might be still building up your catalog and would prefer this to show All as the deafult. Here's how you can make that change:
+By default the initially selected filter defaults to Owned, now you might be still building up your catalog and would prefer this to show All as the default. Here's how you can make that change:
 
 ```tsx title="packages/app/src/App.tsx"
 <Route
@@ -155,7 +155,7 @@ The above customization will override the existing actions. Currently the only w
 
 ## Custom Filters
 
-You can add custom filters. For example, suppose that I want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Her's how we can built a filter to support that need.
+You can add custom filters. For example, suppose that I want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Here is how we can built a filter to support that need.
 
 First we need to create a new filter that implements the `EntityFilter` interface:
 

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -153,7 +153,67 @@ const customActions: TableProps<CatalogTableRow>['actions'] = [
 
 The above customization will override the existing actions. Currently the only way to keep them and add your own is to also include the existing actions in your array by copying them from the [`defaultActions`](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx#L113-L168).
 
-## Custom Filters
+## Customize Filters
+
+There are tree options you have for filters: adjusting the existing filters with props, adding or removing the default filters, or creating a brand new custom filter. The following sections cover these cases
+
+### Default Filter Props
+
+There is a set of default filters that you can use, they surface all the props mentioned earlier in this document. Here's how they can be used:
+
+```tsx title="packages/app/src/App.tsx"
+import { DefaultFilters } from '@backstage/plugin-catalog-react';
+
+<Route
+  path="/catalog"
+  element={
+    <CatalogIndexPage
+      filters={
+        <>
+          <DefaultFilters
+            initialKind="Domain"
+            initiallySelectedFilter="all"
+            ownerPickerMode="all"
+          />
+        </>
+      }
+    />
+  }
+/>;
+```
+
+### Removing Default Filters
+
+You may have reasons not use the Lifecycle, Tag, and Processing Status filters, here's an example of how you would remove them:
+
+```tsx title="packages/app/src/App.tsx"
+import {
+  EntityKindPicker,
+  EntityTypePicker,
+  UserListPicker,
+  EntityOwnerPicker,
+  EntityNamespacePicker,
+} from '@backstage/plugin-catalog-react';
+
+<Route
+  path="/catalog"
+  element={
+    <CatalogIndexPage
+      filters={
+        <>
+          <EntityKindPicker />
+          <EntityTypePicker />
+          <UserListPicker />
+          <EntityOwnerPicker />
+          <EntityNamespacePicker />
+        </>
+      }
+    />
+  }
+/>;
+```
+
+### Custom Filters
 
 You can add custom filters. For example, suppose that I want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Here is how we can build a filter to support that need.
 
@@ -230,6 +290,14 @@ export const EntitySecurityTierPicker = () => {
 Now we can add the component to `CatalogIndexPage`:
 
 ```tsx title="packages/app/src/App.tsx"
+{
+  /* highlight-add-start */
+}
+import { DefaultFilters } from '@backstage/plugin-catalog-react';
+{
+  /* highlight-add-end */
+}
+
 const routes = (
   <FlatRoutes>
     <Navigate key="/" to="catalog" />
@@ -242,14 +310,7 @@ const routes = (
         <CatalogIndexPage
           filters={
             <>
-              <EntityKindPicker />
-              <EntityTypePicker />
-              <UserListPicker />
-              <EntityOwnerPicker />
-              <EntityLifecyclePicker />
-              <EntityTagPicker />
-              <EntityProcessingStatusPicker />
-              <EntityNamespacePicker />
+              <DefaultFilters />
               <EntitySecurityTierPicker />
             </>
           }

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -337,3 +337,85 @@ const routes = (
 ```
 
 The same method can be used to customize the _default_ filters with a different interface - for such usage, the generic argument isn't needed since the filter shape remains the same as the default.
+
+## Advanced Customization
+
+For those where none of the above fits their needs you can take the option of creating a fully custom `CatalogIndexPage`.
+
+```tsx title="packages/app/src/components/catalog/CustomCatalogIndex.tsx"
+import {
+  PageWithHeader,
+  Content,
+  ContentHeader,
+  SupportButton,
+} from '@backstage/core-components';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { CatalogTable } from '@backstage/plugin-catalog';
+import {
+  EntityListProvider,
+  CatalogFilterLayout,
+  EntityKindPicker,
+  EntityLifecyclePicker,
+  EntityNamespacePicker,
+  EntityOwnerPicker,
+  EntityProcessingStatusPicker,
+  EntityTagPicker,
+  EntityTypePicker,
+  UserListPicker,
+} from '@backstage/plugin-catalog-react';
+import React from 'react';
+
+export const CustomCatalogPage = () => {
+  const orgName =
+    useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
+
+  return (
+    <PageWithHeader title={orgName} themeId="home">
+      <Content>
+        <ContentHeader title="">
+          <SupportButton>All your software catalog entities</SupportButton>
+        </ContentHeader>
+        <EntityListProvider pagination>
+          <CatalogFilterLayout>
+            <CatalogFilterLayout.Filters>
+              <EntityKindPicker />
+              <EntityTypePicker />
+              <UserListPicker />
+              <EntityOwnerPicker />
+              <EntityLifecyclePicker />
+              <EntityTagPicker />
+              <EntityProcessingStatusPicker />
+              <EntityNamespacePicker />
+            </CatalogFilterLayout.Filters>
+            <CatalogFilterLayout.Content>
+              <CatalogTable />
+            </CatalogFilterLayout.Content>
+          </CatalogFilterLayout>
+        </EntityListProvider>
+      </Content>
+    </PageWithHeader>
+  );
+};
+```
+
+The above is a very basic version of a fully custom `CatalogIndexPage`, you'll want to explore the various props to see what you can all do with them. This was built off the building blocks seen in the [`DefaultCatalogPage`](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx)
+
+> Note: The catalog index page is designed to have a minimal code footprint to support easy customization, but creating a replica does introduce a possibility of drifting out of date over time. Be sure to check the catalog [CHANGELOG](https://github.com/backstage/backstage/blob/master/plugins/catalog/CHANGELOG.md) periodically.
+
+To use this custom `CatalogIndexPage` which we called `CustomCatalogPage`, you'll need to make the following change:
+
+```tsx title="packages/app/src/App.tsx"
+const routes = (
+  <FlatRoutes>
+    <Navigate key="/" to="catalog" />
+    {/* highlight-remove-next-line */}
+    <Route path="/catalog" element={<CatalogIndexPage />} />
+    {/* highlight-add-start */}
+    <Route path="/catalog" element={<CatalogIndexPage />}>
+      <CustomCatalogPage />
+    </Route>
+    {/* highlight-add-end */}
+    {/* ... */}
+  </FlatRoutes>
+);
+```

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -12,6 +12,7 @@ import { ComponentEntity } from '@backstage/catalog-model';
 import { ComponentProps } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
+import { EntityOwnerPickerProps as EntityOwnerPickerProps_2 } from '@backstage/plugin-catalog-react';
 import { IconButton } from '@material-ui/core';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
@@ -28,6 +29,7 @@ import { SystemEntity } from '@backstage/catalog-model';
 import { TableColumn } from '@backstage/core-components';
 import { TableOptions } from '@backstage/core-components';
 import { TextFieldProps } from '@material-ui/core';
+import { UserListFilterKind as UserListFilterKind_2 } from '@backstage/plugin-catalog-react';
 
 // @public (undocumented)
 export type AllowedEntityFilters<T extends DefaultEntityFilters> = {
@@ -171,6 +173,18 @@ export function defaultEntityPresentation(
     defaultNamespace?: string;
   },
 ): EntityRefPresentationSnapshot;
+
+// @public (undocumented)
+export const DefaultFilters: (
+  props: DefaultFiltersProps,
+) => React_2.JSX.Element;
+
+// @public
+export type DefaultFiltersProps = {
+  initialKind?: string;
+  initiallySelectedFilter?: UserListFilterKind_2;
+  ownerPickerMode?: EntityOwnerPickerProps_2['mode'];
+};
 
 // @public (undocumented)
 export function EntityAutocompletePicker<

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -12,7 +12,6 @@ import { ComponentEntity } from '@backstage/catalog-model';
 import { ComponentProps } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
-import { EntityOwnerPickerProps as EntityOwnerPickerProps_2 } from '@backstage/plugin-catalog-react';
 import { IconButton } from '@material-ui/core';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
@@ -29,7 +28,6 @@ import { SystemEntity } from '@backstage/catalog-model';
 import { TableColumn } from '@backstage/core-components';
 import { TableOptions } from '@backstage/core-components';
 import { TextFieldProps } from '@material-ui/core';
-import { UserListFilterKind as UserListFilterKind_2 } from '@backstage/plugin-catalog-react';
 
 // @public (undocumented)
 export type AllowedEntityFilters<T extends DefaultEntityFilters> = {
@@ -182,8 +180,8 @@ export const DefaultFilters: (
 // @public
 export type DefaultFiltersProps = {
   initialKind?: string;
-  initiallySelectedFilter?: UserListFilterKind_2;
-  ownerPickerMode?: EntityOwnerPickerProps_2['mode'];
+  initiallySelectedFilter?: UserListFilterKind;
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
 };
 
 // @public (undocumented)

--- a/plugins/catalog-react/src/components/DefaultFilters/DefaultFilters.tsx
+++ b/plugins/catalog-react/src/components/DefaultFilters/DefaultFilters.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  EntityKindPicker,
+  EntityTypePicker,
+  UserListPicker,
+  EntityOwnerPicker,
+  EntityLifecyclePicker,
+  EntityTagPicker,
+  EntityProcessingStatusPicker,
+  EntityNamespacePicker,
+  UserListFilterKind,
+  EntityOwnerPickerProps,
+} from '@backstage/plugin-catalog-react';
+import React from 'react';
+
+/**
+ * Props for default filters.
+ *
+ * @public
+ */
+export type DefaultFiltersProps = {
+  initialKind?: string;
+  initiallySelectedFilter?: UserListFilterKind;
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
+};
+
+/** @public */
+export const DefaultFilters = (props: DefaultFiltersProps) => {
+  const { initialKind, initiallySelectedFilter, ownerPickerMode } = props;
+  return (
+    <>
+      <EntityKindPicker initialFilter={initialKind} />
+      <EntityTypePicker />
+      <UserListPicker initialFilter={initiallySelectedFilter} />
+      <EntityOwnerPicker mode={ownerPickerMode} />
+      <EntityLifecyclePicker />
+      <EntityTagPicker />
+      <EntityProcessingStatusPicker />
+      <EntityNamespacePicker />
+    </>
+  );
+};

--- a/plugins/catalog-react/src/components/DefaultFilters/DefaultFilters.tsx
+++ b/plugins/catalog-react/src/components/DefaultFilters/DefaultFilters.tsx
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import {
-  EntityKindPicker,
-  EntityTypePicker,
-  UserListPicker,
-  EntityOwnerPicker,
-  EntityLifecyclePicker,
-  EntityTagPicker,
-  EntityProcessingStatusPicker,
-  EntityNamespacePicker,
-  UserListFilterKind,
-  EntityOwnerPickerProps,
-} from '@backstage/plugin-catalog-react';
 import React from 'react';
+import { UserListFilterKind } from '../../types';
+import { EntityKindPicker } from '../EntityKindPicker';
+import { EntityLifecyclePicker } from '../EntityLifecyclePicker';
+import { EntityNamespacePicker } from '../EntityNamespacePicker';
+import {
+  EntityOwnerPickerProps,
+  EntityOwnerPicker,
+} from '../EntityOwnerPicker';
+import { EntityProcessingStatusPicker } from '../EntityProcessingStatusPicker';
+import { EntityTagPicker } from '../EntityTagPicker';
+import { EntityTypePicker } from '../EntityTypePicker';
+import { UserListPicker } from '../UserListPicker';
 
 /**
  * Props for default filters.

--- a/plugins/catalog-react/src/components/DefaultFilters/index.ts
+++ b/plugins/catalog-react/src/components/DefaultFilters/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type { DefaultFiltersProps } from './DefaultFilters';
+export { DefaultFilters } from './DefaultFilters';

--- a/plugins/catalog-react/src/components/index.ts
+++ b/plugins/catalog-react/src/components/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from './CatalogFilterLayout';
+export * from './DefaultFilters';
 export * from './EntityKindPicker';
 export * from './EntityLifecyclePicker';
 export * from './EntityOwnerPicker';

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -233,6 +233,8 @@ export interface DefaultCatalogPageProps {
   // (undocumented)
   emptyContent?: ReactNode;
   // (undocumented)
+  filters?: ReactNode;
+  // (undocumented)
   initialKind?: string;
   // (undocumented)
   initiallySelectedFilter?: UserListFilterKind;

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -26,16 +26,8 @@ import {
 import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
   CatalogFilterLayout,
-  EntityLifecyclePicker,
   EntityListProvider,
-  EntityProcessingStatusPicker,
-  EntityOwnerPicker,
-  EntityTagPicker,
-  EntityTypePicker,
   UserListFilterKind,
-  UserListPicker,
-  EntityKindPicker,
-  EntityNamespacePicker,
   EntityOwnerPickerProps,
 } from '@backstage/plugin-catalog-react';
 import React, { ReactNode } from 'react';
@@ -47,6 +39,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { CatalogTableColumnsFunc } from '../CatalogTable/types';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
+import { DefaultFilters } from '@backstage/plugin-catalog-react';
 
 /** @internal */
 export type BaseCatalogPageProps = {
@@ -123,16 +116,11 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     <BaseCatalogPage
       filters={
         filters ?? (
-          <>
-            <EntityKindPicker initialFilter={initialKind} />
-            <EntityTypePicker />
-            <UserListPicker initialFilter={initiallySelectedFilter} />
-            <EntityOwnerPicker mode={ownerPickerMode} />
-            <EntityLifecyclePicker />
-            <EntityTagPicker />
-            <EntityProcessingStatusPicker />
-            <EntityNamespacePicker />
-          </>
+          <DefaultFilters
+            initialKind={initialKind}
+            initiallySelectedFilter={initiallySelectedFilter}
+            ownerPickerMode={ownerPickerMode}
+          />
         )
       }
       content={

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -103,6 +103,7 @@ export interface DefaultCatalogPageProps {
   emptyContent?: ReactNode;
   ownerPickerMode?: EntityOwnerPickerProps['mode'];
   pagination?: boolean | { limit?: number };
+  filters?: ReactNode;
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
@@ -115,21 +116,24 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     emptyContent,
     pagination,
     ownerPickerMode,
+    filters,
   } = props;
 
   return (
     <BaseCatalogPage
       filters={
-        <>
-          <EntityKindPicker initialFilter={initialKind} />
-          <EntityTypePicker />
-          <UserListPicker initialFilter={initiallySelectedFilter} />
-          <EntityOwnerPicker mode={ownerPickerMode} />
-          <EntityLifecyclePicker />
-          <EntityTagPicker />
-          <EntityProcessingStatusPicker />
-          <EntityNamespacePicker />
-        </>
+        filters ?? (
+          <>
+            <EntityKindPicker initialFilter={initialKind} />
+            <EntityTypePicker />
+            <UserListPicker initialFilter={initiallySelectedFilter} />
+            <EntityOwnerPicker mode={ownerPickerMode} />
+            <EntityLifecyclePicker />
+            <EntityTagPicker />
+            <EntityProcessingStatusPicker />
+            <EntityNamespacePicker />
+          </>
+        )
       }
       content={
         <CatalogTable


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Expanded and improved Catalog Customization documentation. Also, added support for passing in custom filters to `CatalogIndexPage`.

Closes #19376

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
