### PR TITLE
Fix Tech Radar header cell getting squished and unreadable

### DIFF
--- a/.changeset/poor-beans-cross.md
+++ b/.changeset/poor-beans-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Fixed an issue with the "moved in direction" table header cell getting squished and becoming unreadable if a timeline description is too long

--- a/plugins/tech-radar/src/components/RadarTimeline/RadarTimeline.tsx
+++ b/plugins/tech-radar/src/components/RadarTimeline/RadarTimeline.tsx
@@ -47,7 +47,9 @@ const RadarTimeline = (props: Props): JSX.Element => {
         <Table aria-label="simple table">
           <TableHead>
             <TableRow>
-              <TableCell align="left">Moved in direction</TableCell>
+              <TableCell align="left" style={{ wordBreak: 'normal' }}>
+                Moved in direction
+              </TableCell>
               <TableCell align="left">Moved to ring</TableCell>
               <TableCell align="left">Moved on date</TableCell>
               <TableCell align="left">Description</TableCell>


### PR DESCRIPTION
Signed-off-by: Vladimir Kobzev <vkobzev@bol.com>

## Hey, I just made a Pull Request!

Timeline descriptions are sometimes long enough to take up too much horizontal space and "squish" the first table header cell into an unreadable column of text. This problem is even more apparent on lower resolution screens. The patch prevents the words inside the cell from breaking and becoming unreadable.

Before (dramatic recreation of a long description)
![Screenshot 2024-02-15 at 13 30 18](https://github.com/backstage/backstage/assets/32046496/33e11402-8d71-449e-8680-bb0f0c3b8a98)

After
![Screenshot 2024-02-15 at 13 29 31](https://github.com/backstage/backstage/assets/32046496/2f465840-d635-4770-9674-2c944085877b)

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
