### PR TITLE
A11Y: Fix lighthouse check with new auth system

### DIFF
--- a/.lighthouseci/scripts/guest-auth.js
+++ b/.lighthouseci/scripts/guest-auth.js
@@ -7,5 +7,4 @@ module.exports = async (browser, context) => {
   await page.evaluate(() => {
     localStorage.setItem('@backstage/core:SignInPage:provider', 'guest');
   });
-  await page.goto('http://localhost:3000');
 };

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -16,6 +16,7 @@
 module.exports = {
   ci: {
     collect: {
+      // headful: true,
       url: [
         /** Software Catalog */
         'http://localhost:3000/catalog',
@@ -52,7 +53,7 @@ module.exports = {
         outputPath: './.lighthouseci/reports',
         preset: 'desktop',
       },
-      startServerCommand: 'yarn dev',
+      startServerCommand: 'yarn start:lighthouse',
       startServerReadyPattern: 'webpack compiled successfully',
       startServerReadyTimeout: 600000,
       numberOfRuns: 1,
@@ -64,7 +65,7 @@ module.exports = {
         'categories:pwa': 'off',
         'categories:best-practices': 'off',
         'categories:seo': 'off',
-        'categories:accessibility': ['error', { minScore: 0.89 }],
+        'categories:accessibility': ['error', { minScore: 0.95 }],
       },
     },
   },

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -16,7 +16,6 @@
 module.exports = {
   ci: {
     collect: {
-      // headful: true,
       url: [
         /** Software Catalog */
         'http://localhost:3000/catalog',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "start": "yarn workspace example-app start",
     "start-backend": "yarn workspace example-backend start",
     "start-backend:next": "yarn workspace example-backend-next start",
+    "start:lighthouse": "concurrently 'yarn start' 'yarn start-backend:next'",
     "start:microsite": "cd microsite/ && yarn start",
     "start:next": "yarn workspace example-app-next start",
     "storybook": "yarn ./storybook run start",


### PR DESCRIPTION
Looks like we need to run the new backend system with the `GuestProvider` installed to get through the auth check.

Also, look like the additional `page.goto(...)` in `guest-auth` was causing some issues with local storage contexts for some reason, this is still unclear as to why removing this works.