### PR TITLE
feat: allow defining custom label schema for EntityPicker

### DIFF
--- a/.changeset/thin-jokes-fetch.md
+++ b/.changeset/thin-jokes-fetch.md
@@ -13,7 +13,7 @@ entity:
   ui:field: EntityPicker
   ui:options:
     allowArbitraryValues: false
-    optionLabelSchema: ${{metadata.title}} (${{metadata.name}})
+    optionLabelSchema: @{{metadata.title}} (@{{metadata.name}})
 ```
 
 This does not work if `allowArbitraryValues` is set to `true`.

--- a/.changeset/thin-jokes-fetch.md
+++ b/.changeset/thin-jokes-fetch.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Allow defining custom option label for `EntityPicker`
+
+This allows passing a custom schema to be used for entity picker options for example:
+
+```yaml
+entity:
+  title: My Entity
+  type: string
+  ui:field: EntityPicker
+  ui:options:
+    allowArbitraryValues: false
+    optionLabelSchema: ${{metadata.title}} (${{metadata.name}})
+```
+
+This does not work if `allowArbitraryValues` is set to `true`.

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -401,11 +401,11 @@ export const repoPickerValidation: (
 export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
   string,
   {
-    allowedOwners?: string[] | undefined;
+    allowedHosts?: string[] | undefined;
     allowedOrganizations?: string[] | undefined;
+    allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
     allowedRepos?: string[] | undefined;
-    allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {
           secretsKey: string;
@@ -413,8 +413,8 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
             | {
                 azure?: string[] | undefined;
                 github?: string[] | undefined;
-                bitbucket?: string[] | undefined;
                 gitlab?: string[] | undefined;
+                bitbucket?: string[] | undefined;
                 gerrit?: string[] | undefined;
                 gitea?: string[] | undefined;
               }
@@ -428,11 +428,11 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
 export const RepoUrlPickerFieldSchema: FieldSchema<
   string,
   {
-    allowedOwners?: string[] | undefined;
+    allowedHosts?: string[] | undefined;
     allowedOrganizations?: string[] | undefined;
+    allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
     allowedRepos?: string[] | undefined;
-    allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {
           secretsKey: string;
@@ -440,8 +440,8 @@ export const RepoUrlPickerFieldSchema: FieldSchema<
             | {
                 azure?: string[] | undefined;
                 github?: string[] | undefined;
-                bitbucket?: string[] | undefined;
                 gitlab?: string[] | undefined;
+                bitbucket?: string[] | undefined;
                 gerrit?: string[] | undefined;
                 gitea?: string[] | undefined;
               }

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -83,6 +83,7 @@ export const EntityPickerFieldExtension: FieldExtensionComponent_2<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    optionLabelSchema?: string | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -112,6 +113,7 @@ export const EntityPickerFieldSchema: FieldSchema<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    optionLabelSchema?: string | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -332,6 +334,7 @@ export const OwnerPickerFieldExtension: FieldExtensionComponent_2<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    optionLabelSchema?: string | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -360,6 +363,7 @@ export const OwnerPickerFieldSchema: FieldSchema<
     defaultNamespace?: string | false | undefined;
     allowedKinds?: string[] | undefined;
     allowArbitraryValues?: boolean | undefined;
+    optionLabelSchema?: string | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -397,11 +401,11 @@ export const repoPickerValidation: (
 export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
   string,
   {
-    allowedHosts?: string[] | undefined;
-    allowedOrganizations?: string[] | undefined;
     allowedOwners?: string[] | undefined;
+    allowedOrganizations?: string[] | undefined;
     allowedProjects?: string[] | undefined;
     allowedRepos?: string[] | undefined;
+    allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {
           secretsKey: string;
@@ -409,8 +413,8 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
             | {
                 azure?: string[] | undefined;
                 github?: string[] | undefined;
-                gitlab?: string[] | undefined;
                 bitbucket?: string[] | undefined;
+                gitlab?: string[] | undefined;
                 gerrit?: string[] | undefined;
                 gitea?: string[] | undefined;
               }
@@ -424,11 +428,11 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
 export const RepoUrlPickerFieldSchema: FieldSchema<
   string,
   {
-    allowedHosts?: string[] | undefined;
-    allowedOrganizations?: string[] | undefined;
     allowedOwners?: string[] | undefined;
+    allowedOrganizations?: string[] | undefined;
     allowedProjects?: string[] | undefined;
     allowedRepos?: string[] | undefined;
+    allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {
           secretsKey: string;
@@ -436,8 +440,8 @@ export const RepoUrlPickerFieldSchema: FieldSchema<
             | {
                 azure?: string[] | undefined;
                 github?: string[] | undefined;
-                gitlab?: string[] | undefined;
                 bitbucket?: string[] | undefined;
+                gitlab?: string[] | undefined;
                 gerrit?: string[] | undefined;
                 gitea?: string[] | undefined;
               }

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -111,6 +111,46 @@ describe('<EntityPicker />', () => {
     });
   });
 
+  describe('with optionLabelSchema', () => {
+    beforeEach(() => {
+      uiSchema = {
+        'ui:options': {
+          allowArbitraryValues: false,
+          optionLabelSchema:
+            '${{kind}} - ${{metadata.name}}: ${{ metadata.title }}',
+        },
+      };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps;
+
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+    });
+
+    it('fetches custom fields for label', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+        fields: [
+          'metadata.name',
+          'metadata.namespace',
+          'kind',
+          'metadata.title',
+        ],
+        filter: undefined,
+      });
+    });
+  });
+
   describe('with allowedKinds', () => {
     beforeEach(() => {
       uiSchema = { 'ui:options': { allowedKinds: ['User'] } };

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -117,7 +117,7 @@ describe('<EntityPicker />', () => {
         'ui:options': {
           allowArbitraryValues: false,
           optionLabelSchema:
-            '${{kind}} - ${{metadata.name}}: ${{ metadata.title }}',
+            '@{{kind}} - @{{metadata.name}}: @{{ metadata.title }}',
         },
       };
       props = {

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import {
-  type EntityFilterQuery,
   CATALOG_FILTER_EXISTS,
+  type EntityFilterQuery,
 } from '@backstage/catalog-client';
 import {
   Entity,
@@ -35,13 +35,30 @@ import Autocomplete, {
 import React, { useCallback, useEffect } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import {
+  EntityPickerFilterQuery,
   EntityPickerFilterQueryValue,
   EntityPickerProps,
   EntityPickerUiOptions,
-  EntityPickerFilterQuery,
 } from './schema';
+import lodash from 'lodash';
 
 export { EntityPickerSchema } from './schema';
+
+const getOptionLabelFields = (optionLabelSchema?: string): string[] => {
+  if (!optionLabelSchema) {
+    return [];
+  }
+  const matches = optionLabelSchema.match(/\${{([^}]+)}}/g);
+  if (!matches) {
+    return [];
+  }
+  return matches.map(res =>
+    res
+      .trim()
+      .replace(/\${{|}}/g, '')
+      .trim(),
+  );
+};
 
 /**
  * The underlying component that is rendered in the form for the `EntityPicker`
@@ -63,11 +80,25 @@ export const EntityPicker = (props: EntityPickerProps) => {
   const defaultKind = uiSchema['ui:options']?.defaultKind;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
+  const allowArbitraryValues =
+    uiSchema['ui:options']?.allowArbitraryValues ?? true;
+  const optionLabelSchema =
+    allowArbitraryValues !== true
+      ? uiSchema['ui:options']?.optionLabelSchema
+      : undefined;
+  const additionalFields = getOptionLabelFields(optionLabelSchema);
 
   const catalogApi = useApi(catalogApiRef);
 
   const { value: entities, loading } = useAsync(async () => {
-    const fields = ['metadata.name', 'metadata.namespace', 'kind'];
+    const fields = [
+      ...new Set([
+        'metadata.name',
+        'metadata.namespace',
+        'kind',
+        ...additionalFields,
+      ]),
+    ];
     const { items } = await catalogApi.getEntities(
       catalogFilter
         ? { filter: catalogFilter, fields }
@@ -75,25 +106,32 @@ export const EntityPicker = (props: EntityPickerProps) => {
     );
     return items;
   });
-  const allowArbitraryValues =
-    uiSchema['ui:options']?.allowArbitraryValues ?? true;
 
-  const getLabel = useCallback(
-    (ref: string) => {
+  const getOptionLabel = (option: Entity | string) => {
+    if (typeof option === 'string') {
       try {
         return humanizeEntityRef(
-          parseEntityRef(ref, { defaultKind, defaultNamespace }),
+          parseEntityRef(option, { defaultKind, defaultNamespace }),
           {
             defaultKind,
             defaultNamespace,
           },
         );
       } catch (err) {
-        return ref;
+        return option;
       }
-    },
-    [defaultKind, defaultNamespace],
-  );
+    }
+
+    if (optionLabelSchema && additionalFields.length > 0) {
+      let out = optionLabelSchema;
+      for (const field of additionalFields) {
+        out = out.replace(`\${{${field}}}`, lodash.get(option, field));
+      }
+      return out;
+    }
+
+    return humanizeEntityRef(option, { defaultKind, defaultNamespace })!;
+  };
 
   const onSelect = useCallback(
     (_: any, ref: string | Entity | null, reason: AutocompleteChangeReason) => {
@@ -101,7 +139,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
       if (typeof ref !== 'string') {
         // if ref does not exist: pass 'undefined' to trigger validation for required value
         onChange(ref ? stringifyEntityRef(ref as Entity) : undefined);
-      } else {
+      } else if (!optionLabelSchema) {
         if (reason === 'blur' || reason === 'create-option') {
           // Add in default namespace, etc.
           let entityRef = ref;
@@ -123,14 +161,21 @@ export const EntityPicker = (props: EntityPickerProps) => {
         }
       }
     },
-    [onChange, formData, defaultKind, defaultNamespace, allowArbitraryValues],
+    [
+      onChange,
+      formData,
+      defaultKind,
+      defaultNamespace,
+      allowArbitraryValues,
+      optionLabelSchema,
+    ],
   );
 
   // Since free solo can be enabled, attempt to parse as a full entity ref first, then fall
   // back to the given value.
   const selectedEntity =
     entities?.find(e => stringifyEntityRef(e) === formData) ??
-    (allowArbitraryValues && formData ? getLabel(formData) : '');
+    (allowArbitraryValues && formData ? getOptionLabel(formData) : '');
 
   useEffect(() => {
     if (entities?.length === 1 && selectedEntity === '') {
@@ -151,12 +196,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
         loading={loading}
         onChange={onSelect}
         options={entities || []}
-        getOptionLabel={option =>
-          // option can be a string due to freeSolo.
-          typeof option === 'string'
-            ? option
-            : humanizeEntityRef(option, { defaultKind, defaultNamespace })!
-        }
+        getOptionLabel={getOptionLabel}
         autoSelect
         freeSolo={allowArbitraryValues}
         renderInput={params => (

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -48,14 +48,14 @@ const getOptionLabelFields = (optionLabelSchema?: string): string[] => {
   if (!optionLabelSchema) {
     return [];
   }
-  const matches = optionLabelSchema.match(/\${{([^}]+)}}/g);
+  const matches = optionLabelSchema.match(/@{{([^}]+)}}/g);
   if (!matches) {
     return [];
   }
   return matches.map(res =>
     res
       .trim()
-      .replace(/\${{|}}/g, '')
+      .replace(/@{{|}}/g, '')
       .trim(),
   );
 };
@@ -125,7 +125,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
     if (optionLabelSchema && additionalFields.length > 0) {
       let out = optionLabelSchema;
       for (const field of additionalFields) {
-        out = out.replace(`\${{${field}}}`, lodash.get(option, field));
+        out = out.replace(`@{{${field}}}`, lodash.get(option, field));
       }
       return out;
     }

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -51,6 +51,12 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .boolean()
       .optional()
       .describe('Whether to allow arbitrary user input. Defaults to true'),
+    optionLabelSchema: z
+      .string()
+      .optional()
+      .describe(
+        'Option label schema to be used. For example "${{metadata.title}} (${{metadata.name}})". Does not work with allowArbitraryValues enabled.',
+      ),
     defaultNamespace: z
       .union([z.string(), z.literal(false)])
       .optional()

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -55,7 +55,7 @@ export const EntityPickerFieldSchema = makeFieldSchemaFromZod(
       .string()
       .optional()
       .describe(
-        'Option label schema to be used. For example "${{metadata.title}} (${{metadata.name}})". Does not work with allowArbitraryValues enabled.',
+        'Option label schema to be used. For example "@{{metadata.title}} (@{{metadata.name}})". Does not work with allowArbitraryValues enabled.',
       ),
     defaultNamespace: z
       .union([z.string(), z.literal(false)])

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -46,7 +46,7 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
       defaultKind: 'Group',
       optionLabelSchema:
         uiSchema['ui:options']?.optionLabelSchema ??
-        '${{spec.profile.displayName}} (${{spec.profile.email}})',
+        '@{{spec.profile.displayName}} (@{{spec.profile.email}})',
       allowArbitraryValues:
         uiSchema['ui:options']?.allowArbitraryValues ?? true,
       ...(defaultNamespace !== undefined ? { defaultNamespace } : {}),

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -44,6 +44,9 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
     'ui:options': {
       catalogFilter,
       defaultKind: 'Group',
+      optionLabelSchema:
+        uiSchema['ui:options']?.optionLabelSchema ??
+        '${{spec.profile.displayName}} (${{spec.profile.email}})',
       allowArbitraryValues:
         uiSchema['ui:options']?.allowArbitraryValues ?? true,
       ...(defaultNamespace !== undefined ? { defaultNamespace } : {}),

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
@@ -33,6 +33,12 @@ export const OwnerPickerFieldSchema = makeFieldSchemaFromZod(
       .describe(
         'DEPRECATED: Use `catalogFilter` instead. List of kinds of entities to derive options from. Defaults to Group and User',
       ),
+    optionLabelSchema: z
+      .string()
+      .optional()
+      .describe(
+        'Option label schema to be used. For example "${{metadata.title}} (${{metadata.name}})". Does not work with allowArbitraryValues enabled.',
+      ),
     allowArbitraryValues: z
       .boolean()
       .optional()

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/schema.ts
@@ -37,7 +37,7 @@ export const OwnerPickerFieldSchema = makeFieldSchemaFromZod(
       .string()
       .optional()
       .describe(
-        'Option label schema to be used. For example "${{metadata.title}} (${{metadata.name}})". Does not work with allowArbitraryValues enabled.',
+        'Option label schema to be used. For example "@{{metadata.title}} (@{{metadata.name}})". Does not work with allowArbitraryValues enabled.',
       ),
     allowArbitraryValues: z
       .boolean()


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows passing a custom schema to be used for entity picker options for example:

```yaml
entity:
  title: My Entity
  type: string
  ui:field: EntityPicker
  ui:options:
    allowArbitraryValues: false
    optionLabelSchema: ${{metadata.title}} (${{metadata.name}})
```

This does not work if `allowArbitraryValues` is set to `true`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
