### PR TITLE
fix(catalog-backend): ignore long key paths when building entity search

### DIFF
--- a/.changeset/tricky-donkeys-wink.md
+++ b/.changeset/tricky-donkeys-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Stop failing on stitching when the entity contains deeply nested properties or long keys.

--- a/.changeset/tricky-donkeys-wink.md
+++ b/.changeset/tricky-donkeys-wink.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Stop failing on stitching when the entity contains deeply nested properties or long keys.
+Do not fail on stitching when the entity contains `null` values associated to deeply nested or long keys.

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.test.ts
@@ -111,7 +111,14 @@ describe('buildEntitySearch', () => {
     });
 
     it('skips very large keys', () => {
-      const input = [{ key: 'a'.repeat(10000), value: 'foo' }];
+      const input = [
+        { key: 'a'.repeat(10000), value: true },
+        { key: 'b'.repeat(10000), value: false },
+        { key: 'c'.repeat(10000), value: 7 },
+        { key: 'd'.repeat(10000), value: 'foo' },
+        { key: 'e'.repeat(10000), value: null },
+        { key: 'f'.repeat(10000), value: undefined },
+      ];
       const output = mapToRows(input, 'eid');
       expect(output).toEqual([]);
     });

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
@@ -133,6 +133,9 @@ export function mapToRows(input: Kv[], entityId: string): DbSearchRow[] {
 
   for (const { key: rawKey, value: rawValue } of input) {
     const key = rawKey.toLocaleLowerCase('en-US');
+    if (MAX_KEY_LENGTH < key.length) {
+      continue;
+    }
     if (rawValue === undefined || rawValue === null) {
       result.push({
         entity_id: entityId,
@@ -142,22 +145,20 @@ export function mapToRows(input: Kv[], entityId: string): DbSearchRow[] {
       });
     } else {
       const value = String(rawValue).toLocaleLowerCase('en-US');
-      if (key.length <= MAX_KEY_LENGTH) {
-        if (value.length <= MAX_VALUE_LENGTH) {
-          result.push({
-            entity_id: entityId,
-            key,
-            original_value: String(rawValue),
-            value: value,
-          });
-        } else {
-          result.push({
-            entity_id: entityId,
-            key,
-            original_value: null,
-            value: null,
-          });
-        }
+      if (value.length <= MAX_VALUE_LENGTH) {
+        result.push({
+          entity_id: entityId,
+          key,
+          original_value: String(rawValue),
+          value: value,
+        });
+      } else {
+        result.push({
+          entity_id: entityId,
+          key,
+          original_value: null,
+          value: null,
+        });
       }
     }
   }

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
@@ -133,7 +133,7 @@ export function mapToRows(input: Kv[], entityId: string): DbSearchRow[] {
 
   for (const { key: rawKey, value: rawValue } of input) {
     const key = rawKey.toLocaleLowerCase('en-US');
-    if (MAX_KEY_LENGTH < key.length) {
+    if (key.length > MAX_KEY_LENGTH) {
       continue;
     }
     if (rawValue === undefined || rawValue === null) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Prevent stitching fail while building the entity search when the entity contains long key paths and `null` values; it happens on templates with deeply nested parameters.

This resolves issue #23295.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
