### PR TITLE
:broom: move away from deprecated types, import from auth-node

### DIFF
--- a/.changeset/smart-frogs-help.md
+++ b/.changeset/smart-frogs-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Internal refactor to no longer use deprecated types

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -42,12 +42,12 @@ import { WebMessageResponse as WebMessageResponse_2 } from '@backstage/plugin-au
 // @public @deprecated
 export type AuthHandler<TAuthResult> = (
   input: TAuthResult,
-  context: AuthResolverContext,
+  context: AuthResolverContext_2,
 ) => Promise<AuthHandlerResult>;
 
 // @public @deprecated
 export type AuthHandlerResult = {
-  profile: ProfileInfo;
+  profile: ProfileInfo_2;
 };
 
 // @public
@@ -168,13 +168,13 @@ export type CookieConfigurer = CookieConfigurer_2;
 export function createAuthProviderIntegration<
   TCreateOptions extends unknown[],
   TResolvers extends {
-    [name in string]: (...args: any[]) => SignInResolver<any>;
+    [name in string]: (...args: any[]) => SignInResolver_2<any>;
   },
 >(config: {
-  create: (...args: TCreateOptions) => AuthProviderFactory;
+  create: (...args: TCreateOptions) => AuthProviderFactory_2;
   resolvers?: TResolvers;
 }): Readonly<{
-  create: (...args: TCreateOptions) => AuthProviderFactory;
+  create: (...args: TCreateOptions) => AuthProviderFactory_2;
   resolvers: Readonly<string extends keyof TResolvers ? never : TResolvers>;
 }>;
 
@@ -186,7 +186,7 @@ export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
 export const defaultAuthProviderFactories: {
-  [providerId: string]: AuthProviderFactory;
+  [providerId: string]: AuthProviderFactory_2;
 };
 
 // @public (undocumented)
