### PR TITLE
Added `validateLocationsExist` to the config

### DIFF
--- a/.changeset/mean-apes-wait.md
+++ b/.changeset/mean-apes-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added `validateLocationsExist` to the config

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -136,6 +136,11 @@ export interface Config {
                */
               catalogPath?: string;
               /**
+               * (Optional) Whether to validate locations that exist before emitting them.
+               * Default: `false`.
+               */
+              validateLocationsExist?: boolean;
+              /**
                * (Optional) Filter configuration.
                */
               filters?: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `validateLocationsExist` to the config to fix errors when running config validation via the `backstage-cli`

Ran into this when using this config:

```yaml
providers:
    github:
      providerId:
        organization: 'backstage' 
        catalogPath: '/catalog-info.yaml' 
        validateLocationsExist: true 
        schedule: 
          frequency: { minutes: 30 }
          timeout: { minutes: 3 }
```

Would throw these errors when running `yarn backstage-cli config:check --lax --strict`:

```text
Config must have required property 'organization' { missingProperty=organization } at /catalog/providers/github
Config must NOT have additional properties { additionalProperty=providerId } at /catalog/providers/github
Config must NOT have additional properties { additionalProperty=validateLocationsExist } at /catalog/providers/github/providerId
Config must match a schema in anyOf {  } at /catalog/providers/github
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
