### PR TITLE
Make `Kind` and `Type` entity filter form fields full width 

### DIFF
--- a/.changeset/strange-tools-confess.md
+++ b/.changeset/strange-tools-confess.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog-react': patch
+---
+
+Make `Kind` and `Type` entity filter form fields full width

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -81,6 +81,9 @@ const useStyles = makeStyles(
         margin: theme.spacing(1, 0),
         maxWidth: 300,
       },
+      fullWidth: {
+        maxWidth: '100%',
+      },
       label: {
         transform: 'initial',
         fontWeight: 'bold',
@@ -138,6 +141,7 @@ export type SelectProps = {
   native?: boolean;
   disabled?: boolean;
   margin?: 'dense' | 'none';
+  fullWidth?: boolean;
 };
 
 /** @public */
@@ -153,6 +157,7 @@ export function SelectComponent(props: SelectProps) {
     native = false,
     disabled = false,
     margin,
+    fullWidth = false,
   } = props;
   const classes = useStyles();
   const [value, setValue] = useState<SelectedItems>(
@@ -198,7 +203,11 @@ export function SelectComponent(props: SelectProps) {
 
   return (
     <Box className={classes.root}>
-      <FormControl className={classes.formControl}>
+      <FormControl
+        className={`${classes.formControl} ${
+          fullWidth ? classes.fullWidth : ''
+        }`}
+      >
         <InputLabel className={classes.formLabel}>{label}</InputLabel>
         <Select
           aria-label={label}

--- a/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
@@ -128,6 +128,7 @@ export const EntityKindPicker = (props: EntityKindPickerProps) => {
         items={items}
         selected={selectedKind.toLocaleLowerCase('en-US')}
         onChange={value => setSelectedKind(String(value))}
+        fullWidth
       />
     </Box>
   );

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.tsx
@@ -69,6 +69,7 @@ export const EntityTypePicker = (props: EntityTypePickerProps) => {
         onChange={value =>
           setSelectedTypes(value === 'all' ? [] : [String(value)])
         }
+        fullWidth
       />
     </Box>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request addresses the issue where the **Kind** and **Type** entity filter fields on the catalog page do not occupy the full width, causing misalignment with other form fields vertically.

Closes #22980

**Before**

<img width="1440" alt="Screenshot 2024-02-26 at 12 57 05 pm" src="https://github.com/backstage/backstage/assets/72073614/bb2c7933-5ea0-494e-82be-3460b8b3da69">

**After**

<img width="1440" alt="Screenshot 2024-02-26 at 12 58 16 pm" src="https://github.com/backstage/backstage/assets/72073614/32285a2d-cb64-423c-be71-f9d27c351c92">


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
