### PR TITLE
Improve accessibility in SearchModal component

### DIFF
--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -192,7 +192,8 @@ export const SearchModal = (props: SearchModalProps) => {
         paperFullWidth: classes.paperFullWidth,
       }}
       onClose={toggleModal}
-      aria-labelledby="search-modal-title"
+      aria-label="Search Modal"
+      aria-modal="true"
       fullWidth
       maxWidth="lg"
       open={open}


### PR DESCRIPTION
Replaced aria-labelledby with aria-label for the dialog element to provide a directly accessible name.
Added aria-modal="true" attribute to indicate that the dialog behaves as a modal.
#22906 
