### PR TITLE
Cleaned up creating custom entity docs

### DIFF
--- a/.changeset/short-lamps-wave.md
+++ b/.changeset/short-lamps-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Refactored `doEmit` into a standalone utility function and exported it

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -316,8 +316,6 @@ export type DefaultCatalogCollatorFactoryOptions =
 // @public @deprecated (undocumented)
 export type DeferredEntity = DeferredEntity_2;
 
-// Warning: (ae-missing-release-tag) "doEmit" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export function doEmit(
   emit: CatalogProcessorEmit_2,

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -24,6 +24,7 @@ import { CatalogProcessorParser as CatalogProcessorParser_2 } from '@backstage/p
 import { CatalogProcessorRefreshKeysResult as CatalogProcessorRefreshKeysResult_2 } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorRelationResult as CatalogProcessorRelationResult_2 } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorResult as CatalogProcessorResult_2 } from '@backstage/plugin-catalog-node';
+import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { DefaultCatalogCollatorFactory as DefaultCatalogCollatorFactory_2 } from '@backstage/plugin-search-backend-module-catalog';
 import type { DefaultCatalogCollatorFactoryOptions as DefaultCatalogCollatorFactoryOptions_2 } from '@backstage/plugin-search-backend-module-catalog';
@@ -314,6 +315,21 @@ export type DefaultCatalogCollatorFactoryOptions =
 
 // @public @deprecated (undocumented)
 export type DeferredEntity = DeferredEntity_2;
+
+// Warning: (ae-missing-release-tag) "doEmit" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function doEmit(
+  emit: CatalogProcessorEmit_2,
+  selfRef: CompoundEntityRef,
+  targets: string | string[] | undefined,
+  context: {
+    defaultKind?: string;
+    defaultNamespace: string;
+  },
+  outgoingRelation: string,
+  incomingRelation: string,
+): void;
 
 // @public @deprecated (undocumented)
 export type EntitiesSearchFilter = EntitiesSearchFilter_2;

--- a/plugins/catalog-backend/src/modules/core/index.ts
+++ b/plugins/catalog-backend/src/modules/core/index.ts
@@ -30,3 +30,4 @@ export type {
 } from './PlaceholderProcessor';
 export { UrlReaderProcessor } from './UrlReaderProcessor';
 export { parseEntityYaml } from '../util/parse';
+export { doEmit } from '../util/doEmit';

--- a/plugins/catalog-backend/src/modules/util/doEmit.ts
+++ b/plugins/catalog-backend/src/modules/util/doEmit.ts
@@ -19,6 +19,7 @@ import {
   processingResult,
 } from '@backstage/plugin-catalog-node';
 
+/** @public */
 export function doEmit(
   emit: CatalogProcessorEmit,
   selfRef: CompoundEntityRef,

--- a/plugins/catalog-backend/src/modules/util/doEmit.ts
+++ b/plugins/catalog-backend/src/modules/util/doEmit.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CompoundEntityRef, parseEntityRef } from '@backstage/catalog-model';
+import {
+  CatalogProcessorEmit,
+  processingResult,
+} from '@backstage/plugin-catalog-node';
+
+export function doEmit(
+  emit: CatalogProcessorEmit,
+  selfRef: CompoundEntityRef,
+  targets: string | string[] | undefined,
+  context: { defaultKind?: string; defaultNamespace: string },
+  outgoingRelation: string,
+  incomingRelation: string,
+): void {
+  if (!targets) {
+    return;
+  }
+  for (const target of [targets].flat()) {
+    const targetRef = parseEntityRef(target, context);
+    emit(
+      processingResult.relation({
+        source: selfRef,
+        type: outgoingRelation,
+        target: {
+          kind: targetRef.kind,
+          namespace: targetRef.namespace,
+          name: targetRef.name,
+        },
+      }),
+    );
+    emit(
+      processingResult.relation({
+        source: {
+          kind: targetRef.kind,
+          namespace: targetRef.namespace,
+          name: targetRef.name,
+        },
+        type: incomingRelation,
+        target: selfRef,
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Cleaned up documentation on creating a custom entity based on feedback from various Adopters:

- Removed confusing section about creating common plugin
- Refactored processor example to use `doEmit` for relationships
- Adding link to `BuiltinKindsEntityProcessor` as an example to look at for relationships

As part of this I refactored `doEmit` into a standalone utility function and exported it. This function makes it a lot easier to add relationships and right now Adopters are copying it whereas having it exported means a little less code they have to maintain.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
