### PR TITLE
docs/overview/versioning-policy: commit to backporting high and critical vulnerabilities

### DIFF
--- a/docs/overview/versioning-policy.md
+++ b/docs/overview/versioning-policy.md
@@ -68,7 +68,9 @@ The following versioning policy applies to the main-line releases only.
   done when necessary and with the goal of having minimal impact. When possible,
   there will always be a deprecation path for a breaking change.
 - Security fixes **may** be backported to older releases based on the simplicity
-  of the upgrade path, and the severity of the vulnerability.
+  of the upgrade path, and the severity of the vulnerability. Vulnerabilities
+  with a severity of `high` or `critical` will always be backported to releases
+  for the last 6 months if feasible.
 - Bug reports are valid only if reproducible in the most recent release, and bug
   fixes are only applied to the next release.
 - We will do our best to adhere to this policy.


### PR DESCRIPTION
Had a discussion around this today in the maintainer team and wanted to raise the bar a bit. So far we've been backporting fixes if we felt it was necessary, this is a more direct commitment with a time window. This also means that the last 6 months of releases are effectively supported by security patches.