### PR TITLE
fix: authorized search engine to obey query page limit

### DIFF
--- a/.changeset/light-birds-sparkle.md
+++ b/.changeset/light-birds-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Authorized search engine now obeys query page limit


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously the page size for authorized search engine was forced to 25, now it follows the query `pageLimit` if given

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
