### PR TITLE
Fix azure refresh jank

### DIFF
--- a/.changeset/pretty-olives-travel.md
+++ b/.changeset/pretty-olives-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-sites': minor
+---
+
+Modified azure table to only show loading UI on initial load. Sorted tags in table is their order from the api is indeterminate, and they would randomly shuffle on each load

--- a/.changeset/pretty-olives-travel.md
+++ b/.changeset/pretty-olives-travel.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-azure-sites': minor
+'@backstage/plugin-azure-sites': patch
 ---
 
 Modified azure table to only show loading UI on initial load. Sorted tags in table is their order from the api is indeterminate, and they would randomly shuffle on each load

--- a/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.tsx
+++ b/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.tsx
@@ -99,15 +99,17 @@ const Kind = ({ value }: { value: Kinds }) => {
 };
 
 const Tags = ({ tags }: { tags: any }) => {
-  return Object.keys(tags).map((key: any) => (
-    <Chip
-      key={key}
-      label={`${key}: ${tags[key]}`}
-      size="small"
-      variant="default"
-      style={{ marginBottom: '1px' }}
-    />
-  ));
+  return Object.keys(tags)
+    .toSorted()
+    .map((key: any) => (
+      <Chip
+        key={key}
+        label={`${key}: ${tags[key]}`}
+        size="small"
+        variant="default"
+        style={{ marginBottom: '1px' }}
+      />
+    ));
 };
 
 type TableProps = {
@@ -291,7 +293,7 @@ export const AzureSitesOverviewTable = ({ data, loading }: TableProps) => {
         options={{ paging: true, search: false, pageSize: 10 }}
         data={data}
         emptyContent={<LinearProgress />}
-        isLoading={loading}
+        isLoading={loading && data.length === 0}
         columns={columns}
       />
       <Snackbar

--- a/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.tsx
+++ b/plugins/azure-sites/src/components/AzureSitesOverviewTableComponent/AzureSitesOverviewTable.tsx
@@ -100,7 +100,7 @@ const Kind = ({ value }: { value: Kinds }) => {
 
 const Tags = ({ tags }: { tags: any }) => {
   return Object.keys(tags)
-    .toSorted()
+    .sort()
     .map((key: any) => (
       <Chip
         key={key}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have modified the azure sites table to only show an animation on the first load of data.

Currently, the UI is configured to reload/refresh the data every 15 seconds. In the current iteration of the UI, this will cause the table to stop showing the existing data and display the loading/circle animation until the data is reloaded. this is extremely annoying if you are interacting with and item in the table and it periodically disappears right before you click it.

Additionally, I have sorted the tags in the table before displaying them. The service returns the tags in an indeterminate order, and tags will jump around and re-order on each reload (they did this in the existing implementation as well, but it was less noticeable as the entire list disappeared for a few seconds on every refresh)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
