### PR TITLE
microsite: update VMWare link to point to Tanzu Developer Portal

### DIFF
--- a/microsite/src/pages/community/index.tsx
+++ b/microsite/src/pages/community/index.tsx
@@ -88,7 +88,7 @@ const Community = () => {
     },
     {
       name: 'VMWare',
-      url: 'https://tanzu.vmware.com/',
+      url: 'https://tanzu.vmware.com/developer-portal',
       logo: 'img/partner-logo-tanzubybroadcom.png',
     },
   ];


### PR DESCRIPTION
Had a look at the microsite links to make sure we're sticking to the guidelines at https://github.com/cncf/foundation/blob/main/website-guidelines.md

This makes sure that the VMWare link points to content relevant to Backstage

CC @waldirmontoya25 