### PR TITLE
backend-app-api: filter internal errors

### DIFF
--- a/.changeset/heavy-cameras-provide.md
+++ b/.changeset/heavy-cameras-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Updated the default error handling middleware to filter out certain known error types that should never be returned in responses. The errors are instead logged along with a correlation ID, which is also returned in the response. Initially only PostgreSQL protocol errors from the `pg-protocol` package are filtered out.

--- a/packages/backend-app-api/src/http/MiddlewareFactory.ts
+++ b/packages/backend-app-api/src/http/MiddlewareFactory.ts
@@ -43,6 +43,7 @@ import {
   serializeError,
 } from '@backstage/errors';
 import { NotImplementedError } from '@backstage/errors';
+import { applyInternalErrorFilter } from './applyInternalErrorFilter';
 
 /**
  * Options used to create a {@link MiddlewareFactory}.
@@ -209,7 +210,14 @@ export class MiddlewareFactory {
       type: 'errorHandler',
     });
 
-    return (error: Error, req: Request, res: Response, next: NextFunction) => {
+    return (
+      rawError: Error,
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ) => {
+      const error = applyInternalErrorFilter(rawError, logger);
+
       const statusCode = getStatusCode(error);
       if (options.logAllErrors || statusCode >= 500) {
         logger.error(`Request failed with status ${statusCode}`, error);

--- a/packages/backend-app-api/src/http/applyInternalErrorFilter.ts
+++ b/packages/backend-app-api/src/http/applyInternalErrorFilter.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { assertError } from '@backstage/errors';
+import { randomBytes } from 'crypto';
+
+function handleBadError(error: Error, logger: LoggerService) {
+  const logId = randomBytes(10).toString('hex');
+  logger.error(
+    `Filtered internal error with logId=${logId} from response`,
+    error,
+  );
+  const newError = new Error(`An internal error occurred logId=${logId}`);
+  delete newError.stack; // Trim the stack since it's not particularly useful
+  return newError;
+}
+
+/**
+ * Filters out certain known error types that should never be returned in responses.
+ *
+ * @internal
+ */
+export function applyInternalErrorFilter(
+  error: unknown,
+  logger: LoggerService,
+): Error {
+  try {
+    assertError(error);
+  } catch (assertionError: unknown) {
+    assertError(assertionError);
+    return handleBadError(assertionError, logger);
+  }
+
+  const constructorName = error.constructor.name;
+
+  // DatabaseError are thrown by the pg-protocol module
+  if (constructorName === 'DatabaseError') {
+    return handleBadError(error, logger);
+  }
+
+  return error;
+}

--- a/packages/backend-app-api/src/http/applyInternalErrorFilter.ts
+++ b/packages/backend-app-api/src/http/applyInternalErrorFilter.ts
@@ -20,10 +20,9 @@ import { randomBytes } from 'crypto';
 
 function handleBadError(error: Error, logger: LoggerService) {
   const logId = randomBytes(10).toString('hex');
-  logger.error(
-    `Filtered internal error with logId=${logId} from response`,
-    error,
-  );
+  logger
+    .child({ logId })
+    .error(`Filtered internal error with logId=${logId} from response`, error);
   const newError = new Error(`An internal error occurred logId=${logId}`);
   delete newError.stack; // Trim the stack since it's not particularly useful
   return newError;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a new error filtering capability to the default error handling. The purpose is to filter out errors that we never want to return in a response, and instead log it along with a correlation ID.

Fixes #22982

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
