### PR TITLE
techdocs: escape <code> in changeset

### DIFF
--- a/.changeset/tender-flowers-collect.md
+++ b/.changeset/tender-flowers-collect.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': minor
 ---
 
-Updated the styling for <code> tags to avoid word break.
+Updated the styling for `<code>` tags to avoid word break.

--- a/docs/releases/v1.23.0-next.1-changelog.md
+++ b/docs/releases/v1.23.0-next.1-changelog.md
@@ -399,7 +399,7 @@
 
 ### Minor Changes
 
-- af4d147: Updated the styling for code tags to avoid word break.
+- af4d147: Updated the styling for `<code>` tags to avoid word break.
 
 ### Patch Changes
 

--- a/plugins/techdocs/CHANGELOG.md
+++ b/plugins/techdocs/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 ### Minor Changes
 
-- af4d147: Updated the styling for <code> tags to avoid word break.
+- af4d147: Updated the styling for `<code>` tags to avoid word break.
 
 ### Patch Changes
 


### PR DESCRIPTION
🧹 