### PR TITLE
Add backstage to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,23 +1,9 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: backstage
-  description: |
-    Backstage is an open-source developer portal that puts the developer experience first.
-  links:
-    - title: Website
-      url: http://backstage.io
-    - title: Documentation
-      url: https://backstage.io/docs
-    - title: Storybook
-      url: https://backstage.io/storybook
-    - title: Discord Chat
-      url: https://discord.com/invite/EBHEGzX
-  annotations:
-    github.com/project-slug: backstage/backstage
-    backstage.io/techdocs-ref: dir:.
-    lighthouse.com/website-url: https://backstage.io
-spec:
-  type: library
-  owner: CNCF
-  lifecycle: experimental
+  kind: Component
+  metadata:
+    name: backstage
+  spec:
+    type: service
+    lifecycle: experimental
+    owner: openapi-tooling-maintainers
+    system: example


### PR DESCRIPTION

## TL;DR

This pull request registers backstage, as a component in our Backstage Software Catalog. 
It lists our team, openapi-tooling-maintainers, as the owners of this component.
To add this component to the Backstage Software Catalog, follow the steps here → https://backstage-quickstart.spotify.net/catalog-import

## What is Backstage?

[Backstage](https://backstage.io/) is an open platform for building developer portals. Powered by a centralized 
software catalog, Backstage restores order to your microservices and infrastructure and enables your product teams 
to ship high-quality code quickly without compromising autonomy.

Backstage unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.

[![What is Backstage? (Explainer Video)](https://img.youtube.com/vi/85TQEpNCaU0/hqdefault.jpg)([https://youtu.be/85TQEpNCaU0])]
