### PR TITLE
beps/0003: new cookie auth design

### DIFF
--- a/beps/0003-auth-architecture-evolution/README.md
+++ b/beps/0003-auth-architecture-evolution/README.md
@@ -232,7 +232,7 @@ export default createBackendPlugin({
 
         // Endpoint that sets the cookie for the user
         router.get('/cookie', async (req, res) => {
-          const { expiresAt } = await httpAuth.issueUserCookie(req);
+          const { expiresAt } = await httpAuth.issueUserCookie(res);
 
           res.json({ expiresAt: expiresAt.toISOString() });
         });

--- a/beps/0003-auth-architecture-evolution/README.md
+++ b/beps/0003-auth-architecture-evolution/README.md
@@ -110,6 +110,8 @@ export type BackstageServicePrincipal = {
 export type BackstageCredentials<TPrincipal = unknown> = {
   $$type: '@backstage/BackstageCredentials';
 
+  expiresAt?: Date;
+
   principal: TPrincipal;
 };
 
@@ -131,6 +133,8 @@ export interface AuthService {
     credentials: BackstageCredentials,
     type: TType,
   ): credentials is BackstageCredentials<BackstagePrincipalTypes[TType]>;
+
+  getNoneCredentials(): Promise<BackstageCredentials<BackstageUserPrincipal>>;
 
   getOwnServiceCredentials(): Promise<
     BackstageCredentials<BackstageServicePrincipal>
@@ -228,9 +232,9 @@ export default createBackendPlugin({
 
         // Endpoint that sets the cookie for the user
         router.get('/cookie', async (req, res) => {
-          await httpAuth.issueUserCookie(req);
+          const { expiresAt } = await httpAuth.issueUserCookie(req);
 
-          res.json({ ok: true });
+          res.json({ expiresAt: expiresAt.toISOString() });
         });
 
         // Endpoint protected by cookie auth
@@ -303,7 +307,7 @@ export interface HttpAuthService {
       // If credentials are not provided, they will be read from the request
       credentials?: BackstageCredentials<BackstageUserPrincipal>;
     },
-  ): Promise<void>;
+  ): Promise<{ expiresAt: Date }>;
 }
 ```
 


### PR DESCRIPTION
Having poked around at the cookie auth implementation I think our current design is a little bit too constrained and at the same time not powerful enough. This update suggests that we back away from a cookie-first design of cookie auth, and instead treat it as a more broad "limited access" feature. One potentially very neat part of this is that we can use limited tokens in other places as well, in particular scaffolder workflows. It also detangles the implementation quite a lot, since the `HttpAuthService` no longer directly needs to manage auth tokens, that's all up to the `AuthService` now. Downside ofc being that the `AuthService` is getting pretty big, but tbh I think the design of it is still pretty sensible and attempting something like a split of the `authenticate` method or merging of the `get*Token` methods is prolly just gonna make it messier.

This means that plugins need to do a bit more heavy lifting when it comes to actually implementing cookie auth, but I don't think that's bad at all tbh. Cookie auth should only be used when it's required, and in the two use-cases we have for it atm in the app backend and TechDocs, we already have quite different implementations of the cookie configuration itself too. The downside of this is that re-using cookies across plugins is gonna be a bit trickier, but I think we can put some de-facto standards in place that enables that anyway.