### PR TITLE
(feat/vault-backend): Support kubernetes auth

### DIFF
--- a/.changeset/six-nails-destroy.md
+++ b/.changeset/six-nails-destroy.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-vault-backend': minor
+---
+
+Support Kubernetes authentication for the Vault plugin. To do that, modify the current `vault.token` string
+to an object like the following:
+
+```yaml
+vault:
+  token:
+    type: kubernetes
+    role: <KUBERNETES_ROLE>
+    authPath: <KUBERNETES_AUTH_PATH> # Optional. It defaults to 'kubernetes', but you could set a different authPath if needed
+    serviceAccountTokenPath: <PATH_TO_JWT> # Optional. It defaults to '/var/run/secrets/kubernetes.io/serviceaccount/token'. Where the JWT token is located
+```
+
+To make sure the Kubernetes authentication is applied, and you're using the old
+backend setup, you will need to call `await builder.loadToken()` on demand, to make sure
+the token is fetched. And _always_ after the `builder.build()`.

--- a/.changeset/tasty-mice-marry.md
+++ b/.changeset/tasty-mice-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-vault-node': patch
+---
+
+Added new method to the `VaultApi` to allow loading the token on demand. This is meant to be used together with the Kubernetes Auth Method

--- a/plugins/vault-backend/api-report.md
+++ b/plugins/vault-backend/api-report.md
@@ -33,6 +33,7 @@ export interface VaultApi {
       secretEngine?: string;
     },
   ): Promise<VaultSecret[]>;
+  loadToken(): Promise<void>;
   renewToken?(): Promise<void>;
 }
 
@@ -42,6 +43,8 @@ export class VaultBuilder {
   build(): VaultBuilderReturn;
   static createBuilder(env: VaultEnvironment): VaultBuilder;
   enableTokenRenew(schedule?: TaskRunner): Promise<this>;
+  // (undocumented)
+  loadToken(): Promise<void>;
   setVaultClient(vaultApi: VaultApi): this;
 }
 
@@ -62,6 +65,8 @@ export class VaultClient implements VaultApi {
       secretEngine?: string;
     },
   ): Promise<VaultSecret[]>;
+  // (undocumented)
+  loadToken(): Promise<void>;
   // (undocumented)
   renewToken(): Promise<void>;
 }

