### PR TITLE
Fix for atlassian OAuth flow

### DIFF
--- a/.changeset/stale-bags-hug.md
+++ b/.changeset/stale-bags-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+---
+
+Addressed OAuth flow issue in Atlassian auth module

--- a/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { Strategy as AtlassianStrategy } from 'passport-atlassian-oauth2';
 import {
   createOAuthAuthenticator,
   PassportOAuthAuthenticatorHelper,
   PassportOAuthDoneCallback,
   PassportProfile,
 } from '@backstage/plugin-auth-node';
+import { Strategy as AtlassianStrategy } from 'passport-atlassian-oauth2';
 
 /** @public */
 export const atlassianAuthenticator = createOAuthAuthenticator({
@@ -30,7 +30,7 @@ export const atlassianAuthenticator = createOAuthAuthenticator({
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');
     const baseUrl =
-      config.getOptionalString('audience') || 'https://atlassian.com';
+      config.getOptionalString('audience') || 'https://api.atlassian.com';
 
     return PassportOAuthAuthenticatorHelper.from(
       new AtlassianStrategy(
@@ -39,7 +39,7 @@ export const atlassianAuthenticator = createOAuthAuthenticator({
           clientSecret: clientSecret,
           callbackURL: callbackUrl,
           baseURL: baseUrl,
-          authorizationURL: `${baseUrl}/oauth/authorize`,
+          authorizationURL: `${baseUrl}/authorize`,
           tokenURL: `${baseUrl}/oauth/token`,
           profileURL: `${baseUrl}/api/v4/user`,
         },

--- a/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
@@ -29,8 +29,7 @@ export const atlassianAuthenticator = createOAuthAuthenticator({
   initialize({ callbackUrl, config }) {
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');
-    const baseUrl =
-      config.getOptionalString('audience') || 'https://api.atlassian.com';
+    const baseUrl = 'https://auth.atlassian.com';
 
     return PassportOAuthAuthenticatorHelper.from(
       new AtlassianStrategy(

--- a/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
@@ -15,9 +15,9 @@
  */
 
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
-import { authModuleAtlassianProvider } from './module';
-import request from 'supertest';
 import { decodeOAuthState } from '@backstage/plugin-auth-node';
+import request from 'supertest';
+import { authModuleAtlassianProvider } from './module';
 
 describe('authModuleAtlassianProvider', () => {
   it('should start', async () => {
@@ -60,8 +60,8 @@ describe('authModuleAtlassianProvider', () => {
     expect(nonceCookie).toBeDefined();
 
     const startUrl = new URL(res.get('location'));
-    expect(startUrl.origin).toBe('https://atlassian.com');
-    expect(startUrl.pathname).toBe('/oauth/authorize');
+    expect(startUrl.origin).toBe('https://api.atlassian.com');
+    expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
       response_type: 'code',
       client_id: 'my-client-id',

--- a/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
@@ -60,7 +60,7 @@ describe('authModuleAtlassianProvider', () => {
     expect(nonceCookie).toBeDefined();
 
     const startUrl = new URL(res.get('location'));
-    expect(startUrl.origin).toBe('https://api.atlassian.com');
+    expect(startUrl.origin).toBe('https://auth.atlassian.com');
     expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
       response_type: 'code',

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { AuthHandler } from '../types';
-import { OAuthResult } from '../../lib/oauth';
-import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
+import { atlassianAuthenticator } from '@backstage/plugin-auth-backend-module-atlassian-provider';
 import {
   SignInResolver,
   createOAuthProviderFactory,
@@ -25,7 +23,9 @@ import {
   adaptLegacyOAuthHandler,
   adaptLegacyOAuthSignInResolver,
 } from '../../lib/legacy';
-import { atlassianAuthenticator } from '@backstage/plugin-auth-backend-module-atlassian-provider';
+import { OAuthResult } from '../../lib/oauth';
+import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
+import { AuthHandler } from '../types';
 
 /**
  * Auth provider integration for Atlassian auth


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As described in #23031 and documented [here](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#1--direct-the-user-to-the-authorization-url-to-get-an-authorization-code) the Atlassian auth provider targets the wrong endpoint and has the wrong default audience.
This PR fixes that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
