### PR TITLE
auth: Treat `providerInfo` as a separate property from `authenticate`

### DIFF
--- a/plugins/auth-backend-module-aws-alb-provider/api-report.md
+++ b/plugins/auth-backend-module-aws-alb-provider/api-report.md
@@ -21,7 +21,11 @@ export const awsAlbAuthenticator: ProxyAuthenticator<
     issuer: string;
     getKey: (header: JWTHeaderParameters) => Promise<KeyObject>;
   },
-  AwsAlbResult
+  AwsAlbResult,
+  {
+    accessToken: string;
+    expiresInSeconds: number;
+  }
 >;
 
 // @public

--- a/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
@@ -81,8 +81,12 @@ export const awsAlbAuthenticator = createProxyAuthenticator({
       return {
         result: {
           fullProfile,
+          accessToken: accessToken,
           expiresInSeconds: claims.exp,
-          accessToken,
+        },
+        providerInfo: {
+          accessToken: accessToken,
+          expiresInSeconds: claims.exp,
         },
       };
     } catch (e) {

--- a/plugins/auth-backend-module-gcp-iap-provider/api-report.md
+++ b/plugins/auth-backend-module-gcp-iap-provider/api-report.md
@@ -20,6 +20,9 @@ export const gcpIapAuthenticator: ProxyAuthenticator<
   },
   {
     iapToken: GcpIapTokenInfo;
+  },
+  {
+    iapToken: GcpIapTokenInfo;
   }
 >;
 

--- a/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.ts
@@ -47,6 +47,9 @@ export const gcpIapAuthenticator = createProxyAuthenticator({
 
     const iapToken = await tokenValidator(token);
 
-    return { result: { iapToken } };
+    return {
+      result: { iapToken },
+      providerInfo: { iapToken },
+    };
   },
 });

--- a/plugins/auth-backend-module-oauth2-proxy-provider/api-report.md
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/api-report.md
@@ -19,7 +19,10 @@ export const OAUTH2_PROXY_JWT_HEADER = 'X-OAUTH2-PROXY-ID-TOKEN';
 // @public (undocumented)
 export const oauth2ProxyAuthenticator: ProxyAuthenticator<
   unknown,
-  OAuth2ProxyResult
+  OAuth2ProxyResult,
+  {
+    accessToken: string;
+  }
 >;
 
 // @public

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
@@ -33,7 +33,8 @@ export const OAUTH2_PROXY_JWT_HEADER = 'X-OAUTH2-PROXY-ID-TOKEN';
 /** @public */
 export const oauth2ProxyAuthenticator = createProxyAuthenticator<
   unknown,
