### PR TITLE
ci(renovate): do not pin docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,10 +3,7 @@
 
   labels: ['dependencies'],
 
-  extends: [
-    'config:best-practices',
-    ':gitSignOff',
-  ],
+  extends: ['config:best-practices', ':gitSignOff'],
   // do not pin dev dependencies, which are part of the best-practices preset
   ignorePresets: [':pinDevDependencies', ':pinDigest', 'docker:pinDigests'],
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,10 +6,9 @@
   extends: [
     'config:best-practices',
     ':gitSignOff',
-    'default:pinDigestsDisabled',
   ],
   // do not pin dev dependencies, which are part of the best-practices preset
-  ignorePresets: [':pinDevDependencies', ':pinDigest'],
+  ignorePresets: [':pinDevDependencies', ':pinDigest', 'docker:pinDigests'],
 
   // the default limit are 10 PRs
   prConcurrentLimit: 20,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR disables Renovates pinning for Docker images

cc @freben 
https://github.com/backstage/demo/pull/300#issuecomment-1954369381
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
