### PR TITLE
Add TLS options to support GSuite org data ingestion via LDAP

### DIFF
--- a/.changeset/clean-sloths-grin.md
+++ b/.changeset/clean-sloths-grin.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-ldap': patch
----
-
-Add TLS support to ingest GSuite LDAP data

--- a/.changeset/clean-sloths-grin.md
+++ b/.changeset/clean-sloths-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Add TLS support to ingest GSuite LDAP data

--- a/.changeset/moody-geese-serve.md
+++ b/.changeset/moody-geese-serve.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-ldap': minor
+'@backstage/plugin-catalog-backend-module-ldap': patch
 ---
 
 Add TLS support to ingest GSuite LDAP data

--- a/.changeset/moody-geese-serve.md
+++ b/.changeset/moody-geese-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': minor
+---
+
+Add TLS support to ingest GSuite LDAP data

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -110,6 +110,18 @@ This is the URL of the targeted server, typically on the form
 `ldaps://ds.example.net` for SSL enabled servers or `ldap://ds.example.net`
 without SSL.
 
+#### target.tls.keys
+
+`keys` in TLS options specifies location of a file, that contains private keys
+to establish connection with your LDAP server, in PEM format. See an example
+for Google Secure LDAP Service below.
+
+#### target.tls.certs
+
+`certs` in TLS options specifies location of a file, that contains certificate
+chains to establish connection with your LDAP server, in PEM format. See an
+example for Google Secure LDAP Service below.
+
 ### bind
 
 The bind block specifies how the plugin should bind (essentially, to
@@ -373,4 +385,29 @@ catalog:
       target: ldaps://ds.example.net
       rules:
         - allow: [User, Group]
+```
+
+### Example configurations
+
+#### Google Secure LDAP Service
+
+To sync Google Workspace/Cloud Identity organization data to users and groups in backstage,
+you must [configure Secure LDAP Service](https://support.google.com/a/answer/9048516) first.
+
+Once Secure LDAP Service is configured, you can enable TLS options in LDAP configuration,
+as mentioned below. `keys` and `certs` specify the location of files that are generated
+while configuring Secure LDAP Service above.
+
+```yaml
+ldap:
+  providers:
+    - target: ldaps://ldap.google.com:636
+      tls:
+        rejectUnauthorized: false
+        keys: '/var/secrets/tls/gldap.key'
+        certs: '/var/secrets/tls/gldap.crt'
+      users:
+        # users configuration comes here
+      groups:
+        # groups configuration comes here
 ```

--- a/plugins/catalog-backend-module-ldap/api-report.md
+++ b/plugins/catalog-backend-module-ldap/api-report.md
@@ -197,6 +197,8 @@ export function readLdapOrg(
 // @public
 export type TLSConfig = {
   rejectUnauthorized?: boolean;
+  keys?: string;
+  certs?: string;
 };
 
 // @public

--- a/plugins/catalog-backend-module-ldap/package.json
+++ b/plugins/catalog-backend-module-ldap/package.json
@@ -39,8 +39,8 @@
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@types/ldapjs": "^2.2.0",
-    "ldapjs": "^2.2.0",
+    "@types/ldapjs": "^2.2.5",
+    "ldapjs": "^2.3.3",
     "lodash": "^4.17.21",
     "uuid": "^9.0.0",
     "winston": "^3.2.1"

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -48,8 +48,8 @@ export class LdapClient {
   ): Promise<LdapClient> {
     let secureContext;
     if (tls && tls.certs && tls.keys) {
-      const cert = await readFile(tls.certs).then(f => f.toString());
-      const key = await readFile(tls.keys).then(f => f.toString());
+      const cert = await readFile(tls.certs, 'utf-8');
+      const key = await readFile(tls.keys, 'utf-8');
       secureContext = tlsLib.createSecureContext({
         cert: cert,
         key: key,

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.test.ts
@@ -80,7 +80,11 @@ describe('readLdapConfig', () => {
         {
           target: 'target',
           bind: { dn: 'bdn', secret: 's' },
-          tls: { rejectUnauthorized: false },
+          tls: {
+            rejectUnauthorized: false,
+            keys: '/tmp/keys.pem',
+            certs: '/tmp/certs.pem',
+          },
           users: {
             dn: 'udn',
             options: {
@@ -140,7 +144,11 @@ describe('readLdapConfig', () => {
       {
         target: 'target',
         bind: { dn: 'bdn', secret: 's' },
-        tls: { rejectUnauthorized: false },
+        tls: {
+          rejectUnauthorized: false,
+          keys: '/tmp/keys.pem',
+          certs: '/tmp/certs.pem',
+        },
         users: {
           dn: 'udn',
           options: {

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.ts
@@ -49,6 +49,10 @@ export type LdapProviderConfig = {
 export type TLSConfig = {
   // Node TLS rejectUnauthorized
   rejectUnauthorized?: boolean;
+  // A file containing private keys in PEM format
+  keys?: string;
+  // A file containing cert chains in PEM format
+  certs?: string;
 };
 
 /**
@@ -205,6 +209,8 @@ export function readLdapConfig(config: Config): LdapProviderConfig[] {
     }
     return {
       rejectUnauthorized: c.getOptionalBoolean('rejectUnauthorized'),
+      keys: c.getOptionalString('keys'),
+      certs: c.getOptionalString('certs'),
     };
   }
 

--- a/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
@@ -105,7 +105,7 @@ function decode(
 function formatGUID(objectGUID: string | Buffer): string {
   let data: Buffer;
   if (typeof objectGUID === 'string') {
-    data = new Buffer(objectGUID, 'binary');
+    data = Buffer.from(objectGUID, 'binary');
   } else {
     data = objectGUID;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5672,9 +5672,9 @@ __metadata:
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/types": "workspace:^"
-    "@types/ldapjs": ^2.2.0
+    "@types/ldapjs": ^2.2.5
     "@types/lodash": ^4.14.151
-    ldapjs: ^2.2.0
+    ldapjs: ^2.3.3
     lodash: ^4.17.21
     uuid: ^9.0.0
     winston: ^3.2.1
@@ -19193,7 +19193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ldapjs@npm:^2.2.0":
+"@types/ldapjs@npm:^2.2.5":
   version: 2.2.5
   resolution: "@types/ldapjs@npm:2.2.5"
   dependencies:
@@ -33551,7 +33551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ldapjs@npm:^2.2.0":
+"ldapjs@npm:^2.3.3":
   version: 2.3.3
   resolution: "ldapjs@npm:2.3.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for two additional TLS options `certs` and `keys`. This PR is derived from https://github.com/backstage/backstage/pull/13407, but omits the `vendorOverride` part, since that part is already merged via https://github.com/backstage/backstage/pull/13406.

The changes to documentation also included an example for configuring LDAP sync to work with Secure LDAP Service.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
