### PR TITLE
README references wrong plugin

### DIFF
--- a/.changeset/witty-pears-sniff.md
+++ b/.changeset/witty-pears-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Updated README

--- a/plugins/code-coverage-backend/README.md
+++ b/plugins/code-coverage-backend/README.md
@@ -74,7 +74,7 @@ The code coverage backend plugin has support for the [new backend system](https:
 In your `packages/backend/src/index.ts` make the following changes:
 
 ```diff
-+ backend.add(import('@backstage/plugin-explore-backend'));
++ backend.add(import('@backstage/plugin-code-coverage-backend'));
 ```
 
 ## Configuring your entity


### PR DESCRIPTION
The documentation for the new backend system referenced the wrong plugin. This commit fixes that.
