### PR TITLE
fix: elastic search client to return total number of hits

### DIFF
--- a/.changeset/clean-islands-remain.md
+++ b/.changeset/clean-islands-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Fix elastic search client not returning total hits

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
@@ -118,6 +118,7 @@ describe('ElasticSearchClientWrapper', () => {
         body: { eg: 'etc' },
         ignore_unavailable: true,
         allow_no_indices: true,
+        track_total_hits: true,
       };
       const result = (await wrapper.search(searchInput)) as any;
 

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
@@ -107,6 +107,7 @@ export class ElasticSearchClientWrapper {
       return this.elasticSearchClient.search({
         ...options,
         ...searchOptions,
+        track_total_hits: true,
       });
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, when using ElasticSearch client, it does not return the `result.body.hits.total.value` thus there is no way to load more results for the search.

See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-your-data.html#track-total-hits

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
