### PR TITLE
docs,config: fix proxy provider config wonk

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -397,10 +397,8 @@ auth:
         clientId: ${AUTH_ATLASSIAN_CLIENT_ID}
         clientSecret: ${AUTH_ATLASSIAN_CLIENT_SECRET}
         scopes: ${AUTH_ATLASSIAN_SCOPES}
-    myproxy:
-      development: {}
-    guest:
-      development: {}
+    myproxy: {}
+    guest: {}
 
 costInsights:
   engineerCost: 200000

--- a/docs/auth/guest/provider.md
+++ b/docs/auth/guest/provider.md
@@ -58,9 +58,5 @@ Similar to the other authentication providers, you have to enable the provider i
 ```diff
 auth:
     providers:
-+       guest:
-+           userEntityRef: user:default/guest
-+           development: {}
++       guest: {}
 ```
-
-We need to specify that the provider is enabled for the given environment, and as there are no config values for this provider yet, you can just specify an empty object.

--- a/docs/auth/microsoft/azure-easyauth.md
+++ b/docs/auth/microsoft/azure-easyauth.md
@@ -15,8 +15,7 @@ Add the following into your `app-config.yaml` or `app-config.production.yaml` fi
 auth:
   environment: development
   providers:
-    azure-easyauth:
-      development: {}
+    azure-easyauth: {}
 ```
 
 Add a `providerFactories` entry to the router in

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -22,8 +22,7 @@ The provider configuration can be added to your `app-config.yaml` under the root
 auth:
   environment: development
   providers:
-    oauth2Proxy:
-      development: {}
+    oauth2Proxy: {}
 ```
 
 Right now no configuration options are supported, but the empty object is needed


### PR DESCRIPTION
🧹, only OAuth providers differentiate between different environments, proxy auth providers always use a flat configuration and never need the `development` nesting.

See

https://github.com/backstage/backstage/blob/d3265deba86e8e6dbe653c645a3a98632d5133f0/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts#L43

vs

https://github.com/backstage/backstage/blob/9b810b9a9975d8f4036ff34f1a494d561c4a443b/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts#L39