### PR TITLE
feat: add env variable to reload new backend system in docker

### DIFF
--- a/.changeset/wet-doors-sniff.md
+++ b/.changeset/wet-doors-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Addition of ENABLE_NODE_WATCH environment variable allowing to force reload the new backend system when developing in a docker container

--- a/packages/cli/src/lib/experimental/startBackendExperimental.ts
+++ b/packages/cli/src/lib/experimental/startBackendExperimental.ts
@@ -93,17 +93,24 @@ export async function startBackendExperimental(options: BackendServeOptions) {
       optionArgs.push(inspect);
     }
 
-    if (process.env.ENABLE_NODE_WATCH && envEnv.NODE_ENV === 'development') {
-      optionArgs.push('--watch');
-    }
-
     const userArgs = process.argv
       .slice(['node', 'backstage-cli', 'package', 'start'].length)
       .filter(arg => !optionArgs.includes(arg));
 
+    const additionalArgs = new Array<string>();
+    if (process.env.ENABLE_NODE_WATCH && envEnv.NODE_ENV === 'development') {
+      additionalArgs.push('--watch');
+    }
+
     child = spawn(
       process.execPath,
-      [...loaderArgs, ...optionArgs, options.entry, ...userArgs],
+      [
+        ...loaderArgs,
+        ...optionArgs,
+        ...additionalArgs,
+        options.entry,
+        ...userArgs,
+      ],
       {
         stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
         env: {

--- a/packages/cli/src/lib/experimental/startBackendExperimental.ts
+++ b/packages/cli/src/lib/experimental/startBackendExperimental.ts
@@ -93,6 +93,10 @@ export async function startBackendExperimental(options: BackendServeOptions) {
       optionArgs.push(inspect);
     }
 
+    if (process.env.ENABLE_NODE_WATCH && envEnv.NODE_ENV === 'development') {
+      optionArgs.push('--watch');
+    }
+
     const userArgs = process.argv
       .slice(['node', 'backstage-cli', 'package', 'start'].length)
       .filter(arg => !optionArgs.includes(arg));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We recently migrated to the new backend system, and we have encountered an issue where the backend will not restart when a change is made. This slows down the development process. We are developing the backstage instance in a docker container. 

I have noticed that backstage uses `chokidar` to detect changes: https://github.com/backstage/backstage/blob/4682263fa3127afa865d7fdc224f2077cc9280d9/packages/cli/src/lib/experimental/startBackendExperimental.ts#L133, however there seems to be a bug in which changes are not detected by the package in docker: https://github.com/paulmillr/chokidar/issues/1051.

Although still experiment, the workaround that seemed to work for me was to enable watch mode in node: https://nodejs.org/api/cli.html#--watch. It was introduced in [node v18.11.0](https://nodejs.org/en/blog/release/v18.11.0).


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
