### PR TITLE
catalog-backend-module-unprocessed: refactor for forwards compatibility

### DIFF
--- a/.changeset/clever-steaks-hope.md
+++ b/.changeset/clever-steaks-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-unprocessed': patch
+---
+
+Explicitly only depend on the `use` method from the `HttpRouterService`.

--- a/plugins/catalog-backend-module-unprocessed/api-report.md
+++ b/plugins/catalog-backend-module-unprocessed/api-report.md
@@ -13,7 +13,7 @@ export default catalogModuleUnprocessedEntities;
 
 // @public
 export class UnprocessedEntitiesModule {
-  constructor(database: Knex, router: HttpRouterService);
+  constructor(database: Knex, router: Pick<HttpRouterService, 'use'>);
   // (undocumented)
   registerRoutes(): void;
 }

--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -23,7 +23,6 @@ import {
 import { Knex } from 'knex';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
 import Router from 'express-promise-router';
-import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 
 /**
  * Module providing Unprocessed Entities API endpoints
@@ -35,7 +34,7 @@ export class UnprocessedEntitiesModule {
 
   constructor(
     private readonly database: Knex,
-    private readonly router: HttpRouterService,
+    private readonly router: Pick<HttpRouterService, 'use'>,
   ) {
     this.moduleRouter = Router();
     this.router.use(this.moduleRouter);
@@ -111,9 +110,6 @@ export class UnprocessedEntitiesModule {
           await this.unprocessed({
             reason: 'failed',
             owner: req.query.owner as string,
-            authorizationToken: getBearerTokenFromAuthorizationHeader(
-              req.header('authorization'),
-            ),
           }),
         );
       })
@@ -122,9 +118,6 @@ export class UnprocessedEntitiesModule {
           await this.unprocessed({
             reason: 'pending',
             owner: req.query.owner as string,
-            authorizationToken: getBearerTokenFromAuthorizationHeader(
-              req.header('authorization'),
-            ),
           }),
         );
       });

--- a/plugins/catalog-backend-module-unprocessed/src/types.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/types.ts
@@ -60,7 +60,6 @@ export type RefreshStateError = {
 export interface UnprocessedEntitiesRequest {
   reason: 'failed' | 'pending';
   owner?: string;
-  authorizationToken?: string;
 }
 
 export interface UnprocessedEntitiesResponse {


### PR DESCRIPTION
🧹 , tiny bit of cleanup for forwards-compatibility with some of the ongoing auth work