### PR TITLE
Fixed WorkflowRunStatus component to handle skipped and cancelled status. Fixes #23257

### DIFF
--- a/.changeset/good-seals-argue.md
+++ b/.changeset/good-seals-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Fixed bug in WorkflowRunStatus component where skipped and cancelled workflow runs appeared as success

--- a/plugins/github-actions/src/components/WorkflowRunStatus/WorkflowRunStatus.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunStatus/WorkflowRunStatus.tsx
@@ -52,7 +52,8 @@ export function WorkflowIcon({
       return <StatusRunning />;
     case 'completed':
       switch (conclusion?.toLocaleLowerCase('en-US')) {
-        case 'skipped' || 'canceled':
+        case 'skipped':
+        case 'cancelled':
           return <StatusAborted />;
 
         case 'timed_out':


### PR DESCRIPTION
Fixed WorkflowRunStatus component to handle skipped and cancelled status. Earlier, the switch case was incorrectly setup that made `canceled` and `skipped` status be reported as `StatusOK`. This fix will correctly show `skipped` and `cancelled` status as `StatusAborted`.

This fixes #23257.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
