### PR TITLE
fix: authorized search engine to return approximate amount of results

### DIFF
--- a/.changeset/tender-countries-move.md
+++ b/.changeset/tender-countries-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Authorized search engine now returns approximate number of results

--- a/plugins/search-backend/src/service/AuthorizedSearchEngine.test.ts
+++ b/plugins/search-backend/src/service/AuthorizedSearchEngine.test.ts
@@ -16,11 +16,11 @@
 
 import { ConfigReader } from '@backstage/config';
 import {
-  EvaluatePermissionResponse,
   AuthorizeResult,
   createPermission,
-  PolicyDecision,
+  EvaluatePermissionResponse,
   PermissionEvaluator,
+  PolicyDecision,
 } from '@backstage/plugin-permission-common';
 import {
   DocumentTypeInfo,
@@ -28,9 +28,9 @@ import {
 } from '@backstage/plugin-search-common';
 import { SearchEngine } from '@backstage/plugin-search-backend-node';
 import {
-  encodePageCursor,
-  decodePageCursor,
   AuthorizedSearchEngine,
+  decodePageCursor,
+  encodePageCursor,
 } from './AuthorizedSearchEngine';
 
 describe('AuthorizedSearchEngine', () => {
@@ -232,6 +232,7 @@ describe('AuthorizedSearchEngine', () => {
 
     mockedQuery.mockImplementation(async () => ({
       results: resultsWithAuth,
+      numberOfResults: resultsWithAuth.length,
     }));
 
     mockedPermissionQuery.mockImplementation(async queries =>
@@ -266,7 +267,10 @@ describe('AuthorizedSearchEngine', () => {
 
     await expect(
       authorizedSearchEngine.query({ term: '' }, options),
-    ).resolves.toEqual({ results: [expectedResult] });
+    ).resolves.toEqual({
+      results: [expectedResult],
+      approximateNumberOfResults: 1,
+    });
 
     expect(mockedQuery).toHaveBeenCalledWith(
       { term: '', types: ['users'] },

--- a/plugins/search-common/api-report.md
+++ b/plugins/search-common/api-report.md
@@ -71,6 +71,8 @@ export interface ResultHighlight {
 // @public (undocumented)
 export interface ResultSet<TDocument extends SearchDocument> {
   // (undocumented)
+  approximateNumberOfResults?: number;
+  // (undocumented)
   nextPageCursor?: string;
   // (undocumented)
   numberOfResults?: number;

--- a/plugins/search-common/src/types.ts
+++ b/plugins/search-common/src/types.ts
@@ -88,6 +88,7 @@ export interface ResultSet<TDocument extends SearchDocument> {
   nextPageCursor?: string;
   previousPageCursor?: string;
   numberOfResults?: number;
+  approximateNumberOfResults?: number;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This does not guarantee that user can see all results, thus using cursors is still required

Closes #23086

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
