### PR TITLE
backend-app-api: make sure auth service is compatible with existing plugins in dev

### DIFF
--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
@@ -28,10 +28,12 @@ import {
   BackstageServicePrincipal,
   BackstageUserPrincipal,
 } from '@backstage/backend-plugin-api';
+import { tokenManagerServiceFactory } from '../tokenManager';
 
 // TODO: Ship discovery mock service in the service factory tester
 const mockDeps = [
   discoveryServiceFactory(),
+  tokenManagerServiceFactory,
   mockServices.rootConfig.factory({
     data: {
       backend: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

See https://github.com/backstage/backstage/pull/22565#issuecomment-1965702148

By not re-using the existing token manager service we broke auth for plugins in local development, since we ended up with two different instances with different generated keys. Figured we might as well do the same for the identity service for now, but we'll need to figure out this case once we move the auth service to its own implementation.

Not released yet, so skipping changeset

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
