### PR TITLE
Changed timeline order in Tech Radar plugin snippet

### DIFF
--- a/.changeset/neat-buckets-thank.md
+++ b/.changeset/neat-buckets-thank.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-radar': minor
 ---
 
-Fixed the order of timeline items in the snippet of the README.md file to match the order required by the plugin to reflect the latest event change in the Tech Radar. This brings the README.md snippet to reflect what is shown in the src/sample.ts file.
+Fixed example snippet in `README.md` to reflect correct timeline item order.

--- a/.changeset/neat-buckets-thank.md
+++ b/.changeset/neat-buckets-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': minor
+---
+
+Fixed the order of timeline items in the snippet of the README.md file to match the order required by the plugin to reflect the latest event change in the Tech Radar. This brings the README.md snippet to reflect what is shown in the src/sample.ts file.

--- a/plugins/tech-radar/README.md
+++ b/plugins/tech-radar/README.md
@@ -171,16 +171,16 @@ The TS example can be found [here](src/sample.ts).
             "quadrant": "1",
             "timeline": [
                 {
-                    "moved": 0,
-                    "ringId": "trial",
-                    "date": "2022-02-06",
-                    "description": "Long description for trial"
-                },
-                {
                     "moved": 1,
                     "ringId": "adopt",
                     "date": "2022-02-08",
                     "description": "Long description for adopt"
+                },
+                {
+                    "moved": 0,
+                    "ringId": "trial",
+                    "date": "2022-02-06",
+                    "description": "Long description for trial"
                 }
             ]
         },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix the order of timeline items in the snippet of the README.md file to match the order required by the plugin to reflect the latest event change in the Tech Radar. This brings the README.md snippet to reflect what is shown in the src/sample.ts file.

Closes #23092

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
