### PR TITLE
Fix typo in extending model docs

### DIFF
--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -451,7 +451,7 @@ You can generate an isomorphic plugin package by running:`yarn new --select plug
 or you can run `yarn new` and then select "plugin-common" from the list of options
 
 There's at this point no existing templates for generating isomorphic plugins
-using the `@backstage/cli`. Perhaps the simplest wat to get started right now is
+using the `@backstage/cli`. Perhaps the simplest way to get started right now is
 to copy the contents of one of the existing packages in the main repository,
 such as `plugins/scaffolder-common`, and rename the folder and file contents to
 the desired name. This example uses _foobar_ as the plugin name so the plugin


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix a typo in [Extending the model](https://backstage.io/docs/features/software-catalog/extending-the-model#creating-a-custom-entity-definition) docs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
