### PR TITLE
Send failed process status if knip fails

### DIFF
--- a/.changeset/cool-clouds-jump.md
+++ b/.changeset/cool-clouds-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Fix knip-report command to send 1 exit status in case of fail

--- a/packages/repo-tools/src/commands/knip-reports/knip-extractor.ts
+++ b/packages/repo-tools/src/commands/knip-reports/knip-extractor.ts
@@ -178,5 +178,7 @@ export async function runKnipReports({
       const fullDir = cliPaths.resolveTargetRoot(packageDir);
       cleanKnipConfig({ packageDir: fullDir });
     });
+
+    throw e;
   }
 }

--- a/packages/repo-tools/src/commands/knip-reports/knip-reports.ts
+++ b/packages/repo-tools/src/commands/knip-reports/knip-reports.ts
@@ -46,9 +46,14 @@ export const buildKnipReports = async (paths: string[] = [], opts: Options) => {
 
   if (selectedPackageDirs.length > 0) {
     console.log('# Generating package knip reports');
-    await runKnipReports({
-      packageDirs: selectedPackageDirs,
-      isLocalBuild: !isCiBuild,
-    });
+
+    try {
+      await runKnipReports({
+        packageDirs: selectedPackageDirs,
+        isLocalBuild: !isCiBuild,
+      });
+    } catch (e) {
+      process.exit(1);
+    }
   }
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix knip-report command to send 1 exit status in case of fail

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