-  OAuth2ProxyResult
+  OAuth2ProxyResult,
+  { accessToken: string }
 >({
   defaultProfileTransform: async (result: OAuth2ProxyResult) => {
     return {
@@ -63,7 +64,13 @@ export const oauth2ProxyAuthenticator = createProxyAuthenticator<
           return req.get(name);
         },
       };
-      return { result };
+
+      return {
+        result,
+        providerInfo: {
+          accessToken: result.accessToken,
+        },
+      };
     } catch (e) {
       throw new AuthenticationError('Authentication failed', e);
     }

--- a/plugins/auth-node/api-report.md
+++ b/plugins/auth-node/api-report.md
@@ -173,13 +173,13 @@ export function createOAuthRouteHandlers<TProfile>(
 ): AuthProviderRouteHandlers;
 
 // @public (undocumented)
-export function createProxyAuthenticator<TContext, TResult>(
-  authenticator: ProxyAuthenticator<TContext, TResult>,
-): ProxyAuthenticator<TContext, TResult>;
+export function createProxyAuthenticator<TContext, TResult, TProviderInfo>(
+  authenticator: ProxyAuthenticator<TContext, TResult, TProviderInfo>,
+): ProxyAuthenticator<TContext, TResult, TProviderInfo>;
 
 // @public (undocumented)
 export function createProxyAuthProviderFactory<TResult>(options: {
-  authenticator: ProxyAuthenticator<unknown, TResult>;
+  authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
   signInResolverFactories?: Record<
@@ -538,7 +538,7 @@ export type ProfileTransform<TResult> = (
 }>;
 
 // @public (undocumented)
-export interface ProxyAuthenticator<TContext, TResult> {
+export interface ProxyAuthenticator<TContext, TResult, TProviderInfo> {
   // (undocumented)
   authenticate(
     options: {
@@ -547,6 +547,7 @@ export interface ProxyAuthenticator<TContext, TResult> {
     ctx: TContext,
   ): Promise<{
     result: TResult;
+    providerInfo?: TProviderInfo;
   }>;
   // (undocumented)
   defaultProfileTransform: ProfileTransform<TResult>;
@@ -557,7 +558,7 @@ export interface ProxyAuthenticator<TContext, TResult> {
 // @public (undocumented)
 export interface ProxyAuthRouteHandlersOptions<TResult> {
   // (undocumented)
-  authenticator: ProxyAuthenticator<any, TResult>;
+  authenticator: ProxyAuthenticator<any, TResult, unknown>;
   // (undocumented)
   config: Config;
   // (undocumented)

--- a/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
+++ b/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
@@ -28,7 +28,7 @@ import { ProxyAuthenticator } from './types';
 
 /** @public */
 export function createProxyAuthProviderFactory<TResult>(options: {
-  authenticator: ProxyAuthenticator<unknown, TResult>;
+  authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
   signInResolverFactories?: Record<

--- a/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
+++ b/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
@@ -29,7 +29,7 @@ import { NotImplementedError } from '@backstage/errors';
 
 /** @public */
 export interface ProxyAuthRouteHandlersOptions<TResult> {
-  authenticator: ProxyAuthenticator<any, TResult>;
+  authenticator: ProxyAuthenticator<any, TResult, unknown>;
   config: Config;
   resolverContext: AuthResolverContext;
   signInResolver: SignInResolver<TResult>;
@@ -56,7 +56,7 @@ export function createProxyAuthRouteHandlers<TResult>(
     },
 
     async refresh(this: never, req: Request, res: Response): Promise<void> {
-      const { result } = await authenticator.authenticate(
+      const { result, providerInfo } = await authenticator.authenticate(
         { req },
         authenticatorCtx,
       );
@@ -68,9 +68,9 @@ export function createProxyAuthRouteHandlers<TResult>(
         resolverContext,
       );
 
-      const response: ClientAuthResponse<{}> = {
+      const response: ClientAuthResponse<unknown> = {
         profile,
-        providerInfo: {},
+        providerInfo,
         backstageIdentity: prepareBackstageIdentityResponse(identity),
       };
 

--- a/plugins/auth-node/src/proxy/types.ts
+++ b/plugins/auth-node/src/proxy/types.ts
@@ -19,18 +19,18 @@ import { Request } from 'express';
 import { ProfileTransform } from '../types';
 
 /** @public */
-export interface ProxyAuthenticator<TContext, TResult> {
+export interface ProxyAuthenticator<TContext, TResult, TProviderInfo> {
   defaultProfileTransform: ProfileTransform<TResult>;
   initialize(ctx: { config: Config }): TContext;
   authenticate(
     options: { req: Request },
     ctx: TContext,
-  ): Promise<{ result: TResult }>;
+  ): Promise<{ result: TResult; providerInfo?: TProviderInfo }>;
 }
 
 /** @public */
-export function createProxyAuthenticator<TContext, TResult>(
-  authenticator: ProxyAuthenticator<TContext, TResult>,
-): ProxyAuthenticator<TContext, TResult> {
+export function createProxyAuthenticator<TContext, TResult, TProviderInfo>(
+  authenticator: ProxyAuthenticator<TContext, TResult, TProviderInfo>,
+): ProxyAuthenticator<TContext, TResult, TProviderInfo> {
   return authenticator;
 }


### PR DESCRIPTION
Fixes #23117.

I ended up also copying forward the changes that were potentially missed from the `oauth2proxy` and `google-iap` module too, although we've not had any reports of this being broken, it definitely got dropped with the migration. Happy to back them out of this change though if we feel that we should just ignore it for now?

