### PR TITLE
Increase HTTP request timeout used by OIDC authenticator

### DIFF
--- a/.changeset/light-chicken-search.md
+++ b/.changeset/light-chicken-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+---
+
+Increased HTTP request timeout used by OIDC authenticator.

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  custom,
   Issuer,
   ClientAuthMethod,
   TokenSet,
@@ -29,6 +30,10 @@ import {
   PassportOAuthAuthenticatorHelper,
   PassportOAuthPrivateInfo,
 } from '@backstage/plugin-auth-node';
+
+custom.setHttpOptionsDefaults({
+  timeout: 10000,
+});
 
 /**
  * authentication result for the OIDC which includes the token set and user


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/23267.

This PR increases HTTP request timeout of 3500ms used by OIDC authenticator to 10000ms.

The new value is set on a per-request bases according to the [openid-client documentation](https://github.com/panva/node-openid-client/blob/main/docs/README.md#customizing-individual-http-requests). This requires to set custom HTTP options in four places for different requests but it saves us from overriding HTTP options globally which can affect other libraries.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
