### PR TITLE
Patch release of #23127

### DIFF
--- a/.changeset/tricky-months-hug.md
+++ b/.changeset/tricky-months-hug.md
@@ -1,8 +1,0 @@
----
-'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
-'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
-'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
-'@backstage/plugin-auth-node': patch
----
-
-Fix issue with `providerInfo` not being set properly for some proxy providers, by making `providerInfo` an explicit optional return from `authenticate`

--- a/.changeset/tricky-months-hug.md
+++ b/.changeset/tricky-months-hug.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+'@backstage/plugin-auth-node': patch
+---
+
+Fix issue with `providerInfo` not being set properly for some proxy providers, by making `providerInfo` an explicit optional return from `authenticate`

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch"
   },
-  "version": "1.23.0",
+  "version": "1.23.1",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",

--- a/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-aws-alb-provider
 
+## 0.1.1
+
+### Patch Changes
+
+- 65f76be: Fix issue with `providerInfo` not being set properly for some proxy providers, by making `providerInfo` an explicit optional return from `authenticate`
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.4.5
+
 ## 0.1.0
 
 ### Minor Changes

--- a/plugins/auth-backend-module-aws-alb-provider/api-report.md
+++ b/plugins/auth-backend-module-aws-alb-provider/api-report.md
@@ -21,7 +21,11 @@ export const awsAlbAuthenticator: ProxyAuthenticator<
     issuer: string;
     getKey: (header: JWTHeaderParameters) => Promise<KeyObject>;
   },
-  AwsAlbResult
+  AwsAlbResult,
+  {
+    accessToken: string;
+    expiresInSeconds: number;
+  }
 >;
 
 // @public

--- a/plugins/auth-backend-module-aws-alb-provider/package.json
+++ b/plugins/auth-backend-module-aws-alb-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-auth-backend-module-aws-alb-provider",
   "description": "The aws-alb provider module for the Backstage auth backend.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-aws-alb-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/authenticator.test.ts
@@ -107,6 +107,10 @@ describe('AwsAlbProvider', () => {
           expiresInSeconds: mockClaims.exp,
           accessToken: mockAccessToken,
         },
+        providerInfo: {
+          accessToken: mockAccessToken,
+          expiresInSeconds: mockClaims.exp,
+        },
       });
     });
   });

