### PR TITLE
fix: wrong link fixed for Architecture Overview - Package Architecture

### DIFF
--- a/docs/backend-system/architecture/01-index.md
+++ b/docs/backend-system/architecture/01-index.md
@@ -56,7 +56,7 @@ Just like plugins, modules also have access to services and can depend on their 
 ## Package structure
 
 A detailed explanation of the package architecture can be found in the
-[Backstage Architecture Overview](../../overview/architecture-overview/#package-architecture). The
+[Backstage Architecture Overview](../../overview/architecture-overview.md#package-architecture). The
 most important packages to consider for this system are the following:
 
 - `plugin-<pluginId>-backend` houses the implementation of the backend plugins

--- a/docs/backend-system/architecture/01-index.md
+++ b/docs/backend-system/architecture/01-index.md
@@ -57,7 +57,7 @@ Just like plugins, modules also have access to services and can depend on their 
 
 A detailed explanation of the package architecture can be found in the
 [Backstage Architecture
-Overview](../../overview/architecture-overview.md#package-architecture). The
+Overview](../../overview/architecture-overview/#package-architecture). The
 most important packages to consider for this system are the following:
 
 - `plugin-<pluginId>-backend` houses the implementation of the backend plugins

--- a/docs/backend-system/architecture/01-index.md
+++ b/docs/backend-system/architecture/01-index.md
@@ -56,8 +56,7 @@ Just like plugins, modules also have access to services and can depend on their 
 ## Package structure
 
 A detailed explanation of the package architecture can be found in the
-[Backstage Architecture
-Overview](../../overview/architecture-overview/#package-architecture). The
+[Backstage Architecture Overview](../../overview/architecture-overview/#package-architecture). The
 most important packages to consider for this system are the following:
 
 - `plugin-<pluginId>-backend` houses the implementation of the backend plugins


### PR DESCRIPTION
## Relative link fixed pointing to Architecture Overview - Package Architecture

Just a minor fix on the URL

