### PR TITLE
sort the root package.json, and make sure that all package.json files get sorted going forward

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,50 +1,7 @@
 {
   "name": "root",
+  "version": "1.23.0",
   "private": true,
-  "engines": {
-    "node": "18 || 20"
-  },
-  "scripts": {
-    "dev": "concurrently 'yarn start' 'yarn start-backend'",
-    "dev:next": "concurrently 'yarn start:next' 'yarn start-backend:next'",
-    "start": "yarn workspace example-app start",
-    "start-backend": "yarn workspace example-backend start",
-    "start:next": "yarn workspace example-app-next start",
-    "start-backend:next": "yarn workspace example-backend-next start",
-    "start:microsite": "cd microsite/ && yarn start",
-    "build:backend": "yarn workspace example-backend build",
-    "build:all": "backstage-cli repo build --all",
-    "build:api-reports": "yarn build:api-reports:only --tsc",
-    "build:api-reports:only": "backstage-repo-tools api-reports --allow-warnings 'packages/core-components,plugins/+(catalog|catalog-import|git-release-manager|jenkins|kubernetes)' -o ae-wrong-input-file-type --validate-release-tags",
-    "build:knip-reports": "backstage-repo-tools knip-reports",
-    "build:api-docs": "LANG=en_EN yarn build:api-reports --docs --exclude 'plugins/@(adr|adr-backend|adr-common|airbrake|airbrake-backend|allure|analytics-module-ga|analytics-module-ga4|analytics-module-newrelic-browser|apache-airflow|api-docs|api-docs-module-protoc-gen-doc|apollo-explorer|app-visualizer|azure-devops|azure-devops-backend|azure-devops-common|azure-sites|azure-sites-backend|azure-sites-common|badges|badges-backend|bazaar|bazaar-backend|bitbucket-cloud-common|bitrise|catalog-graph|catalog-graphql|catalog-import|catalog-unprocessed-entities|cicd-statistics|cicd-statistics-module-gitlab|circleci|cloudbuild|code-climate|code-coverage|code-coverage-backend|codescene|config-schema|cost-insights|cost-insights-common|dynatrace|entity-feedback|entity-feedback-backend|entity-feedback-common|entity-validation|example-todo-list|example-todo-list-backend|example-todo-list-common|firehydrant|fossa|gcalendar|gcp-projects|git-release-manager|github-actions|github-deployments|github-issues|github-pull-requests-board|gitops-profiles|gocd|graphiql|graphql-backend|graphql-voyager|ilert|jenkins|jenkins-backend|jenkins-common|kafka|kafka-backend|lighthouse|lighthouse-backend|lighthouse-common|linguist|linguist-backend|linguist-common|microsoft-calendar|newrelic|newrelic-dashboard|nomad|nomad-backend|octopus-deploy|opencost|pagerduty|periskop|periskop-backend|playlist|playlist-backend|playlist-common|proxy-backend|puppetdb|rollbar|rollbar-backend|sentry|shortcuts|splunk-on-call|stack-overflow|stack-overflow-backend|stackstorm|tech-radar|tech-radar-2|todo|todo-backend|xcmetrics)'",
-    "build:plugins-report": "node ./scripts/build-plugins-report",
-    "tsc": "tsc",
-    "tsc:full": "backstage-cli repo clean && tsc --skipLibCheck false --incremental false",
-    "clean": "backstage-cli repo clean",
-    "test": "backstage-cli repo test",
-    "test:all": "backstage-cli repo test --coverage",
-    "test:e2e": "playwright test",
-    "fix": "backstage-cli repo fix",
-    "lint": "backstage-cli repo lint --since origin/master",
-    "lint:docs": "node ./scripts/check-docs-quality",
-    "lint:all": "backstage-cli repo lint",
-    "lint:type-deps": "backstage-repo-tools type-deps",
-    "docker-build": "yarn tsc && yarn workspace example-backend build && yarn workspace example-backend build-image",
-    "new": "backstage-cli new --scope backstage --baseVersion 0.0.0 --no-private",
-    "create-plugin": "echo \"use 'yarn new' instead\"",
-    "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",
-    "prettier:check": "prettier --check .",
-    "prettier:fix": "prettier --write .",
-    "storybook": "yarn ./storybook run start",
-    "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
-    "snyk:test:package": "yarn snyk:test --include",
-    "build-storybook": "yarn ./storybook run build-storybook",
-    "techdocs-cli": "node scripts/techdocs-cli.js",
-    "techdocs-cli:dev": "cross-env TECHDOCS_CLI_DEV_MODE=true node scripts/techdocs-cli.js",
-    "prepare": "husky",
-    "postinstall": "husky || true"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/backstage"
@@ -55,14 +12,83 @@
       "plugins/*"
     ]
   },
