### PR TITLE
Avoid flicker when refreshing page of new frontend system

### DIFF
--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -51,6 +51,7 @@ import {
   ApiResolver,
   AppThemeSelector,
 } from '@backstage/core-app-api';
+import { Progress } from '@backstage/core-components';
 
 // TODO: Get rid of all of these
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
@@ -214,7 +215,7 @@ export function createApp(options?: {
     createRoot() {
       const LazyApp = React.lazy(appLoader);
       return (
-        <React.Suspense fallback="Loading...">
+        <React.Suspense fallback={<Progress />}>
           <LazyApp />
         </React.Suspense>
       );


### PR DESCRIPTION
Due to something (?) async, when refreshing a page using the new frontend system, there's a brief flicker as the `React.Suspense` fallback is shown (which was just the text `Loading...`). Instead, let's show a `<Progress />` - it seems to make the flicker disappear when reloads are fast.

Either way, the UX feels mildly nicer to see a loading bar on the top of the screen instead of the text `Loading...`.
Unfortunately, one downside here is that, if running on a slower network, then the loading bar is shown in two different colours: once unthemed, then again themed.
