### PR TITLE
fix: use orderField and createdAfter to unify for other plugins

### DIFF
--- a/.changeset/poor-coats-boil.md
+++ b/.changeset/poor-coats-boil.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend': minor
+'@backstage/plugin-notifications': minor
+---
+
+notifications-backend URL query parameters changed from sort/sortOrder to orderField and created_after to createdAfter to unify with other plugins

--- a/.changeset/poor-coats-boil.md
+++ b/.changeset/poor-coats-boil.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-notifications': minor
 ---
 
-notifications-backend URL query parameters changed from sort/sortOrder to orderField and created_after to createdAfter to unify with other plugins
+Notifications-backend URL query parameters changed from `sort/sortOrder` to `orderField` and `created_after` to `createdAfter` to unify with other plugins.

--- a/plugins/notifications-backend/package.json
+++ b/plugins/notifications-backend/package.json
@@ -37,7 +37,6 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
-    "@backstage/plugin-catalog-backend": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
     "@backstage/plugin-notifications-common": "workspace:^",
     "@backstage/plugin-notifications-node": "workspace:^",

--- a/plugins/notifications-backend/package.json
+++ b/plugins/notifications-backend/package.json
@@ -37,6 +37,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
+    "@backstage/plugin-catalog-backend": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
     "@backstage/plugin-notifications-common": "workspace:^",
     "@backstage/plugin-notifications-node": "workspace:^",

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
@@ -405,8 +405,7 @@ describe.each(databases.eachSupportedId())(
       it('should sort created asc', async () => {
         const notificationsCreatedAsc = await storage.getNotifications({
           user,
-          sort: 'created',
-          sortOrder: 'asc',
+          orderField: [{ field: 'created', order: 'asc' }],
         });
         expect(notificationsCreatedAsc.map(idOnly)).toEqual([id1, id3, id2]);
       });
@@ -414,8 +413,7 @@ describe.each(databases.eachSupportedId())(
       it('should sort created desc', async () => {
         const notificationsCreatedDesc = await storage.getNotifications({
           user,
-          sort: 'created',
-          sortOrder: 'desc',
+          orderField: [{ field: 'created', order: 'desc' }],
         });
         expect(notificationsCreatedDesc.map(idOnly)).toEqual([id2, id3, id1]);
       });
@@ -423,8 +421,7 @@ describe.each(databases.eachSupportedId())(
       it('should sort topic asc', async () => {
         const notificationsTopicAsc = await storage.getNotifications({
           user,
-          sort: 'topic',
-          sortOrder: 'asc',
+          orderField: [{ field: 'topic', order: 'asc' }],
         });
         expect(notificationsTopicAsc.map(idOnly)).toEqual([id1, id3, id2]);
       });
@@ -432,8 +429,7 @@ describe.each(databases.eachSupportedId())(
       it('should sort topic desc', async () => {
         const notificationsTopicDesc = await storage.getNotifications({
           user,
-          sort: 'topic',
-          sortOrder: 'desc',
+          orderField: [{ field: 'topic', order: 'desc' }],
         });
         expect(notificationsTopicDesc.map(idOnly)).toEqual([id2, id3, id1]);
       });
@@ -441,8 +437,7 @@ describe.each(databases.eachSupportedId())(
       it('should sort origin asc', async () => {
         const notificationsOrigin = await storage.getNotifications({
           user,
-          sort: 'origin',
-          sortOrder: 'asc',
+          orderField: [{ field: 'origin', order: 'asc' }],
           limit: 2,
           offset: 0,
         });
@@ -452,8 +447,7 @@ describe.each(databases.eachSupportedId())(
       it('should sort origin desc', async () => {
         const notificationsOriginNext = await storage.getNotifications({
           user,
-          sort: 'origin',
-          sortOrder: 'desc',
+          orderField: [{ field: 'origin', order: 'desc' }],
           limit: 2,
           offset: 2,
         });

--- a/plugins/notifications-backend/src/database/NotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/NotificationsStore.ts
@@ -20,6 +20,12 @@ import {
   NotificationStatus,
 } from '@backstage/plugin-notifications-common';
 
+/** @internal */
+export type EntityOrder = {
+  field: string;
+  order: 'asc' | 'desc';
+};
+
 // TODO: reuse the common part of the type with front-end
 /** @internal */
 export type NotificationGetOptions = {
@@ -28,8 +34,7 @@ export type NotificationGetOptions = {
   offset?: number;
   limit?: number;
   search?: string;
-  sort?: 'created' | 'topic' | 'origin' | null;
-  sortOrder?: 'asc' | 'desc';
+  orderField?: EntityOrder[];
   read?: boolean;
   saved?: boolean;
   createdAfter?: Date;

--- a/plugins/notifications-backend/src/service/parseEntityOrderFieldParams.test.ts
+++ b/plugins/notifications-backend/src/service/parseEntityOrderFieldParams.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseEntityOrderFieldParams } from './parseEntityOrderFieldParams';
+
+describe('parseEntityOrderFieldParams', () => {
+  it('supports no order fields', () => {
+    const result = parseEntityOrderFieldParams({});
+    expect(result).toEqual(undefined);
+  });
+
+  it('supports single orderField', () => {
+    const result = parseEntityOrderFieldParams({
+      orderField: ['metadata.name,desc'],
+    })!;
+    expect(result).toEqual([{ field: 'metadata.name', order: 'desc' }]);
+  });
+
+  it('supports single orderField without order', () => {
+    const result = parseEntityOrderFieldParams({
+      orderField: ['metadata.name'],
+    })!;
+    expect(result).toEqual([{ field: 'metadata.name' }]);
+  });
+
+  it('supports multiple order fields', () => {
+    const result = parseEntityOrderFieldParams({
+      orderField: ['metadata.name,desc', 'metadata.uid,asc'],
+    });
+
+    expect(result).toEqual([
+      { field: 'metadata.name', order: 'desc' },
+      { field: 'metadata.uid', order: 'asc' },
+    ]);
+  });
+
+  it('throws if orderField order is not valid', () => {
+    expect(() =>
+      parseEntityOrderFieldParams({
+        orderField: ['metadata.name,desc', 'metadata.uid,invalid'],
+      }),
+    ).toThrow(/Invalid order field order/);
+  });
+});

--- a/plugins/notifications-backend/src/service/parseEntityOrderFieldParams.ts
+++ b/plugins/notifications-backend/src/service/parseEntityOrderFieldParams.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is based on the plugins/catalog-backend
+
+import { InputError } from '@backstage/errors';
+import { EntityOrder } from '../database';
+
+/**
+ * Takes a single unknown parameter and makes sure that it's a single string or
+ * an array of strings, and returns as an array.
+ */
+export function parseStringsParam(
+  param: unknown,
+  ctx: string,
+): string[] | undefined {
+  if (param === undefined) {
+    return undefined;
+  }
+
+  const array = [param].flat();
+  if (array.some(p => typeof p !== 'string')) {
+    throw new InputError(`Invalid ${ctx}, not a string`);
+  }
+
+  return array as string[];
+}
+
+export function parseEntityOrderFieldParams(
+  params: Record<string, unknown>,
+): EntityOrder[] | undefined {
+  const orderFieldStrings = parseStringsParam(params.orderField, 'orderField');
+  if (!orderFieldStrings) {
+    return undefined;
+  }
+
+  return orderFieldStrings.map(orderFieldString => {
+    const [field, order] = orderFieldString.split(',');
+
+    if (order !== undefined && !isOrder(order)) {
+      throw new InputError('Invalid order field order, must be asc or desc');
+    }
+    return { field, order };
+  });
+}
+
+export function isOrder(order: string): order is 'asc' | 'desc' {
+  return ['asc', 'desc'].includes(order);
+}

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -45,6 +45,7 @@ import {
   Notification,
   NotificationReadSignal,
 } from '@backstage/plugin-notifications-common';
+import { parseEntityOrderFieldParams } from '@backstage/plugin-catalog-backend';
 
 /** @internal */
 export interface RouterOptions {
@@ -58,28 +59,6 @@ export interface RouterOptions {
   catalog?: CatalogApi;
   processors?: NotificationProcessor[];
 }
-
-const getSort = (input: string): NotificationGetOptions['sort'] | undefined => {
-  const valid: NotificationGetOptions['sort'][] = [
-    'created',
-    'topic',
-    'origin',
-  ];
-
-  if ((valid as string[]).includes(input)) {
-    return input as NotificationGetOptions['sort'];
-  }
-  return undefined;
-};
-
-const getSortOrder = (input: string): NotificationGetOptions['sortOrder'] => {
-  const valid: NotificationGetOptions['sortOrder'][] = ['asc', 'desc'];
-
-  if ((valid as string[]).includes(input)) {
-    return input as NotificationGetOptions['sortOrder'];
-  }
-  return 'desc';
-};
 
 /** @internal */
 export async function createRouter(
@@ -209,11 +188,8 @@ export async function createRouter(
     if (req.query.limit) {
       opts.limit = Number.parseInt(req.query.limit.toString(), 10);
     }
-    if (req.query.sort) {
-      opts.sort = getSort(req.query.sort.toString());
-    }
-    if (req.query.sort_order) {
-      opts.sortOrder = getSortOrder(req.query.sort_order.toString());
+    if (req.query.orderField) {
+      opts.orderField = parseEntityOrderFieldParams(req.query);
     }
     if (req.query.search) {
       opts.search = req.query.search.toString();

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -206,8 +206,8 @@ export async function createRouter(
       opts.saved = false;
       // or keep undefined
     }
-    if (req.query.created_after) {
-      const sinceEpoch = Date.parse(String(req.query.created_after));
+    if (req.query.createdAfter) {
+      const sinceEpoch = Date.parse(String(req.query.createdAfter));
       if (isNaN(sinceEpoch)) {
         throw new InputError('Unexpected date format');
       }

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -45,7 +45,7 @@ import {
   Notification,
   NotificationReadSignal,
 } from '@backstage/plugin-notifications-common';
-import { parseEntityOrderFieldParams } from '@backstage/plugin-catalog-backend';
+import { parseEntityOrderFieldParams } from './parseEntityOrderFieldParams';
 
 /** @internal */
 export interface RouterOptions {

--- a/plugins/notifications/src/api/NotificationsClient.test.ts
+++ b/plugins/notifications/src/api/NotificationsClient.test.ts
@@ -60,7 +60,7 @@ describe('NotificationsClient', () => {
       server.use(
         rest.get(`${mockBaseUrl}/`, (req, res, ctx) => {
           expect(req.url.search).toBe(
-            '?limit=10&offset=0&search=find+me&read=true&created_after=1970-01-01T00%3A00%3A00.005Z',
+            '?limit=10&offset=0&search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
           );
           return res(ctx.json(expectedResp));
         }),

--- a/plugins/notifications/src/api/NotificationsClient.ts
+++ b/plugins/notifications/src/api/NotificationsClient.ts
@@ -50,10 +50,10 @@ export class NotificationsClient implements NotificationsApi {
       queryString.append('offset', options.offset.toString(10));
     }
     if (options?.sort !== undefined) {
-      queryString.append('sort', options.sort);
-    }
-    if (options?.sortOrder !== undefined) {
-      queryString.append('sort_order', options.sortOrder);
+      queryString.append(
+        'orderField',
+        `${options.sort},${options?.sortOrder ?? 'desc'}`,
+      );
     }
     if (options?.search) {
       queryString.append('search', options.search);

--- a/plugins/notifications/src/api/NotificationsClient.ts
+++ b/plugins/notifications/src/api/NotificationsClient.ts
@@ -65,7 +65,7 @@ export class NotificationsClient implements NotificationsApi {
       queryString.append('saved', options.saved ? 'true' : 'false');
     }
     if (options?.createdAfter !== undefined) {
-      queryString.append('created_after', options.createdAfter.toISOString());
+      queryString.append('createdAfter', options.createdAfter.toISOString());
     }
     if (options?.minimumSeverity !== undefined) {
       queryString.append('minimal_severity', options.minimumSeverity);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the Notifications plugin,
- the sort/sortOrder URL query params are replaced by `orderField` to unify with the Catalog
- the `created_after` param is camelCased to `createdAfter`

Follow-up for: https://github.com/backstage/backstage/pull/23351

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
