### PR TITLE
Fixed: ADR file path in Azure DevOps

### DIFF
--- a/.changeset/clever-eagles-boil.md
+++ b/.changeset/clever-eagles-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-adr': patch
+---
+
+Fixed Azure DevOps ADR file path

--- a/plugins/adr/src/components/AdrReader/AdrReader.tsx
+++ b/plugins/adr/src/components/AdrReader/AdrReader.tsx
@@ -45,8 +45,18 @@ export const AdrReader = (props: {
   const scmIntegrations = useApi(scmIntegrationsApiRef);
   const adrApi = useApi(adrApiRef);
   const adrLocationUrl = getAdrLocationUrl(entity, scmIntegrations);
+  let url = `${adrLocationUrl.replace(/\/$/, '')}`;
+  const adrUrlPath = url.match(/path=\/.*\&/);
+  if (adrUrlPath) {
+    // Azure DevOps SCM handle the path in URL Params
+    const adrPath = adrUrlPath![0].replace(/\&$/, '');
+    const regex = new RegExp(`${adrPath}`);
+    url = url.replace(regex, `${adrPath}/${adr}}`);
+  } else {
+    // Other SCM tools
+    url = `${url}/${adr}`;
+  }
 
-  const url = `${adrLocationUrl.replace(/\/$/, '')}/${adr}`;
   const { value, loading, error } = useAsync(
     async () => adrApi.readAdr(url),
     [url],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR will resolve the issue #22102 

The [Azure DevOps Discovery](https://backstage.io/docs/integrations/azure/discovery) offers to fetch the catalog from different branches, if the Adopter uses the branch the target location URL have the parameter versions point the desired branch name. When it come to ADR plugin the ADR `file` backend call append the ADR file at end of the URL after SCM Integration Resolver. 

Many cases the version is placed in the 1st parameter `https://dev.azure.com/org/project/_git/myrepo?version=GBmain&path=%2F`. 

If the version placed in 2nd parameter like `https://dev.azure.com/org/project/_git/myrepo?path=%2F&version=GBmain`. Then the ADR Backend `file` call append the file name at the end. like `https://dev.azure.com/org/project/_git/myrepo?path=%2F&version=GBmain/0001-my-adr.md` and it was failing. This PR solves this issue with our interrupt the other SCM tools.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
