### PR TITLE
Table: Remove textTransform inline styling

### DIFF
--- a/.changeset/empty-ladybugs-perform.md
+++ b/.changeset/empty-ladybugs-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Move the text-transform styling on BackstageTableHeader from inline styling to withStyles so it can be customised easier

--- a/.changeset/empty-ladybugs-perform.md
+++ b/.changeset/empty-ladybugs-perform.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Move the text-transform styling on BackstageTableHeader from inline styling to withStyles so it can be customised easier
+Move the text-transform styling on BackstageTableHeader from inline styling to `withStyles` so it can be customised easier

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -115,6 +115,7 @@ const StyledMTableHeader = withStyles(
       fontWeight: theme.typography.fontWeightBold,
       position: 'static',
       wordBreak: 'normal',
+      textTransform: 'uppercase',
     },
   }),
   { name: 'BackstageTableHeader' },
@@ -436,7 +437,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
           Toolbar,
           ...components,
         }}
-        options={{ headerStyle: { textTransform: 'uppercase' }, ...options }}
+        options={options}
         columns={convertColumns(columns, theme)}
         icons={tableIcons}
         title={


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While theming Backstage, we're needing to use an `!important` to override some inline styling. This PR moves it makeStyles so we can cancel it out without an important statement. 

Screenshot of after the change to show the uppercase styling is still there. 

<img width="1303" alt="Screenshot 2024-02-23 at 16 34 27" src="https://github.com/backstage/backstage/assets/7130591/73e747a6-b6d6-450a-ad6e-ec1ef4343ae9">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
