### PR TITLE
add cmd limiter to the repo tools

### DIFF
--- a/.changeset/nasty-suns-speak.md
+++ b/.changeset/nasty-suns-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Add an internal limiter on concurrency when launching processes


### PR DESCRIPTION
Starting out at effectively the max practical level to begin with. Then we can look at doing like half the number of cores, or a fixed number, or whatnot if the CI problems persist.

I started with a low value, but for example the knip reports already use the number of CPUs as its limit and things slowed down considerably when setting this to a low fixed value at least on my machine. So let's start out ambitiously and evaluate, I thought.