### PR TITLE
do less renovate pinning - starting out with docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,11 @@
 
   labels: ['dependencies'],
 
-  extends: ['config:best-practices', ':gitSignOff'],
+  extends: [
+    'config:best-practices',
+    ':gitSignOff',
+    'default:pinDigestsDisabled',
+  ],
   // do not pin dev dependencies, which are part of the best-practices preset
   ignorePresets: [':pinDevDependencies'],
 
@@ -12,8 +16,11 @@
 
   postUpdateOptions: ['yarnDedupeHighest'],
   rangeStrategy: 'update-lockfile',
-  // @elastic/elasticsearch is ignored due to licensing issues. See #10992
-  ignoreDeps: ['@elastic/elasticsearch', 'event-source-polyfill'],
+  ignoreDeps: [
+    // ignored due to licensing issues. See #10992
+    '@elastic/elasticsearch',
+    'event-source-polyfill',
+  ],
   packageRules: [
     {
       matchSourceUrlPrefixes: ['https://github.com/spotify/web-scripts'],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     name: Test ${{ matrix.node-version }}
     services:
       postgres16:
-        image: postgres:16@sha256:39d764950f22cfe878661247bb15cb344169dc3d55c9d4676303a2ef8675c057
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -166,7 +166,7 @@ jobs:
         ports:
           - 5432/tcp
       postgres12:
-        image: postgres:12@sha256:7a4c3f690fa767db8aaa4a9da3870037535307cc7f8f1880f1d7275a1be29b4d
+        image: postgres:12
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -177,7 +177,7 @@ jobs:
         ports:
           - 5432/tcp
       mysql8:
-        image: mysql:8@sha256:343b82684a6b05812c58ca20ccd3af8bcf8a5f48b1842f251c54379bfce848f9
+        image: mysql:8
         env:
           MYSQL_ROOT_PASSWORD: root
         options: >-

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       postgres16:
-        image: postgres:16@sha256:39d764950f22cfe878661247bb15cb344169dc3d55c9d4676303a2ef8675c057
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -34,7 +34,7 @@ jobs:
         ports:
           - 5432/tcp
       postgres12:
-        image: postgres:12@sha256:7a4c3f690fa767db8aaa4a9da3870037535307cc7f8f1880f1d7275a1be29b4d
+        image: postgres:12
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -45,7 +45,7 @@ jobs:
         ports:
           - 5432/tcp
       mysql8:
-        image: mysql:8@sha256:343b82684a6b05812c58ca20ccd3af8bcf8a5f48b1842f251c54379bfce848f9
+        image: mysql:8
         env:
           MYSQL_ROOT_PASSWORD: root
         options: >-

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12@sha256:7a4c3f690fa767db8aaa4a9da3870037535307cc7f8f1880f1d7275a1be29b4d
+        image: postgres:12
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/contrib/.devcontainer/Dockerfile
+++ b/contrib/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:20@sha256:381a1fde32704f229b439ade94816d5619f710e35698982ec35afcd9384ae6cf
+FROM mcr.microsoft.com/devcontainers/typescript-node:20
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install chromium \

--- a/plugins/scaffolder-backend-module-rails/Rails.dockerfile
+++ b/plugins/scaffolder-backend-module-rails/Rails.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3@sha256:24af4f0bf0af61d04a5ead4f43e7ad468a1b2ff05844d7780555a13a78615ced
+FROM ruby:3.3
 
 RUN apt-get update -qq && \
     apt-get install -y nodejs postgresql-client git && \

--- a/plugins/scaffolder-backend/scripts/Cookiecutter.dockerfile
+++ b/plugins/scaffolder-backend/scripts/Cookiecutter.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160
+FROM alpine:3.18
 
 RUN apk add --update \
 	git \
@@ -8,4 +8,4 @@ RUN apk add --update \
 	g++ && \
 	pip install cookiecutter && \
 	apk del g++ py-pip python-dev && \
-	rm -rf /var/cache/apk/* 
+	rm -rf /var/cache/apk/*


### PR DESCRIPTION
tried it out for a bit, not liking it unless we can rewrite our automerge tooling to deal with pulling them through - which i feel we don't have time for now

these damn things update like every single day

Another strategy might be to lock down to an exact version instead of eg just "12", and let THAT be pinned to a hash ... as long as it doesn't try to also be helpful and update that version with every release. Happy for feedback on that one