+  "scripts": {
+    "build-storybook": "yarn ./storybook run build-storybook",
+    "build:all": "backstage-cli repo build --all",
+    "build:api-docs": "LANG=en_EN yarn build:api-reports --docs --exclude 'plugins/@(adr|adr-backend|adr-common|airbrake|airbrake-backend|allure|analytics-module-ga|analytics-module-ga4|analytics-module-newrelic-browser|apache-airflow|api-docs|api-docs-module-protoc-gen-doc|apollo-explorer|app-visualizer|azure-devops|azure-devops-backend|azure-devops-common|azure-sites|azure-sites-backend|azure-sites-common|badges|badges-backend|bazaar|bazaar-backend|bitbucket-cloud-common|bitrise|catalog-graph|catalog-graphql|catalog-import|catalog-unprocessed-entities|cicd-statistics|cicd-statistics-module-gitlab|circleci|cloudbuild|code-climate|code-coverage|code-coverage-backend|codescene|config-schema|cost-insights|cost-insights-common|dynatrace|entity-feedback|entity-feedback-backend|entity-feedback-common|entity-validation|example-todo-list|example-todo-list-backend|example-todo-list-common|firehydrant|fossa|gcalendar|gcp-projects|git-release-manager|github-actions|github-deployments|github-issues|github-pull-requests-board|gitops-profiles|gocd|graphiql|graphql-backend|graphql-voyager|ilert|jenkins|jenkins-backend|jenkins-common|kafka|kafka-backend|lighthouse|lighthouse-backend|lighthouse-common|linguist|linguist-backend|linguist-common|microsoft-calendar|newrelic|newrelic-dashboard|nomad|nomad-backend|octopus-deploy|opencost|pagerduty|periskop|periskop-backend|playlist|playlist-backend|playlist-common|proxy-backend|puppetdb|rollbar|rollbar-backend|sentry|shortcuts|splunk-on-call|stack-overflow|stack-overflow-backend|stackstorm|tech-radar|tech-radar-2|todo|todo-backend|xcmetrics)'",
+    "build:api-reports": "yarn build:api-reports:only --tsc",
+    "build:api-reports:only": "backstage-repo-tools api-reports --allow-warnings 'packages/core-components,plugins/+(catalog|catalog-import|git-release-manager|jenkins|kubernetes)' -o ae-wrong-input-file-type --validate-release-tags",
+    "build:backend": "yarn workspace example-backend build",
+    "build:knip-reports": "backstage-repo-tools knip-reports",
+    "build:plugins-report": "node ./scripts/build-plugins-report",
+    "clean": "backstage-cli repo clean",
+    "create-plugin": "echo \"use 'yarn new' instead\"",
+    "dev": "concurrently 'yarn start' 'yarn start-backend'",
+    "dev:next": "concurrently 'yarn start:next' 'yarn start-backend:next'",
+    "docker-build": "yarn tsc && yarn workspace example-backend build && yarn workspace example-backend build-image",
+    "fix": "backstage-cli repo fix",
+    "postinstall": "husky || true",
+    "lint": "backstage-cli repo lint --since origin/master",
+    "lint:all": "backstage-cli repo lint",
+    "lint:docs": "node ./scripts/check-docs-quality",
+    "lint:type-deps": "backstage-repo-tools type-deps",
+    "new": "backstage-cli new --scope backstage --baseVersion 0.0.0 --no-private",
+    "prepare": "husky",
+    "prettier:check": "prettier --check .",
+    "prettier:fix": "prettier --write .",
+    "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",
+    "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
+    "snyk:test:package": "yarn snyk:test --include",
+    "start": "yarn workspace example-app start",
+    "start-backend": "yarn workspace example-backend start",
+    "start-backend:next": "yarn workspace example-backend-next start",
+    "start:microsite": "cd microsite/ && yarn start",
+    "start:next": "yarn workspace example-app-next start",
+    "storybook": "yarn ./storybook run start",
+    "techdocs-cli": "node scripts/techdocs-cli.js",
+    "techdocs-cli:dev": "cross-env TECHDOCS_CLI_DEV_MODE=true node scripts/techdocs-cli.js",
+    "test": "backstage-cli repo test",
+    "test:all": "backstage-cli repo test --coverage",
+    "test:e2e": "playwright test",
+    "tsc": "tsc",
+    "tsc:full": "backstage-cli repo clean && tsc --skipLibCheck false --incremental false"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.json": [
+      "prettier --write"
+    ],
+    "*.md": [
+      "prettier --write",
+      "node ./scripts/check-docs-quality"
+    ],
+    "{plugins,packages}/*/catalog-info.yaml": [
+      "yarn backstage-repo-tools generate-catalog-info --ci"
+    ],
+    ".github/CODEOWNERS": [
+      "yarn backstage-repo-tools generate-catalog-info",
+      "git add */catalog-info.yaml"
+    ],
+    "package.json": [
+      "yarn backstage-repo-tools generate-catalog-info",
+      "git add */catalog-info.yaml",
+      "yarn sort-package-json"
+    ],
+    "yarn.lock": [
+      "node ./scripts/verify-lockfile-duplicates --fix"
+    ]
+  },
+  "prettier": "@spotify/prettier-config",
   "resolutions": {
+    "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
+    "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch",
-    "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
-    "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch"
+    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch"
   },
