### PR TITLE
search-backend-module-{catalog,explore,techdocs}: migrate to support new auth services

### DIFF
--- a/.changeset/nice-beans-wait.md
+++ b/.changeset/nice-beans-wait.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-search-backend-module-techdocs': patch
+'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-search-backend-module-explore': patch
+---
+
+Migrated to support new auth services.

--- a/plugins/search-backend-module-catalog/api-report.md
+++ b/plugins/search-backend-module-catalog/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 /// <reference types="node" />
 
+import { AuthService } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
 import { CatalogEntityDocument } from '@backstage/plugin-catalog-common';
 import { Config } from '@backstage/config';
@@ -41,6 +42,7 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
 
 // @public (undocumented)
 export type DefaultCatalogCollatorFactoryOptions = {
+  auth?: AuthService;
   discovery: PluginEndpointDiscovery;
   tokenManager: TokenManager;
   locationTemplate?: string;

--- a/plugins/search-backend-module-explore/api-report.md
+++ b/plugins/search-backend-module-explore/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 /// <reference types="node" />
 
+import { AuthService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { DocumentCollatorFactory } from '@backstage/plugin-search-common';
 import { ExploreTool } from '@backstage/plugin-explore-common';
@@ -37,5 +38,6 @@ export type ToolDocumentCollatorFactoryOptions = {
   discovery: PluginEndpointDiscovery;
   logger: Logger;
   tokenManager?: TokenManager;
+  auth?: AuthService;
 };
 ```

--- a/plugins/search-backend-module-techdocs/api-report.md
+++ b/plugins/search-backend-module-techdocs/api-report.md
@@ -5,10 +5,12 @@
 ```ts
 /// <reference types="node" />
 
+import { AuthService } from '@backstage/backend-plugin-api';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DocumentCollatorFactory } from '@backstage/plugin-search-common';
 import { Entity } from '@backstage/catalog-model';
+import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { Logger } from 'winston';
 import { Permission } from '@backstage/plugin-permission-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -44,6 +46,8 @@ export type TechDocsCollatorFactoryOptions = {
   discovery: PluginEndpointDiscovery;
   logger: Logger;
   tokenManager: TokenManager;
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
   locationTemplate?: string;
   catalogClient?: CatalogApi;
   parallelismLimit?: number;

--- a/plugins/search-backend-module-techdocs/src/alpha.ts
+++ b/plugins/search-backend-module-techdocs/src/alpha.ts
@@ -74,6 +74,8 @@ export default createBackendModule({
       deps: {
         config: coreServices.rootConfig,
         logger: coreServices.logger,
+        auth: coreServices.auth,
+        httpAuth: coreServices.httpAuth,
         discovery: coreServices.discovery,
         tokenManager: coreServices.tokenManager,
         scheduler: coreServices.scheduler,
@@ -83,6 +85,8 @@ export default createBackendModule({
       async init({
         config,
         logger,
+        auth,
+        httpAuth,
         discovery,
         tokenManager,
         scheduler,
@@ -106,6 +110,8 @@ export default createBackendModule({
           factory: DefaultTechDocsCollatorFactory.fromConfig(config, {
             discovery,
             tokenManager,
+            auth,
+            httpAuth,
             logger: loggerToWinstonLogger(logger),
             catalogClient: catalog,
             entityTransformer: transformer,

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
@@ -17,6 +17,7 @@
 import {
   PluginEndpointDiscovery,
   TokenManager,
+  createLegacyAuthAdapters,
 } from '@backstage/backend-common';
 import {
   CatalogApi,
@@ -41,6 +42,7 @@ import { Readable } from 'stream';
 import { Logger } from 'winston';
 import { TechDocsCollatorEntityTransformer } from './TechDocsCollatorEntityTransformer';
 import { defaultTechDocsCollatorEntityTransformer } from './defaultTechDocsCollatorEntityTransformer';
+import { AuthService, HttpAuthService } from '@backstage/backend-plugin-api';
 
 interface MkSearchIndexDoc {
   title: string;
@@ -57,6 +59,8 @@ export type TechDocsCollatorFactoryOptions = {
   discovery: PluginEndpointDiscovery;
   logger: Logger;
   tokenManager: TokenManager;
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
   locationTemplate?: string;
   catalogClient?: CatalogApi;
   parallelismLimit?: number;
@@ -84,8 +88,8 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
   private discovery: PluginEndpointDiscovery;
   private locationTemplate: string;
   private readonly logger: Logger;
+  private readonly auth: AuthService;
   private readonly catalogClient: CatalogApi;
-  private readonly tokenManager: TokenManager;
   private readonly parallelismLimit: number;
   private readonly legacyPathCasing: boolean;
   private entityTransformer: TechDocsCollatorEntityTransformer;
@@ -100,9 +104,14 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
       new CatalogClient({ discoveryApi: options.discovery });
     this.parallelismLimit = options.parallelismLimit ?? 10;
     this.legacyPathCasing = options.legacyPathCasing ?? false;
-    this.tokenManager = options.tokenManager;
     this.entityTransformer =
       options.entityTransformer ?? defaultTechDocsCollatorEntityTransformer;
+
+    this.auth = createLegacyAuthAdapters({
+      auth: options.auth,
+      discovery: options.discovery,
+      tokenManager: options.tokenManager,
+    }).auth;
   }
 
   static fromConfig(config: Config, options: TechDocsCollatorFactoryOptions) {
@@ -131,7 +140,7 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
   private async *execute(): AsyncGenerator<TechDocsDocument, void, undefined> {
     const limit = pLimit(this.parallelismLimit);
     const techDocsBaseUrl = await this.discovery.getBaseUrl('techdocs');
-    const { token } = await this.tokenManager.getToken();
+
     let entitiesRetrieved = 0;
     let moreEntitiesToGet = true;
 
@@ -141,6 +150,11 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
     // parallelism limit to simplify configuration.
     const batchSize = this.parallelismLimit * 50;
     while (moreEntitiesToGet) {
+      const { token: catalogToken } = await this.auth.getPluginRequestToken({
+        onBehalfOf: await this.auth.getOwnServiceCredentials(),
+        targetPluginId: 'catalog',
+      });
+
       const entities = (
         await this.catalogClient.getEntities(
           {
@@ -151,7 +165,7 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
             limit: batchSize,
             offset: entitiesRetrieved,
           },
-          { token },
+          { token: catalogToken },
         )
       ).items;
 
@@ -174,6 +188,12 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
               );
 
             try {
+              const { token: techdocsToken } =
+                await this.auth.getPluginRequestToken({
+                  onBehalfOf: await this.auth.getOwnServiceCredentials(),
+                  targetPluginId: 'techdocs',
+                });
+
               const searchIndexResponse = await fetch(
                 DefaultTechDocsCollatorFactory.constructDocsIndexUrl(
                   techDocsBaseUrl,
@@ -181,7 +201,7 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
                 ),
                 {
                   headers: {
-                    Authorization: `Bearer ${token}`,
+                    Authorization: `Bearer ${techdocsToken}`,
                   },
                 },
               );


### PR DESCRIPTION
On top of #23054, work towards supporting the new auth services