### PR TITLE
Made "checkpoint" on scaffolder action context non-optional

### DIFF
--- a/.changeset/thirty-bikes-stare.md
+++ b/.changeset/thirty-bikes-stare.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-node-test-utils': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Made "checkpoint" on scaffolder action context non-optional

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -138,13 +138,13 @@ describe('NunjucksWorkflowRunner', () => {
       id: 'checkpoints-action',
       description: 'Mock action with checkpoints',
       handler: async ctx => {
-        const key1 = await ctx.checkpoint?.('key1', async () => {
+        const key1 = await ctx.checkpoint('key1', async () => {
           return 'updated';
         });
-        const key2 = await ctx.checkpoint?.('key2', async () => {
+        const key2 = await ctx.checkpoint('key2', async () => {
           return 'updated';
         });
-        const key3 = await ctx.checkpoint?.('key3', async () => {
+        const key3 = await ctx.checkpoint('key3', async () => {
           return 'updated';
         });
 

--- a/plugins/scaffolder-node-test-utils/src/actions/mockActionConext.ts
+++ b/plugins/scaffolder-node-test-utils/src/actions/mockActionConext.ts
@@ -45,6 +45,7 @@ export const createMockActionContext = <
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
     input: {} as TActionInput,
+    checkpoint: jest.fn(),
   };
 
   const createDefaultWorkspace = () => ({

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -30,7 +30,7 @@ export type ActionContext<
   secrets?: TaskSecrets;
   workspacePath: string;
   input: TActionInput;
-  checkpoint?<U extends JsonValue>(
+  checkpoint<U extends JsonValue>(
     key: string,
     fn: () => Promise<U>,
   ): Promise<U>;

--- a/plugins/scaffolder-node/src/actions/types.ts
+++ b/plugins/scaffolder-node/src/actions/types.ts
@@ -35,7 +35,7 @@ export type ActionContext<
   secrets?: TaskSecrets;
   workspacePath: string;
   input: TActionInput;
-  checkpoint?<U extends JsonValue>(
+  checkpoint<U extends JsonValue>(
     key: string,
     fn: () => Promise<U>,
   ): Promise<U>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As a new utility method `createMockActionContext` was merged, we can make checkpoint method non-optional and it won't affect huge amount of tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
