### PR TITLE
Make catalog logging a little quieter where entities are erroring

### DIFF
--- a/.changeset/selfish-rivers-fetch.md
+++ b/.changeset/selfish-rivers-fetch.md
@@ -3,3 +3,35 @@
 ---
 
 Make entity collection errors a little quieter in the logs.
+
+Instead of logging a warning line when an entity has an error
+during processing, it will now instead emit an event on the event
+broker.
+
+This only removes a single log line, however it is possible to
+add the log line back if it is required by subscribing to the
+`CATALOG_ERRORS_TOPIC` as shown below.
+
+```typescript
+env.eventBroker.subscribe({
+  supportsEventTopics(): string[] {
+    return [CATALOG_ERRORS_TOPIC];
+  },
+
+  async onEvent(
+    params: EventParams<{
+      entity: string;
+      location?: string;
+      errors: Array<Error>;
+    }>,
+  ): Promise<void> {
+    const { entity, location, errors } = params.eventPayload;
+    for (const error of errors) {
+      env.logger.warn(error.message, {
+        entity,
+        location,
+      });
+    }
+  },
+});
+```

--- a/.changeset/selfish-rivers-fetch.md
+++ b/.changeset/selfish-rivers-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Make entity collection errors a little quieter in the logs.

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  CATALOG_ERRORS_TOPIC,
-  CatalogBuilder,
-} from '@backstage/plugin-catalog-backend';
+import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-catalog-backend-module-scaffolder-entity-model';
 import { UnprocessedEntitiesModule } from '@backstage/plugin-catalog-backend-module-unprocessed';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 import { DemoEventBasedEntityProvider } from './DemoEventBasedEntityProvider';
-import { EventParams } from '@backstage/plugin-events-node';
 
 export default async function createPlugin(
   env: PluginEnvironment,

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import {
+  CATALOG_ERRORS_TOPIC,
+  CatalogBuilder,
+} from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-catalog-backend-module-scaffolder-entity-model';
 import { UnprocessedEntitiesModule } from '@backstage/plugin-catalog-backend-module-unprocessed';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 import { DemoEventBasedEntityProvider } from './DemoEventBasedEntityProvider';
+import { EventParams } from '@backstage/plugin-events-node';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -33,6 +37,7 @@ export default async function createPlugin(
     eventBroker: env.eventBroker,
   });
   builder.addEntityProvider(demoProvider);
+  builder.setEventBroker(env.eventBroker);
 
   const { processingEngine, router } = await builder.build();
 

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -33,7 +33,6 @@ export default async function createPlugin(
     eventBroker: env.eventBroker,
   });
   builder.addEntityProvider(demoProvider);
-  builder.setEventBroker(env.eventBroker);
 
   const { processingEngine, router } = await builder.build();
 

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -129,6 +129,9 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor_2 {
 // @public (undocumented)
 export const CATALOG_CONFLICTS_TOPIC = 'experimental.catalog.conflict';
 
+// @public (undocumented)
+export const CATALOG_ERRORS_TOPIC = 'experimental.catalog.errors';
+
 // @public
 export class CatalogBuilder {
   addEntityPolicy(

--- a/plugins/catalog-backend/src/constants.ts
+++ b/plugins/catalog-backend/src/constants.ts
@@ -16,4 +16,5 @@
 
 /** @public */
 export const CATALOG_CONFLICTS_TOPIC = 'experimental.catalog.conflict';
+/** @public */
 export const CATALOG_ERRORS_TOPIC = 'experimental.catalog.errors';

--- a/plugins/catalog-backend/src/constants.ts
+++ b/plugins/catalog-backend/src/constants.ts
@@ -16,3 +16,4 @@
 
 /** @public */
 export const CATALOG_CONFLICTS_TOPIC = 'experimental.catalog.conflict';
+export const CATALOG_ERRORS_TOPIC = 'experimental.catalog.errors';

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -195,7 +195,7 @@ export class DefaultCatalogProcessingEngine {
             const location =
               unprocessedEntity?.metadata?.annotations?.[ANNOTATION_LOCATION];
             for (const error of result.errors) {
-              this.logger.warn(error.message, {
+              this.logger.debug(error.message, {
                 entity: entityRef,
                 location,
               });

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -549,6 +549,7 @@ export class CatalogBuilder {
       onProcessingError: event => {
         this.onProcessingError?.(event);
       },
+      eventBroker: this.eventBroker,
     });
 
     const locationAnalyzer =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When an error is raised by a url reader or any other processor in the catalog, those errors are logged to the application logs with a warning level as well as written to the refresh_state table for retrieval later.

Given that these errors are already visible at the application layer via the refresh state table, I would argue that the log line is superfluous. The log line can be useful in some cases so I have made it possible to re-enable the log line.

In the end this change makes the catalog logging a little quieter where entities are erroring.

I dont feel terribly strongly about this, and am happy to close this if there is any contention.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
