### PR TITLE
app-backend: disable default auth policy for now

### DIFF
--- a/.changeset/shiny-bulldogs-run.md
+++ b/.changeset/shiny-bulldogs-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Disable default auth policy, allowing unauthenticated access to app bundle.

--- a/plugins/app-backend/src/service/appPlugin.ts
+++ b/plugins/app-backend/src/service/appPlugin.ts
@@ -81,6 +81,10 @@ export const appPlugin = createBackendPlugin({
           schema,
         });
         httpRouter.use(router);
+        httpRouter.addAuthPolicy({
+          allow: 'unauthenticated',
+          path: '/',
+        });
       },
     });
   },


### PR DESCRIPTION
Plan is to implement cookie-based authentication in the app backend, but for now it makes sense to disable the default auth policy altogether. That way we don't break the app backend for users of the new backend system.