-  "version": "1.23.0",
   "dependencies": {
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
@@ -100,34 +126,12 @@
     "semver": "^7.5.3",
     "shx": "^0.3.2",
     "sloc": "^0.3.1",
+    "sort-package-json": "^2.8.0",
     "ts-node": "^10.4.0",
     "typescript": "~5.1.0"
   },
-  "prettier": "@spotify/prettier-config",
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,mjs,cjs}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.{json,md}": [
-      "prettier --write"
-    ],
-    "*.md": [
-      "node ./scripts/check-docs-quality"
-    ],
-    "{plugins,packages}/*/catalog-info.yaml": [
-      "yarn backstage-repo-tools generate-catalog-info --ci"
-    ],
-    "{.github/CODEOWNERS,package.json}": [
-      "yarn backstage-repo-tools generate-catalog-info",
-      "git add */catalog-info.yaml"
-    ],
-    "./yarn.lock": [
-      "node ./scripts/verify-lockfile-duplicates --fix"
-    ],
-    "*/yarn.lock": [
-      "node ./scripts/verify-lockfile-duplicates --fix"
-    ]
-  },
-  "packageManager": "yarn@3.2.3"
+  "packageManager": "yarn@3.2.3",
+  "engines": {
+    "node": "18 || 20"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25340,6 +25340,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-indent@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "detect-indent@npm:7.0.1"
+  checksum: cbf3f0b1c3c881934ca94428e1179b26ab2a587e0d719031d37a67fb506d49d067de54ff057cb1e772e75975fed5155c01cd4518306fee60988b1486e3fc7768
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.0":
   version: 2.0.1
   resolution: "detect-libc@npm:2.0.1"
@@ -25351,6 +25358,13 @@ __metadata:
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
+  languageName: node
+  linkType: hard
+
+"detect-newline@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "detect-newline@npm:4.0.1"
+  checksum: 0409ecdfb93419591ccff24fccfe2ddddad29b66637d1ed898872125b25af05014fdeedc9306339577060f69f59fe6e9830cdd80948597f136dfbffefa60599c
   languageName: node
   linkType: hard
 
@@ -28859,6 +28873,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-stdin@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "get-stdin@npm:9.0.0"
+  checksum: 5972bc34d05932b45512c8e2d67b040f1c1ca8afb95c56cbc480985f2d761b7e37fe90dc8abd22527f062cc5639a6930ff346e9952ae4c11a2d4275869459594
+  languageName: node
+  linkType: hard
+
 "get-stream@npm:^4.0.0, get-stream@npm:^4.1.0":
   version: 4.1.0
   resolution: "get-stream@npm:4.1.0"
@@ -28935,6 +28956,13 @@ __metadata:
   dependencies:
     assert-plus: ^1.0.0
   checksum: ab18d55661db264e3eac6012c2d3daeafaab7a501c035ae0ccb193c3c23e9849c6e29b6ac762b9c2adae460266f925d55a3a2a3a3c8b94be2f222df94d70c046
+  languageName: node
+  linkType: hard
+
+"git-hooks-list@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "git-hooks-list@npm:3.1.0"
+  checksum: 05cbdb29e1e14f3b6fde78c876a34383e4476b1be32e8486ad03293f01add884c1a8df8c2dce2ca5d99119c94951b2ff9fa9cbd51d834ae6477b6813cefb998f
   languageName: node
   linkType: hard
 
@@ -30979,10 +31007,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "is-plain-obj@npm:4.0.0"
-  checksum: a6bb55a90636345a64c6153b74d85a9b6440f9975f4dcc57eed596c280b7ba228c71c406355a3147ed0488330d2743d5756e052c9492b1aa4f7dcd281f08c4b6
+"is-plain-obj@npm:^4.0.0, is-plain-obj@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "is-plain-obj@npm:4.1.0"
+  checksum: 6dc45da70d04a81f35c9310971e78a6a3c7a63547ef782e3a07ee3674695081b6ca4e977fbb8efc48dae3375e0b34558d2bcd722aec9bddfa2d7db5b041be8ce
   languageName: node
   linkType: hard
 
@@ -40987,6 +41015,7 @@ __metadata:
     semver: ^7.5.3
     shx: ^0.3.2
     sloc: ^0.3.1
+    sort-package-json: ^2.8.0
     ts-node: ^10.4.0
     typescript: ~5.1.0
   languageName: unknown
@@ -41918,6 +41947,30 @@ __metadata:
     atomic-sleep: ^1.0.0
     flatstr: ^1.0.12
   checksum: b08e20dfa8d888ba32393141f96d195ab6fdecf341a736f25d9c1127cf0de8eaa4e03cde38c23cfa06c50a20ba4b5cb1b107dfc1251283b7c7a153c50f646628
+  languageName: node
+  linkType: hard
+
+"sort-object-keys@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "sort-object-keys@npm:1.1.3"
+  checksum: abea944d6722a1710a1aa6e4f9509da085d93d5fc0db23947cb411eedc7731f80022ce8fa68ed83a53dd2ac7441fcf72a3f38c09b3d9bbc4ff80546aa2e151ad
+  languageName: node
+  linkType: hard
+
+"sort-package-json@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "sort-package-json@npm:2.8.0"
+  dependencies:
+    detect-indent: ^7.0.1
+    detect-newline: ^4.0.0
+    get-stdin: ^9.0.0
+    git-hooks-list: ^3.0.0
+    globby: ^13.1.2
+    is-plain-obj: ^4.1.0
+    sort-object-keys: ^1.1.3
+  bin:
+    sort-package-json: cli.js
+  checksum: 8739392ae4f5f6aa07948e317e43c62e2165fa815175c4678b1eef815f27d93846262113a16f17c10f12856f72222c312a8a5ed2dcae60265bfbacee64967312
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It bugged me that the version was far down, and there's a popular auto-sorting library already so why not apply it instead of going manual