### PR TITLE
catalog: fix alpha entity 404

### DIFF
--- a/.changeset/lemon-lemons-sparkle.md
+++ b/.changeset/lemon-lemons-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+The entity page extension provided by the `/alpha` plugin now correctly renders the entity 404 page.

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -65,22 +65,23 @@ export const catalogEntityPage = createPageExtension({
   loader: async ({ inputs }) => {
     const { EntityLayout } = await import('../components/EntityLayout');
     const Component = () => {
-      const { entity, ...rest } = useEntityFromUrl();
       return (
-        <AsyncEntityProvider entity={entity} {...rest}>
-          {entity ? (
-            <EntityLayout>
-              {inputs.contents
-                .filter(({ output: { filterFunction, filterExpression } }) =>
-                  buildFilterFn(filterFunction, filterExpression)(entity),
-                )
-                .map(({ output: { path, title, element } }) => (
-                  <EntityLayout.Route key={path} path={path} title={title}>
-                    {element}
-                  </EntityLayout.Route>
-                ))}
-            </EntityLayout>
-          ) : null}
+        <AsyncEntityProvider {...useEntityFromUrl()}>
+          <EntityLayout>
+            {inputs.contents.map(({ output }) => (
+              <EntityLayout.Route
+                key={output.path}
+                path={output.path}
+                title={output.title}
+                if={buildFilterFn(
+                  output.filterFunction,
+                  output.filterExpression,
+                )}
+              >
+                {output.element}
+              </EntityLayout.Route>
+            ))}
+          </EntityLayout>
         </AsyncEntityProvider>
       );
     };


### PR DESCRIPTION
🧹, fix so that the entity 404 page is rendered rather than empty content