### PR TITLE
Fixed search accordion icon color

### DIFF
--- a/.changeset/early-worms-pretend.md
+++ b/.changeset/early-worms-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Remove the hardcorded 'black' color give to the search type accordion icon as it doesn't work with dark themes

--- a/.changeset/early-worms-pretend.md
+++ b/.changeset/early-worms-pretend.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Remove the hardcorded 'black' color give to the search type accordion icon as it doesn't work with dark themes
+Remove the hardcoded 'black' color give to the search type accordion icon as it doesn't work with dark themes

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles(theme => ({
     paddingTop: theme.spacing(1),
   },
   icon: {
-    color: theme.palette.common.black,
+    color: theme.palette.text.primary,
   },
   list: {
     width: '100%',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes a hardcoded 'black' color on the searchType icon as it doesn't work with dark themes. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
