### PR TITLE
auth-node: deprecate getBearerTokenFromAuthorizationHeader

### DIFF
--- a/.changeset/chilled-dolls-accept.md
+++ b/.changeset/chilled-dolls-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Deprecated the `getBearerTokenFromAuthorizationHeader` function, which is being replaced by the new `HttpAuthService`.

--- a/plugins/auth-node/api-report.md
+++ b/plugins/auth-node/api-report.md
@@ -223,7 +223,7 @@ export class DefaultIdentityClient implements IdentityApi {
 // @public (undocumented)
 export function encodeOAuthState(state: OAuthState): string;
 
-// @public
+// @public @deprecated
 export function getBearerTokenFromAuthorizationHeader(
   authorizationHeader: unknown,
 ): string | undefined;

--- a/plugins/auth-node/src/identity/getBearerTokenFromAuthorizationHeader.ts
+++ b/plugins/auth-node/src/identity/getBearerTokenFromAuthorizationHeader.ts
@@ -24,6 +24,7 @@
  * call it directly with e.g. the output of `req.header('authorization')`
  * without first checking that it exists.
  *
+ * @deprecated Use the `credentials` method of `HttpAuthService` from `@backstage/backend-plugin-api` instead
  * @public
  */
 export function getBearerTokenFromAuthorizationHeader(


### PR DESCRIPTION
On top of #23054, work towards supporting the new auth services