### PR TITLE
backend-common: forward service tokens from request if no token manager is available

### DIFF
--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
@@ -39,10 +39,12 @@ export type InternalBackstageCredentials<TPrincipal = unknown> =
 
 export function createCredentialsWithServicePrincipal(
   sub: string,
+  token?: string,
 ): InternalBackstageCredentials<BackstageServicePrincipal> {
   return {
     $$type: '@backstage/BackstageCredentials',
     version: 'v1',
+    token,
     principal: {
       type: 'service',
       subject: sub,

--- a/packages/backend-common/src/auth/createLegacyAuthAdapters.test.ts
+++ b/packages/backend-common/src/auth/createLegacyAuthAdapters.test.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { mockServices } from '@backstage/backend-test-utils';
 import { createLegacyAuthAdapters } from './createLegacyAuthAdapters';
+import { Request } from 'express';
 
 describe('createLegacyAuthAdapters', () => {
   it('should pass through auth if only auth is provided', () => {
@@ -85,5 +87,55 @@ describe('createLegacyAuthAdapters', () => {
       httpAuth: expect.any(Object),
       userInfo: expect.any(Object),
     });
+  });
+
+  it('should forward tokens if no token manager is provided', async () => {
+    const { auth, httpAuth } = createLegacyAuthAdapters({
+      auth: undefined,
+      httpAuth: undefined,
+      discovery: {} as any,
+      identity: mockServices.identity(),
+    });
+
+    const credentials = await httpAuth.credentials({
+      headers: {
+        authorization: 'Bearer my-token',
+      },
+    } as Request);
+
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: credentials,
+        targetPluginId: 'test',
+      }),
+    ).resolves.toEqual({ token: 'my-token' });
+  });
+
+  it('should issue a new token if a token manager is provided', async () => {
+    const { auth, httpAuth } = createLegacyAuthAdapters({
+      auth: undefined,
+      httpAuth: undefined,
+      tokenManager: {
+        ...mockServices.tokenManager(),
+        async getToken() {
+          return { token: 'new-token' };
+        },
+      },
+      discovery: {} as any,
+      identity: mockServices.identity(),
+    });
+
+    const credentials = await httpAuth.credentials({
+      headers: {
+        authorization: 'Bearer mock-token',
+      },
+    } as Request);
+
+    await expect(
+      auth.getPluginRequestToken({
+        onBehalfOf: credentials,
+        targetPluginId: 'test',
+      }),
+    ).resolves.toEqual({ token: 'new-token' });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addresses https://github.com/backstage/backstage/pull/23095#discussion_r1502414720

Problem was that when there's no token manager then we'll convert any incoming service token to `''`, which might break permissions. This makes sure we forward tokens are they are if we don't have a token manager provided.

No changeset as this has not been released yet

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
