### PR TITLE
feat: export `getOctokitOptions` for easier Octokit config reuse

### DIFF
--- a/.changeset/lucky-ravens-beg.md
+++ b/.changeset/lucky-ravens-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Export `getOctokitOptions` for easy re-use of Octokit configuration handling

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -9,6 +9,7 @@ import { createPullRequest } from 'octokit-plugin-create-pull-request';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { JsonObject } from '@backstage/types';
 import { Octokit } from 'octokit';
+import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmIntegrations } from '@backstage/integration';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';
@@ -391,6 +392,14 @@ export const createPublishGithubPullRequestAction: (
   },
   JsonObject
 >;
+
+// @public
+export function getOctokitOptions(options: {
+  integrations: ScmIntegrationRegistry;
+  credentialsProvider?: GithubCredentialsProvider;
+  token?: string;
+  repoUrl: string;
+}): Promise<OctokitOptions>;
 
 // @public
 const githubModule: () => BackendFeature;

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -39,6 +39,11 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
+/**
+ * Helper for generating octokit configuration options for given repoUrl.
+ * If no token is provided, it will attempt to get a token from the credentials provider.
+ * @public
+ */
 export async function getOctokitOptions(options: {
   integrations: ScmIntegrationRegistry;
   credentialsProvider?: GithubCredentialsProvider;

--- a/plugins/scaffolder-backend-module-github/src/actions/index.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/index.ts
@@ -28,3 +28,5 @@ export {
 } from './githubPullRequest';
 export { createPublishGithubAction } from './github';
 export { createGithubAutolinksAction } from './githubAutolinks';
+
+export { getOctokitOptions } from './helpers';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds #23211

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
