### PR TITLE
Issue/21799

### DIFF
--- a/.changeset/popular-ladybugs-pay.md
+++ b/.changeset/popular-ladybugs-pay.md
@@ -3,5 +3,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-- The `UserListPicker` now only overrides the user query parameters if the kind filter is either `group` or `user`
 - The `SidebarSubmenuItem` component and `SidebarItem` component can now receive an optional prop `reloadDocument` which forces a remount of the page on click, resetting any state for that route

--- a/.changeset/popular-ladybugs-pay.md
+++ b/.changeset/popular-ladybugs-pay.md
@@ -3,5 +3,5 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-- The UserListPicker now only overrides the user query parameters if the kind filter is either **group** or **user**
-- The SidebarSubmenuItem component and SidebarItem component can now recieve an optional prop **reloadDocument** wich forces a remount of the page on click, resetting any state for that route
+- The `UserListPicker` now only overrides the user query parameters if the kind filter is either `group` or `user`
+- The `SidebarSubmenuItem` component and `SidebarItem` component can now receive an optional prop `reloadDocument` which forces a remount of the page on click, resetting any state for that route

--- a/.changeset/popular-ladybugs-pay.md
+++ b/.changeset/popular-ladybugs-pay.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog-react': patch
+---
+
+- The UserListPicker now only overrides the user query parameters if the kind filter is either **group** or **user**
+- The SidebarSubmenuItem component and SidebarItem component can now recieve an optional prop **reloadDocument** wich forces a remount of the page on click, resetting any state for that route

--- a/.changeset/strange-humans-lay.md
+++ b/.changeset/strange-humans-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+The `UserListPicker` now only overrides the user query parameters if the kind filter is either `group` or `user`

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1114,6 +1114,7 @@ export const SidebarSubmenuItem: (
 export type SidebarSubmenuItemDropdownItem = {
   title: string;
   to: string;
+  reloadDocument?: boolean;
 };
 
 // @public
@@ -1124,6 +1125,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
+  reloadDocument?: boolean;
 };
 
 // @public

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -281,6 +281,7 @@ type SidebarItemButtonProps = SidebarItemBaseProps & {
 type SidebarItemLinkProps = SidebarItemBaseProps & {
   to: string;
   onClick?: (ev: React.MouseEvent) => void;
+  reloadDocument?: boolean;
 } & NavLinkProps;
 
 type SidebarItemWithSubmenuProps = SidebarItemBaseProps & {
@@ -325,6 +326,7 @@ export const WorkaroundNavLink = React.forwardRef<
     className,
     activeStyle,
     caseSensitive,
+    reloadDocument,
     activeClassName = 'active',
     'aria-current': ariaCurrentProp = 'page',
     ...rest
@@ -358,6 +360,7 @@ export const WorkaroundNavLink = React.forwardRef<
         typeof className !== 'function' ? className : undefined,
         isActive ? activeClassName : undefined,
       ])}
+      reloadDocument={reloadDocument ?? false}
     />
   );
 });
@@ -484,6 +487,7 @@ const SidebarItemBase = forwardRef<
       aria-label={text ? text : props.to}
       {...navLinkProps}
       onClick={handleClick}
+      reloadDocument={(props as SidebarItemLinkProps).reloadDocument}
     >
       {content}
     </WorkaroundNavLink>

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -111,6 +111,7 @@ const useStyles = makeStyles(
 export type SidebarSubmenuItemDropdownItem = {
   title: string;
   to: string;
+  reloadDocument?: boolean;
 };
 /**
  * Holds submenu item content.
@@ -131,6 +132,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
+  reloadDocument?: boolean;
 };
 
 /**
@@ -139,7 +141,15 @@ export type SidebarSubmenuItemProps = {
  * @public
  */
 export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
-  const { title, subtitle, to, icon: Icon, dropdownItems, exact } = props;
+  const {
+    title,
+    subtitle,
+    to,
+    icon: Icon,
+    dropdownItems,
+    exact,
+    reloadDocument,
+  } = props;
   const classes = useStyles();
   const { setIsHoveredOn } = useContext(SidebarItemWithSubmenuContext);
   const closeSubmenu = () => {
@@ -211,6 +221,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
                   className={classes.dropdownItem}
                   onClick={closeSubmenu}
                   onTouchStart={e => e.stopPropagation()}
+                  reloadDocument={object.reloadDocument ?? false}
                 >
                   <Typography component="span" className={classes.textContent}>
                     {object.title}
@@ -236,6 +247,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
           )}
           onClick={closeSubmenu}
           onTouchStart={e => e.stopPropagation()}
+          reloadDocument={reloadDocument ?? false}
         >
           {Icon && <Icon fontSize="small" />}
           <Typography

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -458,29 +458,48 @@ describe('<UserListPicker />', () => {
         });
       });
 
