### PR TITLE
remove gitattributes again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-**/api-report*.md linguist-generated=true
-**/cli-report.md linguist-generated=true
-**/knip-report.md linguist-generated=true


### PR DESCRIPTION
The report files being collapsed in the PR files view just isn't worth the risk.