### PR TITLE
fix(catalog-backend-module-azure): Fixed issue where specifying a branch for discovery did not work 

### DIFF
--- a/.changeset/real-keys-juggle.md
+++ b/.changeset/real-keys-juggle.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-azure': minor
+'@backstage/plugin-catalog-backend-module-azure': patch
 ---
 
 Fixed issue where specifying a branch for discovery did not work

--- a/.changeset/real-keys-juggle.md
+++ b/.changeset/real-keys-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-azure': minor
+---
+
+Fixed issue where specifying a branch for discovery did not work

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -93,6 +93,8 @@ _Note:_
 5. In the window that appears, enter the name of the branch you want to add and click "Add".
 6. The added branch will now appear in the "Searchable branches" list.
 
+It may take some time before the branch is indexed and searchable.
+
 As this provider is not one of the default providers, you will first need to install
 the Azure catalog plugin:
 
@@ -162,12 +164,12 @@ catalog:
       target: https://dev.azure.com/myorg/myproject/_git/*?path=/src/*/catalog-info.yaml
     # And optionally provide a specific branch name using the version parameter
     - type: azure-discovery
-      target: https://dev.azure.com/myorg/myproject/_git/*?path=/catalog-info.yaml&version=GBdevelopment
+      target: https://dev.azure.com/myorg/myproject/_git/*?path=/catalog-info.yaml&version=GBtopic/catalog-info
 ```
 
 Note the `azure-discovery` type, as this is not a regular `url` processor.
 
-When using a custom pattern, the target is composed of six parts:
+When using a custom pattern, the target is composed of these parts:
 
 - The base instance URL, `https://dev.azure.com` in this case
 - The organization name which is required, `myorg` in this case
@@ -178,4 +180,4 @@ When using a custom pattern, the target is composed of six parts:
 - The path within each repository to find the catalog YAML file. This will
   usually be `/catalog-info.yaml`, `/src/*/catalog-info.yaml` or a similar
   variation for catalog files stored in the root directory of each repository.
-- The repository branch to scan which is optional, `development` in this case. The `GB` prefix is mandatory, as this is how Azure DevOps identifies the version as a branch. If omitted, the repo's default branch will be scanned.
+- The repository branch to scan which is optional, `topic/catalog-info` in this case. If omitted, the repo's default branch will be scanned. The `GB` prefix is required, as this is how Azure DevOps identifies the version as a branch.

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -160,11 +160,14 @@ catalog:
     # Or use a custom file format and location
     - type: azure-discovery
       target: https://dev.azure.com/myorg/myproject/_git/*?path=/src/*/catalog-info.yaml
+    # And optionally provide a specific branch name using the version parameter
+    - type: azure-discovery
+      target: https://dev.azure.com/myorg/myproject/_git/*?path=/catalog-info.yaml&version=GBdevelopment
 ```
 
 Note the `azure-discovery` type, as this is not a regular `url` processor.
 
-When using a custom pattern, the target is composed of five parts:
+When using a custom pattern, the target is composed of six parts:
 
 - The base instance URL, `https://dev.azure.com` in this case
 - The organization name which is required, `myorg` in this case
@@ -175,3 +178,4 @@ When using a custom pattern, the target is composed of five parts:
 - The path within each repository to find the catalog YAML file. This will
   usually be `/catalog-info.yaml`, `/src/*/catalog-info.yaml` or a similar
   variation for catalog files stored in the root directory of each repository.
+- The repository branch to scan which is optional, `development` in this case. The `GB` prefix is mandatory, as this is how Azure DevOps identifies the version as a branch. If omitted, the repo's default branch will be scanned.

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -89,6 +89,7 @@ describe('azure', () => {
           'engineering',
           '',
           '/catalog-info.yaml',
+          '',
         ),
       ).resolves.toEqual([]);
     });
@@ -154,6 +155,7 @@ describe('azure', () => {
         'engineering',
         '',
         '/catalog-info.yaml',
+        '',
       ),
     ).resolves.toEqual(response.results);
   });
@@ -210,6 +212,7 @@ describe('azure', () => {
         'engineering',
         'backstage',
         '/catalog-info.yaml',
+        '',
       ),
     ).resolves.toEqual(response.results);
   });
@@ -325,6 +328,7 @@ describe('azure', () => {
         'engineering',
         '',
         '/catalog-info.yaml',
+        '',
       ),
     ).resolves.toEqual(response.results);
   });
@@ -384,6 +388,7 @@ describe('azure', () => {
         'engineering',
         'backstage',
         '/catalog-info.yaml',
+        '',
       ),
     ).resolves.toHaveLength(totalCount);
   });

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -214,6 +214,66 @@ describe('azure', () => {
     ).resolves.toEqual(response.results);
   });
 
