### PR TITLE
Fix Issue #22980 : Remove maxWidth attribute fixed at 300 px from Select component

### DIFF
--- a/.changeset/violet-eagles-switch.md
+++ b/.changeset/violet-eagles-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed bug in Select component, removed maxWidth: 300 px as it's width was not readjusting after a 2500 px page width.

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -79,7 +79,6 @@ const useStyles = makeStyles(
     createStyles({
       formControl: {
         margin: theme.spacing(1, 0),
-        maxWidth: 300,
       },
       label: {
         transform: 'initial',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the maxWidth attribute from Select component as it was limiting it's width on large screens causing inconsistency in the UI.

### Before
![Screenshot 2024-02-26 at 9 46 35 AM](https://github.com/backstage/backstage/assets/43727735/b409f7ee-2dfa-4c97-a29a-271c5f00e5c6)

### After
![Screenshot 2024-02-26 at 9 47 21 AM](https://github.com/backstage/backstage/assets/43727735/ccf64aec-951b-411e-9142-242477b43850)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


