### PR TITLE
Fix TechDocs sidebar height with large number of links

### DIFF
--- a/.changeset/clean-cycles-suffer.md
+++ b/.changeset/clean-cycles-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bug in TechDocs sidebar render that prevented scrollbar from being displayed

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -71,7 +71,7 @@ export const useTechDocsReaderDom = (
   const [dom, setDom] = useState<HTMLElement | null>(null);
   const isStyleLoading = useShadowDomStylesLoading(dom);
 
-  const updateSidebarPosition = useCallback(() => {
+  const updateSidebarPositionAndHeight = useCallback(() => {
     if (!dom) return;
 
     const sidebars = dom.querySelectorAll<HTMLElement>('.md-sidebar');
@@ -92,7 +92,18 @@ export const useTechDocsReaderDom = (
         if (domTop < pageTop) {
           domTop = pageTop;
         }
-        element.style.top = `${Math.max(domTop, 0) + tabsHeight}px`;
+
+        const scrollbarTopPx = Math.max(domTop, 0) + tabsHeight;
+
+        element.style.top = `${scrollbarTopPx}px`;
+
+        // set scrollbar height to ensure all links can be seen when content is small
+        const footer = dom.querySelector('.md-container > .md-footer');
+        // if no footer, fallback to using the bottom of the window
+        const scrollbarEndPx =
+          footer?.getBoundingClientRect().top ?? window.innerHeight;
+
+        element.style.height = `${scrollbarEndPx - scrollbarTopPx}px`;
       }
 
       // show the sidebar only after updating its position
@@ -101,13 +112,17 @@ export const useTechDocsReaderDom = (
   }, [dom, isMobileMedia]);
 
   useEffect(() => {
-    window.addEventListener('resize', updateSidebarPosition);
-    window.addEventListener('scroll', updateSidebarPosition, true);
+    window.addEventListener('resize', updateSidebarPositionAndHeight);
+    window.addEventListener('scroll', updateSidebarPositionAndHeight, true);
     return () => {
-      window.removeEventListener('resize', updateSidebarPosition);
-      window.removeEventListener('scroll', updateSidebarPosition, true);
+      window.removeEventListener('resize', updateSidebarPositionAndHeight);
+      window.removeEventListener(
+        'scroll',
+        updateSidebarPositionAndHeight,
+        true,
+      );
     };
-  }, [dom, updateSidebarPosition]);
+  }, [dom, updateSidebarPositionAndHeight]);
 
   // dynamically set width of footer to accommodate for pinning of the sidebar
   const updateFooterWidth = useCallback(() => {
@@ -129,10 +144,15 @@ export const useTechDocsReaderDom = (
   useEffect(() => {
     if (!isStyleLoading) {
       updateFooterWidth();
-      updateSidebarPosition();
+      updateSidebarPositionAndHeight();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state, isStyleLoading, updateFooterWidth, updateSidebarPosition]);
+  }, [
+    state,
+    isStyleLoading,
+    updateFooterWidth,
+    updateSidebarPositionAndHeight,
+  ]);
 
   // a function that performs transformations that are executed prior to adding it to the DOM
   const preRender = useCallback(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #23397 , an issue where a long nav bar in tech docs did not provide a scrollbar. It also fixes a related issue where the nav section would overlap the footer links. After the update the sidebar height will update on resize and scroll to fit within the top of the docs container & the footer (if present).

Screenshots:
No scrollbar when enough space is present:
![No scrollbar](https://github.com/backstage/backstage/assets/162351244/1e10696a-ccba-4fdb-bda7-d5903917e5c8)

Scrollbar will appear when expanded sections overflow the page length:
![Scrollbar when expanded](https://github.com/backstage/backstage/assets/162351244/06d0ad95-e859-45ad-b434-4ca5ca860a47)

Scrolling up on the page will also cause a scrollbar to appear to avoid clipping with the footer:
![Scrollbar when footer near top](https://github.com/backstage/backstage/assets/162351244/c9de1c0e-70e4-4346-8fb3-8bac6699b20f)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
