### PR TITLE
Support env var parameter substitution

### DIFF
--- a/.changeset/tricky-clouds-wait.md
+++ b/.changeset/tricky-clouds-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': minor
+---
+
+Support parameter substitution for environment variables

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -199,6 +199,18 @@ configuration value will evaluate to `undefined`.
 The substitution syntax can be escaped using `$${...}`, which will be resolved
 as `${...}`.
 
+Parameter substitution syntax (e.g. `${MY_VAR:-default-value}`) is also
+supported to provide a default or fallback value for a given environment
+variable if it is unset, or is declared but has no value. For example:
+
+```yaml
+app:
+  baseUrl: https://${HOST:-http://localhost:3000}
+```
+
+In the above example, when `HOST` is unset or has no value, it will be
+substituted with `http://localhost:3000`.
+
 ## Combining Includes and Environment Variable Substitution
 
 The Includes and Environment Variable Substitutions can be combined to do

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -205,11 +205,11 @@ variable if it is unset, or is declared but has no value. For example:
 
 ```yaml
 app:
-  baseUrl: https://${HOST:-http://localhost:3000}
+  baseUrl: https://${HOST:-localhost:3000}
 ```
 
 In the above example, when `HOST` is unset or has no value, it will be
-substituted with `http://localhost:3000`.
+substituted with `localhost:3000`.
 
 ## Combining Includes and Environment Variable Substitution
 

--- a/packages/config-loader/src/sources/transform/substitution.test.ts
+++ b/packages/config-loader/src/sources/transform/substitution.test.ts
@@ -56,6 +56,12 @@ describe('substituteTransform', () => {
       value: 'hello my-secret',
     });
     await expect(
+      substituteTransform('hello ${SECRET:-default-secret}', { dir: '/' }),
+    ).resolves.toEqual({
+      applied: true,
+      value: 'hello my-secret',
+    });
+    await expect(
       substituteTransform('${SECRET      } $${} ${TOKEN }', { dir: '/' }),
     ).resolves.toEqual({ applied: true, value: 'my-secret ${} my-token' });
     await expect(
@@ -65,6 +71,24 @@ describe('substituteTransform', () => {
       value: undefined,
     });
     await expect(
+      substituteTransform('foo ${MISSING:-}', { dir: '/' }),
+    ).resolves.toEqual({
+      applied: true,
+      value: undefined,
+    });
+    await expect(
+      substituteTransform('foo ${MISSING:-default-value}', { dir: '/' }),
+    ).resolves.toEqual({
+      applied: true,
+      value: 'foo default-value',
+    });
+    await expect(
+      substituteTransform('foo ${MISSING:-default:-value}', { dir: '/' }),
+    ).resolves.toEqual({
+      applied: true,
+      value: 'foo default:-value',
+    });
+    await expect(
       substituteTransform('empty substitute ${}', { dir: '/' }),
     ).resolves.toEqual({
       applied: true,
@@ -72,6 +96,9 @@ describe('substituteTransform', () => {
     });
     await expect(
       substituteTransform('foo ${MISSING} ${SECRET}', { dir: '/' }),
+    ).resolves.toEqual({ applied: true, value: undefined });
+    await expect(
+      substituteTransform('foo ${MISSING:-} ${SECRET}', { dir: '/' }),
     ).resolves.toEqual({ applied: true, value: undefined });
     await expect(
       substituteTransform('foo ${SECRET} ${SECRET}', { dir: '/' }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the support for parameter substitution in environment variables. For example, `foo ${MISSING:-default-value}` becomes `foo default-value` if `MISSING` is an unset environment variable, or is declared but has no value. This is useful in situations where an environment variable is defined in `app-config.yaml` (e.g. in a proxy block), but a fallback value is desired when the environment variable is not set. For example:
```yaml
proxy:
  endpoints:
    '/foo':
      headers:
        authorization: 'token ${FOO_TOKEN:-my-local-dev-token}'
      target: ${FOO_PROXY_TARGET:-http://localhost:9000}
```
When `FOO_TOKEN` and/or `FOO_PROXY_TARGET` are unset, they will be substituted with `my-local-dev-token` and `http://localhost:9000`, respectively.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
