### PR TITLE
feat: add config for gitlab listGroups parameters

### DIFF
--- a/.changeset/short-planets-glow.md
+++ b/.changeset/short-planets-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+add config option to change listGroups api parameters

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -202,6 +202,7 @@ Lerna
 lightbox
 Lightsail
 limitranges
+listGroups
 LocalStack
 lockdown
 lockfile

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -67,6 +67,12 @@ catalog:
         orgEnabled: true
         group: org/teams # Required for gitlab.com when `orgEnabled: true`. Optional for self managed. Must not end with slash. Accepts only groups under the provided path (which will be stripped)
         groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
+        groupListApiParameters: # Optional. Pass parameters to the listGroups api call used to get the list of available groups
+          all_available: true # Show all the groups you have access to (defaults to false for authenticated users, true for administrators)
+          search: '' # Return the list of authorized groups matching the search criteria
+          owned: true # Limit to groups explicitly owned by the current user.
+          min_access_level: 10 # Limit to groups where current user has at least this role.
+          top_level_only: false # Limit to top level groups, excluding all subgroups
 ```
 
 ### Groups
@@ -81,6 +87,8 @@ order to limit the ingestion to a group within your organisation. `Group`
 entities will only be ingested for the configured group, or its descendant groups,
 but not any ancestor groups higher than the configured group path. Only groups
 which contain members will be ingested.
+
+By default, the GitLab API only displays the groups that you are a member of. However, this behavior can be changed through the use of the `all_available` query option. By default, `all_available` is set to false for authenticated users and true for administrators. Additionally, the groupListApiOptions can be utilized to configure the API's behavior to show more groups. By setting the `all_available` option to true, the API will return all groups that you have access to, including public and internal groups, regardless of whether or not you are a member of them.
 
 ### Users
 

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -68,11 +68,11 @@ catalog:
         group: org/teams # Required for gitlab.com when `orgEnabled: true`. Optional for self managed. Must not end with slash. Accepts only groups under the provided path (which will be stripped)
         groupPattern: '[\s\S]*' # Optional. Filters found groups based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
         groupListApiParameters: # Optional. Pass parameters to the listGroups api call used to get the list of available groups
-          all_available: true # Show all the groups you have access to (defaults to false for authenticated users, true for administrators)
-          search: '' # Return the list of authorized groups matching the search criteria
-          owned: true # Limit to groups explicitly owned by the current user.
-          min_access_level: 10 # Limit to groups where current user has at least this role.
-          top_level_only: false # Limit to top level groups, excluding all subgroups
+          all_available: true # Optional. Show all the groups you have access to (defaults to false for authenticated users, true for administrators)
+          search: '' # Optional. Return the list of authorized groups matching the search criteria
+          owned: true # Optional. Limit to groups explicitly owned by the current user.
+          min_access_level: 10 # Optional. Limit to groups where current user has at least this role.
+          top_level_only: false # Optional. Limit to top level groups, excluding all subgroups
 ```
 
 ### Groups

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -128,6 +128,69 @@ export type GitLabDescendantGroupsResponse = {
     };
   };
 };
+
+/**
+ * Parameters for the gitlab listGroups Api
+ *
+ * @public
+ */
+export type GroupListApiParameters = {
+  /**
+   * Skip the group IDs passed
+   *
+   * not useful for the catalog - use `groupPattern` instead
+   */
+  // skip_groups?: number[];
+  /**
+   * Show all the groups you have access to (defaults to false for authenticated users, true for administrators);
+   * Attributes owned and min_access_level have precedence
+   */
+  all_available?: boolean;
+  /**
+   * Return the list of authorized groups matching the search criteria
+   */
+  search?: string;
+  /**
+   * Order groups by name, path, id, or similarity (if searching, introduced in GitLab 14.1).
+   * Default is name.
+   *
+   * not useful for the catalog
+   */
+  // order_by?: string;
+  /**
+   * Order groups in asc or desc order. Default is asc
+   *
+   * not useful for the catalog
+   */
+  // sort?: string;
+  /**
+   * Include group statistics (administrators only).
+   * Note: The REST API response does not provide the full RootStorageStatistics data that is shown in the UI.
+   *       To match the data in the UI, use GraphQL instead of REST.
+   *
+   * not useful for the catalog
+   */
+  // statistics?: boolean;
+  /**
+   * Include custom attributes in response (admins only).
+   *
+   * not useful for the catalog
+   */
+  // with_custom_attributes?: boolean;
+  /**
+   * Limit to groups explicitly owned by the current user.
+   */
+  owned?: boolean;
+  /**
+   * Limit to groups where current user has at least this role.
+   */
+  min_access_level?: number;
+  /**
+   * Limit to top level groups, excluding all subgroups
+   */
+  top_level_only?: boolean;
+};
+
 /**
  * The configuration parameters for the GitlabProvider
  *
@@ -179,10 +242,10 @@ export type GitlabProviderConfig = {
   groupPattern: RegExp;
 
   /**
-   * Lookup-Options passed to the gitlab api when listing groups.
+   * Parameters passed to the gitlab api when listing groups.
    * @see https://docs.gitlab.com/ee/api/groups.html#list-groups
    */
