### PR TITLE
docs/tutorials/auth-service-migration: add guest auth instructions

### DIFF
--- a/docs/tutorials/auth-service-migration.md
+++ b/docs/tutorials/auth-service-migration.md
@@ -28,7 +28,7 @@ In short, this will allow requests through to plugins in your backend, even if t
 
 ### Migrating the backend
 
-If you do want to keep the default auth policy in effect, there is little action needed to migrate the backend itself. Be sure to upgrade all plugins to their latest versions to pick up any updates that may be needed for the new auth services. If you have any internal plugins or modules, refer to the plugin migration section below.
+If you do want to keep the default auth policy in effect, there is some minor action needed to migrate the backend itself. Be sure to upgrade all plugins to their latest versions to pick up any updates that may be needed for the new auth services. If you have any internal plugins or modules, refer to the plugin migration section below.
 
 With the default auth policy in effect you will now need to ensure that the requests to your backend are authenticated, also during local development. If you already have a setup where you use an auth provider for local development, you can keep using that. But, if you rely on the `'guest'` access for local development we recommend that you install the new guest provider module in your auth backend:
 
@@ -51,7 +51,7 @@ auth:
     guest: {}
 ```
 
-Make sure that you only enable the guest provider for local development, and not in production. It will refuse to be enabled in production by default, but you it still best to avoid it entirely. If you do not have a separate development configuration, add the following to your production configuration:
+Make sure that you only enable the guest provider for local development, and not in production. It will refuse to be enabled in production by default, but it is still best to avoid it entirely. If you do not have a separate development configuration, add the following to your production configuration:
 
 ```yaml
 auth:

--- a/docs/tutorials/auth-service-migration.md
+++ b/docs/tutorials/auth-service-migration.md
@@ -33,7 +33,7 @@ If you do want to keep the default auth policy in effect, there is little action
 With the default auth policy in effect you will now need to ensure that the requests to your backend are authenticated, also during local development. If you already have a setup where you use an auth provider for local development, you can keep using that. But, if you rely on the `'guest'` access for local development we recommend that you install the new guest provider module in your auth backend:
 
 ```sh
-yarn install @backstage/plugin-auth-backend-module-guest-provider
+yarn --cwd packages/backend add @backstage/plugin-auth-backend-module-guest-provider
 ```
 
 Add it to your backend:

--- a/docs/tutorials/auth-service-migration.md
+++ b/docs/tutorials/auth-service-migration.md
@@ -28,7 +28,38 @@ In short, this will allow requests through to plugins in your backend, even if t
 
 ### Migrating the backend
 
-If you do want to keep the default auth policy in effect, there is little action needed to migrate your backend. Be sure to upgrade all plugins to their latest versions to pick up any updates that may be needed for the new auth services. If you have any internal plugins or modules, refer to the plugin migration section below.
+If you do want to keep the default auth policy in effect, there is little action needed to migrate the backend itself. Be sure to upgrade all plugins to their latest versions to pick up any updates that may be needed for the new auth services. If you have any internal plugins or modules, refer to the plugin migration section below.
+
+With the default auth policy in effect you will now need to ensure that the requests to your backend are authenticated, also during local development. If you already have a setup where you use an auth provider for local development, you can keep using that. But, if you rely on the `'guest'` access for local development we recommend that you install the new guest provider module in your auth backend:
+
+```sh
+yarn install @backstage/plugin-auth-backend-module-guest-provider
+```
+
+Add it to your backend:
+
+```ts title="packages/backend/src/index.ts"
+// highlight-add-next-line
+backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
+```
+
+Lastly, add the following to your development configuration:
+
+```yaml
+auth:
+  providers:
+    guest: {}
+```
+
+Make sure that you only enable the guest provider for local development, and not in production. It will refuse to be enabled in production by default, but you it still best to avoid it entirely. If you do not have a separate development configuration, add the following to your production configuration:
+
+```yaml
+auth:
+  providers:
+    guest: null
+```
+
+That's all you need for guest authentication! The default `SignInPage` from `@backstage/core-components` will detect and use the guest provider if it's enabled.
 
 Since the default auth policy is in effect for all plugins running in the new backend system, you do not need to worry about whether individual plugins are protected or not. The impact of plugins not yet being migrated is that they may have endpoints that should allow unauthenticated requests, but are now blocked by the default auth policy. If you want to temporarily work around this for individual plugins, you can install a module for the plugin that adds the required policy via the [http router service](../backend-system/core-services/http-router.md).
 


### PR DESCRIPTION
In many cases setting up the guest auth is going to be required for a smooth local development experience with the new auth system. This adds instructions for how to set it up to the migration guide.