### PR TITLE
consult ui:message schema properties for custom validation messages

### DIFF
--- a/.changeset/modern-parrots-protect.md
+++ b/.changeset/modern-parrots-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+consult ui:message schema properties for custom validation messages

--- a/docs/features/software-templates/input-examples.md
+++ b/docs/features/software-templates/input-examples.md
@@ -26,6 +26,42 @@ parameters:
         ui:help: 'Hint: additional description...'
 ```
 
+#### Custom validation error message
+
+```yaml
+parameters:
+  - title: Fill in some steps
+    properties:
+      name:
+        title: Simple text input
+        type: string
+        description: Description about input
+        maxLength: 8
+        pattern: '^([a-zA-Z][a-zA-Z0-9]*)(-[a-zA-Z0-9]+)*$'
+        ui:autofocus: true
+        ui:help: 'Hint: additional description...'
+        ui:message:
+          pattern: '>= 1 alphanumeric tokens (first starts with letter) delimited by -'
+```
+
+#### Custom validation error message incorporating raw error content
+
+```yaml
+parameters:
+  - title: Fill in some steps
+    properties:
+      name:
+        title: Simple text input
+        type: string
+        description: Description about input
+        maxLength: 8
+        pattern: '^([a-zA-Z][a-zA-Z0-9]*)(-[a-zA-Z0-9]+)*$'
+        ui:autofocus: true
+        ui:help: 'Hint: additional description...'
+        ui:message:
+          pattern: '>= 1 alphanumeric tokens (first starts with letter) delimited by - (@{{err.message}})'
+```
+
 ### Multi line text input
 
 ```yaml

--- a/plugins/scaffolder-react/src/next/components/Form/Form.tsx
+++ b/plugins/scaffolder-react/src/next/components/Form/Form.tsx
@@ -22,6 +22,7 @@ import { DescriptionFieldTemplate } from './DescriptionFieldTemplate';
 import { FieldProps } from '@rjsf/utils';
 import { ScaffolderRJSFFormProps } from '@backstage/plugin-scaffolder-react';
 import { Theme as MuiTheme } from '@rjsf/material-ui';
+import transformErrors from './transformErrors';
 
 const WrappedForm = withTheme(MuiTheme);
 
@@ -62,6 +63,11 @@ export const Form = (props: PropsWithChildren<ScaffolderRJSFFormProps>) => {
   );
 
   return (
-    <WrappedForm {...props} templates={templates} fields={wrappedFields} />
+    <WrappedForm
+      transformErrors={transformErrors}
+      {...props}
+      templates={templates}
+      fields={wrappedFields}
+    />
   );
 };

--- a/plugins/scaffolder-react/src/next/components/Form/transformErrors.ts
+++ b/plugins/scaffolder-react/src/next/components/Form/transformErrors.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  FormContextType,
+  RJSFSchema,
+  RJSFValidationError,
+  StrictRJSFSchema,
+  UiSchema,
+} from '@rjsf/utils';
+
+import lodash from 'lodash';
+
+const disable = /($^)/;
+
+function xlate(
+  err: RJSFValidationError,
+  uiSchema: UiSchema,
+): string | undefined {
+  if (!(err.property && err.name)) {
+    return undefined;
+  }
+  const path = lodash
+    .filter(err.property.split('.'))
+    .map(e => e.replace(/^\d+$/, 'items'));
+
+  for (let i = path.length; i >= 0; i--) {
+    const templatePath = [
+      ...path.slice(0, i),
+      'ui:message',
+      ...path.slice(i),
+      err.name,
+    ];
+    const template = lodash.get(uiSchema, templatePath);
+    if (template) {
+      return lodash.template(template, {
+        interpolate: /@{{([^}]+)}}/,
+        escape: disable,
+        evaluate: disable,
+      })({ err });
+    }
+  }
+  return undefined;
+}
+
+export default function transformErrors<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(
+  errors: RJSFValidationError[],
+  uiSchema?: UiSchema<T, S, F>,
+): RJSFValidationError[] {
+  if (errors.length && uiSchema) {
+    errors.forEach(err => {
+      const msg = xlate(err, uiSchema as any);
+      if (msg) {
+        if (err.stack) {
+          err.stack = err.stack.includes(err.message!)
+            ? err.stack.replace(err.message!, msg)
+            : msg;
+        }
+        err.message = msg;
+      }
+    });
+  }
+  return errors;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
First pass for discussion on issue #22575 . I'd love some guidance on how to formally test these changes.

I will attempt a pass at the documentation, but for now the items of note:

* All levels of the UI schema are searched for `ui:message` with message template overrides for the encountered validation error
* "message template" because embedded `@{{ }}` sequences may refer to the original, rewritten error object as `err` to support the case that the original message or other data should be exposed in the custom message.

Here is a sample template to exercise the functionality:

```
apiVersion: scaffolder.backstage.io/v1beta3
kind: Template

metadata:
  name: foo
  title: Foo
  description: FOO

spec:
  owner: user:bruiser
  type: testing

  parameters:
    - title: Strings
      required:
        - foo
        - bar
      properties:
        foo:
          title: Foo
          description: FOO
          type: string
          pattern: foo
          default: foo
          ui:message:
            pattern: WTF
        bar:
          title: Bar
          description: BAR
          type: string
          pattern: bar
          default: bar
        notBaz:
          title: notBaz
          description: NOT BAZ
          type: string
          not:
            pattern: baz
      ui:message:
        bar:
          pattern: WTAF
        notBaz:
          not: BAZ (@{{ err.message }})
    - title: Arrays
      properties:
        s:
          type: array
          items:
            type: string
            pattern: .{2,}
            ui:message:
              pattern: must be at least 2 characters (@{{ err.message }})
    - title: Nested
      properties:
        o:
          type: object
          properties:
            n:
              type: number
              multipleOf: 2
            a:
              type: array
              items:
                type: object
                properties:
                  s:
                    type: string
                    pattern: .{2,}
              ui:message:
                items:
                  s:
                    pattern: too short (@{{err.message}})
          ui:message:
            n:
              multipleOf: even only, dummy
  steps:
    - id: logstuff
      name: Log Stuff
      action: debug:log
      input:
        message: Nothing to see here
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
