### PR TITLE
feat: Add gitlab group visibility to group entity via annotation

### DIFF
--- a/.changeset/silent-insects-invent.md
+++ b/.changeset/silent-insects-invent.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-Add gitlab group visibility to group entity via annotation
+Add GitLab `visibility` to group entity annotations.

--- a/.changeset/silent-insects-invent.md
+++ b/.changeset/silent-insects-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Add gitlab group visibility to group entity via annotation

--- a/plugins/catalog-backend-module-gitlab/api-report.md
+++ b/plugins/catalog-backend-module-gitlab/api-report.md
@@ -63,6 +63,7 @@ export type GitLabGroup = {
   name: string;
   full_path: string;
   description?: string;
+  visibility: string;
   parent_id?: number;
 };
 

--- a/plugins/catalog-backend-module-gitlab/api-report.md
+++ b/plugins/catalog-backend-module-gitlab/api-report.md
@@ -63,7 +63,7 @@ export type GitLabGroup = {
   name: string;
   full_path: string;
   description?: string;
-  visibility: string;
+  visibility?: string;
   parent_id?: number;
 };
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -136,6 +136,7 @@ export class GitLabClient {
                       name
                       description
                       fullPath
+                      visibility
                       parent {
                         id
                       }
@@ -170,6 +171,7 @@ export class GitLabClient {
           name: groupItem.name,
           description: groupItem.description,
           full_path: groupItem.fullPath,
+          visibility: groupItem.visibility,
           parent_id: Number(
             groupItem.parent.id.replace(/^gid:\/\/gitlab\/Group\//, ''),
           ),

--- a/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
@@ -49,6 +49,7 @@ export function defaultGroupEntitiesTransformer(
     const annotations: { [annotationName: string]: string } = {};
 
     annotations[`${options.providerConfig.host}/team-path`] = group.full_path;
+    annotations[`${options.providerConfig.host}/visibility`] = group.visibility;
 
     const entity: GroupEntity = {
       apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/defaultTransformers.ts
@@ -49,7 +49,10 @@ export function defaultGroupEntitiesTransformer(
     const annotations: { [annotationName: string]: string } = {};
 
     annotations[`${options.providerConfig.host}/team-path`] = group.full_path;
-    annotations[`${options.providerConfig.host}/visibility`] = group.visibility;
+    if (group.visibility !== undefined) {
+      annotations[`${options.providerConfig.host}/visibility`] =
+        group.visibility;
+    }
 
     const entity: GroupEntity = {
       apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -76,6 +76,7 @@ export type GitLabGroup = {
   name: string;
   full_path: string;
   description?: string;
+  visibility: string;
   parent_id?: number;
 };
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -116,6 +116,7 @@ export type GitLabDescendantGroupsResponse = {
             name: string;
             description: string;
             fullPath: string;
+            visibility: string;
             parent: {
               id: string;
             };

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -76,7 +76,7 @@ export type GitLabGroup = {
   name: string;
   full_path: string;
   description?: string;
-  visibility: string;
+  visibility?: string;
   parent_id?: number;
 };
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -526,6 +526,7 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
                       name: 'group2',
                       description: 'Group2',
                       fullPath: 'group1/group2',
+                      visibility: 'private',
                       parent: {
                         id: 'gid://gitlab/Group/123',
                       },
@@ -535,6 +536,7 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
                       name: 'group3',
                       description: 'Group3',
                       fullPath: 'group1/group3',
+                      visibility: 'public',
                       parent: {
                         id: 'gid://gitlab/Group/123',
                       },
@@ -704,6 +706,7 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
               'backstage.io/managed-by-origin-location':
                 'url:https://gitlab.com/group1/group2',
               'gitlab.com/team-path': 'group1/group2',
+              'gitlab.com/visibility': 'private',
             },
             description: 'Group2',
             name: 'group2',
@@ -729,6 +732,7 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
               'backstage.io/managed-by-origin-location':
                 'url:https://gitlab.com/group1/group3',
               'gitlab.com/team-path': 'group1/group3',
+              'gitlab.com/visibility': 'public',
             },
             description: 'Group3',
             name: 'group3',

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -452,6 +452,7 @@ describe('GitlabOrgDiscoveryEntityProvider', () => {
               'backstage.io/managed-by-origin-location':
                 'url:https://test-gitlab/group1/group2',
               'test-gitlab/team-path': 'group1/group2',
+              'test-gitlab/visibility': 'internal',
             },
             description: 'Group2',
             name: 'group1-group2',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds an annotation to groups ingested by gitlab org provider and annotates them with their visibility level:

fixes #22887

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