@@ -226,13 +226,13 @@ export type GithubOAuthResult = {
 export type OAuth2ProxyResult = OAuth2ProxyResult_2;
 
 // @public @deprecated (undocumented)
-export class OAuthAdapter implements AuthProviderRouteHandlers {
+export class OAuthAdapter implements AuthProviderRouteHandlers_2 {
   constructor(handlers: OAuthHandlers, options: OAuthAdapterOptions);
   // (undocumented)
   frameHandler(req: express.Request, res: express.Response): Promise<void>;
   // (undocumented)
   static fromConfig(
-    config: AuthProviderConfig,
+    config: AuthProviderConfig_2,
     handlers: OAuthHandlers,
     options: Pick<
       OAuthAdapterOptions,
@@ -253,7 +253,7 @@ export type OAuthAdapterOptions = {
   persistScopes?: boolean;
   appOrigin: string;
   baseUrl: string;
-  cookieConfigurer: CookieConfigurer;
+  cookieConfigurer: CookieConfigurer_2;
   isOriginAllowed: (origin: string) => boolean;
   callbackUrl: string;
 };
@@ -303,7 +303,7 @@ export type OAuthRefreshRequest = express.Request<{}> & {
 
 // @public @deprecated (undocumented)
 export type OAuthResponse = {
-  profile: ProfileInfo;
+  profile: ProfileInfo_2;
   providerInfo: OAuthProviderInfo;
   backstageIdentity?: BackstageSignInResult;
 };
@@ -354,7 +354,7 @@ export type ProfileInfo = ProfileInfo_2;
 
 // @public (undocumented)
 export type ProviderFactories = {
-  [s: string]: AuthProviderFactory;
+  [s: string]: AuthProviderFactory_2;
 };
 
 // @public
@@ -366,7 +366,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -381,7 +381,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -395,7 +395,7 @@ export const providers: Readonly<{
         | {
             authHandler?: AuthHandler<AwsAlbResult_2> | undefined;
             signIn: {
-              resolver: SignInResolver<AwsAlbResult_2>;
+              resolver: SignInResolver_2<AwsAlbResult_2>;
             };
           }
         | undefined,
@@ -409,15 +409,15 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
         | undefined,
     ) => AuthProviderFactory_2;
     resolvers: Readonly<{
-      usernameMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
-      userIdMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
+      usernameMatchingUserEntityAnnotation(): SignInResolver_2<OAuthResult>;
+      userIdMatchingUserEntityAnnotation(): SignInResolver_2<OAuthResult>;
     }>;
   }>;
   bitbucketServer: Readonly<{
@@ -427,33 +427,33 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<BitbucketServerOAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<BitbucketServerOAuthResult>;
+                  resolver: SignInResolver_2<BitbucketServerOAuthResult>;
                 }
               | undefined;
           }
         | undefined,
     ) => AuthProviderFactory_2;
     resolvers: Readonly<{
-      emailMatchingUserEntityProfileEmail: () => SignInResolver<BitbucketServerOAuthResult>;
+      emailMatchingUserEntityProfileEmail: () => SignInResolver_2<BitbucketServerOAuthResult>;
     }>;
   }>;
   cfAccess: Readonly<{
     create: (options: {
       authHandler?: AuthHandler<CloudflareAccessResult> | undefined;
       signIn: {
-        resolver: SignInResolver<CloudflareAccessResult>;
+        resolver: SignInResolver_2<CloudflareAccessResult>;
       };
       cache?: CacheService | undefined;
     }) => AuthProviderFactory_2;
     resolvers: Readonly<{
-      emailMatchingUserEntityProfileEmail: () => SignInResolver<unknown>;
+      emailMatchingUserEntityProfileEmail: () => SignInResolver_2<unknown>;
     }>;
   }>;
   gcpIap: Readonly<{
     create: (options: {
       authHandler?: AuthHandler<GcpIapResult_2> | undefined;
       signIn: {
-        resolver: SignInResolver<GcpIapResult_2>;
+        resolver: SignInResolver_2<GcpIapResult_2>;
       };
     }) => AuthProviderFactory_2;
     resolvers: never;
@@ -483,7 +483,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -498,7 +498,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -517,7 +517,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -536,7 +536,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -548,7 +548,7 @@ export const providers: Readonly<{
     create: (options: {
       authHandler?: AuthHandler<OAuth2ProxyResult_2> | undefined;
       signIn: {
-        resolver: SignInResolver<OAuth2ProxyResult_2>;
+        resolver: SignInResolver_2<OAuth2ProxyResult_2>;
       };
     }) => AuthProviderFactory_2;
     resolvers: never;
@@ -560,15 +560,15 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OidcAuthResult_2> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OidcAuthResult_2>;
+                  resolver: SignInResolver_2<OidcAuthResult_2>;
                 }
               | undefined;
           }
         | undefined,
     ) => AuthProviderFactory_2;
     resolvers: Readonly<{
-      emailLocalPartMatchingUserEntityName: () => SignInResolver<unknown>;
-      emailMatchingUserEntityProfileEmail: () => SignInResolver<unknown>;
+      emailLocalPartMatchingUserEntityName: () => SignInResolver_2<unknown>;
+      emailMatchingUserEntityProfileEmail: () => SignInResolver_2<unknown>;
     }>;
   }>;
   okta: Readonly<{
@@ -578,16 +578,16 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
         | undefined,
     ) => AuthProviderFactory_2;
     resolvers: Readonly<{
-      emailLocalPartMatchingUserEntityName: () => SignInResolver<unknown>;
-      emailMatchingUserEntityProfileEmail: () => SignInResolver<unknown>;
-      emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
+      emailLocalPartMatchingUserEntityName: () => SignInResolver_2<unknown>;
+      emailMatchingUserEntityProfileEmail: () => SignInResolver_2<unknown>;
+      emailMatchingUserEntityAnnotation(): SignInResolver_2<OAuthResult>;
     }>;
   }>;
   onelogin: Readonly<{
@@ -597,7 +597,7 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<OAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<OAuthResult>;
+                  resolver: SignInResolver_2<OAuthResult>;
                 }
               | undefined;
           }
