### PR TITLE
Use index.cjs.js as entry point to scaffolder-node-test-utils

### DIFF
--- a/.changeset/slimy-bananas-brush.md
+++ b/.changeset/slimy-bananas-brush.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-node-test-utils': patch
 ---
 
-Updated publishConfig.main entry in package.json from `dist/index.esm.js` to `dist/index.cjs.js` for CommonJS compatibility.
+Fix issue with package bundling, should be `dist/index.cjs.js` instead of `dist/index.esm.js`.

--- a/.changeset/slimy-bananas-brush.md
+++ b/.changeset/slimy-bananas-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node-test-utils': patch
+---
+
+Updated publishConfig.main entry in package.json from `dist/index.esm.js` to `dist/index.cjs.js` for CommonJS compatibility.

--- a/plugins/scaffolder-node-test-utils/package.json
+++ b/plugins/scaffolder-node-test-utils/package.json
@@ -6,7 +6,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
+    "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
   "repository": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR makes it so the package.json `main` becomes `dist/index.cjs.js` instead of `dist/index.esm.js` for `@backstage/scaffolder-node-test-utils`, which gets compiled to CommonJS.

`@backstage/scaffolder-node-test-utils` currently specifies in the package.json that its `backstage.role` is `node-library`, which makes it so the TS is compiled to CJS. However, the `publishConfig.main` is  `dist/index.esm.js` and that obviously won't work when the entry point gets compiled to `index.cjs.js` with CJS.

I'm currently assuming that we want to keep compilation to CJS only, as that's also what's happening for `@backstage/scaffolder-node`. If that's wrong, I'm open to doing other changes.

closes #23380

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
