### PR TITLE
feat: add option to ingest group members from Azure Entra ID

### DIFF
--- a/.changeset/little-suns-fly.md
+++ b/.changeset/little-suns-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Added option to ingest groups based on their group membership in Azure Entra ID

--- a/docs/integrations/azure/org.md
+++ b/docs/integrations/azure/org.md
@@ -112,6 +112,17 @@ microsoftGraphOrg:
       search: '"description:One" AND ("displayName:Video" OR "displayName:Drive")'
 ```
 
+If you don't want to only ingest groups matching the `search` and/or `filter` query, but also the groups which are members of the matched groups, you can use the `includeSubGroups` configuration:
+
+```yaml
+microsoftGraphOrg:
+  providerId:
+    group:
+      filter: securityEnabled eq false and mailEnabled eq true and groupTypes/any(c:c+eq+'Unified')
+      search: '"description:One" AND ("displayName:Video" OR "displayName:Drive")'
+      includeSubGroups: true
+```
+
 In addition to these groups, one additional group will be created for your organization.
 All imported groups will be a child of this group.
 

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -39,10 +39,10 @@ export function defaultUserTransformer(
 // @public
 export type GroupMember =
   | (MicrosoftGraph.Group & {
-      '@odata.type': '#microsoft.graph.user';
+      '@odata.type': '#microsoft.graph.group';
     })
   | (MicrosoftGraph.User & {
-      '@odata.type': '#microsoft.graph.group';
+      '@odata.type': '#microsoft.graph.user';
     });
 
 // @public
@@ -210,6 +210,7 @@ export type MicrosoftGraphProviderConfig = {
   groupFilter?: string;
   groupSearch?: string;
   groupSelect?: string[];
+  groupIncludeSubGroups?: boolean;
   queryMode?: 'basic' | 'advanced';
   loadUserPhotos?: boolean;
   schedule?: TaskScheduleDefinition;
@@ -253,6 +254,7 @@ export function readMicrosoftGraphOrg(
     groupSearch?: string;
     groupFilter?: string;
     groupSelect?: string[];
+    groupIncludeSubGroups?: boolean;
     queryMode?: 'basic' | 'advanced';
     userTransformer?: UserTransformer;
     groupTransformer?: GroupTransformer;

--- a/plugins/catalog-backend-module-msgraph/config.d.ts
+++ b/plugins/catalog-backend-module-msgraph/config.d.ts
@@ -192,6 +192,11 @@ export interface Config {
                * E.g. ["id", "displayName", "description"]
                */
               select?: string[];
+              /**
+               * Whether to ingest groups that are members of the found/filtered/searched groups.
+               * Default value is `false`.
+               */
+              includeSubGroups?: boolean;
             };
 
             userGroupMember?: {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
@@ -64,8 +64,8 @@ export type ODataQuery = {
  * @public
  */
 export type GroupMember =
-  | (MicrosoftGraph.Group & { '@odata.type': '#microsoft.graph.user' })
-  | (MicrosoftGraph.User & { '@odata.type': '#microsoft.graph.group' });
+  | (MicrosoftGraph.Group & { '@odata.type': '#microsoft.graph.group' })
+  | (MicrosoftGraph.User & { '@odata.type': '#microsoft.graph.user' });
 
 /**
  * A HTTP Client that communicates with Microsoft Graph API.

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
@@ -175,6 +175,7 @@ describe('readProviderConfigs', () => {
                 expand: 'member',
                 filter: 'securityEnabled eq false',
                 select: ['id', 'displayName', 'description'],
+                includeSubGroups: true,
               },
               schedule: {
                 frequency: 'PT30M',
@@ -203,6 +204,7 @@ describe('readProviderConfigs', () => {
         groupExpand: 'member',
         groupSelect: ['id', 'displayName', 'description'],
         groupFilter: 'securityEnabled eq false',
+        groupIncludeSubGroups: true,
         schedule: {
           frequency: Duration.fromISO('PT30M'),
           timeout: {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -117,6 +117,12 @@ export type MicrosoftGraphProviderConfig = {
   groupSelect?: string[];
 
   /**
+   * Whether to ingest groups that are members of the found/filtered/searched groups.
+   * Default value is `false`.
+   */
+  groupIncludeSubGroups?: boolean;
+
+  /**
    * By default, the Microsoft Graph API only provides the basic feature set
    * for querying. Certain features are limited to advanced query capabilities
    * (see https://docs.microsoft.com/en-us/graph/aad-advanced-queries)
@@ -292,6 +298,9 @@ export function readProviderConfig(
   const groupFilter = config.getOptionalString('group.filter');
   const groupSearch = config.getOptionalString('group.search');
   const groupSelect = config.getOptionalStringArray('group.select');
+  const groupIncludeSubGroups = config.getOptionalBoolean(
+    'group.includeSubGroups',
+  );
 
   const queryMode = config.getOptionalString('queryMode');
   if (
@@ -347,6 +356,7 @@ export function readProviderConfig(
     groupFilter,
     groupSearch,
     groupSelect,
+    groupIncludeSubGroups,
     queryMode,
     userGroupMemberFilter,
     userGroupMemberSearch,

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
@@ -317,6 +317,7 @@ export class MicrosoftGraphOrgEntityProvider implements EntityProvider {
         groupFilter: provider.groupFilter,
         groupSearch: provider.groupSearch,
         groupSelect: provider.groupSelect,
+        groupIncludeSubGroups: provider.groupIncludeSubGroups,
         queryMode: provider.queryMode,
         groupTransformer: this.options.groupTransformer,
         userTransformer: this.options.userTransformer,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding a config option to the `microsoftGraphOrg` provider to ingest not only groups directly matching `filter`/`search` criteratia, but also their member groups (of type group) from Azure Entra ID.

**Background**
See https://github.com/backstage/backstage/issues/22799
This feature enables organizations to control the ingestion of groups in Backstage via group membership in Azure Entra ID.

**Example**

```yaml
microsoftGraphOrg:
  providerId:
    group:
      filter: "id in ('group-1', 'group-2')"
      includeSubGroups: true
```

Given the following group structure
```
    group-1    group-2
      /  \         \
 group-A group-B  group-C
```

This would not only ingest `group-1` and `group-2` (since they match the `filter`), but also all groups that are members, in this example `group-A`, `group-B`, and `group-C`.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