--- a/plugins/vault-backend/config.d.ts
+++ b/plugins/vault-backend/config.d.ts
@@ -31,10 +31,34 @@ export interface Config {
     publicUrl?: string;
 
     /**
-     * The token used by Backstage to access Vault.
-     * @visibility secret
+     * The credentials used to login to Vault
+     * @visibility backend
      */
-    token: string;
+    token:
+      | string
+      | {
+          /** @visibility backend */
+          type: 'kubernetes';
+
+          /**
+           * The role used to login to Vault
+           * @visibility backend
+           */
+          role: string;
+
+          /**
+           * The authPath used to login to Vault. If not set, it defaults to 'kubernetes'.
+           * @visibility backend
+           */
+          authPath?: string;
+
+          /**
+           * The path where the service account token is. If not set,
+           * it defaults to '/var/run/secrets/kubernetes.io/serviceaccount/token'.
+           * @visibility secret
+           */
+          serviceAccountTokenPath?: string;
+        };
 
     /**
      * The secret engine name where in vault. Defaults to `secrets`.

--- a/plugins/vault-backend/src/config/config.test.ts
+++ b/plugins/vault-backend/src/config/config.test.ts
@@ -66,4 +66,28 @@ describe('GetVaultConfig', () => {
       secretEngine: 'test',
     });
   });
+
+  it('loads kubernetes token config', () => {
+    const config = new ConfigReader({
+      vault: {
+        baseUrl: 'http://www.example.com',
+        token: {
+          type: 'kubernetes',
+          role: 'test',
+        },
+      },
+    });
+
+    const vaultConfig = getVaultConfig(config);
+    expect(vaultConfig).toStrictEqual({
+      baseUrl: 'http://www.example.com',
+      publicUrl: undefined,
+      token: {
+        type: 'kubernetes',
+        role: 'test',
+      },
+      kvVersion: 2,
+      secretEngine: 'secrets',
+    });
+  });
 });

--- a/plugins/vault-backend/src/config/config.ts
+++ b/plugins/vault-backend/src/config/config.ts
@@ -17,6 +17,31 @@
 import { Config } from '@backstage/config';
 
 /**
+ * The Kubernetes auth method parameters needed for the vault-backend plugin
+ * to login.
+ *
+ * @public
+ */
+export interface VaultKubernetesAuthConfig {
+  type: 'kubernetes';
+  /**
+   * The role used to login to Vault.
+   */
+  role: string;
+
+  /**
+   * The authPath used to login to Vault. If not set, it defaults to 'kubernetes'.
+   */
+  authPath?: string;
+
+  /**
+   * The path where the service account token is. If not set,
+   * it defaults to '/var/run/secrets/kubernetes.io/serviceaccount/token'.
+   */
+  serviceAccountTokenPath?: string;
+}
+
+/**
  * The configuration needed for the vault-backend plugin
  *
  * @public
@@ -33,9 +58,10 @@ export interface VaultConfig {
   publicUrl?: string;
 
   /**
-   * The token used by Backstage to access Vault.
+   * The credentials used to login to Vault. They can be a raw token
+   * or the Kubernetes
    */
-  token: string;
+  token: string | VaultKubernetesAuthConfig;
 
   /**
    * The secret engine name where in vault. Defaults to `secrets`.
@@ -59,7 +85,7 @@ export function getVaultConfig(config: Config): VaultConfig {
   return {
     baseUrl: config.getString('vault.baseUrl'),
     publicUrl: config.getOptionalString('vault.publicUrl'),
-    token: config.getString('vault.token'),
+    token: config.get<string | VaultKubernetesAuthConfig>('vault.token'),
     kvVersion: config.getOptionalNumber('vault.kvVersion') ?? 2,
     secretEngine: config.getOptionalString('vault.secretEngine') ?? 'secrets',
   };

--- a/plugins/vault-backend/src/service/VaultBuilder.ts
+++ b/plugins/vault-backend/src/service/VaultBuilder.ts
@@ -106,6 +106,11 @@ export class VaultBuilder {
     return this;
   }
 
+  public async loadToken() {
+    this.env.logger.info('Loading Vault token');
+    await this.vaultApi?.loadToken();
+  }
+
   /**
    * Enables the token renewal for Vault. The schedule if configured in the app-config.yaml file.
    * If not set, the renewal is executed hourly

--- a/plugins/vault-backend/src/service/plugin.ts
+++ b/plugins/vault-backend/src/service/plugin.ts
@@ -67,6 +67,7 @@ export const vaultPlugin = createBackendPlugin({
         }
 
         const { router } = builder.build();
+        await builder.loadToken();
         httpRouter.use(router);
       },
     });

--- a/plugins/vault-backend/src/service/vaultApi.test.ts
+++ b/plugins/vault-backend/src/service/vaultApi.test.ts
@@ -17,11 +17,16 @@
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { VaultSecret, VaultClient, VaultSecretList } from './vaultApi';
+import {
+  VaultApi,
+  VaultSecret,
+  VaultClient,
+  VaultSecretList,
+} from './vaultApi';
 import { ConfigReader } from '@backstage/config';
 
 describe('VaultApi', () => {
-  let api: VaultClient;
+  let api: VaultApi;
 
   const server = setupServer();
   setupRequestMockHandlers(server);
@@ -110,7 +115,7 @@ describe('VaultApi', () => {
   });
 
   it('should return success token renew', async () => {
-    expect(await api.renewToken()).toBe(undefined);
+    expect(await api.renewToken?.()).toBe(undefined);
   });
 
   it('should render frontend url', () => {

--- a/plugins/vault-node/api-report.md
+++ b/plugins/vault-node/api-report.md
@@ -14,6 +14,7 @@ export interface VaultApi {
       secretEngine?: string;
     },
   ): Promise<VaultSecret[]>;
+  loadToken(): Promise<void>;
   renewToken?(): Promise<void>;
 }
 

--- a/plugins/vault-node/src/api/types.ts
+++ b/plugins/vault-node/src/api/types.ts
@@ -31,6 +31,12 @@ export type VaultSecret = {
  */
 export interface VaultApi {
   /**
+   * Makes sure the token is loaded into the VaultClient. If the login is done via Kubernetes it
+   * needs to make a request first.
+   */
+  loadToken(): Promise<void>;
+
+  /**
    * Returns the URL to access the Vault UI with the defined config.
    */
   getFrontendSecretsUrl(): string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This plugin was only supporting the login via raw token. However, we think it makes total sense to include other mechanisms to login as well. In our specific case, we need Kubernetes (which I guess it's the most generic one for deployments). Until now we were using a hacky solution to override the config file before calling the `createPlugin`, but with the new backend system we would like to get rid of this solution,

As a simple solution, I extended the `token` parameter to also be a kubernetes configuration object, so the vaultApi will decide what to do on startup. If it's a token like before, nothing new will be done. If the `token` is a Kubernetes config, it will make a call to vault to obtain the token like it's explained in [the docs](https://developer.hashicorp.com/vault/docs/auth/kubernetes#via-the-api) and set the token. From there, the behavior is exactly the same as before.

I'm aware that this might not be the nicest solution, maybe a proper configuration extension that allows different `VaultLoginMethod` or similar might be better. This new type could do internally the needed stuff and simply return the token at the end. But for now, I think this should be fine enough.

Anyways, if you believe the solution above is better for the future, I can also try implementing it

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
