### PR TITLE
Docker Deploy Image tag version when available

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   RELEASE_VERSION: v${{ github.event.client_payload.version }}
+  TAG_VERSION: ghcr.io/${{ github.repository_owner }}/backstage:${{ github.event.client_payload.version }}
 
 jobs:
   build:
@@ -68,6 +69,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/backstage:latest
-            ghcr.io/${{ github.repository_owner }}/backstage:${{ github.event.client_payload.version }}
+            ${{ github.event.client_payload.version && env.TAG_VERSION || '' }}
           labels: |
             org.opencontainers.image.description=Docker image generated from the latest Backstage release; this contains what you would get out of the box by running npx @backstage/create-app and building a Docker image from the generated source. This is meant to ease the process of evaluating Backstage for the first time, but also has the severe limitation that there is no way to install additional plugins relevant to your infrastructure.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Only add the specific version tag when there is a version to use if not do not add the tag.

This should be the last change needed to be able to run the Docker Deploy image workflow manually, making it easy to test creating a new Backstage instance and building the included Docker image.

> Note: running this manually will NOT push the image to the registry 👍 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
