### PR TITLE
add import support for Ico files

### DIFF
--- a/.changeset/slimy-trainers-attend.md
+++ b/.changeset/slimy-trainers-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add .ico import support

--- a/packages/cli/asset-types/asset-types.d.ts
+++ b/packages/cli/asset-types/asset-types.d.ts
@@ -55,6 +55,11 @@ declare module '*.webp' {
   export default src;
 }
 
+declare module '*.ico' {
+  const src: string;
+  export default src;
+}
+
 declare module '*.yaml' {
   const src: string;
   export default src;

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -185,7 +185,7 @@ async function getProjectConfig(targetPath, extraConfig) {
           },
         },
       ],
-      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg|eot|woff|woff2|ttf)$':
+      '\\.(bmp|gif|jpg|jpeg|png|ico|frag|xml|svg|eot|woff|woff2|ttf)$':
         require.resolve('./jestFileTransform.js'),
       '\\.(yaml)$': require.resolve('./jestYamlTransform'),
     },

--- a/packages/cli/src/lib/bundler/transforms.ts
+++ b/packages/cli/src/lib/bundler/transforms.ts
@@ -145,6 +145,7 @@ export const transforms = (options: TransformOptions): Transforms => {
         /\.vert$/,
         { and: [/\.svg$/, { not: [/\.icon\.svg$/] }] },
         /\.xml$/,
+        /\.ico$/,
       ],
       type: 'asset/resource',
       generator: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just a quick and simple update to the webpack config to allow for importing .ico files alongside .png, .jpeg, and .webp files

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
