### PR TITLE
add excludeCI=false param to XCMetrics /build/filter request

### DIFF
--- a/.changeset/hot-feet-divide.md
+++ b/.changeset/hot-feet-divide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-xcmetrics': patch
+---
+
+Fixed bug in XcMetricsClient where it was not including parameter for excludeCI, which is now a required parameter for XCMetrics.

--- a/plugins/xcmetrics/src/api/XcmetricsClient.ts
+++ b/plugins/xcmetrics/src/api/XcmetricsClient.ts
@@ -70,6 +70,7 @@ export class XcmetricsClient implements XcmetricsApi {
       projectName: filters.project,
       page,
       per: perPage,
+      excludeCI: false,
     });
 
     return (await response.json()) as PaginationResult<Build>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

XCMetrics now requires excludeCI parameter to the /build/filter endpoint. This PR adds excludeCI: false to the payload.
![image](https://github.com/backstage/backstage/assets/39035478/027d03a5-10b6-42be-a480-06a4467382de)


This fixes 400 responses from XCMetrics, seen in https://github.com/backstage/backstage/issues/22511. The issue is confirmed https://github.com/spotify/XCMetrics/issues/106 as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
