### PR TITLE
Add support for custom variables on creating unified theme

### DIFF
--- a/.changeset/polite-geckos-bathe.md
+++ b/.changeset/polite-geckos-bathe.md
@@ -1,0 +1,6 @@
+---
+'@backstage/theme': minor
+---
+
+Add support for custom variables on creating unified theme.
+Make `createBaseThemeOptions` accept just `UnifiedThemeOptions`

--- a/packages/theme/src/base/createBaseThemeOptions.ts
+++ b/packages/theme/src/base/createBaseThemeOptions.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { BackstageTypography, PageTheme, PageThemeSelector } from './types';
+import { BackstageTypography, PageThemeSelector } from './types';
 import { pageTheme as defaultPageThemes } from './pageTheme';
+import { UnifiedThemeOptions } from '../unified';
 
 const DEFAULT_HTML_FONT_SIZE = 16;
 const DEFAULT_FONT_FAMILY =
@@ -27,30 +28,21 @@ const DEFAULT_PAGE_THEME = 'home';
  *
  * @public
  */
-export interface BaseThemeOptionsInput<PaletteOptions> {
-  palette: PaletteOptions;
-  defaultPageTheme?: string;
-  pageTheme?: Record<string, PageTheme>;
-  fontFamily?: string;
-  htmlFontSize?: number;
-  typography?: BackstageTypography;
-}
+export type BaseThemeOptionsInput = UnifiedThemeOptions;
 
 /**
  * A helper for creating theme options.
  *
  * @public
  */
-export function createBaseThemeOptions<PaletteOptions>(
-  options: BaseThemeOptionsInput<PaletteOptions>,
-) {
+export function createBaseThemeOptions(options: BaseThemeOptionsInput) {
   const {
-    palette,
     htmlFontSize = DEFAULT_HTML_FONT_SIZE,
     fontFamily = DEFAULT_FONT_FAMILY,
     defaultPageTheme = DEFAULT_PAGE_THEME,
     pageTheme = defaultPageThemes,
     typography,
+    ...rest
   } = options;
 
   if (!pageTheme[defaultPageTheme]) {
@@ -93,7 +85,7 @@ export function createBaseThemeOptions<PaletteOptions>(
   };
 
   return {
-    palette,
+    ...rest,
     typography: typography ?? defaultTypography,
     page: pageTheme[defaultPageTheme],
     getPageTheme: ({ themeId }: PageThemeSelector) =>

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -19,11 +19,9 @@ import {
   ThemeOptions as ThemeOptionsV4,
   createTheme,
 } from '@material-ui/core/styles';
-import type { PaletteOptions as PaletteOptionsV4 } from '@material-ui/core/styles/createPalette';
 import {
   DeprecatedThemeOptions,
   Theme as Mui5Theme,
-  PaletteOptions as PaletteOptionsV5,
   ThemeOptions as ThemeOptionsV5,
   adaptV4Theme,
   createTheme as createV5Theme,
@@ -52,13 +50,14 @@ export class UnifiedThemeHolder implements UnifiedTheme {
   }
 }
 
+type BaseThemeOptions = ThemeOptionsV4 & ThemeOptionsV5;
+
 /**
  * Options for creating a new {@link UnifiedTheme}.
  *
  * @public
  */
-export interface UnifiedThemeOptions {
-  palette: PaletteOptionsV4 & PaletteOptionsV5;
+export interface UnifiedThemeOptions extends BaseThemeOptions {
   defaultPageTheme?: string;
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed current implementation cuts off all the custom variables and even some supported ones, like `shapes`. So added support for that cases

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
