### PR TITLE
integration: add some additional test cases for defaultScmResolveUrl

### DIFF
--- a/packages/integration/src/helpers.test.ts
+++ b/packages/integration/src/helpers.test.ts
@@ -91,6 +91,24 @@ describe('defaultScmResolveUrl', () => {
     expect(
       defaultScmResolveUrl({
         url: './b.yaml',
+        base: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/',
+      }),
+    ).toBe(
+      'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/b.yaml',
+    );
+
+    expect(
+      defaultScmResolveUrl({
+        url: './b.yaml',
+        base: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/subfolder',
+      }),
+    ).toBe(
+      'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/b.yaml',
+    );
+
+    expect(
+      defaultScmResolveUrl({
+        url: './b.yaml',
         base: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/a.yaml',
       }),
     ).toBe(
@@ -104,6 +122,24 @@ describe('defaultScmResolveUrl', () => {
       }),
     ).toBe(
       'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/b.yaml?at=master',
+    );
+
+    expect(
+      defaultScmResolveUrl({
+        url: 'b.yaml',
+        base: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/',
+      }),
+    ).toBe(
+      'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/b.yaml',
+    );
+
+    expect(
+      defaultScmResolveUrl({
+        url: 'b.yaml',
+        base: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/subfolder',
+      }),
+    ).toBe(
+      'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/folder/b.yaml',
     );
 
     expect(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a few more test cases after https://github.com/backstage/backstage/pull/23431 to confirm the behavior with relative URLs. No changeset, hopefully this can go in under https://github.com/backstage/backstage/blob/master/.changeset/chatty-vans-cross.md. If we end up crossing a release, can add one in.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
