### PR TITLE
Match lighthouse accessibility threshold with an actual value

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -64,7 +64,7 @@ module.exports = {
         'categories:pwa': 'off',
         'categories:best-practices': 'off',
         'categories:seo': 'off',
-        'categories:accessibility': ['error', { minScore: 0.95 }],
+        'categories:accessibility': ['error', { minScore: 0.89 }],
       },
     },
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Whenever PR triggers the check on accessibility in Lighthouse CI, it fails. 
Though the changes in PR doesn't have anything related to accessibility degradation.
At the moment *on master* accessibility score is 0.89.
So the suggestion is to match with what is actually now to prevent failing PRs like this https://github.com/backstage/backstage/pull/23281 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
