### PR TITLE
OWNERS.md: add notifications project area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 yarn.lock                                         @backstage/maintainers @backstage-service
 */yarn.lock                                       @backstage/maintainers @backstage-service
 /.changeset/*.md
+/beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
 /docs/assets/search                               @backstage/discoverability-maintainers
 /docs/features/search                             @backstage/discoverability-maintainers
 /docs/features/techdocs                           @backstage/techdocs-maintainers
@@ -66,6 +67,8 @@ yarn.lock                                         @backstage/maintainers @backst
 /plugins/linguist                                 @backstage/maintainers @backstage/reviewers @awanlin
 /plugins/linguist-backend                         @backstage/maintainers @backstage/reviewers @awanlin
 /plugins/linguist-common                          @backstage/maintainers @backstage/reviewers @awanlin
+/plugins/notifications                            @backstage/maintainers @backstage/notifications-maintainers
+/plugins/notifications-*                          @backstage/maintainers @backstage/notifications-maintainers
 /plugins/octopus-deploy                           @backstage/maintainers @backstage/reviewers @jmezach
 /plugins/permission-*                             @backstage/permission-maintainers
 /plugins/playlist                                 @backstage/maintainers @backstage/reviewers @kuangp
@@ -76,6 +79,8 @@ yarn.lock                                         @backstage/maintainers @backst
 /plugins/scaffolder-*                             @backstage/maintainers @backstage/reviewers @backstage/scaffolder-maintainers
 /plugins/search                                   @backstage/discoverability-maintainers
 /plugins/search-*                                 @backstage/discoverability-maintainers
+/plugins/signals                                  @backstage/maintainers @backstage/notifications-maintainers
+/plugins/signals-*                                @backstage/maintainers @backstage/notifications-maintainers
 /plugins/sonarqube                                @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/stack-overflow                           @backstage/discoverability-maintainers
 /plugins/stack-overflow-backend                   @backstage/discoverability-maintainers

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -118,6 +118,16 @@ Scope: Tooling and Community Repo Maintainers for the Backstage [Community Plugi
 | Philipp Hugenroth    | Spotify      | [tudi2d](https://github.com/tudi2d)         | `tudi2d`     |
 | Vincenzo Scamporlino | Spotify      | [vinzscam](https://github.com/vinzscam)     | `vinzscam`   |
 
+### Notifications
+
+Team: @backstage/notifications-maintainers
+
+Scope: The Notifications and Signals plugins and libraries
+
+| Name        | Organization | GitHub                                      | Discord   |
+| ----------- | ------------ | ------------------------------------------- | --------- |
+| Marek Libra | RedHat       | [mareklibra](https://github.com/mareklibra) | `marekli` |
+
 ### OpenAPI Tooling
 
 Team: @backstage/openapi-tooling-maintainers


### PR DESCRIPTION
This introduces the Notifications Project Area 🎉 

The scope is the notifications and the signals backend. The signals backend is currently closely tied to the notifications system and part of its initial implementation, although it is a standalone feature that may be used by other plugins.

@drodil and @mareklibra have both been doing excellent work towards in the early implementations in the signals and notifications plugins along with the the external implementation in https://github.com/janus-idp/backstage-plugins/tree/main/plugins/notifications that is being brought in, as well as aligning on the design in [BEP-0001](https://github.com/backstage/backstage/tree/master/beps/0001-notifications-system).

Made it an incubating area for now, which means that ownership is shared with core maintainers, who will also help out with reviews. That's ofc something that we can change down the line though.