### PR TITLE
catalog-react: roll back style class key type change

### DIFF
--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -109,13 +109,10 @@ export type CatalogReactEntityLifecyclePickerClassKey = 'input';
 export type CatalogReactEntityNamespacePickerClassKey = 'input';
 
 // @public (undocumented)
-export type CatalogReactEntityOwnerPickerClassKey = 'input' | 'root' | 'label';
+export type CatalogReactEntityOwnerPickerClassKey = 'input';
 
 // @public (undocumented)
-export type CatalogReactEntityProcessingStatusPickerClassKey =
-  | 'input'
-  | 'root'
-  | 'label';
+export type CatalogReactEntityProcessingStatusPickerClassKey = 'input';
 
 // @public (undocumented)
 export type CatalogReactEntitySearchBarClassKey = 'searchToolbar' | 'input';

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -44,7 +44,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { useEntityPresentation } from '../../apis';
 
 /** @public */
-export type CatalogReactEntityOwnerPickerClassKey = 'input' | 'root' | 'label';
+export type CatalogReactEntityOwnerPickerClassKey = 'input';
 
 const useStyles = makeStyles(
   {

--- a/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.tsx
@@ -31,10 +31,7 @@ import { useEntityList } from '../../hooks';
 import { Autocomplete } from '@material-ui/lab';
 
 /** @public */
-export type CatalogReactEntityProcessingStatusPickerClassKey =
-  | 'input'
-  | 'root'
-  | 'label';
+export type CatalogReactEntityProcessingStatusPickerClassKey = 'input';
 
 const useStyles = makeStyles(
   {


### PR DESCRIPTION
Rolling back the class key change in #23255 since it's breaking the release. The issue is that we end up with package duplication of `@backstage/plugin-catalog-react` with different class key overrides, which in turn breaks types. For now the class keys will still work, but a bit of `as any` or similar will be needed to make typescript happy.

Will open up a separate issue to discuss the way forward.

@HHogg 👀 