+  it('searches in specific branch if parameter is set', async () => {
+    const response: CodeSearchResponse = {
+      count: 1,
+      results: [
+        {
+          fileName: 'catalog-info.yaml',
+          path: '/catalog-info.yaml',
+          project: {
+            name: '*',
+          },
+          repository: {
+            name: 'backstage',
+          },
+        },
+      ],
+    };
+
+    server.use(
+      rest.post(
+        `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(req.body).toEqual({
+            searchText:
+              'path:/catalog-info.yaml repo:backstage proj:engineering',
+            $orderBy: [
+              {
+                field: 'path',
+                sortOrder: 'ASC',
+              },
+            ],
+            $skip: 0,
+            $top: 1000,
+            filters: {
+              Branch: ['development'],
+            },
+          });
+          return res(ctx.json(response));
+        },
+      ),
+    );
+
+    const { credentialsProvider, azureConfig } = createFixture(
+      'dev.azure.com',
+      'ABC',
+    );
+
+    await expect(
+      codeSearch(
+        credentialsProvider,
+        azureConfig,
+        'shopify',
+        'engineering',
+        'backstage',
+        '/catalog-info.yaml',
+        'development',
+      ),
+    ).resolves.toEqual(response.results);
+  });
+
   it('can search using onpremise api', async () => {
     const response: CodeSearchResponse = {
       count: 1,

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -251,7 +251,7 @@ describe('azure', () => {
             $skip: 0,
             $top: 1000,
             filters: {
-              Branch: ['development'],
+              Branch: ['topic/catalog-info'],
             },
           });
           return res(ctx.json(response));
@@ -272,7 +272,7 @@ describe('azure', () => {
         'engineering',
         'backstage',
         '/catalog-info.yaml',
-        'development',
+        'topic/catalog-info',
       ),
     ).resolves.toEqual(response.results);
   });

--- a/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.test.ts
@@ -35,6 +35,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         project: 'my-proj',
         repo: '',
         catalogPath: '/catalog-info.yaml',
+        branch: '',
       });
 
       expect(
@@ -47,6 +48,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         project: 'engineering',
         repo: 'backstage',
         catalogPath: '/catalog.yaml',
+        branch: '',
       });
 
       expect(
@@ -59,6 +61,20 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         project: 'engineering',
         repo: 'backstage',
         catalogPath: '/src/*/catalog.yaml',
+        branch: '',
+      });
+
+      expect(
+        parseUrl(
+          'https://azuredevops.mycompany.com/spotify/engineering/_git/backstage?path=/src/*/catalog.yaml&version=GBdevelopment',
+        ),
+      ).toEqual({
+        baseUrl: 'https://azuredevops.mycompany.com',
+        org: 'spotify',
+        project: 'engineering',
+        repo: 'backstage',
+        catalogPath: '/src/*/catalog.yaml',
+        branch: 'development',
       });
     });
 
@@ -164,6 +180,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         'engineering',
         '',
         '/catalog-info.yaml',
+        '',
       );
       expect(emitter).toHaveBeenCalledTimes(2);
       expect(emitter).toHaveBeenCalledWith({
@@ -214,6 +231,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         'engineering',
         'backstage',
         '/catalog-info.yaml',
+        '',
       );
       expect(emitter).toHaveBeenCalledTimes(1);
       expect(emitter).toHaveBeenCalledWith({
@@ -222,6 +240,49 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
           type: 'url',
           target:
             'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output locations with branch if specified in target', async () => {
+      const location: LocationSpec = {
+        type: 'azure-discovery',
+        target:
+          'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml&version=GBdevelopment',
+      };
+      mockCodeSearch.mockResolvedValueOnce([
+        {
+          fileName: 'catalog-info.yaml',
+          path: '/catalog-info.yaml',
+          repository: {
+            name: 'backstage',
+          },
+          project: {
+            name: '*',
+          },
+        },
+      ]);
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(mockCodeSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        { host: 'dev.azure.com' },
+        'shopify',
+        'engineering',
+        'backstage',
+        '/catalog-info.yaml',
+        'development',
+      );
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml&version=GBdevelopment',
           presence: 'optional',
         },
       });
@@ -256,6 +317,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         'engineering',
         '',
         '/src/*/catalog.yaml',
+        '',
       );
       expect(emitter).toHaveBeenCalledTimes(1);
       expect(emitter).toHaveBeenCalledWith({
@@ -286,6 +348,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         'engineering',
         'backstage',
         '/catalog-info.yaml',
+        '',
       );
       expect(emitter).not.toHaveBeenCalled();
     });

--- a/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.test.ts
@@ -66,7 +66,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
 
       expect(
         parseUrl(
-          'https://azuredevops.mycompany.com/spotify/engineering/_git/backstage?path=/src/*/catalog.yaml&version=GBdevelopment',
+          'https://azuredevops.mycompany.com/spotify/engineering/_git/backstage?path=/src/*/catalog.yaml&version=GBtopic/catalog-info',
         ),
       ).toEqual({
         baseUrl: 'https://azuredevops.mycompany.com',
@@ -74,7 +74,20 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         project: 'engineering',
         repo: 'backstage',
         catalogPath: '/src/*/catalog.yaml',
-        branch: 'development',
+        branch: 'topic/catalog-info',
+      });
+
+      expect(
+        parseUrl(
+          'https://azuredevops.mycompany.com/spotify/engineering/_git/backstage?path=/src/*/catalog.yaml&version=GBtopic%2Fcatalog-info',
+        ),
+      ).toEqual({
+        baseUrl: 'https://azuredevops.mycompany.com',
+        org: 'spotify',
+        project: 'engineering',
+        repo: 'backstage',
+        catalogPath: '/src/*/catalog.yaml',
+        branch: 'topic/catalog-info',
       });
     });
 
@@ -249,7 +262,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
       const location: LocationSpec = {
         type: 'azure-discovery',
         target:
-          'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml&version=GBdevelopment',
+          'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml&version=GBtopic/catalog-info',
       };
       mockCodeSearch.mockResolvedValueOnce([
         {
@@ -274,7 +287,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         'engineering',
         'backstage',
         '/catalog-info.yaml',
-        'development',
+        'topic/catalog-info',
       );
       expect(emitter).toHaveBeenCalledTimes(1);
       expect(emitter).toHaveBeenCalledWith({
@@ -282,7 +295,7 @@ describe('AzureDevOpsDiscoveryProcessor', () => {
         location: {
           type: 'url',
           target:
-            'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml&version=GBdevelopment',
+            'https://dev.azure.com/shopify/engineering/_git/backstage?path=/catalog-info.yaml&version=GBtopic/catalog-info',
           presence: 'optional',
         },
       });

--- a/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-azure/src/processors/AzureDevOpsDiscoveryProcessor.ts
@@ -92,7 +92,7 @@ export class AzureDevOpsDiscoveryProcessor implements CatalogProcessor {
       );
     }
 
-    const { baseUrl, org, project, repo, catalogPath } = parseUrl(
+    const { baseUrl, org, project, repo, catalogPath, branch } = parseUrl(
       location.target,
     );
     this.logger.info(
@@ -106,6 +106,7 @@ export class AzureDevOpsDiscoveryProcessor implements CatalogProcessor {
       project,
       repo,
       catalogPath,
+      branch,
     );
 
     this.logger.debug(
@@ -113,10 +114,16 @@ export class AzureDevOpsDiscoveryProcessor implements CatalogProcessor {
     );
 
     for (const file of files) {
+      let target = `${baseUrl}/${org}/${project}/_git/${file.repository.name}?path=${file.path}`;
+
+      if (branch) {
+        target += `&version=GB${branch}`;
+      }
+
       emit(
         processingResult.location({
           type: 'url',
-          target: `${baseUrl}/${org}/${project}/_git/${file.repository.name}?path=${file.path}`,
+          target,
           // Not all locations may actually exist, since the user defined them as a wildcard pattern.
           // Thus, we emit them as optional and let the downstream processor find them while not outputting
           // an error if it couldn't.
@@ -138,11 +145,18 @@ export function parseUrl(urlString: string): {
   project: string;
   repo: string;
   catalogPath: string;
+  branch: string;
 } {
   const url = new URL(urlString);
   const path = url.pathname.slice(1).split('/');
 
   const catalogPath = url.searchParams.get('path') || '/catalog-info.yaml';
+  let branch = url.searchParams.get('version') || '';
+
+  if (branch.startsWith('GB')) {
+    // DevOps prefixes branch names with 'GB' in URLs
+    branch = branch.slice(2);
+  }
 
   if (path.length === 2 && path[0].length && path[1].length) {
     return {
@@ -151,6 +165,7 @@ export function parseUrl(urlString: string): {
       project: decodeURIComponent(path[1]),
       repo: '',
       catalogPath,
+      branch,
     };
   } else if (
     path.length === 4 &&
@@ -165,6 +180,7 @@ export function parseUrl(urlString: string): {
       project: decodeURIComponent(path[1]),
       repo: decodeURIComponent(path[3]),
       catalogPath,
+      branch,
     };
   }
 

--- a/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/AzureDevOpsEntityProvider.ts
@@ -158,6 +158,7 @@ export class AzureDevOpsEntityProvider implements EntityProvider {
       this.config.project,
       this.config.repository,
       this.config.path,
+      this.config.branch || '',
     );
 
     logger.info(`Discovered ${files.length} catalog files`);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Was having trouble getting Discovery to work when specifying a specific branch. Apparently, the Azure DevOps search API will only return hits for the default branch unless the name of the branch to be searched is explicitly provided as a filter, even if the branch to be searched has been indexed and is set as searchable. I honestly think this is a bug in the DevOps API, so I'd probably consider this a workaround. The behavior is the same for the newest version of the API (7.1-preview.1).

This PR contains fixes for both for the Catalog Provider and the Static Location configuration techniques. For the Static Location way of discovery, just include a `&version=GB<branchname>` in the URL. This is the same format as the Azure DevOps UI uses for the address bar, so the URL is copy-pasteable from there.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
