### PR TITLE
Updated Azure DevOps, DevTools, and Linguist to use `fetchApi` as per ADR013

### DIFF
--- a/.changeset/olive-mails-tell.md
+++ b/.changeset/olive-mails-tell.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-azure-devops': patch
+'@backstage/plugin-devtools': patch
+'@backstage/plugin-linguist': patch
+---
+
+Updated to use `fetchApi` as per [ADR013](https://backstage.io/docs/architecture-decisions/adrs-adr013)

--- a/.changeset/olive-mails-tell.md
+++ b/.changeset/olive-mails-tell.md
@@ -1,5 +1,4 @@
 ---
-'@backstage/plugin-azure-devops': patch
 '@backstage/plugin-devtools': patch
 '@backstage/plugin-linguist': patch
 ---

--- a/.changeset/rude-sheep-jam.md
+++ b/.changeset/rude-sheep-jam.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-azure-devops': minor
+---
+
+**BREAKING** The `AzureDevOpsClient` no longer requires `identityAPi` but now requires `fetchApi`.
+
+Updated to use `fetchApi` as per [ADR013](https://backstage.io/docs/architecture-decisions/adrs-adr013)

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -12,6 +12,7 @@ import { BuildRunOptions } from '@backstage/plugin-azure-devops-common';
 import { DashboardPullRequest } from '@backstage/plugin-azure-devops-common';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { FetchApi } from '@backstage/core-plugin-api';
 import { GitTag } from '@backstage/plugin-azure-devops-common';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -124,6 +125,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
   constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
+    fetchApi: FetchApi;
   });
   // (undocumented)
   getAllTeams(): Promise<Team[]>;

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -14,7 +14,6 @@ import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { GitTag } from '@backstage/plugin-azure-devops-common';
-import { IdentityApi } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { PullRequest } from '@backstage/plugin-azure-devops-common';
 import { PullRequestOptions } from '@backstage/plugin-azure-devops-common';
