### PR TITLE
Update docs to add profile 

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1052,7 +1052,7 @@ The fields of a profile are:
 
 | Field                    | Type   | Description                                                    |
 | ------------------------ | ------ | -------------------------------------------------------------- |
-| `displayName` (optional) | String | A human-readable name for the group.                           |
+| `displayName` (optional) | String | A human-readable name for the user.                           |
 | `email` (optional)       | String | An email the user may wish to be used for contacting them.    |
 | `picture` (optional)     | String | A URL pointing to an image that's representative of the user. |
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1050,8 +1050,8 @@ and that a browser could fetch and render on a profile page or similar.
 
 The fields of a profile are:
 
-| Field                    | Type   | Description                                                    |
-| ------------------------ | ------ | -------------------------------------------------------------- |
+| Field                    | Type   | Description                                                   |
+| ------------------------ | ------ | ------------------------------------------------------------- |
 | `displayName` (optional) | String | A human-readable name for the user.                           |
 | `email` (optional)       | String | An email the user may wish to be used for contacting them.    |
 | `picture` (optional)     | String | A URL pointing to an image that's representative of the user. |

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1053,7 +1053,7 @@ The fields of a profile are:
 | Field                    | Type   | Description                                                    |
 | ------------------------ | ------ | -------------------------------------------------------------- |
 | `displayName` (optional) | String | A human-readable name for the group.                           |
-| `email` (optional)       | String | An email the group may wish to be used for contacting them.    |
+| `email` (optional)       | String | An email the user may wish to be used for contacting them.    |
 | `picture` (optional)     | String | A URL pointing to an image that's representative of the user. |
 
 ### `spec.memberOf` [required]

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -955,6 +955,14 @@ some form, that the group may wish to be used for contacting them. The picture
 is expected to be a URL pointing to an image that's representative of the group,
 and that a browser could fetch and render on a group page or similar.
 
+The fields of a profile are:
+
+| Field                    | Type   | Description                                                    |
+| ------------------------ | ------ | -------------------------------------------------------------- |
+| `displayName` (optional) | String | A human-readable name for the group.                           |
+| `email` (optional)       | String | An email the group may wish to be used for contacting them.    |
+| `picture` (optional)     | String | A URL pointing to an image that's representative of the group. |
+
 ### `spec.parent` [optional]
 
 The immediate parent group in the hierarchy, if any. Not all groups must have a
@@ -1039,6 +1047,14 @@ fields of this structure are also optional. The email would be a primary email
 of some form, that the user may wish to be used for contacting them. The picture
 is expected to be a URL pointing to an image that's representative of the user,
 and that a browser could fetch and render on a profile page or similar.
+
+The fields of a profile are:
+
+| Field                    | Type   | Description                                                    |
+| ------------------------ | ------ | -------------------------------------------------------------- |
+| `displayName` (optional) | String | A human-readable name for the group.                           |
+| `email` (optional)       | String | An email the group may wish to be used for contacting them.    |
+| `picture` (optional)     | String | A URL pointing to an image that's representative of the group. |
 
 ### `spec.memberOf` [required]
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1054,7 +1054,7 @@ The fields of a profile are:
 | ------------------------ | ------ | -------------------------------------------------------------- |
 | `displayName` (optional) | String | A human-readable name for the group.                           |
 | `email` (optional)       | String | An email the group may wish to be used for contacting them.    |
-| `picture` (optional)     | String | A URL pointing to an image that's representative of the group. |
+| `picture` (optional)     | String | A URL pointing to an image that's representative of the user. |
 
 ### `spec.memberOf` [required]
 


### PR DESCRIPTION
Adding table for profile fields.

## Hey, I just made a Pull Request!

I noticed `spec.profile` docs were missing a nice table for their fields.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
