### PR TITLE
Added config.d.ts entry with secrets for the shared auth block

### DIFF
--- a/.changeset/proud-socks-hear.md
+++ b/.changeset/proud-socks-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Added config.d.ts entry with secrets for the shared auth block

--- a/plugins/search-backend-module-elasticsearch/config.d.ts
+++ b/plugins/search-backend-module-elasticsearch/config.d.ts
@@ -212,6 +212,33 @@ export interface Config {
                 };
           }
       );
+
+      /**
+       * Authentication credentials for ElasticSearch. These are fallback
+       * credentials - in most cases, for known specific ES implementations, the
+       * respective auth block inside the clientOptions above will be used.
+       *
+       * If both ApiKey/Bearer token and username+password is provided, tokens
+       * take precedence
+       */
+      auth?:
+        | {
+            username: string;
+
+            /**
+             * @visibility secret
+             */
+            password: string;
+          }
+        | {
+            /**
+             * Base64 Encoded API key to be used to connect to the cluster.
+             * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+             *
+             * @visibility secret
+             */
+            apiKey: string;
+          };
     };
   };
 }


### PR DESCRIPTION
Fixes https://github.com/backstage/backstage/issues/23300
Fixes https://github.com/backstage/backstage/issues/21430

@emmaindal @aramissennyeydd @schematis

This may seem a bit odd but it matches the code. There seems to be per-provider auth blocks AND a general auth block outside `clientOptions`, used under different circumstances.

After this change, the secrets are properly redacted in the dev tools.