### PR TITLE
fix!: avoid binary file corruption in fetch action

### DIFF
--- a/.changeset/eighty-suits-admire.md
+++ b/.changeset/eighty-suits-admire.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-node': minor
+'@backstage/plugin-scaffolder-node': patch
 ---
 
-**BREAKING** Fixed file corruption for non utf-8 data in fetch contents
+Fixed file corruption for non UTF-8 data in fetch contents

--- a/.changeset/eighty-suits-admire.md
+++ b/.changeset/eighty-suits-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': minor
+---
+
+**BREAKING** Fixed file corruption for non utf-8 data in fetch contents

--- a/plugins/scaffolder-node/src/actions/fetch.test.ts
+++ b/plugins/scaffolder-node/src/actions/fetch.test.ts
@@ -210,7 +210,26 @@ describe('fetchContents helper', () => {
         fetchUrl: 'https://github.com/backstage/foo',
       });
       expect(fs.ensureDir).toHaveBeenCalledWith('.');
-      expect(fs.outputFile).toHaveBeenCalledWith('foo', 'test');
+      expect(fs.outputFile).toHaveBeenCalledWith(
+        'foo',
+        Buffer.from([116, 101, 115, 116]),
+      );
+    });
+
+    it('should fetch binary content from url', async () => {
+      readUrl.mockResolvedValue({
+        buffer: () => Buffer.from([0, 1, 2, 3, 255, 254, 253, 252]),
+      });
+      await fetchFile({
+        ...options,
+        outputPath: 'foo',
+        fetchUrl: 'https://github.com/backstage/foo',
+      });
+      expect(fs.ensureDir).toHaveBeenCalledWith('.');
+      expect(fs.outputFile).toHaveBeenCalledWith(
+        'foo',
+        Buffer.from([0, 1, 2, 3, 255, 254, 253, 252]),
+      );
     });
 
     it('should fetch content from url into directory', async () => {
@@ -223,7 +242,10 @@ describe('fetchContents helper', () => {
         fetchUrl: 'https://github.com/backstage/foo',
       });
       expect(fs.ensureDir).toHaveBeenCalledWith('mydir');
-      expect(fs.outputFile).toHaveBeenCalledWith('mydir/foo', 'test');
+      expect(fs.outputFile).toHaveBeenCalledWith(
+        'mydir/foo',
+        Buffer.from([116, 101, 115, 116]),
+      );
     });
 
     it('should pass through the token provided through to the URL reader', async () => {

--- a/plugins/scaffolder-node/src/actions/fetch.ts
+++ b/plugins/scaffolder-node/src/actions/fetch.ts
@@ -95,7 +95,7 @@ export async function fetchFile(options: {
     const res = await reader.readUrl(readUrl, { token });
     await fs.ensureDir(path.dirname(outputPath));
     const buffer = await res.buffer();
-    await fs.outputFile(outputPath, buffer.toString());
+    await fs.outputFile(outputPath, buffer);
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `.toString()` caused all non utf-8 data to be corrupted on disk. This caused issues when downloading binary files such as zip archives.

Fixes #22899

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