-      it('resets the filter to "all" when entities are loaded', async () => {
-        mockCatalogApi.queryEntities?.mockImplementation(async request => {
-          if (
-            (
-              (request as QueryEntitiesInitialRequest).filter as Record<
-                string,
-                string
+      it.each([
+        ['group', { user: EntityUserFilter.all() }],
+        ['user', { user: EntityUserFilter.all() }],
+      ])(
+        'resets the filter to "all" when kind filter is %s',
+        async (kind, expected) => {
+          mockCatalogApi.queryEntities?.mockImplementation(async request => {
+            if (
+              (
+                (request as QueryEntitiesInitialRequest).filter as Record<
+                  string,
+                  string
+                >
+              )['relations.ownedBy']
+            ) {
+              return { items: [], totalItems: 0, pageInfo: {} };
+            }
+            return mockQueryEntitiesImplementation(request);
+          });
+
+          render(
+            <ApiProvider apis={apis}>
+              <MockEntityListContextProvider
+                value={{
+                  updateFilters,
+                  queryParameters: { user: ['owned'], kind: kind },
+                  filters: {
+                    kind: new EntityKindFilter(kind),
+                    user: undefined,
+                  },
+                }}
               >
-            )['relations.ownedBy']
-          ) {
-            return { items: [], totalItems: 0, pageInfo: {} };
-          }
-          return mockQueryEntitiesImplementation(request);
-        });
+                <UserListPicker initialFilter="owned" />
+              </MockEntityListContextProvider>
+            </ApiProvider>,
+          );
 
-        render(<Picker initialFilter="owned" />);
-
-        await waitFor(() =>
-          expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserFilter.all(),
-          }),
-        );
-      });
+          await waitFor(() =>
+            expect(updateFilters).toHaveBeenLastCalledWith(expected),
+          );
+        },
+      );
     });
 
     describe(`when there are no starred entities match the filter`, () => {
@@ -522,29 +541,48 @@ describe('<UserListPicker />', () => {
         });
       });
 
-      it('resets the filter to "all" when entities are loaded', async () => {
-        mockCatalogApi.queryEntities?.mockImplementation(async request => {
-          if (
-            (
-              (request as QueryEntitiesInitialRequest).filter as Record<
-                string,
-                string
+      it.each([
+        ['group', { user: EntityUserFilter.all() }],
+        ['user', { user: EntityUserFilter.all() }],
+      ])(
+        'resets the filter to "all" when kind filter is %s',
+        async (kind, expected) => {
+          mockCatalogApi.queryEntities?.mockImplementation(async request => {
+            if (
+              (
+                (request as QueryEntitiesInitialRequest).filter as Record<
+                  string,
+                  string
+                >
+              )['metadata.name']
+            ) {
+              return { items: [], totalItems: 0, pageInfo: {} };
+            }
+            return mockQueryEntitiesImplementation(request);
+          });
+
+          render(
+            <ApiProvider apis={apis}>
+              <MockEntityListContextProvider
+                value={{
+                  updateFilters,
+                  queryParameters: { user: ['starred'], kind: kind },
+                  filters: {
+                    kind: new EntityKindFilter(kind),
+                    user: undefined,
+                  },
+                }}
               >
-            )['metadata.name']
-          ) {
-            return { items: [], totalItems: 0, pageInfo: {} };
-          }
-          return mockQueryEntitiesImplementation(request);
-        });
+                <UserListPicker initialFilter="starred" />
+              </MockEntityListContextProvider>
+            </ApiProvider>,
+          );
 
-        render(<Picker initialFilter="starred" />);
-
-        await waitFor(() =>
-          expect(updateFilters).toHaveBeenLastCalledWith({
-            user: EntityUserFilter.all(),
-          }),
-        );
-      });
+          await waitFor(() =>
+            expect(updateFilters).toHaveBeenLastCalledWith(expected),
+          );
+        },
+      );
     });
 
     describe(`when there are some owned entities present`, () => {

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -180,22 +180,15 @@ export const UserListPicker = (props: UserListPickerProps) => {
   // external updates to the page location.
   useEffect(() => {
     if (queryParamUserFilter) {
-      setSelectedUserFilter(queryParamUserFilter as UserListFilterKind);
+      if (['group', 'user'].some(kind => kind === kindParameter)) {
+        setSelectedUserFilter('all');
+      } else {
+        setSelectedUserFilter(queryParamUserFilter as UserListFilterKind);
+      }
     }
-  }, [queryParamUserFilter]);
+  }, [queryParamUserFilter, kindParameter]);
 
   const loading = loadingOwnedEntities || loadingStarredEntities;
-
-  useEffect(() => {
-    if (
-      !loading &&
-      !!selectedUserFilter &&
-      selectedUserFilter !== 'all' &&
-      filterCounts[selectedUserFilter] === 0
-    ) {
-      setSelectedUserFilter('all');
-    }
-  }, [loading, filterCounts, selectedUserFilter, setSelectedUserFilter]);
 
   useEffect(() => {
     if (!selectedUserFilter) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #21799 
- UserListPicker now only overrides the user filter query parameters if the kind filter is either group or user
- Adds optional prop **reloadDocument** that can be passed to SidebarSubmenuItem and SidebarItem that forces a remount of the page on click, resetting and state for that route. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
