### PR TITLE
microsite: update Thoughtworks link to point to Backstage landing page

### DIFF
--- a/microsite/src/pages/community/index.tsx
+++ b/microsite/src/pages/community/index.tsx
@@ -83,7 +83,7 @@ const Community = () => {
     },
     {
       name: 'ThoughtWorks',
-      url: 'https://www.thoughtworks.com',
+      url: 'https://www.thoughtworks.com/about-us/partnerships/technology/backstage-by-spotify',
       logo: 'img/partner-logo-thoughtworks.png',
     },
     {


### PR DESCRIPTION
Had a look at the microsite links to make sure we're sticking to the guidelines at https://github.com/cncf/foundation/blob/main/website-guidelines.md

This makes sure that the Thoughtworks link points to content relevant to Backstage