### PR TITLE
beps/0003: refactor to use principals + add config

### DIFF
--- a/beps/0003-auth-architecture-evolution/README.md
+++ b/beps/0003-auth-architecture-evolution/README.md
@@ -402,7 +402,7 @@ backend:
   dangerouslyDisableServiceAuth: true
 ```
 
-The exact impact that this has is that disabled the check in the `HttpRouterService` implementation, effectively applying the `unauthenticated` access level to all routes. Furthermore, it will also change `AuthService` so that the `issueServiceToken()` method will now issue an empty token for a `'none'` principal, rather than throwing.
+The exact impact that this has is that it disables the check in the `HttpRouterService` implementation, effectively applying the `unauthenticated` access level to all routes. Furthermore, it will also change `AuthService` so that the `issueServiceToken()` method will now issue an empty token for a `'none'` principal, rather than throwing.
 
 ## Release Plan
 


### PR DESCRIPTION
Couple of updates based on our most recent findings:

- Explicitly highlight the ability to configure access control and what happens when you turn it off.
- Switch from using different credential types to using a single opaque credential with different embedded principal types instead. This separates the underlying authentication method from the principal, which also separates the opaque structure from the data it contains, cleaning things up a bit.
- Along with the new `principal` field, there's an `isPrincipal` method for the `AuthService`. This is a lower level API that is intended to be used in very few places. Generally plugins will instead use `httpAuth.credentials()` or forward opaque credentials.
- The `auth.issueServiceToken()` now requires input credentials to be forwarded, this is to avoid accidental scope switches where the lack of credentials are elevated to service credentials. The `.issueServiceToken` can now reject issuing a token for an unauthenticated (`none`) principal. Standalone service-to-service requests must now use the new `getOwnCredentials()` to get the credentials for the plugin itself, and pass those credentials to `.issueServiceToken()`.