### PR TITLE
Removed inline color of select icon

### DIFF
--- a/.changeset/modern-impalas-add.md
+++ b/.changeset/modern-impalas-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Removed the inline color from select icon to allow it to be colored via a theme

--- a/packages/core-components/src/components/Select/static/ClosedDropdown.tsx
+++ b/packages/core-components/src/components/Select/static/ClosedDropdown.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles(
         position: 'absolute',
         right: theme.spacing(0.5),
         pointerEvents: 'none',
+        color: '#616161',
       },
     }),
   { name: 'BackstageClosedDropdown' },
@@ -42,7 +43,7 @@ const ClosedDropdown = () => {
     >
       <path
         d="M7.5 8L6 9.5L12.0703 15.5703L18.1406 9.5L16.6406 8L12.0703 12.5703L7.5 8Z"
-        fill="#616161"
+        fill="currentColor"
       />
     </SvgIcon>
   );

--- a/packages/core-components/src/components/Select/static/OpenedDropdown.tsx
+++ b/packages/core-components/src/components/Select/static/OpenedDropdown.tsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles(
         position: 'absolute',
         right: theme.spacing(0.5),
         pointerEvents: 'none',
+        color: '#616161',
       },
     }),
   { name: 'BackstageOpenedDropdown' },
@@ -41,7 +42,7 @@ const OpenedDropdown = () => {
     >
       <path
         d="M16.5 16L18 14.5L11.9297 8.42969L5.85938 14.5L7.35938 16L11.9297 11.4297L16.5 16Z"
-        fill="#616161"
+        fill="currentColor"
       />
     </SvgIcon>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the inline color from the section icon to allow it to be recolored via a theme. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
