### PR TITLE
feat(scaffolder-backend-module-github): support oidc customization

### DIFF
--- a/.changeset/funny-meals-tease.md
+++ b/.changeset/funny-meals-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': minor
+---
+
+support oidc customization

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -205,6 +205,12 @@ export function createGithubRepoCreateAction(options: {
           [key: string]: string;
         }
       | undefined;
+    oidcCustomization?:
+      | {
+          useDefault: boolean;
+          includeClaimKeys?: string[] | undefined;
+        }
+      | undefined;
     requireCommitSigning?: boolean | undefined;
   },
   JsonObject
@@ -350,6 +356,12 @@ export function createPublishGithubAction(options: {
     secrets?:
       | {
           [key: string]: string;
+        }
+      | undefined;
+    oidcCustomization?:
+      | {
+          useDefault: boolean;
+          includeClaimKeys?: string[] | undefined;
         }
       | undefined;
     requiredCommitSigning?: boolean | undefined;

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -77,6 +77,7 @@ const mockOctokit = {
       getRepoPublicKey: jest.fn(),
     },
   },
+  request: jest.fn(),
 };
 jest.mock('octokit', () => ({
   Octokit: class {
@@ -928,6 +929,40 @@ describe('publish:github', () => {
       key_id: 'keyid',
       encrypted_value: expect.any(String),
     });
+  });
+
+  it('should configure oidc customizations when provided', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        oidcCustomization: {
+          useDefault: false,
+          includeClaimKeys: ['foo', 'bar'],
+        },
+      },
+    });
+
+    expect(mockOctokit.request).toHaveBeenCalledWith(
+      'PUT /repos/{owner}/{repo}/actions/oidc/customization/sub',
+      {
+        include_claim_keys: ['foo', 'bar'],
+        owner: 'owner',
+        repo: 'repo',
+        use_default: false,
+      },
+    );
   });
 
   it('should call output with the remoteUrl and the repoContentsUrl', async () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -109,6 +109,10 @@ export function createPublishGithubAction(options: {
     topics?: string[];
     repoVariables?: { [key: string]: string };
     secrets?: { [key: string]: string };
+    oidcCustomization?: {
+      useDefault: boolean;
+      includeClaimKeys?: string[];
+    };
     requiredCommitSigning?: boolean;
   }>({
     id: 'publish:github',
@@ -156,6 +160,7 @@ export function createPublishGithubAction(options: {
           topics: inputProps.topics,
           repoVariables: inputProps.repoVariables,
           secrets: inputProps.secrets,
+          oidcCustomization: inputProps.oidcCustomization,
           requiredCommitSigning: inputProps.requiredCommitSigning,
         },
       },
@@ -203,6 +208,7 @@ export function createPublishGithubAction(options: {
         topics,
         repoVariables,
         secrets,
+        oidcCustomization,
         token: providedToken,
         requiredCommitSigning = false,
       } = ctx.input;
@@ -243,6 +249,7 @@ export function createPublishGithubAction(options: {
         topics,
         repoVariables,
         secrets,
+        oidcCustomization,
         ctx.logger,
       );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -95,6 +95,10 @@ export function createGithubRepoCreateAction(options: {
     topics?: string[];
     repoVariables?: { [key: string]: string };
     secrets?: { [key: string]: string };
+    oidcCustomization?: {
+      useDefault: boolean;
+      includeClaimKeys?: string[];
+    };
     requireCommitSigning?: boolean;
   }>({
     id: 'github:repo:create',
@@ -133,6 +137,7 @@ export function createGithubRepoCreateAction(options: {
           topics: inputProps.topics,
           repoVariables: inputProps.repoVariables,
           secrets: inputProps.secrets,
+          oidcCustomization: inputProps.oidcCustomization,
           requiredCommitSigning: inputProps.requiredCommitSigning,
         },
       },
@@ -165,6 +170,7 @@ export function createGithubRepoCreateAction(options: {
         topics,
         repoVariables,
         secrets,
+        oidcCustomization,
         token: providedToken,
       } = ctx.input;
 
@@ -204,6 +210,7 @@ export function createGithubRepoCreateAction(options: {
         topics,
         repoVariables,
         secrets,
+        oidcCustomization,
         ctx.logger,
       );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -137,6 +137,12 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
   topics: string[] | undefined,
   repoVariables: { [key: string]: string } | undefined,
   secrets: { [key: string]: string } | undefined,
+  oidcCustomization:
+    | {
+        useDefault: boolean;
+        includeClaimKeys?: string[];
+      }
+    | undefined,
   logger: Logger,
 ) {
   // eslint-disable-next-line testing-library/no-await-sync-queries
@@ -302,6 +308,18 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
         key_id: publicKeyResponse.data.key_id,
       });
     }
+  }
+
+  if (oidcCustomization) {
+    await client.request(
+      'PUT /repos/{owner}/{repo}/actions/oidc/customization/sub',
+      {
+        owner,
+        repo,
+        use_default: oidcCustomization.useDefault,
+        include_claim_keys: oidcCustomization.includeClaimKeys,
+      },
+    );
   }
 
   return newRepo;

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -277,6 +277,28 @@ const secrets = {
   type: 'object',
 };
 
+const oidcCustomization = {
+  title: 'Repository OIDC customization template',
+  description: `OIDC customization template attached to the repository.`,
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    useDefault: {
+      title: 'Use Default',
+      type: 'boolean',
+      description: `Whether to use the default OIDC template or not.`,
+    },
+    includeClaimKeys: {
+      title: 'Include claim keys',
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      description: `Array of unique strings. Each claim key can only contain alphanumeric characters and underscores.`,
+    },
+  },
+};
+
 export { access };
 export { allowMergeCommit };
 export { allowRebaseMerge };
@@ -313,3 +335,4 @@ export { topics };
 export { requiredCommitSigning };
 export { repoVariables };
 export { secrets };
+export { oidcCustomization };


### PR DESCRIPTION
Support configuring oidc customization when scaffolding github repositories.

This is for example useful on Azure, which doesn't support wildcard claims https://github.com/Azure/azure-workload-identity/issues/373.

More docs about it here https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-token-claims and here https://docs.github.com/en/rest/actions/oidc?apiVersion=2022-11-28#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
