### PR TITLE
auth-backend-module-oauth2-proxy-provider: internal refactor to avoid deprecated method

### DIFF
--- a/.changeset/spicy-dragons-sin.md
+++ b/.changeset/spicy-dragons-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+---
+
+Internal refactor to avoid deprecated method.

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
@@ -15,10 +15,7 @@
  */
 
 import { AuthenticationError } from '@backstage/errors';
-import {
-  createProxyAuthenticator,
-  getBearerTokenFromAuthorizationHeader,
-} from '@backstage/plugin-auth-node';
+import { createProxyAuthenticator } from '@backstage/plugin-auth-node';
 import { decodeJwt } from 'jose';
 import { OAuth2ProxyResult } from './types';
 
@@ -46,7 +43,7 @@ export const oauth2ProxyAuthenticator = createProxyAuthenticator({
   async authenticate({ req }) {
     try {
       const authHeader = req.header(OAUTH2_PROXY_JWT_HEADER);
-      const jwt = getBearerTokenFromAuthorizationHeader(authHeader);
+      const jwt = authHeader?.match(/^Bearer[ ]+(\S+)$/i)?.[1];
       const decodedJWT = jwt && decodeJwt(jwt);
 
       const result = {


### PR DESCRIPTION
On top of #23054, work towards supporting the new auth services