### PR TITLE
Allow tree-shaking of frontend plugins

### DIFF
--- a/.changeset/green-adults-push.md
+++ b/.changeset/green-adults-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add preserveModules to rollup, which allows better async loading and tree-shaking in webpack

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -100,6 +100,7 @@ export async function makeRollupConfigs(
         chunkFileNames: `esm/[name]-[hash].esm.js`,
         format: 'module',
         sourcemap: true,
+        preserveModules: true,
       });
       // Assume we're building for the browser if ESM output is included
       mainFields.unshift('browser');

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -101,6 +101,7 @@ export async function makeRollupConfigs(
         format: 'module',
         sourcemap: true,
         preserveModules: true,
+        preserveModulesRoot: `${targetDir}/src`,
       });
       // Assume we're building for the browser if ESM output is included
       mainFields.unshift('browser');


### PR DESCRIPTION
Adding rollup's preserveModules to enable tree-shaking in webpack.

rollup is used to bundle libraries/plugins and webpack to build final app.
This results in non-optimal final app, as webpack is not able to do proper tree shaking.
reference: https://www.whatcouldpossiblygowrongblog.com/posts/tree-shaking-a-right-way

Results are not visible in `packages/app` (I believe because it has access to all .ts files), but clearly visible when building [demo app](https://github.com/backstage/demo).
<img width="1407" alt="image" src="https://github.com/backstage/backstage/assets/603853/318e026f-270f-4fd9-abc2-45985d1e6587">
And can be even greater on custom apps.
<img width="1407" alt="image" src="https://github.com/backstage/backstage/assets/603853/08cb2933-5072-40e0-97ce-1a6a1deba543">


Not sure whether this should be patch, or minor change. On one hand it changes a lot, on the other I tested it, and it works fine. Also from user's perspective there is no action needed, and everything is ocmpatible.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
