### PR TITLE
fix: proxy auth to return provider info

### DIFF
--- a/.changeset/six-geckos-watch.md
+++ b/.changeset/six-geckos-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Fix proxy auth provider not returning provider info on refresh

--- a/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
+++ b/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
@@ -68,9 +68,9 @@ export function createProxyAuthRouteHandlers<TResult>(
         resolverContext,
       );
 
-      const response: ClientAuthResponse<{}> = {
+      const response: ClientAuthResponse<TResult> = {
         profile,
-        providerInfo: {},
+        providerInfo: result,
         backstageIdentity: prepareBackstageIdentityResponse(identity),
       };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

not sure if this is ok security wise but it returns the providerInfo correctly from the authenticator. core team to decide if this can be merged as is, dropping my gloves here.

this closes #23117

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