@@ -122,11 +121,7 @@ export const azureDevOpsApiRef: ApiRef<AzureDevOpsApi>;
 
 // @public (undocumented)
 export class AzureDevOpsClient implements AzureDevOpsApi {
-  constructor(options: {
-    discoveryApi: DiscoveryApi;
-    identityApi: IdentityApi;
-    fetchApi: FetchApi;
-  });
+  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
   // (undocumented)
   getAllTeams(): Promise<Team[]>;
   // (undocumented)

--- a/plugins/azure-devops/src/alpha/plugin.tsx
+++ b/plugins/azure-devops/src/alpha/plugin.tsx
@@ -21,6 +21,7 @@ import {
   createPageExtension,
   createPlugin,
   discoveryApiRef,
+  fetchApiRef,
   identityApiRef,
 } from '@backstage/frontend-plugin-api';
 import { azureDevOpsApiRef, AzureDevOpsClient } from '../api';
@@ -38,9 +39,13 @@ import { azurePullRequestDashboardRouteRef } from '../routes';
 export const azureDevOpsApi = createApiExtension({
   factory: createApiFactory({
     api: azureDevOpsApiRef,
-    deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-    factory: ({ discoveryApi, identityApi }) =>
-      new AzureDevOpsClient({ discoveryApi, identityApi }),
+    deps: {
+      discoveryApi: discoveryApiRef,
+      identityApi: identityApiRef,
+      fetchApi: fetchApiRef,
+    },
+    factory: ({ discoveryApi, identityApi, fetchApi }) =>
+      new AzureDevOpsClient({ discoveryApi, identityApi, fetchApi }),
   }),
 });
 

--- a/plugins/azure-devops/src/alpha/plugin.tsx
+++ b/plugins/azure-devops/src/alpha/plugin.tsx
@@ -22,7 +22,6 @@ import {
   createPlugin,
   discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/frontend-plugin-api';
 import { azureDevOpsApiRef, AzureDevOpsClient } from '../api';
 import {
@@ -41,11 +40,10 @@ export const azureDevOpsApi = createApiExtension({
     api: azureDevOpsApiRef,
     deps: {
       discoveryApi: discoveryApiRef,
-      identityApi: identityApiRef,
       fetchApi: fetchApiRef,
     },
-    factory: ({ discoveryApi, identityApi, fetchApi }) =>
-      new AzureDevOpsClient({ discoveryApi, identityApi, fetchApi }),
+    factory: ({ discoveryApi, fetchApi }) =>
+      new AzureDevOpsClient({ discoveryApi, fetchApi }),
   }),
 });
 

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -27,7 +27,11 @@ import {
   RepoBuildOptions,
   Team,
 } from '@backstage/plugin-azure-devops-common';
-import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
+import {
+  DiscoveryApi,
+  FetchApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { AzureDevOpsApi } from './AzureDevOpsApi';
 
@@ -35,13 +39,16 @@ import { AzureDevOpsApi } from './AzureDevOpsApi';
 export class AzureDevOpsClient implements AzureDevOpsApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
+  private readonly fetchApi: FetchApi;
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
+    fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
     this.identityApi = options.identityApi;
+    this.fetchApi = options.fetchApi;
   }
 
   public async getRepoBuilds(
@@ -201,7 +208,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     const url = new URL(path, baseUrl);
 
     const { token: idToken } = await this.identityApi.getCredentials();
-    const response = await fetch(url.toString(), {
+    const response = await this.fetchApi.fetch(url.toString(), {
       headers: idToken ? { Authorization: `Bearer ${idToken}` } : {},
     });
 

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -27,27 +27,20 @@ import {
   RepoBuildOptions,
   Team,
 } from '@backstage/plugin-azure-devops-common';
-import {
-  DiscoveryApi,
-  FetchApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { AzureDevOpsApi } from './AzureDevOpsApi';
 
 /** @public */
 export class AzureDevOpsClient implements AzureDevOpsApi {
   private readonly discoveryApi: DiscoveryApi;
-  private readonly identityApi: IdentityApi;
   private readonly fetchApi: FetchApi;
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
-    identityApi: IdentityApi;
     fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
-    this.identityApi = options.identityApi;
     this.fetchApi = options.fetchApi;
   }
 
@@ -207,10 +200,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     const baseUrl = `${await this.discoveryApi.getBaseUrl('azure-devops')}/`;
     const url = new URL(path, baseUrl);
 
-    const { token: idToken } = await this.identityApi.getCredentials();
-    const response = await this.fetchApi.fetch(url.toString(), {
-      headers: idToken ? { Authorization: `Bearer ${idToken}` } : {},
-    });
+    const response = await this.fetchApi.fetch(url.toString());
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);

--- a/plugins/azure-devops/src/plugin.ts
+++ b/plugins/azure-devops/src/plugin.ts
@@ -62,8 +62,8 @@ export const azureDevOpsPlugin = createPlugin({
         identityApi: identityApiRef,
         fetchApi: fetchApiRef,
       },
-      factory: ({ discoveryApi, identityApi, fetchApi }) =>
-        new AzureDevOpsClient({ discoveryApi, identityApi, fetchApi }),
+      factory: ({ discoveryApi, fetchApi }) =>
+        new AzureDevOpsClient({ discoveryApi, fetchApi }),
     }),
   ],
 });

--- a/plugins/azure-devops/src/plugin.ts
+++ b/plugins/azure-devops/src/plugin.ts
@@ -27,6 +27,7 @@ import {
   createComponentExtension,
   discoveryApiRef,
   identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 import { AzureDevOpsClient } from './api/AzureDevOpsClient';
@@ -56,9 +57,13 @@ export const azureDevOpsPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: azureDevOpsApiRef,
-      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ discoveryApi, identityApi }) =>
-        new AzureDevOpsClient({ discoveryApi, identityApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        identityApi: identityApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, identityApi, fetchApi }) =>
+        new AzureDevOpsClient({ discoveryApi, identityApi, fetchApi }),
     }),
   ],
 });

