### PR TITLE
Fix Microsoft Auth Provider when Profile not requested

### DIFF
--- a/.changeset/eight-oranges-wave.md
+++ b/.changeset/eight-oranges-wave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-microsoft-provider': patch
 ---
 
-Fix error when Microsoft token is requested without the profile scope.
+Fix error when Microsoft tokens (or any other using the `defaultProfileTransform`) are requested without the profile scope.

--- a/.changeset/eight-oranges-wave.md
+++ b/.changeset/eight-oranges-wave.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-node': patch
 ---
 
 Fix error when Microsoft tokens (or any other using the `defaultProfileTransform`) are requested without the profile scope.

--- a/.changeset/eight-oranges-wave.md
+++ b/.changeset/eight-oranges-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+---
+
+Fix error when microsoft token is requested without the profile scope.

--- a/.changeset/eight-oranges-wave.md
+++ b/.changeset/eight-oranges-wave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-microsoft-provider': patch
 ---
 
-Fix error when microsoft token is requested without the profile scope.
+Fix error when Microsoft token is requested without the profile scope.

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
@@ -16,6 +16,7 @@
 
 import {
   createOAuthAuthenticator,
+  OAuthAuthenticatorResult,
   PassportOAuthAuthenticatorHelper,
   PassportOAuthDoneCallback,
   PassportProfile,
@@ -25,8 +26,16 @@ import { union } from 'lodash';
 
 /** @public */
 export const microsoftAuthenticator = createOAuthAuthenticator({
-  defaultProfileTransform:
-    PassportOAuthAuthenticatorHelper.defaultProfileTransform,
+  defaultProfileTransform: (
+    result: OAuthAuthenticatorResult<PassportProfile>,
+    context,
+  ) => {
+    result.fullProfile = result.fullProfile ?? {};
+    return PassportOAuthAuthenticatorHelper.defaultProfileTransform(
+      result,
+      context,
+    );
+  },
   initialize({ callbackUrl, config }) {
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
@@ -26,16 +26,8 @@ import { union } from 'lodash';
 
 /** @public */
 export const microsoftAuthenticator = createOAuthAuthenticator({
-  defaultProfileTransform: (
-    result: OAuthAuthenticatorResult<PassportProfile>,
-    context,
-  ) => {
-    result.fullProfile = result.fullProfile ?? {};
-    return PassportOAuthAuthenticatorHelper.defaultProfileTransform(
-      result,
-      context,
-    );
-  },
+  defaultProfileTransform:
+    PassportOAuthAuthenticatorHelper.defaultProfileTransform,
   initialize({ callbackUrl, config }) {
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
@@ -16,7 +16,6 @@
 
 import {
   createOAuthAuthenticator,
-  OAuthAuthenticatorResult,
   PassportOAuthAuthenticatorHelper,
   PassportOAuthDoneCallback,
   PassportProfile,

--- a/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.ts
+++ b/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.ts
@@ -57,7 +57,7 @@ export class PassportOAuthAuthenticatorHelper {
     OAuthAuthenticatorResult<PassportProfile>
   > = async input => ({
     profile: PassportHelpers.transformProfile(
-      input.fullProfile,
+      input.fullProfile ?? {},
       input.session.idToken,
     ),
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR ensures that the Microsoft provider passes an empty profile object down if it hasn't received/requested one from the provider.  Fixes #23032.

The legacy Microsoft provider previously did something similar to replace a null profile with an empty object. https://github.com/backstage/backstage/blob/96c4f54bf6070db12676e9af0bf75d0d479c3d72/plugins/auth-backend/src/providers/microsoft/provider.ts#L266

I guess the only question is whether we want to fix this specifically for the Microsoft provider, or should we handle a null profiles deeper in the stack (i.e. `PassportOAuthAuthenticatorHelper.defaultProfileTransform` or in `PassportHelpers.transformProfile`)

Reason this didn't affect the legacy backend is that it was only recently the legacy backend Microsoft module was swapped over to use the path from the newer backend - #22208

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
