### PR TITLE
Add the deprecation plugin to the default linter setup, switched off.

### DIFF
--- a/.changeset/polite-toys-camp.md
+++ b/.changeset/polite-toys-camp.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli': patch
+---
+
+Add the deprecation plugin to the default linter setup, switched off.
+
+This allows to disable deprecation warnings for `backstage-cli repo list-deprecations` with inline comments.

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -66,7 +66,7 @@ function createConfig(dir, extraConfig = {}) {
       ...(extraExtends ?? []),
     ],
     parser: '@typescript-eslint/parser',
-    plugins: ['import', 'unused-imports', ...(plugins ?? [])],
+    plugins: ['import', 'unused-imports', 'deprecation', ...(plugins ?? [])],
     env: {
       jest: true,
       ...env,
@@ -84,6 +84,7 @@ function createConfig(dir, extraConfig = {}) {
       ...(ignorePatterns ?? []),
     ],
     rules: {
+      'deprecation/deprecation': 'off',
       'no-shadow': 'off',
       'no-redeclare': 'off',
       '@typescript-eslint/no-shadow': 'error',


### PR DESCRIPTION
This allows to disable deprecation warnings for `backstage-cli repo list-deprecations` with inline comments.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
