### PR TITLE
Added ternary operator for ref to Docker Deploy Image workflow

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: [release-published]
 
+env:
+  RELEASE_VERSION: v${{ github.event.client_payload.version }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           path: backstage
-          ref: v${{ github.event.client_payload.version }}
+          ref: ${{ github.event.client_payload.version && env.RELEASE_VERSION || github.ref }}
 
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After fixing the syntax issue in the Docker Deploy Image workflow we then ran into an error trying to checkout the repo when running this workflow manually. This adds a [ternary operator](https://docs.github.com/en/actions/learn-github-actions/expressions#example) for setting the `ref` - if there is a version use that if not just fallback to the `github.ref` which in this case would be `refs/heads/master`. One small wrinkle is that tags all begin with "v", to work around that we created an environment variable to do the string concatenation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