--- a/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
@@ -81,8 +81,12 @@ export const awsAlbAuthenticator = createProxyAuthenticator({
       return {
         result: {
           fullProfile,
+          accessToken: accessToken,
           expiresInSeconds: claims.exp,
-          accessToken,
+        },
+        providerInfo: {
+          accessToken: accessToken,
+          expiresInSeconds: claims.exp,
         },
       };
     } catch (e) {

--- a/plugins/auth-backend-module-gcp-iap-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-gcp-iap-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-gcp-iap-provider
 
+## 0.2.5
+
+### Patch Changes
+
+- 65f76be: Fix issue with `providerInfo` not being set properly for some proxy providers, by making `providerInfo` an explicit optional return from `authenticate`
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.4.5
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-gcp-iap-provider/api-report.md
+++ b/plugins/auth-backend-module-gcp-iap-provider/api-report.md
@@ -20,6 +20,9 @@ export const gcpIapAuthenticator: ProxyAuthenticator<
   },
   {
     iapToken: GcpIapTokenInfo;
+  },
+  {
+    iapToken: GcpIapTokenInfo;
   }
 >;
 

--- a/plugins/auth-backend-module-gcp-iap-provider/package.json
+++ b/plugins/auth-backend-module-gcp-iap-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-auth-backend-module-gcp-iap-provider",
   "description": "A GCP IAP auth provider module for the Backstage auth backend",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.test.ts
@@ -45,7 +45,10 @@ describe('GcpIapProvider', () => {
         },
         ctx,
       ),
-    ).resolves.toEqual({ result: { iapToken: { sub: 's', email: 'e' } } });
+    ).resolves.toEqual({
+      result: { iapToken: { sub: 's', email: 'e' } },
+      providerInfo: { iapToken: { sub: 's', email: 'e' } },
+    });
   });
 
   it('should find custom JWT header', async () => {
@@ -66,7 +69,10 @@ describe('GcpIapProvider', () => {
         },
         ctx,
       ),
-    ).resolves.toEqual({ result: { iapToken: { sub: 's', email: 'e' } } });
+    ).resolves.toEqual({
+      result: { iapToken: { sub: 's', email: 'e' } },
+      providerInfo: { iapToken: { sub: 's', email: 'e' } },
+    });
   });
 
   it('should throw if header is missing', async () => {

--- a/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/authenticator.ts
@@ -47,6 +47,9 @@ export const gcpIapAuthenticator = createProxyAuthenticator({
 
     const iapToken = await tokenValidator(token);
 
-    return { result: { iapToken } };
+    return {
+      result: { iapToken },
+      providerInfo: { iapToken },
+    };
   },
 });

--- a/plugins/auth-backend-module-oauth2-proxy-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-oauth2-proxy-provider
 
+## 0.1.3
+
+### Patch Changes
+
+- 65f76be: Fix issue with `providerInfo` not being set properly for some proxy providers, by making `providerInfo` an explicit optional return from `authenticate`
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.4.5
+
 ## 0.1.2
 
 ### Patch Changes

--- a/plugins/auth-backend-module-oauth2-proxy-provider/api-report.md
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/api-report.md
@@ -18,8 +18,11 @@ export const OAUTH2_PROXY_JWT_HEADER = 'X-OAUTH2-PROXY-ID-TOKEN';
 
 // @public (undocumented)
 export const oauth2ProxyAuthenticator: ProxyAuthenticator<
-  unknown,
-  OAuth2ProxyResult
+  Promise<void>,
+  OAuth2ProxyResult,
+  {
+    accessToken: string;
+  }
 >;
 
 // @public

--- a/plugins/auth-backend-module-oauth2-proxy-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-auth-backend-module-oauth2-proxy-provider",
   "description": "The oauth2-proxy-provider backend module for the auth plugin.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
@@ -31,10 +31,7 @@ import { OAuth2ProxyResult } from './types';
 export const OAUTH2_PROXY_JWT_HEADER = 'X-OAUTH2-PROXY-ID-TOKEN';
 
 /** @public */
-export const oauth2ProxyAuthenticator = createProxyAuthenticator<
-  unknown,
-  OAuth2ProxyResult
->({
+export const oauth2ProxyAuthenticator = createProxyAuthenticator({
   defaultProfileTransform: async (result: OAuth2ProxyResult) => {
     return {
       profile: {
@@ -63,7 +60,13 @@ export const oauth2ProxyAuthenticator = createProxyAuthenticator<
           return req.get(name);
         },
       };
-      return { result };
+
+      return {
+        result,
+        providerInfo: {
+          accessToken: result.accessToken,
+        },
+      };
     } catch (e) {
       throw new AuthenticationError('Authentication failed', e);
     }

--- a/plugins/auth-node/CHANGELOG.md
+++ b/plugins/auth-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-auth-node
 
+## 0.4.5
+
+### Patch Changes
+
+- 65f76be: Fix issue with `providerInfo` not being set properly for some proxy providers, by making `providerInfo` an explicit optional return from `authenticate`
+
 ## 0.4.4
 
 ### Patch Changes

--- a/plugins/auth-node/api-report.md
+++ b/plugins/auth-node/api-report.md
@@ -173,13 +173,13 @@ export function createOAuthRouteHandlers<TProfile>(
 ): AuthProviderRouteHandlers;
 
 // @public (undocumented)
-export function createProxyAuthenticator<TContext, TResult>(
-  authenticator: ProxyAuthenticator<TContext, TResult>,
-): ProxyAuthenticator<TContext, TResult>;
+export function createProxyAuthenticator<TContext, TResult, TProviderInfo>(
+  authenticator: ProxyAuthenticator<TContext, TResult, TProviderInfo>,
+): ProxyAuthenticator<TContext, TResult, TProviderInfo>;
 
 // @public (undocumented)
 export function createProxyAuthProviderFactory<TResult>(options: {
-  authenticator: ProxyAuthenticator<unknown, TResult>;
+  authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
   signInResolverFactories?: Record<
@@ -538,7 +538,11 @@ export type ProfileTransform<TResult> = (
 }>;
 
 // @public (undocumented)
-export interface ProxyAuthenticator<TContext, TResult> {
+export interface ProxyAuthenticator<
+  TContext,
+  TResult,
+  TProviderInfo = undefined,
+> {
   // (undocumented)
   authenticate(
     options: {
@@ -547,6 +551,7 @@ export interface ProxyAuthenticator<TContext, TResult> {
     ctx: TContext,
   ): Promise<{
     result: TResult;
+    providerInfo?: TProviderInfo;
   }>;
   // (undocumented)
   defaultProfileTransform: ProfileTransform<TResult>;
@@ -557,7 +562,7 @@ export interface ProxyAuthenticator<TContext, TResult> {
 // @public (undocumented)
 export interface ProxyAuthRouteHandlersOptions<TResult> {
   // (undocumented)
-  authenticator: ProxyAuthenticator<any, TResult>;
+  authenticator: ProxyAuthenticator<any, TResult, unknown>;
   // (undocumented)
   config: Config;
   // (undocumented)

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-node",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
+++ b/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
@@ -28,7 +28,7 @@ import { ProxyAuthenticator } from './types';
 
 /** @public */
 export function createProxyAuthProviderFactory<TResult>(options: {
-  authenticator: ProxyAuthenticator<unknown, TResult>;
+  authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
   signInResolverFactories?: Record<

--- a/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
+++ b/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
@@ -29,7 +29,7 @@ import { NotImplementedError } from '@backstage/errors';
 
 /** @public */
 export interface ProxyAuthRouteHandlersOptions<TResult> {
-  authenticator: ProxyAuthenticator<any, TResult>;
+  authenticator: ProxyAuthenticator<any, TResult, unknown>;
   config: Config;
   resolverContext: AuthResolverContext;
   signInResolver: SignInResolver<TResult>;
@@ -56,7 +56,7 @@ export function createProxyAuthRouteHandlers<TResult>(
     },
 
     async refresh(this: never, req: Request, res: Response): Promise<void> {
-      const { result } = await authenticator.authenticate(
+      const { result, providerInfo } = await authenticator.authenticate(
         { req },
         authenticatorCtx,
       );
@@ -68,9 +68,9 @@ export function createProxyAuthRouteHandlers<TResult>(
         resolverContext,
       );
 
-      const response: ClientAuthResponse<{}> = {
+      const response: ClientAuthResponse<unknown> = {
         profile,
-        providerInfo: {},
+        providerInfo,
         backstageIdentity: prepareBackstageIdentityResponse(identity),
       };
 

--- a/plugins/auth-node/src/proxy/types.ts
+++ b/plugins/auth-node/src/proxy/types.ts
@@ -19,18 +19,22 @@ import { Request } from 'express';
 import { ProfileTransform } from '../types';
 
 /** @public */
-export interface ProxyAuthenticator<TContext, TResult> {
+export interface ProxyAuthenticator<
+  TContext,
+  TResult,
+  TProviderInfo = undefined,
+> {
   defaultProfileTransform: ProfileTransform<TResult>;
   initialize(ctx: { config: Config }): TContext;
   authenticate(
     options: { req: Request },
     ctx: TContext,
-  ): Promise<{ result: TResult }>;
+  ): Promise<{ result: TResult; providerInfo?: TProviderInfo }>;
 }
 
 /** @public */
-export function createProxyAuthenticator<TContext, TResult>(
-  authenticator: ProxyAuthenticator<TContext, TResult>,
-): ProxyAuthenticator<TContext, TResult> {
+export function createProxyAuthenticator<TContext, TResult, TProviderInfo>(
+  authenticator: ProxyAuthenticator<TContext, TResult, TProviderInfo>,
+): ProxyAuthenticator<TContext, TResult, TProviderInfo> {
   return authenticator;
 }


### PR DESCRIPTION
This release fixes an issue with the `@backstage/plugin-auth-backend` package, in particular the `providerInfo` not being set properly for some proxy providers.