### PR TITLE
Remove -5px from SidebarScrollWrapper 

### DIFF
--- a/.changeset/smart-hairs-lick.md
+++ b/.changeset/smart-hairs-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix a spacing issue for the SidebarSubmenu in case a SidebarScrollWrapper is used that made it hard to reach the SidebarSubmenu

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -701,8 +701,7 @@ export const SidebarScrollWrapper = styled('div')(({ theme }) => {
   return {
     flex: '0 1 auto',
     overflowX: 'hidden',
-    // 5px space to the right of the scrollbar
-    width: 'calc(100% - 5px)',
+    width: '100%',
     // Display at least one item in the container
     // Question: Can this be a config/theme variable - if so, which? :/
     minHeight: '48px',


### PR DESCRIPTION
This fixes a usability issue with the sidebar when both SidebarMenuItem and SidebarScrollWrapper is used. 
The `SidebarScrollWrapper`  steals 5px from the width of the `SidebarItem` which makes it cover buttons  and makes the additional `SidebarSubMenu` hard to reach. Removing the 

## Hey, I just made a Pull Request!

### From 
![image](https://github.com/backstage/backstage/assets/3242379/088d93df-ec46-4a5d-b3bd-7612c7b77d8a)

### To
![image](https://github.com/backstage/backstage/assets/3242379/f68a93e7-b1a2-4043-8533-12abba373225)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
