### PR TITLE
feat(plugin-scaffolder-backend-module-gitlab): add gitlab issue iid i…

### DIFF
--- a/.changeset/modern-wasps-wink.md
+++ b/.changeset/modern-wasps-wink.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-gitlab': minor
 ---
 
-Add a mapping from gitlab create issue API to also output the issue iid (id scoped to the gitlab project) in the output of the scaffolder.
+Output the `iid` as `issuesIid` from the `gitlab:issues:create` action

--- a/.changeset/modern-wasps-wink.md
+++ b/.changeset/modern-wasps-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+Add a mapping from gitlab create issue API to also output the issue iid (id scoped to the gitlab project) in the output of the scaffolder.

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -48,6 +48,7 @@ export const createGitlabIssueAction: (options: {
   {
     issueUrl: string;
     issueId: number;
+    issueIid: number;
   }
 >;
 

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabIssueAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabIssueAction.test.ts
@@ -70,6 +70,7 @@ describe('gitlab:issues:create', () => {
 
     mockGitlabClient.Issues.create.mockResolvedValue({
       id: 42,
+      iid: 1,
       web_url: 'https://gitlab.com/hangar18-/issues/42',
     });
 
@@ -97,6 +98,7 @@ describe('gitlab:issues:create', () => {
     );
 
     expect(mockContext.output).toHaveBeenCalledWith('issueId', 42);
+    expect(mockContext.output).toHaveBeenCalledWith('issueIid', 1);
     expect(mockContext.output).toHaveBeenCalledWith(
       'issueUrl',
       'https://gitlab.com/hangar18-/issues/42',
@@ -116,6 +118,7 @@ describe('gitlab:issues:create', () => {
 
     mockGitlabClient.Issues.create.mockResolvedValue({
       id: 42,
+      iid: 1,
       web_url: 'https://gitlab.com/hangar18-/issues/42',
     });
 
@@ -143,6 +146,7 @@ describe('gitlab:issues:create', () => {
     );
 
     expect(mockContext.output).toHaveBeenCalledWith('issueId', 42);
+    expect(mockContext.output).toHaveBeenCalledWith('issueIid', 1);
     expect(mockContext.output).toHaveBeenCalledWith(
       'issueUrl',
       'https://gitlab.com/hangar18-/issues/42',
@@ -168,6 +172,7 @@ describe('gitlab:issues:create', () => {
 
     mockGitlabClient.Issues.create.mockResolvedValue({
       id: 42,
+      iid: 1,
       web_url: 'https://gitlab.com/hangar18-/issues/42',
     });
 
@@ -196,6 +201,7 @@ describe('gitlab:issues:create', () => {
     );
 
     expect(mockContext.output).toHaveBeenCalledWith('issueId', 42);
+    expect(mockContext.output).toHaveBeenCalledWith('issueIid', 1);
     expect(mockContext.output).toHaveBeenCalledWith(
       'issueUrl',
       'https://gitlab.com/hangar18-/issues/42',

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabIssueAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/createGitlabIssueAction.ts
@@ -102,6 +102,7 @@ const issueInputProperties = z.object({
 const issueOutputProperties = z.object({
   issueUrl: z.string({ description: 'Issue Url' }),
   issueId: z.number({ description: 'Issue Id' }),
+  issueIid: z.number({ description: 'Issue Iid' }),
 });
 
 /**
@@ -194,6 +195,7 @@ export const createGitlabIssueAction = (options: {
 
         ctx.output('issueId', response.id);
         ctx.output('issueUrl', response.web_url);
+        ctx.output('issueIid', response.iid);
       } catch (error: any) {
         if (error instanceof z.ZodError) {
           // Handling Zod validation errors


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've implemented an enhancement to the `gitlab:issues:create` action within the Backstage GitLab plugin. This update includes a new output mapping that integrates the `iid` (internal ID) of the issue directly from the GitLab API response post-issue creation.

This modification ensures that users can immediately reference and track the newly created GitLab issue's `iid`, facilitating better automation and integration within the Backstage ecosystem.

### Why is this important?

The `iid` of an issue is crucial for automating follow-up actions, such as linking to dashboards, MR, creating additional tasks based on the issue, or even for audit and tracking purposes within Backstage. By making this information readily available as part of the action's output, it enhances the plugin's utility and user experience.

### Changes

- Added `iid` field to the output mapping of the `gitlab:issues:create` action.
- Updated the action schema to include `iid` as a part of the output.

### Verification and Testing

- Unit tests have been updated to cover the updated functionality.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

I'm looking forward to your feedback and am happy to make any further adjustments to ensure this enhancement aligns well with the project's direction and standards. Let's :shipit: faster! 🚀