### PR TITLE
[code-coverage] fix jacoco to not require scm-only

### DIFF
--- a/.changeset/empty-wolves-rule.md
+++ b/.changeset/empty-wolves-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Fix jacoco convertor to not require annotation to be set to scm-only.

--- a/plugins/code-coverage-backend/src/service/converter/jacoco.test.ts
+++ b/plugins/code-coverage-backend/src/service/converter/jacoco.test.ts
@@ -54,4 +54,10 @@ describe('convert jacoco', () => {
 
     expect(files.sort()).toEqual(expected.sort());
   });
+
+  it('works when not providing files (as per not setting annotation to scm-only)', () => {
+    const files = converter.convert(fixture, []);
+
+    expect(files).toHaveLength(4);
+  });
 });

--- a/plugins/code-coverage-backend/src/service/converter/jacoco.ts
+++ b/plugins/code-coverage-backend/src/service/converter/jacoco.ts
@@ -40,7 +40,6 @@ export class Jacoco implements Converter {
    */
   convert(xml: JacocoXML, scmFiles: Array<string>): Array<FileEntry> {
     const jscov: Array<FileEntry> = [];
-
     xml.report.package.forEach(r => {
       const packageName = r.$.name;
       r.sourcefile.forEach(sf => {
@@ -68,9 +67,12 @@ export class Jacoco implements Converter {
           .map(f => f.trimEnd())
           .find(f => f.endsWith(packageAndFilename));
         this.logger.debug(`matched ${packageAndFilename} to ${currentFile}`);
-        if (Object.keys(lineHits).length > 0 && currentFile) {
+        if (
+          scmFiles.length === 0 ||
+          (Object.keys(lineHits).length > 0 && currentFile)
+        ) {
           jscov.push({
-            filename: currentFile,
+            filename: currentFile || packageAndFilename,
             branchHits: branchHits,
             lineHits: lineHits,
           });


### PR DESCRIPTION
Currently the jacoco plugin only works if you have the annotation set to scm-only.


fixes #21620 


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