@@ -612,14 +612,14 @@ export const providers: Readonly<{
             authHandler?: AuthHandler<SamlAuthResult> | undefined;
             signIn?:
               | {
-                  resolver: SignInResolver<SamlAuthResult>;
+                  resolver: SignInResolver_2<SamlAuthResult>;
                 }
               | undefined;
           }
         | undefined,
     ) => AuthProviderFactory_2;
     resolvers: Readonly<{
-      nameIdMatchingUserEntityName(): SignInResolver<SamlAuthResult>;
+      nameIdMatchingUserEntityName(): SignInResolver_2<SamlAuthResult>;
     }>;
   }>;
   easyAuth: Readonly<{
@@ -628,7 +628,7 @@ export const providers: Readonly<{
         | {
             authHandler?: AuthHandler<EasyAuthResult> | undefined;
             signIn: {
-              resolver: SignInResolver<EasyAuthResult>;
+              resolver: SignInResolver_2<EasyAuthResult>;
             };
           }
         | undefined,

--- a/plugins/auth-backend/src/identity/StaticTokenIssuer.ts
+++ b/plugins/auth-backend/src/identity/StaticTokenIssuer.ts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AnyJWK, TokenIssuer, TokenParams } from './types';
+
+import { AnyJWK, TokenIssuer } from './types';
 import { SignJWT, importJWK, JWK } from 'jose';
 import { parseEntityRef } from '@backstage/catalog-model';
 import { AuthenticationError } from '@backstage/errors';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { StaticKeyStore } from './StaticKeyStore';
+import { TokenParams } from '@backstage/plugin-auth-node';
 
 const MS_IN_S = 1000;
 

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { parseEntityRef } from '@backstage/catalog-model';
 import { AuthenticationError } from '@backstage/errors';
 import { exportJWK, generateKeyPair, importJWK, JWK, SignJWT } from 'jose';
 import { DateTime } from 'luxon';
 import { v4 as uuid } from 'uuid';
 import { LoggerService } from '@backstage/backend-plugin-api';
-
-import { AnyJWK, KeyStore, TokenIssuer, TokenParams } from './types';
+import { TokenParams } from '@backstage/plugin-auth-node';
+import { AnyJWK, KeyStore, TokenIssuer } from './types';
 
 const MS_IN_S = 1000;
 const MAX_TOKEN_LENGTH = 32768; // At 64 bytes per entity ref this still leaves room for about 500 entities

--- a/plugins/auth-backend/src/identity/types.ts
+++ b/plugins/auth-backend/src/identity/types.ts
@@ -37,7 +37,7 @@ export type TokenIssuer = {
   /**
    * Issues a new ID Token
    */
-  issueToken(params: TokenParams): Promise<string>;
+  issueToken(params: _TokenParams): Promise<string>;
 
   /**
    * List all public keys that are currently being used to sign tokens, or have been used

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
@@ -17,8 +17,8 @@
 import express from 'express';
 import { THOUSAND_DAYS_MS, TEN_MINUTES_MS, OAuthAdapter } from './OAuthAdapter';
 import { encodeState } from './helpers';
-import { OAuthHandlers, OAuthLogoutRequest, OAuthState } from './types';
-import { CookieConfigurer } from '../../providers/types';
+import { OAuthHandlers, OAuthLogoutRequest } from './types';
+import { CookieConfigurer, OAuthState } from '@backstage/plugin-auth-node';
 
 const mockResponseData = {
   providerInfo: {

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -18,14 +18,13 @@ import express, { CookieOptions } from 'express';
 import crypto from 'crypto';
 import { URL } from 'url';
 import {
+  AuthProviderConfig,
+  AuthProviderRouteHandlers,
   BackstageIdentityResponse,
   BackstageSignInResult,
-} from '@backstage/plugin-auth-node';
-import {
-  AuthProviderRouteHandlers,
-  AuthProviderConfig,
   CookieConfigurer,
-} from '../../providers/types';
+  OAuthState,
+} from '@backstage/plugin-auth-node';
 import {
   AuthenticationError,
   InputError,
@@ -42,7 +41,6 @@ import {
   OAuthHandlers,
   OAuthStartRequest,
   OAuthRefreshRequest,
-  OAuthState,
   OAuthLogoutRequest,
 } from './types';
 import { prepareBackstageIdentityResponse } from '../../providers/prepareBackstageIdentityResponse';

--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -15,9 +15,9 @@
  */
 
 import express from 'express';
-import { OAuthState } from './types';
-import { CookieConfigurer } from '../../providers/types';
 import {
+  CookieConfigurer,
+  OAuthState,
   decodeOAuthState,
   encodeOAuthState,
 } from '@backstage/plugin-auth-node';

--- a/plugins/auth-backend/src/lib/oauth/types.ts
+++ b/plugins/auth-backend/src/lib/oauth/types.ts
@@ -18,9 +18,10 @@ import express from 'express';
 import { Profile as PassportProfile } from 'passport';
 import {
   BackstageSignInResult,
+  ProfileInfo,
   OAuthState as _OAuthState,
 } from '@backstage/plugin-auth-node';
-import { OAuthStartResponse, ProfileInfo } from '../../providers/types';
+import { OAuthStartResponse } from '../../providers/types';
 
 /**
  * Common options for passport.js-based OAuth providers

--- a/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
@@ -18,9 +18,9 @@ import express from 'express';
 import passport from 'passport';
 import { decodeJwt } from 'jose';
 import { InternalOAuthError } from 'passport-oauth2';
-
+import { ProfileInfo } from '@backstage/plugin-auth-node';
 import { PassportProfile } from './types';
-import { ProfileInfo, OAuthStartResponse } from '../../providers/types';
+import { OAuthStartResponse } from '../../providers/types';
 
 export type PassportDoneCallback<Res, Private = never> = (
   err?: Error,

--- a/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
+++ b/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
@@ -25,10 +25,13 @@ import {
 } from '@backstage/catalog-model';
 import { ConflictError, InputError, NotFoundError } from '@backstage/errors';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { TokenIssuer, TokenParams } from '../../identity/types';
-import { AuthResolverContext } from '../../providers';
-import { AuthResolverCatalogUserQuery } from '../../providers/types';
+import { TokenIssuer } from '../../identity/types';
 import { CatalogIdentityClient } from '../catalog';
+import {
+  AuthResolverCatalogUserQuery,
+  AuthResolverContext,
+  TokenParams,
+} from '@backstage/plugin-auth-node';
 
 /**
  * Uses the default ownership resolution logic to return an array

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-import { SignInResolver, AuthHandler } from '../types';
+import { AuthHandler } from '../types';
 import { OAuthResult } from '../../lib/oauth';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
-import { createOAuthProviderFactory } from '@backstage/plugin-auth-node';
+import {
+  SignInResolver,
+  createOAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
 import {
   adaptLegacyOAuthHandler,
   adaptLegacyOAuthSignInResolver,

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -36,14 +36,13 @@ import {
   makeProfileInfo,
   PassportDoneCallback,
 } from '../../lib/passport';
-import {
-  OAuthStartResponse,
-  AuthHandler,
-  SignInResolver,
-  AuthResolverContext,
-} from '../types';
+import { OAuthStartResponse, AuthHandler } from '../types';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import { StateStore } from 'passport-oauth2';
+import {
+  AuthResolverContext,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 type PrivateInfo = {
   refreshToken: string;

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -18,8 +18,11 @@ import {
   AwsAlbResult,
   awsAlbAuthenticator,
 } from '@backstage/plugin-auth-backend-module-aws-alb-provider';
-import { createProxyAuthProviderFactory } from '@backstage/plugin-auth-node';
-import { AuthHandler, SignInResolver } from '../types';
+import {
+  SignInResolver,
+  createProxyAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
+import { AuthHandler } from '../types';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 
 /**

--- a/plugins/auth-backend/src/providers/azure-easyauth/provider.test.ts
+++ b/plugins/auth-backend/src/providers/azure-easyauth/provider.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AuthHandler, AuthResolverContext } from '../types';
+import { AuthHandler } from '../types';
 import { makeProfileInfo } from '../../lib/passport';
 import {
   easyAuth,
@@ -26,6 +26,7 @@ import {
 import { Request, Response } from 'express';
 import { SignJWT, JWTPayload, errors as JoseErrors } from 'jose';
 import { randomBytes } from 'crypto';
+import { AuthResolverContext } from '@backstage/plugin-auth-node';
 
 const jwtSecret = randomBytes(48);
 

--- a/plugins/auth-backend/src/providers/azure-easyauth/provider.ts
+++ b/plugins/auth-backend/src/providers/azure-easyauth/provider.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  AuthHandler,
-  AuthProviderRouteHandlers,
-  AuthResolverContext,
-  AuthResponse,
-  SignInResolver,
-} from '../types';
+import { AuthHandler } from '../types';
 import { Request, Response } from 'express';
 import { makeProfileInfo } from '../../lib/passport';
 import { AuthenticationError } from '@backstage/errors';
@@ -28,6 +22,12 @@ import { prepareBackstageIdentityResponse } from '../prepareBackstageIdentityRes
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import { Profile } from 'passport';
 import { decodeJwt } from 'jose';
+import {
+  AuthProviderRouteHandlers,
+  AuthResolverContext,
+  ClientAuthResponse,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 export const ID_TOKEN_HEADER = 'x-ms-token-aad-id-token';
 export const ACCESS_TOKEN_HEADER = 'x-ms-token-aad-access-token';
@@ -44,7 +44,7 @@ export type EasyAuthResult = {
   accessToken?: string;
 };
 
-export type EasyAuthResponse = AuthResponse<{}>;
+export type EasyAuthResponse = ClientAuthResponse<{}>;
 
 export class EasyAuthAuthProvider implements AuthProviderRouteHandlers {
   private readonly resolverContext: AuthResolverContext;

--- a/plugins/auth-backend/src/providers/bitbucket/provider.test.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.test.ts
@@ -16,7 +16,7 @@
 
 import { BitbucketAuthProvider, BitbucketOAuthResult } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
-import { AuthResolverContext } from '../types';
+import { AuthResolverContext } from '@backstage/plugin-auth-node';
 
 const mockFrameHandler = jest.spyOn(
   helpers,

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -37,12 +37,11 @@ import {
   PassportDoneCallback,
 } from '../../lib/passport';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
+import { AuthHandler, OAuthStartResponse } from '../types';
 import {
-  AuthHandler,
-  OAuthStartResponse,
-  SignInResolver,
   AuthResolverContext,
-} from '../types';
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 type PrivateInfo = {
   refreshToken: string;

--- a/plugins/auth-backend/src/providers/bitbucketServer/provider.test.ts
+++ b/plugins/auth-backend/src/providers/bitbucketServer/provider.test.ts
@@ -16,7 +16,6 @@
 
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { makeProfileInfo } from '../../lib/passport';
-import { AuthResolverContext } from '../types';
 import {
   bitbucketServer,
   BitbucketServerAuthProvider,
@@ -25,6 +24,7 @@ import {
 import { setupServer } from 'msw/node';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { rest } from 'msw';
+import { AuthResolverContext } from '@backstage/plugin-auth-node';
 
 jest.mock('../../lib/passport/PassportStrategyHelper', () => {
   return {

--- a/plugins/auth-backend/src/providers/bitbucketServer/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucketServer/provider.ts
@@ -32,17 +32,16 @@ import {
   executeRefreshTokenStrategy,
   makeProfileInfo,
 } from '../../lib/passport';
-import {
-  AuthHandler,
-  AuthResolverContext,
-  OAuthStartResponse,
-  SignInResolver,
-} from '../types';
+import { AuthHandler, OAuthStartResponse } from '../types';
 import express from 'express';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import { Profile as PassportProfile } from 'passport';
 import { commonByEmailResolver } from '../resolvers';
 import fetch from 'node-fetch';
+import {
+  AuthResolverContext,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 type PrivateInfo = {
   refreshToken: string;

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.test.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.test.ts
@@ -21,8 +21,8 @@ import {
   CF_AUTH_IDENTITY,
   CloudflareAccessAuthProvider,
 } from './provider';
-import { AuthResolverContext } from '../types';
 import fetch from 'node-fetch';
+import { AuthResolverContext } from '@backstage/plugin-auth-node';
 
 const jwtMock = jwtVerify as jest.Mocked<any>;
 const mockJwt =

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  AuthHandler,
-  AuthProviderRouteHandlers,
-  AuthResolverContext,
-  AuthResponse,
-  SignInResolver,
-} from '../types';
+
+import { AuthHandler } from '../types';
 import fetch, { Headers } from 'node-fetch';
 import express from 'express';
 import * as _ from 'lodash';
@@ -33,6 +28,12 @@ import { CacheClient } from '@backstage/backend-common';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import { prepareBackstageIdentityResponse } from '../prepareBackstageIdentityResponse';
 import { commonByEmailResolver } from '../resolvers';
+import {
+  AuthProviderRouteHandlers,
+  AuthResolverContext,
+  ClientAuthResponse,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 // JWT Web Token definitions are in the URL below
 // https://developers.cloudflare.com/cloudflare-one/identity/users/validating-json/
@@ -174,7 +175,7 @@ export type CloudflareAccessProviderInfo = {
 };
 
 export type CloudflareAccessResponse =
-  AuthResponse<CloudflareAccessProviderInfo>;
+  ClientAuthResponse<CloudflareAccessProviderInfo>;
 
 export class CloudflareAccessAuthProvider implements AuthProviderRouteHandlers {
   private readonly teamName: string;

--- a/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
+++ b/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { AuthProviderFactory, SignInResolver } from './types';
+import {
+  AuthProviderFactory,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 /**
  * Creates a standardized representation of an integration with a third-party

--- a/plugins/auth-backend/src/providers/gcp-iap/provider.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/provider.ts
@@ -15,9 +15,12 @@
  */
 
 import { gcpIapAuthenticator } from '@backstage/plugin-auth-backend-module-gcp-iap-provider';
-import { createProxyAuthProviderFactory } from '@backstage/plugin-auth-node';
+import {
+  SignInResolver,
+  createProxyAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
-import { AuthHandler, SignInResolver } from '../types';
+import { AuthHandler } from '../types';
 import { GcpIapResult } from './types';
 
 /**

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-import { SignInResolver, AuthHandler } from '../types';
+import { AuthHandler } from '../types';
 import { OAuthResult } from '../../lib/oauth';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
-import { createOAuthProviderFactory } from '@backstage/plugin-auth-node';
+import {
+  SignInResolver,
+  createOAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
 import {
   adaptLegacyOAuthHandler,
   adaptLegacyOAuthSignInResolver,

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -19,6 +19,7 @@ import {
   googleSignInResolvers,
 } from '@backstage/plugin-auth-backend-module-google-provider';
 import {
+  SignInResolver,
   commonSignInResolvers,
   createOAuthProviderFactory,
 } from '@backstage/plugin-auth-node';
@@ -29,7 +30,7 @@ import {
 } from '../../lib/legacy';
 import { OAuthResult } from '../../lib/oauth';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
-import { AuthHandler, SignInResolver } from '../types';
+import { AuthHandler } from '../types';
 
 /**
  * Auth provider integration for Google auth

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { SignInResolver, AuthHandler } from '../types';
+import { AuthHandler } from '../types';
 import { OAuthResult } from '../../lib/oauth';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import {
+  SignInResolver,
   commonSignInResolvers,
   createOAuthProviderFactory,
 } from '@backstage/plugin-auth-node';

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { createProxyAuthProviderFactory } from '@backstage/plugin-auth-node';
-import { AuthHandler, SignInResolver } from '../types';
+import {
+  SignInResolver,
+  createProxyAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
+import { AuthHandler } from '../types';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import {
   type OAuth2ProxyResult,

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -15,13 +15,16 @@
  */
 
 import { OAuthResult } from '../../lib/oauth';
-import { AuthHandler, SignInResolver } from '../types';
+import { AuthHandler } from '../types';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import {
   adaptLegacyOAuthHandler,
   adaptLegacyOAuthSignInResolver,
 } from '../../lib/legacy';
-import { createOAuthProviderFactory } from '@backstage/plugin-auth-node';
+import {
+  SignInResolver,
+  createOAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
 import { oauth2Authenticator } from '@backstage/plugin-auth-backend-module-oauth2-provider';
 
 /**

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AuthHandler, SignInResolver } from '../types';
+import { AuthHandler } from '../types';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import {
   createOAuthProviderFactory,
@@ -22,6 +22,7 @@ import {
   BackstageSignInResult,
   OAuthAuthenticatorResult,
   SignInInfo,
+  SignInResolver,
 } from '@backstage/plugin-auth-node';
 import {
   oidcAuthenticator,

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-import { AuthHandler, SignInResolver } from '../types';
+import { AuthHandler } from '../types';
 import { OAuthResult } from '../../lib/oauth';
 
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
-import { createOAuthProviderFactory } from '@backstage/plugin-auth-node';
+import {
+  SignInResolver,
+  createOAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
 import {
   adaptLegacyOAuthHandler,
   adaptLegacyOAuthSignInResolver,

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -36,13 +36,12 @@ import {
   executeFetchUserProfileStrategy,
   PassportDoneCallback,
 } from '../../lib/passport';
-import {
-  OAuthStartResponse,
-  AuthHandler,
-  SignInResolver,
-  AuthResolverContext,
-} from '../types';
+import { OAuthStartResponse, AuthHandler } from '../types';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
+import {
+  AuthResolverContext,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 type PrivateInfo = {
   refreshToken: string;

--- a/plugins/auth-backend/src/providers/providers.ts
+++ b/plugins/auth-backend/src/providers/providers.ts
@@ -30,9 +30,9 @@ import { oidc } from './oidc';
 import { okta } from './okta';
 import { onelogin } from './onelogin';
 import { saml } from './saml';
-import { AuthProviderFactory } from './types';
 import { bitbucketServer } from './bitbucketServer';
 import { easyAuth } from './azure-easyauth';
+import { AuthProviderFactory } from '@backstage/plugin-auth-node';
 
 /**
  * All built-in auth provider integrations.

--- a/plugins/auth-backend/src/providers/resolvers.ts
+++ b/plugins/auth-backend/src/providers/resolvers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SignInResolver } from './types';
+import { SignInResolver } from '@backstage/plugin-auth-node';
 
 /**
  * A common sign-in resolver that looks up the user using the local part of

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -25,17 +25,17 @@ import {
   executeFrameHandlerStrategy,
   executeRedirectStrategy,
 } from '../../lib/passport';
-import {
-  AuthProviderRouteHandlers,
-  AuthHandler,
-  SignInResolver,
-  AuthResponse,
-  AuthResolverContext,
-} from '../types';
+import { AuthHandler } from '../types';
 import { postMessageResponse } from '../../lib/flow';
 import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 import { AuthenticationError, isError } from '@backstage/errors';
 import { prepareBackstageIdentityResponse } from '../prepareBackstageIdentityResponse';
+import {
+  AuthProviderRouteHandlers,
+  AuthResolverContext,
+  ClientAuthResponse,
+  SignInResolver,
+} from '@backstage/plugin-auth-node';
 
 /** @public */
 export type SamlAuthResult = {
@@ -93,7 +93,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
 
       const { profile } = await this.authHandler(result, this.resolverContext);
 
-      const response: AuthResponse<{}> = {
+      const response: ClientAuthResponse<{}> = {
         profile,
         providerInfo: {},
       };

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -110,7 +110,7 @@ export type SignInResolver<TAuthResult> = _SignInResolver<TAuthResult>;
  * @public
  * @deprecated Use `createOAuthRouteHandlers` from `@backstage/plugin-auth-node` instead
  */
-export type AuthHandlerResult = { profile: ProfileInfo };
+export type AuthHandlerResult = { profile: _ProfileInfo };
 
 /**
  * The AuthHandler function is called every time the user authenticates using
@@ -128,7 +128,7 @@ export type AuthHandlerResult = { profile: ProfileInfo };
  */
 export type AuthHandler<TAuthResult> = (
   input: TAuthResult,
-  context: AuthResolverContext,
+  context: _AuthResolverContext,
 ) => Promise<AuthHandlerResult>;
 
 /**

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -18,10 +18,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 import cookieParser from 'cookie-parser';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import {
-  defaultAuthProviderFactories,
-  AuthProviderFactory,
-} from '../providers';
+import { defaultAuthProviderFactories } from '../providers';
 import {
   PluginDatabaseManager,
   PluginEndpointDiscovery,
@@ -41,6 +38,7 @@ import { TokenIssuer } from '../identity/types';
 import { StaticTokenIssuer } from '../identity/StaticTokenIssuer';
 import { StaticKeyStore } from '../identity/StaticKeyStore';
 import { Config } from '@backstage/config';
+import { AuthProviderFactory } from '@backstage/plugin-auth-node';
 
 /** @public */
 export type ProviderFactories = { [s: string]: AuthProviderFactory };


### PR DESCRIPTION
I was bored, alright? :)

No actual changes, just importing from -node instead of actually using the internal deprecated types.

There are a few left for sure, but they are trickier.