### PR TITLE
backend-app-api: fix config secret redactions

### DIFF
--- a/.changeset/large-candles-sniff.md
+++ b/.changeset/large-candles-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fixed an issue where configuration schema for the purpose of redacting secrets from logs was not being read correctly.

--- a/packages/backend-app-api/src/config/config.test.ts
+++ b/packages/backend-app-api/src/config/config.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { loadConfigSchema } from '@backstage/config-loader';
+import { createConfigSecretEnumerator } from './config';
+import { mockServices } from '@backstage/backend-test-utils';
+
+describe('createConfigSecretEnumerator', () => {
+  it('should enumerate secrets', async () => {
+    const logger = mockServices.logger.mock();
+
+    const enumerate = await createConfigSecretEnumerator({
+      logger,
+    });
+    const secrets = enumerate(
+      mockServices.rootConfig({
+        data: {
+          backend: { auth: { keys: [{ secret: 'my-secret-password' }] } },
+        },
+      }),
+    );
+    expect(Array.from(secrets)).toEqual(['my-secret-password']);
+  }, 20_000); // Bit higher timeout since we're loading all config schemas in the repo
+
+  it('should enumerate secrets with explicit schema', async () => {
+    const logger = mockServices.logger.mock();
+
+    const enumerate = await createConfigSecretEnumerator({
+      logger,
+      schema: await loadConfigSchema({
+        serialized: {
+          schemas: [
+            {
+              value: {
+                type: 'object',
+                properties: {
+                  secret: {
+                    visibility: 'secret',
+                    type: 'string',
+                  },
+                },
+              },
+              path: '/mock',
+            },
+          ],
+          backstageConfigSchemaVersion: 1,
+        },
+      }),
+    });
+
+    const secrets = enumerate(
+      mockServices.rootConfig({
+        data: {
+          secret: 'my-secret',
+          other: 'not-secret',
+        },
+      }),
+    );
+    expect(Array.from(secrets)).toEqual(['my-secret']);
+  });
+});

--- a/packages/backend-app-api/src/config/config.ts
+++ b/packages/backend-app-api/src/config/config.ts
@@ -42,7 +42,7 @@ export async function createConfigSecretEnumerator(options: {
   const schema =
     options.schema ??
     (await loadConfigSchema({
-      dependencies: packages.map(p => p.packageJson.name).filter(() => false),
+      dependencies: packages.map(p => p.packageJson.name),
     }));
 
   return (config: Config) => {
@@ -55,7 +55,7 @@ export async function createConfigSecretEnumerator(options: {
     );
     const secrets = new Set<string>();
     JSON.parse(
-      JSON.stringify(secretsData),
+      JSON.stringify(secretsData.data),
       (_, v) => typeof v === 'string' && secrets.add(v),
     );
     logger.info(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Not treating this as a security vulnerability since the log redactions are an additional precaution rather than something to rely on for security. Leaking secrets in logs in the first place would be a vulnerability, even if they are redacted. Will still make sure we ship a patch release for this though.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
