### PR TITLE
Update oidc.md to account for deprecation requiring configApi

### DIFF
--- a/docs/auth/oidc.md
+++ b/docs/auth/oidc.md
@@ -92,6 +92,7 @@ export const apis: AnyApiFactory[] = [
     },
     factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
       OAuth2.create({
+        configApi,
         discoveryApi,
         oauthRequestApi,
         provider: {


### PR DESCRIPTION
Providing update to ensure that deprecation is handled by anyone doing copy-pasta of the custom OIDC provider.

## Hey, I just made a Pull Request!

Using the custom OIDC code provided by the documentation results in a deprecation warning that only gets displayed within the console.

<img width="1030" alt="Screenshot 2024-03-08 at 11 49 02 AM" src="https://github.com/backstage/backstage/assets/133238823/7099d7a6-9d87-4d5d-a95e-a6c5fa034cc8">

Adding the configApi as part of the default auth provider creation to avoid anyone who copy-pasta'd the code from immediately having deprecated changes that require additional action.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
