### PR TITLE
Initial implementation of BEP 0003 - auth architecture evolution

### DIFF
--- a/.changeset/big-yaks-film.md
+++ b/.changeset/big-yaks-film.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Added support for the new [`auth`](https://backstage.io/docs/backend-system/core-services/auth/) and [`httpAuth`](https://backstage.io/docs/backend-system/core-services/http-auth) services that were created as part of [BEP-0003](https://github.com/backstage/backstage/tree/master/beps/0003-auth-architecture-evolution). These services will be present by default in test apps, and you can access mocked versions of their features under `mockServices.auth` and `mockServices.httpAuth` if you want to inspect or replace their behaviors.
+
+There is also a new `mockCredentials` that you can use for acquiring mocks of the various types of credentials that are used in the new system.

--- a/.changeset/eleven-cows-learn.md
+++ b/.changeset/eleven-cows-learn.md
@@ -1,0 +1,9 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Added the new [`auth`](https://backstage.io/docs/backend-system/core-services/auth/), [`httpAuth`](https://backstage.io/docs/backend-system/core-services/http-auth), and [`userInfo`](https://backstage.io/docs/backend-system/core-services/user-info) services that were created as part of [BEP-0003](https://github.com/backstage/backstage/tree/master/beps/0003-auth-architecture-evolution) to the `coreServices`.
+
+At the same time, the [`httpRouter`](https://backstage.io/docs/backend-system/core-services/http-router) service gained a new `addAuthPolicy` method that lets your plugin declare exemptions to the default auth policy - for example if you want to allow unauthenticated or cookie-based access to some subset of your feature routes.
+
+If you have migrated to the new backend system, please see the [Auth Service Migration tutorial](https://backstage.io/docs/tutorials/auth-service-migration) for more information on how to move toward using these services.

--- a/.changeset/perfect-taxis-give.md
+++ b/.changeset/perfect-taxis-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added support for the new auth services, which are now installed by default. See the [migration guide](https://backstage.io/docs/tutorials/auth-service-migration) for details.

--- a/.changeset/smart-owls-tease.md
+++ b/.changeset/smart-owls-tease.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+**BREAKING**: For users that have migrated to the new backend system, incoming requests will now be rejected if they are not properly authenticated (e.g. with a Backstage bearer token or a backend token). Please see the [Auth Service Migration tutorial](https://backstage.io/docs/tutorials/auth-service-migration) for more information on how to circumvent this behavior in the short term and how to properly leverage it in the longer term.
+
+Added service factories for the new [`auth`](https://backstage.io/docs/backend-system/core-services/auth/), [`httpAuth`](https://backstage.io/docs/backend-system/core-services/http-auth), and [`userInfo`](https://backstage.io/docs/backend-system/core-services/user-info) services that were created as part of [BEP-0003](https://github.com/backstage/backstage/tree/master/beps/0003-auth-architecture-evolution).

--- a/.changeset/thirty-shirts-allow.md
+++ b/.changeset/thirty-shirts-allow.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added a `createLegacyAuthAdapters` function that can be used as a compatibility adapter for backend plugins who want to start using the new [`auth`](https://backstage.io/docs/backend-system/core-services/auth/) and [`httpAuth`](https://backstage.io/docs/backend-system/core-services/http-auth) services that were created as part of [BEP-0003](https://github.com/backstage/backstage/tree/master/beps/0003-auth-architecture-evolution).
+
+See the [Auth Service Migration tutorial](https://backstage.io/docs/tutorials/auth-service-migration) for more information on the usage of this adapter.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -32,6 +32,12 @@ backend:
   # auth:
   #   keys:
   #     - secret: ${BACKEND_SECRET}
+
+  auth:
+    # TODO: once plugins have been migrated we can remove this, but right now it
+    # is require for the backend-next to work in this repo
+    dangerouslyDisableDefaultAuthPolicy: true
+
   baseUrl: http://localhost:7007
   listen:
     port: 7007

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -19,6 +19,7 @@ import { Format } from 'logform';
 import { Handler } from 'express';
 import { HelmetOptions } from 'helmet';
 import * as http from 'http';
+import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
 import { HumanDuration } from '@backstage/types';
 import { IdentityService } from '@backstage/backend-plugin-api';
@@ -147,6 +148,12 @@ export class HostDiscovery implements DiscoveryService {
   // (undocumented)
   getExternalBaseUrl(pluginId: string): Promise<string>;
 }
+
+// @public (undocumented)
+export const httpAuthServiceFactory: () => ServiceFactory<
+  HttpAuthService,
+  'plugin'
+>;
 
 // @public (undocumented)
 export interface HttpRouterFactoryOptions {

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 
 import type { AppConfig } from '@backstage/config';
+import { AuthService } from '@backstage/backend-plugin-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CacheClient } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
@@ -40,6 +41,9 @@ import { ServiceFactoryOrFunction } from '@backstage/backend-plugin-api';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { transport } from 'winston';
 import { UrlReader } from '@backstage/backend-common';
+
+// @public (undocumented)
+export const authServiceFactory: () => ServiceFactory<AuthService, 'plugin'>;
 
 // @public (undocumented)
 export interface Backend {

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -42,6 +42,7 @@ import { ServiceFactoryOrFunction } from '@backstage/backend-plugin-api';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { transport } from 'winston';
 import { UrlReader } from '@backstage/backend-common';
+import { UserInfoService } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
 export const authServiceFactory: () => ServiceFactory<AuthService, 'plugin'>;
@@ -332,6 +333,12 @@ export const tokenManagerServiceFactory: () => ServiceFactory<
 
 // @public (undocumented)
 export const urlReaderServiceFactory: () => ServiceFactory<UrlReader, 'plugin'>;
+
+// @public (undocumented)
+export const userInfoServiceFactory: () => ServiceFactory<
+  UserInfoService,
+  'plugin'
+>;
 
 // @public
 export class WinstonLogger implements RootLoggerService {

--- a/packages/backend-app-api/config.d.ts
+++ b/packages/backend-app-api/config.d.ts
@@ -15,6 +15,26 @@
  */
 
 export interface Config {
+  backend?: {
+    auth?: {
+      /**
+       * This disables the otherwise default auth policy, which requires all
+       * requests to be authenticated with either user or service credentials.
+       *
+       * Disabling this check means that the backend will no longer block
+       * unauthenticated requests, but instead allow them to pass through to
+       * plugins.
+       *
+       * If permissions are enabled, unauthenticated requests will be treated
+       * exactly as such, leaving it to the permission policy to determine what
+       * permissions should be allowed for an unauthenticated identity. Note
+       * that this will also apply to service-to-service calls between plugins
+       * unless you configure credentials for service calls.
+       */
+      dangerouslyDisableDefaultAuthPolicy?: boolean;
+    };
+  };
+
   /** Discovery options. */
   discovery?: {
     /**

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -60,6 +60,7 @@
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.6",
     "compression": "^1.7.4",
+    "cookie": "^0.6.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -73,6 +73,7 @@
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",
     "node-forge": "^1.3.1",
+    "path-to-regexp": "^6.2.1",
     "selfsigned": "^2.0.0",
     "stoppable": "^1.1.0",
     "winston": "^3.2.1",

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -66,7 +66,7 @@
     "express-promise-router": "^4.1.0",
     "fs-extra": "^11.2.0",
     "helmet": "^6.0.0",
-    "jose": "^4.6.0",
+    "jose": "^5.0.0",
     "lodash": "^4.17.21",
     "logform": "^2.3.2",
     "minimatch": "^5.0.0",

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -65,6 +65,7 @@
     "express-promise-router": "^4.1.0",
     "fs-extra": "^11.2.0",
     "helmet": "^6.0.0",
+    "jose": "^4.6.0",
     "lodash": "^4.17.21",
     "logform": "^2.3.2",
     "minimatch": "^5.0.0",

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ServiceFactoryTester,
+  mockServices,
+} from '@backstage/backend-test-utils';
+import {
+  InternalBackstageServiceCredentials,
+  InternalBackstageUserCredentials,
+  authServiceFactory,
+} from './authServiceFactory';
+import { decodeJwt } from 'jose';
+import { discoveryServiceFactory } from '../discovery';
+
+// TODO: Ship discovery mock service in the service factory tester
+const mockDeps = [
+  discoveryServiceFactory(),
+  mockServices.rootConfig.factory({
+    data: {
+      backend: {
+        baseUrl: 'http://localhost',
+        auth: { keys: [{ secret: 'abc' }] },
+      },
+    },
+  }),
+];
+
+describe('authServiceFactory', () => {
+  it('should authenticate issued tokens', async () => {
+    const tester = ServiceFactoryTester.from(authServiceFactory, {
+      dependencies: mockDeps,
+    });
+
+    const searchAuth = await tester.get('search');
+    const catalogAuth = await tester.get('catalog');
+
+    const { token: searchToken } = await searchAuth.issueServiceToken();
+
+    await expect(searchAuth.authenticate(searchToken)).resolves.toEqual(
+      expect.objectContaining({
+        type: 'service',
+        subject: 'external:backstage-plugin',
+      }),
+    );
+    await expect(catalogAuth.authenticate(searchToken)).resolves.toEqual(
+      expect.objectContaining({
+        type: 'service',
+        subject: 'external:backstage-plugin',
+      }),
+    );
+  });
+
+  it('should forward user tokens', async () => {
+    const tester = ServiceFactoryTester.from(authServiceFactory, {
+      dependencies: mockDeps,
+    });
+
+    const catalogAuth = await tester.get('catalog');
+
+    await expect(
+      catalogAuth.issueServiceToken({
+        forward: {
+          $$type: '@backstage/BackstageCredentials',
+          version: 'v1',
+          type: 'user',
+          userEntityRef: 'user:default/alice',
+          token: 'alice-token',
+        } as InternalBackstageUserCredentials,
+      }),
+    ).resolves.toEqual({ token: 'alice-token' });
+  });
+
+  it('should not forward service tokens', async () => {
+    const tester = ServiceFactoryTester.from(authServiceFactory, {
+      dependencies: mockDeps,
+    });
+
+    const catalogAuth = await tester.get('catalog');
+
+    const { token } = await catalogAuth.issueServiceToken({
+      forward: {
+        $$type: '@backstage/BackstageCredentials',
+        version: 'v1',
+        type: 'service',
+        subject: 'external:backstage-plugin',
+        token: 'some-upstream-service-token',
+      } as InternalBackstageServiceCredentials,
+    });
+
+    expect(decodeJwt(token)).toEqual(
+      expect.objectContaining({
+        sub: 'backstage-server',
+      }),
+    );
+  });
+});

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
@@ -51,7 +51,9 @@ describe('authServiceFactory', () => {
     const searchAuth = await tester.get('search');
     const catalogAuth = await tester.get('catalog');
 
-    const { token: searchToken } = await searchAuth.issueToken({});
+    const { token: searchToken } = await searchAuth.issueServiceToken({
+      forward: await searchAuth.getOwnCredentials(),
+    });
 
     await expect(searchAuth.authenticate(searchToken)).resolves.toEqual(
       expect.objectContaining({
@@ -79,7 +81,7 @@ describe('authServiceFactory', () => {
     const catalogAuth = await tester.get('catalog');
 
     await expect(
-      catalogAuth.issueToken({
+      catalogAuth.issueServiceToken({
         forward: {
           $$type: '@backstage/BackstageCredentials',
           version: 'v1',
@@ -101,7 +103,7 @@ describe('authServiceFactory', () => {
 
     const catalogAuth = await tester.get('catalog');
 
-    const { token } = await catalogAuth.issueToken({
+    const { token } = await catalogAuth.issueServiceToken({
       forward: {
         $$type: '@backstage/BackstageCredentials',
         version: 'v1',

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
@@ -51,8 +51,9 @@ describe('authServiceFactory', () => {
     const searchAuth = await tester.get('search');
     const catalogAuth = await tester.get('catalog');
 
-    const { token: searchToken } = await searchAuth.issueServiceToken({
-      forward: await searchAuth.getOwnCredentials(),
+    const { token: searchToken } = await searchAuth.getPluginRequestToken({
+      onBehalfOf: await searchAuth.getOwnServiceCredentials(),
+      targetPluginId: 'catalog',
     });
 
     await expect(searchAuth.authenticate(searchToken)).resolves.toEqual(
@@ -81,8 +82,8 @@ describe('authServiceFactory', () => {
     const catalogAuth = await tester.get('catalog');
 
     await expect(
-      catalogAuth.issueServiceToken({
-        forward: {
+      catalogAuth.getPluginRequestToken({
+        onBehalfOf: {
           $$type: '@backstage/BackstageCredentials',
           version: 'v1',
           authMethod: 'token',
@@ -92,6 +93,7 @@ describe('authServiceFactory', () => {
             userEntityRef: 'user:default/alice',
           },
         } as InternalBackstageCredentials<BackstageUserPrincipal>,
+        targetPluginId: 'catalog',
       }),
     ).resolves.toEqual({ token: 'alice-token' });
   });
@@ -103,8 +105,8 @@ describe('authServiceFactory', () => {
 
     const catalogAuth = await tester.get('catalog');
 
-    const { token } = await catalogAuth.issueServiceToken({
-      forward: {
+    const { token } = await catalogAuth.getPluginRequestToken({
+      onBehalfOf: {
         $$type: '@backstage/BackstageCredentials',
         version: 'v1',
         authMethod: 'token',
@@ -114,6 +116,7 @@ describe('authServiceFactory', () => {
           subject: 'external:upstream-service',
         },
       } as InternalBackstageCredentials<BackstageServicePrincipal>,
+      targetPluginId: 'catalog',
     });
 
     expect(decodeJwt(token)).toEqual(

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
@@ -167,6 +167,7 @@ class DefaultAuthService implements AuthService {
     const { type } = internalForward.principal;
 
     switch (type) {
+      // TODO: Check whether the principal is ourselves
       case 'service':
         return this.tokenManager.getToken();
       case 'user':

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ServerTokenManager, TokenManager } from '@backstage/backend-common';
+import {
+  AuthService,
+  BackstageCredentials,
+  BackstageServiceCredentials,
+  BackstageUserCredentials,
+  IdentityService,
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { AuthenticationError } from '@backstage/errors';
+import {
+  DefaultIdentityClient,
+  IdentityApiGetIdentityRequest,
+} from '@backstage/plugin-auth-node';
+import { decodeJwt } from 'jose';
+
+/** @internal */
+export type InternalBackstageServiceCredentials =
+  BackstageServiceCredentials & {
+    version: string;
+    token: string;
+  };
+
+function createServiceCredentials(
+  sub: string,
+  token: string,
+): BackstageServiceCredentials {
+  return {
+    $$type: '@backstage/BackstageCredentials',
+    version: 'v1',
+    token,
+    type: 'service',
+    subject: sub,
+  } as InternalBackstageServiceCredentials;
+}
+
+/** @internal */
+export type InternalBackstageUserCredentials = BackstageUserCredentials & {
+  version: string;
+  token: string;
+};
+
+function createUserCredentials(
+  sub: string,
+  token: string,
+): BackstageUserCredentials {
+  return {
+    $$type: '@backstage/BackstageCredentials',
+    version: 'v1',
+    token,
+    type: 'user',
+    userEntityRef: sub,
+  } as InternalBackstageUserCredentials;
+}
+
+export function toInternalBackstageCredentials(
+  credentials: BackstageCredentials,
+): InternalBackstageServiceCredentials | InternalBackstageUserCredentials {
+  if (credentials.$$type !== '@backstage/BackstageCredentials') {
+    throw new Error('Invalid credential type');
+  }
+  const internalCredentials = credentials as
+    | InternalBackstageServiceCredentials
+    | InternalBackstageUserCredentials;
+  if (internalCredentials.version !== 'v1') {
+    throw new Error(
+      `Invalid credential version ${internalCredentials.version}`,
+    );
+  }
+  return internalCredentials;
+}
+
+/** @internal */
+class DefaultAuthService implements AuthService {
+  constructor(
+    private readonly tokenManager: TokenManager,
+    private readonly identity: IdentityService,
+  ) {}
+
+  async authenticate(token: string): Promise<BackstageCredentials> {
+    const { sub, aud } = decodeJwt(token);
+
+    // Legacy service-to-service token
+    if (sub === 'backstage-server' && !aud) {
+      await this.tokenManager.authenticate(token);
+      return createServiceCredentials('external:backstage-plugin', token);
+    }
+
+    // User Backstage token
+    const identity = await this.identity.getIdentity({
+      request: {
+        headers: { authorization: `Bearer ${token}` },
+      },
+    } as IdentityApiGetIdentityRequest);
+
+    if (!identity) {
+      throw new AuthenticationError('No identity found');
+    }
+
+    return createUserCredentials(identity.identity.userEntityRef, token);
+  }
+
+  async issueServiceToken(options?: {
+    forward?: BackstageCredentials;
+  }): Promise<{ token: string }> {
+    const internalForward =
+      options?.forward && toInternalBackstageCredentials(options.forward);
+
+    if (internalForward) {
+      const { type } = internalForward;
+      if (type === 'user') {
+        return { token: internalForward.token };
+      } else if (type !== 'service') {
+        throw new AuthenticationError(
+          `Refused to issue service token for credential type '${type}'`,
+        );
+      }
+    }
+
+    const { token } = await this.tokenManager.getToken();
+    return { token };
+  }
+}
+
+/** @public */
+export const authServiceFactory = createServiceFactory({
+  service: coreServices.auth,
+  deps: {
+    config: coreServices.rootConfig,
+    logger: coreServices.rootLogger,
+    discovery: coreServices.discovery,
+  },
+  createRootContext({ config, logger }) {
+    return ServerTokenManager.fromConfig(config, { logger });
+  },
+  async factory({ discovery }, tokenManager) {
+    const identity = DefaultIdentityClient.create({ discovery });
+    return new DefaultAuthService(tokenManager, identity);
+  },
+});

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
@@ -154,16 +154,17 @@ class DefaultAuthService implements AuthService {
     return true;
   }
 
-  async getOwnCredentials(): Promise<
+  async getOwnServiceCredentials(): Promise<
     BackstageCredentials<BackstageServicePrincipal>
   > {
     return createCredentialsWithServicePrincipal(`plugin:${this.pluginId}`);
   }
 
-  async issueServiceToken(options: {
-    forward: BackstageCredentials;
+  async getPluginRequestToken(options: {
+    onBehalfOf: BackstageCredentials;
+    targetPluginId: string;
   }): Promise<{ token: string }> {
-    const internalForward = toInternalBackstageCredentials(options.forward);
+    const internalForward = toInternalBackstageCredentials(options.onBehalfOf);
     const { type } = internalForward.principal;
 
     switch (type) {

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
@@ -147,6 +147,10 @@ class DefaultAuthService implements AuthService {
       | BackstageUserPrincipal
       | BackstageServicePrincipal;
 
+    if (type === 'unknown') {
+      return true;
+    }
+
     if (principal.type !== type) {
       return false;
     }

--- a/packages/backend-app-api/src/services/implementations/auth/index.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,4 @@
  * limitations under the License.
  */
 
-export * from './auth';
-export * from './cache';
-export * from './config';
-export * from './database';
-export * from './discovery';
-export * from './httpRouter';
-export * from './identity';
-export * from './lifecycle';
-export * from './logger';
-export * from './permissions';
-export * from './rootHttpRouter';
-export * from './rootLifecycle';
-export * from './rootLogger';
-export * from './scheduler';
-export * from './tokenManager';
-export * from './urlReader';
+export { authServiceFactory } from './authServiceFactory';

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -98,19 +98,14 @@ class DefaultHttpAuthService implements HttpAuthService {
 
   async credentials<
     TAllowed extends
-      | keyof BackstageHttpAccessToPrincipalTypesMapping
-      | undefined = undefined,
+      | keyof BackstageHttpAccessToPrincipalTypesMapping = 'unknown',
   >(
     req: Request,
     options?: {
       allow: Array<TAllowed>;
     },
   ): Promise<
-    BackstageCredentials<
-      TAllowed extends keyof BackstageHttpAccessToPrincipalTypesMapping
-        ? BackstageHttpAccessToPrincipalTypesMapping[TAllowed]
-        : unknown
-    >
+    BackstageCredentials<BackstageHttpAccessToPrincipalTypesMapping[TAllowed]>
   > {
     const credentials = toInternalBackstageCredentials(
       await this.#getCredentials(req),

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -133,10 +133,10 @@ class DefaultHttpAuthService implements HttpAuthService {
   }
 
   async requestHeaders(options: {
-    forward?: BackstageCredentials;
+    forward: BackstageCredentials;
   }): Promise<Record<string, string>> {
     return {
-      Authorization: `Bearer ${await this.auth.issueToken(options)}`,
+      Authorization: `Bearer ${await this.auth.issueServiceToken(options)}`,
     };
   }
 

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AuthService,
+  BackstageCredentialTypes,
+  BackstageCredentials,
+  BackstageUnauthorizedCredentials,
+  DiscoveryService,
+  HttpAuthService,
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { NotAllowedError } from '@backstage/errors';
+import { parse as parseCookie } from 'cookie';
+import { Handler, Request, Response } from 'express';
+import { decodeJwt } from 'jose';
+import { toInternalBackstageCredentials } from '../auth/authServiceFactory';
+
+const BACKSTAGE_AUTH_COOKIE = 'backstage-auth';
+
+function getTokenFromRequest(req: Request) {
+  // TODO: support multiple auth headers (iterate rawHeaders)
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader === 'string') {
+    const matches = authHeader.match(/^Bearer[ ]+(\S+)$/i);
+    const token = matches?.[1];
+    if (token) {
+      return { token, isCookie: false };
+    }
+  }
+
+  const cookieHeader = req.headers.cookie;
+  if (cookieHeader) {
+    const cookies = parseCookie(cookieHeader);
+    const token = cookies[BACKSTAGE_AUTH_COOKIE];
+    if (token) {
+      return { token, isCookie: true };
+    }
+  }
+
+  return { token: undefined, isCookie: false };
+}
+
+const credentialsSymbol = Symbol('backstage-credentials');
+// TODO: This is temporary and should be removed once we have proper cookie handling in place
+const isCookieSymbol = Symbol('backstage-is-cookie-credentials');
+
+type RequestWithCredentials = Request & {
+  [credentialsSymbol]?: BackstageCredentials | BackstageUnauthorizedCredentials;
+  [isCookieSymbol]?: boolean;
+};
+
+function createUnauthorizedCredentials(): BackstageUnauthorizedCredentials {
+  return {
+    $$type: '@backstage/BackstageCredentials',
+    type: 'unauthorized',
+  };
+}
+
+class DefaultHttpAuthService implements HttpAuthService {
+  constructor(
+    private readonly auth: AuthService,
+    private readonly discovery: DiscoveryService,
+    private readonly pluginId: string,
+  ) {}
+
+  createHttpPluginRouterMiddleware(): Handler {
+    return async (req: RequestWithCredentials, _res, next) => {
+      try {
+        const { token, isCookie } = getTokenFromRequest(req);
+        // TODO: Is this where we match against configured rules?
+        if (!token) {
+          req[credentialsSymbol] = createUnauthorizedCredentials();
+        } else {
+          req[credentialsSymbol] = await this.auth.authenticate(token);
+          req[isCookieSymbol] = isCookie;
+        }
+        next();
+      } catch (e) {
+        next(e);
+      }
+    };
+  }
+
+  async credentials<TAllowed extends keyof BackstageCredentialTypes>(
+    req: RequestWithCredentials,
+    options: {
+      allow: TAllowed[];
+    },
+  ): Promise<BackstageCredentialTypes[TAllowed]> {
+    const credentials = req[credentialsSymbol];
+    if (!credentials) {
+      throw new Error('Internal error, no credentials found on request');
+    }
+
+    if (credentials.type === 'user' && req[isCookieSymbol]) {
+      if (options.allow.includes('user-cookie' as TAllowed)) {
+        return credentials as BackstageCredentialTypes[TAllowed];
+      }
+      throw new NotAllowedError(
+        `This endpoint does not allow 'user-cookie' credentials`,
+      );
+    }
+
+    if (!options.allow.includes(credentials.type as TAllowed)) {
+      throw new NotAllowedError(
+        `This endpoint does not allow '${credentials.type}' credentials`,
+      );
+    }
+
+    return credentials as BackstageCredentialTypes[TAllowed];
+  }
+
+  async requestHeaders(options?: {
+    forward?: BackstageCredentials;
+  }): Promise<Record<string, string>> {
+    return {
+      Authorization: `Bearer ${await this.auth.issueServiceToken(options)}`,
+    };
+  }
+
+  async issueUserCookie(res: Response): Promise<void> {
+    const credentials = await this.credentials(res.req, { allow: ['user'] });
+
+    // https://backstage.spotify.net/api/catalog
+    const externalBaseUrlStr = await this.discovery.getExternalBaseUrl(
+      this.pluginId,
+    );
+    const externalBaseUrl = new URL(externalBaseUrlStr);
+
+    const { token } = toInternalBackstageCredentials(credentials);
+
+    // TODO: Proper refresh and expiration handling
+    const expires = decodeJwt(token).exp!;
+
+    // TODO: refresh this thing
+    res.cookie(BACKSTAGE_AUTH_COOKIE, token, {
+      domain: externalBaseUrl.hostname,
+      httpOnly: true,
+      expires: new Date(expires * 1000),
+      path: externalBaseUrl.pathname,
+      priority: 'high',
+      sameSite: 'lax', // TBD
+    });
+    throw new Error('Method not implemented.');
+  }
+}
+
+/** @public */
+export const httpAuthServiceFactory = createServiceFactory({
+  service: coreServices.httpAuth,
+  deps: {
+    config: coreServices.rootConfig,
+    logger: coreServices.rootLogger,
+    discovery: coreServices.discovery,
+    auth: coreServices.auth,
+    plugin: coreServices.pluginMetadata,
+  },
+  async factory({ auth, discovery, plugin }) {
+    return new DefaultHttpAuthService(auth, discovery, plugin.getId());
+  },
+});

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -63,7 +63,7 @@ type RequestWithCredentials = Request & {
   [credentialsSymbol]?: Promise<BackstageCredentials>;
 };
 
-class DefaultHttpAuthService implements HttpAuthService {
+export class DefaultHttpAuthService implements HttpAuthService {
   constructor(
     private readonly auth: AuthService,
     private readonly discovery: DiscoveryService,
@@ -130,14 +130,6 @@ class DefaultHttpAuthService implements HttpAuthService {
     }
 
     return credentials as any;
-  }
-
-  async requestHeaders(options: {
-    forward: BackstageCredentials;
-  }): Promise<Record<string, string>> {
-    return {
-      Authorization: `Bearer ${await this.auth.issueServiceToken(options)}`,
-    };
   }
 
   async issueUserCookie(res: Response): Promise<void> {

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -124,6 +124,9 @@ class DefaultHttpAuthService implements HttpAuthService {
       allowedPrincipalTypes &&
       !allowedPrincipalTypes.includes(credentials.principal.type as TAllowed)
     ) {
+      if (credentials.authMethod === 'none') {
+        throw new AuthenticationError();
+      }
       throw new NotAllowedError(
         `This endpoint does not allow '${credentials.principal.type}' credentials`,
       );

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -91,7 +91,7 @@ class DefaultHttpAuthService implements HttpAuthService {
     return credentials;
   }
 
-  async #getCredentials(req: /*  */ RequestWithCredentials) {
+  async #getCredentials(req: RequestWithCredentials) {
     return (req[credentialsSymbol] ??=
       this.#extractCredentialsFromRequest(req));
   }

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -63,7 +63,7 @@ type RequestWithCredentials = Request & {
   [credentialsSymbol]?: Promise<BackstageCredentials>;
 };
 
-export class DefaultHttpAuthService implements HttpAuthService {
+class DefaultHttpAuthService implements HttpAuthService {
   constructor(
     private readonly auth: AuthService,
     private readonly discovery: DiscoveryService,

--- a/packages/backend-app-api/src/services/implementations/httpAuth/index.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,4 @@
  * limitations under the License.
  */
 
-export * from './auth';
-export * from './cache';
-export * from './config';
-export * from './database';
-export * from './discovery';
-export * from './httpAuth';
-export * from './httpRouter';
-export * from './identity';
-export * from './lifecycle';
-export * from './logger';
-export * from './permissions';
-export * from './rootHttpRouter';
-export * from './rootLifecycle';
-export * from './rootLogger';
-export * from './scheduler';
-export * from './tokenManager';
-export * from './urlReader';
+export { httpAuthServiceFactory } from './httpAuthServiceFactory';

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  HttpAuthService,
+  HttpRouterServiceAuthPolicy,
+} from '@backstage/backend-plugin-api';
+import { RequestHandler } from 'express';
+import { pathToRegexp } from 'path-to-regexp';
+
+export function createPathPolicyPredicate(policyPath: string) {
+  if (policyPath === '/' || policyPath === '*') {
+    return () => true;
+  }
+
+  const pathRegex = pathToRegexp(policyPath, undefined, {
+    end: false,
+  });
+
+  return (path: string): boolean => {
+    return pathRegex.test(path);
+  };
+}
+
+export function createCredentialsBarrier(options: {
+  httpAuth: HttpAuthService;
+}): {
+  middleware: RequestHandler;
+  addAuthPolicy: (policy: HttpRouterServiceAuthPolicy) => void;
+} {
+  const { httpAuth } = options;
+
+  const unauthenticatedPredicates = new Array<(path: string) => boolean>();
+  const cookiePredicates = new Array<(path: string) => boolean>();
+
+  const middleware: RequestHandler = async (req, _, next) => {
+    const allowsUnauthenticated = unauthenticatedPredicates.some(predicate =>
+      predicate(req.path),
+    );
+
+    if (allowsUnauthenticated) {
+      next();
+      return;
+    }
+
+    const allowsCookie = cookiePredicates.some(predicate =>
+      predicate(req.path),
+    );
+
+    if (allowsCookie) {
+      // don't we need a user-cookie allow type here?
+      await httpAuth.credentials(req, {
+        allow: ['user-cookie', 'user', 'service'],
+      });
+      next();
+      return;
+    }
+
+    await httpAuth.credentials(req, {
+      allow: ['user', 'service'],
+    });
+    next();
+  };
+
+  const addAuthPolicy = (policy: HttpRouterServiceAuthPolicy) => {
+    if (policy.allow === 'unauthenticated') {
+      unauthenticatedPredicates.push(createPathPolicyPredicate(policy.path));
+    } else if (policy.allow === 'user-cookie') {
+      cookiePredicates.push(createPathPolicyPredicate(policy.path));
+    }
+
+    throw new Error('Invalid auth policy');
+  };
+
+  return { middleware, addAuthPolicy };
+}

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
@@ -60,18 +60,11 @@ export function createCredentialsBarrier(options: {
       predicate(req.path),
     );
 
-    if (allowsCookie) {
-      // don't we need a user-cookie allow type here?
-      await httpAuth.credentials(req, {
-        allow: ['user-cookie', 'user', 'service'],
-      });
-      next();
-      return;
-    }
-
     await httpAuth.credentials(req, {
       allow: ['user', 'service'],
+      allowedAuthMethods: allowsCookie ? ['token', 'cookie'] : ['token'],
     });
+
     next();
   };
 

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
@@ -73,9 +73,9 @@ export function createCredentialsBarrier(options: {
       unauthenticatedPredicates.push(createPathPolicyPredicate(policy.path));
     } else if (policy.allow === 'user-cookie') {
       cookiePredicates.push(createPathPolicyPredicate(policy.path));
+    } else {
+      throw new Error('Invalid auth policy');
     }
-
-    throw new Error('Invalid auth policy');
   };
 
   return { middleware, addAuthPolicy };

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
@@ -54,7 +54,6 @@ export const httpRouterServiceFactory = createServiceFactory(
       const credentialsBarrier = createCredentialsBarrier({ httpAuth });
 
       router.use(createLifecycleMiddleware({ lifecycle }));
-      router.use(httpAuth.createHttpPluginRouterMiddleware());
       router.use(credentialsBarrier.middleware);
 
       return {

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
@@ -40,18 +40,19 @@ export const httpRouterServiceFactory = createServiceFactory(
     service: coreServices.httpRouter,
     deps: {
       plugin: coreServices.pluginMetadata,
+      config: coreServices.rootConfig,
       lifecycle: coreServices.lifecycle,
       rootHttpRouter: coreServices.rootHttpRouter,
       httpAuth: coreServices.httpAuth,
     },
-    async factory({ httpAuth, plugin, rootHttpRouter, lifecycle }) {
+    async factory({ httpAuth, config, plugin, rootHttpRouter, lifecycle }) {
       const getPath = options?.getPath ?? (id => `/api/${id}`);
       const path = getPath(plugin.getId());
 
       const router = PromiseRouter();
       rootHttpRouter.use(path, router);
 
-      const credentialsBarrier = createCredentialsBarrier({ httpAuth });
+      const credentialsBarrier = createCredentialsBarrier({ httpAuth, config });
 
       router.use(createLifecycleMiddleware({ lifecycle }));
       router.use(credentialsBarrier.middleware);

--- a/packages/backend-app-api/src/services/implementations/userInfo/index.ts
+++ b/packages/backend-app-api/src/services/implementations/userInfo/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,4 @@
  * limitations under the License.
  */
 
-export * from './auth';
-export * from './cache';
-export * from './config';
-export * from './database';
-export * from './discovery';
-export * from './httpAuth';
-export * from './httpRouter';
-export * from './identity';
-export * from './lifecycle';
-export * from './logger';
-export * from './permissions';
-export * from './rootHttpRouter';
-export * from './rootLifecycle';
-export * from './rootLogger';
-export * from './scheduler';
-export * from './tokenManager';
-export * from './urlReader';
-export * from './userInfo';
+export { userInfoServiceFactory } from './userInfoServiceFactory';

--- a/packages/backend-app-api/src/services/implementations/userInfo/userInfoServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/userInfo/userInfoServiceFactory.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackstageUserCredentials,
+  UserInfoService,
+  BackstageUserInfo,
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { toInternalBackstageCredentials } from '../auth/authServiceFactory';
+import { decodeJwt } from 'jose';
+
+// TODO: The intention is for this to eventually be replaced by a call to the auth-backend
+export class DefaultUserInfoService implements UserInfoService {
+  async getUserInfo(
+    credentials: BackstageUserCredentials,
+  ): Promise<BackstageUserInfo> {
+    const internalCredentials = toInternalBackstageCredentials(credentials);
+    if (internalCredentials.type !== 'user') {
+      throw new Error('Only user credentials are supported');
+    }
+    const { sub: userEntityRef, ent: ownershipEntityRefs = [] } = decodeJwt(
+      internalCredentials.token,
+    );
+
+    if (typeof userEntityRef !== 'string') {
+      throw new Error('User entity ref must be a string');
+    }
+    if (!Array.isArray(ownershipEntityRefs)) {
+      throw new Error('Ownership entity refs must be an array');
+    }
+
+    return { userEntityRef, ownershipEntityRefs };
+  }
+}
+
+/** @public */
+export const userInfoServiceFactory = createServiceFactory({
+  service: coreServices.userInfo,
+  deps: {},
+  async factory() {
+    return new DefaultUserInfoService();
+  },
+});

--- a/packages/backend-app-api/src/services/implementations/userInfo/userInfoServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/userInfo/userInfoServiceFactory.ts
@@ -15,11 +15,11 @@
  */
 
 import {
-  BackstageUserCredentials,
   UserInfoService,
   BackstageUserInfo,
   coreServices,
   createServiceFactory,
+  BackstageCredentials,
 } from '@backstage/backend-plugin-api';
 import { toInternalBackstageCredentials } from '../auth/authServiceFactory';
 import { decodeJwt } from 'jose';
@@ -27,11 +27,14 @@ import { decodeJwt } from 'jose';
 // TODO: The intention is for this to eventually be replaced by a call to the auth-backend
 export class DefaultUserInfoService implements UserInfoService {
   async getUserInfo(
-    credentials: BackstageUserCredentials,
+    credentials: BackstageCredentials,
   ): Promise<BackstageUserInfo> {
     const internalCredentials = toInternalBackstageCredentials(credentials);
-    if (internalCredentials.type !== 'user') {
+    if (internalCredentials.principal.type !== 'user') {
       throw new Error('Only user credentials are supported');
+    }
+    if (!internalCredentials.token) {
+      throw new Error('User credentials is unexpectedly missing token');
     }
     const { sub: userEntityRef, ent: ownershipEntityRefs = [] } = decodeJwt(
       internalCredentials.token,

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -8,6 +8,7 @@
 
 import { AppConfig } from '@backstage/config';
 import { AuthCallback } from 'isomorphic-git';
+import { AuthService } from '@backstage/backend-plugin-api';
 import { AwsCredentialsManager } from '@backstage/integration-aws-node';
 import { AwsS3Integration } from '@backstage/integration';
 import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
@@ -30,6 +31,7 @@ import { GithubCredentialsProvider } from '@backstage/integration';
 import { GithubIntegration } from '@backstage/integration';
 import { GitLabIntegration } from '@backstage/integration';
 import { HostDiscovery as HostDiscovery_2 } from '@backstage/backend-app-api';
+import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { IdentityService } from '@backstage/backend-plugin-api';
 import { isChildPath } from '@backstage/cli-common';
 import { Knex } from 'knex';
@@ -231,6 +233,18 @@ export function createDatabaseClient(
     pluginMetadata: PluginMetadataService;
   },
 ): knexFactory.Knex<any, any[]>;
+
+// @public (undocumented)
+export function createLegacyAuthAdapters(options: {
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
+  identity?: IdentityService;
+  tokenManager?: TokenManager;
+  discovery: PluginEndpointDiscovery;
+}): {
+  auth: AuthService;
+  httpAuth: HttpAuthService;
+};
 
 // @public
 export function createRootLogger(

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -235,16 +235,35 @@ export function createDatabaseClient(
 ): knexFactory.Knex<any, any[]>;
 
 // @public (undocumented)
-export function createLegacyAuthAdapters(options: {
-  auth?: AuthService;
-  httpAuth?: HttpAuthService;
-  identity?: IdentityService;
-  tokenManager?: TokenManager;
-  discovery: PluginEndpointDiscovery;
-}): {
-  auth: AuthService;
-  httpAuth: HttpAuthService;
-};
+export function createLegacyAuthAdapters<
+  TOptions extends {
+    auth?: AuthService;
+    httpAuth?: HttpAuthService;
+    identity?: IdentityService;
+    tokenManager?: TokenManager;
+    discovery: PluginEndpointDiscovery;
+  },
+  TAdapters = TOptions extends {
+    auth?: AuthService;
+  }
+    ? TOptions extends {
+        httpAuth?: HttpAuthService;
+      }
+      ? {
+          auth: AuthService;
+          httpAuth: HttpAuthService;
+        }
+      : {
+          auth: AuthService;
+        }
+    : TOptions extends {
+        httpAuth?: HttpAuthService;
+      }
+    ? {
+        httpAuth: HttpAuthService;
+      }
+    : 'error: at least one of auth and/or httpAuth must be provided',
+>(options: TOptions): TAdapters;
 
 // @public
 export function createRootLogger(

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -234,7 +234,7 @@ export function createDatabaseClient(
   },
 ): knexFactory.Knex<any, any[]>;
 
-// @public (undocumented)
+// @public
 export function createLegacyAuthAdapters<
   TOptions extends {
     auth?: AuthService;

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -63,6 +63,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/integration-aws-node": "workspace:^",
+    "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "@google-cloud/storage": "^7.0.0",
     "@keyv/memcache": "^1.3.5",

--- a/packages/backend-common/src/auth/createLegacyAuthAdapters.test.ts
+++ b/packages/backend-common/src/auth/createLegacyAuthAdapters.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mockServices } from '@backstage/backend-test-utils';
+import { createLegacyAuthAdapters } from './createLegacyAuthAdapters';
+
+describe('createLegacyAuthAdapters', () => {
+  it('should pass through auth if only auth is provided', () => {
+    const auth = {};
+    const ret = createLegacyAuthAdapters({
+      auth: auth as any,
+      tokenManager: mockServices.tokenManager(),
+      discovery: {} as any,
+      identity: mockServices.identity(),
+    });
+
+    expect(ret.auth).toBe(auth);
+  });
+
+  it('should pass through httpAuth if only httpAuth is provided', () => {
+    const httpAuth = {};
+    const ret = createLegacyAuthAdapters({
+      httpAuth: httpAuth as any,
+      tokenManager: mockServices.tokenManager(),
+      discovery: {} as any,
+      identity: mockServices.identity(),
+    });
+
+    expect(ret.httpAuth).toBe(httpAuth);
+  });
+
+  it('should pass through both auth and httpAuth if both are provided', () => {
+    const auth = {};
+    const httpAuth = {};
+    const ret = createLegacyAuthAdapters({
+      auth: auth as any,
+      httpAuth: httpAuth as any,
+      tokenManager: mockServices.tokenManager(),
+      discovery: {} as any,
+      identity: mockServices.identity(),
+    });
+
+    expect(ret.auth).toBe(auth);
+    expect(ret.httpAuth).toBe(httpAuth);
+  });
+
+  it('should adapt both auth and httpAuth if neither are provided', () => {
+    const ret = createLegacyAuthAdapters({
+      auth: undefined,
+      httpAuth: undefined,
+      tokenManager: mockServices.tokenManager(),
+      discovery: {} as any,
+      identity: mockServices.identity(),
+    });
+
+    expect(ret).toEqual({
+      auth: expect.any(Object),
+      httpAuth: expect.any(Object),
+    });
+  });
+});

--- a/packages/backend-common/src/auth/createLegacyAuthAdapters.ts
+++ b/packages/backend-common/src/auth/createLegacyAuthAdapters.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AuthService,
+  BackstageCredentials,
+  BackstagePrincipalTypes,
+  BackstageServicePrincipal,
+  BackstageUserPrincipal,
+  HttpAuthService,
+  IdentityService,
+  TokenManagerService,
+} from '@backstage/backend-plugin-api';
+import { ServerTokenManager, TokenManager } from '../tokens';
+import { AuthenticationError, NotAllowedError } from '@backstage/errors';
+import type { Request, Response } from 'express';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import {
+  createCredentialsWithServicePrincipal,
+  createCredentialsWithUserPrincipal,
+  createCredentialsWithNonePrincipal,
+  toInternalBackstageCredentials,
+} from '../../../backend-app-api/src/services/implementations/auth/authServiceFactory';
+// TODO is this circular thingy a problem? Test in e2e
+import {
+  type IdentityApiGetIdentityRequest,
+  DefaultIdentityClient,
+} from '@backstage/plugin-auth-node';
+import { decodeJwt } from 'jose';
+import { PluginEndpointDiscovery } from '../discovery';
+
+class AuthCompat implements AuthService {
+  constructor(
+    private readonly identity: IdentityService,
+    private readonly tokenManager: TokenManagerService,
+  ) {}
+
+  isPrincipal<TType extends keyof BackstagePrincipalTypes>(
+    credentials: BackstageCredentials,
+    type: TType,
+  ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]> {
+    const principal = credentials.principal as
+      | BackstageUserPrincipal
+      | BackstageServicePrincipal;
+
+    if (principal.type !== type) {
+      return false;
+    }
+
+    return true;
+  }
+
+  async getOwnCredentials(): Promise<
+    BackstageCredentials<BackstageServicePrincipal>
+  > {
+    return createCredentialsWithServicePrincipal('external:backstage-plugin');
+  }
+
+  async authenticate(token: string): Promise<BackstageCredentials> {
+    const { sub, aud } = decodeJwt(token);
+
+    // Legacy service-to-service token
+    if (sub === 'backstage-server' && !aud) {
+      await this.tokenManager.authenticate(token);
+      return createCredentialsWithServicePrincipal('external:backstage-plugin');
+    }
+
+    // User Backstage token
+    const identity = await this.identity.getIdentity({
+      request: {
+        headers: { authorization: `Bearer ${token}` },
+      },
+    } as IdentityApiGetIdentityRequest);
+
+    if (!identity) {
+      throw new AuthenticationError('Invalid user token');
+    }
+
+    return createCredentialsWithUserPrincipal(
+      identity.identity.userEntityRef,
+      token,
+    );
+  }
+
+  async issueServiceToken(options: {
+    forward: BackstageCredentials;
+  }): Promise<{ token: string }> {
+    const internalForward = toInternalBackstageCredentials(options.forward);
+    const { type } = internalForward.principal;
+
+    switch (type) {
+      // TODO: Check whether the principal is ourselves
+      case 'service':
+        return this.tokenManager.getToken();
+      case 'user':
+        if (!internalForward.token) {
+          throw new Error('User credentials is unexpectedly missing token');
+        }
+        return { token: internalForward.token };
+      // NOTE: this is not the behavior of this service in the new backend system, it only applies
+      //       here since we'll need to accept and forward requests without authentication.
+      case 'none':
+        return { token: '' };
+      default:
+        throw new AuthenticationError(
+          `Refused to issue service token for credential type '${type}'`,
+        );
+    }
+  }
+}
+
+function getTokenFromRequest(req: Request) {
+  // TODO: support multiple auth headers (iterate rawHeaders)
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader === 'string') {
+    const matches = authHeader.match(/^Bearer[ ]+(\S+)$/i);
+    const token = matches?.[1];
+    if (token) {
+      return token;
+    }
+  }
+
+  return undefined;
+}
+
+const credentialsSymbol = Symbol('backstage-credentials');
+
+type RequestWithCredentials = Request & {
+  [credentialsSymbol]?: Promise<BackstageCredentials>;
+};
+
+class HttpAuthCompat implements HttpAuthService {
+  constructor(private readonly auth: AuthService) {}
+
+  async #extractCredentialsFromRequest(req: Request) {
+    const token = getTokenFromRequest(req);
+    if (!token) {
+      return createCredentialsWithNonePrincipal();
+    }
+
+    const credentials = toInternalBackstageCredentials(
+      await this.auth.authenticate(token),
+    );
+
+    return credentials;
+  }
+
+  async #getCredentials(req: /*  */ RequestWithCredentials) {
+    return (req[credentialsSymbol] ??=
+      this.#extractCredentialsFromRequest(req));
+  }
+
+  async credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(
+    req: Request,
+    options?: {
+      allow?: Array<TAllowed>;
+      allowedAuthMethods?: Array<'token' | 'cookie'>;
+    },
+  ): Promise<BackstageCredentials<BackstagePrincipalTypes[TAllowed]>> {
+    const credentials = toInternalBackstageCredentials(
+      await this.#getCredentials(req),
+    );
+
+    const allowedPrincipalTypes = options?.allow;
+    const allowedAuthMethods: Array<'token' | 'cookie' | 'none'> =
+      options?.allowedAuthMethods ?? ['token'];
+
+    if (
+      credentials.authMethod !== 'none' &&
+      !allowedAuthMethods.includes(credentials.authMethod)
+    ) {
+      throw new NotAllowedError(
+        `This endpoint does not allow the '${credentials.authMethod}' auth method`,
+      );
+    }
+
+    if (
+      allowedPrincipalTypes &&
+      !allowedPrincipalTypes.includes(credentials.principal.type as TAllowed)
+    ) {
+      throw new NotAllowedError(
+        `This endpoint does not allow '${credentials.principal.type}' credentials`,
+      );
+    }
+
+    return credentials as any;
+  }
+
+  async requestHeaders(options: {
+    forward: BackstageCredentials;
+  }): Promise<Record<string, string>> {
+    return {
+      Authorization: `Bearer ${await this.auth.issueServiceToken(options)}`,
+    };
+  }
+
+  async issueUserCookie(_res: Response): Promise<void> {}
+}
+
+/** @public */
+export function createLegacyAuthAdapters(options: {
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
+  identity?: IdentityService;
+  tokenManager?: TokenManager;
+  discovery: PluginEndpointDiscovery;
+}): {
+  auth: AuthService;
+  httpAuth: HttpAuthService;
+} {
+  const { auth, httpAuth, discovery } = options;
+
+  if (auth || httpAuth) {
+    // TODO: Is this sensible? Could be that a lot of plugins only want one of them and in
+    // that case overloads might be better, so that it's possible to only provide one of them.
+    if (!(auth && httpAuth)) {
+      throw new Error('Both auth and httpAuth must be provided');
+    }
+    return {
+      auth,
+      httpAuth,
+    };
+  }
+
+  const identity =
+    options.identity ?? DefaultIdentityClient.create({ discovery });
+  const tokenManager = options.tokenManager ?? ServerTokenManager.noop();
+
+  const authImpl = new AuthCompat(identity, tokenManager);
+  const httpAuthImpl = new HttpAuthCompat(authImpl);
+
+  return {
+    auth: authImpl,
+    httpAuth: httpAuthImpl,
+  };
+}

--- a/packages/backend-common/src/auth/index.ts
+++ b/packages/backend-common/src/auth/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createLegacyAuthAdapters } from './createLegacyAuthAdapters';

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -22,6 +22,7 @@
 
 export { legacyPlugin, makeLegacyPlugin } from './legacy';
 export type { LegacyCreateRouter } from './legacy';
+export * from './auth';
 export * from './cache';
 export { loadBackendConfig } from './config';
 export * from './database';

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -32,13 +32,18 @@ import {
   tokenManagerServiceFactory,
   urlReaderServiceFactory,
   identityServiceFactory,
+  authServiceFactory,
+  httpAuthServiceFactory,
+  userInfoServiceFactory,
 } from '@backstage/backend-app-api';
 
 export const defaultServiceFactories = [
+  authServiceFactory(),
   cacheServiceFactory(),
   rootConfigServiceFactory(),
   databaseServiceFactory(),
   discoveryServiceFactory(),
+  httpAuthServiceFactory(),
   httpRouterServiceFactory(),
   identityServiceFactory(),
   lifecycleServiceFactory(),
@@ -49,6 +54,7 @@ export const defaultServiceFactories = [
   rootLoggerServiceFactory(),
   schedulerServiceFactory(),
   tokenManagerServiceFactory(),
+  userInfoServiceFactory(),
   urlReaderServiceFactory(),
 ];
 

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -30,6 +30,8 @@
     "@backstage/backend-tasks": "workspace:^",
     "@backstage/plugin-adr-backend": "workspace:^",
     "@backstage/plugin-app-backend": "workspace:^",
+    "@backstage/plugin-auth-backend": "workspace:^",
+    "@backstage/plugin-auth-backend-module-github-provider": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-azure-devops-backend": "workspace:^",
     "@backstage/plugin-badges-backend": "workspace:^",

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -28,6 +28,7 @@
     "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
+    "@backstage/catalog-model": "workspace:^",
     "@backstage/plugin-adr-backend": "workspace:^",
     "@backstage/plugin-app-backend": "workspace:^",
     "@backstage/plugin-auth-backend": "workspace:^",

--- a/packages/backend-next/src/authModuleGithubProvider.ts
+++ b/packages/backend-next/src/authModuleGithubProvider.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { githubAuthenticator } from '@backstage/plugin-auth-backend-module-github-provider';
+import {
+  authProvidersExtensionPoint,
+  createOAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
+
+export default createBackendModule({
+  pluginId: 'auth',
+  moduleId: 'githubProvider',
+  register(reg) {
+    reg.registerInit({
+      deps: { providers: authProvidersExtensionPoint },
+      async init({ providers }) {
+        providers.registerProvider({
+          providerId: 'github',
+          factory: createOAuthProviderFactory({
+            authenticator: githubAuthenticator,
+            async signInResolver({ result: { fullProfile } }, ctx) {
+              const userId = fullProfile.username;
+              if (!userId) {
+                throw new Error(
+                  `GitHub user profile does not contain a username`,
+                );
+              }
+
+              const userEntityRef = `user:default/${userId}`;
+
+              return ctx.issueToken({
+                claims: {
+                  sub: userEntityRef,
+                  ent: [userEntityRef],
+                },
+              });
+            },
+          }),
+        });
+      },
+    });
+  },
+});

--- a/packages/backend-next/src/authModuleGithubProvider.ts
+++ b/packages/backend-next/src/authModuleGithubProvider.ts
@@ -15,6 +15,10 @@
  */
 
 import { createBackendModule } from '@backstage/backend-plugin-api';
+import {
+  DEFAULT_NAMESPACE,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import { githubAuthenticator } from '@backstage/plugin-auth-backend-module-github-provider';
 import {
   authProvidersExtensionPoint,
@@ -40,7 +44,11 @@ export default createBackendModule({
                 );
               }
 
-              const userEntityRef = `user:default/${userId}`;
+              const userEntityRef = stringifyEntityRef({
+                kind: 'User',
+                name: userId,
+                namespace: DEFAULT_NAMESPACE,
+              });
 
               return ctx.issueToken({
                 claims: {

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -18,6 +18,9 @@ import { createBackend } from '@backstage/backend-defaults';
 
 const backend = createBackend();
 
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('./authModuleGithubProvider'));
+
 backend.add(import('@backstage/plugin-adr-backend'));
 backend.add(import('@backstage/plugin-app-backend/alpha'));
 backend.add(import('@backstage/plugin-azure-devops-backend'));

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -125,7 +125,6 @@ export type BackstagePrincipalTypes = {
 export type BackstageServicePrincipal = {
   type: 'service';
   subject: string;
-  permissions?: string[];
 };
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -102,15 +102,6 @@ export type BackstageCredentials<TPrincipal = unknown> = {
 };
 
 // @public (undocumented)
-export type BackstageHttpAccessToPrincipalTypesMapping = {
-  user: BackstageUserPrincipal;
-  'user-cookie': BackstageUserPrincipal;
-  service: BackstageServicePrincipal;
-  unauthenticated: BackstageNonePrincipal;
-  unknown: unknown;
-};
-
-// @public (undocumented)
 export type BackstageNonePrincipal = {
   type: 'none';
 };
@@ -119,6 +110,8 @@ export type BackstageNonePrincipal = {
 export type BackstagePrincipalTypes = {
   user: BackstageUserPrincipal;
   service: BackstageServicePrincipal;
+  unauthenticated: BackstageNonePrincipal;
+  unknown: unknown;
 };
 
 // @public (undocumented)
@@ -293,16 +286,13 @@ export interface ExtensionPointConfig {
 // @public (undocumented)
 export interface HttpAuthService {
   // (undocumented)
-  credentials<
-    TAllowed extends keyof BackstageHttpAccessToPrincipalTypesMapping = 'unknown',
-  >(
+  credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(
     req: Request_2,
     options?: {
-      allow: Array<TAllowed>;
+      allow?: Array<TAllowed>;
+      allowedAuthMethods?: Array<'token' | 'cookie'>;
     },
-  ): Promise<
-    BackstageCredentials<BackstageHttpAccessToPrincipalTypesMapping[TAllowed]>
-  >;
+  ): Promise<BackstageCredentials<BackstagePrincipalTypes[TAllowed]>>;
   // (undocumented)
   issueUserCookie(res: Response_2): Promise<void>;
   // (undocumented)

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -22,12 +22,14 @@ export interface AuthService {
   // (undocumented)
   authenticate(token: string): Promise<BackstageCredentials>;
   // (undocumented)
+  getOwnCredentials(): Promise<BackstageCredentials<BackstageServicePrincipal>>;
+  // (undocumented)
   isPrincipal<TType extends keyof BackstagePrincipalTypes>(
     credentials: BackstageCredentials,
     type: TType,
   ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]>;
   // (undocumented)
-  issueToken(options: { forward?: BackstageCredentials }): Promise<{
+  issueServiceToken(options: { forward: BackstageCredentials }): Promise<{
     token: string;
   }>;
 }
@@ -305,8 +307,8 @@ export interface HttpAuthService {
   // (undocumented)
   issueUserCookie(res: Response_2): Promise<void>;
   // (undocumented)
-  requestHeaders(options?: {
-    forward?: BackstageCredentials;
+  requestHeaders(options: {
+    forward: BackstageCredentials;
   }): Promise<Record<string, string>>;
 }
 

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -14,6 +14,8 @@ import { Knex } from 'knex';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Readable } from 'stream';
+import { Request as Request_2 } from 'express';
+import { Response as Response_2 } from 'express';
 
 // @public (undocumented)
 export interface AuthService {
@@ -92,10 +94,24 @@ export type BackstageCredentials =
   | BackstageServiceCredentials;
 
 // @public (undocumented)
+export type BackstageCredentialTypes = {
+  user: BackstageUserCredentials;
+  'user-cookie': BackstageUserCredentials;
+  service: BackstageServiceCredentials;
+  unauthorized: BackstageUnauthorizedCredentials;
+};
+
+// @public (undocumented)
 export type BackstageServiceCredentials = {
   $$type: '@backstage/BackstageCredentials';
   type: 'service';
   subject: string;
+};
+
+// @public (undocumented)
+export type BackstageUnauthorizedCredentials = {
+  $$type: '@backstage/BackstageCredentials';
+  type: 'unauthorized';
 };
 
 // @public (undocumented)
@@ -134,6 +150,7 @@ export namespace coreServices {
   const rootConfig: ServiceRef<RootConfigService, 'root'>;
   const database: ServiceRef<DatabaseService, 'plugin'>;
   const discovery: ServiceRef<DiscoveryService, 'plugin'>;
+  const httpAuth: ServiceRef<HttpAuthService, 'plugin'>;
   const httpRouter: ServiceRef<HttpRouterService, 'plugin'>;
   const lifecycle: ServiceRef<LifecycleService, 'plugin'>;
   const logger: ServiceRef<LoggerService, 'plugin'>;
@@ -250,6 +267,25 @@ export type ExtensionPoint<T> = {
 // @public
 export interface ExtensionPointConfig {
   id: string;
+}
+
+// @public (undocumented)
+export interface HttpAuthService {
+  // (undocumented)
+  createHttpPluginRouterMiddleware(): Handler;
+  // (undocumented)
+  credentials<TAllowed extends keyof BackstageCredentialTypes>(
+    req: Request_2,
+    options: {
+      allow: Array<TAllowed>;
+    },
+  ): Promise<BackstageCredentialTypes[TAllowed]>;
+  // (undocumented)
+  issueUserCookie(res: Response_2): Promise<void>;
+  // (undocumented)
+  requestHeaders(options?: {
+    forward?: BackstageCredentials;
+  }): Promise<Record<string, string>>;
 }
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -16,6 +16,16 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Readable } from 'stream';
 
 // @public (undocumented)
+export interface AuthService {
+  // (undocumented)
+  authenticate(token: string): Promise<BackstageCredentials>;
+  // (undocumented)
+  issueServiceToken(options?: { forward?: BackstageCredentials }): Promise<{
+    token: string;
+  }>;
+}
+
+// @public (undocumented)
 export interface BackendFeature {
   // (undocumented)
   $$type: '@backstage/BackendFeature';
@@ -76,6 +86,25 @@ export interface BackendPluginRegistrationPoints {
   }): void;
 }
 
+// @public (undocumented)
+export type BackstageCredentials =
+  | BackstageUserCredentials
+  | BackstageServiceCredentials;
+
+// @public (undocumented)
+export type BackstageServiceCredentials = {
+  $$type: '@backstage/BackstageCredentials';
+  type: 'service';
+  subject: string;
+};
+
+// @public (undocumented)
+export type BackstageUserCredentials = {
+  $$type: '@backstage/BackstageCredentials';
+  type: 'user';
+  userEntityRef: string;
+};
+
 // @public
 export interface CacheService {
   delete(key: string): Promise<void>;
@@ -100,6 +129,7 @@ export type CacheServiceSetOptions = {
 
 // @public
 export namespace coreServices {
+  const auth: ServiceRef<AuthService, 'plugin'>;
   const cache: ServiceRef<CacheService, 'plugin'>;
   const rootConfig: ServiceRef<RootConfigService, 'root'>;
   const database: ServiceRef<DatabaseService, 'plugin'>;

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -105,6 +105,7 @@ export type BackstageHttpAccessToPrincipalTypesMapping = {
   'user-cookie': BackstageUserPrincipal;
   service: BackstageServicePrincipal;
   unauthenticated: BackstageNonePrincipal;
+  unknown: unknown;
 };
 
 // @public (undocumented)
@@ -292,20 +293,14 @@ export interface ExtensionPointConfig {
 export interface HttpAuthService {
   // (undocumented)
   credentials<
-    TAllowed extends
-      | keyof BackstageHttpAccessToPrincipalTypesMapping
-      | undefined = undefined,
+    TAllowed extends keyof BackstageHttpAccessToPrincipalTypesMapping = 'unknown',
   >(
     req: Request_2,
     options?: {
       allow: Array<TAllowed>;
     },
   ): Promise<
-    BackstageCredentials<
-      TAllowed extends keyof BackstageHttpAccessToPrincipalTypesMapping
-        ? BackstageHttpAccessToPrincipalTypesMapping[TAllowed]
-        : unknown
-    >
+    BackstageCredentials<BackstageHttpAccessToPrincipalTypesMapping[TAllowed]>
   >;
   // (undocumented)
   issueUserCookie(res: Response_2): Promise<void>;

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -300,7 +300,17 @@ export interface HttpAuthService {
 // @public (undocumented)
 export interface HttpRouterService {
   // (undocumented)
+  addAuthPolicy(policy: HttpRouterServiceAuthPolicy): void;
+  // (undocumented)
   use(handler: Handler): void;
+}
+
+// @public (undocumented)
+export interface HttpRouterServiceAuthPolicy {
+  // (undocumented)
+  allow: 'unauthenticated' | 'user-cookie';
+  // (undocumented)
+  path: string;
 }
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -121,6 +121,14 @@ export type BackstageUserCredentials = {
   userEntityRef: string;
 };
 
+// @public (undocumented)
+export interface BackstageUserInfo {
+  // (undocumented)
+  ownershipEntityRefs: string[];
+  // (undocumented)
+  userEntityRef: string;
+}
+
 // @public
 export interface CacheService {
   delete(key: string): Promise<void>;
@@ -146,6 +154,7 @@ export type CacheServiceSetOptions = {
 // @public
 export namespace coreServices {
   const auth: ServiceRef<AuthService, 'plugin'>;
+  const userInfo: ServiceRef<UserInfoService, 'plugin'>;
   const cache: ServiceRef<CacheService, 'plugin'>;
   const rootConfig: ServiceRef<RootConfigService, 'root'>;
   const database: ServiceRef<DatabaseService, 'plugin'>;
@@ -523,5 +532,13 @@ export interface UrlReaderService {
   readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
   readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
   search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+}
+
+// @public (undocumented)
+export interface UserInfoService {
+  // (undocumented)
+  getUserInfo(
+    credentials: BackstageUserCredentials,
+  ): Promise<BackstageUserInfo>;
 }
 ```

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -292,7 +292,7 @@ export interface ExtensionPointConfig {
 export interface HttpAuthService {
   // (undocumented)
   credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(
-    req: Request_2,
+    req: Request_2<any, any, any, any, any>,
     options?: {
       allow?: Array<TAllowed>;
       allowedAuthMethods?: Array<'token' | 'cookie'>;

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -115,7 +115,7 @@ export type BackstageNonePrincipal = {
 export type BackstagePrincipalTypes = {
   user: BackstageUserPrincipal;
   service: BackstageServicePrincipal;
-  unauthenticated: BackstageNonePrincipal;
+  none: BackstageNonePrincipal;
   unknown: unknown;
 };
 

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -22,16 +22,21 @@ export interface AuthService {
   // (undocumented)
   authenticate(token: string): Promise<BackstageCredentials>;
   // (undocumented)
-  getOwnCredentials(): Promise<BackstageCredentials<BackstageServicePrincipal>>;
+  getOwnServiceCredentials(): Promise<
+    BackstageCredentials<BackstageServicePrincipal>
+  >;
+  // (undocumented)
+  getPluginRequestToken(options: {
+    onBehalfOf: BackstageCredentials;
+    targetPluginId: string;
+  }): Promise<{
+    token: string;
+  }>;
   // (undocumented)
   isPrincipal<TType extends keyof BackstagePrincipalTypes>(
     credentials: BackstageCredentials,
     type: TType,
   ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]>;
-  // (undocumented)
-  issueServiceToken(options: { forward: BackstageCredentials }): Promise<{
-    token: string;
-  }>;
 }
 
 // @public (undocumented)
@@ -295,10 +300,6 @@ export interface HttpAuthService {
   ): Promise<BackstageCredentials<BackstagePrincipalTypes[TAllowed]>>;
   // (undocumented)
   issueUserCookie(res: Response_2): Promise<void>;
-  // (undocumented)
-  requestHeaders(options: {
-    forward: BackstageCredentials;
-  }): Promise<Record<string, string>>;
 }
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -55,6 +55,8 @@ export type BackstageCredentials<TPrincipal = unknown> = {
 export type BackstagePrincipalTypes = {
   user: BackstageUserPrincipal;
   service: BackstageServicePrincipal;
+  unauthenticated: BackstageNonePrincipal;
+  unknown: unknown;
 };
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @public
+ */
+export type BackstageUserCredentials = {
+  $$type: '@backstage/BackstageCredentials';
+
+  type: 'user';
+
+  userEntityRef: string;
+};
+
+/**
+ * @public
+ */
+export type BackstageServiceCredentials = {
+  $$type: '@backstage/BackstageCredentials';
+
+  type: 'service';
+
+  subject: string;
+};
+
+/**
+ * @public
+ */
+export type BackstageCredentials =
+  | BackstageUserCredentials
+  | BackstageServiceCredentials;
+
+/**
+ * @public
+ */
+export interface AuthService {
+  authenticate(token: string): Promise<BackstageCredentials>;
+  issueServiceToken(options?: {
+    forward?: BackstageCredentials;
+  }): Promise<{ token: string }>;
+}

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -38,9 +38,6 @@ export type BackstageServicePrincipal = {
 
   // Exact format TBD, possibly 'plugin:<pluginId>' or 'external:<externalServiceId>'
   subject: string;
-
-  // Not implemented in the first iteration, but this is how we might extend this in the future
-  permissions?: string[];
 };
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -17,9 +17,7 @@
 /**
  * @public
  */
-export type BackstageUserCredentials = {
-  $$type: '@backstage/BackstageCredentials';
-
+export type BackstageUserPrincipal = {
   type: 'user';
 
   userEntityRef: string;
@@ -28,27 +26,54 @@ export type BackstageUserCredentials = {
 /**
  * @public
  */
-export type BackstageServiceCredentials = {
-  $$type: '@backstage/BackstageCredentials';
-
-  type: 'service';
-
-  subject: string;
+export type BackstageNonePrincipal = {
+  type: 'none';
 };
 
 /**
  * @public
  */
-export type BackstageCredentials =
-  | BackstageUserCredentials
-  | BackstageServiceCredentials;
+export type BackstageServicePrincipal = {
+  type: 'service';
+
+  // Exact format TBD, possibly 'plugin:<pluginId>' or 'external:<externalServiceId>'
+  subject: string;
+
+  // Not implemented in the first iteration, but this is how we might extend this in the future
+  permissions?: string[];
+};
+
+/**
+ * @public
+ */
+export type BackstageCredentials<TPrincipal = unknown> = {
+  $$type: '@backstage/BackstageCredentials';
+
+  principal: TPrincipal;
+};
+
+/**
+ * @public
+ */
+export type BackstagePrincipalTypes = {
+  user: BackstageUserPrincipal;
+  service: BackstageServicePrincipal;
+};
 
 /**
  * @public
  */
 export interface AuthService {
   authenticate(token: string): Promise<BackstageCredentials>;
-  issueServiceToken(options?: {
+
+  isPrincipal<TType extends keyof BackstagePrincipalTypes>(
+    credentials: BackstageCredentials,
+    type: TType,
+  ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]>;
+
+  // TODO: should the caller provide the target plugin ID?
+  // TODO: how can we make it very difficult to forget to forward credentials
+  issueToken(options: {
     forward?: BackstageCredentials;
   }): Promise<{ token: string }>;
 }

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -71,9 +71,10 @@ export interface AuthService {
     type: TType,
   ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]>;
 
+  getOwnCredentials(): Promise<BackstageCredentials<BackstageServicePrincipal>>;
+
   // TODO: should the caller provide the target plugin ID?
-  // TODO: how can we make it very difficult to forget to forward credentials
-  issueToken(options: {
-    forward?: BackstageCredentials;
+  issueServiceToken(options: {
+    forward: BackstageCredentials;
   }): Promise<{ token: string }>;
 }

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -70,10 +70,12 @@ export interface AuthService {
     type: TType,
   ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]>;
 
-  getOwnCredentials(): Promise<BackstageCredentials<BackstageServicePrincipal>>;
+  getOwnServiceCredentials(): Promise<
+    BackstageCredentials<BackstageServicePrincipal>
+  >;
 
-  // TODO: should the caller provide the target plugin ID?
-  issueServiceToken(options: {
-    forward: BackstageCredentials;
+  getPluginRequestToken(options: {
+    onBehalfOf: BackstageCredentials;
+    targetPluginId: string;
   }): Promise<{ token: string }>;
 }

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -55,7 +55,7 @@ export type BackstageCredentials<TPrincipal = unknown> = {
 export type BackstagePrincipalTypes = {
   user: BackstageUserPrincipal;
   service: BackstageServicePrincipal;
-  unauthenticated: BackstageNonePrincipal;
+  none: BackstageNonePrincipal;
   unknown: unknown;
 };
 

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Request, Response, Handler } from 'express';
+import {
+  BackstageUserCredentials,
+  BackstageServiceCredentials,
+  BackstageCredentials,
+} from './AuthService';
+
+/** @public */
+export type BackstageUnauthorizedCredentials = {
+  $$type: '@backstage/BackstageCredentials';
+
+  type: 'unauthorized';
+};
+
+/** @public */
+export type BackstageCredentialTypes = {
+  user: BackstageUserCredentials;
+  'user-cookie': BackstageUserCredentials;
+  service: BackstageServiceCredentials;
+  unauthorized: BackstageUnauthorizedCredentials;
+};
+
+/** @public */
+export interface HttpAuthService {
+  createHttpPluginRouterMiddleware(): Handler;
+
+  credentials<TAllowed extends keyof BackstageCredentialTypes>(
+    req: Request,
+    options: {
+      allow: Array<TAllowed>;
+    },
+  ): Promise<BackstageCredentialTypes[TAllowed]>;
+
+  // TODO: Keep an eye on this, might not be needed
+  requestHeaders(options?: {
+    forward?: BackstageCredentials;
+  }): Promise<Record<string, string>>;
+
+  issueUserCookie(res: Response): Promise<void>;
+}

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Request, Response, Handler } from 'express';
+import { Request, Response } from 'express';
 import {
   BackstageUserCredentials,
   BackstageServiceCredentials,
@@ -38,8 +38,6 @@ export type BackstageCredentialTypes = {
 
 /** @public */
 export interface HttpAuthService {
-  createHttpPluginRouterMiddleware(): Handler;
-
   credentials<TAllowed extends keyof BackstageCredentialTypes>(
     req: Request,
     options: {

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -28,25 +28,19 @@ export type BackstageHttpAccessToPrincipalTypesMapping = {
   'user-cookie': BackstageUserPrincipal;
   service: BackstageServicePrincipal;
   unauthenticated: BackstageNonePrincipal;
+  unknown: unknown;
 };
 
 /** @public */
 export interface HttpAuthService {
   credentials<
     TAllowed extends
-      | keyof BackstageHttpAccessToPrincipalTypesMapping
-      | undefined = undefined,
+      | keyof BackstageHttpAccessToPrincipalTypesMapping = 'unknown',
   >(
     req: Request,
-    options?: {
-      allow: Array<TAllowed>;
-    },
+    options?: { allow: Array<TAllowed> },
   ): Promise<
-    BackstageCredentials<
-      TAllowed extends keyof BackstageHttpAccessToPrincipalTypesMapping
-        ? BackstageHttpAccessToPrincipalTypesMapping[TAllowed]
-        : unknown
-    >
+    BackstageCredentials<BackstageHttpAccessToPrincipalTypesMapping[TAllowed]>
   >;
 
   requestHeaders(options?: {

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -16,36 +16,39 @@
 
 import { Request, Response } from 'express';
 import {
-  BackstageUserCredentials,
-  BackstageServiceCredentials,
   BackstageCredentials,
+  BackstageServicePrincipal,
+  BackstageNonePrincipal,
+  BackstageUserPrincipal,
 } from './AuthService';
 
 /** @public */
-export type BackstageUnauthorizedCredentials = {
-  $$type: '@backstage/BackstageCredentials';
-
-  type: 'unauthorized';
-};
-
-/** @public */
-export type BackstageCredentialTypes = {
-  user: BackstageUserCredentials;
-  'user-cookie': BackstageUserCredentials;
-  service: BackstageServiceCredentials;
-  unauthorized: BackstageUnauthorizedCredentials;
+export type BackstageHttpAccessToPrincipalTypesMapping = {
+  user: BackstageUserPrincipal;
+  'user-cookie': BackstageUserPrincipal;
+  service: BackstageServicePrincipal;
+  unauthenticated: BackstageNonePrincipal;
 };
 
 /** @public */
 export interface HttpAuthService {
-  credentials<TAllowed extends keyof BackstageCredentialTypes>(
+  credentials<
+    TAllowed extends
+      | keyof BackstageHttpAccessToPrincipalTypesMapping
+      | undefined = undefined,
+  >(
     req: Request,
-    options: {
+    options?: {
       allow: Array<TAllowed>;
     },
-  ): Promise<BackstageCredentialTypes[TAllowed]>;
+  ): Promise<
+    BackstageCredentials<
+      TAllowed extends keyof BackstageHttpAccessToPrincipalTypesMapping
+        ? BackstageHttpAccessToPrincipalTypesMapping[TAllowed]
+        : unknown
+    >
+  >;
 
-  // TODO: Keep an eye on this, might not be needed
   requestHeaders(options?: {
     forward?: BackstageCredentials;
   }): Promise<Record<string, string>>;

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -15,33 +15,17 @@
  */
 
 import { Request, Response } from 'express';
-import {
-  BackstageCredentials,
-  BackstageServicePrincipal,
-  BackstageNonePrincipal,
-  BackstageUserPrincipal,
-} from './AuthService';
-
-/** @public */
-export type BackstageHttpAccessToPrincipalTypesMapping = {
-  user: BackstageUserPrincipal;
-  'user-cookie': BackstageUserPrincipal;
-  service: BackstageServicePrincipal;
-  unauthenticated: BackstageNonePrincipal;
-  unknown: unknown;
-};
+import { BackstageCredentials, BackstagePrincipalTypes } from './AuthService';
 
 /** @public */
 export interface HttpAuthService {
-  credentials<
-    TAllowed extends
-      | keyof BackstageHttpAccessToPrincipalTypesMapping = 'unknown',
-  >(
+  credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(
     req: Request,
-    options?: { allow: Array<TAllowed> },
-  ): Promise<
-    BackstageCredentials<BackstageHttpAccessToPrincipalTypesMapping[TAllowed]>
-  >;
+    options?: {
+      allow?: Array<TAllowed>;
+      allowedAuthMethods?: Array<'token' | 'cookie'>;
+    },
+  ): Promise<BackstageCredentials<BackstagePrincipalTypes[TAllowed]>>;
 
   requestHeaders(options: {
     forward: BackstageCredentials;

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -43,8 +43,8 @@ export interface HttpAuthService {
     BackstageCredentials<BackstageHttpAccessToPrincipalTypesMapping[TAllowed]>
   >;
 
-  requestHeaders(options?: {
-    forward?: BackstageCredentials;
+  requestHeaders(options: {
+    forward: BackstageCredentials;
   }): Promise<Record<string, string>>;
 
   issueUserCookie(res: Response): Promise<void>;

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -27,9 +27,5 @@ export interface HttpAuthService {
     },
   ): Promise<BackstageCredentials<BackstagePrincipalTypes[TAllowed]>>;
 
-  requestHeaders(options: {
-    forward: BackstageCredentials;
-  }): Promise<Record<string, string>>;
-
   issueUserCookie(res: Response): Promise<void>;
 }

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -20,7 +20,7 @@ import { BackstageCredentials, BackstagePrincipalTypes } from './AuthService';
 /** @public */
 export interface HttpAuthService {
   credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(
-    req: Request,
+    req: Request<any, any, any, any, any>,
     options?: {
       allow?: Array<TAllowed>;
       allowedAuthMethods?: Array<'token' | 'cookie'>;

--- a/packages/backend-plugin-api/src/services/definitions/HttpRouterService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpRouterService.ts
@@ -16,9 +16,17 @@
 
 import { Handler } from 'express';
 
+/** @public */
+export interface HttpRouterServiceAuthPolicy {
+  path: string;
+  allow: 'unauthenticated' | 'user-cookie';
+}
+
 /**
  * @public
  */
 export interface HttpRouterService {
   use(handler: Handler): void;
+
+  addAuthPolicy(policy: HttpRouterServiceAuthPolicy): void;
 }

--- a/packages/backend-plugin-api/src/services/definitions/UserInfoService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UserInfoService.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BackstageUserCredentials } from './AuthService';
+import { BackstageCredentials } from './AuthService';
 
 /** @public */
 export interface BackstageUserInfo {
@@ -24,7 +24,5 @@ export interface BackstageUserInfo {
 
 /** @public */
 export interface UserInfoService {
-  getUserInfo(
-    credentials: BackstageUserCredentials,
-  ): Promise<BackstageUserInfo>;
+  getUserInfo(credentials: BackstageCredentials): Promise<BackstageUserInfo>;
 }

--- a/packages/backend-plugin-api/src/services/definitions/UserInfoService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UserInfoService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-export * from './auth';
-export * from './cache';
-export * from './config';
-export * from './database';
-export * from './discovery';
-export * from './httpAuth';
-export * from './httpRouter';
-export * from './identity';
-export * from './lifecycle';
-export * from './logger';
-export * from './permissions';
-export * from './rootHttpRouter';
-export * from './rootLifecycle';
-export * from './rootLogger';
-export * from './scheduler';
-export * from './tokenManager';
-export * from './urlReader';
-export * from './userInfo';
+import { BackstageUserCredentials } from './AuthService';
+
+/** @public */
+export interface BackstageUserInfo {
+  userEntityRef: string;
+  ownershipEntityRefs: string[];
+}
+
+/** @public */
+export interface UserInfoService {
+  getUserInfo(
+    credentials: BackstageUserCredentials,
+  ): Promise<BackstageUserInfo>;
+}

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -23,6 +23,15 @@ import { createServiceRef } from '../system';
  */
 export namespace coreServices {
   /**
+   * The service reference for the plugin scoped {@link IdentityService}.
+   *
+   * @public
+   */
+  export const auth = createServiceRef<import('./AuthService').AuthService>({
+    id: 'core.auth',
+  });
+
+  /**
    * The service reference for the plugin scoped {@link CacheService}.
    *
    * @public

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -32,6 +32,17 @@ export namespace coreServices {
   });
 
   /**
+   * The service reference for the plugin scoped {@link UserInfoService}.
+   *
+   * @public
+   */
+  export const userInfo = createServiceRef<
+    import('./UserInfoService').UserInfoService
+  >({
+    id: 'core.userInfo',
+  });
+
+  /**
    * The service reference for the plugin scoped {@link CacheService}.
    *
    * @public

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -68,6 +68,15 @@ export namespace coreServices {
   >({ id: 'core.discovery' });
 
   /**
+   * The service reference for the plugin scoped {@link HttpAuthService}.
+   *
+   * @public
+   */
+  export const httpAuth = createServiceRef<
+    import('./HttpAuthService').HttpAuthService
+  >({ id: 'core.httpAuth' });
+
+  /**
    * The service reference for the plugin scoped {@link HttpRouterService}.
    *
    * @public

--- a/packages/backend-plugin-api/src/services/definitions/coreServices.ts
+++ b/packages/backend-plugin-api/src/services/definitions/coreServices.ts
@@ -23,7 +23,7 @@ import { createServiceRef } from '../system';
  */
 export namespace coreServices {
   /**
-   * The service reference for the plugin scoped {@link IdentityService}.
+   * The service reference for the plugin scoped {@link AuthService}.
    *
    * @public
    */

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -18,8 +18,10 @@ export { coreServices } from './coreServices';
 export type {
   AuthService,
   BackstageCredentials,
-  BackstageServiceCredentials,
-  BackstageUserCredentials,
+  BackstageUserPrincipal,
+  BackstageServicePrincipal,
+  BackstagePrincipalTypes,
+  BackstageNonePrincipal,
 } from './AuthService';
 export type {
   CacheService,
@@ -35,8 +37,7 @@ export type {
 } from './HttpRouterService';
 export type {
   HttpAuthService,
-  BackstageCredentialTypes,
-  BackstageUnauthorizedCredentials,
+  BackstageHttpAccessToPrincipalTypesMapping,
 } from './HttpAuthService';
 export type {
   LifecycleService,

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -31,6 +31,11 @@ export type { DatabaseService } from './DatabaseService';
 export type { DiscoveryService } from './DiscoveryService';
 export type { HttpRouterService } from './HttpRouterService';
 export type {
+  HttpAuthService,
+  BackstageCredentialTypes,
+  BackstageUnauthorizedCredentials,
+} from './HttpAuthService';
+export type {
   LifecycleService,
   LifecycleServiceStartupHook,
   LifecycleServiceStartupOptions,

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -62,4 +62,5 @@ export type {
   SearchResponseFile,
   UrlReaderService,
 } from './UrlReaderService';
+export type { BackstageUserInfo, UserInfoService } from './UserInfoService';
 export type { IdentityService } from './IdentityService';

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -29,7 +29,10 @@ export type {
 export type { RootConfigService } from './RootConfigService';
 export type { DatabaseService } from './DatabaseService';
 export type { DiscoveryService } from './DiscoveryService';
-export type { HttpRouterService } from './HttpRouterService';
+export type {
+  HttpRouterService,
+  HttpRouterServiceAuthPolicy,
+} from './HttpRouterService';
 export type {
   HttpAuthService,
   BackstageCredentialTypes,

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -16,6 +16,12 @@
 
 export { coreServices } from './coreServices';
 export type {
+  AuthService,
+  BackstageCredentials,
+  BackstageServiceCredentials,
+  BackstageUserCredentials,
+} from './AuthService';
+export type {
   CacheService,
   CacheServiceOptions,
   CacheServiceSetOptions,

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -35,10 +35,7 @@ export type {
   HttpRouterService,
   HttpRouterServiceAuthPolicy,
 } from './HttpRouterService';
-export type {
-  HttpAuthService,
-  BackstageHttpAccessToPrincipalTypesMapping,
-} from './HttpAuthService';
+export type { HttpAuthService } from './HttpAuthService';
 export type {
   LifecycleService,
   LifecycleServiceStartupHook,

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -53,6 +53,7 @@ export namespace mockCredentials {
     subject?: string,
   ): BackstageCredentials<BackstageServicePrincipal>;
   export namespace service {
+    export function header(payload?: TokenPayload): string;
     export function token(payload?: TokenPayload): string;
     export type TokenPayload = {
       subject?: string;
@@ -63,9 +64,10 @@ export namespace mockCredentials {
     userEntityRef?: string,
   ): BackstageCredentials<BackstageUserPrincipal>;
   export namespace user {
+    export function header(payload?: TokenPayload): string;
     export function token(payload?: TokenPayload): string;
     export type TokenPayload = {
-      userEntityRef: string;
+      userEntityRef?: string;
     };
   }
 }

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -9,6 +9,10 @@
 import { AuthService } from '@backstage/backend-plugin-api';
 import { Backend } from '@backstage/backend-app-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
+import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { BackstageNonePrincipal } from '@backstage/backend-plugin-api';
+import { BackstageServicePrincipal } from '@backstage/backend-plugin-api';
+import { BackstageUserPrincipal } from '@backstage/backend-plugin-api';
 import { CacheService } from '@backstage/backend-plugin-api';
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
@@ -41,6 +45,30 @@ export function createMockDirectory(
 
 // @public (undocumented)
 export function isDockerDisabledForTests(): boolean;
+
+// @public (undocumented)
+export namespace mockCredentials {
+  export function none(): BackstageCredentials<BackstageNonePrincipal>;
+  export function service(
+    subject?: string,
+  ): BackstageCredentials<BackstageServicePrincipal>;
+  export namespace service {
+    export function token(payload?: TokenPayload): string;
+    export type TokenPayload = {
+      subject?: string;
+      targetPluginId?: string;
+    };
+  }
+  export function user(
+    userEntityRef?: string,
+  ): BackstageCredentials<BackstageUserPrincipal>;
+  export namespace user {
+    export function token(payload?: TokenPayload): string;
+    export type TokenPayload = {
+      userEntityRef: string;
+    };
+  }
+}
 
 // @public
 export interface MockDirectory {

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -6,12 +6,14 @@
 /// <reference types="jest" />
 /// <reference types="node" />
 
+import { AuthService } from '@backstage/backend-plugin-api';
 import { Backend } from '@backstage/backend-app-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CacheService } from '@backstage/backend-plugin-api';
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import { ExtendedHttpServer } from '@backstage/backend-app-api';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
+import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { HttpRouterFactoryOptions } from '@backstage/backend-app-api';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
 import { IdentityService } from '@backstage/backend-plugin-api';
@@ -87,6 +89,17 @@ export interface MockDirectoryOptions {
 // @public (undocumented)
 export namespace mockServices {
   // (undocumented)
+  export function auth(options?: { pluginId?: string }): AuthService;
+  // (undocumented)
+  export namespace auth {
+    const // (undocumented)
+      factory: () => ServiceFactory<AuthService, 'plugin'>;
+    const // (undocumented)
+      mock: (
+        partialImpl?: Partial<AuthService> | undefined,
+      ) => ServiceMock<AuthService>;
+  }
+  // (undocumented)
   export namespace cache {
     const // (undocumented)
       factory: () => ServiceFactory<CacheService, 'plugin'>;
@@ -103,6 +116,15 @@ export namespace mockServices {
       mock: (
         partialImpl?: Partial<DatabaseService> | undefined,
       ) => ServiceMock<DatabaseService>;
+  }
+  // (undocumented)
+  export namespace httpAuth {
+    const // (undocumented)
+      factory: () => ServiceFactory<HttpAuthService, 'plugin'>;
+    const // (undocumented)
+      mock: (
+        partialImpl?: Partial<HttpAuthService> | undefined,
+      ) => ServiceMock<HttpAuthService>;
   }
   // (undocumented)
   export namespace httpRouter {

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -49,15 +49,22 @@ export function isDockerDisabledForTests(): boolean;
 // @public (undocumented)
 export namespace mockCredentials {
   export function none(): BackstageCredentials<BackstageNonePrincipal>;
+  export namespace none {
+    export function header(): string;
+  }
   export function service(
     subject?: string,
   ): BackstageCredentials<BackstageServicePrincipal>;
   export namespace service {
-    export function header(payload?: TokenPayload): string;
-    export function token(payload?: TokenPayload): string;
-    export type TokenPayload = {
-      subject?: string;
-      targetPluginId?: string;
+    export function header(options?: TokenOptions): string;
+    // (undocumented)
+    export function invalidHeader(): string;
+    // (undocumented)
+    export function invalidToken(): string;
+    export function token(options?: TokenOptions): string;
+    export type TokenOptions = {
+      onBehalfOf: BackstageCredentials;
+      targetPluginId: string;
     };
   }
   export function user(
@@ -65,10 +72,11 @@ export namespace mockCredentials {
   ): BackstageCredentials<BackstageUserPrincipal>;
   export namespace user {
     export function header(userEntityRef?: string): string;
+    // (undocumented)
+    export function invalidHeader(): string;
+    // (undocumented)
+    export function invalidToken(): string;
     export function token(userEntityRef?: string): string;
-    export type TokenPayload = {
-      userEntityRef?: string;
-    };
   }
 }
 
@@ -159,12 +167,19 @@ export namespace mockServices {
         partialImpl?: Partial<DiscoveryService> | undefined,
       ) => ServiceMock<DiscoveryService>;
   }
-  // (undocumented)
-  export function httpAuth(options?: { pluginId?: string }): HttpAuthService;
+  export function httpAuth(options?: {
+    pluginId?: string;
+    defaultCredentials?: BackstageCredentials;
+  }): HttpAuthService;
   // (undocumented)
   export namespace httpAuth {
-    const // (undocumented)
-      factory: () => ServiceFactory<HttpAuthService, 'plugin'>;
+    const factory: (
+      options?:
+        | {
+            defaultCredentials?: BackstageCredentials | undefined;
+          }
+        | undefined,
+    ) => ServiceFactory<HttpAuthService, 'plugin'>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<HttpAuthService> | undefined,

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -64,8 +64,8 @@ export namespace mockCredentials {
     userEntityRef?: string,
   ): BackstageCredentials<BackstageUserPrincipal>;
   export namespace user {
-    export function header(payload?: TokenPayload): string;
-    export function token(payload?: TokenPayload): string;
+    export function header(userEntityRef?: string): string;
+    export function token(userEntityRef?: string): string;
     export type TokenPayload = {
       userEntityRef?: string;
     };

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -128,7 +128,10 @@ export interface MockDirectoryOptions {
 // @public (undocumented)
 export namespace mockServices {
   // (undocumented)
-  export function auth(options?: { pluginId?: string }): AuthService;
+  export function auth(options?: {
+    pluginId?: string;
+    disableDefaultAuthPolicy?: boolean;
+  }): AuthService;
   // (undocumented)
   export namespace auth {
     const // (undocumented)

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -11,6 +11,7 @@ import { Backend } from '@backstage/backend-app-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CacheService } from '@backstage/backend-plugin-api';
 import { DatabaseService } from '@backstage/backend-plugin-api';
+import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { ExtendedHttpServer } from '@backstage/backend-app-api';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
@@ -117,6 +118,19 @@ export namespace mockServices {
         partialImpl?: Partial<DatabaseService> | undefined,
       ) => ServiceMock<DatabaseService>;
   }
+  // (undocumented)
+  export function discovery(): DiscoveryService;
+  // (undocumented)
+  export namespace discovery {
+    const // (undocumented)
+      factory: () => ServiceFactory<DiscoveryService, 'plugin'>;
+    const // (undocumented)
+      mock: (
+        partialImpl?: Partial<DiscoveryService> | undefined,
+      ) => ServiceMock<DiscoveryService>;
+  }
+  // (undocumented)
+  export function httpAuth(options?: { pluginId?: string }): HttpAuthService;
   // (undocumented)
   export namespace httpAuth {
     const // (undocumented)

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -24,7 +24,10 @@ import {
 } from './mockCredentials';
 
 describe('MockAuthService', () => {
-  const auth = new MockAuthService('test');
+  const auth = new MockAuthService({
+    pluginId: 'test',
+    disableDefaultAuthPolicy: false,
+  });
 
   it('should reject invalid tokens', async () => {
     await expect(auth.authenticate('')).rejects.toThrow('Token is empty');

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -57,6 +57,10 @@ describe('MockAuthService', () => {
     await expect(
       auth.authenticate(mockCredentials.user.token('user:default/other')),
     ).resolves.toEqual(mockCredentials.user('user:default/other'));
+
+    await expect(
+      auth.authenticate(mockCredentials.user.invalidToken()),
+    ).rejects.toThrow('User token is invalid');
   });
 
   it('should authenticate mock service tokens', async () => {
@@ -91,6 +95,10 @@ describe('MockAuthService', () => {
     ).rejects.toThrow(
       "Invalid mock token target plugin ID, got 'other' but expected 'test'",
     );
+
+    await expect(
+      auth.authenticate(mockCredentials.service.invalidToken()),
+    ).rejects.toThrow('Service token is invalid');
   });
 
   it('should return own service credentials', async () => {

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -55,9 +55,7 @@ describe('MockAuthService', () => {
     ).resolves.toEqual(mockCredentials.user(DEFAULT_MOCK_USER_ENTITY_REF));
 
     await expect(
-      auth.authenticate(
-        mockCredentials.user.token({ userEntityRef: 'user:default/other' }),
-      ),
+      auth.authenticate(mockCredentials.user.token('user:default/other')),
     ).resolves.toEqual(mockCredentials.user('user:default/other'));
   });
 

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MockAuthService } from './MockAuthService';
+import {
+  DEFAULT_MOCK_SERVICE_SUBJECT,
+  DEFAULT_MOCK_USER_ENTITY_REF,
+  MOCK_SERVICE_TOKEN_PREFIX,
+  MOCK_USER_TOKEN_PREFIX,
+  mockCredentials,
+} from './mockCredentials';
+
+describe('MockAuthService', () => {
+  const auth = new MockAuthService('test');
+
+  it('should reject invalid tokens', async () => {
+    await expect(auth.authenticate('')).rejects.toThrow('Invalid mock token');
+    await expect(auth.authenticate('not-a-mock-token')).rejects.toThrow(
+      'Invalid mock token',
+    );
+    await expect(auth.authenticate(MOCK_USER_TOKEN_PREFIX)).rejects.toThrow(
+      'Unexpected end of JSON input',
+    );
+    await expect(
+      auth.authenticate(`${MOCK_USER_TOKEN_PREFIX}{"invalid":json}`),
+    ).rejects.toThrow('Unexpected token');
+    await expect(auth.authenticate(MOCK_SERVICE_TOKEN_PREFIX)).rejects.toThrow(
+      'Unexpected end of JSON input',
+    );
+    await expect(
+      auth.authenticate(`${MOCK_SERVICE_TOKEN_PREFIX}{"invalid":json}`),
+    ).rejects.toThrow('Unexpected token');
+  });
+
+  it('should authenticate mock user tokens', async () => {
+    await expect(
+      auth.authenticate(mockCredentials.user.token()),
+    ).resolves.toEqual(mockCredentials.user());
+
+    await expect(
+      auth.authenticate(mockCredentials.user.token()),
+    ).resolves.toEqual(mockCredentials.user(DEFAULT_MOCK_USER_ENTITY_REF));
+
+    await expect(
+      auth.authenticate(
+        mockCredentials.user.token({ userEntityRef: 'user:default/other' }),
+      ),
+    ).resolves.toEqual(mockCredentials.user('user:default/other'));
+  });
+
+  it('should authenticate mock service tokens', async () => {
+    await expect(
+      auth.authenticate(mockCredentials.service.token()),
+    ).resolves.toEqual(mockCredentials.service());
+
+    await expect(
+      auth.authenticate(mockCredentials.service.token()),
+    ).resolves.toEqual(mockCredentials.service(DEFAULT_MOCK_SERVICE_SUBJECT));
+
+    await expect(
+      auth.authenticate(
+        mockCredentials.service.token({ subject: 'plugin:catalog' }),
+      ),
+    ).resolves.toEqual(mockCredentials.service('plugin:catalog'));
+
+    await expect(
+      auth.authenticate(
+        mockCredentials.service.token({
+          targetPluginId: 'test',
+        }),
+      ),
+    ).resolves.toEqual(mockCredentials.service());
+
+    await expect(
+      auth.authenticate(
+        mockCredentials.service.token({
+          targetPluginId: 'other',
+        }),
+      ),
+    ).rejects.toThrow(
+      "Invalid mock token target plugin ID, got 'other' but expected 'test'",
+    );
+  });
+
+  it('should return own service credentials', async () => {
+    await expect(auth.getOwnServiceCredentials()).resolves.toEqual(
+      mockCredentials.service('plugin:test'),
+    );
+  });
+
+  it('should check principal types', () => {
+    const none = mockCredentials.none();
+    const user = mockCredentials.user();
+    const service = mockCredentials.service();
+
+    expect(auth.isPrincipal(none, 'unknown')).toBe(true);
+    expect(auth.isPrincipal(user, 'unknown')).toBe(true);
+    expect(auth.isPrincipal(service, 'unknown')).toBe(true);
+
+    expect(auth.isPrincipal(none, 'none')).toBe(true);
+    expect(auth.isPrincipal(user, 'none')).toBe(false);
+    expect(auth.isPrincipal(service, 'none')).toBe(false);
+
+    expect(auth.isPrincipal(none, 'user')).toBe(false);
+    expect(auth.isPrincipal(user, 'user')).toBe(true);
+    expect(auth.isPrincipal(service, 'user')).toBe(false);
+
+    expect(auth.isPrincipal(none, 'service')).toBe(false);
+    expect(auth.isPrincipal(user, 'service')).toBe(false);
+    expect(auth.isPrincipal(service, 'service')).toBe(true);
+  });
+
+  it('should issue plugin request tokens', async () => {
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: mockCredentials.user(),
+        targetPluginId: 'test',
+      }),
+    ).resolves.toEqual({ token: mockCredentials.user.token() });
+
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: mockCredentials.service(),
+        targetPluginId: 'test',
+      }),
+    ).resolves.toEqual({
+      token: mockCredentials.service.token({
+        targetPluginId: 'test',
+      }),
+    });
+
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: mockCredentials.service('external:other'),
+        targetPluginId: 'test',
+      }),
+    ).resolves.toEqual({
+      token: mockCredentials.service.token({
+        subject: 'external:other',
+        targetPluginId: 'test',
+      }),
+    });
+
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: await auth.getOwnServiceCredentials(),
+        targetPluginId: 'other',
+      }),
+    ).resolves.toEqual({
+      token: mockCredentials.service.token({
+        subject: 'plugin:test',
+        targetPluginId: 'other',
+      }),
+    });
+  });
+});

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -139,6 +139,15 @@ describe('MockAuthService', () => {
 
     await expect(
       auth.getPluginRequestToken({
+        onBehalfOf: mockCredentials.user('user:default/other'),
+        targetPluginId: 'test',
+      }),
+    ).resolves.toEqual({
+      token: mockCredentials.user.token('user:default/other'),
+    });
+
+    await expect(
+      auth.getPluginRequestToken({
         onBehalfOf: mockCredentials.service(),
         targetPluginId: 'test',
       }),
@@ -171,5 +180,14 @@ describe('MockAuthService', () => {
         targetPluginId: 'other',
       }),
     });
+
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: await mockCredentials.none(),
+        targetPluginId: 'other',
+      }),
+    ).rejects.toThrow(
+      `Refused to issue service token for credential type 'none'`,
+    );
   });
 });

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -27,9 +27,9 @@ describe('MockAuthService', () => {
   const auth = new MockAuthService('test');
 
   it('should reject invalid tokens', async () => {
-    await expect(auth.authenticate('')).rejects.toThrow('Invalid mock token');
+    await expect(auth.authenticate('')).rejects.toThrow('Token is empty');
     await expect(auth.authenticate('not-a-mock-token')).rejects.toThrow(
-      'Invalid mock token',
+      "Unknown mock token 'not-a-mock-token'",
     );
     await expect(auth.authenticate(MOCK_USER_TOKEN_PREFIX)).rejects.toThrow(
       'Unexpected end of JSON input',

--- a/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.test.ts
@@ -73,22 +73,31 @@ describe('MockAuthService', () => {
     ).resolves.toEqual(mockCredentials.service(DEFAULT_MOCK_SERVICE_SUBJECT));
 
     await expect(
+      auth.authenticate(mockCredentials.service.token()),
+    ).resolves.toEqual(mockCredentials.service());
+
+    await expect(
       auth.authenticate(
-        mockCredentials.service.token({ subject: 'plugin:catalog' }),
+        mockCredentials.service.token({
+          onBehalfOf: mockCredentials.service('plugin:catalog'),
+          targetPluginId: 'test',
+        }),
       ),
     ).resolves.toEqual(mockCredentials.service('plugin:catalog'));
 
     await expect(
       auth.authenticate(
         mockCredentials.service.token({
+          onBehalfOf: await auth.getOwnServiceCredentials(),
           targetPluginId: 'test',
         }),
       ),
-    ).resolves.toEqual(mockCredentials.service());
+    ).resolves.toEqual(mockCredentials.service('plugin:test'));
 
     await expect(
       auth.authenticate(
         mockCredentials.service.token({
+          onBehalfOf: await auth.getOwnServiceCredentials(),
           targetPluginId: 'other',
         }),
       ),
@@ -135,7 +144,12 @@ describe('MockAuthService', () => {
         onBehalfOf: mockCredentials.user(),
         targetPluginId: 'test',
       }),
-    ).resolves.toEqual({ token: mockCredentials.user.token() });
+    ).resolves.toEqual({
+      token: mockCredentials.service.token({
+        onBehalfOf: mockCredentials.user(),
+        targetPluginId: 'test',
+      }),
+    });
 
     await expect(
       auth.getPluginRequestToken({
@@ -143,7 +157,10 @@ describe('MockAuthService', () => {
         targetPluginId: 'test',
       }),
     ).resolves.toEqual({
-      token: mockCredentials.user.token('user:default/other'),
+      token: mockCredentials.service.token({
+        onBehalfOf: mockCredentials.user('user:default/other'),
+        targetPluginId: 'test',
+      }),
     });
 
     await expect(
@@ -153,6 +170,7 @@ describe('MockAuthService', () => {
       }),
     ).resolves.toEqual({
       token: mockCredentials.service.token({
+        onBehalfOf: mockCredentials.service(),
         targetPluginId: 'test',
       }),
     });
@@ -164,7 +182,7 @@ describe('MockAuthService', () => {
       }),
     ).resolves.toEqual({
       token: mockCredentials.service.token({
-        subject: 'external:other',
+        onBehalfOf: mockCredentials.service('external:other'),
         targetPluginId: 'test',
       }),
     });
@@ -176,7 +194,7 @@ describe('MockAuthService', () => {
       }),
     ).resolves.toEqual({
       token: mockCredentials.service.token({
-        subject: 'plugin:test',
+        onBehalfOf: await mockCredentials.service('plugin:test'),
         targetPluginId: 'other',
       }),
     });

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -49,6 +49,8 @@ export class MockAuthService implements AuthService {
         throw new AuthenticationError('User token is invalid');
       case MOCK_INVALID_SERVICE_TOKEN:
         throw new AuthenticationError('Service token is invalid');
+      case '':
+        throw new AuthenticationError('Token is empty');
       default:
     }
 
@@ -73,7 +75,7 @@ export class MockAuthService implements AuthService {
       return mockCredentials.service(subject);
     }
 
-    throw new AuthenticationError('Invalid mock token');
+    throw new AuthenticationError(`Unknown mock token '${token}'`);
   }
 
   async getOwnServiceCredentials(): Promise<

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -59,7 +59,7 @@ export class MockAuthService implements AuthService {
 
       if (targetPluginId && targetPluginId !== this.pluginId) {
         throw new AuthenticationError(
-          `Invalid mock token target, got ${targetPluginId} but expected ${this.pluginId}`,
+          `Invalid mock token target plugin ID, got '${targetPluginId}' but expected '${this.pluginId}'`,
         );
       }
 
@@ -72,10 +72,7 @@ export class MockAuthService implements AuthService {
   async getOwnServiceCredentials(): Promise<
     BackstageCredentials<BackstageServicePrincipal>
   > {
-    return {
-      $$type: '@backstage/BackstageCredentials',
-      principal: { type: 'service', subject: `plugin:${this.pluginId}` },
-    };
+    return mockCredentials.service(`plugin:${this.pluginId}`);
   }
 
   isPrincipal<TType extends keyof BackstagePrincipalTypes>(

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackstageCredentials,
+  BackstageServicePrincipal,
+  BackstagePrincipalTypes,
+  BackstageUserPrincipal,
+  BackstageNonePrincipal,
+  AuthService,
+} from '@backstage/backend-plugin-api';
+import { AuthenticationError } from '@backstage/errors';
+
+/** @internal */
+export class MockAuthService implements AuthService {
+  constructor(private readonly pluginId: string) {}
+
+  async authenticate(token: string): Promise<BackstageCredentials> {
+    if (token === 'mock-user-token') {
+      return {
+        $$type: '@backstage/BackstageCredentials',
+        principal: { type: 'user', userEntityRef: 'user:default/mock' },
+      };
+    } else if (token === 'mock-service-token') {
+      return {
+        $$type: '@backstage/BackstageCredentials',
+        principal: { type: 'service', subject: 'external:test-service' },
+      };
+    }
+
+    throw new AuthenticationError('Invalid token');
+  }
+
+  async getOwnCredentials(): Promise<
+    BackstageCredentials<BackstageServicePrincipal>
+  > {
+    return {
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'service', subject: `plugin:${this.pluginId}` },
+    };
+  }
+
+  isPrincipal<TType extends keyof BackstagePrincipalTypes>(
+    credentials: BackstageCredentials,
+    type: TType,
+  ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]> {
+    const principal = credentials.principal as
+      | BackstageUserPrincipal
+      | BackstageServicePrincipal
+      | BackstageNonePrincipal;
+    if (principal.type !== type) {
+      return false;
+    }
+
+    return true;
+  }
+
+  async issueServiceToken(options: {
+    forward: BackstageCredentials;
+  }): Promise<{ token: string }> {
+    const principal = options.forward.principal as
+      | BackstageUserPrincipal
+      | BackstageServicePrincipal
+      | BackstageNonePrincipal;
+
+    switch (principal.type) {
+      case 'user':
+        return { token: 'mock-user-token' };
+      case 'service':
+        return { token: 'mock-service-token' };
+      default:
+        throw new AuthenticationError(
+          `Refused to issue service token for credential type '${principal.type}'`,
+        );
+    }
+  }
+}

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -31,6 +31,8 @@ import {
   MOCK_SERVICE_TOKEN_PREFIX,
   DEFAULT_MOCK_USER_ENTITY_REF,
   DEFAULT_MOCK_SERVICE_SUBJECT,
+  MOCK_INVALID_USER_TOKEN,
+  MOCK_INVALID_SERVICE_TOKEN,
 } from './mockCredentials';
 
 /** @internal */
@@ -38,11 +40,16 @@ export class MockAuthService implements AuthService {
   constructor(private readonly pluginId: string) {}
 
   async authenticate(token: string): Promise<BackstageCredentials> {
-    if (token === MOCK_USER_TOKEN) {
-      return mockCredentials.user();
-    }
-    if (token === MOCK_SERVICE_TOKEN) {
-      return mockCredentials.service();
+    switch (token) {
+      case MOCK_USER_TOKEN:
+        return mockCredentials.user();
+      case MOCK_SERVICE_TOKEN:
+        return mockCredentials.service();
+      case MOCK_INVALID_USER_TOKEN:
+        throw new AuthenticationError('User token is invalid');
+      case MOCK_INVALID_SERVICE_TOKEN:
+        throw new AuthenticationError('Service token is invalid');
+      default:
     }
 
     if (token.startsWith(MOCK_USER_TOKEN_PREFIX)) {

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -37,7 +37,16 @@ import {
 
 /** @internal */
 export class MockAuthService implements AuthService {
-  constructor(private readonly pluginId: string) {}
+  readonly pluginId: string;
+  readonly disableDefaultAuthPolicy: boolean;
+
+  constructor(options: {
+    pluginId: string;
+    disableDefaultAuthPolicy: boolean;
+  }) {
+    this.pluginId = options.pluginId;
+    this.disableDefaultAuthPolicy = options.disableDefaultAuthPolicy;
+  }
 
   async authenticate(token: string): Promise<BackstageCredentials> {
     switch (token) {
@@ -116,6 +125,10 @@ export class MockAuthService implements AuthService {
       | BackstageUserPrincipal
       | BackstageServicePrincipal
       | BackstageNonePrincipal;
+
+    if (principal.type === 'none' && this.disableDefaultAuthPolicy) {
+      return { token: '' };
+    }
 
     if (principal.type !== 'user' && principal.type !== 'service') {
       throw new AuthenticationError(

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -110,9 +110,7 @@ export class MockAuthService implements AuthService {
           return { token: mockCredentials.user.token() };
         }
         return {
-          token: mockCredentials.user.token({
-            userEntityRef: principal.userEntityRef,
-          }),
+          token: mockCredentials.user.token(principal.userEntityRef),
         };
       case 'service':
         return {

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -44,7 +44,7 @@ export class MockAuthService implements AuthService {
     throw new AuthenticationError('Invalid token');
   }
 
-  async getOwnCredentials(): Promise<
+  async getOwnServiceCredentials(): Promise<
     BackstageCredentials<BackstageServicePrincipal>
   > {
     return {
@@ -68,10 +68,11 @@ export class MockAuthService implements AuthService {
     return true;
   }
 
-  async issueServiceToken(options: {
-    forward: BackstageCredentials;
+  async getPluginRequestToken(options: {
+    onBehalfOf: BackstageCredentials;
+    targetPluginId: string;
   }): Promise<{ token: string }> {
-    const principal = options.forward.principal as
+    const principal = options.onBehalfOf.principal as
       | BackstageUserPrincipal
       | BackstageServicePrincipal
       | BackstageNonePrincipal;
@@ -80,7 +81,7 @@ export class MockAuthService implements AuthService {
       case 'user':
         return { token: 'mock-user-token' };
       case 'service':
-        return { token: 'mock-service-token' };
+        return { token: `mock-service-token-for-${options.targetPluginId}` };
       default:
         throw new AuthenticationError(
           `Refused to issue service token for credential type '${principal.type}'`,

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -61,6 +61,7 @@ export class MockAuthService implements AuthService {
       case '':
         throw new AuthenticationError('Token is empty');
       default:
+        break;
     }
 
     if (token.startsWith(MOCK_USER_TOKEN_PREFIX)) {

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -86,6 +86,11 @@ export class MockAuthService implements AuthService {
       | BackstageUserPrincipal
       | BackstageServicePrincipal
       | BackstageNonePrincipal;
+
+    if (type === 'unknown') {
+      return true;
+    }
+
     if (principal.type !== type) {
       return false;
     }

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
@@ -19,7 +19,7 @@ import { MockHttpAuthService } from './MockHttpAuthService';
 import { mockCredentials } from './mockCredentials';
 
 describe('MockHttpAuthService', () => {
-  const httpAuth = new MockHttpAuthService('test');
+  const httpAuth = new MockHttpAuthService('test', mockCredentials.none());
 
   function makeAuthReq(header?: string) {
     return { headers: { authorization: header } } as Request;
@@ -91,6 +91,54 @@ describe('MockHttpAuthService', () => {
         allow: ['user'],
       }),
     ).rejects.toThrow("This endpoint does not allow 'service' credentials");
+  });
+
+  it('should default to different credential types', async () => {
+    const noneAuth = new MockHttpAuthService('test', mockCredentials.none());
+    const userAuth = new MockHttpAuthService('test', mockCredentials.user());
+    const serviceAuth = new MockHttpAuthService(
+      'test',
+      mockCredentials.service(),
+    );
+
+    await expect(noneAuth.credentials(makeAuthReq())).resolves.toEqual(
+      mockCredentials.none(),
+    );
+    await expect(
+      noneAuth.credentials(makeAuthReq(mockCredentials.none.header())),
+    ).resolves.toEqual(mockCredentials.none());
+    await expect(
+      noneAuth.credentials(makeAuthReq(mockCredentials.user.header())),
+    ).resolves.toEqual(mockCredentials.user());
+    await expect(
+      noneAuth.credentials(makeAuthReq(mockCredentials.service.header())),
+    ).resolves.toEqual(mockCredentials.service());
+
+    await expect(userAuth.credentials(makeAuthReq())).resolves.toEqual(
+      mockCredentials.user(),
+    );
+    await expect(
+      userAuth.credentials(makeAuthReq(mockCredentials.none.header())),
+    ).resolves.toEqual(mockCredentials.none());
+    await expect(
+      userAuth.credentials(makeAuthReq(mockCredentials.user.header())),
+    ).resolves.toEqual(mockCredentials.user());
+    await expect(
+      userAuth.credentials(makeAuthReq(mockCredentials.service.header())),
+    ).resolves.toEqual(mockCredentials.service());
+
+    await expect(serviceAuth.credentials(makeAuthReq())).resolves.toEqual(
+      mockCredentials.service(),
+    );
+    await expect(
+      serviceAuth.credentials(makeAuthReq(mockCredentials.none.header())),
+    ).resolves.toEqual(mockCredentials.none());
+    await expect(
+      serviceAuth.credentials(makeAuthReq(mockCredentials.user.header())),
+    ).resolves.toEqual(mockCredentials.user());
+    await expect(
+      serviceAuth.credentials(makeAuthReq(mockCredentials.service.header())),
+    ).resolves.toEqual(mockCredentials.service());
   });
 
   it('should reject invalid credentials', async () => {

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Request } from 'express';
+import { MockHttpAuthService } from './MockHttpAuthService';
+import { mockCredentials } from './mockCredentials';
+
+describe('MockHttpAuthService', () => {
+  const httpAuth = new MockHttpAuthService('test');
+
+  it('should authenticate requests', async () => {
+    await expect(
+      httpAuth.credentials({
+        headers: {},
+      } as Request),
+    ).resolves.toEqual(mockCredentials.none());
+
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: mockCredentials.user.header(),
+        },
+      } as Request),
+    ).resolves.toEqual(mockCredentials.user());
+
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: mockCredentials.user.header('user:default/other'),
+        },
+      } as Request),
+    ).resolves.toEqual(mockCredentials.user('user:default/other'));
+
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: mockCredentials.service.header(),
+        },
+      } as Request),
+    ).resolves.toEqual(mockCredentials.service());
+
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: mockCredentials.service.header({
+            subject: 'plugin:other',
+          }),
+        },
+      } as Request),
+    ).resolves.toEqual(mockCredentials.service('plugin:other'));
+  });
+
+  it('should reject invalid credentials', async () => {
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: 'Bearer bad',
+        },
+      } as Request),
+    ).rejects.toThrow("Unknown mock token 'bad'");
+
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: mockCredentials.user.invalidHeader(),
+        },
+      } as Request),
+    ).rejects.toThrow('User token is invalid');
+
+    await expect(
+      httpAuth.credentials({
+        headers: {
+          authorization: mockCredentials.service.invalidHeader(),
+        },
+      } as Request),
+    ).rejects.toThrow('Service token is invalid');
+  });
+});

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
@@ -81,7 +81,10 @@ describe('MockHttpAuthService', () => {
     await expect(
       httpAuth.credentials(
         makeAuthReq(
-          mockCredentials.service.header({ subject: 'plugin:other' }),
+          mockCredentials.service.header({
+            onBehalfOf: mockCredentials.service('plugin:other'),
+            targetPluginId: 'test',
+          }),
         ),
       ),
     ).resolves.toEqual(mockCredentials.service('plugin:other'));

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.test.ts
@@ -17,6 +17,7 @@
 import { Request } from 'express';
 import { MockHttpAuthService } from './MockHttpAuthService';
 import { mockCredentials } from './mockCredentials';
+import { AuthenticationError } from '@backstage/errors';
 
 describe('MockHttpAuthService', () => {
   const httpAuth = new MockHttpAuthService('test', mockCredentials.none());
@@ -36,7 +37,7 @@ describe('MockHttpAuthService', () => {
 
     await expect(
       httpAuth.credentials(makeAuthReq(), { allow: ['user'] }),
-    ).rejects.toThrow("This endpoint does not allow 'none' credentials");
+    ).rejects.toThrow(AuthenticationError);
 
     await expect(httpAuth.credentials(makeAuthReq())).resolves.toEqual(
       mockCredentials.none(),

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
@@ -60,13 +60,13 @@ export class MockHttpAuthService implements HttpAuthService {
       return credentials as any;
     }
 
-    if (this.#auth.isPrincipal(credentials, 'unauthenticated')) {
+    if (this.#auth.isPrincipal(credentials, 'none')) {
       if (allowedPrincipalTypes.includes('none' as TAllowed)) {
         return credentials as any;
       }
 
       throw new NotAllowedError(
-        `This endpoint does not allow 'unauthenticated' credentials`,
+        `This endpoint does not allow 'none' credentials`,
       );
     } else if (this.#auth.isPrincipal(credentials, 'user')) {
       if (allowedPrincipalTypes.includes('user' as TAllowed)) {

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AuthService,
+  BackstageCredentials,
+  BackstagePrincipalTypes,
+  HttpAuthService,
+} from '@backstage/backend-plugin-api';
+import { Request, Response } from 'express';
+import { mockCredentials } from './mockCredentials';
+import { MockAuthService } from './MockAuthService';
+import { NotAllowedError, NotImplementedError } from '@backstage/errors';
+
+// TODO: support mock cookie auth?
+export class MockHttpAuthService implements HttpAuthService {
+  #auth: AuthService;
+
+  constructor(pluginId: string) {
+    this.#auth = new MockAuthService(pluginId);
+  }
+
+  async #getCredentials(req: Request) {
+    const header = req.headers.authorization;
+    const token =
+      typeof header === 'string'
+        ? header.match(/^Bearer[ ]+(\S+)$/i)?.[1]
+        : undefined;
+    if (!token) {
+      return mockCredentials.none();
+    }
+
+    return await this.#auth.authenticate(token);
+  }
+
+  async credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(
+    req: Request,
+    options?: {
+      allow?: Array<TAllowed>;
+      allowedAuthMethods?: Array<'token' | 'cookie'>;
+    },
+  ): Promise<BackstageCredentials<BackstagePrincipalTypes[TAllowed]>> {
+    const credentials = await this.#getCredentials(req);
+
+    const allowedPrincipalTypes = options?.allow;
+    if (!allowedPrincipalTypes) {
+      return credentials as any;
+    }
+
+    if (this.#auth.isPrincipal(credentials, 'unauthenticated')) {
+      if (allowedPrincipalTypes.includes('none' as TAllowed)) {
+        return credentials as any;
+      }
+
+      throw new NotAllowedError(
+        `This endpoint does not allow 'unauthenticated' credentials`,
+      );
+    } else if (this.#auth.isPrincipal(credentials, 'user')) {
+      if (allowedPrincipalTypes.includes('user' as TAllowed)) {
+        return credentials as any;
+      }
+
+      throw new NotAllowedError(
+        `This endpoint does not allow 'user' credentials`,
+      );
+    } else if (this.#auth.isPrincipal(credentials, 'service')) {
+      if (allowedPrincipalTypes.includes('service' as TAllowed)) {
+        return credentials as any;
+      }
+
+      throw new NotAllowedError(
+        `This endpoint does not allow 'service' credentials`,
+      );
+    }
+
+    throw new NotAllowedError(
+      'Unknown principal type, this should never happen',
+    );
+  }
+
+  async issueUserCookie(_res: Response): Promise<void> {
+    throw new NotImplementedError('Not implemented');
+  }
+}

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
@@ -35,7 +35,10 @@ export class MockHttpAuthService implements HttpAuthService {
   #defaultCredentials: BackstageCredentials;
 
   constructor(pluginId: string, defaultCredentials: BackstageCredentials) {
-    this.#auth = new MockAuthService(pluginId);
+    this.#auth = new MockAuthService({
+      pluginId,
+      disableDefaultAuthPolicy: false,
+    });
     this.#defaultCredentials = defaultCredentials;
   }
 

--- a/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockHttpAuthService.ts
@@ -22,7 +22,11 @@ import {
 } from '@backstage/backend-plugin-api';
 import { Request, Response } from 'express';
 import { MockAuthService } from './MockAuthService';
-import { NotAllowedError, NotImplementedError } from '@backstage/errors';
+import {
+  AuthenticationError,
+  NotAllowedError,
+  NotImplementedError,
+} from '@backstage/errors';
 import { mockCredentials } from './mockCredentials';
 
 // TODO: support mock cookie auth?
@@ -73,9 +77,7 @@ export class MockHttpAuthService implements HttpAuthService {
         return credentials as any;
       }
 
-      throw new NotAllowedError(
-        `This endpoint does not allow 'none' credentials`,
-      );
+      throw new AuthenticationError();
     } else if (this.#auth.isPrincipal(credentials, 'user')) {
       if (allowedPrincipalTypes.includes('user' as TAllowed)) {
         return credentials as any;

--- a/packages/backend-test-utils/src/next/services/index.ts
+++ b/packages/backend-test-utils/src/next/services/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { mockServices, type ServiceMock } from './mockServices';
+export { mockCredentials } from './mockCredentials';

--- a/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
@@ -55,13 +55,13 @@ describe('mockCredentials', () => {
   it('creates user tokens and headers', () => {
     expect(mockCredentials.user.token()).toBe('mock-user-token');
     expect(mockCredentials.user.token('user:default/other')).toBe(
-      'mock-user-token:{"userEntityRef":"user:default/other"}',
+      'mock-user-token:{"sub":"user:default/other"}',
     );
     expect(mockCredentials.user.invalidToken()).toBe('mock-invalid-user-token');
 
     expect(mockCredentials.user.header()).toBe('Bearer mock-user-token');
     expect(mockCredentials.user.header('user:default/other')).toBe(
-      'Bearer mock-user-token:{"userEntityRef":"user:default/other"}',
+      'Bearer mock-user-token:{"sub":"user:default/other"}',
     );
     expect(mockCredentials.user.invalidHeader()).toBe(
       'Bearer mock-invalid-user-token',
@@ -70,60 +70,38 @@ describe('mockCredentials', () => {
 
   it('creates service tokens and headers', () => {
     expect(mockCredentials.service.token()).toBe('mock-service-token');
-    expect(mockCredentials.service.token({ subject: 'external:other' })).toBe(
-      'mock-service-token:{"subject":"external:other"}',
-    );
     expect(
       mockCredentials.service.token({
+        onBehalfOf: mockCredentials.service('external:other'),
         targetPluginId: 'other',
       }),
-    ).toBe('mock-service-token:{"targetPluginId":"other"}');
+    ).toBe('mock-service-token:{"sub":"external:other","target":"other"}');
     expect(
       mockCredentials.service.token({
-        subject: 'external:other',
+        onBehalfOf: mockCredentials.user('user:default/other'),
         targetPluginId: 'other',
       }),
-    ).toBe(
-      'mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
-    );
-    // Object keys are reordered, ordering in the token should be stable
-    expect(
-      mockCredentials.service.token({
-        targetPluginId: 'other',
-        subject: 'external:other',
-      }),
-    ).toBe(
-      'mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
-    );
+    ).toBe('mock-service-token:{"obo":"user:default/other","target":"other"}');
     expect(mockCredentials.service.invalidToken()).toBe(
       'mock-invalid-service-token',
     );
 
     expect(mockCredentials.service.header()).toBe('Bearer mock-service-token');
-    expect(mockCredentials.service.header({ subject: 'external:other' })).toBe(
-      'Bearer mock-service-token:{"subject":"external:other"}',
-    );
     expect(
       mockCredentials.service.header({
-        targetPluginId: 'other',
-      }),
-    ).toBe('Bearer mock-service-token:{"targetPluginId":"other"}');
-    expect(
-      mockCredentials.service.header({
-        subject: 'external:other',
+        onBehalfOf: mockCredentials.service('external:other'),
         targetPluginId: 'other',
       }),
     ).toBe(
-      'Bearer mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+      'Bearer mock-service-token:{"sub":"external:other","target":"other"}',
     );
-    // Object keys are reordered, ordering in the token should be stable
     expect(
       mockCredentials.service.header({
+        onBehalfOf: mockCredentials.user('user:default/other'),
         targetPluginId: 'other',
-        subject: 'external:other',
       }),
     ).toBe(
-      'Bearer mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+      'Bearer mock-service-token:{"obo":"user:default/other","target":"other"}',
     );
     expect(mockCredentials.service.invalidHeader()).toBe(
       'Bearer mock-invalid-service-token',

--- a/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
@@ -53,9 +53,14 @@ describe('mockCredentials', () => {
     expect(mockCredentials.user.token('user:default/other')).toBe(
       'mock-user-token:{"userEntityRef":"user:default/other"}',
     );
+    expect(mockCredentials.user.invalidToken()).toBe('mock-invalid-user-token');
+
     expect(mockCredentials.user.header()).toBe('Bearer mock-user-token');
     expect(mockCredentials.user.header('user:default/other')).toBe(
       'Bearer mock-user-token:{"userEntityRef":"user:default/other"}',
+    );
+    expect(mockCredentials.user.invalidHeader()).toBe(
+      'Bearer mock-invalid-user-token',
     );
   });
 
@@ -86,6 +91,9 @@ describe('mockCredentials', () => {
     ).toBe(
       'mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
     );
+    expect(mockCredentials.service.invalidToken()).toBe(
+      'mock-invalid-service-token',
+    );
 
     expect(mockCredentials.service.header()).toBe('Bearer mock-service-token');
     expect(mockCredentials.service.header({ subject: 'external:other' })).toBe(
@@ -112,6 +120,9 @@ describe('mockCredentials', () => {
       }),
     ).toBe(
       'Bearer mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+    );
+    expect(mockCredentials.service.invalidHeader()).toBe(
+      'Bearer mock-invalid-service-token',
     );
   });
 

--- a/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
@@ -48,6 +48,10 @@ describe('mockCredentials', () => {
     });
   });
 
+  it('creates unauthenticated tokens and headers', () => {
+    expect(mockCredentials.none.header()).toBe('Bearer mock-none-token');
+  });
+
   it('creates user tokens and headers', () => {
     expect(mockCredentials.user.token()).toBe('mock-user-token');
     expect(mockCredentials.user.token('user:default/other')).toBe(

--- a/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockCredentials } from './mockCredentials';
+
+describe('mockCredentials', () => {
+  it('creates a mocked credentials object for a none principal', () => {
+    expect(mockCredentials.none()).toEqual({
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'none' },
+    });
+  });
+
+  it('creates a mocked credentials object for a user principal', () => {
+    expect(mockCredentials.user()).toEqual({
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'user', userEntityRef: 'user:default/mock' },
+    });
+
+    expect(mockCredentials.user('user:default/other')).toEqual({
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'user', userEntityRef: 'user:default/other' },
+    });
+  });
+
+  it('creates a mocked credentials object for a service principal', () => {
+    expect(mockCredentials.service()).toEqual({
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'service', subject: 'external:test-service' },
+    });
+
+    expect(mockCredentials.service('plugin:other')).toEqual({
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'service', subject: 'plugin:other' },
+    });
+  });
+
+  it('creates user tokens and headers', () => {
+    expect(mockCredentials.user.token()).toBe('mock-user-token');
+    expect(mockCredentials.user.token('user:default/other')).toBe(
+      'mock-user-token:{"userEntityRef":"user:default/other"}',
+    );
+    expect(mockCredentials.user.header()).toBe('Bearer mock-user-token');
+    expect(mockCredentials.user.header('user:default/other')).toBe(
+      'Bearer mock-user-token:{"userEntityRef":"user:default/other"}',
+    );
+  });
+
+  it('creates service tokens and headers', () => {
+    expect(mockCredentials.service.token()).toBe('mock-service-token');
+    expect(mockCredentials.service.token({ subject: 'external:other' })).toBe(
+      'mock-service-token:{"subject":"external:other"}',
+    );
+    expect(
+      mockCredentials.service.token({
+        targetPluginId: 'other',
+      }),
+    ).toBe('mock-service-token:{"targetPluginId":"other"}');
+    expect(
+      mockCredentials.service.token({
+        subject: 'external:other',
+        targetPluginId: 'other',
+      }),
+    ).toBe(
+      'mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+    );
+    // Object keys are reordered, ordering in the token should be stable
+    expect(
+      mockCredentials.service.token({
+        targetPluginId: 'other',
+        subject: 'external:other',
+      }),
+    ).toBe(
+      'mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+    );
+
+    expect(mockCredentials.service.header()).toBe('Bearer mock-service-token');
+    expect(mockCredentials.service.header({ subject: 'external:other' })).toBe(
+      'Bearer mock-service-token:{"subject":"external:other"}',
+    );
+    expect(
+      mockCredentials.service.header({
+        targetPluginId: 'other',
+      }),
+    ).toBe('Bearer mock-service-token:{"targetPluginId":"other"}');
+    expect(
+      mockCredentials.service.header({
+        subject: 'external:other',
+        targetPluginId: 'other',
+      }),
+    ).toBe(
+      'Bearer mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+    );
+    // Object keys are reordered, ordering in the token should be stable
+    expect(
+      mockCredentials.service.header({
+        targetPluginId: 'other',
+        subject: 'external:other',
+      }),
+    ).toBe(
+      'Bearer mock-service-token:{"subject":"external:other","targetPluginId":"other"}',
+    );
+  });
+
+  it('should throw on invalid user entity refs', () => {
+    expect(() => mockCredentials.user('wrong')).toThrow(
+      "Invalid user entity reference 'wrong', expected <kind>:<namespace>/<name>",
+    );
+    expect(() => mockCredentials.user('wr:ong')).toThrow(
+      "Invalid user entity reference 'wr:ong', expected <kind>:<namespace>/<name>",
+    );
+    expect(() => mockCredentials.user('wr/ong')).toThrow(
+      "Invalid user entity reference 'wr/ong', expected <kind>:<namespace>/<name>",
+    );
+    expect(() => mockCredentials.user('wr/o:ng')).toThrow(
+      "Invalid user entity reference 'wr/o:ng', expected <kind>:<namespace>/<name>",
+    );
+    expect(() => mockCredentials.user('wr:/ong')).toThrow(
+      "Invalid user entity reference 'wr:/ong', expected <kind>:<namespace>/<name>",
+    );
+
+    expect(() => mockCredentials.user.token('wrong')).toThrow(
+      "Invalid user entity reference 'wrong', expected <kind>:<namespace>/<name>",
+    );
+    expect(() => mockCredentials.user.header('wrong')).toThrow(
+      "Invalid user entity reference 'wrong', expected <kind>:<namespace>/<name>",
+    );
+  });
+});

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -78,6 +78,15 @@ export namespace mockCredentials {
       }
       return MOCK_USER_TOKEN;
     }
+
+    /**
+     * Returns an authorization header with a mocked user token. If a payload is
+     * provided it will be encoded into the token and forwarded to the
+     * credentials object when authenticated by the mock auth service.
+     */
+    export function header(payload?: TokenPayload): string {
+      return `Bearer ${token(payload)}`;
+    }
   }
 
   /**
@@ -120,6 +129,15 @@ export namespace mockCredentials {
         })}`;
       }
       return MOCK_SERVICE_TOKEN;
+    }
+
+    /**
+     * Returns an authorization header with a mocked service token.  If a
+     * payload is provided it will be encoded into the token and forwarded to
+     * the credentials object when authenticated by the mock auth service.
+     */
+    export function header(payload?: TokenPayload): string {
+      return `Bearer ${token(payload)}`;
     }
   }
 }

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -29,6 +29,14 @@ export const MOCK_USER_TOKEN_PREFIX = 'mock-user-token:';
 export const MOCK_SERVICE_TOKEN = 'mock-service-token';
 export const MOCK_SERVICE_TOKEN_PREFIX = 'mock-service-token:';
 
+function validateUserEntityRef(ref: string) {
+  if (!ref.match(/^.+:.+\/.+$/)) {
+    throw new TypeError(
+      `Invalid user entity reference '${ref}', expected <kind>:<namespace>/<name>`,
+    );
+  }
+}
+
 /**
  * @public
  */
@@ -51,6 +59,7 @@ export namespace mockCredentials {
   export function user(
     userEntityRef: string = DEFAULT_MOCK_USER_ENTITY_REF,
   ): BackstageCredentials<BackstageUserPrincipal> {
+    validateUserEntityRef(userEntityRef);
     return {
       $$type: '@backstage/BackstageCredentials',
       principal: { type: 'user', userEntityRef },
@@ -71,9 +80,9 @@ export namespace mockCredentials {
      * into the token and forwarded to the credentials object when authenticated
      * by the mock auth service.
      */
-    export function token(payload?: TokenPayload): string {
-      if (payload) {
-        const { userEntityRef } = payload; // for fixed ordering
+    export function token(userEntityRef?: string): string {
+      if (userEntityRef) {
+        validateUserEntityRef(userEntityRef);
         return `${MOCK_USER_TOKEN_PREFIX}${JSON.stringify({ userEntityRef })}`;
       }
       return MOCK_USER_TOKEN;
@@ -84,8 +93,8 @@ export namespace mockCredentials {
      * provided it will be encoded into the token and forwarded to the
      * credentials object when authenticated by the mock auth service.
      */
-    export function header(payload?: TokenPayload): string {
-      return `Bearer ${token(payload)}`;
+    export function header(userEntityRef?: string): string {
+      return `Bearer ${token(userEntityRef)}`;
     }
   }
 

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackstageCredentials,
+  BackstageNonePrincipal,
+  BackstageServicePrincipal,
+  BackstageUserPrincipal,
+} from '@backstage/backend-plugin-api';
+
+export const DEFAULT_MOCK_USER_ENTITY_REF = 'user:default/mock';
+export const DEFAULT_MOCK_SERVICE_SUBJECT = 'external:test-service';
+
+export const MOCK_USER_TOKEN = 'mock-user-token';
+export const MOCK_USER_TOKEN_PREFIX = 'mock-user-token:';
+export const MOCK_SERVICE_TOKEN = 'mock-service-token';
+export const MOCK_SERVICE_TOKEN_PREFIX = 'mock-service-token:';
+
+/**
+ * @public
+ */
+export namespace mockCredentials {
+  /**
+   * Creates a mocked credentials object for a unauthenticated principal.
+   */
+  export function none(): BackstageCredentials<BackstageNonePrincipal> {
+    return {
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'none' },
+    };
+  }
+
+  /**
+   * Creates a mocked credentials object for a user principal.
+   *
+   * The default user entity reference is 'user:default/mock'.
+   */
+  export function user(
+    userEntityRef: string = DEFAULT_MOCK_USER_ENTITY_REF,
+  ): BackstageCredentials<BackstageUserPrincipal> {
+    return {
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'user', userEntityRef },
+    };
+  }
+
+  /**
+   * Utilities related to user credentials.
+   */
+  export namespace user {
+    /**
+     * The payload that can be encoded into a mock user token.
+     */
+    export type TokenPayload = { userEntityRef?: string };
+
+    /**
+     * Creates a mocked user token. If a payload is provided it will be encoded
+     * into the token and forwarded to the credentials object when authenticated
+     * by the mock auth service.
+     */
+    export function token(payload?: TokenPayload): string {
+      if (payload) {
+        return `${MOCK_USER_TOKEN_PREFIX}:${JSON.stringify(payload)}`;
+      }
+      return MOCK_USER_TOKEN;
+    }
+  }
+
+  /**
+   * Creates a mocked credentials object for a service principal.
+   *
+   * The default subject is 'external:test-service'.
+   */
+  export function service(
+    subject: string = DEFAULT_MOCK_SERVICE_SUBJECT,
+  ): BackstageCredentials<BackstageServicePrincipal> {
+    return {
+      $$type: '@backstage/BackstageCredentials',
+      principal: { type: 'service', subject },
+    };
+  }
+
+  /**
+   * Utilities related to service credentials.
+   */
+  export namespace service {
+    /**
+     * The payload that can be encoded into a mock service token.
+     */
+    export type TokenPayload = {
+      subject?: string;
+      targetPluginId?: string;
+    };
+
+    /**
+     * Creates a mocked service token. If a payload is provided it will be
+     * encoded into the token and forwarded to the credentials object when
+     * authenticated by the mock auth service.
+     */
+    export function token(payload?: TokenPayload): string {
+      if (payload) {
+        return `${MOCK_SERVICE_TOKEN_PREFIX}:${payload}`;
+      }
+      return MOCK_SERVICE_TOKEN;
+    }
+  }
+}

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -26,8 +26,10 @@ export const DEFAULT_MOCK_SERVICE_SUBJECT = 'external:test-service';
 
 export const MOCK_USER_TOKEN = 'mock-user-token';
 export const MOCK_USER_TOKEN_PREFIX = 'mock-user-token:';
+export const MOCK_INVALID_USER_TOKEN = 'mock-invalid-user-token';
 export const MOCK_SERVICE_TOKEN = 'mock-service-token';
 export const MOCK_SERVICE_TOKEN_PREFIX = 'mock-service-token:';
+export const MOCK_INVALID_SERVICE_TOKEN = 'mock-invalid-service-token';
 
 function validateUserEntityRef(ref: string) {
   if (!ref.match(/^.+:.+\/.+$/)) {
@@ -96,6 +98,14 @@ export namespace mockCredentials {
     export function header(userEntityRef?: string): string {
       return `Bearer ${token(userEntityRef)}`;
     }
+
+    export function invalidToken(): string {
+      return MOCK_INVALID_USER_TOKEN;
+    }
+
+    export function invalidHeader(): string {
+      return `Bearer ${invalidToken()}`;
+    }
   }
 
   /**
@@ -147,6 +157,14 @@ export namespace mockCredentials {
      */
     export function header(payload?: TokenPayload): string {
       return `Bearer ${token(payload)}`;
+    }
+
+    export function invalidToken(): string {
+      return MOCK_INVALID_SERVICE_TOKEN;
+    }
+
+    export function invalidHeader(): string {
+      return `Bearer ${invalidToken()}`;
     }
   }
 }

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -73,7 +73,8 @@ export namespace mockCredentials {
      */
     export function token(payload?: TokenPayload): string {
       if (payload) {
-        return `${MOCK_USER_TOKEN_PREFIX}:${JSON.stringify(payload)}`;
+        const { userEntityRef } = payload; // for fixed ordering
+        return `${MOCK_USER_TOKEN_PREFIX}${JSON.stringify({ userEntityRef })}`;
       }
       return MOCK_USER_TOKEN;
     }
@@ -112,7 +113,11 @@ export namespace mockCredentials {
      */
     export function token(payload?: TokenPayload): string {
       if (payload) {
-        return `${MOCK_SERVICE_TOKEN_PREFIX}:${payload}`;
+        const { subject, targetPluginId } = payload; // for fixed ordering
+        return `${MOCK_SERVICE_TOKEN_PREFIX}${JSON.stringify({
+          subject,
+          targetPluginId,
+        })}`;
       }
       return MOCK_SERVICE_TOKEN;
     }

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -24,6 +24,7 @@ import {
 export const DEFAULT_MOCK_USER_ENTITY_REF = 'user:default/mock';
 export const DEFAULT_MOCK_SERVICE_SUBJECT = 'external:test-service';
 
+export const MOCK_NONE_TOKEN = 'mock-none-token';
 export const MOCK_USER_TOKEN = 'mock-user-token';
 export const MOCK_USER_TOKEN_PREFIX = 'mock-user-token:';
 export const MOCK_INVALID_USER_TOKEN = 'mock-invalid-user-token';
@@ -51,6 +52,25 @@ export namespace mockCredentials {
       $$type: '@backstage/BackstageCredentials',
       principal: { type: 'none' },
     };
+  }
+
+  /**
+   * Utilities related to none credentials.
+   */
+  export namespace none {
+    /**
+     * Returns an authorization header that translates to unauthenticated
+     * credentials.
+     *
+     * This is useful when one wants to explicitly test unauthenticated requests
+     * while still using the default behavior of the mock HttpAuthService where
+     * it defaults to user credentials.
+     */
+    export function header(): string {
+      // NOTE: there is no .token() version of this because only the
+      //       HttpAuthService should know about and consume this token
+      return `Bearer ${MOCK_NONE_TOKEN}`;
+    }
   }
 
   /**

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -182,6 +182,7 @@ export namespace mockServices {
     export const factory = httpRouterServiceFactory;
     export const mock = simpleMock(coreServices.httpRouter, () => ({
       use: jest.fn(),
+      addAuthPolicy: jest.fn(),
     }));
   }
   export namespace rootHttpRouter {

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -180,9 +180,9 @@ export namespace mockServices {
     });
     export const mock = simpleMock(coreServices.auth, () => ({
       authenticate: jest.fn(),
-      getOwnCredentials: jest.fn(),
+      getOwnServiceCredentials: jest.fn(),
       isPrincipal: jest.fn() as any,
-      issueServiceToken: jest.fn(),
+      getPluginRequestToken: jest.fn(),
     }));
   }
 
@@ -217,7 +217,6 @@ export namespace mockServices {
     export const mock = simpleMock(coreServices.httpAuth, () => ({
       credentials: jest.fn(),
       issueUserCookie: jest.fn(),
-      requestHeaders: jest.fn(),
     }));
   }
 

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -38,7 +38,6 @@ import {
   rootLifecycleServiceFactory,
   schedulerServiceFactory,
   urlReaderServiceFactory,
-  httpAuthServiceFactory,
   discoveryServiceFactory,
   HostDiscovery,
 } from '@backstage/backend-app-api';
@@ -47,8 +46,7 @@ import { JsonObject } from '@backstage/types';
 import { MockIdentityService } from './MockIdentityService';
 import { MockRootLoggerService } from './MockRootLoggerService';
 import { MockAuthService } from './MockAuthService';
-// eslint-disable-next-line @backstage/no-relative-monorepo-imports
-import { DefaultHttpAuthService } from '../../../../backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory';
+import { MockHttpAuthService } from './MockHttpAuthService';
 
 /** @internal */
 function simpleFactory<
@@ -206,14 +204,14 @@ export namespace mockServices {
   }
 
   export function httpAuth(options?: { pluginId?: string }): HttpAuthService {
-    return new DefaultHttpAuthService(
-      auth(),
-      discovery(),
-      options?.pluginId ?? 'test',
-    );
+    return new MockHttpAuthService(options?.pluginId ?? 'test');
   }
   export namespace httpAuth {
-    export const factory = httpAuthServiceFactory;
+    export const factory = createServiceFactory({
+      service: coreServices.httpAuth,
+      deps: { plugin: coreServices.pluginMetadata },
+      factory: ({ plugin }) => new MockHttpAuthService(plugin.getId()),
+    });
     export const mock = simpleMock(coreServices.httpAuth, () => ({
       credentials: jest.fn(),
       issueUserCookie: jest.fn(),

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -169,14 +169,33 @@ export namespace mockServices {
     }));
   }
 
-  export function auth(options?: { pluginId?: string }): AuthService {
-    return new MockAuthService(options?.pluginId ?? 'test');
+  export function auth(options?: {
+    pluginId?: string;
+    disableDefaultAuthPolicy?: boolean;
+  }): AuthService {
+    return new MockAuthService({
+      pluginId: options?.pluginId ?? 'test',
+      disableDefaultAuthPolicy: Boolean(options?.disableDefaultAuthPolicy),
+    });
   }
   export namespace auth {
     export const factory = createServiceFactory({
       service: coreServices.auth,
-      deps: { plugin: coreServices.pluginMetadata },
-      factory: ({ plugin }) => new MockAuthService(plugin.getId()),
+      deps: {
+        plugin: coreServices.pluginMetadata,
+        config: coreServices.rootConfig,
+      },
+      factory({ plugin, config }) {
+        const disableDefaultAuthPolicy = Boolean(
+          config.getOptionalBoolean(
+            'backend.auth.dangerouslyDisableDefaultAuthPolicy',
+          ),
+        );
+        return new MockAuthService({
+          pluginId: plugin.getId(),
+          disableDefaultAuthPolicy,
+        });
+      },
     });
     export const mock = simpleMock(coreServices.auth, () => ({
       authenticate: jest.fn(),

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.test.ts
@@ -26,6 +26,7 @@ import { Router } from 'express';
 import request from 'supertest';
 
 import { startTestBackend } from './TestBackend';
+import { mockCredentials } from '../services';
 
 // This bit makes sure that test backends are cleaned up properly
 let globalTestBackendHasBeenStopped = false;
@@ -199,9 +200,11 @@ describe('TestBackend', () => {
             scheduler: coreServices.scheduler,
             tokenManager: coreServices.tokenManager,
             urlReader: coreServices.urlReader,
+            auth: coreServices.auth,
+            httpAuth: coreServices.httpAuth,
           },
           async init(deps) {
-            expect(Object.keys(deps)).toHaveLength(15);
+            expect(Object.keys(deps)).toHaveLength(17);
             expect(Object.values(deps)).not.toContain(undefined);
           },
         });
@@ -232,7 +235,9 @@ describe('TestBackend', () => {
 
     const { server } = await startTestBackend({ features: [testPlugin()] });
 
-    const res = await request(server).get('/api/test/ping-me');
+    const res = await request(server)
+      .get('/api/test/ping-me')
+      .set('authorization', mockCredentials.user.header());
     expect(res.status).toEqual(200);
     expect(res.body).toEqual({ message: 'pong' });
   });

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -66,9 +66,11 @@ export interface TestBackend extends Backend {
 }
 
 export const defaultServiceFactories = [
+  mockServices.auth.factory(),
   mockServices.cache.factory(),
   mockServices.rootConfig.factory(),
   mockServices.database.factory(),
+  mockServices.httpAuth.factory(),
   mockServices.httpRouter.factory(),
   mockServices.identity.factory(),
   mockServices.lifecycle.factory(),

--- a/plugins/kubernetes-backend/src/routes/resourceRoutes.test.ts
+++ b/plugins/kubernetes-backend/src/routes/resourceRoutes.test.ts
@@ -102,6 +102,12 @@ describe('resourcesRoutes', () => {
                 },
               ],
             },
+            backend: {
+              auth: {
+                // TODO: Remove once migrated to support new auth services
+                dangerouslyDisableDefaultAuthPolicy: true,
+              },
+            },
           },
         }),
         import('@backstage/plugin-kubernetes-backend/alpha'),

--- a/scripts/verify-links.js
+++ b/scripts/verify-links.js
@@ -78,6 +78,9 @@ async function verifyUrl(basePath, absUrl, docPages) {
   }
 
   if (basePath.startsWith('.changeset/')) {
+    if (absUrl.match(/^https?:\/\//)) {
+      return undefined;
+    }
     return { url, basePath, problem: 'out-of-changeset' };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,6 +3287,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
     "@backstage/integration-aws-node": "workspace:^"
+    "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@google-cloud/storage": ^7.0.0
     "@keyv/memcache": ^1.3.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,6 +3258,7 @@ __metadata:
     minimist: ^1.2.5
     morgan: ^1.10.0
     node-forge: ^1.3.1
+    path-to-regexp: ^6.2.1
     selfsigned: ^2.0.0
     stoppable: ^1.1.0
     supertest: ^6.1.3
@@ -37508,10 +37509,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "path-to-regexp@npm:6.2.0"
-  checksum: a6aca74d2d6e2e7594d812f653cf85e9cb5054d3a8d80f099722a44ef6ad22639b02078e5ea83d11db16321c3e4359e3f1ab0274fa78dad0754a6e53f630b0fc
+"path-to-regexp@npm:^6.2.0, path-to-regexp@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "path-to-regexp@npm:6.2.1"
+  checksum: f0227af8284ea13300f4293ba111e3635142f976d4197f14d5ad1f124aebd9118783dd2e5f1fe16f7273743cc3dbeddfb7493f237bb27c10fdae07020cc9b698
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3244,6 +3244,7 @@ __metadata:
     "@types/node-forge": ^1.3.0
     "@types/stoppable": ^1.1.0
     compression: ^1.7.4
+    cookie: ^0.6.0
     cors: ^2.8.5
     express: ^4.17.1
     express-promise-router: ^4.1.0
@@ -23958,7 +23959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.6.0, cookie@npm:~0.6.0":
+"cookie@npm:0.6.0, cookie@npm:^0.6.0, cookie@npm:~0.6.0":
   version: 0.6.0
   resolution: "cookie@npm:0.6.0"
   checksum: f56a7d32a07db5458e79c726b77e3c2eff655c36792f2b6c58d351fb5f61531e5b1ab7f46987150136e366c65213cbe31729e02a3eaed630c3bf7334635fb410

--- a/yarn.lock
+++ b/yarn.lock
@@ -27355,6 +27355,7 @@ __metadata:
     "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-tasks": "workspace:^"
+    "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/plugin-adr-backend": "workspace:^"
     "@backstage/plugin-app-backend": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3250,6 +3250,7 @@ __metadata:
     fs-extra: ^11.2.0
     helmet: ^6.0.0
     http-errors: ^2.0.0
+    jose: ^4.6.0
     lodash: ^4.17.21
     logform: ^2.3.2
     minimatch: ^5.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -27358,6 +27358,8 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/plugin-adr-backend": "workspace:^"
     "@backstage/plugin-app-backend": "workspace:^"
+    "@backstage/plugin-auth-backend": "workspace:^"
+    "@backstage/plugin-auth-backend-module-github-provider": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-azure-devops-backend": "workspace:^"
     "@backstage/plugin-badges-backend": "workspace:^"
@@ -32125,7 +32127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jose@npm:^4.15.4":
+"jose@npm:^4.15.4, jose@npm:^4.6.0":
   version: 4.15.4
   resolution: "jose@npm:4.15.4"
   checksum: dccad91cb3357f36423774a0b89ad830dd84b31090de65cd139b85488439f16a00f8c59c0773825e8a1adb0dd9d13ad725ad66e6ea33880ecb3959bb99e1ea5b

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,7 @@ __metadata:
     fs-extra: ^11.2.0
     helmet: ^6.0.0
     http-errors: ^2.0.0
-    jose: ^4.6.0
+    jose: ^5.0.0
     lodash: ^4.17.21
     logform: ^2.3.2
     minimatch: ^5.0.0
@@ -32127,7 +32127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jose@npm:^4.15.4, jose@npm:^4.6.0":
+"jose@npm:^4.15.4":
   version: 4.15.4
   resolution: "jose@npm:4.15.4"
   checksum: dccad91cb3357f36423774a0b89ad830dd84b31090de65cd139b85488439f16a00f8c59c0773825e8a1adb0dd9d13ad725ad66e6ea33880ecb3959bb99e1ea5b


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is the initial implementation of [BEP-0003](https://github.com/backstage/backstage/tree/master/beps/0003-auth-architecture-evolution) for the old and new backend system. It adds the `AuthService`, `HttpAuthService`, `UserInfoService`, and adds the new policy method to the `HttpRouterService`.

The release plan in the BEP mentions backwards compatibility APIs. That is all implemented through `createLegacyAuthAdapters` from `@backstage/backend-common`.

The following still needs to be implemented as part of this initial work, but likely in followup PRs:

- Proper cookie configuration based on the request, secure/samesite policy/host, etc.
- Service documentation
- Migration guide
- TechDocs integration with cookie auth
- App backend integration with cookie auth and separate sign-in page
- Basic rate limiting for unauthenticated requests
- Add switch that lets integrators disable the built-in auth

The following future work is planned but not required for the system to work:

- Improved cookie auth that doesn't re-use the user token
- Improved OBO flow that doesn't re-use the user token
- Improved service to service auth that allows plugins to restrict callers and permissions
- Ability to issue and configure secrets for external services and tools with ability restrict the scope to individual plugins and permissions

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
