### PR TITLE
Removed inline styling from breadcrumbs

### DIFF
--- a/.changeset/famous-forks-listen.md
+++ b/.changeset/famous-forks-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Removed inline styling in breadcrumbs and replaced with a theme targetable class of BreadcrumbsCurrentPage

--- a/.changeset/famous-forks-listen.md
+++ b/.changeset/famous-forks-listen.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Removed inline styling in breadcrumbs and replaced with a theme targetable class of BreadcrumbsCurrentPage
+Removed inline styling in breadcrumbs and replaced with a theme reachable class of BreadcrumbsCurrentPage

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -137,6 +137,9 @@ export function Breadcrumbs(props: Props_18): React_2.JSX.Element;
 export type BreadcrumbsClickableTextClassKey = 'root';
 
 // @public (undocumented)
+export type BreadcrumbsCurrentPageClassKey = 'root';
+
+// @public (undocumented)
 export type BreadcrumbsStyledBoxClassKey = 'root';
 
 // @public

--- a/packages/core-components/src/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/core-components/src/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -51,6 +51,18 @@ const StyledBox = withStyles(
   { name: 'BackstageBreadcrumbsStyledBox' },
 )(Box);
 
+/** @public */
+export type BreadcrumbsCurrentPageClassKey = 'root';
+
+const BreadcrumbsCurrentPage = withStyles(
+  {
+    root: {
+      fontStyle: 'italic',
+    },
+  },
+  { name: 'BreadcrumbsCurrentPage' },
+)(Box);
+
 /**
  * Breadcrumbs component to show navigation hierarchical structure
  *
@@ -88,7 +100,7 @@ export function Breadcrumbs(props: Props) {
         {hasHiddenBreadcrumbs && (
           <ClickableText onClick={handleClick}>...</ClickableText>
         )}
-        <Box style={{ fontStyle: 'italic' }}>{currentPage}</Box>
+        <BreadcrumbsCurrentPage>{currentPage}</BreadcrumbsCurrentPage>
       </MaterialBreadcrumbs>
       <Popover
         open={open}

--- a/packages/core-components/src/layout/Breadcrumbs/index.ts
+++ b/packages/core-components/src/layout/Breadcrumbs/index.ts
@@ -18,4 +18,5 @@ export { Breadcrumbs } from './Breadcrumbs';
 export type {
   BreadcrumbsClickableTextClassKey,
   BreadcrumbsStyledBoxClassKey,
+  BreadcrumbsCurrentPageClassKey,
 } from './Breadcrumbs';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

At the moment it's not possible to remove the italic styling from the breadcrumbs (without a nasty selector and !important). Removed the inline styling and replaced with themeable component. 

Note: I haven't managed to test this in the UI because the only place I can see that would show this, is techdocs and that's currently not working locally. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
