### PR TITLE
[badges] Fix the authentication middleware

### DIFF
--- a/.changeset/curvy-icons-peel.md
+++ b/.changeset/curvy-icons-peel.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-badges-backend': patch
 ---
 
-Removing the authentication middleware from the obfuscated routes, as it doesn't do what it's supposed to do.
+Updating the `authorization` middleware to call the Catalog to check that the requesting user has permission to see the Entity before generating the UUID.

--- a/.changeset/curvy-icons-peel.md
+++ b/.changeset/curvy-icons-peel.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-badges-backend': patch
 ---
 
-Removing the authentication middleware as it's not used
+Removing the authentication middleware from the obfuscated routes, as it doesn't do what it's supposed to do.

--- a/.changeset/curvy-icons-peel.md
+++ b/.changeset/curvy-icons-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges-backend': patch
+---
+
+Removing the authentication middleware as it's not used

--- a/plugins/badges-backend/src/service/router.ts
+++ b/plugins/badges-backend/src/service/router.ts
@@ -60,7 +60,7 @@ export async function createRouter(
     );
   const router = Router();
 
-  const { config, logger, tokenManager, discovery, identity } = options;
+  const { config, logger, tokenManager, discovery } = options;
   const baseUrl = await discovery.getExternalBaseUrl('badges');
 
   if (config.getOptionalBoolean('app.badges.obfuscate')) {
@@ -72,7 +72,6 @@ export async function createRouter(
       logger,
       options,
       config,
-      identity,
       baseUrl,
     );
   }
@@ -94,7 +93,6 @@ async function obfuscatedRoute(
   logger: Logger,
   options: RouterOptions,
   config: Config,
-  identity: IdentityApi,
   baseUrl: string,
 ) {
   logger.info('Badges obfuscation is enabled');
@@ -130,6 +128,7 @@ async function obfuscatedRoute(
       },
       token,
     );
+
     if (isNil(entity)) {
       throw new NotFoundError(
         `No ${kind} entity in ${namespace} named "${name}"`,

--- a/plugins/badges-backend/src/service/router.ts
+++ b/plugins/badges-backend/src/service/router.ts
@@ -24,7 +24,7 @@ import {
 } from '@backstage/backend-common';
 import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
-import { AuthenticationError, NotFoundError } from '@backstage/errors';
+import { NotFoundError } from '@backstage/errors';
 import { BadgeBuilder, DefaultBadgeBuilder } from '../lib/BadgeBuilder';
 import { BadgeContext, BadgeFactories } from '../types';
 import { isNil } from 'lodash';
@@ -236,10 +236,8 @@ async function obfuscatedRoute(
       );
 
       if (!entity) {
-        next(
-          new NotFoundError(
-            `No ${kind} entity in ${namespace} named "${name}"`,
-          ),
+        throw new NotFoundError(
+          `No ${kind} entity in ${namespace} named "${name}"`,
         );
       } else {
         next();


### PR DESCRIPTION
Removed the old logic as it actually doesn't do anything.

This now checks that the user has permissions to see the entity in the catalog before generating a UUID.