### PR TITLE
Fixed Azure Portal link and filtered returned tags

### DIFF
--- a/.changeset/violet-chicken-smell.md
+++ b/.changeset/violet-chicken-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-sites-backend': minor
+---
+
+Azure Sites list now hides the internal/microsoft only `hidden-` tags from the list of tags that are returned. Updated the log endpoint to /logstream-quickstart rather than just /logstream to stream logs in the Azure Portal UI.

--- a/plugins/azure-sites-backend/src/api/AzureSitesApi.ts
+++ b/plugins/azure-sites-backend/src/api/AzureSitesApi.ts
@@ -78,9 +78,17 @@ export class AzureSitesApi {
       subscriptions: this.config.subscriptions,
     });
     for (const v of result.data) {
+      const tags = Object.fromEntries(
+        Object.entries(v.properties.tags ?? {}).filter(
+          ([k, _]) => !k.startsWith('hidden-'),
+        ),
+      );
+
       items.push({
         href: `${this.baseHref(this.config.domain)}${v.id!}`,
-        logstreamHref: `${this.baseHref(this.config.domain)}${v.id!}/logStream`,
+        logstreamHref: `${this.baseHref(
+          this.config.domain,
+        )}${v.id!}/logStream-quickstart`,
         name: v.name!,
         kind: v.kind!,
         resourceGroup: v.resourceGroup!,
@@ -90,7 +98,7 @@ export class AzureSitesApi {
         usageState: v.properties.usageState!,
         state: v.properties.state!,
         containerSize: v.properties.containerSize!,
-        tags: v.properties.tags!,
+        tags,
       });
     }
     return { items: items };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the internal/microsoft only "hidden-link: " tags from the list of tags that are removed, as they are extremely long and cause the UI to extend beyond a regular screen width.

see : https://stackoverflow.com/questions/38578122/what-does-hidden-link-mean-in-azure-resource-manager-tags

These tags are not viewable in the azure portal and only used by Microsoft for linking related resources (presumably they gave that one to the work experience guy to design and they just overloaded the tags property rather than engineer it properly)

![image](https://github.com/backstage/backstage/assets/1361894/f2fd63f6-b1e2-4003-88a0-cbe792f840c7)

Additionally, the logstream in the azure portal UI links to the Azure portal ending in /logStream-quickstart, the current plugin links to just /logStream. The existing endpoint just times out,  /logStream-quickstart works as expected. I cannot find any history as to whether this has changed recently or any information on this.  I assume as the portal UI/menu option links to /logstream-quickstart this should be the one in use.

![image](https://github.com/backstage/backstage/assets/1361894/b606f0b6-881d-4e55-95a7-81f9549fea40)

![image](https://github.com/backstage/backstage/assets/1361894/0100e44e-cd12-45ac-b37a-6103e626f3de)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
