### PR TITLE
feat: Add option for SidebarSubmenuItem to have sub menus expanded by default

### DIFF
--- a/.changeset/rare-fireants-tickle.md
+++ b/.changeset/rare-fireants-tickle.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Added expanded property to allow optionally have sub menu items automatically expand their contents on the sidebar
+Added optional `initialShowDropDown` prop to `SidebarSubmenuItem` to internally manage the initial display state of the dropdown items.

--- a/.changeset/rare-fireants-tickle.md
+++ b/.changeset/rare-fireants-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added expanded property to allow optionally have sub menu items automatically expand their contents on the sidebar

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1128,6 +1128,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
+  expanded?: boolean;
 };
 
 // @public

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1128,7 +1128,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
-  expanded?: boolean;
+  initialShowDropDown?: boolean;
 };
 
 // @public

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1128,7 +1128,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
-  initialShowDropDown?: boolean;
+  initialShowDropdown?: boolean;
 };
 
 // @public

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -131,6 +131,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
+  expanded?: boolean;
 };
 
 /**
@@ -149,7 +150,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
   const currentLocation = useLocation();
   let isActive = isLocationMatch(currentLocation, toLocation, exact);
 
-  const [showDropDown, setShowDropDown] = useState(false);
+  const [showDropDown, setShowDropDown] = useState(props.expanded ?? false);
   const handleClickDropdown = () => {
     setShowDropDown(!showDropDown);
   };

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -131,7 +131,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
-  expanded?: boolean;
+  initialShowDropDown?: boolean;
 };
 
 /**
@@ -150,7 +150,9 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
   const currentLocation = useLocation();
   let isActive = isLocationMatch(currentLocation, toLocation, exact);
 
-  const [showDropDown, setShowDropDown] = useState(props.expanded ?? false);
+  const [showDropDown, setShowDropDown] = useState(
+    props.initialShowDropDown ?? false,
+  );
   const handleClickDropdown = () => {
     setShowDropDown(!showDropDown);
   };

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -131,7 +131,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
-  initialShowDropDown?: boolean;
+  initialShowDropdown?: boolean;
 };
 
 /**
@@ -151,7 +151,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
   let isActive = isLocationMatch(currentLocation, toLocation, exact);
 
   const [showDropDown, setShowDropDown] = useState(
-    props.initialShowDropDown ?? false,
+    props.initialShowDropdown ?? false,
   );
   const handleClickDropdown = () => {
     setShowDropDown(!showDropDown);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added an optional `expanded` flag to the `SidebarSubmenuItem.tsx` file to allow submenu items to be expanded by default on the sidebar menu.

![image](https://github.com/backstage/backstage/assets/7111043/f51dd395-e1af-4032-8cf2-b1d9a2344627)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