--- a/plugins/azure-devops/src/plugin.ts
+++ b/plugins/azure-devops/src/plugin.ts
@@ -26,7 +26,6 @@ import {
   createRoutableExtension,
   createComponentExtension,
   discoveryApiRef,
-  identityApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
 
@@ -59,7 +58,6 @@ export const azureDevOpsPlugin = createPlugin({
       api: azureDevOpsApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
         fetchApi: fetchApiRef,
       },
       factory: ({ discoveryApi, fetchApi }) =>

--- a/plugins/devtools/src/alpha/plugin.tsx
+++ b/plugins/devtools/src/alpha/plugin.tsx
@@ -23,7 +23,6 @@ import {
   createPlugin,
   discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/frontend-plugin-api';
 
 import { devToolsApiRef, DevToolsClient } from '../api';
@@ -40,11 +39,10 @@ export const devToolsApi = createApiExtension({
     api: devToolsApiRef,
     deps: {
       discoveryApi: discoveryApiRef,
-      identityApi: identityApiRef,
       fetchApi: fetchApiRef,
     },
-    factory: ({ discoveryApi, identityApi, fetchApi }) =>
-      new DevToolsClient({ discoveryApi, identityApi, fetchApi }),
+    factory: ({ discoveryApi, fetchApi }) =>
+      new DevToolsClient({ discoveryApi, fetchApi }),
   }),
 });
 

--- a/plugins/devtools/src/alpha/plugin.tsx
+++ b/plugins/devtools/src/alpha/plugin.tsx
@@ -22,6 +22,7 @@ import {
   createPageExtension,
   createPlugin,
   discoveryApiRef,
+  fetchApiRef,
   identityApiRef,
 } from '@backstage/frontend-plugin-api';
 
@@ -37,9 +38,13 @@ import { rootRouteRef } from '../routes';
 export const devToolsApi = createApiExtension({
   factory: createApiFactory({
     api: devToolsApiRef,
-    deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-    factory: ({ discoveryApi, identityApi }) =>
-      new DevToolsClient({ discoveryApi, identityApi }),
+    deps: {
+      discoveryApi: discoveryApiRef,
+      identityApi: identityApiRef,
+      fetchApi: fetchApiRef,
+    },
+    factory: ({ discoveryApi, identityApi, fetchApi }) =>
+      new DevToolsClient({ discoveryApi, identityApi, fetchApi }),
   }),
 });
 

--- a/plugins/devtools/src/api/DevToolsClient.ts
+++ b/plugins/devtools/src/api/DevToolsClient.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
+import {
+  DiscoveryApi,
+  FetchApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
 import {
   ConfigInfo,
   DevToolsInfo,
@@ -26,13 +30,16 @@ import { DevToolsApi } from './DevToolsApi';
 export class DevToolsClient implements DevToolsApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
+  private readonly fetchApi: FetchApi;
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
+    fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
     this.identityApi = options.identityApi;
+    this.fetchApi = options.fetchApi;
   }
 
   public async getConfig(): Promise<ConfigInfo | undefined> {
@@ -65,7 +72,7 @@ export class DevToolsClient implements DevToolsApi {
     const url = new URL(path, baseUrl);
 
     const { token } = await this.identityApi.getCredentials();
-    const response = await fetch(url.toString(), {
+    const response = await this.fetchApi.fetch(url.toString(), {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
 

--- a/plugins/devtools/src/api/DevToolsClient.ts
+++ b/plugins/devtools/src/api/DevToolsClient.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  DiscoveryApi,
-  FetchApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import {
   ConfigInfo,
   DevToolsInfo,
@@ -29,16 +25,13 @@ import { DevToolsApi } from './DevToolsApi';
 
 export class DevToolsClient implements DevToolsApi {
   private readonly discoveryApi: DiscoveryApi;
-  private readonly identityApi: IdentityApi;
   private readonly fetchApi: FetchApi;
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
-    identityApi: IdentityApi;
     fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
-    this.identityApi = options.identityApi;
     this.fetchApi = options.fetchApi;
   }
 
@@ -71,10 +64,7 @@ export class DevToolsClient implements DevToolsApi {
     const baseUrl = `${await this.discoveryApi.getBaseUrl('devtools')}/`;
     const url = new URL(path, baseUrl);
 
-    const { token } = await this.identityApi.getCredentials();
-    const response = await this.fetchApi.fetch(url.toString(), {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
+    const response = await this.fetchApi.fetch(url.toString());
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);

--- a/plugins/devtools/src/plugin.ts
+++ b/plugins/devtools/src/plugin.ts
@@ -19,6 +19,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  fetchApiRef,
   identityApiRef,
 } from '@backstage/core-plugin-api';
 import { devToolsApiRef, DevToolsClient } from './api';
@@ -31,9 +32,13 @@ export const devToolsPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: devToolsApiRef,
-      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ discoveryApi, identityApi }) =>
-        new DevToolsClient({ discoveryApi, identityApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        identityApi: identityApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, identityApi, fetchApi }) =>
+        new DevToolsClient({ discoveryApi, identityApi, fetchApi }),
     }),
   ],
   routes: {

--- a/plugins/devtools/src/plugin.ts
+++ b/plugins/devtools/src/plugin.ts
@@ -20,7 +20,6 @@ import {
   createRoutableExtension,
   discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/core-plugin-api';
 import { devToolsApiRef, DevToolsClient } from './api';
 
@@ -34,11 +33,10 @@ export const devToolsPlugin = createPlugin({
       api: devToolsApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
         fetchApi: fetchApiRef,
       },
-      factory: ({ discoveryApi, identityApi, fetchApi }) =>
-        new DevToolsClient({ discoveryApi, identityApi, fetchApi }),
+      factory: ({ discoveryApi, fetchApi }) =>
+        new DevToolsClient({ discoveryApi, fetchApi }),
     }),
   ],
   routes: {

--- a/plugins/linguist/src/alpha/plugin.tsx
+++ b/plugins/linguist/src/alpha/plugin.tsx
@@ -21,7 +21,6 @@ import {
   createPlugin,
   discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/frontend-plugin-api';
 
 import { LinguistClient, linguistApiRef } from '../api';
@@ -43,11 +42,10 @@ export const linguistApi = createApiExtension({
     api: linguistApiRef,
     deps: {
       discoveryApi: discoveryApiRef,
-      identityApi: identityApiRef,
       fetchApi: fetchApiRef,
     },
-    factory: ({ discoveryApi, identityApi, fetchApi }) =>
-      new LinguistClient({ discoveryApi, identityApi, fetchApi }),
+    factory: ({ discoveryApi, fetchApi }) =>
+      new LinguistClient({ discoveryApi, fetchApi }),
   }),
 });
 

--- a/plugins/linguist/src/alpha/plugin.tsx
+++ b/plugins/linguist/src/alpha/plugin.tsx
@@ -20,6 +20,7 @@ import {
   createApiFactory,
   createPlugin,
   discoveryApiRef,
+  fetchApiRef,
   identityApiRef,
 } from '@backstage/frontend-plugin-api';
 
@@ -40,9 +41,13 @@ export const entityLinguistCard = createEntityCardExtension({
 export const linguistApi = createApiExtension({
   factory: createApiFactory({
     api: linguistApiRef,
-    deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-    factory: ({ discoveryApi, identityApi }) =>
-      new LinguistClient({ discoveryApi, identityApi }),
+    deps: {
+      discoveryApi: discoveryApiRef,
+      identityApi: identityApiRef,
+      fetchApi: fetchApiRef,
+    },
+    factory: ({ discoveryApi, identityApi, fetchApi }) =>
+      new LinguistClient({ discoveryApi, identityApi, fetchApi }),
   }),
 });
 

--- a/plugins/linguist/src/api/LinguistClient.ts
+++ b/plugins/linguist/src/api/LinguistClient.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
+import {
+  DiscoveryApi,
+  FetchApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { Languages } from '@backstage/plugin-linguist-common';
 import { LinguistApi } from './LinguistApi';
@@ -22,13 +26,16 @@ import { LinguistApi } from './LinguistApi';
 export class LinguistClient implements LinguistApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
+  private readonly fetchApi: FetchApi;
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
+    fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
     this.identityApi = options.identityApi;
+    this.fetchApi = options.fetchApi;
   }
 
   public async getLanguages(entityRef: string): Promise<Languages> {
@@ -46,7 +53,7 @@ export class LinguistClient implements LinguistApi {
     const url = new URL(path, baseUrl);
 
     const { token } = await this.identityApi.getCredentials();
-    const response = await fetch(url.toString(), {
+    const response = await this.fetchApi.fetch(url.toString(), {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
 

--- a/plugins/linguist/src/api/LinguistClient.ts
+++ b/plugins/linguist/src/api/LinguistClient.ts
@@ -14,27 +14,20 @@
  * limitations under the License.
  */
 
-import {
-  DiscoveryApi,
-  FetchApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { Languages } from '@backstage/plugin-linguist-common';
 import { LinguistApi } from './LinguistApi';
 
 export class LinguistClient implements LinguistApi {
   private readonly discoveryApi: DiscoveryApi;
-  private readonly identityApi: IdentityApi;
   private readonly fetchApi: FetchApi;
 
   public constructor(options: {
     discoveryApi: DiscoveryApi;
-    identityApi: IdentityApi;
     fetchApi: FetchApi;
   }) {
     this.discoveryApi = options.discoveryApi;
-    this.identityApi = options.identityApi;
     this.fetchApi = options.fetchApi;
   }
 
@@ -52,10 +45,7 @@ export class LinguistClient implements LinguistApi {
     const baseUrl = `${await this.discoveryApi.getBaseUrl('linguist')}/`;
     const url = new URL(path, baseUrl);
 
-    const { token } = await this.identityApi.getCredentials();
-    const response = await this.fetchApi.fetch(url.toString(), {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
+    const response = await this.fetchApi.fetch(url.toString());
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);

--- a/plugins/linguist/src/plugin.ts
+++ b/plugins/linguist/src/plugin.ts
@@ -20,7 +20,6 @@ import {
   createPlugin,
   discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/core-plugin-api';
 import { linguistApiRef, LinguistClient } from './api';
 import { LINGUIST_ANNOTATION } from '@backstage/plugin-linguist-common';
@@ -38,11 +37,10 @@ export const linguistPlugin = createPlugin({
       api: linguistApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
         fetchApi: fetchApiRef,
       },
-      factory: ({ discoveryApi, identityApi, fetchApi }) =>
-        new LinguistClient({ discoveryApi, identityApi, fetchApi }),
+      factory: ({ discoveryApi, fetchApi }) =>
+        new LinguistClient({ discoveryApi, fetchApi }),
     }),
   ],
 });

--- a/plugins/linguist/src/plugin.ts
+++ b/plugins/linguist/src/plugin.ts
@@ -19,6 +19,7 @@ import {
   createComponentExtension,
   createPlugin,
   discoveryApiRef,
+  fetchApiRef,
   identityApiRef,
 } from '@backstage/core-plugin-api';
 import { linguistApiRef, LinguistClient } from './api';
@@ -35,9 +36,13 @@ export const linguistPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: linguistApiRef,
-      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ discoveryApi, identityApi }) =>
-        new LinguistClient({ discoveryApi, identityApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        identityApi: identityApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, identityApi, fetchApi }) =>
+        new LinguistClient({ discoveryApi, identityApi, fetchApi }),
     }),
   ],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated Azure DevOps, DevTools, and Linguist to use `fetchApi` as per [ADR013](https://backstage.io/docs/architecture-decisions/adrs-adr013)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