-  groupListApiOptions?: { [name: string]: string };
+  groupListApiParameters?: GroupListApiParameters;
 
   orgEnabled?: boolean;
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -178,7 +178,14 @@ export type GitlabProviderConfig = {
    */
   groupPattern: RegExp;
 
+  /**
+   * Lookup-Options passed to the gitlab api when listing groups.
+   * @see https://docs.gitlab.com/ee/api/groups.html#list-groups
+   */
+  groupListApiOptions?: { [name: string]: string };
+
   orgEnabled?: boolean;
+
   schedule?: TaskScheduleDefinition;
   /**
    * If the project is a fork, skip repository

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -208,6 +208,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       groups = paginated<GitLabGroup>(options => client.listGroups(options), {
         page: 1,
         per_page: 100,
+        ...this.config.groupListApiOptions,
       });
 
       users = paginated<GitLabUser>(options => client.listUsers(options), {

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -43,6 +43,13 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     config.getOptionalString('groupPattern') ?? /[\s\S]*/,
   );
   const orgEnabled: boolean = config.getOptionalBoolean('orgEnabled') ?? false;
+  const groupListApiOptions: { [name: string]: string } = {};
+  const groupListApiOptionsCfg = config.getOptionalConfig(
+    'groupListApiOptions',
+  );
+  groupListApiOptionsCfg?.keys().forEach(key => {
+    groupListApiOptions[key] = groupListApiOptionsCfg.get(key);
+  });
   const skipForkedRepos: boolean =
     config.getOptionalBoolean('skipForkedRepos') ?? false;
 
@@ -60,6 +67,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     projectPattern,
     userPattern,
     groupPattern,
+    groupListApiOptions,
     schedule,
     orgEnabled,
     skipForkedRepos,
@@ -77,6 +85,9 @@ export function readGitlabConfigs(config: Config): GitlabProviderConfig[] {
   const configs: GitlabProviderConfig[] = [];
 
   const providerConfigs = config.getOptionalConfig('catalog.providers.gitlab');
+  console.log('readGitlabConfigs');
+  console.log(JSON.stringify(config, null, 2));
+  console.log(JSON.stringify(providerConfigs, null, 2));
 
   if (!providerConfigs) {
     return configs;

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -17,6 +17,7 @@
 import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
 import { Config } from '@backstage/config';
 import { GitlabProviderConfig } from '../lib';
+import { GroupListApiOptions } from '../lib/types';
 
 /**
  * Extracts the gitlab config from a config object
@@ -43,13 +44,23 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     config.getOptionalString('groupPattern') ?? /[\s\S]*/,
   );
   const orgEnabled: boolean = config.getOptionalBoolean('orgEnabled') ?? false;
-  const groupListApiOptions: { [name: string]: string } = {};
   const groupListApiOptionsCfg = config.getOptionalConfig(
     'groupListApiOptions',
   );
-  groupListApiOptionsCfg?.keys().forEach(key => {
-    groupListApiOptions[key] = groupListApiOptionsCfg.get(key);
-  });
+  const groupListApiOptions: GroupListApiOptions = {};
+  if (groupListApiOptionsCfg !== undefined) {
+    groupListApiOptions.all_available =
+      groupListApiOptionsCfg.getOptionalBoolean('all_available');
+    groupListApiOptions.min_access_level =
+      groupListApiOptionsCfg.getOptionalNumber('min_access_level');
+    groupListApiOptions.owned =
+      groupListApiOptionsCfg.getOptionalBoolean('owned');
+    groupListApiOptions.search =
+      groupListApiOptionsCfg.getOptionalString('search');
+    groupListApiOptions.top_level_only =
+      groupListApiOptionsCfg.getOptionalBoolean('top_level_only');
+  }
+
   const skipForkedRepos: boolean =
     config.getOptionalBoolean('skipForkedRepos') ?? false;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes: #23284

This PR introduces a new config option, that allows to configure options passed to the listGroups gitlab api call.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
