### PR TITLE
core-components: roll back translation of Link component

### DIFF
--- a/.changeset/curvy-carrots-dream.md
+++ b/.changeset/curvy-carrots-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+The translation support for the `Link` component has been removed for now, in order to avoid broad breakages of tests in existing projects where the component is tested without being wrapped in an API provider.

--- a/packages/core-components/api-report-alpha.md
+++ b/packages/core-components/api-report-alpha.md
@@ -9,7 +9,6 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 export const coreComponentsTranslationRef: TranslationRef<
   'core-components',
   {
-    readonly 'link.openNewWindow': 'Opens in a new window';
     readonly 'table.filter.title': 'Filters';
     readonly 'table.filter.clearAll': 'Clear all';
     readonly 'signIn.title': 'Sign In';

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
-import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 // eslint-disable-next-line no-restricted-imports
 import MaterialLink, {
   LinkProps as MaterialLinkProps,
@@ -30,7 +29,6 @@ import {
   LinkProps as RouterLinkProps,
   Route,
 } from 'react-router-dom';
-import { coreComponentsTranslationRef } from '../../translation';
 
 export function isReactRouterBeta(): boolean {
   const [obj] = createRoutesFromChildren(<Route index element={<div />} />);
@@ -163,7 +161,6 @@ export const Link = React.forwardRef<any, LinkProps>(
   ({ onClick, noTrack, ...props }, ref) => {
     const classes = useStyles();
     const analytics = useAnalytics();
-    const { t } = useTranslationRef(coreComponentsTranslationRef);
 
     // Adding the base path to URLs breaks react-router v6 stable, so we only
     // do it for beta. The react router version won't change at runtime so it is
@@ -202,7 +199,7 @@ export const Link = React.forwardRef<any, LinkProps>(
       >
         {props.children}
         <Typography component="span" className={classes.visuallyHidden}>
-          {`, ${t('link.openNewWindow')}`}
+          , Opens in a new window
         </Typography>
       </MaterialLink>
     ) : (

--- a/packages/core-components/src/translation.ts
+++ b/packages/core-components/src/translation.ts
@@ -80,9 +80,6 @@ export const coreComponentsTranslationRef = createTranslationRef({
       login: 'Log in',
       rejectAll: 'Reject All',
     },
-    link: {
-      openNewWindow: 'Opens in a new window',
-    },
     supportButton: {
       title: 'Support',
       close: 'Close',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We realized that translating specifically the `Link` component has a big impact on existing tests, since it's a pretty low level component where you don't typically needed to wrap it in an API context. We may try to introduce a change to `useTranslationRef` to let it fall back in case of a missing API context in tests, or some other similar solution. For now let's roll back this specific translation in order to avoid the breakage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
