### PR TITLE
Removed hardcoded font-family on select input

### DIFF
--- a/.changeset/five-beers-accept.md
+++ b/.changeset/five-beers-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Removed hardcoded font-family on select input

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -55,7 +55,6 @@ const BootstrapInput = withStyles(
         fontSize: theme.typography.body1.fontSize,
         padding: theme.spacing(1.25, 3.25, 1.25, 1.5),
         transition: theme.transitions.create(['border-color', 'box-shadow']),
-        fontFamily: 'Helvetica Neue',
         '&:focus': {
           background: theme.palette.background.paper,
           borderRadius: theme.shape.borderRadius,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed hardcoded font-family on select input

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
