### PR TITLE
microsite: update RedHat link to point to RHDP

### DIFF
--- a/microsite/src/pages/community/index.tsx
+++ b/microsite/src/pages/community/index.tsx
@@ -73,7 +73,7 @@ const Community = () => {
     },
     {
       name: 'RedHat',
-      url: 'https://www.redhat.com/',
+      url: 'https://developers.redhat.com/rhdh',
       logo: 'img/partner-logo-redhat.png',
     },
     {


### PR DESCRIPTION
Had a look at the microsite links to make sure we're sticking to the guidelines at https://github.com/cncf/foundation/blob/main/website-guidelines.md

This makes sure that the RedHat link points to content relevant to Backstage

CC @christophe-f